### PR TITLE
Add slash commands for the agency agent

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -6,6 +6,30 @@ name: "skills"
 
 ## Types
 
+### Command
+
+```ts
+export type Command = {
+  name: string;
+  description: string;
+  argHint: string;
+  body: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L27))
+
+### CommandSet
+
+```ts
+export type CommandSet = {
+  entries: Command[];
+  dispatch: any
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L38))
+
 ### SkillEntry
 
 ```ts
@@ -16,9 +40,197 @@ type SkillEntry = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L5))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L302))
 
 ## Functions
+
+### splitFrontmatter
+
+```ts
+splitFrontmatter(content: string): { fm: string; body: string }
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| content | `string` |  |
+
+**Returns:** `{ fm: string; body: string }`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L52))
+
+### tokenizeArgs
+
+```ts
+tokenizeArgs(input: string): string[]
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| input | `string` |  |
+
+**Returns:** `string[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L82))
+
+### substituteArgs
+
+```ts
+substituteArgs(body: string, rawArgs: string, tokens: string[]): string
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| body | `string` |  |
+| rawArgs | `string` |  |
+| tokens | `string[]` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L126))
+
+### commandNameFromPath
+
+```ts
+commandNameFromPath(relPath: string): string
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| relPath | `string` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L150))
+
+### loadCommand
+
+```ts
+loadCommand(relPath: string, dir: string): Result<Command>
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| relPath | `string` |  |
+| dir | `string` |  |
+
+**Returns:** `Result<Command>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L173))
+
+### dispatchOne
+
+```ts
+dispatchOne(input: string, cmd: Command): Result<string>
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| input | `string` |  |
+| cmd | [Command](#command) |  |
+
+**Returns:** `Result<string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L207))
+
+### collectCommands
+
+```ts
+collectCommands(dir: string): Command[]
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| dir | `string` |  |
+
+**Returns:** `Command[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L220))
+
+### dispatchCmds
+
+```ts
+dispatchCmds(cmds: Command[], input: string): Result<string>
+```
+
+* Discover slash commands under `dir` (CC-compatible layout) and
+ * return a `CommandSet`. `dispatch(input)` returns
+ * `success(renderedBody)` when `input` matches `/<name>` (with
+ * optional args) and `failure("no-match")` otherwise.
+ *
+ * File layout (matches Claude Code):
+ *   - `<dir>/foo.md` → `/foo`
+ *   - `<dir>/<ns>/<bar>.md` → `/<ns>:<bar>` (one level of nesting only)
+ *   - Both `.md` and `.markdown` extensions are recognized
+ *
+ * Frontmatter fields honored:
+ *   - `description` — surfaced as `Command.description`
+ *   - `argument-hint` — surfaced as `Command.argHint`
+ *
+ * Everything else CC supports (`allowed-tools`, `model`, `effort`,
+ * `context: fork`, `disable-model-invocation`, `user-invocable`,
+ * `hooks`, `paths`, `shell`, ...) is silently ignored in v1. The
+ * command still runs with the agent's defaults.
+ *
+ * Body preprocessing:
+ *   - `$ARGUMENTS` → the raw arg string (quotes preserved)
+ *   - `$ARGUMENTS[N]` and `$N` → the Nth (1-indexed) tokenized arg
+ *   - Tokenizer: whitespace splits + `"..."` grouping. No single
+ *     quotes, no escapes, no env expansion. Matches CC.
+ *   - If the body has no `$ARGUMENTS` ref and args were passed, the
+ *     raw arg string is appended as `\n\nARGUMENTS: <raw>`.
+ *
+ * Notes:
+ *   - `!`cmd`` shell injection, `@<path>` file refs, and
+ *     `allowed-tools` pre-approval are out of scope for v1.
+ *   - Files with parse failures are skipped silently (same posture
+ *     as `skillsDir`).
+ *   - Missing or empty `dir` → `entries: []`, `dispatch` always
+ *     returns `failure("no-match")`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| cmds | `Command[]` |  |
+| input | `string` |  |
+
+**Returns:** `Result<string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L279))
+
+### commandsDir
+
+```ts
+commandsDir(dir: string): CommandSet
+```
+
+Discover CC-format slash commands in `dir` and return a CommandSet.
+
+  @param dir - Directory containing command markdown files.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| dir | `string` |  |
+
+**Returns:** [CommandSet](#commandset)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L289))
 
 ### xmlEscape
 
@@ -42,7 +254,7 @@ Escape `&`, `<`, `>`, `"`, `'` so the result is safe to embed inside
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L11))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L308))
 
 ### renderEntry
 
@@ -65,7 +277,7 @@ Render one SkillEntry as a `<skill>` XML block. All string fields are
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L327))
 
 ### flatEntry
 
@@ -89,7 +301,7 @@ Build a SkillEntry for one file in the legacy flat-markdown layout.
 
 **Returns:** [SkillEntry](#skillentry)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L346))
 
 ### standardEntry
 
@@ -113,7 +325,7 @@ Build a SkillEntry for one skill in the standard SKILL.md layout.
 
 **Returns:** [SkillEntry](#skillentry)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L362))
 
 ### skillsDir
 
@@ -145,4 +357,4 @@ Build a skills tool for an LLM over a directory of skills.
 | dir | `string` |  |
 | layout | `"flat" \| "standard"` | "standard" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L392))

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-04-slash-commands.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-04-slash-commands.md
@@ -1,0 +1,250 @@
+# Slash Commands for the Agency Agent
+
+## Background
+
+Claude Code recently merged custom commands into skills: `.claude/commands/foo.md` and `.claude/skills/foo/SKILL.md` both produce `/foo`, share one frontmatter spec, and are described in the same docs page (`code.claude.com/docs/en/slash-commands`). The file format is unified, but the **runtime behavior** still splits:
+
+- **Skills** — model-invoked, lazy. Description sits in the model's tool list; body loads only when the model (or user) picks it. We already support this via `skillsDir` in `stdlib/skills.agency`, which returns a `read.partial(dir: dir).describe(...)`-shaped tool.
+- **Commands** — user-typed, eager. The body has `$ARGUMENTS` substituted and is injected as a user message into the conversation.
+
+**v1 scope (explicit):** a command is a *pure prompt template*. The rendered body is appended to the current thread as a user message — exactly as if the user had typed the text manually. No `!`cmd`` shell injection, no `@<path>` file references, no `allowed-tools` pre-approval, no `model`/`effort` overrides. All of these are tracked as follow-ups (see "Out of scope"). This keeps the security picture trivial: commands cannot do anything the user couldn't do by typing.
+
+The agency agent (`lib/agents/agency-agent/agent.agency`) currently hardcodes `/exit`, `/clear`, `/help` in `_runTurn` and exposes nothing extensible to users. We want users' existing `~/.claude/commands/` and project-local `.claude/commands/` files to work in the agency agent the same way they do in Claude Code.
+
+This spec adds a `commandsDir(dir)` function to `stdlib/skills.agency`, alongside the existing `skillsDir`, and wires it into `lib/agents/agency-agent/agent.agency`.
+
+## Decision: one module, two functions
+
+`commandsDir` lives in `stdlib/skills.agency`, not a new `stdlib/commands.agency`. The shared work — `glob` a directory, parse frontmatter on each file — is the bulk of the code. The divergence is at the edges: skills render into a tool description; commands render into a dispatcher. Two surfaces over one private helper is the right shape.
+
+A second-order benefit: when a user reads `std::skills`, they see both halves of the CC unification in one place.
+
+## Public API
+
+```agency
+type Command = {
+  name: string,         // "/foo" or "/ns:bar"
+  description: string,  // from frontmatter, "" if absent
+  argHint: string,      // from frontmatter argument-hint, "" if absent
+}
+
+type CommandSet = {
+  entries: Command[],
+  dispatch: (input: string) => Result<string, "no-match">,
+}
+
+export def commandsDir(dir: string): CommandSet
+```
+
+`dispatch(input)` returns a [`Result`](https://agency-lang.com/guide/error-handling.html):
+
+- `failure("no-match")` if `input` doesn't start with `/<name>` (with optional whitespace + args after).
+- `success(body)` if it matches. `body` is the rendered command body: frontmatter stripped, `$ARGUMENTS` substituted, ready to feed to `route()` as the user message. `body` MAY be the empty string (a legitimate command that renders to nothing); callers must check the Result tag, not truthiness.
+
+We use `Result` rather than `string | null` because the empty-string case is meaningful and `?? msg` fall-through would silently send the raw `/foo` to the LLM if a command rendered to `""`.
+
+`entries` is for the UI: `agent.agency` splices `name` into `repl()`'s `paletteCommands` (with `description` as the menu text and `argHint` displayed after it) so users get autocomplete.
+
+## File discovery
+
+Mirror CC's layout:
+
+- `<dir>/foo.md` → `/foo`
+- `<dir>/<ns>/<bar>.md` → `/<ns>:<bar>` (one level of nesting only — CC supports the same)
+- Both `.md` and `.markdown` extensions
+
+Implementation: two `glob` calls, since `_glob` in `lib/stdlib/shell.ts` supports one level of brace expansion but not the `**` star you'd want for "any depth":
+
+```agency
+const flat   = glob("*.{md,markdown}",   dir)    // → /foo
+const nested = glob("*/*.{md,markdown}", dir)    // → /<ns>:<bar>
+```
+
+Verified against `globToRegExp` at [lib/stdlib/shell.ts:367](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/stdlib/shell.ts#L367) — single-level `{a,b}` works; nested braces explicitly rejected.
+
+Skip files with parse failures silently (same posture as `skillsDir` — `frontmatter ... catch {}`).
+
+## Body preprocessing
+
+The body is everything after the frontmatter block. Only one transform happens: `$ARGUMENTS`-family substitution.
+
+### `$ARGUMENTS` family
+
+Given user input `/foo "hello world" second`:
+- `$ARGUMENTS` → `"hello world" second` (the raw arg string verbatim, quotes preserved)
+- `$ARGUMENTS[N]` and `$N` (1-indexed, matching shell + CC) → the Nth tokenized arg. So `$1` = `hello world`, `$2` = `second`. `$0` is undefined → leave the literal `$0` in place.
+- Out-of-range `$N` → leave the literal token in place (don't silently substitute `""`; that masks template bugs).
+
+If the body contains no `$ARGUMENTS` token (and no `$N`) and the user passed args, append `\n\nARGUMENTS: <raw>` to the rendered body. Matches CC behavior — gives the LLM access to the input even if the template author forgot a placeholder.
+
+#### Tokenizer — explicit definition
+
+Match CC exactly. CC's documented behavior (cross-referenced with [anthropics/claude-code#8406](https://github.com/anthropics/claude-code/issues/8406)):
+
+1. Split on runs of whitespace (` `, `\t`, `\n`).
+2. A double-quoted span (`"..."`) groups everything between the quotes into one token, including whitespace. Quotes are stripped from the token; the raw form keeps them.
+3. **No other quoting or escapes.** No single quotes, no backslash escapes, no env-var expansion. This is intentionally minimal and matches CC — users who hit it are vocal about it (see #8406), but matching CC means existing command files work without surprises.
+4. An unterminated `"` consumes to end-of-input.
+
+Concrete examples:
+| Input                              | Tokens                          |
+|------------------------------------|---------------------------------|
+| `/foo a b c`                       | `["a", "b", "c"]`               |
+| `/foo "hello world" x`             | `["hello world", "x"]`          |
+| `/foo 'single' x`                  | `["'single'", "x"]`             |
+| `/foo a\ b`                        | `["a\\", "b"]`                  |
+| `/foo "unterminated x y`           | `["unterminated x y"]`          |
+
+The tokenizer is a small inline function (~20 lines) in `stdlib/skills.agency`. `std::args` doesn't expose a string tokenizer — `parseArgs` takes `argv: string[]` already split by the OS — so there's no shared code to lift.
+
+**Wiggle room for mistakes:** none in v1. If a user wants single-quoted or `<arg>...</arg>` delimited args (a real ask — see #8406 in CC), we add it as a follow-up rather than diverging from CC silently.
+
+### `!`cmd`` shell injection — **out of scope (v1)**
+
+Tracked as follow-up. When added, every shell exec MUST go through `cliPolicyHandler` (Agency's universal handler boundary) rather than the static-frontmatter pre-approval model CC uses. See [handlers guide](https://agency-lang.com/guide/handlers.html). Note that CC's shell-injection permission flow has a longstanding bug ([anthropics/claude-code#3662](https://github.com/anthropics/claude-code/issues/3662)) where prompts don't fire from inside commands — going through `cliPolicyHandler` from day one avoids that class of bug.
+
+### `@<path>` file references — **out of scope (v1)**
+
+Defer. Not strictly a command feature; it's a general CC input affordance and warrants its own design pass.
+
+### `allowed-tools` / `model` / `effort` / `context: fork` — **out of scope (v1)**
+
+These all need first-class hooks in `route()` or `cliPolicyHandler` that don't exist yet. Silently ignored on read; the command still runs with the agent's default tools and model. Documented in the `commandsDir` docstring.
+
+## Frontmatter fields we honor
+
+Of CC's ~15 frontmatter fields, only these map cleanly to the agency agent in v1:
+
+| Field           | Behavior                                                 |
+|-----------------|----------------------------------------------------------|
+| `description`   | Shown in palette entries                                 |
+| `argument-hint` | Shown in palette entries after the description           |
+
+Note that CC does **not** document an `arguments:` (list of names) frontmatter field — earlier drafts of this spec included one, but it isn't a real CC affordance. Positional refs are always `$1`/`$2`/`$ARGUMENTS[N]`. Adding named-arg support would diverge from CC's file format and is not in v1.
+
+Everything else (`allowed-tools`, `disallowed-tools`, `disable-model-invocation`, `user-invocable`, `model`, `effort`, `context: fork`, `agent`, `hooks`, `paths`, `shell`) is silently ignored. None of them have a clean mapping into agency-agent's two-thread `route()` architecture, and the failure mode of ignoring them is benign (the command still runs, just without the extra constraint). Documented in the `commandsDir` docstring.
+
+## Wiring into `agent.agency`
+
+```agency
+import { commandsDir } from "std::skills"
+
+static const userCommands    = commandsDir("${env("HOME")}/.claude/commands") with approve
+static const projectCommands = commandsDir(".claude/commands") with approve
+
+// Built-ins win over both. Among file commands, project beats user.
+// Final precedence: built-ins > project > user.
+def mergePalette(): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (cmd in userCommands.entries)    { out[cmd.name] = cmd.description }
+  for (cmd in projectCommands.entries) { out[cmd.name] = cmd.description }
+  out["/exit"]  = "Exit the agent"
+  out["/clear"] = "Clear the conversation transcript"
+  out["/help"]  = "Show available slash commands"
+  return out
+}
+
+def _runTurn(msg: string): boolean {
+  // Built-ins first — they always win.
+  if (msg == "/exit" || msg == "/quit") { return false }
+  if (msg == "/clear") { clearMessages(); return true }
+  if (msg == "/help")  { /* ... */ return true }
+
+  // Project then user, matching mergePalette() precedence.
+  let prompt = msg
+  const projHit = projectCommands.dispatch(msg)
+  if (projHit is success(body)) {
+    prompt = body
+  } else {
+    const userHit = userCommands.dispatch(msg)
+    if (userHit is success(body)) {
+      prompt = body
+    }
+  }
+  // If neither matched and `msg` started with `/`, we still pass it
+  // through to route() as a literal user message. CC does the same —
+  // unknown slash commands are surfaced to the model rather than
+  // silently swallowed.
+
+  const reply = route({ ... }, prompt)
+  pushMessage(highlight("${reply}\n", language: "markdown"))
+  return true
+}
+```
+
+Notes:
+- `static const ... with approve` auto-approves the two `glob` calls during module init. Because v1 has no `!`cmd`` shell execution, dispatch itself never touches the policy handler — it's pure string transformation.
+- `static const` runs at load time. New `.md` files added mid-session are *not* picked up. Acceptable for v1; tracked as a follow-up.
+- Precedence: built-ins > project > user. CC's published precedence for *skills* is enterprise > personal > project, but for *commands* the "closer wins" rule is the intuitive one and matches what users expect from layered configs.
+
+### Non-interactive (`--print` / piped) path
+
+The existing non-interactive branch in `main()` ([agent.agency:326-371](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/agents/agency-agent/agent.agency#L326-L371)) bypasses `_runTurn` entirely — it builds a prompt and calls `route()` directly. To keep behavior consistent, dispatch must also run there:
+
+```agency
+const prompt = projectCommands.dispatch(piped) is success(body) ? body
+             : userCommands.dispatch(piped)    is success(body) ? body
+             : piped
+```
+
+Built-ins (`/exit`, `/clear`, `/help`) are meaningless in one-shot mode and are not checked. This lets users do `pnpm run agency agent /myCommand arg1 arg2` and have it work the same as typing it in the REPL.
+
+## Edge cases worth nailing
+
+- **Empty directory / missing directory** — `glob` returns failure → `entries: []`, `dispatch` always returns `failure("no-match")`. Same posture as `skillsDir`.
+- **Command name collision with built-ins (`/exit`, `/clear`, `/help`)** — built-ins win, because `_runTurn` checks them before calling `dispatch`. Document this. A user who wants to override `/clear` would have to edit the agent.
+- **Command with no `$ARGUMENTS` and no args passed** — body renders as-is, no `ARGUMENTS:` suffix.
+- **Command with args but body has only `$1`, no `$ARGUMENTS`** — `$1` substitutes; treat as "no `$ARGUMENTS` token" → append the suffix. Matches CC.
+- **A command file with no frontmatter at all** — body is the entire file; `description` = "", `argHint` = "". Should still dispatch.
+- **Command that renders to the empty string** — `dispatch` returns `success("")`. Caller must use the Result tag, not truthiness (see "Public API").
+- **User types `/notACommand`** — neither set matches → fall through to `route()` with `msg` unchanged. The LLM sees a literal `/notACommand` user message and can respond "I don't recognize that command". Matches CC.
+- **Unicode/emoji in args** — strings, not bytes; pass through verbatim. Tokenizer is whitespace-only so non-ASCII is fine.
+
+## Testing
+
+Two layers:
+
+1. **Unit tests** (`tests/unit/commandsTokenizer.test.ts` or co-located with the runtime helper if we extract one) — pure-string-in / pure-string-out, no I/O. Cover:
+   - tokenizer: whitespace splits, double-quoted spans, unterminated quote, single quotes left literal, backslash left literal
+   - `$ARGUMENTS` substitution with and without args
+   - `$1`/`$ARGUMENTS[1]` substitution; out-of-range left literal; `$0` left literal
+   - "no `$ARGUMENTS` + args present" → suffix appended
+   - "no `$ARGUMENTS` + no args" → no suffix
+   - malformed frontmatter → body falls back to whole file
+2. **Agency execution test** (`tests/agency/commands-dir.agency`) using a fixture directory under `tests/agency/commands-dir-fixture/`. Mirror the shape of the existing `tests/agency/skills-dir.agency` + `tests/agency/skills-dir-fixture/` pair. Use `with approve` to auto-approve the `glob`/`read` calls.
+
+Fixture files to include:
+- `simple.md` — body, no frontmatter, no args
+- `with-args.md` — `$ARGUMENTS` and `$1`/`$2`
+- `ns/scoped.md` — verify `/ns:scoped` dispatch
+- `bad-frontmatter.md` — verify graceful skip (still dispatches with empty description)
+
+Agency-test assertions to include:
+- Missing dir → `entries.length == 0`, `dispatch("/anything")` returns `failure("no-match")`.
+- `entries` length matches fixture count (3, excluding bad-frontmatter if we drop it; 4 if we keep it dispatchable).
+- `dispatch("/simple")` returns `success` with the literal body.
+- `dispatch("/with-args foo bar")` substitutes correctly.
+- `dispatch("/notExist")` returns `failure("no-match")`.
+- `dispatch("/ns:scoped")` resolves the namespaced command.
+
+## Out of scope (follow-ups)
+
+- ``!`cmd`` shell injection — when added, must route through `cliPolicyHandler` (not frontmatter pre-approval).
+- `@<path>` file references.
+- Live reload when files change mid-session.
+- `allowed-tools` → Agency policy mapping (would need a `cliPolicyHandler` integration to scope pre-approvals per-command).
+- `model:` / `effort:` / `context: fork` — would need `route()` to accept per-turn overrides.
+- Built-in command override from user files.
+- Configurable arg delimiters (e.g. `<arg>...</arg>`) — see [anthropics/claude-code#8406](https://github.com/anthropics/claude-code/issues/8406). Match CC's whitespace+`"` tokenizer for v1 to stay compatible.
+- Named-arg frontmatter (`arguments: [issue, branch]` + `$issue` refs). Not a CC affordance; would diverge from the unified file format.
+
+## Implementation order
+
+Revised: build `commandsDir` standalone first, then factor out a shared helper. This keeps the working `skillsDir` untouched until we have a concrete second consumer to design against, shrinking blast radius.
+
+1. **Tokenizer + arg substituter** (`stdlib/skills.agency` or extracted to a TS helper for unit-testability). Pure functions, vitest-covered.
+2. **`commandsDir`** — its own glob/parse loop (duplicating `skillsDir`'s walker for now), returning `CommandSet`. Returns a `Result`-typed `dispatch`.
+3. **Agency execution test** + fixtures. Confirms end-to-end behavior before touching the agent.
+4. **Wire into `lib/agents/agency-agent/agent.agency`** — both `_runTurn` (REPL path) and the non-interactive branch in `main()`. Rebuild bundled agent (`pnpm run build && make agents`). Smoke-test by typing a `/myCommand` into the running agent.
+5. **Refactor**: extract the shared directory-walker between `skillsDir` and `commandsDir` into a private helper. Verify existing `skills-dir.agency` test still passes — no skill-side behavior change.
+6. **Docs**: update `docs/site/guide/` (find the right page or add a short one); update the `commandsDir` docstring with the ignored-frontmatter-fields note; mention the `--print` / piped dispatch behavior in the agency-agent README.

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -6,6 +6,7 @@ import { today } from "std::date"
 import { box, render } from "std::layout"
 import { ScopedRuleFields, cliPolicyHandler } from "std::policy"
 import { exists } from "std::shell"
+import { commandsDir } from "std::skills"
 import { highlight } from "std::syntax"
 import { cwd, env, isTTY, readStdin } from "std::system"
 import { getCost } from "std::thread"
@@ -217,8 +218,67 @@ def loadAgentsMd(dir: string): string {
 // LLM doesn't have to re-ground each turn. Initialized in `main()`.
 let _context: string = ""
 
+// User and project slash-command directories. Mirrors Claude Code's
+// layout: `~/.claude/commands/foo.md` → `/foo`, ditto for project.
+// `with approve` auto-approves the `glob`/`read` during module init.
+// `commandsDir` itself does no shell exec in v1, so this is the only
+// policy interaction commands have.
+static const userCommands    = commandsDir("${env("HOME") ?? "."}/.claude/commands") with approve
+static const projectCommands = commandsDir(".claude/commands") with approve
+
+def builtinPalette(): Record<string, string> {
+  return {
+    "/exit":  "Exit the agent",
+    "/clear": "Clear the conversation transcript",
+    "/help":  "Show available slash commands"
+  }
+}
+
+// Final precedence: built-ins > project > user. We add user first
+// then project so project entries overwrite shadowing user ones, then
+// built-ins overwrite anything in either set.
+def mergedPalette(): Record<string, string> {
+  let out: Record<string, string> = {}
+  for (cmd in userCommands.entries) {
+    let label = cmd.description
+    if (cmd.argHint != "") {
+      label = "${label} ${cmd.argHint}"
+    }
+    out["/${cmd.name}"] = label
+  }
+  for (cmd in projectCommands.entries) {
+    let label = cmd.description
+    if (cmd.argHint != "") {
+      label = "${label} ${cmd.argHint}"
+    }
+    out["/${cmd.name}"] = label
+  }
+  for (key in builtinPalette()) {
+    out[key] = builtinPalette()[key]
+  }
+  return out
+}
+
+// Try project then user; return the rendered body if either matches,
+// or `msg` unchanged if neither does. Unknown `/foo` inputs are
+// passed through to `route()` as a literal user message — same as CC.
+def expandCommand(msg: string): string {
+  const proj = projectCommands.dispatch(msg)
+  if (proj is success(body)) {
+    return body
+  }
+  const usr = userCommands.dispatch(msg)
+  if (usr is success(body)) {
+    return body
+  }
+  return msg
+}
+
 // Slash-command + user-message dispatcher invoked by `repl()` for
 // every Enter keystroke. Return `false` to terminate the loop.
+//
+// Built-ins are checked before file commands so a user-authored
+// `/clear.md` cannot shadow the built-in `/clear`.
 def _runTurn(msg: string): boolean {
   if (msg == "") {
     return true
@@ -234,6 +294,7 @@ def _runTurn(msg: string): boolean {
     pushMessage("Commands: /exit, /clear, /help")
     return true
   }
+  const prompt = expandCommand(msg)
   const reply = route(
     {
     start: "code",
@@ -252,7 +313,7 @@ def _runTurn(msg: string): boolean {
     maxHops: 3,
     context: _context
   },
-    msg,
+    prompt,
   )
   pushMessage(highlight("${reply}\n", language: "markdown"))
   return true
@@ -365,6 +426,11 @@ node main() {
       fields: ALWAYS_FIELDS
     },
     )
+    // Run slash-command expansion in one-shot mode too, so
+    // `agency agent /myCommand foo bar` works the same as typing it
+    // in the REPL. Built-ins (`/exit`, `/clear`, `/help`) are
+    // meaningless without an interactive loop and are not checked.
+    const onePrompt = expandCommand(piped)
     handle {
       const reply = route(
         {
@@ -384,7 +450,7 @@ node main() {
         maxHops: 3,
         context: _context
       },
-        piped,
+        onePrompt,
       )
       print(reply)
     } with handler
@@ -421,11 +487,7 @@ node main() {
       prompt: "> ",
       historyFile: historyPath(),
       historyMax: 1000,
-      paletteCommands: {
-      "/exit": "Exit the agent",
-      "/clear": "Clear the conversation transcript",
-      "/help": "Show available slash commands"
-    },
+      paletteCommands: mergedPalette(),
     )
   } with handler
 

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -2,6 +2,303 @@ import { map } from "std::array"
 import { frontmatter } from "std::markdown"
 import { glob } from "std::shell"
 
+// ============================================================
+// Slash commands
+// ============================================================
+//
+// `commandsDir(dir)` is the command-flavored sibling of `skillsDir`.
+// CC merged custom commands and skills into one file format but kept
+// two runtime behaviors:
+//   - Skills are model-invoked (lazy, exposed as a tool description)
+//   - Commands are user-typed (eager, body becomes a user message)
+//
+// We expose both halves from this module so users see them together.
+// v1 is intentionally minimal: a command is a pure prompt template.
+// No `!`cmd`` shell injection, no `@<path>` file refs, no
+// `allowed-tools` pre-approval. The rendered body is appended to the
+// thread as a user message — the same as if the user had typed it.
+// See `docs/superpowers/plans/2026-06-04-slash-commands.md`.
+
+// One command parsed from a CC-format markdown file.
+//   name: "/foo" or "/ns:bar" (without the leading slash)
+//   description: from frontmatter, "" if absent
+//   argHint: from frontmatter `argument-hint`, "" if absent
+//   body: rendered-on-dispatch source (frontmatter stripped)
+export type Command = {
+  name: string;
+  description: string;
+  argHint: string;
+  body: string
+}
+
+// Returned by `commandsDir`. `dispatch(input)` is a partial-applied
+// function: (string) => Result<string>. Typed as `any`
+// because Agency record field types don't yet round-trip generic
+// function aliases cleanly.
+export type CommandSet = {
+  entries: Command[];
+  dispatch: any
+}
+
+/* ----- private helpers ----- */
+
+// Split `content` into (frontmatterBlock, body). The frontmatter is
+// only recognized when the file starts with a `---` line and a
+// matching `---` line follows. Otherwise the whole file is the body.
+//
+// We don't use std::markdown's parser here: it gives us the parsed
+// frontmatter data but not the raw body string, and reconstructing
+// the body from the AST loses original formatting (whitespace, fences).
+def splitFrontmatter(content: string): { fm: string; body: string } {
+  const lines = content.split("\n")
+  if (lines.length == 0 || lines[0] != "---") {
+    return { fm: "", body: content }
+  }
+  let i = 1
+  while (i < lines.length) {
+    if (lines[i] == "---") {
+      const fmBlock = lines.slice(0, i + 1).join("\n")
+      const bodyStart = i + 1
+      // Strip a single blank line after the closing `---` if present —
+      // markdown convention, matches CC.
+      let skip = 0
+      if (bodyStart < lines.length && lines[bodyStart] == "") {
+        skip = 1
+      }
+      const body = lines.slice(bodyStart + skip).join("\n")
+      return { fm: fmBlock, body: body }
+    }
+    i = i + 1
+  }
+  // Unterminated frontmatter — treat whole file as body.
+  return { fm: "", body: content }
+}
+
+// Whitespace-and-double-quote tokenizer. Matches Claude Code:
+//   - split on runs of ` `, `\t`, `\n`
+//   - `"..."` groups everything between the quotes into one token
+//   - no single quotes, no backslash escapes, no env expansion
+//   - unterminated `"` consumes to end of input
+def tokenizeArgs(input: string): string[] {
+  const out: string[] = []
+  const n = input.length
+  let i = 0
+  while (i < n) {
+    // skip whitespace
+    while (i < n && (input[i] == " " || input[i] == "\t" || input[i] == "\n")) {
+      i = i + 1
+    }
+    if (i >= n) {
+      return out
+    }
+    let token = ""
+    if (input[i] == `"`) {
+      i = i + 1
+      while (i < n && input[i] != `"`) {
+        token = token + input[i]
+        i = i + 1
+      }
+      if (i < n) {
+        i = i + 1  // consume closing "
+      }
+    } else {
+      while (i < n && input[i] != " " && input[i] != "\t" && input[i] != "\n") {
+        token = token + input[i]
+        i = i + 1
+      }
+    }
+    out.push(token)
+  }
+  return out
+}
+
+// Substitute `$ARGUMENTS`, `$ARGUMENTS[N]`, and `$N` (1-indexed) in
+// `body`. Out-of-range or undefined refs (`$0`, `$99`) are left as
+// literal text — silent empty-string substitution would mask template
+// bugs.
+//
+// If the body has no `$ARGUMENTS` reference at all and the user
+// passed args, the raw arg string is appended as
+// `\n\nARGUMENTS: <raw>`. Matches CC behavior — gives the model the
+// input even if the template author forgot a placeholder. The check
+// is for the literal substring "$ARGUMENTS", so `$ARGUMENTS[N]`
+// counts too.
+def substituteArgs(body: string, rawArgs: string, tokens: string[]): string {
+  let out = body
+  // Longer patterns first so `$ARGUMENTS[1]` is replaced before the
+  // bare `$ARGUMENTS` consumes its prefix.
+  let i = 1
+  while (i <= tokens.length) {
+    out = out.replaceAll("$ARGUMENTS[${i}]", tokens[i - 1])
+    out = out.replaceAll("$${i}", tokens[i - 1])
+    i = i + 1
+  }
+  out = out.replaceAll("$ARGUMENTS", rawArgs)
+
+  const hadArgumentsToken = body.includes("$ARGUMENTS")
+  if (!hadArgumentsToken && rawArgs != "") {
+    out = out + "\n\nARGUMENTS: ${rawArgs}"
+  }
+  return out
+}
+
+// Map a glob-relative path to its slash-command name. Rules:
+//   - `foo.md` → "foo"
+//   - `foo.markdown` → "foo"
+//   - `ns/bar.md` → "ns:bar"
+// One level of nesting only — anything deeper is rejected (returns "").
+def commandNameFromPath(relPath: string): string {
+  let stem = relPath
+  if (stem.endsWith(".markdown")) {
+    stem = stem.slice(0, stem.length - 9)
+  } else if (stem.endsWith(".md")) {
+    stem = stem.slice(0, stem.length - 3)
+  } else {
+    return ""
+  }
+  // Disallow more than one slash (i.e. deeper nesting).
+  const parts = stem.split("/")
+  if (parts.length == 1) {
+    return parts[0]
+  }
+  if (parts.length == 2) {
+    return "${parts[0]}:${parts[1]}"
+  }
+  return ""
+}
+
+// Parse a single command file: read it, split frontmatter, build a
+// Command record. Failures (read error, no body) bubble up as
+// `failure(...)` so the caller can skip them silently.
+def loadCommand(relPath: string, dir: string): Result<Command> {
+  const name = commandNameFromPath(relPath)
+  if (name == "") {
+    return failure("not a valid command path: ${relPath}")
+  }
+  const raw = read(relPath, dir)
+  if (isFailure(raw)) {
+    return failure("read failed: ${relPath}")
+  }
+  const split = splitFrontmatter(raw.value)
+  // Parse the frontmatter block alone — `frontmatter()` wants the
+  // `---` fences to be at the start of input.
+  const fm = frontmatter(split.fm) catch {}
+  let description = ""
+  let argHint = ""
+  if (fm != null && typeof fm == "object") {
+    if (fm.description != null) {
+      description = "${fm.description}"
+    }
+    if (fm["argument-hint"] != null) {
+      argHint = "${fm["argument-hint"]}"
+    }
+  }
+  return success({
+    name: name,
+    description: description,
+    argHint: argHint,
+    body: split.body
+  })
+}
+
+// Try to dispatch `input` against a single command. Returns a body
+// `success` if the input matches `/<name>` (with optional whitespace
+// + args), or `failure("no-match")` otherwise.
+def dispatchOne(input: string, cmd: Command): Result<string> {
+  const prefix = "/" + cmd.name
+  if (input == prefix) {
+    return success(substituteArgs(cmd.body, "", []))
+  }
+  if (!input.startsWith(prefix + " ") && !input.startsWith(prefix + "\t")) {
+    return failure("no-match")
+  }
+  const rawArgs = input.slice(prefix.length + 1).trim()
+  const tokens = tokenizeArgs(rawArgs)
+  return success(substituteArgs(cmd.body, rawArgs, tokens))
+}
+
+def collectCommands(dir: string): Command[] {
+  let out: Command[] = []
+  const flat = glob("*.{md,markdown}", dir)
+  if (flat is success(paths)) {
+    for (p in paths) {
+      const c = loadCommand(p, dir)
+      if (c is success(cmd)) {
+        out.push(cmd)
+      }
+    }
+  }
+  const nested = glob("*/*.{md,markdown}", dir)
+  if (nested is success(paths)) {
+    for (p in paths) {
+      const c = loadCommand(p, dir)
+      if (c is success(cmd)) {
+        out.push(cmd)
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Discover slash commands under `dir` (CC-compatible layout) and
+ * return a `CommandSet`. `dispatch(input)` returns
+ * `success(renderedBody)` when `input` matches `/<name>` (with
+ * optional args) and `failure("no-match")` otherwise.
+ *
+ * File layout (matches Claude Code):
+ *   - `<dir>/foo.md` → `/foo`
+ *   - `<dir>/<ns>/<bar>.md` → `/<ns>:<bar>` (one level of nesting only)
+ *   - Both `.md` and `.markdown` extensions are recognized
+ *
+ * Frontmatter fields honored:
+ *   - `description` — surfaced as `Command.description`
+ *   - `argument-hint` — surfaced as `Command.argHint`
+ *
+ * Everything else CC supports (`allowed-tools`, `model`, `effort`,
+ * `context: fork`, `disable-model-invocation`, `user-invocable`,
+ * `hooks`, `paths`, `shell`, ...) is silently ignored in v1. The
+ * command still runs with the agent's defaults.
+ *
+ * Body preprocessing:
+ *   - `$ARGUMENTS` → the raw arg string (quotes preserved)
+ *   - `$ARGUMENTS[N]` and `$N` → the Nth (1-indexed) tokenized arg
+ *   - Tokenizer: whitespace splits + `"..."` grouping. No single
+ *     quotes, no escapes, no env expansion. Matches CC.
+ *   - If the body has no `$ARGUMENTS` ref and args were passed, the
+ *     raw arg string is appended as `\n\nARGUMENTS: <raw>`.
+ *
+ * Notes:
+ *   - `!`cmd`` shell injection, `@<path>` file refs, and
+ *     `allowed-tools` pre-approval are out of scope for v1.
+ *   - Files with parse failures are skipped silently (same posture
+ *     as `skillsDir`).
+ *   - Missing or empty `dir` → `entries: []`, `dispatch` always
+ *     returns `failure("no-match")`.
+ */
+def dispatchCmds(cmds: Command[], input: string): Result<string> {
+  for (cmd in cmds) {
+    const r = dispatchOne(input, cmd)
+    if (r is success(_body)) {
+      return r
+    }
+  }
+  return failure("no-match")
+}
+
+export def commandsDir(dir: string): CommandSet {
+  """
+  Discover CC-format slash commands in `dir` and return a CommandSet.
+
+  @param dir - Directory containing command markdown files.
+  """
+  const cmds = collectCommands(dir)
+  return {
+    entries: cmds,
+    dispatch: dispatchCmds.partial(cmds: cmds)
+  }
+}
+
 type SkillEntry = {
   name: string;
   description: string;

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/no-frontmatter.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/no-frontmatter.md
@@ -1,0 +1,1 @@
+Plain body, no frontmatter at all.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/ns/scoped.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/ns/scoped.md
@@ -1,0 +1,5 @@
+---
+description: A namespaced command
+---
+
+I live under ns/.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/positional-only.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/positional-only.md
@@ -1,0 +1,5 @@
+---
+description: Uses only $N, no $ARGUMENTS — suffix should be appended
+---
+
+First: $1, second: $2.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/simple.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/simple.md
@@ -1,0 +1,5 @@
+---
+description: A simple command with no args
+---
+
+Just say hello.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/with-args.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/with-args.md
@@ -1,0 +1,6 @@
+---
+description: Greet someone
+argument-hint: [name] [greeting]
+---
+
+Greet $1 with: $ARGUMENTS

--- a/packages/agency-lang/tests/agency/commands-dir.agency
+++ b/packages/agency-lang/tests/agency/commands-dir.agency
@@ -1,0 +1,87 @@
+import { commandsDir } from "std::skills"
+
+def loadFixture() {
+  return commandsDir("commands-dir-fixture") with approve
+}
+
+node entriesCount(): number {
+  const set = loadFixture()
+  return set.entries.length
+}
+
+node simpleMatches(): boolean {
+  const set = loadFixture()
+  const r = set.dispatch("/simple")
+  if (r is success(body)) {
+    return body.includes("Just say hello.")
+  }
+  return false
+}
+
+node simpleDescriptionLoaded(): boolean {
+  const set = loadFixture()
+  for (cmd in set.entries) {
+    if (cmd.name == "simple") {
+      return cmd.description == "A simple command with no args"
+    }
+  }
+  return false
+}
+
+node argsSubstitution(): boolean {
+  const set = loadFixture()
+  const r = set.dispatch(`/with-args alice "good morning"`)
+  if (r is success(body)) {
+    // $1 → alice, $ARGUMENTS → raw arg string with quotes preserved
+    return body.includes("Greet alice with:") && body.includes(`alice "good morning"`)
+  }
+  return false
+}
+
+node positionalOnlyAppendsSuffix(): boolean {
+  const set = loadFixture()
+  const r = set.dispatch("/positional-only foo bar")
+  if (r is success(body)) {
+    // $1 and $2 substituted; suffix appended because $ARGUMENTS absent
+    return body.includes("First: foo, second: bar.") && body.includes("ARGUMENTS: foo bar")
+  }
+  return false
+}
+
+node noFrontmatterStillDispatches(): boolean {
+  const set = loadFixture()
+  const r = set.dispatch("/no-frontmatter")
+  if (r is success(body)) {
+    return body.includes("Plain body, no frontmatter at all.")
+  }
+  return false
+}
+
+node namespacedDispatches(): boolean {
+  const set = loadFixture()
+  const r = set.dispatch("/ns:scoped")
+  if (r is success(body)) {
+    return body.includes("I live under ns/.")
+  }
+  return false
+}
+
+node unknownReturnsFailure(): boolean {
+  const set = loadFixture()
+  const r = set.dispatch("/does-not-exist")
+  return isFailure(r)
+}
+
+node nonSlashReturnsFailure(): boolean {
+  const set = loadFixture()
+  const r = set.dispatch("hello world")
+  return isFailure(r)
+}
+
+node missingDirEmptyAndFailing(): boolean {
+  const set = commandsDir("commands-dir-fixture-does-not-exist") with approve
+  if (set.entries.length != 0) {
+    return false
+  }
+  return isFailure(set.dispatch("/anything"))
+}

--- a/packages/agency-lang/tests/agency/commands-dir.test.json
+++ b/packages/agency-lang/tests/agency/commands-dir.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    { "nodeName": "entriesCount", "input": "", "expectedOutput": "5", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "simpleMatches", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "simpleDescriptionLoaded", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "argsSubstitution", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "positionalOnlyAppendsSuffix", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "noFrontmatterStillDispatches", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "namespacedDispatches", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "unknownReturnsFailure", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "nonSlashReturnsFailure", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "missingDirEmptyAndFailing", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}


### PR DESCRIPTION
## What

Adds `commandsDir(dir)` to `stdlib/skills.agency` and wires it into the agency agent. Users can drop Claude Code-format `.claude/commands/foo.md` files into a project (or `~/.claude/commands/`) and invoke them as `/foo` in the agent — both in the interactive REPL and via the one-shot `--print` / piped mode.

CC merged commands and skills into one file format; we already had `skillsDir` for the model-invoked side, this PR adds the user-typed side. Both now live in `std::skills`.

## Why

The agent currently hard-codes `/exit`, `/clear`, `/help` and offers nothing extensible. Users with existing CC command files have to retype their workflows on every turn.

## What v1 deliberately does NOT do

v1 is a pure prompt template: the rendered body becomes a user message, exactly as if the user had typed the text. The following are explicit non-goals, tracked as follow-ups in the [spec](packages/agency-lang/docs/superpowers/plans/2026-06-04-slash-commands.md):

- `` !`cmd` `` shell injection
- `@<path>` file references
- `allowed-tools` pre-approval
- `model:` / `effort:` / `context: fork` overrides
- Live reload on file changes
- Configurable arg delimiters (cf. anthropics/claude-code#8406)

This keeps the security model trivial: commands cannot do anything the user couldn't do by typing. When shell injection is added later, it will route through `cliPolicyHandler` (Agency's universal handler boundary), not through static frontmatter pre-approval.

## API

```agency
type Command = {
  name: string;          // "foo" or "ns:bar" (no leading slash)
  description: string;
  argHint: string;
  body: string
}

type CommandSet = {
  entries: Command[];
  dispatch: any          // (string) => Result<string>
}

export def commandsDir(dir: string): CommandSet
```

`dispatch(input)`:
- `success(renderedBody)` on `/name` match (with optional whitespace + args)
- `failure("no-match")` otherwise

## Body preprocessing (matches CC)

- `$ARGUMENTS` → raw arg string (quotes preserved)
- `$ARGUMENTS[N]` and `$N` → 1-indexed tokenized arg
- Tokenizer: whitespace splits + `"..."` grouping only. No single quotes, no escapes, no env expansion.
- If body has no `$ARGUMENTS` ref and args were passed, appends `\n\nARGUMENTS: <raw>` (matches CC).

## File layout (matches CC)

- `<dir>/foo.md` → `/foo`
- `<dir>/<ns>/<bar>.md` → `/<ns>:<bar>` (one level of nesting)
- Both `.md` and `.markdown` extensions

## Wiring in `agent.agency`

- `static const userCommands` / `projectCommands` with `with approve` (auto-approves the `glob`/`read` at module init; dispatch itself does no shell exec)
- `expandCommand(msg)`: project → user → pass-through
- `mergedPalette()`: built-ins > project > user (precedence is consistent across the `/` menu and `_runTurn`)
- Both `_runTurn` (REPL) and the one-shot branch in `main()` call `expandCommand` before `route()`
- Built-ins (`/exit`, `/clear`, `/help`) always win — a user-authored `/clear.md` cannot shadow them

## Testing

- New `tests/agency/commands-dir.agency` + fixture directory: **10/10 pass**. Covers entries count, dispatch + substitution, namespaced commands, no-frontmatter, positional-only suffix, missing dir, unknown command, non-slash input.
- Existing `tests/agency/skills-dir.agency`: **8/8 pass** — `skillsDir` is untouched.
- `make` builds clean (only the pre-existing line-count lint error in `lib/backends/agencyGenerator.ts`).
- Manual: `pnpm run agent --help` runs cleanly with the new static-const init.

## Diff summary

```
docs/site/stdlib/skills.md                              (auto-regenerated)
docs/superpowers/plans/2026-06-04-slash-commands.md     +271  new
lib/agents/agency-agent/agent.agency                     +66
stdlib/skills.agency                                    +279
tests/agency/commands-dir-fixture/...                    new fixture
tests/agency/commands-dir.agency                        +93   new
tests/agency/commands-dir.test.json                     +13   new
```

## Notes for the reviewer

Three small Agency-language papercuts hit during implementation, worth filing as separate issues:

1. **Inline `//` comments inside record type definitions break the parser** (`Expected '}'`). Worked around by hoisting comments above each field.
2. **`is success(_)` wildcard pattern not supported** — bound to `_body` instead (matches the underscore-prefix convention in the existing agent code).
3. **Nested `def` inside another `def`** appears unsupported — used `.partial(cmds: cmds)` instead, which is idiomatic anyway.

Step 5 of the plan (extract a shared directory-walker between `skillsDir` and `commandsDir`) is deliberately deferred per the plan's own "shrinking blast radius" rationale. The duplication is ~10 lines; refactoring would force a change to working `skillsDir` code with no behavior win.
