### PR TITLE
Add explicit eval input and output annotations

### DIFF
--- a/packages/agency-lang/docs/site/cli/eval.md
+++ b/packages/agency-lang/docs/site/cli/eval.md
@@ -36,22 +36,39 @@ The extractor output is deliberately **generic** — it knows nothing about spec
 
 The two semantic anchors the extractor does surface at the top level are:
 
-- `userMessage` — the prompt the user typed (the last user-role message of the first `promptCompletion` on the top-level thread).
-- `finalResponse` — the final reply the user saw (the `completion` of the last `promptCompletion` on the top-level thread).
+- `evalInputs` — chronological values recorded by `evalInput(value)`.
+- `evalOutputs` — chronological values recorded by `evalOutput(value)`.
 
-Both are hoisted because they're load-bearing for the planned `agency eval compare` command (the LLM judge sees these two strings side-by-side across two runs). Everything else — thread tree, per-event sequence, interrupts, errors, incomplete tool calls, aggregated metrics — lives in `events`, `threads`, `interrupts`, `errors`, `incomplete`, and `metrics`.
+Both are hoisted because they're load-bearing for eval consumers and judges. Everything else — thread tree, per-event sequence, interrupts, errors, incomplete tool calls, aggregated metrics — lives in `events`, `threads`, `interrupts`, `errors`, `incomplete`, and `metrics`.
+
+## How to annotate a run
+
+Import `std::statelog` and call `evalInput` / `evalOutput` where values cross the user-facing boundary:
+
+```ts
+import { evalInput, evalOutput } from "std::statelog"
+
+node main(prompt: string): string {
+  evalInput(prompt)
+  const reply = doWork(prompt)
+  evalOutput(reply)
+  return reply
+}
+```
+
+Without annotations, `extract` falls back to approximate trace-level heuristics: the last user-role message of the first top-level `promptCompletion` for `evalInputs`, and the last top-level `promptCompletion` completion for `evalOutputs`. Falling back is supported for backwards compatibility, but the inference is approximate. Annotate your agent for trustworthy evals.
 
 ## Record shape (overview)
 
 ```jsonc
 {
   "traceId": "...",
-  "recordVersion": 1,
+  "recordVersion": 2,
   "formatVersion": 1,
   "durationMs": 12345,
   "source": "/path/to/run.statelog.jsonl",
-  "userMessage": "what the user asked",
-  "finalResponse": "what the agent replied",
+  "evalInputs": [{ "value": "what the user asked", "threadId": "0", "tMs": 120 }],
+  "evalOutputs": [{ "value": "what the agent replied", "threadId": "0", "tMs": 420 }],
   "threads": [{ "threadId": "0", "label": "main", "parentThreadId": null, ... }],
   "events":  [{ "kind": "llm", "threadId": "0", "model": "gpt-5", ... }, ...],
   "interrupts": [...],
@@ -69,6 +86,19 @@ Every entry in `events` is one of three discriminated shapes:
 - `{ kind: "tool_end" }` — one per `toolCall`. Carries `outputPreview` and duration.
 
 All three carry `threadId`, `spanId`, `parentSpanId`, and `tMs` (milliseconds from the start of the run).
+
+Every entry in `evalInputs` and `evalOutputs` has this shape:
+
+```jsonc
+{ "value": unknown, "threadId": "0", "tMs": 420, "truncated": true }
+```
+
+- `value` is the JSON-serializable value passed to `evalInput` / `evalOutput`, or a heuristic fallback value when annotations are missing.
+- `threadId` identifies the active thread that recorded the value, or `null` when unavailable.
+- `tMs` is milliseconds from the trace start, derived from the statelog envelope timestamp.
+- `truncated` is present only when the serialized value exceeded `STATELOG_EVAL_MAX_VALUE_BYTES`. The default cap is 100KB; set that environment variable before running `agency eval extract` to override it. Oversized string values are kept as readable string prefixes; oversized non-string values are converted to JSON-preview strings.
+
+Consumers that need one response typically read `record.evalOutputs.at(-1)?.value`. A pairwise judge compares the last element of `evalOutputs`; without annotations, that value may be the last LLM completion rather than what the user actually saw.
 
 ## Behavioral-flag recipe
 
@@ -94,7 +124,7 @@ If a convention emerges (a set of rules every project wants), it can be promoted
 
 ## Downstream chain
 
-`userMessage` and `finalResponse` are hoisted to the top level specifically because the planned `agency eval compare <a> <b>` will feed them to an LLM judge for pairwise quality comparison across two runs. `threads[*].label` is what consumer behavioral queries grep on. These are the two seams that connect `extract` to its (future) sibling commands.
+`evalInputs` and `evalOutputs` are hoisted to the top level specifically because eval consumers and pairwise judges need the user-facing inputs and outputs without digging through raw `promptCompletion` events. `threads[*].label` is what consumer behavioral queries grep on. These are the two seams that connect `extract` to its sibling commands.
 
 ## Legacy traces
 

--- a/packages/agency-lang/docs/site/stdlib/statelog.md
+++ b/packages/agency-lang/docs/site/stdlib/statelog.md
@@ -1,0 +1,76 @@
+---
+name: "statelog"
+---
+
+# statelog
+
+## Functions
+
+### evalInput
+
+```ts
+evalInput(value: any)
+```
+
+Record an eval input — a value that should be considered part of
+  the user-facing input to this agent. Captured in the statelog as
+  an `evalInputRecorded` event and surfaced by `agency eval extract`
+  on the `evalInputs[]` field of the produced record.
+
+  Call this once per discrete user input. May be called multiple
+  times in a single trace; all firings are collected in order. The
+  consuming eval / judge / task definition decides what to do with
+  multiple firings.
+
+  When no eval annotation exists in a trace, `eval extract` falls
+  back to a heuristic (first user-role message of the first LLM
+  call) and emits a warning. Annotating explicitly is preferred.
+
+  @param value - The value to record. Any JSON-serializable type is
+    accepted; stored as `unknown` in the eval record. Top-level
+    `undefined` records as `null`; nested functions, `undefined`,
+    and symbols follow JSON serialization rules; circular references
+    and `bigint` throw at the call site (with your stack), not later
+    inside the log writer.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L3))
+
+### evalOutput
+
+```ts
+evalOutput(value: any)
+```
+
+Record an eval output — a value that should be considered the
+  agent's user-facing response. Captured in the statelog as an
+  `evalOutputRecorded` event and surfaced by `agency eval extract`
+  on the `evalOutputs[]` field of the produced record.
+
+  Call this once per discrete user-facing response. May be called
+  multiple times in a single trace; all firings are collected in
+  order. The consuming eval / judge / task definition decides what
+  to do with multiple firings (e.g. a pairwise judge can use the
+  last firing).
+
+  When no eval annotation exists in a trace, `eval extract` falls
+  back to a heuristic (last LLM completion on the top-level thread)
+  and emits a warning. Annotating explicitly is preferred — the
+  heuristic does NOT account for post-LLM processing the agent
+  applies before showing a response to the user.
+
+  @param value - The value to record. Any JSON-serializable type is
+    accepted; same serialization rules as `evalInput`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L29))

--- a/packages/agency-lang/docs/site/stdlib/statelog.md
+++ b/packages/agency-lang/docs/site/stdlib/statelog.md
@@ -28,10 +28,11 @@ Record an eval input — a value that should be considered part of
 
   @param value - The value to record. Any JSON-serializable type is
     accepted; stored as `unknown` in the eval record. Top-level
-    `undefined` records as `null`; nested functions, `undefined`,
-    and symbols follow JSON serialization rules; circular references
-    and `bigint` throw at the call site (with your stack), not later
-    inside the log writer.
+    `undefined` records as `null`; top-level functions and symbols
+    throw a TypeError; nested functions, `undefined`, and symbols
+    follow JSON serialization rules; circular references and `bigint`
+    throw at the call site (with your stack), not later inside the
+    log writer.
 
 **Parameters:**
 
@@ -73,4 +74,4 @@ Record an eval output — a value that should be considered the
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L30))

--- a/packages/agency-lang/lib/eval/extract.test.ts
+++ b/packages/agency-lang/lib/eval/extract.test.ts
@@ -116,20 +116,31 @@ describe("extractEvalRecord", () => {
       expect(rec.incomplete).toEqual([]);
     });
 
-    it("userMessage / finalResponse populated", () => {
-      expect(rec.userMessage).toBe("do the thing");
-      expect(rec.finalResponse).toBe("done.");
+    it("evalInputs / evalOutputs populated from heuristic", () => {
+      expect(rec.evalInputs.at(-1)?.value).toBe("do the thing");
+      expect(rec.evalInputs.at(-1)?.threadId).toBe("0");
+      expect(rec.evalOutputs.at(-1)?.value).toBe("done.");
+      expect(rec.evalOutputs.at(-1)?.threadId).toBe("0");
+      expect(
+        rec.warnings.some((w) => w.includes("Call evalInput(prompt)")),
+      ).toBe(true);
+      expect(
+        rec.warnings.some((w) => w.includes("Call evalOutput(reply)")),
+      ).toBe(true);
     });
 
     it("traceId / formatVersion / source / recordVersion", () => {
       expect(rec.traceId).toBe("trace-A");
       expect(rec.formatVersion).toBe(1);
       expect(rec.source).toBe("test:A");
-      expect(rec.recordVersion).toBe(1);
+      expect(rec.recordVersion).toBe(2);
     });
 
-    it("no warnings", () => {
-      expect(rec.warnings).toEqual([]);
+    it("only warns about heuristic eval extraction", () => {
+      expect(rec.warnings).toEqual([
+        expect.stringContaining("Call evalInput(prompt)"),
+        expect.stringContaining("Call evalOutput(reply)"),
+      ]);
     });
   });
 
@@ -164,8 +175,10 @@ describe("extractEvalRecord", () => {
       expect(rec.metrics.toolEnds).toBe(0);
     });
 
-    it("warnings empty", () => {
-      expect(rec.warnings).toEqual([]);
+    it("only warns about the heuristic eval input it can extract", () => {
+      expect(rec.warnings).toEqual([
+        expect.stringContaining("Call evalInput(prompt)"),
+      ]);
     });
   });
 
@@ -218,12 +231,14 @@ describe("extractEvalRecord", () => {
       for (const e of toolEvents) expect(e.threadId).toBe("1");
     });
 
-    it("userMessage is the TOP-LEVEL thread's user prompt, not the subagent's", () => {
-      expect(rec.userMessage).toBe("delegate");
+    it("evalInputs uses the TOP-LEVEL thread's user prompt, not the subagent's", () => {
+      expect(rec.evalInputs[0].value).toBe("delegate");
+      expect(rec.evalInputs[0].threadId).toBe("0");
     });
 
-    it("finalResponse is the TOP-LEVEL thread's last completion, not the subagent's", () => {
-      expect(rec.finalResponse).toBe("delegating");
+    it("evalOutputs uses the TOP-LEVEL thread's last completion, not the subagent's", () => {
+      expect(rec.evalOutputs[0].value).toBe("delegating");
+      expect(rec.evalOutputs[0].threadId).toBe("0");
     });
   });
 
@@ -250,9 +265,11 @@ describe("extractEvalRecord", () => {
       expect(rec.warnings.some((w) => /no threadId field/i.test(w))).toBe(true);
     });
 
-    it("falls back to all promptCompletions for userMessage / finalResponse", () => {
-      expect(rec.userMessage).toBe("hello");
-      expect(rec.finalResponse).toBe("hi");
+    it("falls back to all promptCompletions for evalInputs / evalOutputs", () => {
+      expect(rec.evalInputs[0].value).toBe("hello");
+      expect(rec.evalInputs[0].threadId).toBeNull();
+      expect(rec.evalOutputs[0].value).toBe("hi");
+      expect(rec.evalOutputs[0].threadId).toBeNull();
     });
 
     it("attributes tool/LLM events with null threadId", () => {
@@ -328,6 +345,153 @@ describe("extractEvalRecord", () => {
       const rec = extractEvalRecord(events, "test:preview", { previewChars: 0 });
       const end = rec.events.find((e) => e.kind === "tool_end");
       expect((end as any).outputPreview.length).toBeGreaterThan(400);
+    });
+  });
+
+  describe("explicit eval annotation extraction", () => {
+    it("uses explicit evalInputRecorded / evalOutputRecorded events without fallback warnings", () => {
+      resetClock();
+      const events: EventEnvelope[] = [
+        ev("threadCreated", { threadId: "0", threadType: "thread", label: "main" }),
+        ev("evalInputRecorded", { threadId: "0", value: { prompt: "real input" } }),
+        ev("evalOutputRecorded", { threadId: "0", value: "real output" }),
+      ];
+      const rec = extractEvalRecord(events, "test:explicit");
+
+      expect(rec.evalInputs).toEqual([
+        { value: { prompt: "real input" }, threadId: "0", tMs: 100 },
+      ]);
+      expect(rec.evalOutputs).toEqual([
+        { value: "real output", threadId: "0", tMs: 200 },
+      ]);
+      expect(rec.warnings).not.toEqual(
+        expect.arrayContaining([expect.stringMatching(/Call eval(Input|Output)/)]),
+      );
+    });
+
+    it("preserves chronological order for multiple firings", () => {
+      resetClock();
+      const events: EventEnvelope[] = [
+        ev("evalInputRecorded", { threadId: "0", value: "first in" }),
+        ev("evalOutputRecorded", { threadId: "0", value: "first out" }),
+        ev("evalInputRecorded", { threadId: "0", value: "second in" }),
+        ev("evalOutputRecorded", { threadId: "0", value: "second out" }),
+      ];
+      const rec = extractEvalRecord(events, "test:multiple");
+
+      expect(rec.evalInputs.map((v) => v.value)).toEqual(["first in", "second in"]);
+      expect(rec.evalOutputs.map((v) => v.value)).toEqual([
+        "first out",
+        "second out",
+      ]);
+    });
+
+    it("emits no eval warnings when neither explicit events nor promptCompletions exist", () => {
+      resetClock();
+      const rec = extractEvalRecord([ev("agentStart", { entryNode: "main" })], "test:none");
+
+      expect(rec.evalInputs).toEqual([]);
+      expect(rec.evalOutputs).toEqual([]);
+      expect(rec.warnings).not.toEqual(
+        expect.arrayContaining([expect.stringMatching(/eval(Input|Output)\(\)/)]),
+      );
+    });
+
+    it("mixes explicit output with heuristic input", () => {
+      resetClock();
+      const events: EventEnvelope[] = [
+        ev("threadCreated", { threadId: "0", threadType: "thread", label: "main" }),
+        ev(
+          "promptCompletion",
+          {
+            threadId: "0",
+            model: "gpt-5",
+            messages: [{ role: "user", content: "heuristic input" }],
+            completion: { output: "raw llm output" },
+          },
+          "span-llm",
+        ),
+        ev("evalOutputRecorded", { threadId: "0", value: "real output" }),
+      ];
+      const rec = extractEvalRecord(events, "test:mixed");
+
+      expect(rec.evalInputs).toEqual([
+        { value: "heuristic input", threadId: "0", tMs: 100 },
+      ]);
+      expect(rec.evalOutputs).toEqual([
+        { value: "real output", threadId: "0", tMs: 200 },
+      ]);
+      expect(rec.warnings).toEqual([
+        expect.stringContaining("Call evalInput(prompt)"),
+      ]);
+    });
+
+    it("truncates oversized explicit values without mutating smaller entries", () => {
+      resetClock();
+      const huge = "x".repeat(100_100);
+      const events: EventEnvelope[] = [
+        ev("evalInputRecorded", { threadId: "0", value: huge }),
+        ev("evalInputRecorded", { threadId: "0", value: "small" }),
+        ev("evalOutputRecorded", { threadId: "0", value: "ok" }),
+      ];
+      const rec = extractEvalRecord(events, "test:truncate");
+
+      expect(rec.evalInputs[0].truncated).toBe(true);
+      expect(typeof rec.evalInputs[0].value).toBe("string");
+      expect(String(rec.evalInputs[0].value)).toContain("[truncated");
+      expect(String(rec.evalInputs[0].value).length).toBeLessThan(huge.length);
+      expect(rec.evalInputs[1]).toEqual({
+        value: "small",
+        threadId: "0",
+        tMs: 100,
+      });
+    });
+
+    it("truncates oversized strings as readable string content", () => {
+      resetClock();
+      const huge = "actual text ".repeat(10_000);
+      const rec = extractEvalRecord(
+        [ev("evalOutputRecorded", { threadId: "0", value: huge })],
+        "test:truncate-string",
+      );
+
+      expect(rec.evalOutputs[0].truncated).toBe(true);
+      expect(String(rec.evalOutputs[0].value).startsWith("actual text ")).toBe(true);
+      expect(String(rec.evalOutputs[0].value).startsWith('"actual text')).toBe(false);
+    });
+
+    it("caps truncated unicode values by UTF-8 bytes", () => {
+      resetClock();
+      const huge = "🙂".repeat(40_000);
+      const rec = extractEvalRecord(
+        [ev("evalOutputRecorded", { threadId: "0", value: huge })],
+        "test:truncate-unicode",
+      );
+
+      const truncated = String(rec.evalOutputs[0].value);
+      expect(rec.evalOutputs[0].truncated).toBe(true);
+      expect(Buffer.byteLength(JSON.stringify(truncated), "utf8")).toBeLessThanOrEqual(
+        100_000,
+      );
+    });
+
+    it("preserves subagent explicit evalOutputRecorded firings", () => {
+      resetClock();
+      const events: EventEnvelope[] = [
+        ev("threadCreated", { threadId: "0", threadType: "thread", label: "main" }),
+        ev("threadCreated", {
+          threadId: "1",
+          threadType: "subthread",
+          parentThreadId: "0",
+          label: "worker",
+        }),
+        ev("evalOutputRecorded", { threadId: "1", value: "subagent output" }),
+      ];
+      const rec = extractEvalRecord(events, "test:subagent-explicit");
+
+      expect(rec.evalOutputs).toEqual([
+        { value: "subagent output", threadId: "1", tMs: 200 },
+      ]);
     });
   });
 });

--- a/packages/agency-lang/lib/eval/extract.ts
+++ b/packages/agency-lang/lib/eval/extract.ts
@@ -13,6 +13,7 @@ import { extractThreads, normalize, type Normalized, type NormalizedEnvelope } f
 import type {
   ErrorEntry,
   EvalRecord,
+  EvalValue,
   IncompleteInvocation,
   InterruptEntry,
   Metrics,
@@ -29,6 +30,12 @@ export type ExtractOptions = {
 type WithWarnings<T> = { result: T; warnings: string[] };
 
 const DEFAULT_PREVIEW_CHARS = 200;
+const DEFAULT_EVAL_MAX_VALUE_BYTES = 100_000;
+const EVAL_MAX_VALUE_BYTES = parseEvalMaxValueBytes();
+const NO_EVAL_INPUT_WARNING =
+  "no evalInput() calls in trace; user input inferred from last user-role message of first promptCompletion on the top-level thread. Call evalInput(prompt) in your agent code to record the actual user input.";
+const NO_EVAL_OUTPUT_WARNING =
+  "no evalOutput() calls in trace; final response inferred from last promptCompletion completion on the top-level thread. Call evalOutput(reply) in your agent code to record the actual user-facing response.";
 
 /** Top-level extractor. Composes pure helpers over the Normalized
  *  form produced by `normalize()`; no shared mutable state, no
@@ -65,19 +72,21 @@ export function extractEvalRecord(
   const incomplete = findIncompleteInvocations(n);
   const metrics = computeMetrics(n);
   const topThreadProms = topLevelPromptCompletions(n, threads);
-  const userMessage = extractUserMessage(topThreadProms);
-  const finalResponse = extractFinalResponse(topThreadProms);
+  const evalInputs =
+    collectExplicit("evalInputRecorded", n) ?? heuristicInputs(topThreadProms);
+  const evalOutputs =
+    collectExplicit("evalOutputRecorded", n) ?? heuristicOutputs(topThreadProms);
 
   const last = n.events[n.events.length - 1];
 
   return {
     traceId,
-    recordVersion: 1,
+    recordVersion: 2,
     formatVersion: events[0].format_version,
     durationMs: last.tMs,
     source,
-    userMessage: userMessage.result,
-    finalResponse: finalResponse.result,
+    evalInputs: capValues(evalInputs.result),
+    evalOutputs: capValues(evalOutputs.result),
     threads,
     events: normalized.result,
     interrupts: interrupts.result,
@@ -91,8 +100,8 @@ export function extractEvalRecord(
       ...errors.warnings,
       ...incomplete.warnings,
       ...metrics.warnings,
-      ...userMessage.warnings,
-      ...finalResponse.warnings,
+      ...evalInputs.warnings,
+      ...evalOutputs.warnings,
     ],
   };
 }
@@ -287,19 +296,115 @@ function topLevelPromptCompletions(
 
 function extractUserMessage(
   prompts: NormalizedEnvelope[],
-): WithWarnings<string | null> {
-  if (prompts.length === 0) return { result: null, warnings: [] };
-  return { result: userMessageOf(prompts[0].raw), warnings: [] };
+): { value: string | null; source: NormalizedEnvelope | null } {
+  if (prompts.length === 0) return { value: null, source: null };
+  return { value: userMessageOf(prompts[0].raw), source: prompts[0] };
 }
 
 function extractFinalResponse(
   prompts: NormalizedEnvelope[],
-): WithWarnings<string | null> {
-  if (prompts.length === 0) return { result: null, warnings: [] };
+): { value: string | null; source: NormalizedEnvelope | null } {
+  if (prompts.length === 0) return { value: null, source: null };
+  const last = prompts[prompts.length - 1];
   return {
-    result: completionOf(prompts[prompts.length - 1].raw),
+    value: completionOf(last.raw),
+    source: last,
+  };
+}
+
+function collectExplicit(
+  eventType: string,
+  n: Normalized,
+): WithWarnings<EvalValue[]> | null {
+  const events = n.byType[eventType] ?? [];
+  if (events.length === 0) return null;
+  return {
+    result: events.map((ev) => ({
+      value: ev.raw.data.value,
+      threadId: ev.threadId,
+      tMs: ev.tMs,
+    })),
     warnings: [],
   };
+}
+
+function heuristicInputs(prompts: NormalizedEnvelope[]): WithWarnings<EvalValue[]> {
+  const extracted = extractUserMessage(prompts);
+  if (extracted.value === null || extracted.source === null) {
+    return { result: [], warnings: [] };
+  }
+  return {
+    result: [
+      {
+        value: extracted.value,
+        threadId: extracted.source.threadId,
+        tMs: extracted.source.tMs,
+      },
+    ],
+    warnings: [NO_EVAL_INPUT_WARNING],
+  };
+}
+
+function heuristicOutputs(prompts: NormalizedEnvelope[]): WithWarnings<EvalValue[]> {
+  const extracted = extractFinalResponse(prompts);
+  if (extracted.value === null || extracted.source === null) {
+    return { result: [], warnings: [] };
+  }
+  return {
+    result: [
+      {
+        value: extracted.value,
+        threadId: extracted.source.threadId,
+        tMs: extracted.source.tMs,
+      },
+    ],
+    warnings: [NO_EVAL_OUTPUT_WARNING],
+  };
+}
+
+function capValues(values: EvalValue[]): EvalValue[] {
+  return values.map((entry) => capValue(entry));
+}
+
+function capValue(entry: EvalValue): EvalValue {
+  const serialized = JSON.stringify(entry.value ?? null);
+  const bytes = Buffer.byteLength(serialized, "utf8");
+  if (bytes <= EVAL_MAX_VALUE_BYTES) return entry;
+  const suffix = `…[truncated ${bytes - EVAL_MAX_VALUE_BYTES} bytes]`;
+  const source = typeof entry.value === "string" ? entry.value : serialized;
+  return {
+    ...entry,
+    value: truncateStringForJsonRecord(source, suffix, EVAL_MAX_VALUE_BYTES),
+    truncated: true,
+  };
+}
+
+function truncateStringForJsonRecord(
+  source: string,
+  suffix: string,
+  maxBytes: number,
+): string {
+  const chars = Array.from(source);
+  let lo = 0;
+  let hi = chars.length;
+  let best = suffix;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const candidate = chars.slice(0, mid).join("") + suffix;
+    if (Buffer.byteLength(JSON.stringify(candidate), "utf8") <= maxBytes) {
+      best = candidate;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}
+
+function parseEvalMaxValueBytes(): number {
+  const parsed = Number(process.env.STATELOG_EVAL_MAX_VALUE_BYTES);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_EVAL_MAX_VALUE_BYTES;
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/packages/agency-lang/lib/eval/types.ts
+++ b/packages/agency-lang/lib/eval/types.ts
@@ -41,19 +41,21 @@ export type EvalRecord = {
    *  input is not supported. */
   source: string;
 
-  /** Values explicitly recorded via std::statelog.evalInput(). Empty
-   *  if the agent didn't annotate; in that case the extractor falls
-   *  back to a heuristic and populates a single element from the
-   *  last user-role message of the first promptCompletion on the
-   *  top-level thread (warning emitted in `warnings`). */
+  /** Values used as eval inputs. Explicit values recorded via
+   *  std::statelog.evalInput() are preferred; if absent, the
+   *  extractor may synthesize one fallback entry from the last
+   *  user-role message of the first promptCompletion on the top-level
+   *  thread (warning emitted in `warnings`). Empty only when neither
+   *  explicit events nor a heuristic source exists. */
   evalInputs: EvalValue[];
 
-  /** Values explicitly recorded via std::statelog.evalOutput(). Empty
-   *  if the agent didn't annotate; in that case the extractor falls
-   *  back to a heuristic and populates a single element from the last
+  /** Values used as eval outputs. Explicit values recorded via
+   *  std::statelog.evalOutput() are preferred; if absent, the
+   *  extractor may synthesize one fallback entry from the last
    *  promptCompletion's completion on the top-level thread (warning
-   *  emitted in `warnings`). Consumers that want a single answer
-   *  usually consume the last element. */
+   *  emitted in `warnings`). Empty only when neither explicit events
+   *  nor a heuristic source exists. Consumers that want a single
+   *  answer usually consume the last element. */
   evalOutputs: EvalValue[];
 
   /** Every thread observed in the trace. Each `threadCreated` event

--- a/packages/agency-lang/lib/eval/types.ts
+++ b/packages/agency-lang/lib/eval/types.ts
@@ -18,6 +18,8 @@
  * | promptCompletion.threadId            | ✗                     | ✓                         |
  * | toolCall.threadId                    | ✗                     | ✓                         |
  * | toolCallStart.threadId               | ✗                     | ✓                         |
+ * | evalInputRecorded                    | ✗                     | only if agent annotates   |
+ * | evalOutputRecorded                   | ✗                     | only if agent annotates   |
  *
  * Legacy traces parse without errors; extraction degrades by leaving
  * the missing fields null and emitting one warning during normalize.
@@ -27,7 +29,7 @@ export type EvalRecord = {
   traceId: string;
   /** Format version of the EvalRecord shape itself (NOT the statelog
    *  format_version). Bump when fields change incompatibly. */
-  recordVersion: 1;
+  recordVersion: 2;
   /** Statelog wire-format version, copied from the source envelope
    *  (`events[0].format_version`). Lets consumers reason about which
    *  optional fields they can expect (label, threadId, etc.). */
@@ -39,19 +41,20 @@ export type EvalRecord = {
    *  input is not supported. */
   source: string;
 
-  /** The user's prompt that drove this run — the user-role message
-   *  from the first chronologically-ordered `promptCompletion` on
-   *  the top-level thread. Hoisted to the top level because both
-   *  the LLM judge and any diff tool need it, and digging it out of
-   *  `events[*].messages` is awkward. Null if the trace has no
-   *  `promptCompletion` events. */
-  userMessage: string | null;
+  /** Values explicitly recorded via std::statelog.evalInput(). Empty
+   *  if the agent didn't annotate; in that case the extractor falls
+   *  back to a heuristic and populates a single element from the
+   *  last user-role message of the first promptCompletion on the
+   *  top-level thread (warning emitted in `warnings`). */
+  evalInputs: EvalValue[];
 
-  /** The final assistant-facing reply the user saw — the
-   *  `completion` from the LAST `promptCompletion` on the top-level
-   *  thread. This is what `eval compare` shows to an LLM judge.
-   *  Null if no `promptCompletion` events were captured. */
-  finalResponse: string | null;
+  /** Values explicitly recorded via std::statelog.evalOutput(). Empty
+   *  if the agent didn't annotate; in that case the extractor falls
+   *  back to a heuristic and populates a single element from the last
+   *  promptCompletion's completion on the top-level thread (warning
+   *  emitted in `warnings`). Consumers that want a single answer
+   *  usually consume the last element. */
+  evalOutputs: EvalValue[];
 
   /** Every thread observed in the trace. Each `threadCreated` event
    *  becomes one entry. Resumes (`threadResumed`) do NOT create new
@@ -191,4 +194,19 @@ export type Metrics = {
   /** Count of tool END events (`toolCall`) per tool name. Does NOT
    *  count incomplete `toolCallStart`s — those live in `incomplete`. */
   toolCounts: Record<string, number>;
+};
+
+/** One firing of `evalInput(...)` or `evalOutput(...)` from agent
+ *  code, plus enough provenance for consumers to filter by thread
+ *  (e.g. drop subagent firings) or correlate with the event timeline.
+ *  `tMs` is derived from the envelope timestamp at extract time, not
+ *  emitted on the wire. `value` is whatever the agent passed —
+ *  already JSON-round-tripped at the stdlib boundary, may be
+ *  truncated by the extractor if it exceeds STATELOG_EVAL_MAX_VALUE_BYTES
+ *  (in which case `truncated: true` is set; otherwise omitted). */
+export type EvalValue = {
+  value: unknown;
+  threadId: string | null;
+  tMs: number;
+  truncated?: true;
 };

--- a/packages/agency-lang/lib/logsViewer/summary.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.ts
@@ -54,6 +54,10 @@ export function summarize(evt: EventEnvelope): string {
       const hiddenSuffix = d.hidden ? " hidden" : "";
       return `threadCreated ${d.threadType ?? "?"} #${shortId(d.threadId)}${tag}${hiddenSuffix}`;
     }
+    case "evalInputRecorded":
+      return `evalInputRecorded ${truncate(stringifyValue(d.value), 60)}`;
+    case "evalOutputRecorded":
+      return `evalOutputRecorded ${truncate(stringifyValue(d.value), 60)}`;
     case "agentStart":
       return `agentStart "${d.entryNode ?? "?"}"`;
     case "agentEnd":
@@ -129,6 +133,10 @@ function stripQuotes(s?: string): string {
 
 function truncate(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+function stringifyValue(v: unknown): string {
+  return typeof v === "string" ? v : JSON.stringify(v ?? null) ?? "undefined";
 }
 
 /** Format the optional `{kind, message, data}` interrupt summary

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -645,6 +645,34 @@ export class StatelogClient {
     });
   }
 
+  async evalInputRecorded({
+    value,
+    threadId,
+  }: {
+    value: unknown;
+    threadId: string | null;
+  }): Promise<void> {
+    await this.post({
+      type: "evalInputRecorded",
+      value,
+      threadId: threadId ?? null,
+    });
+  }
+
+  async evalOutputRecorded({
+    value,
+    threadId,
+  }: {
+    value: unknown;
+    threadId: string | null;
+  }): Promise<void> {
+    await this.post({
+      type: "evalOutputRecorded",
+      value,
+      threadId: threadId ?? null,
+    });
+  }
+
   async diff({
     itemA,
     itemB,

--- a/packages/agency-lang/lib/stdlib/statelog.test.ts
+++ b/packages/agency-lang/lib/stdlib/statelog.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runInTestContext } from "../runtime/asyncContext.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { StateStack } from "../runtime/state/stateStack.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+import { StatelogClient } from "../statelogClient.js";
+import { _evalInput, _evalOutput } from "./statelog.js";
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: {},
+    dirname: "/tmp",
+  });
+}
+
+function spyClient(ctx: RuntimeContext<any>) {
+  const evalInputRecorded = vi.fn(async () => undefined);
+  const evalOutputRecorded = vi.fn(async () => undefined);
+  ctx.statelogClient = {
+    ...ctx.statelogClient,
+    evalInputRecorded,
+    evalOutputRecorded,
+  } as any;
+  return { evalInputRecorded, evalOutputRecorded };
+}
+
+async function withFrame(
+  threads: ThreadStore,
+  fn: (spies: ReturnType<typeof spyClient>) => Promise<void>,
+): Promise<void> {
+  const ctx = makeCtx();
+  const spies = spyClient(ctx);
+  await runInTestContext(ctx, new StateStack(), threads, () => fn(spies));
+}
+
+describe("std::statelog eval annotations", () => {
+  it("records eval input with the active thread id", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const threadId = threads.activeId();
+    const spies = spyClient(ctx);
+
+    await runInTestContext(ctx, new StateStack(), threads, async () => {
+      await _evalInput("hello");
+    });
+
+    expect(spies.evalInputRecorded).toHaveBeenCalledOnce();
+    expect(spies.evalInputRecorded).toHaveBeenCalledWith({
+      value: "hello",
+      threadId,
+    });
+  });
+
+  it("round-trips plain objects before recording", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const spies = spyClient(ctx);
+
+    await runInTestContext(ctx, new StateStack(), threads, async () => {
+      await _evalInput({ foo: 1 });
+    });
+
+    expect(spies.evalInputRecorded).toHaveBeenCalledWith({
+      value: { foo: 1 },
+      threadId: threads.activeId(),
+    });
+  });
+
+  it("records null and coerces undefined to null", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const spies = spyClient(ctx);
+
+    await runInTestContext(ctx, new StateStack(), threads, async () => {
+      await _evalOutput(null);
+      await _evalOutput(undefined);
+    });
+
+    expect(spies.evalOutputRecorded).toHaveBeenNthCalledWith(1, {
+      value: null,
+      threadId: threads.activeId(),
+    });
+    expect(spies.evalOutputRecorded).toHaveBeenNthCalledWith(2, {
+      value: null,
+      threadId: threads.activeId(),
+    });
+  });
+
+  it("no-ops outside an Agency execution frame", async () => {
+    await expect(_evalInput("hello")).resolves.toBeUndefined();
+  });
+
+  it("rejects circular values at the call site", async () => {
+    const circular: any = {};
+    circular.self = circular;
+    await withFrame(ThreadStore.withDefaultActive(makeCtx().statelogClient), async () => {
+      await expect(_evalInput(circular)).rejects.toThrow(TypeError);
+    });
+  });
+
+  it("resolves with a disabled statelog client", async () => {
+    const ctx = makeCtx();
+    ctx.statelogClient = new StatelogClient({
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+      observability: false,
+    });
+    await runInTestContext(ctx, new StateStack(), new ThreadStore(), async () => {
+      await expect(_evalInput("x")).resolves.toBeUndefined();
+      await expect(_evalOutput("y")).resolves.toBeUndefined();
+    });
+  });
+
+  it("records null threadId when there is no active thread", async () => {
+    const ctx = makeCtx();
+    const threads = new ThreadStore();
+    const spies = spyClient(ctx);
+
+    await runInTestContext(ctx, new StateStack(), threads, async () => {
+      await _evalOutput("x");
+    });
+
+    expect(spies.evalOutputRecorded).toHaveBeenCalledWith({
+      value: "x",
+      threadId: null,
+    });
+  });
+});

--- a/packages/agency-lang/lib/stdlib/statelog.test.ts
+++ b/packages/agency-lang/lib/stdlib/statelog.test.ts
@@ -105,6 +105,22 @@ describe("std::statelog eval annotations", () => {
     });
   });
 
+  it("rejects top-level functions with a clear serialization error", async () => {
+    await withFrame(ThreadStore.withDefaultActive(makeCtx().statelogClient), async () => {
+      await expect(_evalInput(() => "nope")).rejects.toThrow(
+        /must be JSON-serializable/i,
+      );
+    });
+  });
+
+  it("rejects top-level symbols with a clear serialization error", async () => {
+    await withFrame(ThreadStore.withDefaultActive(makeCtx().statelogClient), async () => {
+      await expect(_evalOutput(Symbol("nope"))).rejects.toThrow(
+        /must be JSON-serializable/i,
+      );
+    });
+  });
+
   it("resolves with a disabled statelog client", async () => {
     const ctx = makeCtx();
     ctx.statelogClient = new StatelogClient({

--- a/packages/agency-lang/lib/stdlib/statelog.ts
+++ b/packages/agency-lang/lib/stdlib/statelog.ts
@@ -1,0 +1,32 @@
+import { agencyStore } from "../runtime/asyncContext.js";
+import type { StatelogClient } from "../statelogClient.js";
+
+/** Pick the statelog client method to call for this eval event. */
+type EvalEmit = (
+  client: StatelogClient,
+  payload: { value: unknown; threadId: string | null },
+) => Promise<void>;
+
+/**
+ * std::statelog TS impls. Called from the agency-side wrappers in
+ * stdlib/statelog.agency, which pass through the user's value
+ * argument. Each function reads the active AgencyStore from
+ * AsyncLocalStorage and emits the corresponding wire event.
+ *
+ * No-op when called outside an Agency execution frame (e.g. a tool
+ * function invoked directly from a test). This is the lenient pattern
+ * used by the generated-code accessors in lib/runtime/asyncContext.ts.
+ */
+async function emitEvalEvent(emit: EvalEmit, value: unknown): Promise<void> {
+  const frame = agencyStore.getStore();
+  if (!frame) return;
+  const safeValue = JSON.parse(JSON.stringify(value ?? null));
+  const threadId = frame.threads.activeId() ?? null;
+  await emit(frame.ctx.statelogClient, { value: safeValue, threadId });
+}
+
+export const _evalInput = (value: unknown) =>
+  emitEvalEvent((c, p) => c.evalInputRecorded(p), value);
+
+export const _evalOutput = (value: unknown) =>
+  emitEvalEvent((c, p) => c.evalOutputRecorded(p), value);

--- a/packages/agency-lang/lib/stdlib/statelog.ts
+++ b/packages/agency-lang/lib/stdlib/statelog.ts
@@ -1,11 +1,15 @@
 import { agencyStore } from "../runtime/asyncContext.js";
 import type { StatelogClient } from "../statelogClient.js";
 
-/** Pick the statelog client method to call for this eval event. */
-type EvalEmit = (
-  client: StatelogClient,
-  payload: { value: unknown; threadId: string | null },
-) => Promise<void>;
+type EvalPayload = {
+  value: unknown;
+  threadId: string | null;
+};
+
+type PreparedEvalEvent = {
+  client: StatelogClient;
+  payload: EvalPayload;
+};
 
 /**
  * std::statelog TS impls. Called from the agency-side wrappers in
@@ -17,16 +21,35 @@ type EvalEmit = (
  * function invoked directly from a test). This is the lenient pattern
  * used by the generated-code accessors in lib/runtime/asyncContext.ts.
  */
-async function emitEvalEvent(emit: EvalEmit, value: unknown): Promise<void> {
+function prepareEvalEvent(value: unknown): PreparedEvalEvent | null {
   const frame = agencyStore.getStore();
-  if (!frame) return;
-  const safeValue = JSON.parse(JSON.stringify(value ?? null));
+  if (!frame) return null;
+  const safeValue = serializeEvalValue(value);
   const threadId = frame.threads.activeId() ?? null;
-  await emit(frame.ctx.statelogClient, { value: safeValue, threadId });
+  return {
+    client: frame.ctx.statelogClient,
+    payload: { value: safeValue, threadId },
+  };
 }
 
-export const _evalInput = (value: unknown) =>
-  emitEvalEvent((c, p) => c.evalInputRecorded(p), value);
+function serializeEvalValue(value: unknown): unknown {
+  const json = JSON.stringify(value ?? null);
+  if (json === undefined) {
+    throw new TypeError(
+      "evalInput/evalOutput value must be JSON-serializable; top-level functions and symbols cannot be recorded",
+    );
+  }
+  return JSON.parse(json);
+}
 
-export const _evalOutput = (value: unknown) =>
-  emitEvalEvent((c, p) => c.evalOutputRecorded(p), value);
+export async function _evalInput(value: unknown): Promise<void> {
+  const prepared = prepareEvalEvent(value);
+  if (!prepared) return;
+  await prepared.client.evalInputRecorded(prepared.payload);
+}
+
+export async function _evalOutput(value: unknown): Promise<void> {
+  const prepared = prepareEvalEvent(value);
+  if (!prepared) return;
+  await prepared.client.evalOutputRecorded(prepared.payload);
+}

--- a/packages/agency-lang/stdlib/statelog.agency
+++ b/packages/agency-lang/stdlib/statelog.agency
@@ -1,0 +1,52 @@
+import { _evalInput, _evalOutput } from "agency-lang/stdlib-lib/statelog.js"
+
+export def evalInput(value: any) {
+  """
+  Record an eval input — a value that should be considered part of
+  the user-facing input to this agent. Captured in the statelog as
+  an `evalInputRecorded` event and surfaced by `agency eval extract`
+  on the `evalInputs[]` field of the produced record.
+
+  Call this once per discrete user input. May be called multiple
+  times in a single trace; all firings are collected in order. The
+  consuming eval / judge / task definition decides what to do with
+  multiple firings.
+
+  When no eval annotation exists in a trace, `eval extract` falls
+  back to a heuristic (first user-role message of the first LLM
+  call) and emits a warning. Annotating explicitly is preferred.
+
+  @param value - The value to record. Any JSON-serializable type is
+    accepted; stored as `unknown` in the eval record. Top-level
+    `undefined` records as `null`; nested functions, `undefined`,
+    and symbols follow JSON serialization rules; circular references
+    and `bigint` throw at the call site (with your stack), not later
+    inside the log writer.
+  """
+  _evalInput(value)
+}
+
+export def evalOutput(value: any) {
+  """
+  Record an eval output — a value that should be considered the
+  agent's user-facing response. Captured in the statelog as an
+  `evalOutputRecorded` event and surfaced by `agency eval extract`
+  on the `evalOutputs[]` field of the produced record.
+
+  Call this once per discrete user-facing response. May be called
+  multiple times in a single trace; all firings are collected in
+  order. The consuming eval / judge / task definition decides what
+  to do with multiple firings (e.g. a pairwise judge can use the
+  last firing).
+
+  When no eval annotation exists in a trace, `eval extract` falls
+  back to a heuristic (last LLM completion on the top-level thread)
+  and emits a warning. Annotating explicitly is preferred — the
+  heuristic does NOT account for post-LLM processing the agent
+  applies before showing a response to the user.
+
+  @param value - The value to record. Any JSON-serializable type is
+    accepted; same serialization rules as `evalInput`.
+  """
+  _evalOutput(value)
+}

--- a/packages/agency-lang/stdlib/statelog.agency
+++ b/packages/agency-lang/stdlib/statelog.agency
@@ -18,10 +18,11 @@ export def evalInput(value: any) {
 
   @param value - The value to record. Any JSON-serializable type is
     accepted; stored as `unknown` in the eval record. Top-level
-    `undefined` records as `null`; nested functions, `undefined`,
-    and symbols follow JSON serialization rules; circular references
-    and `bigint` throw at the call site (with your stack), not later
-    inside the log writer.
+    `undefined` records as `null`; top-level functions and symbols
+    throw a TypeError; nested functions, `undefined`, and symbols
+    follow JSON serialization rules; circular references and `bigint`
+    throw at the call site (with your stack), not later inside the
+    log writer.
   """
   _evalInput(value)
 }


### PR DESCRIPTION
## Summary
- Add `std::statelog.evalInput` / `evalOutput` wrappers and statelog wire events for explicit eval annotations.
- Change eval records to version 2 with `evalInputs[]` / `evalOutputs[]`, preserving `value`, `threadId`, `tMs`, and `truncated` metadata.
- Update `agency eval extract` to prefer explicit annotations, fall back to existing promptCompletion heuristics with actionable warnings, and cap oversized eval values at extraction time.

## Test Plan
- `make`
- `pnpm run ast stdlib/statelog.agency`
- `pnpm exec vitest run lib/stdlib/statelog.test.ts lib/eval/extract.test.ts`
- `pnpm run typecheck`
- `pnpm run lint:structure`
- CLI smoke: run an Agency file that calls `evalInput` / `evalOutput`, extract its statelog, and assert `evalInputRecorded` / `evalOutputRecorded` plus populated `evalInputs` / `evalOutputs` with no warnings
