### PR TITLE
Parser: anchor squiggles at the real error position, and target the params-separated-by-semicolon message

### DIFF
--- a/packages/agency-lang/lib/parser.test.ts
+++ b/packages/agency-lang/lib/parser.test.ts
@@ -198,34 +198,40 @@ describe("parseAgency structured errors", () => {
   // the right position. The structured `errorData` is what the LSP
   // actually reads, so we have to populate it from the tarsec
   // rightmost-failure offset.
+  //
+  // Use `x = 5\n!!!` (not `def ... ; ...`) so the failure flows through
+  // the recoverable-failure branch — `def`'s param list is wrapped in
+  // `parseError(...)` and would throw `TarsecError` instead, exercising
+  // a different code path.
   it("returns errorData with the right line/col for recoverable parse failures", () => {
-    const source = "def greet(name: string; greeting: string) { }";
+    const source = "x = 5\n!!!";
     const result = parseAgency(source, {}, false);
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.errorData).toBeDefined();
-    expect(result.errorData!.line).toBe(0);
-    // `def greet(name: string` is 22 chars; `;` is at col 22.
-    expect(result.errorData!.column).toBe(22);
+    expect(result.errorData!.line).toBe(1);
+    expect(result.errorData!.column).toBe(0);
   });
 
   it("subtracts the template offset from recoverable-failure line numbers", () => {
-    const source = "def greet(name: string; greeting: string) { }";
+    const source = "x = 5\n!!!";
     const result = parseAgency(source, {}, true);
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.errorData).toBeDefined();
     // Same source, but rendered through the template — line should
-    // still be 0 in the user's coordinates.
-    expect(result.errorData!.line).toBe(0);
-    expect(result.errorData!.column).toBe(22);
+    // still be 1 in the user's coordinates (where `!!!` lives).
+    expect(result.errorData!.line).toBe(1);
+    expect(result.errorData!.column).toBe(0);
   });
 
   // Pins the targeted message produced by the `parseError` wrapper
   // around `def`'s parameter-list close-paren. Before this, the same
   // input dumped the full top-level alternatives list ("expected
   // 'break', 'continue', 'import', ..., a function definition, ...")
-  // which made the actual mistake nearly invisible.
+  // which made the actual mistake nearly invisible. This case goes
+  // through the `TarsecError` branch (parseError throws), so it also
+  // exercises that branch's errorData construction.
   it("produces a targeted message when params are separated by `;`", () => {
     const source = "def greet(name: string; greeting: string) { }";
     const result = parseAgency(source, {}, false);
@@ -234,9 +240,9 @@ describe("parseAgency structured errors", () => {
     expect(result.errorData?.message).toMatch(
       /expected `,` between parameters or `\)` to close the parameter list/,
     );
-    expect(result.errorData?.message).toMatch(
-      /parameters are separated by `,`, not `;`/,
-    );
+    // The squiggle should anchor on the `;` at col 22.
+    expect(result.errorData!.line).toBe(0);
+    expect(result.errorData!.column).toBe(22);
   });
 });
 

--- a/packages/agency-lang/lib/parser.test.ts
+++ b/packages/agency-lang/lib/parser.test.ts
@@ -191,6 +191,53 @@ describe("parseAgency structured errors", () => {
       expect(result.message).toBeDefined();
     }
   });
+
+  // Without this, the LSP fell back to anchoring the squiggle at line 0,
+  // col 0 for any error that wasn't surfaced via `parseError(...)` —
+  // even though the formatted message ("Line X, col Y: …") contained
+  // the right position. The structured `errorData` is what the LSP
+  // actually reads, so we have to populate it from the tarsec
+  // rightmost-failure offset.
+  it("returns errorData with the right line/col for recoverable parse failures", () => {
+    const source = "def greet(name: string; greeting: string) { }";
+    const result = parseAgency(source, {}, false);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.errorData).toBeDefined();
+    expect(result.errorData!.line).toBe(0);
+    // `def greet(name: string` is 22 chars; `;` is at col 22.
+    expect(result.errorData!.column).toBe(22);
+  });
+
+  it("subtracts the template offset from recoverable-failure line numbers", () => {
+    const source = "def greet(name: string; greeting: string) { }";
+    const result = parseAgency(source, {}, true);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.errorData).toBeDefined();
+    // Same source, but rendered through the template — line should
+    // still be 0 in the user's coordinates.
+    expect(result.errorData!.line).toBe(0);
+    expect(result.errorData!.column).toBe(22);
+  });
+
+  // Pins the targeted message produced by the `parseError` wrapper
+  // around `def`'s parameter-list close-paren. Before this, the same
+  // input dumped the full top-level alternatives list ("expected
+  // 'break', 'continue', 'import', ..., a function definition, ...")
+  // which made the actual mistake nearly invisible.
+  it("produces a targeted message when params are separated by `;`", () => {
+    const source = "def greet(name: string; greeting: string) { }";
+    const result = parseAgency(source, {}, false);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.errorData?.message).toMatch(
+      /expected `,` between parameters or `\)` to close the parameter list/,
+    );
+    expect(result.errorData?.message).toMatch(
+      /parameters are separated by `,`, not `;`/,
+    );
+  });
 });
 
 describe("parseAgency loc.line invariant", () => {

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -1,10 +1,12 @@
 import {
+  buildLineTable,
   capture,
   eof,
-  failure,
   getErrorMessage,
+  getRightmostFailure,
   many,
   map,
+  offsetToPosition,
   or,
   Parser,
   ParserResult,
@@ -126,10 +128,20 @@ export function replaceBlankLines(input: string): string {
   );
 }
 
+/** Failure result enriched with the tarsec rightmost-failure position so
+ *  the LSP can surface a real squiggle range instead of falling back to
+ *  line 0, col 0. `pos` is a byte offset into the normalized input. */
+export type ParserFailureWithPos = {
+  success: false;
+  message: string;
+  rest: string;
+  rightmostPos?: number;
+};
+
 export function _parseAgency(
   input: string,
   config: AgencyConfig = {},
-): ParserResult<AgencyProgram> {
+): ParserResult<AgencyProgram> | ParserFailureWithPos {
   const normalized = normalizeCode(input);
   if (normalized.trim().length === 0) {
     return success(
@@ -151,8 +163,22 @@ export function _parseAgency(
   const result = agencyParser(normalized);
   if (!result.success) {
     const betterMessage = getErrorMessage();
+    const rightmost = getRightmostFailure();
     if (betterMessage) {
-      return failure(betterMessage, normalized);
+      return {
+        success: false,
+        message: betterMessage,
+        rest: normalized,
+        ...(rightmost ? { rightmostPos: rightmost.pos } : {}),
+      };
+    }
+    if (rightmost) {
+      return {
+        success: false,
+        message: result.message ?? "Parse error",
+        rest: normalized,
+        rightmostPos: rightmost.pos,
+      };
     }
   }
   return result;
@@ -187,22 +213,66 @@ export function parseAgency(
   setTemplateOffset(offset);
   try {
     const result = _parseAgency(input, config);
-    if (result.success && lower) {
-      // Apply pattern lowering pass: transforms destructuring/pattern syntax
-      // into existing AST constructs. The format path opts out by passing
-      // `lower: false` so it can print patterns back as patterns.
-      result.result.nodes = lowerPatterns(result.result.nodes);
+    if (result.success) {
+      if (lower) {
+        // Apply pattern lowering pass: transforms destructuring/pattern syntax
+        // into existing AST constructs. The format path opts out by passing
+        // `lower: false` so it can print patterns back as patterns.
+        result.result.nodes = lowerPatterns(result.result.nodes);
+      }
+      return result;
     }
-    return result;
+    // Recoverable parse failure (no TarsecError thrown). Convert the
+    // tarsec rightmost-failure offset into editor-coordinate line/col
+    // so the LSP can anchor its squiggle on the actual error site
+    // instead of falling back to line 0, col 0. Without this, the
+    // diagnostics layer only has the message string to go on, and the
+    // location info embedded in that string ("Line X, col Y: ...") is
+    // never extracted.
+    if ("rightmostPos" in result && typeof result.rightmostPos === "number") {
+      const lineTable = buildLineTable(input);
+      const pos = offsetToPosition(lineTable, result.rightmostPos);
+      // Strip the "Line X, col Y: " prefix that getErrorMessage prepends
+      // so the LSP / CLI can render the location separately without
+      // duplicating it inside the message body.
+      const message = result.message.replace(/^Line \d+, col \d+: /, "");
+      return {
+        success: false,
+        message: result.message,
+        rest: input,
+        errorData: {
+          line: pos.line - offset,
+          column: pos.column,
+          length: 1,
+          message,
+          prettyMessage: result.message,
+        },
+      };
+    }
+    return { success: false, message: result.message, rest: result.rest };
   } catch (error) {
     if (error instanceof TarsecError) {
+      // Prefer the rightmost-failure offset over tarsec's own
+      // line/column. tarsec's `getDiagnostics` line/col computation
+      // ignores `\n` separators when walking the line table, which
+      // makes columns drift right by the number of preceding
+      // newlines once the template is applied. Recomputing from
+      // the absolute offset avoids that drift entirely.
+      const rightmost = getRightmostFailure();
+      let line = error.data.line - offset;
+      let column = error.data.column;
+      if (rightmost) {
+        const pos = offsetToPosition(buildLineTable(input), rightmost.pos);
+        line = pos.line - offset;
+        column = pos.column;
+      }
       return {
         success: false,
         message: error.message,
         rest: input,
         errorData: {
-          line: error.data.line - offset,
-          column: error.data.column,
+          line,
+          column,
           length: error.data.length,
           message: error.data.message,
           prettyMessage: error.data.prettyMessage,

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -138,6 +138,26 @@ export type ParserFailureWithPos = {
   rightmostPos?: number;
 };
 
+/**
+ * Raw parse entry point. Normalizes the source, primes tarsec's
+ * input-string / memo state, runs the top-level `agencyParser`, and
+ * returns the result with an optional `rightmostPos` so callers can
+ * recover an editor-coordinate location for recoverable failures.
+ *
+ * Difference vs `parseAgency`:
+ *   - `_parseAgency` is the **raw** parse. It does NOT wrap the source
+ *     in the CLI template prelude, does NOT run the pattern-lowering
+ *     pass, and does NOT catch `TarsecError` / `PatternLoweringError`
+ *     — those exceptions propagate to the caller as-is.
+ *   - `parseAgency` is the **user-facing** layer. It optionally renders
+ *     the template (which prepends stdlib imports the CLI auto-injects),
+ *     runs the lowering pass on success, and converts thrown errors
+ *     into a structured `ParseAgencyResult` with `errorData` populated
+ *     so the LSP / CLI can render a useful diagnostic.
+ *
+ * Exported because `scripts/agency.ts diagnostics` calls it directly
+ * to get raw tarsec error data without the higher-level wrapping.
+ */
 export function _parseAgency(
   input: string,
   config: AgencyConfig = {},
@@ -196,6 +216,39 @@ export type ParseAgencyResult =
   | { success: true; result: AgencyProgram; rest: string }
   | { success: false; message?: string; rest: string; errorData?: ParseAgencyErrorData };
 
+/**
+ * Build a structured `ParseAgencyErrorData` from a tarsec
+ * rightmost-failure offset (or a fallback `{line, column, length}` if
+ * one isn't available). When `rightmostPos` is provided we recompute
+ * line/col from the absolute offset via `offsetToPosition` —
+ * deliberately ignoring any line/col tarsec might have computed
+ * itself, because tarsec's `getDiagnostics` undercounts `\n`
+ * separators when walking its line table and that drifts columns
+ * right by the number of preceding newlines once the template wrapper
+ * is applied. Used by both the recoverable-failure branch and the
+ * `TarsecError` branch in `parseAgency`.
+ */
+function buildErrorData(
+  input: string,
+  rightmostPos: number | null,
+  offset: number,
+  fallback: { line: number; column: number; length: number },
+  message: string,
+  prettyMessage: string,
+): ParseAgencyErrorData {
+  if (rightmostPos != null) {
+    const pos = offsetToPosition(buildLineTable(input), rightmostPos);
+    return {
+      line: pos.line - offset,
+      column: pos.column,
+      length: fallback.length,
+      message,
+      prettyMessage,
+    };
+  }
+  return { ...fallback, message, prettyMessage };
+}
+
 export function parseAgency(
   input: string,
   config: AgencyConfig = {},
@@ -229,54 +282,49 @@ export function parseAgency(
     // diagnostics layer only has the message string to go on, and the
     // location info embedded in that string ("Line X, col Y: ...") is
     // never extracted.
-    if ("rightmostPos" in result && typeof result.rightmostPos === "number") {
-      const lineTable = buildLineTable(input);
-      const pos = offsetToPosition(lineTable, result.rightmostPos);
+    const rightmostPos =
+      "rightmostPos" in result && typeof result.rightmostPos === "number"
+        ? result.rightmostPos
+        : null;
+    if (rightmostPos != null) {
       // Strip the "Line X, col Y: " prefix that getErrorMessage prepends
       // so the LSP / CLI can render the location separately without
       // duplicating it inside the message body.
-      const message = result.message.replace(/^Line \d+, col \d+: /, "");
+      const cleanMessage = result.message.replace(/^Line \d+, col \d+: /, "");
       return {
         success: false,
         message: result.message,
         rest: input,
-        errorData: {
-          line: pos.line - offset,
-          column: pos.column,
-          length: 1,
-          message,
-          prettyMessage: result.message,
-        },
+        errorData: buildErrorData(
+          input,
+          rightmostPos,
+          offset,
+          { line: 0, column: 0, length: 1 },
+          cleanMessage,
+          result.message,
+        ),
       };
     }
     return { success: false, message: result.message, rest: result.rest };
   } catch (error) {
     if (error instanceof TarsecError) {
-      // Prefer the rightmost-failure offset over tarsec's own
-      // line/column. tarsec's `getDiagnostics` line/col computation
-      // ignores `\n` separators when walking the line table, which
-      // makes columns drift right by the number of preceding
-      // newlines once the template is applied. Recomputing from
-      // the absolute offset avoids that drift entirely.
       const rightmost = getRightmostFailure();
-      let line = error.data.line - offset;
-      let column = error.data.column;
-      if (rightmost) {
-        const pos = offsetToPosition(buildLineTable(input), rightmost.pos);
-        line = pos.line - offset;
-        column = pos.column;
-      }
       return {
         success: false,
         message: error.message,
         rest: input,
-        errorData: {
-          line,
-          column,
-          length: error.data.length,
-          message: error.data.message,
-          prettyMessage: error.data.prettyMessage,
-        },
+        errorData: buildErrorData(
+          input,
+          rightmost ? rightmost.pos : null,
+          offset,
+          // Fallback line is already in templated coordinates; subtract
+          // the template offset here so the user sees user-source lines
+          // either way (the rightmost-offset path subtracts inside the
+          // helper).
+          { line: error.data.line - offset, column: error.data.column, length: error.data.length },
+          error.data.message,
+          error.data.prettyMessage,
+        ),
       };
     } else if (error instanceof PatternLoweringError) {
       // Compile-time error from the lowering pass (e.g. shorthand binder in

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -1395,18 +1395,27 @@ describe("functionParser", () => {
         },
       },
     },
-    // Failure cases for type hints
+    // Failure cases for type hints / parameter separators.
+    // These now throw TarsecError instead of returning a recoverable
+    // failure: once `def NAME (` is consumed, the parameter list is
+    // wrapped in a `parseError` that fires fatally on anything other
+    // than `,` or `)`. That's what produces the targeted "expected `,`
+    // between parameters or `)` …" message in the LSP/CLI instead of a
+    // junk dump of every top-level alternative.
     {
       input: "def bad(x:) { x }",
       expected: { success: false },
+      throws: true,
     },
     {
       input: "def bad(: number) { x }",
       expected: { success: false },
+      throws: true,
     },
     {
       input: "def bad(x: number y: string) { x }",
       expected: { success: false },
+      throws: true,
     },
     // Functions with return types - primitive types
     {

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3899,7 +3899,7 @@ const _baseFunctionParser: Parser<any> = memo(
     // top-level alternatives list and dumping every possible statement
     // form the user might have meant.
     parseError(
-      "expected `,` between parameters or `)` to close the parameter list (note: parameters are separated by `,`, not `;`)",
+      "expected `,` between parameters or `)` to close the parameter list",
       char(")"),
     ),
     optionalSpaces,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3890,7 +3890,18 @@ const _baseFunctionParser: Parser<any> = memo(
     ),
     optional(comma),
     optionalSpacesOrNewline,
-    char(")"),
+    // Once we've consumed `def NAME (` plus parameters, we're committed
+    // to a function definition. Anything other than `,` (another param)
+    // or `)` (end of list) is a user mistake — most commonly using `;`
+    // to separate params. Surface a targeted error via `parseError`
+    // (which throws a TarsecError, bypassing `or(...)` backtracking and
+    // `label(...)` suppression) instead of falling through to the
+    // top-level alternatives list and dumping every possible statement
+    // form the user might have meant.
+    parseError(
+      "expected `,` between parameters or `)` to close the parameter list (note: parameters are separated by `,`, not `;`)",
+      char(")"),
+    ),
     optionalSpaces,
     capture(optional(functionReturnTypeParser), "returnType"),
     capture(optional(map(str("!"), () => true)), "returnTypeValidated"),


### PR DESCRIPTION
Two fixes that compound. They are both surfaced by inputs like:

```agency
def greet(name: string; greeting: string) { ... }
```

(`;` instead of `,` between parameters)

### 1. Squiggle position

For parse failures that don't go through `parseError(...)`, the LSP was anchoring its red squiggle at line 0, col 0 even when the underlying message embedded the correct location (`"Line X, col Y: ..."`).

`parseAgency` now extracts the tarsec rightmost-failure offset and converts it to editor-coordinate line/col via `buildLineTable` + `offsetToPosition`, populating `errorData` the same way the `TarsecError` branch does.

tarsec's own `getDiagnostics` also undercounts `\n` separators when walking its line table, so the `TarsecError` branch is overridden with the same rightmost-offset computation to avoid column drift once the template wrapper is applied.

### 2. Targeted message for `def NAME (... ; ...)`

Once `def NAME (` plus parameters is consumed, we're committed to a function definition. The parameter list's close-paren is now wrapped in `parseError(...)` so anything other than `,` (another param) or `)` (end of list) throws a `TarsecError` with:

> expected `` ` ``,`` ` `` between parameters or `` ` ``)`` ` `` to close the parameter list (note: parameters are separated by `` ` ``,`` ` ``, not `` ` ``;`` ` ``)

instead of letting `or(...)` backtrack to the top-level alternatives and dump every possible statement form the user might have meant (the prior message listed ~30 things: `"break", "continue", "import", "export", a node definition, ...`).

### Test impact

The `parseError` change reaches three existing function-parser unit tests (`def bad(x:)`, `def bad(: number)`, `def bad(x: number y: string)`) which previously returned a recoverable failure; they now throw and are marked `throws: true`. Three new tests pin the structured `errorData` line/col and the targeted message.

All 5283 unit tests pass.

### Before / after

```
$ cat foo.agency
import { highlight } from "std::syntax"

def greet(name: string; greeting: string) {
  print("${greeting}, ${name}!")
}
...

$ # BEFORE
Failed to parse Agency program: Line 5, col 10: expected whitespace, "break",
"continue", "import", "export", a node definition, "class", a type alias, an if
statement, a for loop, a while loop, a match block, "thread", "subthread",
"handle", "debugger", "skills", "skill", a function definition, a return
statement, a goto statement, an interrupt statement, a tag, "static", an
assignment, a function call, an expression, a boolean, "async", "sync",
"await", one of " 	", "/*", "//", "", "...", "...", or end of input

$ # AFTER
Failed to parse Agency program: expected `,` between parameters or `)` to
close the parameter list (note: parameters are separated by `,`, not `;`)
```

In the LSP, the squiggle now anchors on the `;` (line 2, col 22 in the source above) instead of line 0, col 0.
