### PR TITLE
feat: add 'agency interrupts <file>' subcommand

### DIFF
--- a/packages/agency-lang/docs/dev/interrupts-command.md
+++ b/packages/agency-lang/docs/dev/interrupts-command.md
@@ -1,0 +1,245 @@
+# `agency interrupts` — Static Handler-Set Analysis
+
+## What it does
+
+`agency interrupts <file>` statically prints, for every `interruptStatement` reachable in the import tree rooted at `<file>`, the set of `handle` blocks that could enclose it on the active stack.
+
+The motivating debugging story: you wrap a call in `with approve` expecting auto-approval, but the interrupt still surfaces to the user. The command lists every handler that could intercept the interrupt — your `with approve` plus anything else higher on the stack. The "anything else" is the culprit.
+
+## CLI surface
+
+```
+agency interrupts <file>
+```
+
+- One positional arg, no flags in v1.
+- Plain text output to stdout. Errors (file not found, parse errors) go to stderr with exit code 1.
+- No color, no JSON, no policy filtering. See "Out of scope" below.
+
+Example output:
+
+```
+src/agent.agency:42  interrupt of kind std::read
+  Possible enclosing handlers:
+    handle block at src/main.agency:10
+    handle via fn approveReads at src/main.agency:18
+
+src/agent.agency:67  interrupt
+  Possible enclosing handlers:
+    (none)
+```
+
+- The `of kind <Kind>` clause is omitted when `kind === "unknown"` (the bare `interrupt(...)` form).
+- Inline handlers render as `handle block at <file>:<line>`.
+- `functionRef` handlers render as `handle via fn <name> at <file>:<line>`.
+- `(none)` appears under any site with an empty handler set.
+- Sites are sorted by `(file, line)`; handlers within a site are sorted the same way.
+
+## Pipeline overview
+
+```diagram
+╭─────────────────────╮     ╭──────────────────────────╮
+│ parse + SymbolTable │────▶│ buildCompilationUnit     │
+╰─────────────────────╯     │ (per file)               │
+                            ╰─────────┬────────────────╯
+                                      ▼
+                            ╭──────────────────────────╮
+                            │ typeCheck                │
+                            │  → interruptCallGraph    │
+                            ╰─────────┬────────────────╯
+                                      ▼
+                            ╭──────────────────────────╮
+                            │ analyzeInterrupts        │
+                            │  worklist fixed-point    │
+                            ╰─────────┬────────────────╯
+                                      ▼
+                            ╭──────────────────────────╮
+                            │ renderInterrupts → stdout│
+                            ╰──────────────────────────╯
+```
+
+Three layers, three files:
+
+| Layer | Module | Responsibility |
+|-------|--------|----------------|
+| Typechecker call graph | [lib/typeChecker/interruptAnalysis.ts](../../lib/typeChecker/interruptAnalysis.ts) | `buildInterruptCallGraph(scopes, ctx)` records, per function, every call edge and every `interruptStatement` along with its lexically enclosing `handle` blocks. Purely structural — no propagation. |
+| Handler-set analyzer | [lib/analysis/interrupts.ts](../../lib/analysis/interrupts.ts) | `analyzeInterrupts(rootFile, config)` runs the typechecker on every reachable `.agency` file, merges the call graphs, and runs a worklist fixed-point to compute per-site handler sets. |
+| CLI shim | [lib/cli/interrupts.ts](../../lib/cli/interrupts.ts) | `renderInterrupts(result)` plus the Commander `action` that reads the file and writes stdout. |
+
+## Layer 1: the interrupt call graph
+
+`buildInterruptCallGraph` walks `scopes` (the same `ScopeInfo[]` the rest of the typechecker uses). For each non-top-level scope it visits every node and records:
+
+- **Interrupt sites.** For every `interruptStatement` node, store the AST node plus the list of `handle` blocks in `ancestors` that lexically enclose it.
+- **Call edges.** For every `functionCall`, store the callee name plus the same enclosing-handlers list. Function references appearing as arguments (e.g. `llm(..., { tools: [deploy] })`) are added as synthetic call edges via `functionRefsInArgs` — same code path the existing transitive-kinds analyzer uses. `gotoStatement` targets are also recorded as call edges.
+
+Each handler is a `TaggedHandler = { block: HandleBlock; file: string }`. The file tag is the file the *enclosing function* lives in, looked up via `SymbolTable.findFileForName(name)`. This is essential because `SourceLocation` carries only `{line, col, start, end}` — there is no `loc.file`, so the file has to be threaded explicitly through every level of the analysis.
+
+The output:
+
+```ts
+type CallGraphFunction = {
+  file: string;
+  callEdges: { calleeName: string; enclosingHandlers: TaggedHandler[] }[];
+  interruptSites: {
+    site: InterruptStatement;
+    file: string;
+    enclosingHandlers: TaggedHandler[];
+  }[];
+};
+type InterruptCallGraph = Record<string, CallGraphFunction>;
+```
+
+This lives on `TypeCheckResult.interruptCallGraph` alongside the existing `interruptKindsByFunction`. The two analyses are intentionally independent: this one records exact handler identities, the other propagates kind sets.
+
+## Layer 2: the handler-set analyzer
+
+`analyzeInterrupts(rootFile, config)` is a five-phase declarative pipeline:
+
+```ts
+const cg               = loadCallGraph(rootFile, config);
+const sites            = collectAllSites(cg);
+const reachableHandlers = propagateHandlers(cg);
+const perSite          = unionAcrossEntries(reachableHandlers, collectEntries(cg));
+return buildResult(sites, perSite);
+```
+
+### Phase 1: load (multi-file)
+
+The typechecker only knows about one file's local definitions at a time — `scopes` is built from the entry file's `CompilationUnit.functionDefinitions` and `graphNodes`. Imported functions appear as signatures in `importedFunctions` but their **bodies** are not in `scopes`, so they contribute zero interrupt sites and zero call edges when only the entry file is typechecked.
+
+To analyze the whole import closure, `loadCallGraph` builds the symbol table once and then runs the typechecker on **every** `.agency` file in `symbolTable.filePaths()`, calling `Object.assign(merged, cg)` to merge the per-file call graphs into one. Function names are unique across the symbol table (the symbol table itself enforces that), so the merge is safe.
+
+### Phase 2: collect sites
+
+`collectAllSites(cg)` flattens every `interruptSite` from every function into a `Map<SiteId, SiteRecord>`, keyed by `${file}:${line}:${col}`. Multiple paths reaching the same site collapse into one map entry.
+
+### Phase 3: worklist fixed-point
+
+This is the heart. For each function `f` and each site `s` reachable from `f`, we maintain the set of `handle` blocks that could be on the active stack when `s` is reached starting from `f`. Inner set keyed by `HandleBlock` object identity for dedup:
+
+```ts
+type HandlerSet = Map<unknown, TaggedHandler>;
+type ReachableHandlers = Record<string, Record<SiteId, HandlerSet>>;
+```
+
+**Seed.** For each function with a direct `interruptStatement` site `s`, initialize `state[f][s] = handlers in f enclosing s`.
+
+**Propagation rule.** For each call edge `f --call(H)--> g` (where `H` is the set of `handle` blocks in `f` enclosing the call):
+
+```
+for every site s in state[g]:
+    state[f][s] ∪= state[g][s] ∪ H
+```
+
+**Growth detection.** A pass reports "grew" if any of the following changed:
+
+- A *new* site key was added to `state[f]` (we previously didn't know `f` could reach `s`). This is critical: a chain like `main → a1 → shared` where `shared`'s site has no enclosing handlers in `a1` would never propagate if we only tracked handler-set-size growth. The empty handler set still *carries the site*.
+- The handler set's size grew for an existing site.
+
+This runs in `O(iterations × edges × sites)` with the fixed point bounded by the total number of (function, site) pairs — cycles add nothing once both sides converge.
+
+### Phase 4: entry detection + union
+
+An **entry** is a function with no incoming call edges. The final per-site handler set is the union of `state[entry][s]` across every entry that reaches `s`.
+
+**Stdlib filter.** Stdlib functions are excluded from entry candidates via [`isInStdlib(filePath, getStdlibDir())`](../../lib/analysis/interrupts.ts). Without this filter, every orphan stdlib function (anything not called by the user's code) would count as an entry and contribute its own interrupt sites — which is noise. Stdlib functions remain valid *callees* — when reached from a user entry, their sites propagate normally and their handlers are included.
+
+### Phase 5: build result
+
+For each site (with a non-empty per-site map entry), produce a `SiteResult` and sort by `(file, line)`. Each handler is rendered into a `HandlerRef` with the right `shape`.
+
+**Line numbers.** The parser stores `loc.line` as 0-indexed in the user's source (see [lib/parsers/parsers.ts](../../lib/parsers/parsers.ts) `AGENCY_TEMPLATE_OFFSET`). The analyzer adds 1 when producing the public `InterruptSite.line` / `HandlerRef.line` so the rendered output uses the human convention (line 1 = first line of the file). The template prelude added by `parseAgency` is already compensated for by the parser — see the docstring at `parsers.ts:179`.
+
+## Layer 3: CLI
+
+`renderInterrupts(result)` is a pure function: `AnalysisResult → string`. No I/O, easy to test. The CLI shim (`interruptsCmd`) calls `existsSync(file)`, runs the analyzer, writes `renderInterrupts(...)` to stdout, and handles errors by printing to stderr + `process.exit(1)`.
+
+Registered in [scripts/agency.ts](../../scripts/agency.ts) via Commander. Help text in [lib/cli/help.ts](../../lib/cli/help.ts) (mostly inert — Commander auto-generates the visible help from each subcommand's `.description()`).
+
+## File-path tracking
+
+`SourceLocation` carries only `{line, col, start, end}` — never the file. Every layer that touches a site or handler has to carry the file explicitly:
+
+- `SymbolTable.findFileForName(name)` resolves a top-level function/node name to its defining file.
+- `ScopeInfo.file` is populated in `buildScopes` from the symbol-table lookup, threaded through `TypeCheckerContext.symbolTable` which itself comes from `CompilationUnit.symbolTable`.
+- `CallGraphFunction.file` is taken from the scope's file when the call graph is built.
+- `TaggedHandler.file` is set when handlers are collected per function, so the file survives the propagation hops in Phase 3.
+
+The top-level scope (`name === "top-level"`) gets `file: ""` because it spans the whole compilation unit and no single file. It's skipped by `buildInterruptCallGraph`.
+
+## Known limitations
+
+These are all **call-graph fidelity** issues. The handler-set analysis itself is complete; what it can't see is the call graph's missing edges.
+
+### Function references through object properties
+
+The analyzer extracts function-typed arguments via `synthType` + `functionNamesFromType`, which recurses into array/object/union types. But once a function reference passes through a variable with type `any` or `any[]`, the names are erased.
+
+Example that **fails**:
+
+```agency
+static const codeTools: any[] = [foo, bar]  // erased to any[]
+
+node main() {
+  // route(...) eventually does llm({ tools: spec.tools }) inside
+  // a stdlib function, several call hops away.
+  route({ agents: { code: { tools: codeTools, ... } }, ... }, msg)
+}
+```
+
+The call edge from `main` to `route` records no synthetic edges for `foo`/`bar`, because `codeTools` synthesizes to `any[]`. Even if it didn't, the analyzer would still need to track that `route`'s `config` parameter flows into `runOneTurnPrompt`'s `spec.tools` which flows into `llm({ tools: ... })` — full interprocedural data-flow.
+
+**Workaround:** invoke tools inline at the `llm` call site, or accept the false negative.
+
+**Long-term fix:** more precise typing for `static const` arrays of function refs (tuple-of-`functionRefType`), plus interprocedural tool-flow tracking. Doable but out of scope for v1.
+
+### Handlers bound via a function-returned value
+
+```agency
+const handler = cliPolicyHandler(file: "policy.json", fields: ...)
+handle { ... } with handler
+```
+
+`cliPolicyHandler` returns `_handler` (a function value). The analyzer sees `with handler` as a `functionRef` with `functionName === "handler"` — but `"handler"` is a local variable, not a defined function, so there's no `CallGraphFunction["handler"]` entry. The handler-body interrupts (`maybeLoad` → `parsePolicyFile` → `interrupt std::read`) are invisible.
+
+This requires return-value-of-function-call escape analysis: tracking that `cliPolicyHandler(...)` returns the function value `_handler`. Agency's type system doesn't track this today.
+
+**Workaround:** use the handler factory inline (`with cliPolicyHandler(...)`) if the callable syntax allows it, or document the binding so a human reader knows which function gets dispatched.
+
+### Interrupts thrown directly from `.ts` / `.js` runtime code
+
+Almost all stdlib interrupts are written as `interrupt std::foo(...)` in `stdlib/*.agency`, so they're visible. The handful raised from raw runtime code are invisible.
+
+### Other indirect calls
+
+Only `llm(...)` tool arguments and `gotoStatement` targets are resolved as call edges. Higher-order calls like `someArray.forEach(fn)` or stored-callback dispatch are ignored.
+
+## Things explicitly out of scope (v1)
+
+These are documented decisions, not bugs:
+
+- **Handler-safety warnings.** Already a type error in `checkHandlerBodyInterrupts`; resurfacing them would be duplication.
+- **Uncaught-interrupt warnings.** Already a typechecker diagnostic.
+- **`--json` output, `--entry` flag, color/`NO_COLOR`, LSP integration.**
+- **Special rendering for `llm()`-reachable sites.** The call graph routes through `llm()` tools correctly; no special header needed.
+- **Stack-order of handlers.** A set is enough for the debugging story.
+- **Policy analysis / interrupt-kind filtering.**
+
+## Testing
+
+Three test files, all in normal `vitest` style:
+
+- [lib/typeChecker/interruptCallGraph.test.ts](../../lib/typeChecker/interruptCallGraph.test.ts) — 8 unit tests for `buildInterruptCallGraph` (call edges with/without handlers, llm tool synthetic edges, goto, file identity, top-level skip, multiple sites).
+- [lib/analysis/interrupts.test.ts](../../lib/analysis/interrupts.test.ts) — 14 unit tests for `analyzeInterrupts` (direct sites, bare interrupts, diamond dedup, recursion, both handler shapes, nested handlers across function boundaries, multi-entry union, orphan functions, cross-file imports).
+- [lib/cli/interrupts.test.ts](../../lib/cli/interrupts.test.ts) — 6 unit tests for `renderInterrupts` (header format, unknown-kind clause, both shapes, block separation, trailing newline, empty input).
+
+Five integration fixtures under [tests/integration/cli-main/fixtures/interrupts/](../../tests/integration/cli-main/fixtures/interrupts/) plus expected snapshots under `expected/interrupts-*.txt`. `make fixtures` regenerates the snapshots via the block at the end of [scripts/regenerate-fixtures.ts](../../scripts/regenerate-fixtures.ts). The cli-main smoke test ([tests/integration/cli-main/test.mjs](../../tests/integration/cli-main/test.mjs)) runs `agency interrupts` against each fixture and diffs the output.
+
+**Path normalization.** Both the regenerate script and the test harness normalize absolute fixture paths to a `<fixtures>/interrupts` token so snapshots are reproducible across machines, and both convert Windows backslashes to forward slashes. They also handle the macOS `/private/var/folders/...` realpath form. The two normalization blocks must stay in sync — comments in both files cross-reference each other.
+
+## Related docs
+
+- [interrupts.md](./interrupts.md) — how interrupts resume inside blocks at runtime (substeps).
+- [typechecker.md](./typechecker.md) — bidirectional type checking pipeline.
+- [Spec](../superpowers/specs/2026-06-06-agency-interrupts-command-design.md) and [implementation plan](../superpowers/plans/2026-06-06-agency-interrupts-command.md).

--- a/packages/agency-lang/lib/analysis/interrupts.test.ts
+++ b/packages/agency-lang/lib/analysis/interrupts.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, mkdtempSync, rmSync } from "fs";
+import path from "path";
+import os from "os";
+import { analyzeInterrupts } from "./interrupts.js";
+
+function withSingleFile(source: string, fn: (file: string) => void) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "agency-int-"));
+  const file = path.join(dir, "main.agency");
+  writeFileSync(file, source);
+  try {
+    fn(file);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("analyzeInterrupts", () => {
+  it("reports a direct interrupt with the right handler identity", () => {
+    withSingleFile(
+      `
+node main() {
+  handle {
+    interrupt std::read("hi")
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        const s = result.sites[0];
+        expect(s.site.kind).toBe("std::read");
+        expect(s.site.file).toBe(file);
+        expect(s.site.line).toBe(4); // 1-indexed line of `interrupt std::read(...)`
+        expect(s.handlers).toHaveLength(1);
+        // `with approve` parses as a functionRef handler (approve is a
+        // builtin), not an inline handler — inline syntax is
+        // `} with (param) { …body… }`.
+        expect(s.handlers[0]).toMatchObject({
+          shape: "functionRef",
+          functionName: "approve",
+          file,
+          line: 3, // 1-indexed line of the `handle {` block
+        });
+      },
+    );
+  });
+
+  it("reports an empty handler list when the interrupt is bare", () => {
+    withSingleFile(
+      `
+node main() {
+  interrupt std::read("hi")
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        expect(result.sites[0].handlers).toHaveLength(0);
+      },
+    );
+  });
+
+  it("reports the unknown kind for the bare `interrupt(...)` form", () => {
+    withSingleFile(
+      `
+node main() {
+  interrupt("hi")
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        expect(result.sites[0].site.kind).toBe("unknown");
+      },
+    );
+  });
+
+  it("propagates handlers across a function call chain with correct identity", () => {
+    withSingleFile(
+      `
+def helper() {
+  interrupt std::read("hi")
+}
+
+node main() {
+  handle {
+    helper()
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        expect(result.sites[0].handlers).toEqual([
+          { shape: "functionRef", functionName: "approve", file, line: 7 },
+        ]);
+      },
+    );
+  });
+
+  it("dedupes handlers across diamond paths", () => {
+    withSingleFile(
+      `
+def shared() {
+  interrupt std::read("hi")
+}
+
+def a1() { shared() }
+def a2() { shared() }
+def a3() { shared() }
+
+node main() {
+  handle {
+    a1()
+    a2()
+    a3()
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        // Single handler at main's handle block, NOT three copies.
+        expect(result.sites[0].handlers).toHaveLength(1);
+        expect(result.sites[0].handlers[0].line).toBe(11); // main's `handle {` 1-indexed
+      },
+    );
+  });
+
+  it("handles recursion without looping (fixed point converges)", () => {
+    withSingleFile(
+      `
+def loop() {
+  loop()
+  interrupt std::read("hi")
+}
+
+node main() {
+  handle {
+    loop()
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        expect(result.sites[0].handlers).toHaveLength(1);
+      },
+    );
+  });
+
+  it("reports both inline and functionRef handler shapes with correct identity", () => {
+    withSingleFile(
+      `
+def myHandler(e: any): any { return e }
+
+def doWork() {
+  interrupt std::read("hi")
+}
+
+node main() {
+  handle {
+    doWork()
+  } with myHandler
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        const h = result.sites[0].handlers[0];
+        expect(h).toMatchObject({
+          shape: "functionRef",
+          functionName: "myHandler",
+          file,
+          line: 9,
+        });
+      },
+    );
+  });
+
+  it("propagates through llm() tool arguments", () => {
+    withSingleFile(
+      `
+def deleteEmails() {
+  interrupt std::write("delete?")
+}
+
+node main() {
+  handle {
+    let _: string = llm("do work", { tools: [deleteEmails] })
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        const site = result.sites.find((s) => s.site.kind === "std::write");
+        expect(site).toBeDefined();
+        expect(site!.handlers).toHaveLength(1);
+        expect(site!.handlers[0].line).toBe(7);
+      },
+    );
+  });
+
+  it("collects all lexically nested handle blocks", () => {
+    withSingleFile(
+      `
+node main() {
+  handle {
+    handle {
+      interrupt std::read("hi")
+    } with approve
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        const lines = result.sites[0].handlers.map((h) => h.line).sort();
+        expect(lines).toEqual([3, 4]); // both `handle {` lines (1-indexed)
+      },
+    );
+  });
+
+  it("collects handle blocks nested across function boundaries", () => {
+    // Outer handle is in main; inner handle is in foo. Both must appear.
+    withSingleFile(
+      `
+def foo() {
+  handle {
+    interrupt std::read("hi")
+  } with approve
+}
+
+node main() {
+  handle {
+    foo()
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        const lines = result.sites[0].handlers.map((h) => h.line).sort();
+        expect(lines).toEqual([3, 9]); // foo's inner handle, main's outer handle
+      },
+    );
+  });
+
+  it("reports multiple distinct sites sorted by file then line", () => {
+    withSingleFile(
+      `
+node main() {
+  handle {
+    interrupt std::write("b")
+    interrupt std::read("a")
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(2);
+        // Sites are sorted by line, so std::write (line 4) comes first.
+        expect(result.sites.map((s) => s.site.line)).toEqual([4, 5]);
+        expect(result.sites.map((s) => s.site.kind)).toEqual(["std::write", "std::read"]);
+      },
+    );
+  });
+
+  it("unions handler sets when a site is reachable from multiple entries with different handlers", () => {
+    withSingleFile(
+      `
+def shared() {
+  interrupt std::read("hi")
+}
+
+node entryA() {
+  handle {
+    shared()
+  } with approve
+}
+
+node entryB() {
+  handle {
+    shared()
+  } with approve
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        // Both handlers (one per entry) should be reported.
+        const lines = result.sites[0].handlers.map((h) => h.line).sort((a, b) => a - b);
+        expect(lines).toEqual([7, 13]);
+      },
+    );
+  });
+
+  it("reports interrupts from an orphan function (no incoming callers)", () => {
+    // `foo` is not called from anywhere; it is therefore an entry itself.
+    // Spec: every site reachable from any function in the unit is reported.
+    withSingleFile(
+      `
+def foo() {
+  interrupt std::read("hi")
+}
+`,
+      (file) => {
+        const result = analyzeInterrupts(file, {});
+        expect(result.sites).toHaveLength(1);
+        expect(result.sites[0].handlers).toHaveLength(0);
+      },
+    );
+  });
+
+  it("follows imports across multiple files", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "agency-int-"));
+    try {
+      const helperFile = path.join(dir, "helper.agency");
+      writeFileSync(
+        helperFile,
+        `
+def helper() {
+  interrupt std::read("hi")
+}
+`,
+      );
+      const mainFile = path.join(dir, "main.agency");
+      writeFileSync(
+        mainFile,
+        `
+import { helper } from "./helper.agency"
+
+node main() {
+  handle {
+    helper()
+  } with approve
+}
+`,
+      );
+      const result = analyzeInterrupts(mainFile, {});
+      expect(result.sites).toHaveLength(1);
+      expect(result.sites[0].site.file).toBe(path.resolve(helperFile));
+      expect(result.sites[0].handlers).toHaveLength(1);
+      expect(result.sites[0].handlers[0].file).toBe(path.resolve(mainFile));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agency-lang/lib/analysis/interrupts.ts
+++ b/packages/agency-lang/lib/analysis/interrupts.ts
@@ -1,0 +1,292 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { parseAgency } from "@/parser.js";
+import { SymbolTable } from "@/symbolTable.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { liftCallbackBlocks } from "@/preprocessors/liftCallbacks.js";
+import { typeCheck } from "@/typeChecker/index.js";
+import { getStdlibDir } from "@/importPaths.js";
+import type { AgencyConfig } from "@/config.js";
+import type {
+  InterruptCallGraph,
+  TaggedHandler,
+} from "@/typeChecker/interruptAnalysis.js";
+import type { InterruptStatement } from "@/types/interruptStatement.js";
+
+// -- Public types --
+
+/**
+ * One interrupt site: a single `interruptStatement` AST node, located by
+ * (file, line, kind). `line` is **1-indexed** for human consumption (the
+ * parser stores 0-indexed lines, so we add 1 when building this shape).
+ */
+export type InterruptSite = {
+  file: string;
+  /** 1-indexed line number of the `interrupt …` statement. */
+  line: number;
+  /** Interrupt kind, e.g. `"std::read"`. `"unknown"` for the bare
+   *  `interrupt(...)` form. */
+  kind: string;
+};
+
+/**
+ * One handler reference, ready for rendering. `line` is **1-indexed**.
+ */
+export type HandlerRef = {
+  file: string;
+  /** 1-indexed line of the `handle {` block. */
+  line: number;
+  shape: "inline" | "functionRef";
+  /** Present iff `shape === "functionRef"`. */
+  functionName?: string;
+};
+
+/** The final per-site result. */
+export type SiteResult = {
+  site: InterruptSite;
+  /** Deduped handler set. May be empty. */
+  handlers: HandlerRef[];
+};
+
+export type AnalysisResult = {
+  /** Sorted by `site.file`, then `site.line`. */
+  sites: SiteResult[];
+};
+
+// -- Top-level entry point --
+//
+// Declarative pipeline: load → collect sites → propagate → union → render.
+// Each phase is a named helper; this function is the "what".
+
+export function analyzeInterrupts(
+  rootFile: string,
+  config: AgencyConfig,
+): AnalysisResult {
+  const cg = loadCallGraph(rootFile, config);
+  const sites = collectAllSites(cg);
+  const reachableHandlers = propagateHandlers(cg);
+  const perSite = unionAcrossEntries(reachableHandlers, collectEntries(cg));
+  return buildResult(sites, perSite);
+}
+
+// -- Phase 1: Load --
+//
+// The typechecker only sees the entry file's local definitions in
+// `scopes`; imported functions live in `importedFunctions` (signatures
+// only, no body). To analyze interrupt sites across the import tree we
+// build the symbol table once and then run the typechecker on every
+// reachable .agency file, merging the resulting call graphs. Names
+// collide across files only on duplication, and the symbol table
+// already throws on that.
+
+function loadCallGraph(rootFile: string, config: AgencyConfig): InterruptCallGraph {
+  const absPath = path.resolve(rootFile);
+  const symbolTable = SymbolTable.build(absPath, config);
+  const merged: InterruptCallGraph = {};
+  for (const filePath of symbolTable.filePaths()) {
+    const cg = analyzeOneFile(filePath, symbolTable, config);
+    Object.assign(merged, cg);
+  }
+  return merged;
+}
+
+function analyzeOneFile(
+  filePath: string,
+  symbolTable: SymbolTable,
+  config: AgencyConfig,
+): InterruptCallGraph {
+  const source = readFileSync(filePath, "utf-8");
+  const parseResult = parseAgency(source, config);
+  if (!parseResult.success) {
+    throw new Error(`Failed to parse ${filePath}`);
+  }
+  const lifted = liftCallbackBlocks(parseResult.result);
+  const info = buildCompilationUnit(lifted, symbolTable, filePath, source);
+  return typeCheck(lifted, config, info).interruptCallGraph;
+}
+
+// -- Phase 2: Site collection --
+
+type SiteId = string;
+type SiteRecord = { site: InterruptStatement; file: string };
+
+function siteKey(file: string, site: InterruptStatement): SiteId {
+  return `${file}:${site.loc?.line ?? 0}:${site.loc?.col ?? 0}`;
+}
+
+function collectAllSites(cg: InterruptCallGraph): Map<SiteId, SiteRecord> {
+  const entries = Object.values(cg).flatMap((fn) => fn.interruptSites);
+  return new Map(
+    entries.map((e) => [siteKey(e.file, e.site), { site: e.site, file: e.file }]),
+  );
+}
+
+// -- Phase 3: Fixed-point handler propagation --
+//
+// For each function f and each interrupt site s reachable from f, the set
+// of handle blocks that could enclose s on a control-flow path starting
+// at f. Inner map keyed by HandleBlock object identity for dedup.
+
+type HandlerSet = Map<unknown, TaggedHandler>;
+type ReachableHandlers = Record<string, Record<SiteId, HandlerSet>>;
+
+function propagateHandlers(cg: InterruptCallGraph): ReachableHandlers {
+  const state = seedFromDirectSites(cg);
+  runFixedPoint(state, cg);
+  return state;
+}
+
+function seedFromDirectSites(cg: InterruptCallGraph): ReachableHandlers {
+  const state: ReachableHandlers = {};
+  for (const fnName of Object.keys(cg)) state[fnName] = {};
+  for (const [fnName, fn] of Object.entries(cg)) {
+    for (const entry of fn.interruptSites) {
+      state[fnName][siteKey(entry.file, entry.site)] = handlerSetFrom(entry.enclosingHandlers);
+    }
+  }
+  return state;
+}
+
+function runFixedPoint(state: ReachableHandlers, cg: InterruptCallGraph): void {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [fnName, fn] of Object.entries(cg)) {
+      for (const edge of fn.callEdges) {
+        if (propagateEdge(state, fnName, edge, cg)) changed = true;
+      }
+    }
+  }
+}
+
+function propagateEdge(
+  state: ReachableHandlers,
+  fnName: string,
+  edge: InterruptCallGraph[string]["callEdges"][number],
+  _cg: InterruptCallGraph,
+): boolean {
+  const calleeState = state[edge.calleeName];
+  if (!calleeState) return false;
+  let grew = false;
+  for (const [sid, calleeHandlers] of Object.entries(calleeState)) {
+    // Reaching a new site for `fnName` is itself growth — even if the
+    // merged handler set is empty, we now know `fnName` can reach `sid`,
+    // which means callers of `fnName` will see this site on the next
+    // pass. Without this, a chain `main → a1 → shared` where `shared`
+    // has an unhandled interrupt fails to propagate, because the empty
+    // handler set on each hop would otherwise be reported as "not grown".
+    const isNewSite = !(sid in state[fnName]);
+    const merged = mergeHandlers(state[fnName][sid], calleeHandlers, edge.enclosingHandlers);
+    if (isNewSite || merged.grew) {
+      state[fnName][sid] = merged.set;
+      grew = true;
+    }
+  }
+  return grew;
+}
+
+function handlerSetFrom(handlers: TaggedHandler[]): HandlerSet {
+  return new Map(handlers.map((th) => [th.block, th]));
+}
+
+function mergeHandlers(
+  existing: HandlerSet | undefined,
+  fromCallee: HandlerSet,
+  fromEdge: TaggedHandler[],
+): { set: HandlerSet; grew: boolean } {
+  const out: HandlerSet = new Map(existing ?? []);
+  const before = out.size;
+  for (const [k, v] of fromCallee) out.set(k, v);
+  for (const th of fromEdge) out.set(th.block, th);
+  return { set: out, grew: out.size !== before };
+}
+
+// -- Phase 4: Entry detection + union across entries --
+//
+// An entry is a function/node with no incoming call edges. Stdlib
+// functions are filtered out so their own interrupt sites don't pollute
+// the report when they aren't actually reached from user code. Stdlib
+// functions can still be CALLEES — when reached from a user entry, their
+// sites propagate normally through the graph.
+
+function collectEntries(cg: InterruptCallGraph): string[] {
+  const calledBySomeone = new Set(
+    Object.values(cg).flatMap((fn) => fn.callEdges.map((e) => e.calleeName)),
+  );
+  const stdlibDir = getStdlibDir();
+  return Object.keys(cg).filter((fn) => {
+    if (calledBySomeone.has(fn)) return false;
+    const file = cg[fn].file;
+    if (file && isInStdlib(file, stdlibDir)) return false;
+    return true;
+  });
+}
+
+function isInStdlib(filePath: string, stdlibDir: string): boolean {
+  const rel = path.relative(stdlibDir, filePath);
+  return !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+function unionAcrossEntries(
+  reachable: ReachableHandlers,
+  entries: string[],
+): Map<SiteId, HandlerSet> {
+  const perSite = new Map<SiteId, HandlerSet>();
+  for (const entry of entries) {
+    for (const [sid, handlers] of Object.entries(reachable[entry] ?? {})) {
+      const acc = perSite.get(sid) ?? new Map();
+      for (const [k, v] of handlers) acc.set(k, v);
+      perSite.set(sid, acc);
+    }
+  }
+  return perSite;
+}
+
+// -- Phase 5: Build the public result --
+
+/** `loc.line` is 0-indexed (see lib/parsers/parsers.ts line-number comment
+ *  and parser.test.ts "loc.line invariant"). Convert to 1-indexed for the
+ *  human-facing output. */
+function toDisplayLine(line: number | undefined): number {
+  return (line ?? -1) + 1;
+}
+
+function buildResult(
+  sitesById: Map<SiteId, SiteRecord>,
+  perSite: Map<SiteId, HandlerSet>,
+): AnalysisResult {
+  const sites = Array.from(perSite.entries())
+    .map(([sid, hSet]) => buildSiteResult(sitesById.get(sid)!, hSet))
+    .sort(compareSites);
+  return { sites };
+}
+
+function buildSiteResult(rec: SiteRecord, handlers: HandlerSet): SiteResult {
+  return {
+    site: {
+      file: rec.file,
+      line: toDisplayLine(rec.site.loc?.line),
+      kind: rec.site.kind,
+    },
+    handlers: Array.from(handlers.values()).map(toHandlerRef).sort(compareHandlerRefs),
+  };
+}
+
+function toHandlerRef(th: TaggedHandler): HandlerRef {
+  const { block, file } = th;
+  const line = toDisplayLine(block.loc?.line);
+  if (block.handler.kind === "functionRef") {
+    return { file, line, shape: "functionRef", functionName: block.handler.functionName };
+  }
+  return { file, line, shape: "inline" };
+}
+
+function compareHandlerRefs(a: HandlerRef, b: HandlerRef): number {
+  if (a.file !== b.file) return a.file < b.file ? -1 : 1;
+  return a.line - b.line;
+}
+
+function compareSites(a: SiteResult, b: SiteResult): number {
+  if (a.site.file !== b.site.file) return a.site.file < b.site.file ? -1 : 1;
+  return a.site.line - b.site.line;
+}

--- a/packages/agency-lang/lib/cli/help.ts
+++ b/packages/agency-lang/lib/cli/help.ts
@@ -5,6 +5,7 @@ Agency Language CLI
 Usage:
   agency help                           Show this help message
   agency compile <input> [output]       Compile .agency file or directory to TypeScript
+  agency interrupts <file>              Print every interrupt site and its possible enclosing handlers
   agency run <input> [output]           Compile and run .agency file
   agency format [input]                 Format .agency file or directory (reads from stdin if no input)
   agency format -i <input>              Format .agency file or directory in-place

--- a/packages/agency-lang/lib/cli/interrupts.test.ts
+++ b/packages/agency-lang/lib/cli/interrupts.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { renderInterrupts } from "./interrupts.js";
+import type { AnalysisResult } from "@/analysis/interrupts.js";
+
+describe("renderInterrupts", () => {
+  it("renders a site with no handlers as (none) under the standard header", () => {
+    const r: AnalysisResult = {
+      sites: [{
+        site: { file: "/x/a.agency", line: 5, kind: "std::read" },
+        handlers: [],
+      }],
+    };
+    const out = renderInterrupts(r);
+    expect(out).toContain("/x/a.agency:5  interrupt of kind std::read");
+    expect(out).toContain("Possible enclosing handlers:");
+    expect(out).toContain("(none)");
+  });
+
+  it("omits the kind clause when kind is unknown", () => {
+    const r: AnalysisResult = {
+      sites: [{
+        site: { file: "/x/a.agency", line: 5, kind: "unknown" },
+        handlers: [],
+      }],
+    };
+    const out = renderInterrupts(r);
+    expect(out).toContain("/x/a.agency:5  interrupt");
+    expect(out).not.toContain("of kind");
+  });
+
+  it("renders inline and functionRef handlers in the right format", () => {
+    const r: AnalysisResult = {
+      sites: [{
+        site: { file: "/x/a.agency", line: 5, kind: "std::read" },
+        handlers: [
+          { file: "/x/m.agency", line: 10, shape: "inline" },
+          { file: "/x/m.agency", line: 18, shape: "functionRef", functionName: "approveReads" },
+        ],
+      }],
+    };
+    const out = renderInterrupts(r);
+    expect(out).toContain("handle block at /x/m.agency:10");
+    expect(out).toContain("handle via fn approveReads at /x/m.agency:18");
+  });
+
+  it("emits one block per site, separated by blank lines", () => {
+    const r: AnalysisResult = {
+      sites: [
+        { site: { file: "/x/a.agency", line: 1, kind: "std::read" }, handlers: [] },
+        { site: { file: "/x/a.agency", line: 5, kind: "std::write" }, handlers: [] },
+      ],
+    };
+    const out = renderInterrupts(r);
+    const blocks = out.trim().split(/\n\n/);
+    expect(blocks).toHaveLength(2);
+  });
+
+  it("ends the output with a single trailing newline", () => {
+    const r: AnalysisResult = {
+      sites: [{
+        site: { file: "/x/a.agency", line: 5, kind: "std::read" },
+        handlers: [],
+      }],
+    };
+    const out = renderInterrupts(r);
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.endsWith("\n\n")).toBe(false);
+  });
+
+  it("returns an empty-ish (newline-only) string for no sites", () => {
+    const out = renderInterrupts({ sites: [] });
+    expect(out).toBe("\n");
+  });
+});

--- a/packages/agency-lang/lib/cli/interrupts.ts
+++ b/packages/agency-lang/lib/cli/interrupts.ts
@@ -1,0 +1,51 @@
+import { existsSync } from "fs";
+import { analyzeInterrupts, type AnalysisResult, type HandlerRef } from "@/analysis/interrupts.js";
+import type { AgencyConfig } from "@/config.js";
+
+/**
+ * `agency interrupts <file>`: statically print every interrupt site
+ * reachable from `file` and the set of handle blocks that could be on
+ * the active stack at each site. Plain text output; no color, no JSON.
+ */
+export function interruptsCmd(config: AgencyConfig, file: string): void {
+  if (!existsSync(file)) {
+    console.error(`File not found: ${file}`);
+    process.exit(1);
+  }
+  try {
+    const result = analyzeInterrupts(file, config);
+    process.stdout.write(renderInterrupts(result));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+}
+
+export function renderInterrupts(result: AnalysisResult): string {
+  const blocks: string[] = [];
+  for (const s of result.sites) {
+    const lines: string[] = [];
+    const header =
+      s.site.kind === "unknown"
+        ? `${s.site.file}:${s.site.line}  interrupt`
+        : `${s.site.file}:${s.site.line}  interrupt of kind ${s.site.kind}`;
+    lines.push(header);
+    lines.push("  Possible enclosing handlers:");
+    if (s.handlers.length === 0) {
+      lines.push("    (none)");
+    } else {
+      for (const h of s.handlers) {
+        lines.push(`    ${formatHandler(h)}`);
+      }
+    }
+    blocks.push(lines.join("\n"));
+  }
+  return blocks.join("\n\n") + "\n";
+}
+
+function formatHandler(h: HandlerRef): string {
+  if (h.shape === "functionRef") {
+    return `handle via fn ${h.functionName} at ${h.file}:${h.line}`;
+  }
+  return `handle block at ${h.file}:${h.line}`;
+}

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -118,6 +118,12 @@ export type CompilationUnit = {
   sourceText?: string;
   /** Transitive interrupt kinds per function/node, populated from the symbol table. */
   interruptKindsByFunction?: Record<string, InterruptKind[]>;
+  /** Symbol table used to build this unit. Forwarded so downstream
+   *  consumers (e.g. the typechecker) can use it for cross-file lookups
+   *  like resolving the file a function/node lives in. Optional because
+   *  in-process callers that build a unit from a raw program (no entry
+   *  file) don't have one. */
+  symbolTable?: SymbolTable;
 };
 
 export function scopeKey(scope: Scope): string {
@@ -304,6 +310,7 @@ export function buildCompilationUnit(
       }
     }
     unit.interruptKindsByFunction = interruptKindsByFunction;
+    unit.symbolTable = symbolTable;
   }
 
   return unit;

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -222,6 +222,22 @@ export class SymbolTable {
   }
 
   /**
+   * Locate the file path that defines a top-level symbol (function or
+   * node) by name. Returns `undefined` if the name is not defined in any
+   * file in this unit. Used by the interrupt call-graph analysis to tag
+   * each function/node scope with the file it lives in.
+   */
+  findFileForName(name: string): string | undefined {
+    for (const [filePath, fileSymbols] of Object.entries(this.files)) {
+      const sym = fileSymbols[name];
+      if (sym && (sym.kind === "function" || sym.kind === "node")) {
+        return filePath;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Walk every file looking for a type alias with the given name. Returns
    * the first match in iteration order. Used to surface imported type
    * definitions for Zod schema generation.

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -34,10 +34,12 @@ import { inferReturnTypeFor } from "./inference.js";
 import { effectiveReturnType } from "./validation.js";
 import {
   analyzeInterruptsFromScopes,
+  buildInterruptCallGraph,
   checkUnhandledInterruptWarnings,
   checkCallbackBodyInterrupts,
   checkHandlerBodyInterrupts,
 } from "./interruptAnalysis.js";
+import type { SymbolTable } from "../symbolTable.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
 import { checkToolBlockBindings } from "./toolBlockBinding.js";
@@ -60,6 +62,7 @@ export class TypeChecker {
   private importedFunctions: Record<string, ImportedFunctionSignature> = {};
   private jsImportedNames: Record<string, true> = {};
   private interruptKindsByFunction: Record<string, InterruptKind[]> = {};
+  private symbolTable?: SymbolTable;
   private errors: TypeCheckError[] = [];
   private inferredReturnTypes: Record<string, VariableType | "any"> = {};
   private inferringReturnType = new Set<string>();
@@ -81,6 +84,7 @@ export class TypeChecker {
     this.importedFunctions = { ...resolved.importedFunctions };
     this.jsImportedNames = { ...resolved.jsImportedNames };
     this.interruptKindsByFunction = resolved.interruptKindsByFunction ?? {};
+    this.symbolTable = resolved.symbolTable;
     this.sourceText = resolved.sourceText;
   }
 
@@ -108,6 +112,7 @@ export class TypeChecker {
       importedFunctions: this.importedFunctions,
       jsImportedNames: this.jsImportedNames,
       interruptKindsByFunction: this.interruptKindsByFunction,
+      symbolTable: this.symbolTable,
       errors: this.errors,
       inferredReturnTypes: this.inferredReturnTypes,
       inferringReturnType: this.inferringReturnType,
@@ -287,6 +292,12 @@ export class TypeChecker {
     // 5. Analyze interrupts using functionRefType
     const interruptKindsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
 
+    // 5a. Build the per-function interrupt call graph used by
+    // `agency interrupts` for static handler-set analysis. The
+    // existing analyzeInterruptsFromScopes pass continues to compute
+    // transitive kinds; this is purely additive structural info.
+    const interruptCallGraph = buildInterruptCallGraph(scopes, ctx);
+
     // 6. Check for unhandled interrupt warnings (uses transitive results)
     checkUnhandledInterruptWarnings(scopes, interruptKindsByFunction, ctx);
 
@@ -324,6 +335,7 @@ export class TypeChecker {
       errors: this.applySuppressions(this.deduplicateErrors()),
       scopes,
       interruptKindsByFunction,
+      interruptCallGraph,
     };
   }
 

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -1,11 +1,30 @@
 import type { InterruptKind } from "../symbolTable.js";
 import type { TypeCheckerContext, ScopeInfo } from "./types.js";
 import { synthType } from "./synthesizer.js";
-import { walkNodes } from "../utils/node.js";
+import { walkNodes, type WalkAncestor } from "../utils/node.js";
 import type { AgencyNode, Expression, VariableType } from "../types.js";
 import type { SplatExpression, NamedArgument } from "../types/dataStructures.js";
 import type { Scope } from "./scope.js";
 import { isInsideHandler } from "./checker.js";
+import type { HandleBlock } from "../types/handleBlock.js";
+import type { InterruptStatement } from "../types/interruptStatement.js";
+
+export type TaggedHandler = { block: HandleBlock; file: string };
+
+export type CallGraphFunction = {
+  /** Absolute path to the .agency file this function/node is defined in. */
+  file: string;
+  callEdges: { calleeName: string; enclosingHandlers: TaggedHandler[] }[];
+  interruptSites: {
+    site: InterruptStatement;
+    /** Same as the function's `file`. Carried explicitly so consumers don't
+     *  have to look it up. */
+    file: string;
+    enclosingHandlers: TaggedHandler[];
+  }[];
+};
+
+export type InterruptCallGraph = Record<string, CallGraphFunction>;
 
 /** Per-function analysis: what it directly interrupts and what it calls. */
 type FunctionProfile = {
@@ -169,6 +188,76 @@ function functionNamesFromType(t: VariableType | "any", out: string[]): void {
 
 function addUnique(arr: string[], value: string): void {
   if (!arr.includes(value)) arr.push(value);
+}
+
+/**
+ * Build a per-function call graph that, for each call edge and each
+ * `interruptStatement`, records the list of `handle` blocks in the
+ * enclosing function body that lexically wrap it. Each handler is
+ * tagged with its file so the file survives propagation in the
+ * downstream handler-set analyzer.
+ *
+ * Unlike `analyzeInterruptsFromScopes` this does NOT propagate kinds
+ * transitively — it only records direct, per-function structural facts.
+ * The propagation lives in `lib/analysis/interrupts.ts`.
+ */
+export function buildInterruptCallGraph(
+  scopes: ScopeInfo[],
+  ctx: TypeCheckerContext,
+): InterruptCallGraph {
+  const out: InterruptCallGraph = {};
+  for (const info of scopes) {
+    if (!info.name || info.name === "top-level") continue;
+    const file = info.file;
+    const entry: CallGraphFunction = { file, callEdges: [], interruptSites: [] };
+    ctx.withScope(info.scopeKey, () => {
+      for (const { node, ancestors } of walkNodes(info.body)) {
+        const enclosing = enclosingHandleBlocks(ancestors, file);
+        if (node.type === "interruptStatement") {
+          entry.interruptSites.push({
+            site: node,
+            file,
+            enclosingHandlers: enclosing,
+          });
+        } else if (node.type === "functionCall") {
+          entry.callEdges.push({
+            calleeName: node.functionName,
+            enclosingHandlers: enclosing,
+          });
+          for (const refName of functionRefsInArgs(node.arguments, info.scope, ctx)) {
+            entry.callEdges.push({
+              calleeName: refName,
+              enclosingHandlers: enclosing,
+            });
+          }
+        } else if (node.type === "gotoStatement") {
+          entry.callEdges.push({
+            calleeName: node.nodeCall.functionName,
+            enclosingHandlers: enclosing,
+          });
+        }
+      }
+    });
+    out[info.name] = entry;
+  }
+  return out;
+}
+
+/** Return the `handle` block ancestors of a walked node, tagged with the
+ *  file they live in (always the enclosing function's file). `walkNodes`
+ *  yields `WalkAncestor[]` (a union including `BlockArgument`), so the
+ *  filter narrows by `type === "handleBlock"`. */
+function enclosingHandleBlocks(
+  ancestors: WalkAncestor[],
+  file: string,
+): TaggedHandler[] {
+  const out: TaggedHandler[] = [];
+  for (const a of ancestors) {
+    if (a.type === "handleBlock") {
+      out.push({ block: a, file });
+    }
+  }
+  return out;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/interruptCallGraph.test.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptCallGraph.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { liftCallbackBlocks } from "../preprocessors/liftCallbacks.js";
+import { typeCheck } from "./index.js";
+
+function callGraphFrom(source: string) {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-cg-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath);
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) throw new Error("Parse failed");
+    const lifted = liftCallbackBlocks(parseResult.result);
+    const info = buildCompilationUnit(lifted, symbolTable, absPath, source);
+    return typeCheck(lifted, {}, info).interruptCallGraph;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+describe("buildInterruptCallGraph", () => {
+  it("records an interrupt site with enclosing handle blocks, including the right block identity", () => {
+    const cg = callGraphFrom(`
+node main() {
+  handle {
+    interrupt std::read("hi")
+  } with approve
+}
+`);
+    const main = cg["main"];
+    expect(main).toBeDefined();
+    expect(main.file).toMatch(/\.agency$/);
+    expect(main.interruptSites).toHaveLength(1);
+    const site = main.interruptSites[0];
+    expect(site.site.kind).toBe("std::read");
+    expect(site.file).toBe(main.file); // site file matches enclosing function's file
+    expect(site.enclosingHandlers).toHaveLength(1);
+    // Identity check: the captured handler is the `handle {` on the third
+    // line of the source. `loc.line` is 0-indexed (see parser.test.ts
+    // "loc.line invariant"), so 0-indexed line 2 ≡ 1-indexed line 3.
+    expect(site.enclosingHandlers[0].block.loc?.line).toBe(2);
+    expect(site.enclosingHandlers[0].file).toBe(main.file);
+  });
+
+  it("records a call edge with the right enclosing handler identity", () => {
+    const cg = callGraphFrom(`
+def helper() {
+  interrupt std::read("hi")
+}
+
+node main() {
+  handle {
+    helper()
+  } with approve
+}
+`);
+    const main = cg["main"];
+    const edge = main.callEdges.find((e) => e.calleeName === "helper");
+    expect(edge).toBeDefined();
+    expect(edge!.enclosingHandlers).toHaveLength(1);
+    // 0-indexed line 6 ≡ 1-indexed line 7 (the `handle {` line).
+    expect(edge!.enclosingHandlers[0].block.loc?.line).toBe(6);
+  });
+
+  it("records a call edge with NO enclosing handlers when the call is bare", () => {
+    const cg = callGraphFrom(`
+def helper() {
+  interrupt std::read("hi")
+}
+
+node main() {
+  helper()
+}
+`);
+    const main = cg["main"];
+    const edge = main.callEdges.find((e) => e.calleeName === "helper");
+    expect(edge).toBeDefined();
+    expect(edge!.enclosingHandlers).toHaveLength(0);
+  });
+
+  it("attaches enclosing handlers to llm() tool-argument synthetic edges", () => {
+    const cg = callGraphFrom(`
+def deleteEmails() {
+  interrupt std::write("delete?")
+}
+
+node main() {
+  handle {
+    let _: string = llm("do work", { tools: [deleteEmails] })
+  } with approve
+}
+`);
+    const main = cg["main"];
+    const synthetic = main.callEdges.find((e) => e.calleeName === "deleteEmails");
+    expect(synthetic).toBeDefined();
+    // Critical: the synthetic edge must inherit the handlers from the
+    // llm(...) call site, otherwise llm-tool propagation silently loses
+    // handlers downstream.
+    expect(synthetic!.enclosingHandlers).toHaveLength(1);
+  });
+
+  it("records a gotoStatement target as a call edge", () => {
+    const cg = callGraphFrom(`
+node finish() {
+  interrupt std::read("hi")
+}
+
+node main() {
+  goto finish()
+}
+`);
+    const main = cg["main"];
+    expect(main.callEdges.some((e) => e.calleeName === "finish")).toBe(true);
+  });
+
+  it("populates CallGraphFunction.file from the symbol table lookup", () => {
+    const cg = callGraphFrom(`
+def helper() {}
+
+node main() {
+  helper()
+}
+`);
+    expect(cg["main"].file).toMatch(/\.agency$/);
+    expect(cg["helper"].file).toBe(cg["main"].file);
+  });
+
+  it("skips the top-level scope", () => {
+    const cg = callGraphFrom(`
+node main() {
+  interrupt std::read("hi")
+}
+`);
+    expect(cg["top-level"]).toBeUndefined();
+    expect(Object.keys(cg)).toEqual(["main"]);
+  });
+
+  it("records every distinct interrupt site in one function", () => {
+    const cg = callGraphFrom(`
+node main() {
+  interrupt std::read("hi")
+  interrupt std::write("bye")
+}
+`);
+    expect(cg["main"].interruptSites).toHaveLength(2);
+    expect(cg["main"].interruptSites.map((s) => s.site.kind)).toEqual(["std::read", "std::write"]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -33,6 +33,7 @@ export function buildScopes(ctx: TypeCheckerContext): ScopeInfo[] {
     body: ctx.programNodes,
     name: "top-level",
     scopeKey: GLOBAL_SCOPE_KEY,
+    file: "",
   });
 
   for (const def of [
@@ -66,6 +67,7 @@ function buildDefScope(
     body: def.body,
     name,
     scopeKey: sk,
+    file: ctx.symbolTable?.findFileForName(name) ?? "",
     returnType: def.returnType,
   };
 }

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -12,7 +12,8 @@ import type {
   ImportedFunctionSignature,
   ScopedTypeAliases,
 } from "../compilationUnit.js";
-import type { InterruptKind } from "../symbolTable.js";
+import type { InterruptKind, SymbolTable } from "../symbolTable.js";
+import type { InterruptCallGraph } from "./interruptAnalysis.js";
 
 export type TypeCheckError = {
   message: string;
@@ -27,6 +28,7 @@ export type TypeCheckResult = {
   errors: TypeCheckError[];
   scopes: ScopeInfo[];
   interruptKindsByFunction: Record<string, InterruptKind[]>;
+  interruptCallGraph: InterruptCallGraph;
 };
 
 export type ScopeInfo = {
@@ -34,6 +36,10 @@ export type ScopeInfo = {
   body: AgencyNode[];
   name: string;
   scopeKey: string;
+  /** Absolute path to the .agency file this scope's body lives in. Empty
+   *  for the synthetic top-level scope that spans the whole compilation
+   *  unit. Populated from the symbol table via `findFileForName`. */
+  file: string;
   returnType?: VariableType | null;
 };
 
@@ -73,6 +79,12 @@ export type TypeCheckerContext = {
   inferredReturnTypes: Record<string, VariableType | "any">;
   inferringReturnType: Set<string>;
   config: AgencyConfig;
+  /** Optional symbol table threaded through from `buildCompilationUnit`.
+   *  Used by `buildScopes` to populate `ScopeInfo.file` via
+   *  `SymbolTable.findFileForName`. Optional because callers that
+   *  construct a TypeCheckerContext directly (e.g. in legacy tests) may
+   *  not have a symbol table. */
+  symbolTable?: SymbolTable;
   getTypeAliases(): Record<string, TypeAliasEntry>;
   withScope<T>(key: string, fn: () => T): T;
   inferReturnTypeFor(

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -36,6 +36,7 @@ import process from "process";
 import { agent } from "@/cli/agent.js";
 import { review } from "@/cli/review.js";
 import { policyGen } from "@/cli/policy.js";
+import { interruptsCmd } from "@/cli/interrupts.js";
 import {
   scheduleAdd,
   scheduleList,
@@ -1104,6 +1105,15 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action((file: string, options: { output?: string; existing?: string }) => {
       const config = getConfig();
       policyGen(config, file, options);
+    });
+
+  program
+    .command("interrupts")
+    .description("Print every interrupt site and the handle blocks that could enclose it")
+    .argument("<file>", "The .agency file to analyze")
+    .action((file: string) => {
+      const config = getConfig();
+      interruptsCmd(config, file);
     });
 
   addRunOptions(

--- a/packages/agency-lang/scripts/regenerate-fixtures.ts
+++ b/packages/agency-lang/scripts/regenerate-fixtures.ts
@@ -6,6 +6,8 @@ import { generateTypeScript } from "../lib/backends/typescriptGenerator.js";
 import { TypescriptPreprocessor } from "../lib/preprocessors/typescriptPreprocessor.js";
 import { parseAgency } from "../lib/parser.js";
 import { buildCompilationUnit } from "../lib/compilationUnit.js";
+import { analyzeInterrupts } from "../lib/analysis/interrupts.js";
+import { renderInterrupts } from "../lib/cli/interrupts.js";
 import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -65,5 +67,48 @@ regenerate(preprocessorFixturesDir, preprocessorTransform);
 
 console.log("\n--- TypeScript Builder Fixtures ---");
 regenerate(builderFixturesDir, generatorTransform);
+
+// IMPORTANT: keep this normalization in sync with the matching block in
+// tests/integration/cli-main/test.mjs (normalizeInterruptOutput). If one
+// changes, the integration snapshots will drift and tests will fail.
+function regenerateInterruptFixtures(): void {
+  const interruptsDir = path.join(
+    __dirname,
+    "../../tests/integration/cli-main/fixtures/interrupts"
+  );
+  const expectedDir = path.join(
+    __dirname,
+    "../../tests/integration/cli-main/fixtures/expected"
+  );
+  // Each entry: { name (for expected/<name>.txt), entryFile (relative to interruptsDir) }
+  const cases = [
+    { name: "single-file", entryFile: "single-file.agency" },
+    { name: "cross-file", entryFile: "cross-file/main.agency" },
+    { name: "llm-tool", entryFile: "llm-tool.agency" },
+    { name: "recursion", entryFile: "recursion.agency" },
+    { name: "no-handler", entryFile: "no-handler.agency" },
+  ];
+  for (const c of cases) {
+    const entryPath = path.join(interruptsDir, c.entryFile);
+    const result = analyzeInterrupts(entryPath, {});
+    // (1) Replace absolute fixture path with a portable token so the
+    //     snapshot is reproducible across machines / CI containers.
+    // (2) Normalize Windows backslashes to forward slashes so the
+    //     snapshot matches regardless of OS.
+    const rendered = renderInterrupts(result)
+      .replace(new RegExp(escapeForRegex(interruptsDir), "g"), "<fixtures>/interrupts")
+      .replace(/\\/g, "/");
+    const outPath = path.join(expectedDir, `interrupts-${c.name}.txt`);
+    fs.writeFileSync(outPath, rendered, "utf-8");
+    console.log(`✓ Updated interrupts-${c.name}.txt`);
+  }
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+console.log("\n--- Interrupts Fixtures ---");
+regenerateInterruptFixtures();
 
 console.log("\nDone!");

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-cross-file.txt
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-cross-file.txt
@@ -1,0 +1,3 @@
+<fixtures>/interrupts/cross-file/helper.agency:2  interrupt of kind std::read
+  Possible enclosing handlers:
+    handle via fn approve at <fixtures>/interrupts/cross-file/main.agency:4

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-llm-tool.txt
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-llm-tool.txt
@@ -1,0 +1,3 @@
+<fixtures>/interrupts/llm-tool.agency:2  interrupt of kind std::write
+  Possible enclosing handlers:
+    handle via fn approve at <fixtures>/interrupts/llm-tool.agency:6

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-no-handler.txt
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-no-handler.txt
@@ -1,0 +1,3 @@
+<fixtures>/interrupts/no-handler.agency:2  interrupt of kind std::read
+  Possible enclosing handlers:
+    (none)

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-recursion.txt
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-recursion.txt
@@ -1,0 +1,3 @@
+<fixtures>/interrupts/recursion.agency:3  interrupt of kind std::read
+  Possible enclosing handlers:
+    handle via fn approve at <fixtures>/interrupts/recursion.agency:7

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-single-file.txt
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/expected/interrupts-single-file.txt
@@ -1,0 +1,3 @@
+<fixtures>/interrupts/single-file.agency:3  interrupt of kind std::read
+  Possible enclosing handlers:
+    handle via fn approve at <fixtures>/interrupts/single-file.agency:2

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/cross-file/helper.agency
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/cross-file/helper.agency
@@ -1,0 +1,3 @@
+export def helper() {
+  interrupt std::read("hi")
+}

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/cross-file/main.agency
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/cross-file/main.agency
@@ -1,0 +1,7 @@
+import { helper } from "./helper.agency"
+
+node main() {
+  handle {
+    helper()
+  } with approve
+}

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/llm-tool.agency
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/llm-tool.agency
@@ -1,0 +1,9 @@
+def deleteEmails() {
+  interrupt std::write("delete?")
+}
+
+node main() {
+  handle {
+    let _: string = llm("do work", { tools: [deleteEmails] })
+  } with approve
+}

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/no-handler.agency
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/no-handler.agency
@@ -1,0 +1,3 @@
+node main() {
+  interrupt std::read("hi")
+}

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/recursion.agency
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/recursion.agency
@@ -1,0 +1,10 @@
+def loop() {
+  loop()
+  interrupt std::read("hi")
+}
+
+node main() {
+  handle {
+    loop()
+  } with approve
+}

--- a/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/single-file.agency
+++ b/packages/agency-lang/tests/integration/cli-main/fixtures/interrupts/single-file.agency
@@ -1,0 +1,5 @@
+node main() {
+  handle {
+    interrupt std::read("hi")
+  } with approve
+}

--- a/packages/agency-lang/tests/integration/cli-main/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-main/test.mjs
@@ -7,6 +7,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -396,6 +397,58 @@ try {
     join(dir, "src/fmt-stdout.agency"),
     join(fixtureDir, "project", "src", "fmt-input.agency"),
   );
+
+  // interrupts
+
+  console.log("--- interrupts ---");
+
+  // Copy the interrupts fixtures into the temp project.
+  cpSync(
+    join(fixtureDir, "interrupts"),
+    join(dir, "interrupts"),
+    { recursive: true },
+  );
+
+  const interruptCases = [
+    { name: "single-file", entryFile: "interrupts/single-file.agency" },
+    { name: "cross-file", entryFile: "interrupts/cross-file/main.agency" },
+    { name: "llm-tool", entryFile: "interrupts/llm-tool.agency" },
+    { name: "recursion", entryFile: "interrupts/recursion.agency" },
+    { name: "no-handler", entryFile: "interrupts/no-handler.agency" },
+  ];
+
+  // IMPORTANT: keep this normalization in sync with the matching block in
+  // scripts/regenerate-fixtures.ts (regenerateInterruptFixtures). If one
+  // changes, the snapshots will drift and these tests will fail spuriously.
+  //
+  // On macOS, `/tmp` and `/var/folders/...` are symlinks to
+  // `/private/tmp` and `/private/var/folders/...`. Node's path.resolve
+  // does not follow symlinks, but the agency CLI ends up surfacing the
+  // realpath-resolved form, so we normalize both the original temp dir
+  // and its realpath to the same token.
+  const interruptsDir = join(dir, "interrupts");
+  const interruptsDirReal = realpathSync(interruptsDir);
+  function normalizeInterruptOutput(s) {
+    return s
+      .replaceAll(interruptsDirReal, "<fixtures>/interrupts")
+      .replaceAll(interruptsDir, "<fixtures>/interrupts")
+      .replaceAll(/\\/g, "/");
+  }
+
+  for (const c of interruptCases) {
+    const actualOutput = runAgency(
+      `interrupts-${c.name}`,
+      ["interrupts", c.entryFile],
+    );
+    const normalized = normalizeInterruptOutput(actualOutput);
+    const actualPath = join(logsDir, `interrupts-${c.name}.actual.txt`);
+    writeFileSync(actualPath, normalized);
+    assertFileEquals(
+      actualPath,
+      join(expectedDir, `interrupts-${c.name}.txt`),
+      { normalizeTrailingNewline: true },
+    );
+  }
 
   // parse
 


### PR DESCRIPTION
## Summary

Adds a new `agency interrupts <file>` CLI subcommand that statically prints, for every `interruptStatement` reachable in the import tree, the set of `handle` blocks that could enclose it on the call stack.

Solves the concrete debugging problem: a developer wraps a call in `with approve` expecting auto-approval, but the interrupt still surfaces to the user. The command lists every handler that could catch the interrupt so the developer can find the other handler that is eating their `with approve`.

## Example

```
$ agency interrupts src/agent.agency
src/agent.agency:42  interrupt of kind std::read
  Possible enclosing handlers:
    handle via fn approve at src/main.agency:10
    handle via fn approveReads at src/main.agency:18
```

## Architecture

- Reuses the typechecker pipeline (`parse` → `SymbolTable.build` → `buildCompilationUnit` → `typeCheck`) — same as `lib/cli/policy.ts`.
- Extends `lib/typeChecker/interruptAnalysis.ts` with a new `buildInterruptCallGraph` that records, per function/node, every call edge and `interruptStatement` site along with the list of enclosing `handle` blocks (tagged with their source file via a `TaggedHandler`). The existing `analyzeInterruptsFromScopes` is untouched.
- New `lib/analysis/interrupts.ts` runs a worklist fixed-point over the call graph to compute, per site, the deduped set of handlers that could be on the active stack. Written as a declarative pipeline (`loadCallGraph` → `collectAllSites` → `propagateHandlers` → `collectEntries`+`unionAcrossEntries` → `buildResult`).
- New `lib/cli/interrupts.ts` is a thin renderer + CLI shim.
- Wired into `scripts/agency.ts` via Commander, with help text in `lib/cli/help.ts`.

## File-tracking detail

`SourceLocation` only carries `{line, col, start, end}` — no `file`. To track which file each site/handler lives in:
- Added `findFileForName(name)` to `SymbolTable`.
- Added `file: string` to `ScopeInfo`, populated from the symbol table in `buildScopes`.
- Threaded `SymbolTable` through `CompilationUnit` and `TypeCheckerContext`.
- Each `TaggedHandler` carries the file so it survives propagation across the call graph.

## Multi-file analysis

The typechecker only sees the entry file's local definitions, so the analyzer runs the typechecker on every reachable `.agency` file in the symbol table and merges the resulting call graphs. Stdlib functions are excluded from entry detection so stdlib's own interrupt sites don't pollute the report when they aren't actually reachable from user code.

## Commits

1. `feat(typechecker): add interrupt call graph to TypeCheckResult`
2. `feat(analysis): add interrupt handler-set analyzer`
3. `feat(cli): add renderInterrupts and interruptsCmd`
4. `feat(cli): register agency interrupts subcommand`
5. `test(interrupts): add fixtures and wire into make fixtures`
6. `test(interrupts): add cli-main integration smoke test`

## Testing

- 8 unit tests for `buildInterruptCallGraph` (call edges, interrupt sites, llm-tool synthetic edges, goto, file identity, skip top-level).
- 14 unit tests for `analyzeInterrupts` (direct sites, bare interrupts, diamond dedup, recursion, both handler shapes, llm tool propagation, nested handlers across function boundaries, multi-entry union, orphan functions, cross-file imports).
- 6 unit tests for `renderInterrupts` (header format, unknown-kind clause omission, both handler shapes, block separation, trailing newline, empty input).
- 5 integration fixtures hooked into `make fixtures` and the `tests/integration/cli-main/test.mjs` smoke harness.

All 592 typechecker + analysis + CLI tests pass locally. The integration harness's `--- interrupts ---` block passes. (The pre-existing `--- doc ---` failure in the same harness is unrelated to this PR — it reproduces on `main`.)

## Out of scope (per spec)

Handler-safety warnings (already a type error), uncaught-interrupt warnings (already a typechecker diagnostic), llm()-specific rendering, color/`NO_COLOR`, `--json`, `--entry`, stack ordering of handlers.

🤖 Generated with [Amp](https://ampcode.com)
