### PR TITLE
parser/formatter: round-trip string delimiters, accept single quotes

### DIFF
--- a/packages/agency-lang/docs/site/guide/basic-syntax.md
+++ b/packages/agency-lang/docs/site/guide/basic-syntax.md
@@ -114,11 +114,12 @@ arr[:3] = [10, 20, 30] // arr is now [10, 20, 30, 4, 5]
 
 ### String literals
 
-Strings are delimited by `"` or `` ` ``. The other quote character can appear unescaped inside, so you rarely need to escape anything:
+Strings are delimited by `"`, `'`, or `` ` ``. All three are equivalent — same escape rules, same `${...}` interpolation. The two delimiters you didn't pick can appear unescaped inside, so you rarely need to escape anything:
 
 ```ts
 const s1 = "she said `hi`"
 const s2 = `she said "hi"`
+const s3 = 'she said "hi" and `bye`'
 ```
 
 For cases where the same quote character must appear inside the string, use a backslash escape. The recognized escapes are:
@@ -127,6 +128,7 @@ For cases where the same quote character must appear inside the string, use a ba
 |--------|--------------------|
 | `\\`   | literal backslash  |
 | `\"`   | literal `"`        |
+| `\'`   | literal `'`        |
 | `` \` `` | literal `` ` ``  |
 | `\n`   | newline            |
 | `\t`   | tab                |
@@ -134,7 +136,7 @@ For cases where the same quote character must appear inside the string, use a ba
 | `\0`   | null character     |
 | `\${`  | literal `${` (no interpolation) |
 
-Any other backslash sequence is left as-is — `"a\zb"` is the four-character string `a\zb`, not an error. Interpolation works inside both quote styles with `${expression}`:
+Any other backslash sequence is left as-is — `"a\zb"` is the four-character string `a\zb`, not an error. Interpolation works inside all three quote styles with `${expression}`:
 
 ```ts
 const name = "world"

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -633,3 +633,83 @@ describe("AgencyGenerator - string escape round-tripping", () => {
   });
 });
 
+describe("AgencyGenerator - string delimiter round-tripping", () => {
+  // Emit, parse, and check that (a) the emitted source is exactly the
+  // input source (no delimiter rewrite, no needless escapes) and (b)
+  // the re-parsed text value matches the original.
+  const cases = [
+    {
+      name: "backtick string containing double quote",
+      source: '`she said "hi"`',
+      value: 'she said "hi"',
+    },
+    {
+      name: "double-quoted string containing backtick",
+      source: '"she said `hi`"',
+      value: "she said `hi`",
+    },
+    {
+      name: "single-quoted string containing the other two delimiters",
+      source: '\'she said "hi" and `hi`\'',
+      value: 'she said "hi" and `hi`',
+    },
+    {
+      name: "backtick string with an escaped backtick",
+      source: "`with a \\` escaped backtick`",
+      value: "with a ` escaped backtick",
+    },
+    {
+      name: "single-quoted string with an escaped single quote",
+      source: "'it\\'s fine'",
+      value: "it's fine",
+    },
+  ];
+
+  cases.forEach(({ name, source, value }) => {
+    it(`round-trips: ${name}`, () => {
+      const input = `let s = ${source}`;
+
+      const r1 = parseAgency(input, {}, false);
+      expect(r1.success, "first parse").toBe(true);
+      if (!r1.success) return;
+
+      const gen = new AgencyGenerator();
+      const emitted = gen.generate(r1.result).output;
+
+      // The emitted assignment line should contain the original source
+      // verbatim — the formatter must not rewrite the delimiter.
+      expect(emitted).toContain(source);
+
+      const r2 = parseAgency(emitted, {}, false);
+      expect(r2.success, `second parse of ${JSON.stringify(emitted)}`).toBe(true);
+      if (!r2.success) return;
+
+      const stringOf = (program: { nodes: unknown[] }): string | null => {
+        const assignment = program.nodes.find(
+          (n: any) => n?.type === "assignment",
+        ) as { value?: { type?: string; segments?: { type: string; value?: string }[] } } | undefined;
+        if (assignment?.value?.type !== "string") return null;
+        const segs = assignment.value.segments ?? [];
+        if (segs.length === 0) return "";
+        if (segs.length !== 1 || segs[0].type !== "text") return null;
+        return segs[0].value ?? "";
+      };
+
+      expect(stringOf(r1.result), "first-parse value").toBe(value);
+      expect(stringOf(r2.result), "round-tripped value").toBe(value);
+    });
+  });
+
+  it("synthesized literals (no delimiter field) format as \"...\"", () => {
+    const gen = new AgencyGenerator();
+    const synth = {
+      type: "string" as const,
+      segments: [{ type: "text" as const, value: "hello" }],
+    };
+    // Reach into the same path the public emitter would. processNode is
+    // the generic dispatch in AgencyGenerator.
+    const out = (gen as any).processNode(synth);
+    expect(out).toBe('"hello"');
+  });
+});
+

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -74,18 +74,22 @@ import {
   WildcardPattern,
 } from "@/types/pattern.js";
 
-// Escape the characters that have special meaning inside a `"..."`
-// string literal so the formatter's output round-trips through the
-// parser. Mirror the escapes recognized by `stringTextSegmentParserFor`
-// in `parsers.ts`. Backticks are *not* escaped because Agency strings
-// allow the other quote character to appear unescaped inside.
-function escapeStringText(s: string): string {
+// Escape the characters that have special meaning inside a string
+// literal so the formatter's output round-trips through the parser.
+// Mirror the escapes recognized by `stringTextSegmentParserFor` in
+// `parsers.ts`. Only the *same* delimiter is escaped — the other two
+// quote characters are left literal because Agency strings allow them
+// to appear unescaped inside.
+function escapeStringText(s: string, delim: '"' | "'" | "`"): string {
   let out = "";
   for (let i = 0; i < s.length; i++) {
     const c = s[i];
+    if (c === delim) {
+      out += "\\" + delim;
+      continue;
+    }
     switch (c) {
       case "\\": out += "\\\\"; break;
-      case '"':  out += '\\"';  break;
       case "\n": out += "\\n";  break;
       case "\t": out += "\\t";  break;
       case "\r": out += "\\r";  break;
@@ -810,17 +814,18 @@ export class AgencyGenerator {
   }
 
   private generateStringLiteral(node: StringLiteral): string {
-    let result = '"';
+    const delim = node.delimiter ?? '"';
+    let result = delim;
     for (const segment of node.segments) {
       if (segment.type === "text") {
-        result += escapeStringText(segment.value);
+        result += escapeStringText(segment.value, delim);
       } else if (segment.type === "interpolation") {
         // processNode (not expressionToString) so nested function calls with
         // block arguments and quoted string literals round-trip correctly.
         result += `\${${this.processNode(segment.expression).trim()}}`;
       }
     }
-    result += '"';
+    result += delim;
     return result;
   }
 

--- a/packages/agency-lang/lib/parsers/literals.test.ts
+++ b/packages/agency-lang/lib/parsers/literals.test.ts
@@ -4,6 +4,8 @@ import {
   numberParser,
   regexLiteralParser,
   stringParser,
+  simpleStringParser,
+  staticInterpolatedStringParser,
   multiLineStringParser,
   variableNameParser,
   booleanParser,
@@ -537,7 +539,6 @@ describe("literals parsers", () => {
       // Failure cases
       { input: '"hello', expected: { success: false } },
       { input: 'hello"', expected: { success: false } },
-      { input: "'hello'", expected: { success: false } },
       { input: "", expected: { success: false } },
       { input: "hello", expected: { success: false } },
     ];
@@ -627,6 +628,106 @@ describe("literals parsers", () => {
       if (result.success) {
         expect(result.result.segments).toHaveLength(1);
         expect(result.result.segments[0].type).toBe("interpolation");
+      }
+    });
+  });
+
+  describe("stringParser - delimiter round-tripping", () => {
+    const delimiterCases: { input: string; delimiter: '"' | "'" | "`"; value: string }[] = [
+      { input: '"hello"',  delimiter: '"', value: "hello" },
+      { input: "'hello'",  delimiter: "'", value: "hello" },
+      { input: "`hello`",  delimiter: "`", value: "hello" },
+    ];
+
+    delimiterCases.forEach(({ input, delimiter, value }) => {
+      it(`records delimiter for ${JSON.stringify(input)}`, () => {
+        const result = stringParser(input);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.result.delimiter).toBe(delimiter);
+          expect(result.result.segments).toEqual([
+            { type: "text", value },
+          ]);
+        }
+      });
+    });
+
+    it("accepts single quotes (regression — used to be rejected)", () => {
+      const result = stringParser("'hello world'");
+      expect(result.success).toBe(true);
+    });
+
+    it("parses interpolation inside single-quoted strings", () => {
+      const result = stringParser("'hello ${name}'");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.delimiter).toBe("'");
+        expect(result.result.segments).toHaveLength(2);
+        expect(result.result.segments[0]).toEqual({ type: "text", value: "hello " });
+        expect(result.result.segments[1].type).toBe("interpolation");
+      }
+    });
+
+    it("parses an empty single-quoted string", () => {
+      const result = stringParser("''");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.delimiter).toBe("'");
+      }
+    });
+
+    it("escapes the same delimiter only (single quote)", () => {
+      const result = stringParser("'it\\'s'");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.segments).toEqual([
+          { type: "text", value: "it's" },
+        ]);
+      }
+    });
+
+    it("leaves the other two delimiters literal inside a single-quoted string", () => {
+      const result = stringParser('\'she said "hi" and `bye`\'');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.delimiter).toBe("'");
+        expect(result.result.segments).toEqual([
+          { type: "text", value: 'she said "hi" and `bye`' },
+        ]);
+      }
+    });
+
+    it("simpleStringParser records the single-quote delimiter", () => {
+      const result = simpleStringParser("'hi'");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.delimiter).toBe("'");
+      }
+    });
+
+    it("simpleStringParser round-trips an escaped \\n in a single-quoted string", () => {
+      // tarsec's `quotedString` handles single quotes natively; the test
+      // confirms its escape semantics line up with Agency's expectations
+      // for the simple (non-interpolated) path.
+      const result = simpleStringParser("'foo\\nbar'");
+      expect(result.success).toBe(true);
+    });
+
+    it("preserves the first delimiter across `+` concatenation", () => {
+      // The merged StringLiteral can only carry one delimiter; we pick
+      // the first string piece.
+      const result = stringParser("`a` + 'b'");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.delimiter).toBe("`");
+      }
+    });
+
+    it("staticInterpolatedStringParser accepts single quotes", () => {
+      const result = staticInterpolatedStringParser("'divisible by ${divisor}'");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.delimiter).toBe("'");
       }
     });
   });
@@ -1622,7 +1723,6 @@ describe("literals parsers", () => {
       // Failure cases
       { input: "", expected: { success: false } },
       { input: "`unterminated", expected: { success: false } },
-      { input: "'single quotes'", expected: { success: false } },
     ];
 
     testCases.forEach(({ input, expected }) => {

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -329,7 +329,7 @@ export const stringTextSegmentParser: Parser<TextSegment> = map(
 // preserved verbatim — both the backslash and the character — so existing
 // strings containing literal `\` followed by non-escape characters are
 // unaffected. This is the same behavior as Python's regular strings.
-const stringTextSegmentParserFor = (delim: '"' | "`"): Parser<TextSegment> =>
+const stringTextSegmentParserFor = (delim: '"' | "'" | "`"): Parser<TextSegment> =>
   (input: string): ParserResult<TextSegment> => {
     let i = 0;
     let value = "";
@@ -350,6 +350,7 @@ const stringTextSegmentParserFor = (delim: '"' | "`"): Parser<TextSegment> =>
         switch (next) {
           case "\\": value += "\\"; break;
           case '"':  value += '"';  break;
+          case "'":  value += "'";  break;
           case "`":  value += "`";  break;
           case "n":  value += "\n"; break;
           case "t":  value += "\t"; break;
@@ -544,21 +545,23 @@ export const regexLiteralParser: Parser<RegexLiteral> = label("a regex", (input:
 
 // `_stringParser` is written as a plain function (rather than `seqC`) so it
 // can capture the opening delimiter and require the *same* character to
-// close. This is what allows the other quote character to appear unescaped
-// inside the string — e.g. backticks inside `"…"`, or double quotes inside
-// `` `…` ``.
+// close. This is what allows the other quote characters to appear unescaped
+// inside the string — e.g. backticks and single quotes inside `"…"`, etc.
 //
 // `simpleStringParser` (no interpolation) just reuses tarsec's `quotedString`
-// (which already enforces matching open/close delimiters) and filters out
-// single-quoted strings, since Agency only uses `"` and `` ` `` for string
-// literals.
+// (which already enforces matching open/close delimiters and supports `"`,
+// `'`, and `` ` `` natively). We capture the opening char before delegating
+// so the returned node remembers which delimiter the user wrote.
 export const simpleStringParser: Parser<StringLiteral> = (input: string) => {
-  if (input[0] !== '"' && input[0] !== "`") {
-    return failure(`expected '"' or '\`'`, input);
+  const first = input[0];
+  if (first !== '"' && first !== "'" && first !== "`") {
+    return failure(`expected '"', "'", or '\`'`, input);
   }
+  const delim = first as '"' | "'" | "`";
   return map(quotedString, (s) => ({
     type: "string" as const,
     segments: [{ type: "text" as const, value: s.slice(1, -1) }],
+    delimiter: delim,
   }))(input);
 };
 
@@ -637,9 +640,9 @@ function makeInterpolatedStringParser(
   segmentParser: Parser<InterpolationSegment>,
 ): Parser<StringLiteral> {
   return (input: string) => {
-    const open = oneOf('"`')(input);
+    const open = oneOf("\"'`")(input);
     if (!open.success) return open as ParserResult<StringLiteral>;
-    const delim = open.result as '"' | "`";
+    const delim = open.result as '"' | "'" | "`";
     const segments = many(
       or(stringTextSegmentParserFor(delim), segmentParser),
     )(open.rest);
@@ -647,7 +650,7 @@ function makeInterpolatedStringParser(
     const close = char(delim)(segments.rest);
     if (!close.success) return failure(`expected closing ${delim}`, input);
     return success(
-      { type: "string" as const, segments: segments.result },
+      { type: "string" as const, segments: segments.result, delimiter: delim },
       close.rest,
     );
   };
@@ -673,9 +676,16 @@ export const stringParser: Parser<StringLiteral> = label("a string", (input: str
   }
 
   const segments: (TextSegment | InterpolationSegment)[] = [];
+  let delimiter: '"' | "'" | "`" | undefined;
   parsed.forEach((part) => {
     if (part.type === "string") {
       segments.push(...part.segments);
+      // For `"a" + 'b' + ...`-style concatenation, keep the delimiter
+      // of the first string piece. The formatter sees one merged
+      // StringLiteral anyway, so we have to pick one.
+      if (delimiter === undefined && part.delimiter !== undefined) {
+        delimiter = part.delimiter;
+      }
     } else {
       segments.push({
         type: "interpolation",
@@ -690,6 +700,7 @@ export const stringParser: Parser<StringLiteral> = label("a string", (input: str
     {
       type: "string" as const,
       segments,
+      ...(delimiter !== undefined ? { delimiter } : {}),
     },
     result.rest,
   );

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -314,13 +314,13 @@ export const stringTextSegmentParser: Parser<TextSegment> = map(
 );
 
 // Delimiter-aware text segment: stops only on the matching closing quote
-// (the one that opened the string) or `${`. Lets the *other* quote character
-// appear unescaped inside, just like single quotes already do — e.g. a
-// double-quoted string can contain backticks, and vice versa.
+// (the one that opened the string) or `${`. Lets the *other two* quote
+// characters appear unescaped inside — e.g. a double-quoted string can
+// contain backticks and single quotes, and so on.
 //
 // Supports the following backslash escapes:
 //   \\ → \    \n → newline   \t → tab    \r → carriage return
-//   \" → "    \` → `         \0 → null
+//   \" → "    \' → '         \` → `      \0 → null
 //   \${ → ${ (the only `\$` escape — writes a literal `${` without
 //   starting interpolation; bare `\$` is preserved verbatim so existing
 //   strings like regex patterns are not silently changed).

--- a/packages/agency-lang/lib/parsers/vitest.setup.ts
+++ b/packages/agency-lang/lib/parsers/vitest.setup.ts
@@ -54,9 +54,9 @@ expect.extend({
       pass,
       message: () => {
         if (pass) {
-          return `expected values not to be equal (ignoring loc fields and newline nodes)`;
+          return `expected values not to be equal (ignoring loc, delimiter, and newline nodes)`;
         }
-        return `expected values to be equal (ignoring loc fields and newline nodes)\n\nReceived: ${JSON.stringify(normalizedReceived, null, 2)}\n\nExpected: ${JSON.stringify(normalizeExpected, null, 2)}`;
+        return `expected values to be equal (ignoring loc, delimiter, and newline nodes)\n\nReceived: ${JSON.stringify(normalizedReceived, null, 2)}\n\nExpected: ${JSON.stringify(normalizeExpected, null, 2)}`;
       },
     };
   },

--- a/packages/agency-lang/lib/parsers/vitest.setup.ts
+++ b/packages/agency-lang/lib/parsers/vitest.setup.ts
@@ -1,9 +1,15 @@
 import { expect } from "vitest";
 
 /**
- * Recursively strip `loc` fields and newline nodes from an object.
+ * Recursively strip `loc` fields, `delimiter` fields, and newline nodes
+ * from an object.
  * - `loc` fields are stripped because source location tracking adds them
  *   to all AST nodes, but existing test expectations don't include them.
+ * - `delimiter` is stripped from string AST nodes for the same reason:
+ *   the parser now records which quote the user wrote so the formatter
+ *   can round-trip it, but existing test expectations predate the field.
+ *   Tests that specifically care about the delimiter should check it
+ *   directly rather than via `toEqualWithoutLoc`.
  * - NewLine nodes (`{ type: "newLine" }`) are stripped from arrays because
  *   removing .trim() from normalizeCode causes the parser to produce extra
  *   newline nodes that weren't present when whitespace was pre-stripped.
@@ -31,6 +37,7 @@ function normalize(obj: unknown): unknown {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     if (key === "loc") continue;
+    if (key === "delimiter") continue;
     result[key] = normalize(value);
   }
   return result;

--- a/packages/agency-lang/lib/types/literals.ts
+++ b/packages/agency-lang/lib/types/literals.ts
@@ -48,6 +48,10 @@ export function formatUnitLiteral(lit: Pick<UnitLiteral, "value" | "unit">): str
 export type StringLiteral = BaseNode & {
   type: "string";
   segments: PromptSegment[];
+  // The delimiter the user wrote: `"`, `'`, or `` ` ``. Absent on
+  // synthesized literals (e.g. parallelDesugar, patternLowering),
+  // in which case the formatter defaults to `"`.
+  delimiter?: '"' | "'" | "`";
 };
 
 export type MultiLineStringLiteral = BaseNode & {


### PR DESCRIPTION
## Summary

- The formatter used to normalize every string literal to `"..."`, which after the string-escapes change meant a backtick string containing `"` would be rewritten as `"she said \"hi\""` — technically correct but noisy and not what the user wrote. `StringLiteral` now carries an optional `delimiter` field that the parser populates and the formatter respects, so the user's delimiter choice round-trips.
- `'...'` is now accepted as a third equivalent delimiter (same escape rules, same `${...}` interpolation). LLMs frequently default to single quotes, and a parse error there is needless friction.
- `vitest.setup.ts` strips `delimiter` alongside `loc` in `toEqualWithoutLoc`, so the ~2400 existing test expectations did not need to be updated.

## Test plan

- [x] `pnpm test:run lib/parsers lib/typeChecker lib/backends` — 2423 passing. Two pre-existing failures (`docstringInterpolationRuntime.test.ts`, `jsonSchemaAnnotation.test.ts`) are unrelated package-resolution errors that need `make` to build the runtime; neither touches changed code paths.
- [x] New parser tests cover all three delimiters, single-quote interpolation, empty `''`, `\'` escape, `simpleStringParser` delimiter capture, first-wins across `+` concatenation, and `staticInterpolatedStringParser` accepting `'`.
- [x] New formatter tests cover backtick / single-quote / double-quote round-trips, escaped same-delimiter cases, and synthesized `StringLiteral` defaulting to `"`.
- [ ] CI runs the agency execution suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
