### PR TITLE
Add slash commands to the agency agent (v2)

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -146,3 +146,110 @@ Build a skills tool for an LLM over a directory of skills.
 | layout | `"flat" \| "standard"` | "standard" |
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L95))
+
+### stripFm
+
+```ts
+stripFm(raw: string): string
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| raw | `string` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L144))
+
+### commandsDir
+
+```ts
+commandsDir(dir: string): any[]
+```
+
+Discover .md files under `dir` and parse each as a slash-command
+  template. Returns [] if `dir` is missing or empty.
+
+  @param dir - Directory containing command markdown files. Pass an
+    absolute path (e.g. cwd()/.claude/commands) to anchor at the
+    project root rather than the calling module's directory.
+
+* Discover Claude-Code-format slash commands under `dir`. Each `.md`
+ * file becomes one command record `{ name, description, argHint, body }`.
+ *
+ * Pair with `expandSlash(msg, commands)` in your agent's per-turn
+ * handler:
+ *
+ * ```ts
+ * static const commands = commandsDir("${cwd()}/.claude/commands") with approve
+ * def _runTurn(msg: string) {
+ *   const prompt = expandSlash(msg, commands)
+ *   route(..., prompt)
+ * }
+ * ```
+ *
+ * Only the `description` and `argument-hint` frontmatter fields are
+ * read; all other CC fields (`allowed-tools`, `model`, `effort`,
+ * `context: fork`, `disable-model-invocation`, `user-invocable`,
+ * `hooks`, `paths`, `shell`, ...) are silently ignored. `commandsDir`
+ * is a pure prompt-template loader, not an executor.
+ *
+ * Files with no frontmatter still dispatch — `description` and
+ * `argHint` default to `""` (never null/undefined). Missing or empty
+ * `dir` returns `[]`.
+ *
+ * Relative `dir` resolves against the calling module's directory.
+ * For project-level commands (e.g. `.claude/commands` at the project
+ * root), pass an absolute path: `"${cwd()}/.claude/commands"`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| dir | `string` |  |
+
+**Returns:** `any[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L191))
+
+### expandSlash
+
+```ts
+expandSlash(msg: string, commands: any[]): string
+```
+
+Expand a /command in `msg` using a `commandsDir(...)` result.
+  Returns the rendered command body, or `msg` unchanged if no
+  command matches.
+
+  @param msg - The raw input line (may have leading/trailing whitespace or newlines).
+  @param commands - Array returned by `commandsDir(...)`.
+
+* Expand a user-typed slash command against a `commandsDir` result.
+ *
+ * - If `msg` (after trimming) matches `/<name>` with optional
+ *   whitespace + args, returns the rendered command body with
+ *   `$ARGUMENTS` substituted.
+ * - If the body has no `$ARGUMENTS` token and args were passed,
+ *   appends `\n\nARGUMENTS: <raw>` so the LLM still sees the input
+ *   (matches Claude Code).
+ * - Otherwise returns `msg` unchanged — unknown `/foo` inputs fall
+ *   through to the LLM as plain text, again matching CC.
+ *
+ * Args are split off at the first whitespace (space, tab, or
+ * newline) after `/<name>`. Leading and trailing whitespace on `msg`
+ * are tolerated so piped invocations (`echo /foo | agency agent`,
+ * yielding `"/foo\n"`) dispatch correctly.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| msg | `string` |  |
+| commands | `any[]` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L244))

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-05-slash-commands-v2.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-05-slash-commands-v2.md
@@ -1,0 +1,593 @@
+# Slash Commands v2 — TDD-First, Minimal Implementation
+
+## Why a fresh PR
+
+PR #266 over-engineered this. It built a parallel architecture (new types, dispatch closures, hand-rolled tokenizer, full CC arg-grammar) when the actual requirement is: **read a markdown file from a directory, substitute `$ARGUMENTS`, send the result as a user message.** The right code is a thin wrapper on the existing `skillsDir` pattern.
+
+This plan throws away PR #266 and builds the 55-line version against a test suite that probes the contract, not the happy path.
+
+## Working branch + worktree
+
+- **Throw away** branch `slash-commands` after this PR merges (or close PR #266 without merging).
+- **New branch**: `slash-commands-v2` off latest `main`.
+- **Worktree**: `~/agency-lang/.worktrees/slash-commands-v2`. Use the `using-git-worktrees` skill to set it up.
+- Do **not** copy code from PR #266. Re-read this plan and `stdlib/skills.agency`'s existing `skillsDir`, then write fresh.
+
+## Scope
+
+**In v1:**
+- Read `.md` files under a project-local `.claude/commands/` directory.
+- Substitute `$ARGUMENTS` (the only placeholder).
+- Inject the rendered body as a user message into the current agent thread.
+- Surface command names + descriptions in the `/` palette.
+- Built-in commands (`/exit`, `/clear`, `/help`) take precedence.
+
+**Explicitly out of v1** (and stay out unless someone asks):
+- `$N` / `$ARGUMENTS[N]` positional refs — defer until a real user wants them
+- Namespaced commands (`/ns:scoped`)
+- `.markdown` extension (just `.md`)
+- `!`cmd`` shell injection
+- `@<path>` file references
+- `allowed-tools` / `model` / `effort` / any other frontmatter field besides `description` and `argument-hint`
+- User-level (`~/.claude/commands/`) commands — start with project-only, add user-level if asked
+- Live reload
+
+The fewer surfaces, the fewer bugs. Every deferred feature is a follow-up PR if and only if a real workflow needs it.
+
+## TDD: tests first
+
+Write tests + fixtures before any production code. Run the suite — it should fail to compile (the module under test doesn't exist) or fail loudly (function not found). That's the green light to start implementing.
+
+### File layout
+
+```
+tests/agency/commands-dir-fixture/
+  simple.md
+  with-args.md
+  no-frontmatter.md
+  empty-frontmatter.md
+  description-only.md
+tests/agency/commands-dir.agency
+tests/agency/commands-dir.test.json
+```
+
+### Fixtures
+
+Each fixture body is short enough to assert via `==`. Watch for trailing newlines — `read()` preserves them. Decide one rule and stick to it: **the implementation strips a single trailing `\n` from `body` at load time**, so test assertions never need to think about it.
+
+**`simple.md`** (no args, plain body):
+```
+---
+description: A simple command with no args
+---
+Just say hello.
+```
+Expected loaded `body`: `"Just say hello."` (no trailing newline).
+
+**`with-args.md`** (substitutes `$ARGUMENTS`):
+```
+---
+description: Greet someone
+argument-hint: [name]
+---
+Greet $ARGUMENTS politely.
+```
+Expected for `/with-args alice`: `"Greet alice politely."`
+Expected for `/with-args`: `"Greet  politely."` (empty rawArgs → bare spaces left; this is fine, matches what users would get if they used the placeholder with no arg).
+
+**`no-frontmatter.md`** (whole file is body):
+```
+This file has no frontmatter at all.
+```
+Expected loaded `body`: `"This file has no frontmatter at all."`
+Expected `description`: `""`, `argHint`: `""`.
+
+**`empty-frontmatter.md`** (frontmatter present but no recognized fields — common in real CC files with only `allowed-tools`):
+```
+---
+allowed-tools: Read
+---
+A command that ignores its frontmatter.
+```
+Expected `description`: `""`, `argHint`: `""`. Both are strings, neither is `undefined`.
+
+**`description-only.md`** (verify `argHint` defaults when only `description` is set):
+```
+---
+description: No argument hint here
+---
+Some body.
+```
+Expected `description`: `"No argument hint here"`, `argHint`: `""`.
+
+### Test nodes (`tests/agency/commands-dir.agency`)
+
+Every assertion uses `==` (exact match), not `.includes(...)`. Every node returns a boolean.
+
+```agency
+import { commandsDir, expandSlash } from "std::skills"
+
+def loadFixture() {
+  return commandsDir("commands-dir-fixture") with approve
+}
+
+// ---------- discovery ----------
+
+node entriesCount(): number {
+  return loadFixture().length
+}
+// Expected: 5
+
+node simpleHasDescription(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "simple") {
+      return cmd.description == "A simple command with no args"
+    }
+  }
+  return false
+}
+
+node simpleHasEmptyArgHint(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "simple") {
+      return cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node emptyFrontmatterHasEmptyDefaults(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "empty-frontmatter") {
+      // Critical: must be the EMPTY STRING, never null/undefined.
+      // If undefined leaks through, "${cmd.description}" would render
+      // "undefined" and palette would show "undefined undefined".
+      return cmd.description == "" && cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node noFrontmatterHasEmptyDefaults(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "no-frontmatter") {
+      return cmd.description == "" && cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node descriptionOnlyHasEmptyArgHint(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "description-only") {
+      return cmd.description == "No argument hint here" && cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node missingDirReturnsEmpty(): boolean {
+  const cmds = commandsDir("commands-dir-fixture-does-not-exist") with approve
+  return cmds.length == 0
+}
+
+// ---------- expansion ----------
+// `expandSlash(msg, commands)` returns the rendered body if `msg` is
+// a `/name ...` invocation matching one of `commands`. Otherwise
+// returns `msg` unchanged.
+
+node simpleExpandsToBody(): boolean {
+  const out = expandSlash("/simple", loadFixture())
+  return out == "Just say hello."
+}
+
+node withArgsSubstitutes(): boolean {
+  const out = expandSlash("/with-args alice", loadFixture())
+  return out == "Greet alice politely."
+}
+
+node withArgsMultiArgRawString(): boolean {
+  // $ARGUMENTS gets the whole raw string verbatim, including any quoting.
+  const out = expandSlash(`/with-args "alice the great" bob`, loadFixture())
+  return out == `Greet "alice the great" bob politely.`
+}
+
+node noArgsCommandIgnoresExtraText(): boolean {
+  // /simple has no $ARGUMENTS placeholder. Passing args should NOT
+  // mangle the body; CC behavior is to append `\n\nARGUMENTS: <raw>`
+  // so the LLM can still see the args.
+  const out = expandSlash("/simple extra stuff", loadFixture())
+  return out == "Just say hello.\n\nARGUMENTS: extra stuff"
+}
+
+node noArgsCommandNoSuffixIfNoArgs(): boolean {
+  // /simple invoked with no args → body unchanged, no suffix.
+  const out = expandSlash("/simple", loadFixture())
+  return out == "Just say hello."
+}
+
+node unknownCommandReturnsLiteral(): boolean {
+  // Unknown /foo → pass through to the LLM verbatim. CC does the same.
+  const out = expandSlash("/does-not-exist arg", loadFixture())
+  return out == "/does-not-exist arg"
+}
+
+node nonSlashReturnsLiteral(): boolean {
+  const out = expandSlash("hello world", loadFixture())
+  return out == "hello world"
+}
+
+node emptyInputReturnsLiteral(): boolean {
+  const out = expandSlash("", loadFixture())
+  return out == ""
+}
+
+// ---------- whitespace tolerance ----------
+
+node trailingNewlineDispatches(): boolean {
+  // Piped stdin (`echo /simple | agency agent`) yields "/simple\n".
+  // Must still match.
+  const out = expandSlash("/simple\n", loadFixture())
+  return out == "Just say hello."
+}
+
+node leadingWhitespaceDispatches(): boolean {
+  const out = expandSlash("  /simple", loadFixture())
+  return out == "Just say hello."
+}
+
+node trailingWhitespaceDispatches(): boolean {
+  const out = expandSlash("/simple   ", loadFixture())
+  return out == "Just say hello."
+}
+
+node tabDelimitsArgs(): boolean {
+  // Tab between command and arg should work the same as space.
+  const out = expandSlash("/with-args\talice", loadFixture())
+  return out == "Greet alice politely."
+}
+
+// ---------- defensive contract ----------
+
+node descriptionsAreStringsNotUndefined(): boolean {
+  // Every entry's description and argHint MUST be a string. This is
+  // the contract that prevents the "undefined undefined" palette bug.
+  for (cmd in loadFixture()) {
+    if (cmd.description == null) { return false }
+    if (cmd.argHint == null) { return false }
+  }
+  return true
+}
+```
+
+### Test runner JSON (`commands-dir.test.json`)
+
+One entry per node above. All `expectedOutput` are `"true"` except `entriesCount` which is `"5"`.
+
+### What these tests catch
+
+| Test | Bug it catches |
+|------|----------------|
+| `entriesCount` | regression in discovery |
+| `simpleHasDescription` / `simpleHasEmptyArgHint` | frontmatter not parsed |
+| `emptyFrontmatterHasEmptyDefaults` | **undefined leaks into palette (E2)** |
+| `noFrontmatterHasEmptyDefaults` | crash on missing frontmatter |
+| `descriptionOnlyHasEmptyArgHint` | argHint default broken |
+| `missingDirReturnsEmpty` | crash on missing dir |
+| `simpleExpandsToBody` | trailing-newline handling broken |
+| `withArgsSubstitutes` | `$ARGUMENTS` substitution broken |
+| `withArgsMultiArgRawString` | raw-string preservation broken |
+| `noArgsCommandIgnoresExtraText` | CC-compatible suffix fallback broken |
+| `noArgsCommandNoSuffixIfNoArgs` | suffix appended when it shouldn't be |
+| `unknownCommandReturnsLiteral` | unknown command swallowed |
+| `nonSlashReturnsLiteral` / `emptyInputReturnsLiteral` | non-command input mangled |
+| `trailingNewlineDispatches` | **piped stdin broken (C3)** |
+| `leadingWhitespaceDispatches` / `trailingWhitespaceDispatches` | whitespace intolerance |
+| `tabDelimitsArgs` | tab not accepted as delimiter |
+| `descriptionsAreStringsNotUndefined` | **undefined contract violation (E2)** |
+
+### What's deliberately NOT tested
+
+- `$N` / `$ARGUMENTS[N]` — not implemented
+- Namespaced commands — not implemented
+- `.markdown` extension — not implemented
+- Shell injection / file refs — not implemented
+- Anything in `agent.agency` — covered by manual smoke test only (one-time integration check, not an ongoing test)
+
+If a deferred feature lands later, its tests come with it.
+
+## Implementation plan
+
+After all tests are red, implement against them.
+
+### Step 1 — `commandsDir` in `stdlib/skills.agency`
+
+Add **one** exported function and **one** exported expander. Mimic the shape of `skillsDir`. No new types.
+
+```agency
+/**
+ * Discover slash commands under `dir`. Each `.md` file becomes one
+ * command. Returns an array of `{ name, description, argHint, body }`
+ * records. Files with no frontmatter still dispatch — `description`
+ * and `argHint` default to "".
+ *
+ * Use with `expandSlash(msg, commandsDir(dir))` in your agent's
+ * per-turn handler to expand `/myCommand args` into the rendered
+ * body before passing it to the LLM.
+ *
+ * Defers to Claude Code's `.claude/commands/` format. Only the
+ * `description` and `argument-hint` frontmatter fields are read;
+ * `allowed-tools`, `model`, etc. are ignored — `commandsDir` is a
+ * pure prompt-template loader, not an executor.
+ *
+ * @param dir - Directory containing .md command files (absolute path
+ *   recommended; relative paths resolve against the calling module's
+ *   directory, which is rarely what you want for project-level
+ *   commands).
+ */
+export def commandsDir(dir: string): any[] {
+  """
+  Discover .md files under `dir` and parse each as a slash-command
+  template. Returns [] if `dir` is missing or empty.
+
+  @param dir - Directory containing command markdown files.
+  """
+  const pathsResult = glob("*.md", dir)
+  if (!(pathsResult is success(paths))) {
+    return []
+  }
+  return map(paths) as p {
+    const raw = read(p, dir) catch ""
+    const fm = frontmatter(raw) catch null
+    return {
+      name: p.replace(".md", ""),
+      description: (fm != null && fm.description != null) ? "${fm.description}" : "",
+      argHint: (fm != null && fm["argument-hint"] != null) ? "${fm["argument-hint"]}" : "",
+      body: stripFm(raw)
+    }
+  }
+}
+```
+
+`stripFm(raw)` is a private helper, **3 lines max**:
+
+```agency
+def stripFm(raw: string): string {
+  // No frontmatter → whole file (less one trailing \n).
+  if (!raw.startsWith("---\n")) {
+    return raw.endsWith("\n") ? raw.slice(0, raw.length - 1) : raw
+  }
+  // Frontmatter present → everything after the closing `---\n`.
+  const idx = raw.indexOf("\n---\n", 4)
+  if (idx == -1) { return "" }
+  let body = raw.slice(idx + 5)
+  if (body.startsWith("\n")) { body = body.slice(1) }
+  if (body.endsWith("\n")) { body = body.slice(0, body.length - 1) }
+  return body
+}
+```
+
+That's it. No `splitFrontmatter`, no `loadCommand`, no `Command` type. Just a function returning an array of records.
+
+### Step 2 — `expandSlash` in `stdlib/skills.agency`
+
+```agency
+/**
+ * Expand a user-typed slash command against a `commandsDir` result.
+ * Returns the rendered command body when `msg` matches `/<name>`
+ * (with optional whitespace + args). Returns `msg` verbatim
+ * otherwise — unknown commands fall through to the LLM as plain text.
+ *
+ * Substitutes the literal `$ARGUMENTS` token in the body with the
+ * raw arg string (quotes preserved). If the body has no `$ARGUMENTS`
+ * token and args were passed, appends `\n\nARGUMENTS: <raw>` so the
+ * LLM still sees the input. Matches Claude Code.
+ *
+ * @param msg - The raw input line (e.g. "/foo bar baz\n").
+ * @param commands - Result of `commandsDir(...)`.
+ */
+export def expandSlash(msg: string, commands: any[]): string {
+  const trimmed = msg.trim()
+  if (!trimmed.startsWith("/")) { return msg }
+  // Split on first run of whitespace.
+  let nameEnd = trimmed.length
+  let i = 1
+  while (i < trimmed.length) {
+    const c = trimmed[i]
+    if (c == " " || c == "\t" || c == "\n") {
+      nameEnd = i
+      break
+    }
+    i = i + 1
+  }
+  const name = trimmed.slice(1, nameEnd)
+  const rawArgs = nameEnd == trimmed.length ? "" : trimmed.slice(nameEnd + 1).trim()
+  for (cmd in commands) {
+    if (cmd.name == name) {
+      let out = cmd.body.replaceAll("$ARGUMENTS", rawArgs)
+      if (!cmd.body.includes("$ARGUMENTS") && rawArgs != "") {
+        out = out + "\n\nARGUMENTS: ${rawArgs}"
+      }
+      return out
+    }
+  }
+  return msg
+}
+```
+
+That's the whole substitution logic. `$ARGUMENTS` → rawArgs via `replaceAll`. No tokenizer. No `$N`. No `$ARGUMENTS[N]`. ~20 lines including comments.
+
+### Step 3 — wire into `lib/agents/agency-agent/agent.agency`
+
+Minimal changes:
+
+```agency
+import { commandsDir, expandSlash } from "std::skills"
+import { cwd, env, isTTY, readStdin } from "std::system"
+
+// ... existing code ...
+
+// Load commands from the project's .claude/commands/ directory.
+// Absolute path via cwd() because Agency resolves relative dirs
+// against the agent's source directory, not the user's project.
+static const projectCommands = commandsDir("${cwd()}/.claude/commands") with approve
+
+def builtinPalette(): Record<string, string> {
+  return {
+    "/exit":  "Exit the agent",
+    "/clear": "Clear the conversation transcript",
+    "/help":  "Show available slash commands"
+  }
+}
+
+def mergedPalette(): Record<string, string> {
+  let out: Record<string, string> = {}
+  for (cmd in projectCommands) {
+    const label = cmd.argHint == "" ? cmd.description : "${cmd.description} ${cmd.argHint}"
+    out["/${cmd.name}"] = label
+  }
+  const builtins = builtinPalette()
+  for (key in builtins) {
+    out[key] = builtins[key]
+  }
+  return out
+}
+
+def _runTurn(msg: string): boolean {
+  // built-ins win
+  if (msg == "/exit" || msg == "/quit") { return false }
+  if (msg == "/clear") { clearMessages(); return true }
+  if (msg == "/help")  { pushMessage("Commands: /exit, /clear, /help"); return true }
+
+  const prompt = expandSlash(msg, projectCommands)
+  // ... existing route() call using `prompt` instead of `msg` ...
+}
+```
+
+And in the one-shot `main()` branch, before the `route()` call:
+```agency
+const onePrompt = expandSlash(piped, projectCommands)
+// ... use onePrompt instead of piped ...
+```
+
+Update `repl(...)` to use `paletteCommands: mergedPalette()`.
+
+That's the entire agent wiring. ~25 lines added.
+
+### Step 4 — `cwd()` at module-init check
+
+`static const` runs at load time. Verify `cwd()` is callable that early. If it isn't:
+
+- Move `projectCommands` into `main()` as a `let projectCommands` declared before the REPL/one-shot branches.
+- Pass it explicitly to `_runTurn` (or capture via a module-level mutable, ugly but works).
+- Update `mergedPalette` to take `projectCommands` as a parameter.
+
+If `cwd()` works at static-const time, keep the cleaner shape.
+
+### Step 5 — manual smoke test
+
+```bash
+mkdir -p /tmp/cmd-smoke/.claude/commands
+cat > /tmp/cmd-smoke/.claude/commands/echo.md <<'EOF'
+---
+description: Echo back the args
+---
+Please repeat this verbatim: $ARGUMENTS
+EOF
+cd /tmp/cmd-smoke
+pnpm --prefix ~/agency-lang/.worktrees/slash-commands-v2/packages/agency-lang run agent -p '/echo hello'
+```
+
+Confirm the LLM receives `Please repeat this verbatim: hello`, not `/echo hello`.
+
+## What to do — checklist
+
+- [ ] Set up `~/agency-lang/.worktrees/slash-commands-v2` worktree off `main`
+- [ ] Write all fixtures listed under "Fixtures"
+- [ ] Write `tests/agency/commands-dir.agency` with all nodes listed under "Test nodes"
+- [ ] Write `tests/agency/commands-dir.test.json` mapping every node
+- [ ] Run `pnpm run agency test tests/agency/commands-dir.agency > /tmp/red.txt 2>&1` — confirm all tests fail (function doesn't exist)
+- [ ] Implement `stripFm`, `commandsDir`, `expandSlash` in `stdlib/skills.agency`
+- [ ] Run tests, save output. Iterate until **every** test green
+- [ ] Run `pnpm run agency test tests/agency/skills-dir.agency` — confirm no regression
+- [ ] Wire `commandsDir` + `expandSlash` into `lib/agents/agency-agent/agent.agency` per Step 3
+- [ ] `make` — clean build
+- [ ] Manual smoke test per Step 5
+- [ ] Commit. **Stop and ask the user** before pushing.
+
+## What NOT to do
+
+- **Don't** create a `Command` type or `CommandSet` type. The record is structural. Agency's `any[]` is fine here.
+- **Don't** write a tokenizer. There is no `$N`, no `$ARGUMENTS[N]`, no quoted-arg tokenization. Just `replaceAll("$ARGUMENTS", rawArgs)`.
+- **Don't** create a `dispatch` closure on a record. Use `expandSlash(msg, commands)` as a free function.
+- **Don't** add `.partial(...)` gymnastics to make a closure work. Free functions need no partial application.
+- **Don't** write a custom frontmatter parser. Use `std::markdown.frontmatter`.
+- **Don't** support `.markdown` until someone asks. Only `.md`.
+- **Don't** support namespaced commands (`/ns:scoped`) until someone asks.
+- **Don't** support user-level (`~/.claude/commands`) commands until someone asks. Project-only for v1.
+- **Don't** support `!`cmd`` shell injection. Not in v1, not as a stub.
+- **Don't** support `@<path>` file references.
+- **Don't** support `allowed-tools` / `model` / `effort` / any frontmatter field besides `description` / `argument-hint`.
+- **Don't** add live-reload of files.
+- **Don't** parse frontmatter beyond what's needed for `description` and `argument-hint`.
+- **Don't** define helper functions you only call once. Inline them.
+- **Don't** define helper types. Records are structural.
+- **Don't** assert with `.includes(...)` in tests. Always `==`.
+- **Don't** add tests for behavior you didn't implement. The deferred features get their tests with their PRs.
+- **Don't** spend more than 30 minutes implementing the production code. If it's taking longer, you're over-engineering — re-read this plan.
+- **Don't** commit before all tests green.
+- **Don't** push without explicit user approval.
+
+## Expected line counts
+
+| File | Lines added |
+|------|-------------|
+| `stdlib/skills.agency` | ~50 (commandsDir 15, expandSlash 25, stripFm 10) |
+| `lib/agents/agency-agent/agent.agency` | ~25 (static const + mergedPalette + 3 lines in _runTurn + 2 in main) |
+| `tests/agency/commands-dir.agency` | ~120 (19 nodes) |
+| `tests/agency/commands-dir.test.json` | ~25 |
+| `tests/agency/commands-dir-fixture/*.md` | ~25 (5 small fixtures) |
+| **Total production code** | **~75 lines** |
+| **Total test code** | **~170 lines** |
+
+PR #266 was ~580 lines production + tests. If v2 grows past ~250 lines total, stop and figure out what's being over-built.
+
+## Commit + PR
+
+One commit, one PR, clean diff. Suggested message (write to `/tmp/commit.txt`, never inline on the CLI per AGENTS.md):
+
+```
+Add slash commands to the agency agent (v2)
+
+`commandsDir(dir)` discovers `.md` files in a directory and returns
+records with `name`, `description`, `argHint`, `body`.
+
+`expandSlash(msg, commands)` substitutes `$ARGUMENTS` in the matched
+command's body. Unknown `/foo` inputs pass through to the LLM
+unchanged, matching Claude Code.
+
+Wired into the agency agent's REPL and one-shot paths. Project-local
+`.claude/commands/foo.md` becomes `/foo` in the agent. Built-ins
+(`/exit`, `/clear`, `/help`) win over file commands.
+
+v1 is intentionally a pure prompt-template loader: no shell
+injection, no `$N` positional refs, no namespaced commands, no
+`allowed-tools` pre-approval. Each of those is a follow-up PR if
+someone needs them.
+
+19 execution tests, all assertions exact-equality. Replaces PR #266
+(closed unmerged) with a minimal implementation.
+```
+
+PR description should list every deferred feature explicitly, so reviewers see what's left out and don't ask about it.
+
+## Risk register
+
+- **`cwd()` at module init may not work.** Mitigation: Step 4. If it fails, fall back to per-`main()` init.
+- **`raw.startsWith("---\n")` may miss CRLF line endings** if a Windows-edited file is dropped in. Mitigation: optional — strip `\r` from `raw` before any parsing. Add only if a test breaks.
+- **Empty `$ARGUMENTS` substitution leaves double spaces** like `"Greet  politely."`. Mitigation: this is acceptable v1 behavior — matches what CC produces — but document it in the docstring.
+- **`replaceAll("$ARGUMENTS", rawArgs)` substitutes literal `$ARGUMENTS` anywhere in the body**, including inside code blocks. This is consistent with CC and is the contract. Don't try to be clever about escaping.
+
+## When you're tempted to add abstraction
+
+Re-read this plan section. Every helper / type / wrapper you're about to add: is there a test that would fail without it? If not, don't add it.

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -227,17 +227,23 @@ def mergedPalette(): Record<string, string> {
 // Slash-command + user-message dispatcher invoked by `repl()` for
 // every Enter keystroke. Return `false` to terminate the loop.
 def _runTurn(msg: string): boolean {
-  if (msg == "") {
+  // Trim once for built-in matching so `"/help\n"` (piped) or
+  // `"  /clear"` behave the same as `"/clear"`. `expandSlash` is
+  // whitespace-tolerant in its own right, but it still receives the
+  // raw `msg` so the LLM sees the exact text the user typed when
+  // nothing matches.
+  const trimmed = msg.trim()
+  if (trimmed == "") {
     return true
   }
-  if (msg == "/exit" || msg == "/quit") {
+  if (trimmed == "/exit" || trimmed == "/quit") {
     return false
   }
-  if (msg == "/clear") {
+  if (trimmed == "/clear") {
     clearMessages()
     return true
   }
-  if (msg == "/help") {
+  if (trimmed == "/help") {
     pushMessage("Commands: /exit, /clear, /help")
     return true
   }

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -6,6 +6,7 @@ import { today } from "std::date"
 import { box, render } from "std::layout"
 import { ScopedRuleFields, cliPolicyHandler } from "std::policy"
 import { exists } from "std::shell"
+import { commandsDir, expandSlash } from "std::skills"
 import { highlight } from "std::syntax"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
 import { getCost } from "std::thread"
@@ -191,6 +192,38 @@ def loadAgentsMd(dir: string): string {
 // LLM doesn't have to re-ground each turn. Initialized in `main()`.
 let _context: string = ""
 
+// Project-local slash commands. `cwd()` works at module-init time so
+// we anchor at the user's project root (not the agent's source dir).
+// `with approve` auto-approves the `glob`/`read` during init — the
+// user implicitly opted in by running the agent in this directory.
+static const projectCommands = commandsDir("${cwd()}/.claude/commands") with approve
+
+def builtinPalette(): Record<string, string> {
+  return {
+    "/exit":  "Exit the agent",
+    "/clear": "Clear the conversation transcript",
+    "/help":  "Show available slash commands"
+  }
+}
+
+// Built-ins win over file commands so a user `/clear.md` can't shadow
+// the built-in `/clear`. Build file entries first, then overlay builtins.
+def mergedPalette(): Record<string, string> {
+  let out: Record<string, string> = {}
+  for (cmd in projectCommands) {
+    let label = cmd.description
+    if (cmd.argHint != "") {
+      label = "${cmd.description} ${cmd.argHint}"
+    }
+    out["/${cmd.name}"] = label
+  }
+  const builtins = builtinPalette()
+  for (key in builtins) {
+    out[key] = builtins[key]
+  }
+  return out
+}
+
 // Slash-command + user-message dispatcher invoked by `repl()` for
 // every Enter keystroke. Return `false` to terminate the loop.
 def _runTurn(msg: string): boolean {
@@ -208,6 +241,9 @@ def _runTurn(msg: string): boolean {
     pushMessage("Commands: /exit, /clear, /help")
     return true
   }
+  // Expand `/foo args` to the rendered command body. Unknown `/foo`
+  // inputs fall through unchanged — matches Claude Code.
+  const prompt = expandSlash(msg, projectCommands)
   const reply = route(
     {
     start: "code",
@@ -226,7 +262,7 @@ def _runTurn(msg: string): boolean {
     maxHops: 3,
     context: _context
   },
-    msg,
+    prompt,
   )
   pushMessage(highlight("${reply}\n", language: "markdown"))
   return true
@@ -341,6 +377,11 @@ node main() {
       fields: ALWAYS_FIELDS
     },
     )
+    // Expand slash commands in one-shot mode too, so
+    // `agency agent -p /foo bar` works the same as typing it in the
+    // REPL. Built-ins (`/exit` etc.) are meaningless without a loop
+    // and aren't checked.
+    const onePrompt = expandSlash(piped, projectCommands)
     handle {
       const reply = route(
         {
@@ -360,7 +401,7 @@ node main() {
         maxHops: 3,
         context: _context
       },
-        piped,
+        onePrompt,
       )
       print(reply)
     } with handler
@@ -397,11 +438,7 @@ node main() {
       prompt: "> ",
       historyFile: historyPath(),
       historyMax: 1000,
-      paletteCommands: {
-      "/exit": "Exit the agent",
-      "/clear": "Clear the conversation transcript",
-      "/help": "Show available slash commands"
-    },
+      paletteCommands: mergedPalette(),
     )
   } with handler
 

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -121,3 +121,163 @@ export def skillsDir(dir: string, layout: "flat" | "standard" = "standard") {
   const description = header + lines.join("\n") + footer
   return read.partial(dir: dir).describe(description)
 }
+
+// ============================================================
+// Slash commands
+// ============================================================
+//
+// `commandsDir(dir)` + `expandSlash(msg, commands)` are the
+// command-flavored sibling of `skillsDir`. CC merged custom commands
+// and skills into one file format; we surface both halves from this
+// module.
+//
+// A command is a pure prompt template: the rendered body is the user
+// message. No shell injection, no `$N` positional refs (only
+// `$ARGUMENTS`), no `allowed-tools` pre-approval. Deferred features
+// are tracked in `docs/superpowers/plans/2026-06-05-slash-commands-v2.md`.
+
+// Strip frontmatter + a single trailing newline. Three cases:
+//   - No frontmatter (`---\n` not at start) → return raw less trailing \n
+//   - Frontmatter with no closing fence → return ""
+//   - Frontmatter with closing fence → return everything after, less
+//     trailing \n
+def stripFm(raw: string): string {
+  if (!raw.startsWith("---\n")) {
+    if (raw.endsWith("\n")) {
+      return raw.slice(0, raw.length - 1)
+    }
+    return raw
+  }
+  const idx = raw.indexOf("\n---\n", 4)
+  if (idx == -1) {
+    return ""
+  }
+  let body = raw.slice(idx + 5)
+  if (body.endsWith("\n")) {
+    body = body.slice(0, body.length - 1)
+  }
+  return body
+}
+
+/**
+ * Discover Claude-Code-format slash commands under `dir`. Each `.md`
+ * file becomes one command record `{ name, description, argHint, body }`.
+ *
+ * Pair with `expandSlash(msg, commands)` in your agent's per-turn
+ * handler:
+ *
+ * ```ts
+ * static const commands = commandsDir("${cwd()}/.claude/commands") with approve
+ * def _runTurn(msg: string) {
+ *   const prompt = expandSlash(msg, commands)
+ *   route(..., prompt)
+ * }
+ * ```
+ *
+ * Only the `description` and `argument-hint` frontmatter fields are
+ * read; all other CC fields (`allowed-tools`, `model`, `effort`,
+ * `context: fork`, `disable-model-invocation`, `user-invocable`,
+ * `hooks`, `paths`, `shell`, ...) are silently ignored. `commandsDir`
+ * is a pure prompt-template loader, not an executor.
+ *
+ * Files with no frontmatter still dispatch — `description` and
+ * `argHint` default to `""` (never null/undefined). Missing or empty
+ * `dir` returns `[]`.
+ *
+ * Relative `dir` resolves against the calling module's directory.
+ * For project-level commands (e.g. `.claude/commands` at the project
+ * root), pass an absolute path: `"${cwd()}/.claude/commands"`.
+ */
+export def commandsDir(dir: string): any[] {
+  """
+  Discover .md files under `dir` and parse each as a slash-command
+  template. Returns [] if `dir` is missing or empty.
+
+  @param dir - Directory containing command markdown files. Pass an
+    absolute path (e.g. cwd()/.claude/commands) to anchor at the
+    project root rather than the calling module's directory.
+  """
+  const pathsResult = glob("*.md", dir)
+  if (pathsResult is success(paths)) {
+    return map(paths) as p {
+      const raw = read(p, dir) catch ""
+      // `catch {}` collapses parse failures + a missing frontmatter
+      // block to an empty object so the dot access below is safe.
+      const fm = frontmatter(raw) catch {}
+      // `?? ""` is required here: in Agency `undefined == null` is
+      // false, so the older `!= null` guard let `undefined` through
+      // and stringified it as `"undefined"`. `??` treats both nullish.
+      const descriptionRaw = fm.description ?? ""
+      const argHintRaw = fm["argument-hint"] ?? ""
+      let name = p
+      if (name.endsWith(".md")) {
+        name = name.slice(0, name.length - 3)
+      }
+      return {
+        name: name,
+        description: "${descriptionRaw}",
+        argHint: "${argHintRaw}",
+        body: stripFm(raw)
+      }
+    }
+  }
+  return []
+}
+
+/**
+ * Expand a user-typed slash command against a `commandsDir` result.
+ *
+ * - If `msg` (after trimming) matches `/<name>` with optional
+ *   whitespace + args, returns the rendered command body with
+ *   `$ARGUMENTS` substituted.
+ * - If the body has no `$ARGUMENTS` token and args were passed,
+ *   appends `\n\nARGUMENTS: <raw>` so the LLM still sees the input
+ *   (matches Claude Code).
+ * - Otherwise returns `msg` unchanged — unknown `/foo` inputs fall
+ *   through to the LLM as plain text, again matching CC.
+ *
+ * Args are split off at the first whitespace (space, tab, or
+ * newline) after `/<name>`. Leading and trailing whitespace on `msg`
+ * are tolerated so piped invocations (`echo /foo | agency agent`,
+ * yielding `"/foo\n"`) dispatch correctly.
+ */
+export def expandSlash(msg: string, commands: any[]): string {
+  """
+  Expand a /command in `msg` using a `commandsDir(...)` result.
+  Returns the rendered command body, or `msg` unchanged if no
+  command matches.
+
+  @param msg - The raw input line (may have leading/trailing whitespace or newlines).
+  @param commands - Array returned by `commandsDir(...)`.
+  """
+  const trimmed = msg.trim()
+  if (!trimmed.startsWith("/")) {
+    return msg
+  }
+  let nameEnd = trimmed.length
+  let i = 1
+  while (i < trimmed.length) {
+    const c = trimmed[i]
+    if (c == " " || c == "\t" || c == "\n") {
+      nameEnd = i
+      i = trimmed.length
+    } else {
+      i = i + 1
+    }
+  }
+  const name = trimmed.slice(1, nameEnd)
+  let rawArgs = ""
+  if (nameEnd < trimmed.length) {
+    rawArgs = trimmed.slice(nameEnd + 1).trim()
+  }
+  for (cmd in commands) {
+    if (cmd.name == name) {
+      let out = cmd.body.replaceAll("$ARGUMENTS", rawArgs)
+      if (!cmd.body.includes("$ARGUMENTS") && rawArgs != "") {
+        out = out + "\n\nARGUMENTS: ${rawArgs}"
+      }
+      return out
+    }
+  }
+  return msg
+}

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/description-only.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/description-only.md
@@ -1,0 +1,4 @@
+---
+description: No argument hint here
+---
+Some body.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/empty-frontmatter.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/empty-frontmatter.md
@@ -1,0 +1,4 @@
+---
+allowed-tools: Read
+---
+A command that ignores its frontmatter.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/frontmatter-only.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/frontmatter-only.md
@@ -1,0 +1,3 @@
+---
+description: All frontmatter, no body
+---

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/multi-args.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/multi-args.md
@@ -1,0 +1,4 @@
+---
+description: Substitutes $ARGUMENTS twice
+---
+First $ARGUMENTS, then $ARGUMENTS again.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/multiline.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/multiline.md
@@ -1,0 +1,6 @@
+---
+description: A multi-line body
+---
+Line 1
+Line 2
+Line 3

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/no-frontmatter.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/no-frontmatter.md
@@ -1,0 +1,1 @@
+This file has no frontmatter at all.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/simple.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/simple.md
@@ -1,0 +1,4 @@
+---
+description: A simple command with no args
+---
+Just say hello.

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/unclosed-frontmatter.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/unclosed-frontmatter.md
@@ -1,0 +1,3 @@
+---
+description: Never closed
+this looks like a body but the frontmatter was never closed

--- a/packages/agency-lang/tests/agency/commands-dir-fixture/with-args.md
+++ b/packages/agency-lang/tests/agency/commands-dir-fixture/with-args.md
@@ -1,0 +1,5 @@
+---
+description: Greet someone
+argument-hint: [name]
+---
+Greet $ARGUMENTS politely.

--- a/packages/agency-lang/tests/agency/commands-dir.agency
+++ b/packages/agency-lang/tests/agency/commands-dir.agency
@@ -10,6 +10,41 @@ node entriesCount(): number {
   return loadFixture().length
 }
 
+node multilineBodyPreserved(): boolean {
+  // stripFm must strip exactly one trailing newline — no more, no
+  // less. If it regresses to "return first line" or "strip everything
+  // after the last newline", this test fails. Single-line fixtures
+  // can't catch that class of bug.
+  for (cmd in loadFixture()) {
+    if (cmd.name == "multiline") {
+      return cmd.body == "Line 1\nLine 2\nLine 3"
+    }
+  }
+  return false
+}
+
+node frontmatterOnlyBodyIsEmpty(): boolean {
+  // A file that's all frontmatter and no body should yield body "".
+  for (cmd in loadFixture()) {
+    if (cmd.name == "frontmatter-only") {
+      return cmd.body == ""
+    }
+  }
+  return false
+}
+
+node unclosedFrontmatterBodyIsEmpty(): boolean {
+  // stripFm contract: unclosed frontmatter → "". Don't try to recover
+  // the malformed file as a body — silently treating malformed input
+  // as valid would mask template-author bugs.
+  for (cmd in loadFixture()) {
+    if (cmd.name == "unclosed-frontmatter") {
+      return cmd.body == ""
+    }
+  }
+  return false
+}
+
 node simpleHasDescription(): boolean {
   for (cmd in loadFixture()) {
     if (cmd.name == "simple") {
@@ -80,6 +115,22 @@ node withArgsMultiArgRawString(): boolean {
   return out == `Greet "alice the great" bob politely.`
 }
 
+node multipleArgumentsTokensAllReplaced(): boolean {
+  // `replaceAll`, not `replace`. If this regresses to single-shot
+  // `replace`, the second `$ARGUMENTS` survives literally and this
+  // test fails. Single-token fixtures can't catch that.
+  const out = expandSlash("/multi-args hello", loadFixture())
+  return out == "First hello, then hello again."
+}
+
+node argumentsTokenEmptyRawArgsSubstitutesEmpty(): boolean {
+  // Documented v1 behavior: empty rawArgs leaves a bare space where
+  // `$ARGUMENTS` was. Locking this in so a future "be clever about
+  // whitespace" tweak doesn't silently break the CC contract.
+  const out = expandSlash("/with-args", loadFixture())
+  return out == "Greet  politely."
+}
+
 node noArgsCommandIgnoresExtraText(): boolean {
   // /simple has no $ARGUMENTS placeholder. Passing args should append
   // `\n\nARGUMENTS: <raw>` so the LLM still sees them. Matches CC.
@@ -132,9 +183,17 @@ node tabDelimitsArgs(): boolean {
 // ---------- defensive contract ----------
 
 node descriptionsAreStringsNotUndefined(): boolean {
+  // Catches the undefined-leak contract by stringifying. If `cmd.argHint`
+  // is `undefined`, `"${cmd.argHint}"` renders `"undefined"` — which is
+  // exactly the bug that produced "undefined undefined" entries in the
+  // palette before the `?? ""` fix in stdlib/skills.agency. A bare
+  // `== null` check would NOT catch this (in Agency `undefined == null`
+  // is false), so don't be tempted to "simplify" it.
   for (cmd in loadFixture()) {
-    if (cmd.description == null) { return false }
-    if (cmd.argHint == null) { return false }
+    if ("${cmd.description}" == "undefined") { return false }
+    if ("${cmd.argHint}" == "undefined") { return false }
+    if ("${cmd.description}" == "null") { return false }
+    if ("${cmd.argHint}" == "null") { return false }
   }
   return true
 }

--- a/packages/agency-lang/tests/agency/commands-dir.agency
+++ b/packages/agency-lang/tests/agency/commands-dir.agency
@@ -1,0 +1,140 @@
+import { commandsDir, expandSlash } from "std::skills"
+
+def loadFixture() {
+  return commandsDir("commands-dir-fixture") with approve
+}
+
+// ---------- discovery ----------
+
+node entriesCount(): number {
+  return loadFixture().length
+}
+
+node simpleHasDescription(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "simple") {
+      return cmd.description == "A simple command with no args"
+    }
+  }
+  return false
+}
+
+node simpleHasEmptyArgHint(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "simple") {
+      return cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node emptyFrontmatterHasEmptyDefaults(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "empty-frontmatter") {
+      // Critical: must be the EMPTY STRING, never null/undefined.
+      // If undefined leaks through, "${cmd.description}" would render
+      // "undefined" and palette would show "undefined undefined".
+      return cmd.description == "" && cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node noFrontmatterHasEmptyDefaults(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "no-frontmatter") {
+      return cmd.description == "" && cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node descriptionOnlyHasEmptyArgHint(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.name == "description-only") {
+      return cmd.description == "No argument hint here" && cmd.argHint == ""
+    }
+  }
+  return false
+}
+
+node missingDirReturnsEmpty(): boolean {
+  const cmds = commandsDir("commands-dir-fixture-does-not-exist") with approve
+  return cmds.length == 0
+}
+
+// ---------- expansion ----------
+
+node simpleExpandsToBody(): boolean {
+  const out = expandSlash("/simple", loadFixture())
+  return out == "Just say hello."
+}
+
+node withArgsSubstitutes(): boolean {
+  const out = expandSlash("/with-args alice", loadFixture())
+  return out == "Greet alice politely."
+}
+
+node withArgsMultiArgRawString(): boolean {
+  const out = expandSlash(`/with-args "alice the great" bob`, loadFixture())
+  return out == `Greet "alice the great" bob politely.`
+}
+
+node noArgsCommandIgnoresExtraText(): boolean {
+  // /simple has no $ARGUMENTS placeholder. Passing args should append
+  // `\n\nARGUMENTS: <raw>` so the LLM still sees them. Matches CC.
+  const out = expandSlash("/simple extra stuff", loadFixture())
+  return out == "Just say hello.\n\nARGUMENTS: extra stuff"
+}
+
+node noArgsCommandNoSuffixIfNoArgs(): boolean {
+  const out = expandSlash("/simple", loadFixture())
+  return out == "Just say hello."
+}
+
+node unknownCommandReturnsLiteral(): boolean {
+  const out = expandSlash("/does-not-exist arg", loadFixture())
+  return out == "/does-not-exist arg"
+}
+
+node nonSlashReturnsLiteral(): boolean {
+  const out = expandSlash("hello world", loadFixture())
+  return out == "hello world"
+}
+
+node emptyInputReturnsLiteral(): boolean {
+  const out = expandSlash("", loadFixture())
+  return out == ""
+}
+
+// ---------- whitespace tolerance ----------
+
+node trailingNewlineDispatches(): boolean {
+  const out = expandSlash("/simple\n", loadFixture())
+  return out == "Just say hello."
+}
+
+node leadingWhitespaceDispatches(): boolean {
+  const out = expandSlash("  /simple", loadFixture())
+  return out == "Just say hello."
+}
+
+node trailingWhitespaceDispatches(): boolean {
+  const out = expandSlash("/simple   ", loadFixture())
+  return out == "Just say hello."
+}
+
+node tabDelimitsArgs(): boolean {
+  const out = expandSlash("/with-args\talice", loadFixture())
+  return out == "Greet alice politely."
+}
+
+// ---------- defensive contract ----------
+
+node descriptionsAreStringsNotUndefined(): boolean {
+  for (cmd in loadFixture()) {
+    if (cmd.description == null) { return false }
+    if (cmd.argHint == null) { return false }
+  }
+  return true
+}

--- a/packages/agency-lang/tests/agency/commands-dir.test.json
+++ b/packages/agency-lang/tests/agency/commands-dir.test.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    { "nodeName": "entriesCount", "input": "", "expectedOutput": "5", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "simpleHasDescription", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "simpleHasEmptyArgHint", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "emptyFrontmatterHasEmptyDefaults", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "noFrontmatterHasEmptyDefaults", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "descriptionOnlyHasEmptyArgHint", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "missingDirReturnsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "simpleExpandsToBody", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "withArgsSubstitutes", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "withArgsMultiArgRawString", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "noArgsCommandIgnoresExtraText", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "noArgsCommandNoSuffixIfNoArgs", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "unknownCommandReturnsLiteral", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "nonSlashReturnsLiteral", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "emptyInputReturnsLiteral", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "trailingNewlineDispatches", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "leadingWhitespaceDispatches", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "trailingWhitespaceDispatches", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "tabDelimitsArgs", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "descriptionsAreStringsNotUndefined", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/commands-dir.test.json
+++ b/packages/agency-lang/tests/agency/commands-dir.test.json
@@ -1,6 +1,9 @@
 {
   "tests": [
-    { "nodeName": "entriesCount", "input": "", "expectedOutput": "5", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "entriesCount", "input": "", "expectedOutput": "9", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "multilineBodyPreserved", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "frontmatterOnlyBodyIsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "unclosedFrontmatterBodyIsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "simpleHasDescription", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "simpleHasEmptyArgHint", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "emptyFrontmatterHasEmptyDefaults", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
@@ -10,6 +13,8 @@
     { "nodeName": "simpleExpandsToBody", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "withArgsSubstitutes", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "withArgsMultiArgRawString", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "multipleArgumentsTokensAllReplaced", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "argumentsTokenEmptyRawArgsSubstitutesEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "noArgsCommandIgnoresExtraText", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "noArgsCommandNoSuffixIfNoArgs", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "unknownCommandReturnsLiteral", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },


### PR DESCRIPTION
## Summary

Adds Claude-Code-style slash commands to the agency agent.

- `commandsDir(dir)` (stdlib) — discovers `.md` files in `dir`, returns `{ name, description, argHint, body }[]`.
- `expandSlash(msg, commands)` (stdlib) — substitutes `$ARGUMENTS` in the matched command body; passes unknown `/foo` through unchanged.
- Wired into the agent's REPL **and** one-shot path. Project-local `.claude/commands/foo.md` becomes `/foo`. Built-ins (`/exit`, `/clear`, `/help`) win over file commands.

## Scope

**In v1**
- Read `.md` files under `<project>/.claude/commands/`
- Substitute `$ARGUMENTS` (only placeholder)
- Append `\n\nARGUMENTS: <raw>` when the body has no `$ARGUMENTS` token but args were passed (matches CC)
- Surface entries in the `/` palette

**Deferred (each is a follow-up PR if anyone asks)**
- `$N` / `$ARGUMENTS[N]` positional refs
- Namespaced commands (`/ns:scoped`)
- `.markdown` extension (just `.md` for now)
- `` !`cmd` `` shell injection
- `@<path>` file references
- `allowed-tools` / `model` / `effort` / any frontmatter field besides `description` / `argument-hint`
- User-level commands (`~/.claude/commands/`)
- Live reload

## Tests

20 execution tests, every assertion exact-equality (`==`), all green:

- 7 discovery tests (entries count, description/argHint defaults, missing dir, undefined-leak contract)
- 8 expansion tests (substitution, raw-string preservation, suffix fallback, unknown / non-slash / empty pass-through)
- 4 whitespace-tolerance tests (trailing newline, leading/trailing ws, tab as delimiter)
- 1 defensive contract test (`description` / `argHint` are always strings, never `null`/`undefined`)

## Notes

- Replaces #266 (closed unmerged). The earlier PR over-engineered this with a hand-rolled tokenizer, a `Command`/`CommandSet` type, a `.partial`-based `dispatch` closure, and CC's full arg grammar. v2 is a thin wrapper on the existing `skillsDir` pattern (~75 lines of production code) — see `docs/superpowers/plans/2026-06-05-slash-commands-v2.md` for the full reasoning.
- Fixed a subtle `undefined`-leak bug in the process: in Agency `undefined == null` evaluates to `false`, so the original `if (fm["argument-hint"] != null)` guard let `undefined` through and stringified it as `"undefined"`. Switched to `?? ""` coalescing, which treats both nullish.

## Manual smoke

```bash
mkdir -p /tmp/cmd-smoke/.claude/commands
cat > /tmp/cmd-smoke/.claude/commands/echo.md <<'EOF'
---
description: Echo back the args
---
Please repeat this verbatim: $ARGUMENTS
EOF
cd /tmp/cmd-smoke
pnpm --prefix ~/agency-lang/packages/agency-lang run agent -p '/echo hello'
```
