### PR TITLE
parser: support backslash escapes in single-line strings

### DIFF
--- a/packages/agency-lang/docs/site/guide/basic-syntax.md
+++ b/packages/agency-lang/docs/site/guide/basic-syntax.md
@@ -112,6 +112,44 @@ const negativeSlice = arr[-3:-1] // negativeSlice is [3, 4]
 arr[:3] = [10, 20, 30] // arr is now [10, 20, 30, 4, 5]
 ```
 
+### String literals
+
+Strings are delimited by `"` or `` ` ``. The other quote character can appear unescaped inside, so you rarely need to escape anything:
+
+```ts
+const s1 = "she said `hi`"
+const s2 = `she said "hi"`
+```
+
+For cases where the same quote character must appear inside the string, use a backslash escape. The recognized escapes are:
+
+| Escape | Meaning            |
+|--------|--------------------|
+| `\\`   | literal backslash  |
+| `\"`   | literal `"`        |
+| `` \` `` | literal `` ` ``  |
+| `\n`   | newline            |
+| `\t`   | tab                |
+| `\r`   | carriage return    |
+| `\0`   | null character     |
+| `\${`  | literal `${` (no interpolation) |
+
+Any other backslash sequence is left as-is — `"a\zb"` is the four-character string `a\zb`, not an error. Interpolation works inside both quote styles with `${expression}`:
+
+```ts
+const name = "world"
+const greeting = "hello, ${name}!"
+```
+
+Multi-line strings use `"""` triple-quotes and do **not** interpret backslash escapes (so docstrings containing prose like `path\to\file` work as written):
+
+```ts
+const block = """
+  first line
+  second line
+"""
+```
+
 ### Unit literals
 
 Agency supports unit literals for time, cost, and size values. They compile to plain numbers at compile time:

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -579,3 +579,57 @@ describe("AgencyGenerator - preserveOrder mode", () => {
   });
 });
 
+describe("AgencyGenerator - string escape round-tripping", () => {
+  // For each test we parse a `let s = "<source>"` declaration, emit
+  // it through the generator, parse the emitted output again, and
+  // confirm the second parse produces the same string value as the
+  // first. This guards against codegen producing source that the
+  // parser would mis-interpret (e.g. forgetting to escape `\` so
+  // `"\\"` parses as `\` the first time and as a syntax error the
+  // second time).
+  const cases = [
+    { name: "embedded double-quote",   source: '"a\\"b"',       value: 'a"b' },
+    { name: "embedded backslash",      source: '"a\\\\b"',      value: 'a\\b' },
+    { name: "newline / tab",           source: '"x\\ny\\tz"',   value: 'x\ny\tz' },
+    { name: "escaped interpolation",   source: '"\\${foo}"',    value: '${foo}' },
+    { name: "plain dollar sign",       source: '"$5"',          value: '$5' },
+    { name: "backtick allowed inline", source: '"a`b"',         value: 'a`b' },
+  ];
+
+  cases.forEach(({ name, source, value }) => {
+    it(`round-trips: ${name}`, () => {
+      const input = `let s = ${source}`;
+
+      const r1 = parseAgency(input, {}, false);
+      expect(r1.success, "first parse").toBe(true);
+      if (!r1.success) return;
+
+      const gen = new AgencyGenerator();
+      const emitted = gen.generate(r1.result).output;
+
+      const r2 = parseAgency(emitted, {}, false);
+      expect(r2.success, `second parse of ${JSON.stringify(emitted)}`).toBe(
+        true,
+      );
+      if (!r2.success) return;
+
+      // Extract the string literal from both parses and compare its
+      // text-segment value. The parsed value should match what the
+      // test asked for, both before and after the round trip.
+      const stringOf = (program: { nodes: unknown[] }): string | null => {
+        const assignment = program.nodes.find(
+          (n: any) => n?.type === "assignment",
+        ) as { value?: { type?: string; segments?: { type: string; value?: string }[] } } | undefined;
+        if (assignment?.value?.type !== "string") return null;
+        const segs = assignment.value.segments ?? [];
+        if (segs.length === 0) return "";
+        if (segs.length !== 1 || segs[0].type !== "text") return null;
+        return segs[0].value ?? "";
+      };
+
+      expect(stringOf(r1.result), "first-parse value").toBe(value);
+      expect(stringOf(r2.result), "round-tripped value").toBe(value);
+    });
+  });
+});
+

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -74,6 +74,38 @@ import {
   WildcardPattern,
 } from "@/types/pattern.js";
 
+// Escape the characters that have special meaning inside a `"..."`
+// string literal so the formatter's output round-trips through the
+// parser. Mirror the escapes recognized by `stringTextSegmentParserFor`
+// in `parsers.ts`. Backticks are *not* escaped because Agency strings
+// allow the other quote character to appear unescaped inside.
+function escapeStringText(s: string): string {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    switch (c) {
+      case "\\": out += "\\\\"; break;
+      case '"':  out += '\\"';  break;
+      case "\n": out += "\\n";  break;
+      case "\t": out += "\\t";  break;
+      case "\r": out += "\\r";  break;
+      case "\0": out += "\\0";  break;
+      case "$":
+        // Only `${` starts an interpolation. Escape a bare `$` only
+        // when followed by `{` so a literal `$5` stays as `$5`.
+        if (s[i + 1] === "{") {
+          out += "\\$";
+        } else {
+          out += "$";
+        }
+        break;
+      default:
+        out += c;
+    }
+  }
+  return out;
+}
+
 export class AgencyGenerator {
   protected graphNodes: GraphNodeDefinition[] = [];
   protected generatedStatements: string[] = [];
@@ -781,7 +813,7 @@ export class AgencyGenerator {
     let result = '"';
     for (const segment of node.segments) {
       if (segment.type === "text") {
-        result += segment.value;
+        result += escapeStringText(segment.value);
       } else if (segment.type === "interpolation") {
         // processNode (not expressionToString) so nested function calls with
         // block arguments and quoted string literals round-trip correctly.

--- a/packages/agency-lang/lib/parsers/literals.test.ts
+++ b/packages/agency-lang/lib/parsers/literals.test.ts
@@ -560,6 +560,72 @@ describe("literals parsers", () => {
     });
   });
 
+  describe("stringParser - backslash escapes", () => {
+    const cases: { input: string; value: string }[] = [
+      // Quote character inside the same-quote string. Before escapes
+      // landed, the only way to write `"` in a double-quoted string was
+      // to switch to backticks. Now both forms work.
+      { input: '"\\""', value: '"' },
+      { input: '"`"', value: "`" },        // other quote stays unescaped
+      { input: '"a\\"b"', value: 'a"b' },
+      { input: "`\\``", value: "`" },
+      { input: '`"`', value: '"' },
+
+      // Backslash itself.
+      { input: '"\\\\"', value: "\\" },
+      { input: '"a\\\\b"', value: "a\\b" },
+
+      // Control characters.
+      { input: '"\\n"', value: "\n" },
+      { input: '"\\t"', value: "\t" },
+      { input: '"\\r"', value: "\r" },
+      { input: '"line1\\nline2"', value: "line1\nline2" },
+
+      // Escaping the interpolation start so `${...}` appears literally.
+      { input: '"\\${foo}"', value: "${foo}" },
+      { input: '"price: \\$5"', value: "price: $5" },
+
+      // Unknown escapes are preserved verbatim: `\z` stays as the two
+      // chars `\` and `z` so existing strings that happen to contain a
+      // backslash don't change meaning.
+      { input: '"\\z"', value: "\\z" },
+      { input: '"\\q\\w\\e"', value: "\\q\\w\\e" },
+    ];
+
+    cases.forEach(({ input, value }) => {
+      it(`parses ${JSON.stringify(input)} → ${JSON.stringify(value)}`, () => {
+        const result = stringParser(input);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.result).toEqualWithoutLoc({
+            type: "string",
+            segments: [{ type: "text", value }],
+          });
+        }
+      });
+    });
+
+    it("an escaped ${ does not start interpolation", () => {
+      const result = stringParser('"\\${1 + 1}"');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({
+          type: "string",
+          segments: [{ type: "text", value: "${1 + 1}" }],
+        });
+      }
+    });
+
+    it("an unescaped ${ still starts interpolation", () => {
+      const result = stringParser('"${foo}"');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.segments).toHaveLength(1);
+        expect(result.result.segments[0].type).toBe("interpolation");
+      }
+    });
+  });
+
   describe("stringParser - string concatenation with + operator", () => {
     const testCases = [
       // String + Variable

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -317,11 +317,46 @@ export const stringTextSegmentParser: Parser<TextSegment> = map(
 // (the one that opened the string) or `${`. Lets the *other* quote character
 // appear unescaped inside, just like single quotes already do — e.g. a
 // double-quoted string can contain backticks, and vice versa.
+//
+// Supports the following backslash escapes:
+//   \\ → \    \n → newline   \t → tab    \r → carriage return
+//   \" → "    \` → `         \0 → null   \$ → $   (use \${ to write a
+// literal `${` without starting interpolation).
+//
+// An unrecognized escape (`\x`, where `x` isn't in the list above) is
+// preserved verbatim — both the backslash and the character — so existing
+// strings containing literal `\` followed by non-escape characters are
+// unaffected. This is the same behavior as Python's regular strings.
 const stringTextSegmentParserFor = (delim: '"' | "`"): Parser<TextSegment> =>
-  map(
-    many1Till(or(char(delim), str("${"))),
-    (text) => ({ type: "text", value: text }),
-  );
+  (input: string): ParserResult<TextSegment> => {
+    let i = 0;
+    let value = "";
+    while (i < input.length) {
+      const c = input[i];
+      if (c === delim) break;
+      if (c === "$" && input[i + 1] === "{") break;
+      if (c === "\\" && i + 1 < input.length) {
+        const next = input[i + 1];
+        switch (next) {
+          case "\\": value += "\\"; break;
+          case '"':  value += '"';  break;
+          case "`":  value += "`";  break;
+          case "n":  value += "\n"; break;
+          case "t":  value += "\t"; break;
+          case "r":  value += "\r"; break;
+          case "0":  value += "\0"; break;
+          case "$":  value += "$";  break;
+          default:   value += "\\" + next; break;
+        }
+        i += 2;
+        continue;
+      }
+      value += c;
+      i++;
+    }
+    if (i === 0) return failure("expected string text", input);
+    return success({ type: "text" as const, value }, input.slice(i));
+  };
 
 export const multiLineStringTextSegmentParser: Parser<TextSegment> = map(
   many1Till(or(str('"""'), str("${"))),


### PR DESCRIPTION
## What

Single-line Agency string literals (`"..."` and `` `...` ``) now recognize a small set of backslash escapes:

| Escape | Meaning           |
|--------|-------------------|
| `\\`   | literal backslash |
| `\"`   | literal `"`       |
| `` \` `` | literal `` ` `` |
| `\n`   | newline           |
| `\t`   | tab               |
| `\r`   | carriage return   |
| `\0`   | null              |
| `\${`  | literal `${` (no interpolation) |

Any other `\X` sequence is preserved verbatim, so existing strings containing `\` followed by an unrecognized char keep the same meaning.

Multi-line `"""..."""` strings are intentionally **not** changed — many docstrings contain prose like `\n\n` or `path\to\file` written literally, and changing that would silently break them.

## Why

Prior to this change there was no way to put `"` inside a double-quoted string without switching to backticks: `"\""` parsed as the empty string followed by a stray `"`. A typo in `stdlib/skills.agency` (`replaceAll(""", "&quot;")` — three quotes started a multi-line string and ate the function body) made this surface with the misleading error "Expected function body" pointing at the docstring opening, not the actual problem 13 lines later.

## Round-trip safety

The formatter (`AgencyGenerator.generateStringLiteral`) now escapes `\`, `"`, control chars, and `${` when emitting a string text segment. New tests parse a string, emit it, re-parse it, and confirm the value is preserved.

## Tests

- `lib/parsers/literals.test.ts`: 17 new cases covering each escape, escaped-vs-unescaped interpolation, and unknown-escape passthrough.
- `lib/backends/agencyGenerator.test.ts`: 6 round-trip cases (parse → emit → parse → compare value).

`pnpm vitest run lib/parsers lib/typeChecker lib/backends`: **2407/2407 passing** locally (after `make stdlib` to materialize the runtime test fixtures).

## Docs

Adds a "String literals" section to [docs/site/guide/basic-syntax.md](https://github.com/egonSchiele/agency-lang/blob/main/packages/agency-lang/docs/site/guide/basic-syntax.md) listing the escape table and clarifying the multi-line exception.

## Not done in this PR

- Improving the "Expected function body" error message for unterminated multi-line strings — separate parser-error-quality work.
- Adding escape support inside `"""..."""` — would require auditing existing docstrings for `\n`/`\t` patterns.
