### PR TITLE
std::args: schema-driven CLI flag parser

### DIFF
--- a/packages/agency-lang/docs/site/guide/cli-args.md
+++ b/packages/agency-lang/docs/site/guide/cli-args.md
@@ -65,7 +65,7 @@ Call `parseArgs` as the **first thing** in `main`, before installing handlers, b
 
 ## What the schema accepts
 
-Each flag has a `type` (`"string"`, `"number"`, or `"boolean"`) and optional metadata. Long flag names must match `/^[a-z0-9][a-z0-9-]*/` — lowercase with dashes.
+Each flag has a `type` (`"string"`, `"number"`, or `"boolean"`) and optional metadata. Long flag names must match `/^[a-z0-9][a-z0-9-]*$/` — lowercase with dashes.
 
 ```ts
 type FlagSpec = {

--- a/packages/agency-lang/docs/site/guide/cli-args.md
+++ b/packages/agency-lang/docs/site/guide/cli-args.md
@@ -1,0 +1,190 @@
+---
+name: CLI argument parsing
+description: How to use `std::args` to parse command-line flags in Agency programs — schema-driven, with auto-generated --help, strict number coercion, required/default handling, and exclusive / required-together flag groups.
+---
+
+# CLI argument parsing
+
+When your Agency program is invoked from a shell, `std::args` parses the command line. You declare a schema; the parser returns a typed object of flags plus any positional arguments. On `--help` or a parse error, the parser prints the appropriate output and exits — your `main` only runs when the command line was valid.
+
+## Quick start
+
+```ts
+import { parseArgs } from "std::args"
+
+node main() {
+  const args = parseArgs({
+    programName: "greet",
+    description: "Print a friendly greeting.",
+    flags: {
+      name:    { type: "string",  short: "n", default: "world", description: "Who to greet" },
+      repeat:  { type: "number",  short: "r", default: 1,       description: "How many times" },
+      verbose: { type: "boolean", short: "v",                   description: "Chatty output" },
+      out:     { type: "string",  required: true,               description: "Output path" },
+    },
+  })
+
+  for (i in range(args.flags.repeat)) {
+    print("Hello, " + args.flags.name + "!")
+  }
+}
+```
+
+Invoking the program:
+
+```
+$ greet --name alice --out result.txt -v
+Hello, alice!
+```
+
+```
+$ greet --help
+Usage: greet [options] [args...]
+
+Print a friendly greeting.
+
+Options:
+  -n, --name <string>    Who to greet (default: "world")
+  -r, --repeat <number>  How many times (default: 1)
+  -v, --verbose          Chatty output
+      --out <string>     Output path (required)
+  -h, --help             Show this help and exit
+```
+
+```
+$ greet
+Error: missing required flag --out
+
+Usage: greet [options] [args...]
+  ...
+```
+
+## Usage contract
+
+Call `parseArgs` as the **first thing** in `main`, before installing handlers, before starting a REPL (`std::ui` or `std::cli`), before any side-effectful initialization. The parser exits the process on usage errors and on `--help` — running it before anything exists that would need cleanup keeps that exit safe.
+
+## What the schema accepts
+
+Each flag has a `type` (`"string"`, `"number"`, or `"boolean"`) and optional metadata. Long flag names must match `/^[a-z0-9][a-z0-9-]*/` — lowercase with dashes.
+
+```ts
+type FlagSpec = {
+  type: "string" | "number" | "boolean"
+  short?: string             // single character
+  default?: string | number | boolean
+  required?: boolean
+  description?: string       // shown in --help
+  choices?: string[]         // string flags only; enum constraint
+  hidden?: boolean           // parse but omit from --help
+}
+```
+
+The top-level schema:
+
+```ts
+type ArgsSchema = {
+  programName?: string       // defaults to basename(process.argv[1])
+  description?: string       // shown in --help
+  version?: string           // setting this enables --version / -V
+  epilog?: string            // free text printed after the options block
+  flags: Record<string, FlagSpec>
+  groups?: {
+    exclusive?: string[][]         // at most one set per inner array
+    requiredTogether?: string[][]  // all set, or none
+  }
+}
+```
+
+## Values and coercion
+
+- **String** values come straight through. `--name ""` is allowed.
+- **Number** values are parsed strictly. We accept decimal integers and floats (`-1.5e3`); we reject empty strings, leading or trailing whitespace, hex (`0x10`), octal (`0o10`), binary (`0b10`), `NaN`, and `Infinity`.
+- **Boolean** flags are `true` when present, `false` otherwise. There is no `--no-verbose` form in v1.
+
+Short flags accept either form: `-n alice` or `-nalice`. Boolean shorts can be clustered: `-vh`. Long flags accept either `--name alice` or `--name=alice`.
+
+`--` ends option parsing: everything after it becomes a positional, even if it looks like a flag.
+
+## Required, default, and groups
+
+- `required: true` means the flag must be provided. The program exits 2 with `missing required flag --out` if it's not.
+- `default: <value>` is used when the flag is absent. `required` and `default` together is a schema bug.
+- Boolean flags default to `false` when no default is set. `default: true` is rejected as a schema bug in v1, since without `--no-X` such a flag could never be turned off.
+- `groups.exclusive` rejects calls that set more than one flag in the listed set: `--json and --yaml are mutually exclusive`.
+- `groups.requiredTogether` requires all-or-none of the listed flags: `--output requires --format`. A flag with a `default` counts as "set" here.
+
+## Choices
+
+String flags can constrain values to an enumerated set:
+
+```ts
+format: { type: "string", choices: ["json", "yaml", "toml"], default: "json" }
+```
+
+Comparison is case-sensitive. An unlisted value triggers `invalid value for --format: "xml" (expected one of: json, yaml, toml)` and exit 2. The placeholder in `--help` is rendered as `<json|yaml|toml>`.
+
+## Auto-help and auto-version
+
+`--help` / `-h` are auto-injected. They print the generated usage to stdout and exit `0`. If your schema declares its own `help` flag, yours wins and auto-help is disabled.
+
+`--version` / `-V` are auto-injected **only** when `schema.version` is set:
+
+```ts
+parseArgs({ version: "1.2.3", flags: { /* ... */ } })
+```
+
+When `--version` is passed, the parser prints the version string and exits `0`.
+
+`--help` short-circuits before required-flag checking, so `mytool --help` always works even when a required flag would otherwise be missing.
+
+## Errors
+
+Every parse failure writes to **stderr**, prints the generated usage block, and exits with code `2` (the GNU convention for usage errors). The error catalog:
+
+| Situation | Message |
+|-----------|---------|
+| Unknown long flag | `unknown flag --foo` |
+| Unknown short flag | `unknown short flag -x` |
+| Missing value | `missing value for --name` |
+| Missing required flag | `missing required flag --out` |
+| Bad number | `invalid number for --port: "abc"` |
+| Bad choice | `invalid value for --format: "xml" (expected one of: json, yaml)` |
+| Value passed to boolean | `flag --verbose does not take a value` |
+| Greedy flag-value | `--name expects a value; got --verbose (use --name=--verbose to force)` |
+| `-x=value` form | `invalid short flag syntax in "-n=alice": use -n alice or -nalice` |
+| Repeated single-value flag | `flag --name was provided more than once` |
+| Mutex group violation | `--json and --yaml are mutually exclusive` |
+| Required-together violation | `--output requires --format` |
+
+## Positionals
+
+Anything in argv that isn't a flag or flag-value, plus everything after `--`, lands in `args.positionals` as a `string[]` in original order. v1 does not typecheck positionals — handle them yourself.
+
+```ts
+node main() {
+  const args = parseArgs({ flags: { verbose: { type: "boolean" } } })
+  for (file in args.positionals) {
+    print("processing: " + file)
+  }
+}
+```
+
+## What's not supported (v1)
+
+These have natural future shapes but were left out of v1:
+
+- Repeated flags (`--include a --include b` → `["a", "b"]`).
+- Subcommands (`mytool serve --port 3000`). Each subcommand needs its own schema, help, and usage line — a separate concept.
+- Negatable booleans (`--no-verbose`). When this lands, `default: true` on booleans becomes meaningful.
+- Per-flag custom validators.
+- Env-var fallback (`MYTOOL_PORT=3000`).
+- Typed positionals.
+- `--help <topic>` per-flag help.
+- "Did you mean --name?" suggestions.
+
+## Security notes
+
+- The parser produces a data object. It does not `eval`, `require`, or auto-read files referenced by flag values — those are caller decisions.
+- The returned `flags` object has a `null` prototype, so a stray `--__proto__` flag (caught as unknown anyway because `strict: true` is on) can never pollute `Object.prototype`.
+- Strict number parsing rejects the `0x10` / whitespace / `NaN` family of ambiguous inputs.
+- No env-var fallback by default — leaking parent-shell state into flag defaults is a footgun for CI and sandboxed contexts.

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -58,6 +58,11 @@ type TestCase = {
   // OpenAI client on push-to-main CI (where the env var is unset) and
   // become flaky or expensive.
   useTestLLMProvider?: boolean;
+  // Optional process command-line arguments to pass to the spawned
+  // subprocess. These show up as `process.argv.slice(2)` in the running
+  // agent — handy for testing CLI flag parsers (std::args) and any
+  // other code that reads argv. Defaults to no extra args.
+  argv?: string[];
 };
 type Tests = {
   sourceFile?: string;
@@ -574,6 +579,7 @@ async function runSingleTest(
       signal,
       llmMocks: testCase.llmMocks,
       useTestLLMProvider: testCase.useTestLLMProvider,
+      argv: testCase.argv,
     });
     if (result.stdout) log(result.stdout.trimEnd());
     if (result.stderr) log(result.stderr.trimEnd(), "stderr");

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -209,6 +209,10 @@ type ExecuteNodeArgs = {
   // per-call cost / token output. Setting this is equivalent to running
   // with AGENCY_USE_TEST_LLM_PROVIDER=1 for the spawned subprocess only.
   useTestLLMProvider?: boolean;
+  // Extra command-line arguments forwarded to the spawned subprocess.
+  // These land in `process.argv.slice(2)` of the running agent —
+  // primarily for testing std::args and other argv-reading code.
+  argv?: string[];
 };
 
 export async function executeNodeAsync({
@@ -222,6 +226,7 @@ export async function executeNodeAsync({
   signal,
   llmMocks,
   useTestLLMProvider,
+  argv,
 }: ExecuteNodeArgs): Promise<{ data: any; stdout: string; stderr: string }> {
   let evaluateFile = "";
   let resultsFile = "";
@@ -284,7 +289,11 @@ export async function executeNodeAsync({
     const mocksEnv = useDeterministic
       ? { AGENCY_LLM_MOCKS: JSON.stringify(llmMocks ?? []) }
       : {};
-    const { stdout, stderr } = await execFileAsync("node", [evaluateFile], {
+    // Forward `argv` so the spawned subprocess sees them as
+    // `process.argv.slice(2)`. Used by std::args smoke tests and any
+    // other code that reads command-line flags.
+    const nodeArgs = argv !== undefined ? [evaluateFile, ...argv] : [evaluateFile];
+    const { stdout, stderr } = await execFileAsync("node", nodeArgs, {
       maxBuffer: 10 * 1024 * 1024,
       ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
       ...(signal !== undefined ? { signal } : {}),

--- a/packages/agency-lang/lib/stdlib/args.test.ts
+++ b/packages/agency-lang/lib/stdlib/args.test.ts
@@ -1,0 +1,1120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  validateSchema,
+  normalizeSchema,
+  preScanArgv,
+  callNodeParse,
+  coerceValues,
+  parseStrictNumber,
+  applyDefaults,
+  checkGroups,
+  formatHelp,
+  formatError,
+  _parseArgsWith,
+  type ArgsSchema,
+  type ParseError,
+} from "./args.js";
+
+// Test harness: each `expectExit(...)` call captures process.exit code,
+// stdout, stderr, then throws a sentinel so the call site can assert
+// without continuing past the would-be exit.
+type ExitCapture = {
+  code: number | undefined;
+  stdout: string;
+  stderr: string;
+};
+
+class ExitSentinel extends Error {
+  constructor(public capture: ExitCapture) {
+    super("__exit__");
+  }
+}
+
+function withMockedProcess<T>(fn: () => T): { ran: boolean; result?: T; capture: ExitCapture } {
+  const capture: ExitCapture = { code: undefined, stdout: "", stderr: "" };
+  const stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk: any) => {
+      capture.stdout += String(chunk);
+      return true;
+    });
+  const stderrSpy = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk: any) => {
+      capture.stderr += String(chunk);
+      return true;
+    });
+  const exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation(((code?: number) => {
+      capture.code = code;
+      throw new ExitSentinel(capture);
+    }) as never);
+  try {
+    const result = fn();
+    return { ran: true, result, capture };
+  } catch (e) {
+    if (e instanceof ExitSentinel) {
+      return { ran: false, capture };
+    }
+    throw e;
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  }
+}
+
+// Tiny helper: build a schema with one flag, override fields per test.
+function oneFlag(over: Partial<ArgsSchema["flags"][string]>): ArgsSchema {
+  return {
+    flags: {
+      name: { type: "string", ...over },
+    },
+  };
+}
+
+describe("validateSchema", () => {
+  describe("accepts", () => {
+    it("a minimal valid schema", () => {
+      expect(() => validateSchema(oneFlag({}))).not.toThrow();
+    });
+
+    it("each flag type", () => {
+      for (const type of ["string", "number", "boolean"] as const) {
+        expect(() =>
+          validateSchema({ flags: { f: { type } } }),
+        ).not.toThrow();
+      }
+    });
+
+    it("boolean with default: false", () => {
+      expect(() =>
+        validateSchema({ flags: { v: { type: "boolean", default: false } } }),
+      ).not.toThrow();
+    });
+
+    it("a flag with a short alias", () => {
+      expect(() =>
+        validateSchema(oneFlag({ short: "n" })),
+      ).not.toThrow();
+    });
+
+    it("choices on a string flag", () => {
+      expect(() =>
+        validateSchema(oneFlag({ choices: ["a", "b"] })),
+      ).not.toThrow();
+    });
+
+    it("groups referencing declared flags", () => {
+      expect(() =>
+        validateSchema({
+          flags: { a: { type: "boolean" }, b: { type: "boolean" } },
+          groups: { exclusive: [["a", "b"]] },
+        }),
+      ).not.toThrow();
+    });
+
+    it("user declares own help flag with non-boolean short -h", () => {
+      // When the user declares `help`, auto-help is disabled, so a
+      // non-boolean -h collision is allowed.
+      expect(() =>
+        validateSchema({
+          flags: {
+            help: { type: "string" },
+            host: { type: "string", short: "h" },
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("rejects", () => {
+    it("invalid flag name (uppercase)", () => {
+      expect(() =>
+        validateSchema({ flags: { Name: { type: "string" } } }),
+      ).toThrow(/invalid flag name "Name"/);
+    });
+
+    it("invalid flag name (leading dash)", () => {
+      expect(() =>
+        validateSchema({ flags: { "-name": { type: "string" } } }),
+      ).toThrow(/invalid flag name/);
+    });
+
+    it("invalid flag name (contains =)", () => {
+      expect(() =>
+        validateSchema({ flags: { "na=me": { type: "string" } } }),
+      ).toThrow(/invalid flag name/);
+    });
+
+    it("invalid type", () => {
+      expect(() =>
+        // @ts-expect-error — intentionally wrong
+        validateSchema({ flags: { f: { type: "int" } } }),
+      ).toThrow(/has invalid type "int"/);
+    });
+
+    it("short alias not exactly one character", () => {
+      expect(() => validateSchema(oneFlag({ short: "nn" }))).toThrow(
+        /must be exactly one character/,
+      );
+      expect(() => validateSchema(oneFlag({ short: "" }))).toThrow(
+        /must be exactly one character/,
+      );
+    });
+
+    it("duplicate short aliases", () => {
+      expect(() =>
+        validateSchema({
+          flags: {
+            name: { type: "string", short: "n" },
+            number: { type: "number", short: "n" },
+          },
+        }),
+      ).toThrow(/both declare short alias -n/);
+    });
+
+    it("default type does not match flag type", () => {
+      expect(() =>
+        validateSchema(oneFlag({ default: 5 })),
+      ).toThrow(/has type "string" but default 5 is a number/);
+      expect(() =>
+        validateSchema({ flags: { p: { type: "number", default: "x" } } }),
+      ).toThrow(/has type "number" but default "x" is a string/);
+    });
+
+    it("required and default both set", () => {
+      expect(() =>
+        validateSchema(oneFlag({ required: true, default: "world" })),
+      ).toThrow(/declares both required and default/);
+    });
+
+    it("choices on a non-string flag", () => {
+      expect(() =>
+        validateSchema({
+          flags: { p: { type: "number", choices: ["1", "2"] as any } },
+        }),
+      ).toThrow(/has choices but is not a string flag/);
+    });
+
+    it("boolean default: true", () => {
+      expect(() =>
+        validateSchema({ flags: { v: { type: "boolean", default: true } } }),
+      ).toThrow(/v1 does not support negatable booleans/);
+    });
+
+    it("short -h with non-boolean type when auto-help is active", () => {
+      expect(() =>
+        validateSchema({
+          flags: { host: { type: "string", short: "h" } },
+        }),
+      ).toThrow(/uses short -h with non-boolean type; conflicts with auto-help/);
+    });
+
+    it("short -V with non-boolean type when auto-version is active", () => {
+      expect(() =>
+        validateSchema({
+          version: "1.0",
+          flags: { verbose: { type: "string", short: "V" } },
+        }),
+      ).toThrow(/uses short -V with non-boolean type; conflicts with auto-version/);
+    });
+
+    it("group references unknown flag", () => {
+      expect(() =>
+        validateSchema({
+          flags: { a: { type: "boolean" } },
+          groups: { exclusive: [["a", "ghost"]] },
+        }),
+      ).toThrow(/groups.exclusive references unknown flag --ghost/);
+
+      expect(() =>
+        validateSchema({
+          flags: { a: { type: "boolean" } },
+          groups: { requiredTogether: [["a", "ghost"]] },
+        }),
+      ).toThrow(/groups.requiredTogether references unknown flag --ghost/);
+    });
+  });
+});
+
+describe("normalizeSchema", () => {
+  it("injects auto-help when user does not declare help", () => {
+    const n = normalizeSchema({ flags: {} });
+    expect(n.autoHelp).toBe(true);
+    expect(n.flagsByName["help"]).toBeDefined();
+    expect(n.flagsByName["help"].type).toBe("boolean");
+    expect(n.flagsByShort["h"]).toBe(n.flagsByName["help"]);
+  });
+
+  it("does not inject auto-help when user declares help", () => {
+    const n = normalizeSchema({
+      flags: { help: { type: "boolean", short: "h" } },
+    });
+    expect(n.autoHelp).toBe(false);
+    expect(n.flagsByName["help"].description).toBe(""); // user's, not auto's
+  });
+
+  it("injects auto-version only when schema.version is set", () => {
+    const without = normalizeSchema({ flags: {} });
+    expect(without.autoVersion).toBe(false);
+    expect(without.flagsByName["version"]).toBeUndefined();
+
+    const withV = normalizeSchema({ flags: {}, version: "1.0" });
+    expect(withV.autoVersion).toBe(true);
+    expect(withV.flagsByName["version"]).toBeDefined();
+    expect(withV.flagsByShort["V"]).toBe(withV.flagsByName["version"]);
+  });
+
+  it("fills boolean default to false when not specified", () => {
+    const n = normalizeSchema({
+      flags: { verbose: { type: "boolean" } },
+    });
+    expect(n.flagsByName["verbose"].default).toBe(false);
+  });
+
+  it("preserves explicit boolean default: false", () => {
+    const n = normalizeSchema({
+      flags: { verbose: { type: "boolean", default: false } },
+    });
+    expect(n.flagsByName["verbose"].default).toBe(false);
+  });
+
+  it("leaves string/number default as null when not specified", () => {
+    const n = normalizeSchema({
+      flags: {
+        name: { type: "string" },
+        port: { type: "number" },
+      },
+    });
+    expect(n.flagsByName["name"].default).toBeNull();
+    expect(n.flagsByName["port"].default).toBeNull();
+  });
+
+  it("preserves explicit string/number defaults", () => {
+    const n = normalizeSchema({
+      flags: {
+        name: { type: "string", default: "world" },
+        port: { type: "number", default: 3000 },
+      },
+    });
+    expect(n.flagsByName["name"].default).toBe("world");
+    expect(n.flagsByName["port"].default).toBe(3000);
+  });
+
+  it("normalizes absent optionals to null/false/empty", () => {
+    const n = normalizeSchema({ flags: { f: { type: "string" } } });
+    const f = n.flagsByName["f"];
+    expect(f.short).toBeNull();
+    expect(f.choices).toBeNull();
+    expect(f.required).toBe(false);
+    expect(f.description).toBe("");
+    expect(f.hidden).toBe(false);
+  });
+
+  it("preserves flag declaration order in flags array", () => {
+    const n = normalizeSchema({
+      flags: {
+        zebra: { type: "string" },
+        apple: { type: "number" },
+        mango: { type: "boolean" },
+      },
+    });
+    const names = n.flags.map((f) => f.name);
+    expect(names.slice(0, 3)).toEqual(["zebra", "apple", "mango"]);
+    expect(names).toContain("help"); // auto-injected at end
+  });
+
+  it("defaults groups to empty arrays when absent", () => {
+    const n = normalizeSchema({ flags: {} });
+    expect(n.groups.exclusive).toEqual([]);
+    expect(n.groups.requiredTogether).toEqual([]);
+  });
+
+  it("derives programName from process.argv[1] basename when absent", () => {
+    const n = normalizeSchema({ flags: {} });
+    expect(typeof n.programName).toBe("string");
+    expect(n.programName.length).toBeGreaterThan(0);
+  });
+
+  it("uses explicit programName when provided", () => {
+    const n = normalizeSchema({ flags: {}, programName: "mytool" });
+    expect(n.programName).toBe("mytool");
+  });
+});
+
+describe("preScanArgv", () => {
+  const schema = normalizeSchema({
+    flags: {
+      name: { type: "string", short: "n" },
+      port: { type: "number", short: "p" },
+      verbose: { type: "boolean", short: "v" },
+    },
+  });
+
+  it("accepts a normal long flag with value", () => {
+    expect(preScanArgv(["--name", "alice"], schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("accepts --flag=value", () => {
+    expect(preScanArgv(["--name=alice"], schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("accepts -n value", () => {
+    expect(preScanArgv(["-n", "alice"], schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("accepts -nalice (attached short value)", () => {
+    expect(preScanArgv(["-nalice"], schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("rejects -n=value", () => {
+    const result = preScanArgv(["-n=alice"], schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        kind: "shortEqualsSyntax",
+        raw: "-n=alice",
+        suggestion: "-n alice or -nalice",
+      });
+    }
+  });
+
+  it("rejects greedy --x --y for a string flag", () => {
+    const result = preScanArgv(["--name", "--verbose"], schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        kind: "greedyValue",
+        flag: "name",
+        raw: "--verbose",
+      });
+    }
+  });
+
+  it("rejects greedy --x --y for a number flag", () => {
+    const result = preScanArgv(["--port", "--name"], schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.kind === "greedyValue") {
+      expect(result.error.flag).toBe("port");
+    }
+  });
+
+  it("does not flag --verbose --port (verbose is boolean)", () => {
+    expect(preScanArgv(["--verbose", "--port"], schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("honors -- end-of-options marker", () => {
+    // Even -x=v after -- is accepted as a positional.
+    expect(preScanArgv(["--", "-n=alice"], schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("accepts --name=--verbose (escape via equals)", () => {
+    // The greedy rule only fires when the value is a separate token.
+    expect(preScanArgv(["--name=--verbose"], schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+});
+
+describe("callNodeParse", () => {
+  const schema = normalizeSchema({
+    flags: {
+      name: { type: "string", short: "n" },
+      port: { type: "number", short: "p" },
+      verbose: { type: "boolean", short: "v" },
+    },
+  });
+
+  it("parses a long flag", () => {
+    const r = callNodeParse(["--name", "alice"], schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.flags.name).toBe("alice");
+  });
+
+  it("parses --flag=value", () => {
+    const r = callNodeParse(["--name=alice"], schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.flags.name).toBe("alice");
+  });
+
+  it("parses a short alias", () => {
+    const r = callNodeParse(["-n", "alice"], schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.flags.name).toBe("alice");
+  });
+
+  it("parses a boolean flag as true when present", () => {
+    const r = callNodeParse(["--verbose"], schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.flags.verbose).toBe(true);
+  });
+
+  it("number flag comes through as a string (coerce step handles it)", () => {
+    const r = callNodeParse(["--port", "3000"], schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.flags.port).toBe("3000");
+  });
+
+  it("collects positionals", () => {
+    const r = callNodeParse(["a", "--name", "alice", "b"], schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.positionals).toEqual(["a", "b"]);
+  });
+
+  it("-- ends option parsing", () => {
+    const r = callNodeParse(["--", "--name", "alice"], schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.flags.name).toBeUndefined();
+      expect(r.value.positionals).toEqual(["--name", "alice"]);
+    }
+  });
+
+  it("returns unknownLong for an unknown --flag", () => {
+    const r = callNodeParse(["--ghost"], schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toEqual({ kind: "unknownLong", flag: "ghost" });
+  });
+
+  it("returns unknownShort for an unknown -x", () => {
+    const r = callNodeParse(["-x"], schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toEqual({ kind: "unknownShort", flag: "x" });
+  });
+
+  it("returns booleanTakesNoValue for --verbose=foo", () => {
+    const r = callNodeParse(["--verbose=foo"], schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok)
+      expect(r.error).toEqual({ kind: "booleanTakesNoValue", flag: "verbose" });
+  });
+
+  it("returns missingValue for --name at end of argv", () => {
+    const r = callNodeParse(["--name"], schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toEqual({ kind: "missingValue", flag: "name" });
+  });
+
+  it("clusters boolean short flags (-vp would be unknown for a non-boolean p though)", () => {
+    const boolSchema = normalizeSchema({
+      flags: {
+        verbose: { type: "boolean", short: "v" },
+        quiet: { type: "boolean", short: "q" },
+      },
+    });
+    const r = callNodeParse(["-vq"], boolSchema);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.flags.verbose).toBe(true);
+      expect(r.value.flags.quiet).toBe(true);
+    }
+  });
+});
+
+describe("parseStrictNumber", () => {
+  it("accepts decimal integers", () => {
+    expect(parseStrictNumber("0")).toBe(0);
+    expect(parseStrictNumber("42")).toBe(42);
+    expect(parseStrictNumber("-7")).toBe(-7);
+    expect(parseStrictNumber("+7")).toBe(7);
+  });
+
+  it("accepts decimal floats and scientific notation", () => {
+    expect(parseStrictNumber("3.14")).toBe(3.14);
+    expect(parseStrictNumber("-1.5e3")).toBe(-1500);
+  });
+
+  it.each([
+    ["", "empty"],
+    ["abc", "non-numeric"],
+    ["3 ", "trailing space"],
+    [" 3", "leading space"],
+    ["0x10", "hex"],
+    ["0o10", "octal"],
+    ["0b10", "binary"],
+    ["NaN", "NaN"],
+    ["Infinity", "infinity"],
+    ["-Infinity", "negative infinity"],
+  ])("rejects %s (%s)", (raw) => {
+    expect(parseStrictNumber(raw)).toBeNull();
+  });
+});
+
+describe("coerceValues", () => {
+  const schema = normalizeSchema({
+    flags: {
+      name: { type: "string" },
+      port: { type: "number" },
+      verbose: { type: "boolean" },
+      format: { type: "string", choices: ["json", "yaml"] },
+    },
+  });
+
+  it("passes string values through", () => {
+    const r = coerceValues({ name: "alice" }, schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.name).toBe("alice");
+  });
+
+  it("coerces number strings to numbers", () => {
+    const r = coerceValues({ port: "3000" }, schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.port).toBe(3000);
+  });
+
+  it("rejects an unparseable number", () => {
+    const r = coerceValues({ port: "abc" }, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toEqual({
+        kind: "invalidNumber",
+        flag: "port",
+        raw: "abc",
+      });
+    }
+  });
+
+  it("passes through booleans", () => {
+    const r = coerceValues({ verbose: true }, schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.verbose).toBe(true);
+  });
+
+  it("accepts a listed choice", () => {
+    const r = coerceValues({ format: "json" }, schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.format).toBe("json");
+  });
+
+  it("rejects an unlisted choice", () => {
+    const r = coerceValues({ format: "xml" }, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toEqual({
+        kind: "invalidChoice",
+        flag: "format",
+        raw: "xml",
+        choices: ["json", "yaml"],
+      });
+    }
+  });
+
+  it("choices comparison is case-sensitive", () => {
+    const r = coerceValues({ format: "JSON" }, schema);
+    expect(r.ok).toBe(false);
+  });
+
+  it("accepts empty string for string flags (when no choices)", () => {
+    const r = coerceValues({ name: "" }, schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.name).toBe("");
+  });
+});
+
+describe("applyDefaults", () => {
+  const schema = normalizeSchema({
+    flags: {
+      name: { type: "string", default: "world" },
+      port: { type: "number", default: 3000 },
+      verbose: { type: "boolean" }, // boolean → default: false (filled in normalize)
+      out: { type: "string", required: true },
+    },
+  });
+
+  it("applies defaults for absent flags", () => {
+    const r = applyDefaults({}, schema);
+    expect(r.ok).toBe(false); // required `out` missing
+  });
+
+  it("user value overrides default", () => {
+    const r = applyDefaults({ name: "alice", out: "x" }, schema);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.name).toBe("alice");
+      expect(r.value.port).toBe(3000);
+      expect(r.value.verbose).toBe(false);
+      expect(r.value.out).toBe("x");
+    }
+  });
+
+  it("returns missingRequired when a required flag has no value and no default", () => {
+    const r = applyDefaults({ name: "alice" }, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toEqual({ kind: "missingRequired", flag: "out" });
+    }
+  });
+
+  it("auto-injected help/version booleans get filled with false", () => {
+    // The orchestrator's buildResult strips help/version from the
+    // user-visible output; applyDefaults itself just fills booleans.
+    const s = normalizeSchema({
+      flags: { f: { type: "string", default: "x" } },
+      version: "1.0",
+    });
+    const r = applyDefaults({}, s);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.f).toBe("x");
+      expect(r.value.help).toBe(false);
+      expect(r.value.version).toBe(false);
+    }
+  });
+});
+
+describe("checkGroups", () => {
+  const schema = normalizeSchema({
+    flags: {
+      json: { type: "boolean" },
+      yaml: { type: "boolean" },
+      output: { type: "string" },
+      format: { type: "string" },
+    },
+    groups: {
+      exclusive: [["json", "yaml"]],
+      requiredTogether: [["output", "format"]],
+    },
+  });
+
+  it("passes when neither exclusive flag is set", () => {
+    expect(checkGroups({}, schema)).toEqual({ ok: true, value: undefined });
+  });
+
+  it("passes when exactly one exclusive flag is set", () => {
+    expect(checkGroups({ json: true }, schema)).toEqual({
+      ok: true,
+      value: undefined,
+    });
+  });
+
+  it("rejects when both exclusive flags are set", () => {
+    const r = checkGroups({ json: true, yaml: true }, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toEqual({
+        kind: "mutuallyExclusive",
+        a: "json",
+        b: "yaml",
+      });
+    }
+  });
+
+  it("passes when none of the required-together flags are set", () => {
+    expect(checkGroups({}, schema)).toEqual({ ok: true, value: undefined });
+  });
+
+  it("passes when all required-together flags are set", () => {
+    expect(
+      checkGroups({ output: "f.txt", format: "json" }, schema),
+    ).toEqual({ ok: true, value: undefined });
+  });
+
+  it("rejects when one required-together flag is set without the other", () => {
+    const r = checkGroups({ output: "f.txt" }, schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toEqual({
+        kind: "requiredTogether",
+        missing: "format",
+        trigger: "output",
+      });
+    }
+  });
+});
+
+describe("formatHelp", () => {
+  it("renders the documented layout for a full schema", () => {
+    const schema = normalizeSchema({
+      programName: "greet",
+      description: "Print a friendly greeting.",
+      flags: {
+        name: {
+          type: "string",
+          short: "n",
+          default: "world",
+          description: "Who to greet",
+        },
+        repeat: {
+          type: "number",
+          short: "r",
+          default: 1,
+          description: "How many times",
+        },
+        verbose: {
+          type: "boolean",
+          short: "v",
+          description: "Chatty output",
+        },
+        out: {
+          type: "string",
+          required: true,
+          description: "Output path",
+        },
+      },
+    });
+    const help = formatHelp(schema);
+    expect(help).toContain("Usage: greet [options] [args...]");
+    expect(help).toContain("Print a friendly greeting.");
+    expect(help).toContain("-n, --name <string>");
+    expect(help).toContain("Who to greet");
+    expect(help).toContain('(default: "world")');
+    expect(help).toContain("(default: 1)");
+    expect(help).toContain("    --out <string>");
+    expect(help).toContain("(required)");
+    expect(help).toContain("-h, --help");
+    expect(help).toContain("Show this help and exit");
+    expect(help.endsWith("\n")).toBe(true);
+  });
+
+  it("omits description line when not provided", () => {
+    const help = formatHelp(normalizeSchema({ programName: "x", flags: {} }));
+    expect(help).not.toContain("Print a");
+    expect(help).toContain("Usage: x");
+  });
+
+  it("renders choices as <a|b>", () => {
+    const help = formatHelp(
+      normalizeSchema({
+        flags: { format: { type: "string", choices: ["json", "yaml"] } },
+      }),
+    );
+    expect(help).toContain("--format <json|yaml>");
+  });
+
+  it("omits hidden flags", () => {
+    const help = formatHelp(
+      normalizeSchema({
+        flags: {
+          shown: { type: "string", description: "visible" },
+          secret: { type: "string", hidden: true, description: "INVISIBLE" },
+        },
+      }),
+    );
+    expect(help).toContain("--shown");
+    expect(help).not.toContain("--secret");
+    expect(help).not.toContain("INVISIBLE");
+  });
+
+  it("renders version flag when schema.version is set", () => {
+    const help = formatHelp(
+      normalizeSchema({ flags: {}, version: "1.0" }),
+    );
+    expect(help).toContain("-V, --version");
+  });
+
+  it("renders epilog as a trailing paragraph", () => {
+    const help = formatHelp(
+      normalizeSchema({
+        flags: {},
+        epilog: "Bug reports: https://example.com",
+      }),
+    );
+    expect(help).toMatch(/\n\nBug reports: https:\/\/example\.com\n$/);
+  });
+
+  it("does not show (default: false) for booleans", () => {
+    const help = formatHelp(
+      normalizeSchema({
+        flags: { verbose: { type: "boolean", description: "Chatty" } },
+      }),
+    );
+    expect(help).not.toContain("default: false");
+  });
+
+  it("renders option block with only help when flags is empty", () => {
+    const help = formatHelp(normalizeSchema({ flags: {} }));
+    expect(help).toContain("Options:");
+    expect(help).toContain("--help");
+  });
+});
+
+describe("formatError", () => {
+  const schema = normalizeSchema({
+    programName: "greet",
+    flags: { name: { type: "string" } },
+  });
+
+  const cases: { error: ParseError; expectedMessage: string }[] = [
+    { error: { kind: "unknownLong", flag: "foo" }, expectedMessage: "unknown flag --foo" },
+    { error: { kind: "unknownShort", flag: "x" }, expectedMessage: "unknown short flag -x" },
+    { error: { kind: "missingValue", flag: "name" }, expectedMessage: "missing value for --name" },
+    {
+      error: { kind: "missingRequired", flag: "out" },
+      expectedMessage: "missing required flag --out",
+    },
+    {
+      error: { kind: "invalidNumber", flag: "port", raw: "abc" },
+      expectedMessage: 'invalid number for --port: "abc"',
+    },
+    {
+      error: {
+        kind: "invalidChoice",
+        flag: "format",
+        raw: "xml",
+        choices: ["json", "yaml"],
+      },
+      expectedMessage:
+        'invalid value for --format: "xml" (expected one of: json, yaml)',
+    },
+    {
+      error: { kind: "booleanTakesNoValue", flag: "verbose" },
+      expectedMessage: "flag --verbose does not take a value",
+    },
+    {
+      error: { kind: "greedyValue", flag: "name", raw: "--verbose" },
+      expectedMessage:
+        "--name expects a value; got --verbose (use --name=--verbose to force)",
+    },
+    {
+      error: {
+        kind: "shortEqualsSyntax",
+        raw: "-n=alice",
+        suggestion: "-n alice or -nalice",
+      },
+      expectedMessage:
+        'invalid short flag syntax in "-n=alice": use -n alice or -nalice',
+    },
+    {
+      error: { kind: "duplicateFlag", flag: "name" },
+      expectedMessage: "flag --name was provided more than once",
+    },
+    {
+      error: { kind: "mutuallyExclusive", a: "json", b: "yaml" },
+      expectedMessage: "--json and --yaml are mutually exclusive",
+    },
+    {
+      error: { kind: "requiredTogether", missing: "format", trigger: "output" },
+      expectedMessage: "--output requires --format",
+    },
+  ];
+
+  it.each(cases)("formats $error.kind", ({ error, expectedMessage }) => {
+    const out = formatError(error, schema);
+    expect(out).toContain(`Error: ${expectedMessage}`);
+    expect(out).toContain("Usage: greet"); // help tail printed
+  });
+});
+
+describe("_parseArgsWith (end-to-end)", () => {
+  const greetSchema: ArgsSchema = {
+    programName: "greet",
+    description: "Print a friendly greeting.",
+    version: "1.2.3",
+    flags: {
+      name: { type: "string", short: "n", default: "world" },
+      port: { type: "number", short: "p", default: 3000 },
+      verbose: { type: "boolean", short: "v" },
+      out: { type: "string", required: true },
+    },
+  };
+
+  it("parses a successful invocation", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--name", "alice", "--out", "f.txt"], greetSchema),
+    );
+    expect(ran).toBe(true);
+    expect(result).toBeDefined();
+    expect(result!.flags.name).toBe("alice");
+    expect(result!.flags.port).toBe(3000);
+    expect(result!.flags.verbose).toBe(false);
+    expect(result!.flags.out).toBe("f.txt");
+    expect(result!.positionals).toEqual([]);
+  });
+
+  it("returns a null-prototype flags object (prototype-pollution guard)", () => {
+    // Use a schema that does NOT declare --__proto__ — the strict
+    // parseArgs will reject unknown flags. Instead, we verify with a
+    // valid schema that the returned object has no Object prototype.
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--out", "f.txt"], greetSchema),
+    );
+    expect(ran).toBe(true);
+    expect(Object.getPrototypeOf(result!.flags)).toBeNull();
+  });
+
+  it("coerces number flags", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--port", "8080", "--out", "x"], greetSchema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.port).toBe(8080);
+  });
+
+  it("collects positionals", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--out", "x", "a", "b"], greetSchema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.positionals).toEqual(["a", "b"]);
+  });
+
+  it("--help short-circuits and exits 0 even when required flag is missing", () => {
+    const { ran, capture } = withMockedProcess(() =>
+      _parseArgsWith(["--help"], greetSchema),
+    );
+    expect(ran).toBe(false);
+    expect(capture.code).toBe(0);
+    expect(capture.stdout).toContain("Usage: greet");
+    expect(capture.stderr).toBe("");
+  });
+
+  it("-h short alias works the same", () => {
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(["-h"], greetSchema),
+    );
+    expect(capture.code).toBe(0);
+    expect(capture.stdout).toContain("Usage: greet");
+  });
+
+  it("--version short-circuits when schema.version is set", () => {
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(["--version"], greetSchema),
+    );
+    expect(capture.code).toBe(0);
+    expect(capture.stdout).toBe("1.2.3\n");
+  });
+
+  it("--help wins even with --port bad-value also present", () => {
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(["--port", "abc", "--help"], greetSchema),
+    );
+    expect(capture.code).toBe(0);
+    expect(capture.stdout).toContain("Usage:");
+  });
+
+  it("missing required flag exits 2 with stderr message + usage", () => {
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith([], greetSchema),
+    );
+    expect(capture.code).toBe(2);
+    expect(capture.stderr).toContain("missing required flag --out");
+    expect(capture.stderr).toContain("Usage: greet");
+    expect(capture.stdout).toBe("");
+  });
+
+  it("bad number exits 2 with strict-parse message", () => {
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(["--out", "x", "--port", "abc"], greetSchema),
+    );
+    expect(capture.code).toBe(2);
+    expect(capture.stderr).toContain('invalid number for --port: "abc"');
+  });
+
+  it("unknown flag exits 2", () => {
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(["--out", "x", "--ghost"], greetSchema),
+    );
+    expect(capture.code).toBe(2);
+    expect(capture.stderr).toContain("unknown flag --ghost");
+  });
+
+  it("prototype-pollution probe: --__proto__ x is rejected as unknown flag", () => {
+    // It can't pollute Object.prototype because (a) strict: true makes
+    // Node reject unknown flags, and (b) buildResult uses a
+    // null-prototype object regardless. Belt and braces.
+    const before = (Object.prototype as any).polluted;
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(
+        ["--out", "x", "--__proto__", "polluted"],
+        greetSchema,
+      ),
+    );
+    expect(capture.code).toBe(2);
+    expect((Object.prototype as any).polluted).toBe(before);
+  });
+
+  it("caller-defined help flag wins; no auto-help", () => {
+    const custom: ArgsSchema = {
+      flags: {
+        help: { type: "string", description: "help topic" },
+      },
+    };
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--help", "syntax"], custom),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.help).toBe("syntax");
+  });
+
+  it("-- ends option parsing", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--out", "x", "--", "--name", "alice"], greetSchema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.name).toBe("world"); // default; not consumed
+    expect(result!.positionals).toEqual(["--name", "alice"]);
+  });
+
+  it("mutually exclusive group", () => {
+    const s: ArgsSchema = {
+      flags: { a: { type: "boolean" }, b: { type: "boolean" } },
+      groups: { exclusive: [["a", "b"]] },
+    };
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(["--a", "--b"], s),
+    );
+    expect(capture.code).toBe(2);
+    expect(capture.stderr).toContain("--a and --b are mutually exclusive");
+  });
+
+  it("required-together group", () => {
+    const s: ArgsSchema = {
+      flags: { output: { type: "string" }, format: { type: "string" } },
+      groups: { requiredTogether: [["output", "format"]] },
+    };
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(["--output", "f.txt"], s),
+    );
+    expect(capture.code).toBe(2);
+    expect(capture.stderr).toContain("--output requires --format");
+  });
+
+  it("choices accept listed value, reject unlisted", () => {
+    const s: ArgsSchema = {
+      flags: { format: { type: "string", choices: ["json", "yaml"] } },
+    };
+    const ok = withMockedProcess(() =>
+      _parseArgsWith(["--format", "json"], s),
+    );
+    expect(ok.ran).toBe(true);
+    expect(ok.result!.flags.format).toBe("json");
+
+    const bad = withMockedProcess(() =>
+      _parseArgsWith(["--format", "xml"], s),
+    );
+    expect(bad.capture.code).toBe(2);
+    expect(bad.capture.stderr).toContain("expected one of: json, yaml");
+  });
+
+  it("schema bug throws synchronously (before any argv touched)", () => {
+    expect(() =>
+      withMockedProcess(() =>
+        _parseArgsWith(
+          [],
+          { flags: { f: { type: "boolean", default: true } } } as ArgsSchema,
+        ),
+      ),
+    ).toThrow(/v1 does not support negatable booleans/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/args.test.ts
+++ b/packages/agency-lang/lib/stdlib/args.test.ts
@@ -204,21 +204,34 @@ describe("validateSchema", () => {
       ).toThrow(/v1 does not support negatable booleans/);
     });
 
-    it("short -h with non-boolean type when auto-help is active", () => {
+    it("short -h on any user flag when auto-help is active", () => {
+      // Non-boolean
       expect(() =>
         validateSchema({
           flags: { host: { type: "string", short: "h" } },
         }),
-      ).toThrow(/uses short -h with non-boolean type; conflicts with auto-help/);
+      ).toThrow(/collides with the auto-injected --help/);
+      // Boolean too — would shadow auto-help silently otherwise.
+      expect(() =>
+        validateSchema({
+          flags: { headless: { type: "boolean", short: "h" } },
+        }),
+      ).toThrow(/collides with the auto-injected --help/);
     });
 
-    it("short -V with non-boolean type when auto-version is active", () => {
+    it("short -V on any user flag when auto-version is active", () => {
       expect(() =>
         validateSchema({
           version: "1.0",
           flags: { verbose: { type: "string", short: "V" } },
         }),
-      ).toThrow(/uses short -V with non-boolean type; conflicts with auto-version/);
+      ).toThrow(/collides with the auto-injected --version/);
+      expect(() =>
+        validateSchema({
+          version: "1.0",
+          flags: { verbose: { type: "boolean", short: "V" } },
+        }),
+      ).toThrow(/collides with the auto-injected --version/);
     });
 
     it("group references unknown flag", () => {
@@ -434,6 +447,62 @@ describe("preScanArgv", () => {
       ok: true,
       value: undefined,
     });
+  });
+
+  it("rejects repeated single-value flag (string)", () => {
+    const result = preScanArgv(
+      ["--name", "alice", "--name", "bob"],
+      schema,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({ kind: "duplicateFlag", flag: "name" });
+    }
+  });
+
+  it("rejects repeated single-value flag (number)", () => {
+    const result = preScanArgv(["--port", "80", "--port", "8080"], schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.kind === "duplicateFlag") {
+      expect(result.error.flag).toBe("port");
+    }
+  });
+
+  it("rejects repeated single-value flag via short alias", () => {
+    const result = preScanArgv(["-n", "alice", "-n", "bob"], schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.kind === "duplicateFlag") {
+      expect(result.error.flag).toBe("name");
+    }
+  });
+
+  it("rejects mixed long/short repeated flag", () => {
+    const result = preScanArgv(["-n", "alice", "--name", "bob"], schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.kind === "duplicateFlag") {
+      expect(result.error.flag).toBe("name");
+    }
+  });
+
+  it("rejects --name=foo --name=bar via equals form", () => {
+    const result = preScanArgv(["--name=foo", "--name=bar"], schema);
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.error.kind === "duplicateFlag") {
+      expect(result.error.flag).toBe("name");
+    }
+  });
+
+  it("accepts repeated boolean flag (harmless)", () => {
+    expect(
+      preScanArgv(["--verbose", "--verbose"], schema),
+    ).toEqual({ ok: true, value: undefined });
+  });
+
+  it("duplicate check stops at --", () => {
+    // Anything after -- is a positional, not a flag.
+    expect(
+      preScanArgv(["--name", "alice", "--", "--name", "bob"], schema),
+    ).toEqual({ ok: true, value: undefined });
   });
 });
 
@@ -1105,6 +1174,19 @@ describe("_parseArgsWith (end-to-end)", () => {
     );
     expect(bad.capture.code).toBe(2);
     expect(bad.capture.stderr).toContain("expected one of: json, yaml");
+  });
+
+  it("repeated single-value flag exits 2 with reformatted message", () => {
+    const { capture } = withMockedProcess(() =>
+      _parseArgsWith(
+        ["--out", "x", "--name", "a", "--name", "b"],
+        greetSchema,
+      ),
+    );
+    expect(capture.code).toBe(2);
+    expect(capture.stderr).toContain(
+      "flag --name was provided more than once",
+    );
   });
 
   it("schema bug throws synchronously (before any argv touched)", () => {

--- a/packages/agency-lang/lib/stdlib/args.ts
+++ b/packages/agency-lang/lib/stdlib/args.ts
@@ -1,0 +1,916 @@
+import process from "process";
+import * as path from "path";
+import { parseArgs as nodeParseArgs } from "node:util";
+
+// ---------------------------------------------------------------------------
+// TS bridge for `std::args` — CLI flag parser.
+//
+// Thin wrapper over Node's built-in `node:util.parseArgs` (stable
+// since Node 18.3). On top of Node's tokenization we add:
+//   - strict number coercion
+//   - required-flag checking with explicit defaults
+//   - auto-generated --help / --version
+//   - mutually-exclusive / required-together flag groups
+//   - unified error formatting → stderr → exit 2
+//
+// The orchestrator (_parseArgs / _parseArgsWith at the bottom) is the
+// only thing in this file that touches process.argv, process.exit,
+// process.stdout, or process.stderr. Every other function is a pure
+// data transform that returns either data or a tagged ParseResult.
+//
+// Design doc: docs/superpowers/specs/2026-06-04-cli-args-design.md
+// Impl plan:  docs/superpowers/plans/2026-06-04-cli-args-plan.md
+// ---------------------------------------------------------------------------
+
+// =============================================================================
+// Public types — mirrored in stdlib/args.agency
+// =============================================================================
+
+export type FlagType = "string" | "number" | "boolean";
+
+export type FlagSpec = {
+  type: FlagType;
+  short?: string;
+  default?: string | number | boolean;
+  required?: boolean;
+  description?: string;
+  choices?: string[];
+  hidden?: boolean;
+};
+
+export type FlagGroups = {
+  exclusive?: string[][];
+  requiredTogether?: string[][];
+};
+
+export type ArgsSchema = {
+  programName?: string;
+  description?: string;
+  version?: string;
+  epilog?: string;
+  flags: Record<string, FlagSpec>;
+  groups?: FlagGroups;
+};
+
+export type ParsedArgs = {
+  flags: Record<string, string | number | boolean>;
+  positionals: string[];
+};
+
+// =============================================================================
+// Internal types
+// =============================================================================
+
+// Every downstream step works on the normalized form so it never has
+// to re-check "did the user set this optional field". Absent optionals
+// are represented as `null` / `false` / `""` / `[]` — never `undefined`.
+export type NormalizedFlag = {
+  name: string;
+  type: FlagType;
+  short: string | null;
+  default: string | number | boolean | null;
+  required: boolean;
+  description: string;
+  choices: string[] | null;
+  hidden: boolean;
+};
+
+export type NormalizedSchema = {
+  programName: string;
+  description: string | null;
+  version: string | null;
+  epilog: string | null;
+  // Array preserves declaration order for --help. flagsByName / flagsByShort
+  // are the lookup indexes.
+  flags: NormalizedFlag[];
+  flagsByName: Record<string, NormalizedFlag>;
+  flagsByShort: Record<string, NormalizedFlag>;
+  groups: {
+    exclusive: string[][];
+    requiredTogether: string[][];
+  };
+  autoHelp: boolean;
+  autoVersion: boolean;
+};
+
+// Discriminated union — one variant per error case in the spec catalog.
+// Adding a new error case = add a variant + add a row to ERROR_FORMATTERS
+// at the bottom. TypeScript will fail the build if the formatter table
+// is incomplete.
+export type ParseError =
+  | { kind: "unknownLong"; flag: string }
+  | { kind: "unknownShort"; flag: string }
+  | { kind: "missingValue"; flag: string }
+  | { kind: "missingRequired"; flag: string }
+  | { kind: "invalidNumber"; flag: string; raw: string }
+  | { kind: "invalidChoice"; flag: string; raw: string; choices: string[] }
+  | { kind: "booleanTakesNoValue"; flag: string }
+  | { kind: "greedyValue"; flag: string; raw: string }
+  | { kind: "shortEqualsSyntax"; raw: string; suggestion: string }
+  | { kind: "duplicateFlag"; flag: string }
+  | { kind: "mutuallyExclusive"; a: string; b: string }
+  | { kind: "requiredTogether"; missing: string; trigger: string };
+
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: ParseError };
+
+// =============================================================================
+// validateSchema — fail-fast schema bug detection
+// =============================================================================
+//
+// Each rule is a row in the SCHEMA_RULES table. Adding a rule = adding
+// one row. No nested conditionals, no order dependency between rules,
+// no shared state.
+
+const FLAG_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+type SchemaRule = {
+  name: string;
+  check: (schema: ArgsSchema) => string | null;
+};
+
+const SCHEMA_RULES: SchemaRule[] = [
+  {
+    name: "flag name is valid identifier",
+    check: (s) => {
+      const bad = Object.keys(s.flags).find(
+        (n) => !FLAG_NAME_PATTERN.test(n),
+      );
+      return bad
+        ? `invalid flag name "${bad}" (must match /^[a-z0-9][a-z0-9-]*$/)`
+        : null;
+    },
+  },
+  {
+    name: "every flag has a valid type",
+    check: (s) => {
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) =>
+          spec.type !== "string" &&
+          spec.type !== "number" &&
+          spec.type !== "boolean",
+      );
+      return bad
+        ? `flag --${bad[0]} has invalid type "${String(bad[1].type)}" (must be "string", "number", or "boolean")`
+        : null;
+    },
+  },
+  {
+    name: "short alias is single character",
+    check: (s) => {
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) => spec.short !== undefined && spec.short.length !== 1,
+      );
+      return bad
+        ? `flag --${bad[0]} short alias "${bad[1].short}" must be exactly one character`
+        : null;
+    },
+  },
+  { name: "no duplicate short aliases", check: (s) => duplicateShort(s) },
+  { name: "default type matches flag type", check: (s) => mismatchedDefault(s) },
+  {
+    name: "required and default are not both set",
+    check: (s) => {
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) => spec.required === true && spec.default !== undefined,
+      );
+      return bad
+        ? `flag --${bad[0]} declares both required and default; pick one`
+        : null;
+    },
+  },
+  {
+    name: "choices only on string flags",
+    check: (s) => {
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) => spec.choices !== undefined && spec.type !== "string",
+      );
+      return bad
+        ? `flag --${bad[0]} has choices but is not a string flag`
+        : null;
+    },
+  },
+  {
+    // v1 does not support negatable booleans (--no-X), so a boolean
+    // declared default: true can never be set to false from the CLI.
+    // Reject as a schema bug rather than silently shipping a dead flag.
+    name: "boolean flags must not default to true (v1, no --no-X)",
+    check: (s) => {
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) => spec.type === "boolean" && spec.default === true,
+      );
+      return bad
+        ? `flag --${bad[0]} is a boolean with default: true; v1 does not support negatable booleans (--no-${bad[0]}), so this flag could never be set to false. Drop the default, or wait for negatableBooleans.`
+        : null;
+    },
+  },
+  {
+    name: "h short collision is boolean only (compatible with auto-help)",
+    check: (s) => {
+      const userDeclaresHelp = "help" in s.flags;
+      if (userDeclaresHelp) return null;
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) => spec.short === "h" && spec.type !== "boolean",
+      );
+      return bad
+        ? `flag --${bad[0]} uses short -h with non-boolean type; conflicts with auto-help. Declare your own boolean "help" flag if you want to override it.`
+        : null;
+    },
+  },
+  {
+    name: "V short collision is boolean only (compatible with auto-version)",
+    check: (s) => {
+      if (s.version === undefined) return null;
+      const userDeclaresVersion = "version" in s.flags;
+      if (userDeclaresVersion) return null;
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) => spec.short === "V" && spec.type !== "boolean",
+      );
+      return bad
+        ? `flag --${bad[0]} uses short -V with non-boolean type; conflicts with auto-version.`
+        : null;
+    },
+  },
+  { name: "group references known flags", check: (s) => unknownGroupRef(s) },
+];
+
+export function validateSchema(schema: ArgsSchema): void {
+  for (const rule of SCHEMA_RULES) {
+    const failure = rule.check(schema);
+    if (failure !== null) {
+      throw new Error(`std::args: schema error: ${failure}`);
+    }
+  }
+}
+
+function duplicateShort(schema: ArgsSchema): string | null {
+  const seen: Record<string, string> = {};
+  for (const [name, spec] of Object.entries(schema.flags)) {
+    if (spec.short === undefined) continue;
+    const prev = seen[spec.short];
+    if (prev !== undefined) {
+      return `flags --${prev} and --${name} both declare short alias -${spec.short}`;
+    }
+    seen[spec.short] = name;
+  }
+  return null;
+}
+
+function mismatchedDefault(schema: ArgsSchema): string | null {
+  for (const [name, spec] of Object.entries(schema.flags)) {
+    if (spec.default === undefined) continue;
+    const actual = typeof spec.default;
+    if (actual !== spec.type) {
+      return `flag --${name} has type "${spec.type}" but default ${JSON.stringify(spec.default)} is a ${actual}`;
+    }
+  }
+  return null;
+}
+
+function unknownGroupRef(schema: ArgsSchema): string | null {
+  const known = new Set(Object.keys(schema.flags));
+  const allGroups: { kind: string; group: string[] }[] = [
+    ...(schema.groups?.exclusive ?? []).map((g) => ({ kind: "exclusive", group: g })),
+    ...(schema.groups?.requiredTogether ?? []).map((g) => ({
+      kind: "requiredTogether",
+      group: g,
+    })),
+  ];
+  for (const { kind, group } of allGroups) {
+    const missing = group.find((name) => !known.has(name));
+    if (missing !== undefined) {
+      return `groups.${kind} references unknown flag --${missing}`;
+    }
+  }
+  return null;
+}
+
+// =============================================================================
+// normalizeSchema — flatten the user-facing schema into the internal form
+// =============================================================================
+//
+// Every absent optional becomes `null` / `false` / `""` / `[]` so the
+// rest of the pipeline doesn't have to keep asking "is this set?".
+// Boolean flags without an explicit default get `default: false` here,
+// per the spec's "Booleans without a default behave as false" rule —
+// validateSchema has already rejected default: true on booleans, so
+// the only possible boolean defaults at this point are false (explicit
+// or filled-in).
+
+export function normalizeSchema(schema: ArgsSchema): NormalizedSchema {
+  const userDeclaresHelp = "help" in schema.flags;
+  const userDeclaresVersion = "version" in schema.flags;
+  const autoHelp = !userDeclaresHelp;
+  const autoVersion = !userDeclaresVersion && schema.version !== undefined;
+
+  const userFlags: NormalizedFlag[] = Object.entries(schema.flags).map(
+    ([name, spec]) => normalizeFlag(name, spec),
+  );
+
+  const helpFlag: NormalizedFlag | null = autoHelp
+    ? normalizeFlag("help", {
+        type: "boolean",
+        short: "h",
+        description: "Show this help and exit",
+      })
+    : null;
+  const versionFlag: NormalizedFlag | null = autoVersion
+    ? normalizeFlag("version", {
+        type: "boolean",
+        short: "V",
+        description: "Show version and exit",
+      })
+    : null;
+
+  const flags = [...userFlags, helpFlag, versionFlag].filter(
+    (f): f is NormalizedFlag => f !== null,
+  );
+
+  return {
+    programName: schema.programName ?? deriveProgramName(),
+    description: schema.description ?? null,
+    version: schema.version ?? null,
+    epilog: schema.epilog ?? null,
+    flags,
+    flagsByName: indexBy(flags, (f) => f.name),
+    flagsByShort: indexBy(
+      flags.filter((f) => f.short !== null),
+      (f) => f.short as string,
+    ),
+    groups: {
+      exclusive: schema.groups?.exclusive ?? [],
+      requiredTogether: schema.groups?.requiredTogether ?? [],
+    },
+    autoHelp,
+    autoVersion,
+  };
+}
+
+function normalizeFlag(name: string, spec: FlagSpec): NormalizedFlag {
+  const defaultValue =
+    spec.default !== undefined
+      ? spec.default
+      : spec.type === "boolean"
+        ? false
+        : null;
+  return {
+    name,
+    type: spec.type,
+    short: spec.short ?? null,
+    default: defaultValue,
+    required: spec.required ?? false,
+    description: spec.description ?? "",
+    choices: spec.choices ?? null,
+    hidden: spec.hidden ?? false,
+  };
+}
+
+function deriveProgramName(): string {
+  return path.basename(process.argv[1] ?? "program");
+}
+
+function indexBy<T>(items: T[], key: (item: T) => string): Record<string, T> {
+  const out: Record<string, T> = {};
+  for (const item of items) {
+    out[key(item)] = item;
+  }
+  return out;
+}
+
+// =============================================================================
+// preScanArgv — reject -n=value and --x --y greedy values
+// =============================================================================
+
+type ArgvRule = (
+  token: string,
+  next: string | undefined,
+  schema: NormalizedSchema,
+) => ParseError | null;
+
+const ARGV_RULES: ArgvRule[] = [
+  // -n=value: short flag with attached "=" (Node would produce "=value")
+  (token) => {
+    const match = /^-([a-zA-Z])=(.*)$/.exec(token);
+    if (!match) return null;
+    const [, letter, value] = match;
+    return {
+      kind: "shortEqualsSyntax",
+      raw: token,
+      suggestion: `-${letter} ${value} or -${letter}${value}`,
+    };
+  },
+  // --name --foo: greedy value capture for string/number flags
+  (token, next, schema) => {
+    if (!token.startsWith("--") || token.includes("=") || token === "--") {
+      return null;
+    }
+    const name = token.slice(2);
+    const flag = schema.flagsByName[name];
+    if (flag === undefined || flag.type === "boolean") return null;
+    if (next === undefined || !next.startsWith("--")) return null;
+    return { kind: "greedyValue", flag: name, raw: next };
+  },
+];
+
+export function preScanArgv(
+  argv: string[],
+  schema: NormalizedSchema,
+): ParseResult<void> {
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--") break; // honor end-of-options
+    for (const rule of ARGV_RULES) {
+      const err = rule(argv[i], argv[i + 1], schema);
+      if (err !== null) return { ok: false, error: err };
+    }
+  }
+  return { ok: true, value: undefined };
+}
+
+// =============================================================================
+// callNodeParse — thin wrapper over node:util.parseArgs
+// =============================================================================
+//
+// Maps our schema to Node's options object, calls parseArgs, and
+// translates Node's error codes into our ParseError union. Numbers
+// are passed through as Node `string` type and coerced later in
+// coerceValues — Node only knows "string" and "boolean".
+
+type NodeParseOutput = {
+  flags: Record<string, string | boolean>;
+  positionals: string[];
+};
+
+// Shape of the errors `node:util.parseArgs` throws. They carry an
+// ErrnoException-style `code` we dispatch on, and arbitrary string
+// formatting in `message` we pattern-match for the offending flag.
+type NodeParseError = Error & { code?: string };
+
+const NODE_ERROR_TRANSLATIONS: Record<string, (e: NodeParseError) => ParseError> = {
+  ERR_PARSE_ARGS_UNKNOWN_OPTION: translateUnknown,
+  ERR_PARSE_ARGS_INVALID_OPTION_VALUE: translateInvalidValue,
+};
+
+export function callNodeParse(
+  argv: string[],
+  schema: NormalizedSchema,
+): ParseResult<NodeParseOutput> {
+  const options = buildNodeOptions(schema);
+  try {
+    const out = nodeParseArgs({
+      args: argv,
+      options,
+      strict: true,
+      allowPositionals: true,
+    });
+    return {
+      ok: true,
+      value: {
+        flags: out.values as Record<string, string | boolean>,
+        positionals: [...out.positionals],
+      },
+    };
+  } catch (e) {
+    const err = e as NodeParseError;
+    const translate = err.code !== undefined
+      ? NODE_ERROR_TRANSLATIONS[err.code]
+      : undefined;
+    if (translate === undefined) throw e; // unknown Node error — surface loudly
+    return { ok: false, error: translate(err) };
+  }
+}
+
+function buildNodeOptions(
+  schema: NormalizedSchema,
+): Record<string, { type: "string" | "boolean"; short?: string; multiple?: boolean }> {
+  const out: Record<
+    string,
+    { type: "string" | "boolean"; short?: string; multiple?: boolean }
+  > = {};
+  for (const f of schema.flags) {
+    const nodeType: "string" | "boolean" =
+      f.type === "boolean" ? "boolean" : "string";
+    const entry: { type: "string" | "boolean"; short?: string } = {
+      type: nodeType,
+    };
+    if (f.short !== null) entry.short = f.short;
+    out[f.name] = entry;
+  }
+  return out;
+}
+
+function translateUnknown(err: NodeParseError): ParseError {
+  // Node messages look like: Unknown option '--foo'  OR  Unknown option '-x'
+  const m = /Unknown option '(-{1,2})([^']+)'/.exec(err.message);
+  if (m === null) {
+    // Defensive: fall back to a generic unknown-long with the whole message.
+    return { kind: "unknownLong", flag: err.message };
+  }
+  const [, dashes, name] = m;
+  if (dashes === "-") {
+    return { kind: "unknownShort", flag: name };
+  }
+  return { kind: "unknownLong", flag: name };
+}
+
+function translateInvalidValue(err: NodeParseError): ParseError {
+  // ERR_PARSE_ARGS_INVALID_OPTION_VALUE is emitted by Node for two
+  // distinct situations; the message format always includes the long
+  // flag name as `--name` somewhere inside the quoted Option clause,
+  // even when a short alias is also reported (e.g. `-n, --name`).
+  //
+  //   "Option '--name <value>' argument missing"
+  //   "Option '-n, --name <value>' argument missing"
+  //     → string/number flag with no value (kind: "missingValue")
+  //
+  //   "Option '--verbose' does not take an argument"
+  //   "Option '-v, --verbose' does not take an argument"
+  //     → boolean flag given a value (kind: "booleanTakesNoValue")
+  const longName = /--([a-zA-Z0-9][a-zA-Z0-9-]*)/.exec(err.message)?.[1];
+  if (longName !== undefined) {
+    if (err.message.endsWith("argument missing")) {
+      return { kind: "missingValue", flag: longName };
+    }
+    if (err.message.includes("does not take an argument")) {
+      return { kind: "booleanTakesNoValue", flag: longName };
+    }
+  }
+  // Defensive: surface the whole message as the flag — better than
+  // swallowing. The orchestrator's formatError will still print it.
+  return { kind: "missingValue", flag: err.message };
+}
+
+// =============================================================================
+// coerceValues — strict number parsing + choices validation
+// =============================================================================
+
+const REJECTED_NUMBER_PATTERNS: { test: (raw: string) => boolean; why: string }[] = [
+  { test: (s) => s === "", why: "empty string" },
+  { test: (s) => s !== s.trim(), why: "leading/trailing whitespace" },
+  { test: (s) => /^[+-]?0[xob]/i.test(s), why: "non-decimal literal" },
+  {
+    test: (s) => /^[+-]?Infinity$|^NaN$/.test(s),
+    why: "non-finite",
+  },
+];
+
+export function parseStrictNumber(raw: string): number | null {
+  if (REJECTED_NUMBER_PATTERNS.some((p) => p.test(raw))) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function coerceValues(
+  parsed: Record<string, string | boolean>,
+  schema: NormalizedSchema,
+): ParseResult<Record<string, string | number | boolean>> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const [name, raw] of Object.entries(parsed)) {
+    const flag = schema.flagsByName[name];
+    // Node should never give us a flag we didn't declare since strict: true.
+    // If it does (auto-help passes through here), just pass the value.
+    if (flag === undefined) {
+      out[name] = raw;
+      continue;
+    }
+    const coerced = coerceOne(flag, raw);
+    if (!coerced.ok) return coerced;
+    out[name] = coerced.value;
+  }
+  return { ok: true, value: out };
+}
+
+function coerceOne(
+  flag: NormalizedFlag,
+  raw: string | boolean,
+): ParseResult<string | number | boolean> {
+  if (flag.type === "boolean") {
+    return { ok: true, value: raw };
+  }
+  if (flag.type === "number") {
+    const n = parseStrictNumber(raw as string);
+    if (n === null) {
+      return {
+        ok: false,
+        error: { kind: "invalidNumber", flag: flag.name, raw: raw as string },
+      };
+    }
+    return { ok: true, value: n };
+  }
+  // string: validate choices if present
+  const value = raw as string;
+  if (flag.choices !== null && !flag.choices.includes(value)) {
+    return {
+      ok: false,
+      error: {
+        kind: "invalidChoice",
+        flag: flag.name,
+        raw: value,
+        choices: flag.choices,
+      },
+    };
+  }
+  return { ok: true, value };
+}
+
+// =============================================================================
+// applyDefaults — fill in missing flags from their declared defaults,
+// then check that every required flag without a default was provided
+// =============================================================================
+
+export function applyDefaults(
+  parsed: Record<string, string | number | boolean>,
+  schema: NormalizedSchema,
+): ParseResult<Record<string, string | number | boolean>> {
+  const out: Record<string, string | number | boolean> = {};
+  for (const f of schema.flags) {
+    if (f.name in parsed) {
+      out[f.name] = parsed[f.name];
+    } else if (f.default !== null) {
+      out[f.name] = f.default;
+    }
+  }
+  const missing = schema.flags.find((f) => f.required && !(f.name in out));
+  if (missing !== undefined) {
+    return {
+      ok: false,
+      error: { kind: "missingRequired", flag: missing.name },
+    };
+  }
+  return { ok: true, value: out };
+}
+
+// =============================================================================
+// checkGroups — exclusive and requiredTogether
+// =============================================================================
+//
+// Runs after applyDefaults, so a flag with a default counts as "set"
+// for group purposes (per spec: "A flag listed in requiredTogether
+// interacts cleanly with required/default: a flag with a default is
+// considered 'set' for group purposes.").
+
+export function checkGroups(
+  parsed: Record<string, unknown>,
+  schema: NormalizedSchema,
+): ParseResult<void> {
+  for (const group of schema.groups.exclusive) {
+    const set = group.filter((name) => name in parsed);
+    if (set.length >= 2) {
+      return {
+        ok: false,
+        error: { kind: "mutuallyExclusive", a: set[0], b: set[1] },
+      };
+    }
+  }
+  for (const group of schema.groups.requiredTogether) {
+    const set = group.filter((name) => name in parsed);
+    if (set.length > 0 && set.length < group.length) {
+      const missing = group.find((name) => !(name in parsed));
+      if (missing !== undefined) {
+        return {
+          ok: false,
+          error: { kind: "requiredTogether", missing, trigger: set[0] },
+        };
+      }
+    }
+  }
+  return { ok: true, value: undefined };
+}
+
+// =============================================================================
+// formatHelp — generate the --help text
+// =============================================================================
+
+// Layout constants. Pulled out so they're easy to find and adjust as
+// a group. v1 emits no ANSI.
+const HELP_MAX_LEFT_WIDTH = 30;
+const HELP_MIN_DESC_WIDTH = 20;
+const HELP_GUTTER = 2; // spaces between left column and description
+const DEFAULT_TERMINAL_WIDTH = 80;
+
+type OptionRow = {
+  shortPart: string; // "-n, " or "    "
+  longPart: string; // "--name <string>"
+  description: string;
+};
+
+export function formatHelp(schema: NormalizedSchema): string {
+  const rows = schema.flags
+    .filter((f) => !f.hidden)
+    .map(toRow);
+
+  const longestLeft = Math.max(
+    0,
+    ...rows.map((r) => r.shortPart.length + r.longPart.length),
+  );
+  const leftWidth = Math.min(HELP_MAX_LEFT_WIDTH, longestLeft);
+  const termWidth = process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH;
+  const descWidth = Math.max(
+    HELP_MIN_DESC_WIDTH,
+    termWidth - leftWidth - HELP_GUTTER,
+  );
+
+  const optionsBlock =
+    "Options:\n" +
+    rows.map((r) => renderRow(r, leftWidth, descWidth)).join("\n");
+
+  const sections: string[] = [
+    `Usage: ${schema.programName} [options] [args...]`,
+  ];
+  if (schema.description !== null) sections.push(schema.description);
+  sections.push(optionsBlock);
+  if (schema.epilog !== null) sections.push(schema.epilog);
+
+  return sections.join("\n\n") + "\n";
+}
+
+function toRow(f: NormalizedFlag): OptionRow {
+  return {
+    shortPart: f.short !== null ? `-${f.short}, ` : "    ",
+    longPart: `--${f.name}${valuePlaceholder(f)}`,
+    description: composeDescription(f),
+  };
+}
+
+function valuePlaceholder(f: NormalizedFlag): string {
+  if (f.type === "boolean") return "";
+  if (f.choices !== null) return ` <${f.choices.join("|")}>`;
+  return ` <${f.type}>`;
+}
+
+function composeDescription(f: NormalizedFlag): string {
+  const parts: string[] = [];
+  if (f.description.length > 0) parts.push(f.description);
+  // Boolean defaults are always false (validateSchema rejects true) and
+  // implied — don't clutter help with "(default: false)".
+  if (f.type !== "boolean" && f.default !== null && !f.required) {
+    parts.push(`(default: ${formatDefault(f.default)})`);
+  }
+  if (f.required && f.default === null) parts.push("(required)");
+  return parts.join(" ");
+}
+
+function formatDefault(value: string | number | boolean): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  return String(value);
+}
+
+function renderRow(row: OptionRow, leftWidth: number, descWidth: number): string {
+  const left = row.shortPart + row.longPart;
+  const padded = left.padEnd(leftWidth + HELP_GUTTER, " ");
+  const lines = wrapText(row.description, descWidth);
+  if (lines.length === 0) return "  " + padded.trimEnd();
+  const indent = " ".repeat(2 + leftWidth + HELP_GUTTER);
+  return (
+    "  " +
+    padded +
+    lines[0] +
+    lines.slice(1).map((l) => "\n" + indent + l).join("")
+  );
+}
+
+function wrapText(text: string, width: number): string[] {
+  if (text.length === 0) return [];
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+  for (const w of words) {
+    if (current.length === 0) {
+      current = w;
+      continue;
+    }
+    if (current.length + 1 + w.length > width) {
+      lines.push(current);
+      current = w;
+    } else {
+      current += " " + w;
+    }
+  }
+  if (current.length > 0) lines.push(current);
+  return lines;
+}
+
+// =============================================================================
+// formatError — every ParseError kind → one-line message
+// =============================================================================
+//
+// One row per ParseError kind. The mapped-object type makes the
+// formatter table exhaustive — drop a kind and TS won't compile.
+
+const ERROR_FORMATTERS: {
+  [K in ParseError["kind"]]: (e: Extract<ParseError, { kind: K }>) => string;
+} = {
+  unknownLong: (e) => `unknown flag --${e.flag}`,
+  unknownShort: (e) => `unknown short flag -${e.flag}`,
+  missingValue: (e) => `missing value for --${e.flag}`,
+  missingRequired: (e) => `missing required flag --${e.flag}`,
+  invalidNumber: (e) => `invalid number for --${e.flag}: "${e.raw}"`,
+  invalidChoice: (e) =>
+    `invalid value for --${e.flag}: "${e.raw}" (expected one of: ${e.choices.join(", ")})`,
+  booleanTakesNoValue: (e) => `flag --${e.flag} does not take a value`,
+  greedyValue: (e) =>
+    `--${e.flag} expects a value; got ${e.raw} (use --${e.flag}=${e.raw} to force)`,
+  shortEqualsSyntax: (e) =>
+    `invalid short flag syntax in "${e.raw}": use ${e.suggestion}`,
+  duplicateFlag: (e) => `flag --${e.flag} was provided more than once`,
+  mutuallyExclusive: (e) => `--${e.a} and --${e.b} are mutually exclusive`,
+  requiredTogether: (e) => `--${e.trigger} requires --${e.missing}`,
+};
+
+export function formatError(error: ParseError, schema: NormalizedSchema): string {
+  // Cast through the lookup: TS can't narrow `error.kind` to the
+  // formatter's parameter type without an explicit dispatch, but the
+  // mapped-object type above guarantees the lookup is exhaustive.
+  const fn = ERROR_FORMATTERS[error.kind] as (e: ParseError) => string;
+  return `Error: ${fn(error)}\n\n${formatHelp(schema)}`;
+}
+
+// =============================================================================
+// _parseArgs / _parseArgsWith — orchestrator
+// =============================================================================
+//
+// The only functions in this file that touch process.argv,
+// process.exit, process.stdout, or process.stderr. Each step is one
+// const + one explicit early-return on failure. The --help / --version
+// short-circuit sits between callNodeParse and coerceValues so that
+// `mytool --help` always prints help, even when required flags are
+// missing or other coerce errors would fire.
+
+export function _parseArgs(schema: ArgsSchema): ParsedArgs {
+  return _parseArgsWith(process.argv.slice(2), schema);
+}
+
+// Exported for tests; NOT re-exported from stdlib/args.agency.
+export function _parseArgsWith(
+  argv: string[],
+  schema: ArgsSchema,
+): ParsedArgs {
+  validateSchema(schema); // throws on schema bugs
+  const normalized = normalizeSchema(schema);
+
+  // Stage 1: tokenize. Pre-scan rejects -n=v and --x --y greedy values.
+  const preScan = preScanArgv(argv, normalized);
+  if (!preScan.ok) return exitWithError(preScan.error, normalized);
+
+  const parsed = callNodeParse(argv, normalized);
+  if (!parsed.ok) return exitWithError(parsed.error, normalized);
+
+  // Stage 2: short-circuit --help / --version BEFORE coerce/defaults/required.
+  if (normalized.autoHelp && parsed.value.flags.help === true) {
+    return exitWithHelp(normalized);
+  }
+  if (normalized.autoVersion && parsed.value.flags.version === true) {
+    return exitWithVersion(normalized);
+  }
+
+  // Stage 3: coerce types, apply defaults, check required, check groups.
+  const coerced = coerceValues(parsed.value.flags, normalized);
+  if (!coerced.ok) return exitWithError(coerced.error, normalized);
+
+  const withDefaults = applyDefaults(coerced.value, normalized);
+  if (!withDefaults.ok) return exitWithError(withDefaults.error, normalized);
+
+  const grouped = checkGroups(withDefaults.value, normalized);
+  if (!grouped.ok) return exitWithError(grouped.error, normalized);
+
+  return buildResult(
+    withDefaults.value,
+    parsed.value.positionals,
+    normalized,
+  );
+}
+
+function buildResult(
+  flags: Record<string, string | number | boolean>,
+  positionals: string[],
+  schema: NormalizedSchema,
+): ParsedArgs {
+  // Strip auto-injected help/version flags from the user-visible result.
+  const visible = Object.create(null) as Record<
+    string,
+    string | number | boolean
+  >;
+  for (const [name, value] of Object.entries(flags)) {
+    if (schema.autoHelp && name === "help") continue;
+    if (schema.autoVersion && name === "version") continue;
+    visible[name] = value;
+  }
+  return { flags: visible, positionals };
+}
+
+function exitWithError(error: ParseError, schema: NormalizedSchema): never {
+  process.stderr.write(formatError(error, schema));
+  process.exit(2);
+}
+
+function exitWithHelp(schema: NormalizedSchema): never {
+  process.stdout.write(formatHelp(schema));
+  process.exit(0);
+}
+
+function exitWithVersion(schema: NormalizedSchema): never {
+  // schema.version is non-null whenever autoVersion is true; the cast
+  // is safe given the dispatch in _parseArgsWith.
+  process.stdout.write((schema.version ?? "") + "\n");
+  process.exit(0);
+}

--- a/packages/agency-lang/lib/stdlib/args.ts
+++ b/packages/agency-lang/lib/stdlib/args.ts
@@ -206,29 +206,35 @@ const SCHEMA_RULES: SchemaRule[] = [
     },
   },
   {
-    name: "h short collision is boolean only (compatible with auto-help)",
+    // When auto-help is active, NOTHING else can claim -h — even
+    // another boolean flag would silently collide with the injected
+    // --help (duplicate shortAlias in flagsByShort / buildNodeOptions).
+    // The user must declare their own `help` flag to override auto-help.
+    name: "no -h short collision when auto-help is active",
     check: (s) => {
       const userDeclaresHelp = "help" in s.flags;
       if (userDeclaresHelp) return null;
       const bad = Object.entries(s.flags).find(
-        ([, spec]) => spec.short === "h" && spec.type !== "boolean",
+        ([, spec]) => spec.short === "h",
       );
       return bad
-        ? `flag --${bad[0]} uses short -h with non-boolean type; conflicts with auto-help. Declare your own boolean "help" flag if you want to override it.`
+        ? `flag --${bad[0]} uses short -h, which collides with the auto-injected --help. Declare your own "help" flag in the schema to override auto-help.`
         : null;
     },
   },
   {
-    name: "V short collision is boolean only (compatible with auto-version)",
+    // Same rule as -h: when auto-version is active, no other flag can
+    // claim -V. User must declare their own `version` flag to override.
+    name: "no -V short collision when auto-version is active",
     check: (s) => {
       if (s.version === undefined) return null;
       const userDeclaresVersion = "version" in s.flags;
       if (userDeclaresVersion) return null;
       const bad = Object.entries(s.flags).find(
-        ([, spec]) => spec.short === "V" && spec.type !== "boolean",
+        ([, spec]) => spec.short === "V",
       );
       return bad
-        ? `flag --${bad[0]} uses short -V with non-boolean type; conflicts with auto-version.`
+        ? `flag --${bad[0]} uses short -V, which collides with the auto-injected --version. Declare your own "version" flag in the schema to override auto-version.`
         : null;
     },
   },
@@ -417,14 +423,55 @@ export function preScanArgv(
   argv: string[],
   schema: NormalizedSchema,
 ): ParseResult<void> {
+  // Tracks single-value (string/number) flags we've already seen, so
+  // a second occurrence trips the duplicateFlag rule below. Booleans
+  // are excluded — repeating `--verbose --verbose` is harmless and
+  // node:util.parseArgs accepts it without warning.
+  const seen: Record<string, boolean> = {};
+
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--") break; // honor end-of-options
+    const token = argv[i];
+    if (token === "--") break; // honor end-of-options
+
     for (const rule of ARGV_RULES) {
-      const err = rule(argv[i], argv[i + 1], schema);
+      const err = rule(token, argv[i + 1], schema);
       if (err !== null) return { ok: false, error: err };
+    }
+
+    const flagName = flagNameOf(token, schema);
+    if (flagName !== null) {
+      const flag = schema.flagsByName[flagName];
+      if (flag !== undefined && flag.type !== "boolean") {
+        if (seen[flagName] === true) {
+          return {
+            ok: false,
+            error: { kind: "duplicateFlag", flag: flagName },
+          };
+        }
+        seen[flagName] = true;
+      }
     }
   }
   return { ok: true, value: undefined };
+}
+
+// Extract the long flag name a token is referring to, if any.
+// Handles `--name`, `--name=value`, `-n`, and `-nvalue` (attached
+// short value). Returns null for non-flag tokens (positionals,
+// `-`, etc.). Resolves short aliases to their declared long names.
+function flagNameOf(token: string, schema: NormalizedSchema): string | null {
+  if (token.startsWith("--")) {
+    if (token === "--") return null;
+    const body = token.slice(2);
+    const eq = body.indexOf("=");
+    return eq === -1 ? body : body.slice(0, eq);
+  }
+  if (token.startsWith("-") && token.length >= 2 && token !== "-") {
+    const shortLetter = token[1];
+    const flag = schema.flagsByShort[shortLetter];
+    return flag !== undefined ? flag.name : null;
+  }
+  return null;
 }
 
 // =============================================================================

--- a/packages/agency-lang/stdlib/args.agency
+++ b/packages/agency-lang/stdlib/args.agency
@@ -1,0 +1,117 @@
+import { _parseArgs } from "agency-lang/stdlib-lib/args.js"
+
+/** @module
+  ## Module: std::args
+
+  Parse the program's command-line flags. Thin wrapper over Node's
+  built-in `node:util.parseArgs` with Agency-friendly defaults:
+
+  - Number coercion with strict parsing (rejects `0x10`, whitespace,
+    `NaN`, `Infinity`, etc.).
+  - Required-flag and default-value handling.
+  - Auto-generated `--help` / `--version`.
+  - Mutually-exclusive / required-together flag groups.
+  - On parse error: writes a formatted message + usage to stderr and
+    exits 2. On `--help` / `--version`: writes to stdout and exits 0.
+
+  ## Usage contract
+
+  Call `parseArgs` as the **first thing** in `main`, before installing
+  handlers, before starting a REPL (`std::ui` / `std::cli`), before
+  any side-effectful initialization. The function exits the process
+  on usage errors and on `--help`; running it before any handlers /
+  checkpoints / TUI exist keeps that exit safe.
+
+  ## Example
+
+  ```ts
+  import { parseArgs } from "std::args"
+
+  node main() {
+    const args = parseArgs({
+      programName: "greet",
+      description: "Print a friendly greeting.",
+      flags: {
+        name:    { type: "string",  short: "n", default: "world", description: "Who to greet" },
+        repeat:  { type: "number",  short: "r", default: 1,       description: "How many times" },
+        verbose: { type: "boolean", short: "v",                   description: "Chatty output" },
+        out:     { type: "string",  required: true,               description: "Output path" },
+      },
+    })
+
+    for (i in range(args.flags.repeat)) {
+      print("Hello, " + args.flags.name + "!")
+    }
+  }
+  ```
+*/
+
+/** Description of a single flag.
+
+    `type` declares the value shape. `short` is a single-character alias.
+    `default` is applied when the flag is absent (mutually exclusive with
+    `required`). `choices` constrains string flags to a fixed set of
+    case-sensitive values. `hidden` flags still parse but are omitted
+    from `--help`. */
+type FlagSpec = {
+  type: "string" | "number" | "boolean"
+  short?: string
+  default?: string | number | boolean
+  required?: boolean
+  description?: string
+  choices?: string[]
+  hidden?: boolean
+}
+
+/** Optional flag-group constraints. `exclusive` declares sets of
+    flags where at most one may be set; `requiredTogether` declares
+    sets where setting one requires setting all. A flag with a
+    `default` counts as "set" for group purposes. */
+type FlagGroups = {
+  exclusive?: string[][]
+  requiredTogether?: string[][]
+}
+
+/** Full schema for one call to `parseArgs`.
+
+    `programName` defaults to `process.argv[1]`'s basename if omitted —
+    set it explicitly when running under the agency CLI or a bundled
+    agent. Setting `version` enables auto-generated `--version` / `-V`. */
+type ArgsSchema = {
+  programName?: string
+  description?: string
+  version?: string
+  epilog?: string
+  flags: Record<string, FlagSpec>
+  groups?: FlagGroups
+}
+
+/** Result of a successful parse.
+
+    `flags` is a null-prototype map of declared flag names to coerced
+    values (string / number / boolean per the schema). `positionals` is
+    every argv token that wasn't a flag or flag-value, in original
+    order, plus everything after `--`. */
+type ParsedArgs = {
+  flags: Record<string, any>
+  positionals: string[]
+}
+
+/** Parse `process.argv` against `schema`.
+
+    See the module docstring for the usage contract — call this before
+    installing handlers or starting a REPL.
+
+    Returns `{ flags, positionals }`. On usage error, writes a message
+    + usage block to stderr and exits 2. On `--help` / `--version`,
+    writes to stdout and exits 0. Schema bugs (duplicate `short`,
+    `required` + `default`, etc.) throw at call time before any argv
+    is touched.
+
+    @param schema - Flag schema describing the program's CLI. See
+    `FlagSpec` and `ArgsSchema` for the field reference.
+    @returns Parsed `{ flags, positionals }`.
+*/
+export def parseArgs(schema: ArgsSchema): ParsedArgs {
+  return _parseArgs(schema)
+}

--- a/packages/agency-lang/tests/agency/args/basic.agency
+++ b/packages/agency-lang/tests/agency/args/basic.agency
@@ -1,0 +1,19 @@
+import { parseArgs } from "std::args"
+
+node main() {
+  const args = parseArgs({
+    programName: "basic-test",
+    flags: {
+      name: { type: "string", short: "n", default: "world" },
+      port: { type: "number", default: 3000 },
+      verbose: { type: "boolean", short: "v" },
+    },
+  })
+
+  return {
+    name: args.flags.name,
+    port: args.flags.port,
+    verbose: args.flags.verbose,
+    positionals: args.positionals,
+  }
+}

--- a/packages/agency-lang/tests/agency/args/basic.test.json
+++ b/packages/agency-lang/tests/agency/args/basic.test.json
@@ -1,0 +1,28 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Parses string, number, and boolean flags from argv",
+      "input": "",
+      "argv": ["--name", "alice", "--port", "8080", "-v", "extra", "positional"],
+      "expectedOutput": "{\"name\":\"alice\",\"port\":8080,\"verbose\":true,\"positionals\":[\"extra\",\"positional\"]}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "main",
+      "description": "Applies defaults when flags are absent",
+      "input": "",
+      "argv": [],
+      "expectedOutput": "{\"name\":\"world\",\"port\":3000,\"verbose\":false,\"positionals\":[]}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `std::args`, a schema-driven CLI flag parser for Agency programs. Thin wrapper over Node's built-in `node:util.parseArgs` — no new npm dependency. Spec at `docs/superpowers/specs/2026-06-04-cli-args-design.md`, plan at `docs/superpowers/plans/2026-06-04-cli-args-plan.md`.

```ts
import { parseArgs } from "std::args"

node main() {
  const args = parseArgs({
    programName: "greet",
    description: "Print a friendly greeting.",
    flags: {
      name:    { type: "string",  short: "n", default: "world", description: "Who to greet" },
      port:    { type: "number",  default: 3000,                description: "Listen port" },
      verbose: { type: "boolean", short: "v",                   description: "Chatty output" },
      out:     { type: "string",  required: true,               description: "Output path" },
    },
  })
  print("Hello, " + args.flags.name + "!")
}
```

### What's in v1

- `string`, `number`, `boolean` flags with short aliases, defaults, required flags.
- Strict number coercion (rejects `0x10`, whitespace, `NaN`, `Infinity`).
- `choices` for string flags.
- `hidden` flags (parse but omit from `--help`).
- Auto-generated `--help` / `-h`; `--version` / `-V` when `schema.version` is set.
- Mutually-exclusive (`groups.exclusive`) and required-together (`groups.requiredTogether`) flag groups.
- Fail-fast schema validation (duplicate shorts, `required` + `default`, `choices` on non-string, etc.) — surfaces bugs at call time.
- Unified error output: bad input → stderr + usage block + exit 2. `--help` / `--version` → stdout + exit 0.
- `--help` short-circuits before required-flag checking, so it always works.
- Null-prototype result object (defense against `--__proto__` shenanigans).

### Explicit non-goals (future work)

Repeated flags, subcommands, negatable booleans (`--no-verbose`), env-var fallback, per-flag custom validators, typed positionals. Documented in the spec's "Future work" section.

### Implementation

- `lib/stdlib/args.ts` — TS implementation (~700 lines): `validateSchema` → `normalizeSchema` → `preScanArgv` → `callNodeParse` → help/version short-circuit → `coerceValues` → `applyDefaults` → `checkGroups` → `buildResult`. Each stage returns `ParseResult<T>`; the orchestrator threads them with explicit early returns. Schema rules, error formatters, and number-rejection patterns are data tables.
- `stdlib/args.agency` — Agency-side surface with typed `FlagSpec` / `ArgsSchema` / `ParsedArgs`.
- `docs/site/guide/cli-args.md` — user guide.

### Smoke-test plumbing

`TestCase` (in `lib/cli/test.ts`) now has an optional `argv: string[]` field, forwarded through `executeNodeAsync` to the spawned subprocess. This lets `tests/agency/args/basic.agency` drive `process.argv` from `basic.test.json`.

## Test plan

- [x] 122 new vitest unit tests in `lib/stdlib/args.test.ts` covering each step and full `_parseArgsWith` e2e via a `withMockedProcess` harness (mocks `process.exit` / stdout / stderr).
- [x] 2 agency-level smoke tests in `tests/agency/args/basic.agency` (parses a real argv through a spawned subprocess; verifies defaults).
- [x] Full vitest suite passes locally: 5179 tests (5056 baseline + 123 new).
- [ ] Agency execution test suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
