### PR TITLE
Add layout width sizing and text wrapping

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/layout.md
+++ b/packages/agency-lang/docs/site/stdlib/layout.md
@@ -43,6 +43,29 @@ name: "layout"
 
   Both styles produce the same `LayoutNode` tree.
 
+  ### Sizing and wrap
+
+  Every container (`box`, `row`, `column`, `table`) accepts a `width`
+  parameter:
+
+  - `width: "full"` (root only) fills the terminal columns.
+  - `width: 80` sets a target column count.
+  - `width: "50%"` takes 50% of the parent's available width.
+
+  Inside a `table`, each `ColumnSpec` accepts the same `width` field.
+  A percentage column is sized as a share of the table's remaining
+  inner width after borders, cell padding, interior dividers, fixed
+  columns, and natural unsized columns.
+
+  Text inside a width-constrained container or column automatically
+  wraps at word boundaries. Long single words are broken at the column
+  width. `raw` content is never wrapped — use `text` if you want
+  wrapping.
+
+  Width is the only sized dimension. There is no height sizing and no
+  truncation: content that overflows wraps, or (for `raw`) extends
+  visibly past the container.
+
   ### See also
 
   `std::ui` exports `box`, `row`, `column` for interactive TUI
@@ -71,7 +94,7 @@ export type LayoutNode = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L84))
 
 ### LayoutBuilder
 
@@ -97,7 +120,7 @@ export type LayoutBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L95))
 
 ### Alignment
 
@@ -105,7 +128,7 @@ export type LayoutBuilder = {
 export type Alignment = "start" | "center" | "end"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L106))
 
 ### BorderStyle
 
@@ -113,7 +136,15 @@ export type Alignment = "start" | "center" | "end"
 export type BorderStyle = "rounded" | "heavy" | "double" | "light"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L108))
+
+### Width
+
+```ts
+export type Width = number | "full" | string
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L110))
 
 ### Cell
 
@@ -130,7 +161,7 @@ export type BorderStyle = "rounded" | "heavy" | "double" | "light"
 export type Cell = string | LayoutNode
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L92))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L117))
 
 ### CellRow
 
@@ -138,7 +169,7 @@ export type Cell = string | LayoutNode
 export type CellRow = Cell[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L122))
 
 ### ColumnSpec
 
@@ -147,6 +178,10 @@ export type CellRow = Cell[]
  *
  * @param align - Horizontal alignment of every cell in this column
  * @param minWidth - Lower bound on column width; widens narrow columns
+ * @param width - Optional per-column constraint. A number caps the
+ *   column's content width in cells. `"X%"` takes a percentage of the
+ *   table's remaining inner width after fixed and natural unsized
+ *   columns. `"full"` is not allowed at the column level.
  * @param fgColor - Default foreground color applied to every cell in
  *   this column that doesn't carry its own `fgColor`. Cell-level
  *   `fgColor` always wins.
@@ -158,6 +193,10 @@ export type CellRow = Cell[]
  *
  * @param align - Horizontal alignment of every cell in this column
  * @param minWidth - Lower bound on column width; widens narrow columns
+ * @param width - Optional per-column constraint. A number caps the
+ *   column's content width in cells. `"X%"` takes a percentage of the
+ *   table's remaining inner width after fixed and natural unsized
+ *   columns. `"full"` is not allowed at the column level.
  * @param fgColor - Default foreground color applied to every cell in
  *   this column that doesn't carry its own `fgColor`. Cell-level
  *   `fgColor` always wins.
@@ -165,11 +204,12 @@ export type CellRow = Cell[]
 export type ColumnSpec = {
   align?: Alignment;
   minWidth?: number;
+  width?: Width;
   fgColor?: string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L138))
 
 ### TableBuilder
 
@@ -192,7 +232,7 @@ export type TableBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L150))
 
 ## Functions
 
@@ -232,7 +272,7 @@ text(content: string, fgColor: string, bgColor: string, bold: boolean, italic: b
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L180))
 
 ### raw
 
@@ -260,7 +300,7 @@ raw(content: string, align: Alignment): LayoutNode
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L188))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L218))
 
 ### space
 
@@ -281,7 +321,7 @@ space(count: number): LayoutNode
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L235))
 
 ### hline
 
@@ -310,7 +350,7 @@ hline(char: string, length: number, fgColor: string, bold: boolean, dim: boolean
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L225))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L255))
 
 ### vline
 
@@ -339,7 +379,7 @@ vline(char: string, length: number, fgColor: string, bold: boolean, dim: boolean
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L255))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L285))
 
 ### _addText
 
@@ -363,7 +403,7 @@ _addText(kids: any[], content: string, fgColor: string, bgColor: string, bold: b
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L281))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L311))
 
 ### _addRaw
 
@@ -381,7 +421,7 @@ _addRaw(kids: any[], content: string, align: Alignment): LayoutNode
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L306))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L336))
 
 ### _addSpace
 
@@ -398,7 +438,7 @@ _addSpace(kids: any[], count: number): LayoutNode
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L316))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L346))
 
 ### _addHline
 
@@ -419,7 +459,7 @@ _addHline(kids: any[], char: string, length: number, fgColor: string, bold: bool
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L322))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L352))
 
 ### _addVline
 
@@ -440,12 +480,12 @@ _addVline(kids: any[], char: string, length: number, fgColor: string, bold: bool
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L335))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L365))
 
 ### _addRow
 
 ```ts
-_addRow(kids: any[], gap: number, align: Alignment, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
+_addRow(kids: any[], gap: number, align: Alignment, width: Width, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
 ```
 
 **Parameters:**
@@ -455,17 +495,18 @@ _addRow(kids: any[], gap: number, align: Alignment, children: LayoutNode[], bloc
 | kids | `any[]` |  |
 | gap | `number` | 0 |
 | align | [Alignment](markdown.md#alignment) | "start" |
+| width | [Width](#width) | null |
 | children | `LayoutNode[]` | null |
 | block | `(LayoutBuilder) => void` | null |
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L348))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L378))
 
 ### _addColumn
 
 ```ts
-_addColumn(kids: any[], gap: number, align: Alignment, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
+_addColumn(kids: any[], gap: number, align: Alignment, width: Width, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
 ```
 
 **Parameters:**
@@ -475,17 +516,18 @@ _addColumn(kids: any[], gap: number, align: Alignment, children: LayoutNode[], b
 | kids | `any[]` |  |
 | gap | `number` | 0 |
 | align | [Alignment](markdown.md#alignment) | "start" |
+| width | [Width](#width) | null |
 | children | `LayoutNode[]` | null |
 | block | `(LayoutBuilder) => void` | null |
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L360))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L391))
 
 ### _addBox
 
 ```ts
-_addBox(kids: any[], title: string, titleColor: string, borderStyle: BorderStyle, borderColor: string, padding: number, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
+_addBox(kids: any[], title: string, titleColor: string, borderStyle: BorderStyle, borderColor: string, padding: number, width: Width, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
 ```
 
 **Parameters:**
@@ -498,12 +540,13 @@ _addBox(kids: any[], title: string, titleColor: string, borderStyle: BorderStyle
 | borderStyle | [BorderStyle](#borderstyle) | "rounded" |
 | borderColor | `string` | "" |
 | padding | `number` | 1 |
+| width | [Width](#width) | null |
 | children | `LayoutNode[]` | null |
 | block | `(LayoutBuilder) => void` | null |
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L372))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L404))
 
 ### _makeBuilder
 
@@ -519,18 +562,21 @@ _makeBuilder(kids: any[]): LayoutBuilder
 
 **Returns:** [LayoutBuilder](#layoutbuilder)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L395))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L429))
 
 ### row
 
 ```ts
-row(gap: number, align: Alignment, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
+row(gap: number, align: Alignment, width: Width, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
 ```
 
 * A horizontal container. Children render left-to-right.
  *
  * @param gap - Cells of blank space between siblings
  * @param align - Cross-axis (vertical) alignment of shorter children
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param children - Pre-built children (LLM / JSON construction)
  * @param block - Trailing builder block; appended after `children`
 
@@ -540,23 +586,27 @@ row(gap: number, align: Alignment, children: LayoutNode[], block: (LayoutBuilder
 |---|---|---|
 | gap | `number` | 0 |
 | align | [Alignment](markdown.md#alignment) | "start" |
+| width | [Width](#width) | null |
 | children | `LayoutNode[]` | null |
 | block | `(LayoutBuilder) => void` | null |
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L422))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L459))
 
 ### column
 
 ```ts
-column(gap: number, align: Alignment, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
+column(gap: number, align: Alignment, width: Width, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
 ```
 
 * A vertical container. Children render top-to-bottom.
  *
  * @param gap - Blank rows between siblings
  * @param align - Cross-axis (horizontal) alignment of narrower children
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param children - Pre-built children
  * @param block - Trailing builder block
 
@@ -566,17 +616,18 @@ column(gap: number, align: Alignment, children: LayoutNode[], block: (LayoutBuil
 |---|---|---|
 | gap | `number` | 0 |
 | align | [Alignment](markdown.md#alignment) | "start" |
+| width | [Width](#width) | null |
 | children | `LayoutNode[]` | null |
 | block | `(LayoutBuilder) => void` | null |
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L455))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L500))
 
 ### box
 
 ```ts
-box(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: string, padding: number, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
+box(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: string, padding: number, width: Width, children: LayoutNode[], block: (LayoutBuilder) => void): LayoutNode
 ```
 
 * A bordered panel. When given more than one child (or built via a
@@ -589,6 +640,9 @@ box(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: st
  * @param borderStyle - One of `"rounded"`, `"heavy"`, `"double"`, `"light"`
  * @param borderColor - Color of the border characters
  * @param padding - Cells of padding between border and content
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param children - Pre-built children
  * @param block - Trailing builder block
 
@@ -601,17 +655,18 @@ box(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: st
 | borderStyle | [BorderStyle](#borderstyle) | "rounded" |
 | borderColor | `string` | "" |
 | padding | `number` | 1 |
+| width | [Width](#width) | null |
 | children | `LayoutNode[]` | null |
 | block | `(LayoutBuilder) => void` | null |
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L494))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L547))
 
 ### render
 
 ```ts
-render(node: LayoutNode, color: "auto" | boolean): string
+render(node: LayoutNode, color: "auto" | boolean, cols: number, rows: number): string
 ```
 
 * Render a layout tree to a string.
@@ -620,6 +675,9 @@ render(node: LayoutNode, color: "auto" | boolean): string
  * @param color - `"auto"` (default) emits ANSI sequences only when stdout
  *   is a TTY. `true` always emits them. `false` strips all styling for
  *   plain ASCII output (logs, non-TTY consumers).
+ * @param cols - Optional viewport columns override. `0` auto-detects.
+ * @param rows - Optional viewport rows override. Reserved for future
+ *   height-aware layout; `0` uses the default.
 
 **Parameters:**
 
@@ -627,10 +685,12 @@ render(node: LayoutNode, color: "auto" | boolean): string
 |---|---|---|
 | node | [LayoutNode](#layoutnode) |  |
 | color | `"auto" \| boolean` | "auto" |
+| cols | `number` | 0 |
+| rows | `number` | 0 |
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L533))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L594))
 
 ### _setTableColumns
 
@@ -647,7 +707,7 @@ _setTableColumns(state: any, specs: ColumnSpec[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L546))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L609))
 
 ### _setTableCaption
 
@@ -664,7 +724,7 @@ _setTableCaption(state: any, text: string): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L551))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L614))
 
 ### _setTableHeader
 
@@ -681,7 +741,7 @@ _setTableHeader(state: any, ...cells: Cell[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L556))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L619))
 
 ### _addTableRow
 
@@ -698,7 +758,7 @@ _addTableRow(state: any, ...cells: Cell[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L561))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L624))
 
 ### _addTableFooter
 
@@ -715,7 +775,7 @@ _addTableFooter(state: any, ...cells: Cell[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L566))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L629))
 
 ### _makeTableBuilder
 
@@ -731,12 +791,12 @@ _makeTableBuilder(state: any): TableBuilder
 
 **Returns:** [TableBuilder](#tablebuilder)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L571))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L634))
 
 ### table
 
 ```ts
-table(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: string, caption: string, cellPadding: number, columns: ColumnSpec[], header: Cell[], body: CellRow[], footer: CellRow[], headerDivider: boolean, footerDivider: boolean, rowDividers: boolean, columnDividers: boolean, block: (TableBuilder) => void): LayoutNode
+table(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: string, caption: string, cellPadding: number, width: Width, columns: ColumnSpec[], header: Cell[], body: CellRow[], footer: CellRow[], headerDivider: boolean, footerDivider: boolean, rowDividers: boolean, columnDividers: boolean, block: (TableBuilder) => void): LayoutNode
 ```
 
 * Tabular layout. Columns line up across header / body / footer; the
@@ -789,6 +849,9 @@ table(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: 
  * @param borderColor - Color of the border characters
  * @param caption - Dim, centered single line drawn BELOW the bottom border
  * @param cellPadding - Spaces of horizontal padding inside each cell (default 1)
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param columns - Per-column align / minWidth (length must equal column count)
  * @param header - Optional header row of cells
  * @param body - Optional body rows
@@ -809,6 +872,7 @@ table(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: 
 | borderColor | `string` | "" |
 | caption | `string` | "" |
 | cellPadding | `number` | 1 |
+| width | [Width](#width) | null |
 | columns | `ColumnSpec[]` | null |
 | header | `Cell[]` | null |
 | body | `CellRow[]` | null |
@@ -821,4 +885,4 @@ table(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: 
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L642))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L708))

--- a/packages/agency-lang/docs/site/stdlib/layout.md
+++ b/packages/agency-lang/docs/site/stdlib/layout.md
@@ -634,8 +634,9 @@ box(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: st
  * block with multiple builder calls), the children are stacked in an
  * implicit `column`.
  *
- * @param title - Text embedded in the top border (no truncation; box
- *   grows to fit). Empty string for no title.
+ * @param title - Text embedded in the top border. Without an explicit
+ *   width, the box grows to fit; with width set, over-long titles wrap
+ *   inside the frame. Empty string for no title.
  * @param titleColor - Color of the title text
  * @param borderStyle - One of `"rounded"`, `"heavy"`, `"double"`, `"light"`
  * @param borderColor - Color of the border characters
@@ -661,7 +662,7 @@ box(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: st
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L547))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L548))
 
 ### render
 
@@ -690,7 +691,7 @@ render(node: LayoutNode, color: "auto" | boolean, cols: number, rows: number): s
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L594))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L595))
 
 ### _setTableColumns
 
@@ -707,7 +708,7 @@ _setTableColumns(state: any, specs: ColumnSpec[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L609))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L610))
 
 ### _setTableCaption
 
@@ -724,7 +725,7 @@ _setTableCaption(state: any, text: string): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L614))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L615))
 
 ### _setTableHeader
 
@@ -741,7 +742,7 @@ _setTableHeader(state: any, ...cells: Cell[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L619))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L620))
 
 ### _addTableRow
 
@@ -758,7 +759,7 @@ _addTableRow(state: any, ...cells: Cell[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L624))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L625))
 
 ### _addTableFooter
 
@@ -775,7 +776,7 @@ _addTableFooter(state: any, ...cells: Cell[]): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L629))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L630))
 
 ### _makeTableBuilder
 
@@ -791,7 +792,7 @@ _makeTableBuilder(state: any): TableBuilder
 
 **Returns:** [TableBuilder](#tablebuilder)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L634))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L635))
 
 ### table
 
@@ -843,7 +844,9 @@ table(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: 
  * emits it by default, so treating it as "set" would mean no
  * `text()` header cell ever got the auto-bold).
  *
- * @param title - Text embedded in the top border; box grows to fit
+ * @param title - Text embedded in the top border. Without an explicit
+ *   width, the table grows to fit; with width set, over-long titles wrap
+ *   inside the frame.
  * @param titleColor - Color of the title text
  * @param borderStyle - One of `"rounded"`, `"heavy"`, `"double"`, `"light"`
  * @param borderColor - Color of the border characters
@@ -885,4 +888,4 @@ table(title: string, titleColor: string, borderStyle: BorderStyle, borderColor: 
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L708))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/layout.agency#L711))

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-04-layout-width-sizing-and-wrap.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-04-layout-width-sizing-and-wrap.md
@@ -1,0 +1,1149 @@
+# Layout Width Sizing + Text Wrap Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add top-down width sizing to `std::layout`. Users can mark a root container with `width: "full"` (terminal columns), give an exact column count with `width: 80`, or give child containers `width: "33%"` / `"50%"` / etc. (fraction of parent's available width). The same machinery applies uniformly to `box`, `row`, `column`, and `table` — and, for `table`, to each `ColumnSpec` (per-column percentage or fixed cells). Text content inside any width-constrained container auto-wraps on word boundaries (with char-break fallback for over-long single words). No height sizing, no truncation option, no error-on-overflow — wrap is the only overflow policy for text content. `raw` remains the explicit verbatim escape hatch and may overflow visibly.
+
+**Why now:** The table primitive shipped without per-column or table-level sizing. Real-world callers want `width: 80` for a status table, or "first column is exactly 2 cells, last column fills the rest". Width sizing is a cross-cutting problem — `box`/`row`/`column` need it too — so building one top-down resolver pass that every container reads from is cheaper than bolting per-feature sizing into each renderer.
+
+**Architecture:** Insert a top-down `resolveSizes` pass between build and render. The renderer stays a dumb bottom-up function from node → block. The resolver walks the tree once with a viewport size and annotates every container with `attrs.resolvedWidth` (a number, or `undefined` for content-driven). Text leaves and table text-cells inside a width-constrained container get an `attrs.wrapWidth` annotation that the renderer honours. Compose functions read resolved widths and grow their output to fit. Tables have a table-specific dispatch branch in the resolver (their children are rows, not width-distributed siblings — the per-column distribution is its own axis).
+
+```diagram
+╭─────────╮     ╭──────────────────╮     ╭───────────╮     ╭──────────╮
+│  build  │────▶│  resolveSizes    │────▶│  compose  │────▶│ toString │
+│ (Agency)│     │  (TS, top-down)  │     │ renderers │     │          │
+╰─────────╯     ╰──────────────────╯     ╰───────────╯     ╰──────────╯
+                  inputs: viewport          reads:
+                  outputs: per-node         attrs.resolvedWidth
+                  resolvedWidth +           attrs.wrapWidth
+                  wrapWidth annotations     (+ table column layouts)
+```
+
+**Tech Stack:** TypeScript (TS bridge + Vitest unit tests), Agency (stdlib wrapper + integration tests in `tests/agency/layout/`)
+
+**Out of scope (deferred to a follow-up plan if needed):**
+- Height sizing (terminal rows is a less useful constraint — content normally extends past the viewport).
+- `width: "fill"` / `"flex"` to consume remaining space after fixed-percentage siblings.
+- `text(..., wrap: false)` opt-out — `raw` already serves the "do not transform" use case.
+- A `truncate` overflow policy or wrap/truncate selector. This plan implements wrap only.
+- Auto-fit of unsized table columns into table-level slack (today: unsized columns are content-driven, leftover space becomes trailing slack — same as `row`).
+
+**Decisions locked in upfront (from design discussion):**
+
+*Universal width semantics (apply to `box`, `row`, `column`, `table`, and `ColumnSpec`):*
+- `width` accepts: `number` (cells), `"full"` (root only), `"X%"` (percentage of parent's available width).
+- `"full"` is **root-only**. Nested `"full"` is a runtime error from `resolveSizes`. (Type-level enforcement is not expressible with the current Agency type system.)
+- Percentages may sum to **less than 100** — remaining space is trailing slack (no auto-fill). Summing to **more than 100** is allowed but the last child(ren) may be clipped to 0 width; document this.
+- `gap`, border, padding, and (for tables) `cellPadding` + interior column dividers are subtracted from the parent's resolved width **before** distributing percentages. Matches CSS `box-sizing: border-box`.
+- Fixed widths (`width: 2`) are a **target width** and a hard wrap constraint for wrappable text content. Not a floor. `ColumnSpec.minWidth` continues to be the floor knob; the two are independent.
+- `raw` does **not** wrap, ever. Documented asymmetry: `text` wraps, `raw` is verbatim and can visibly overflow a fixed-width container.
+- Long `box` / `table` titles do **not** force an explicitly resolved container wider. When an explicit resolved width leaves too little room for an embedded title, wrap the title text inside the frame as normal text instead of truncating or widening. (For content-driven containers, keep today's title-driven growth.)
+- Wrap is **word-boundary** by default with **char-break fallback** for single words longer than the column.
+- Wrap is **ANSI-aware** via `visualWidth` (already exists).
+- Non-TTY viewport fallback: **80 columns × 24 rows**. Overridable via `render(tree, { viewport: { cols, rows } })`.
+
+*Table-specific:*
+- `table(width: ...)` sets the table's outer width (the bordered frame). Resolved the same way `box(width: ...)` is.
+- `ColumnSpec.width: "X%"` is a percentage of the **table's remaining resolved inner width** after subtracting table chrome, fixed columns, and natural unsized columns. NOT a percentage of terminal/parent.
+- `ColumnSpec.width: N` (number) is a hard cap on the column's content width; text cells in that column wrap to `N` cells. Cell-level fixed/percentage on a cell node (e.g. a `box(width: 10)` used as a cell) is independent and resolves like any nested container.
+- Unsized columns inside a width-constrained table are **content-driven**. Their natural width is measured first; the resolver then distributes percentages from `table.resolvedWidth - chrome - sum(fixedColumns) - sum(naturalUnsizedColumns)`. If the sum exceeds available width the last percentage column(s) shrink; if it's less, slack accumulates at the right edge of the table.
+- The existing `minWidthForTitle` floor (table-level title bumps inner width) continues to win when the title is wider than the natural cell grid AND no explicit table width is set. If `table.resolvedWidth` is set explicitly, the resolved width wins; if it's smaller than `minWidthForTitle`, wrap the title inside the table frame instead of widening or truncating. Logging a warning is not in scope.
+
+---
+
+## File Structure
+
+### New files
+
+```
+(none — all changes happen in existing files)
+```
+
+### Modified files
+
+```
+lib/stdlib/layout/render.ts            # New: _viewport, resolveSizes, resolveNode, resolveChild,
+                                       #      growToWidth. Updated: render() entry point.
+lib/stdlib/layout/ansi.ts              # New: wrapText, wrapSingleLine, breakLongToken (live next to visualWidth)
+lib/stdlib/layout/border.ts            # Updated: explicit-width boxes do not grow to fit long titles;
+                                       #          over-long titles wrap inside the frame.
+lib/stdlib/layout/nodes.ts             # New: parseWidth + Width type (used by render.ts and table.ts).
+                                       # Updated: ColumnSpec gains optional `width`.
+                                       # Updated: text leaf renderer reads attrs.wrapWidth.
+lib/stdlib/layout/box.ts               # composeBox reads attrs.resolvedWidth and grows.
+lib/stdlib/layout/axis.ts              # composeRow / composeColumn read attrs.resolvedWidth and grow.
+lib/stdlib/layout/table.ts             # New: _resolveTableWidths (per-column width distribution +
+                                       #      cell wrapWidth annotation).
+                                       # Updated: _computeColumnLayouts honours resolved column widths
+                                       #          (skips natural measurement when width is fixed).
+                                       # Updated: composeTable reads attrs.resolvedWidth and grows.
+lib/stdlib/layout.ts                   # Re-export new types/functions (Viewport, Width, wrapText).
+                                       # Update `_internal` with new helpers used by layout.test.ts.
+lib/stdlib/layout.test.ts              # New unit tests for each new helper.
+stdlib/layout.agency                   # New `width` param on box / row / column / table and their
+                                       #     _add* / builder helpers.
+                                       # New `Width` type alias.
+                                       # ColumnSpec gains optional `width`.
+                                       # Optional `cols` / `rows` params on `render`.
+docs/site/stdlib/layout.md             # Regenerated by `make doc`.
+examples/layoutDemo.agency             # Add a section demoing full-width + 33% three-column layout +
+                                       #     a sized table with one fixed and one percentage column.
+tests/agency/layout/width-sizing.agency      # New: integration tests for box/row/column sizing.
+tests/agency/layout/width-sizing.test.json
+tests/agency/layout/text-wrap.agency         # New: integration tests for wrap behaviour.
+tests/agency/layout/text-wrap.test.json
+tests/agency/layout/table-width.agency       # New: integration tests for table + column sizing.
+tests/agency/layout/table-width.test.json
+```
+
+No changes to the `Block` primitive, `pad`, `beside`, `above`, or `styled` operators — they already do everything we need. `bordered` / `buildTopEdge` may need a small explicit-width title path so long titles wrap instead of widening fixed-width boxes.
+
+---
+
+## Task 1: Viewport + size types + plumbing
+
+**Files:**
+- Modify: `lib/stdlib/layout/render.ts` (or wherever the public `render` lives today)
+- Modify: `lib/stdlib/layout/nodes.ts`
+- Modify: `lib/stdlib/layout.test.ts`
+- Modify: `stdlib/layout.agency`
+
+Lay the foundation: viewport detection, the `Width` type the resolver will operate on, and the new `width` parameter on `box`/`row`/`column`/`table`/`ColumnSpec` and their `_add*` / builder helpers. No resolver yet — just the surface and types.
+
+- [ ] **Step 1: `_viewport` helper + `Viewport` type**
+
+```ts
+// lib/stdlib/layout/render.ts
+
+// Viewport describes the rendering surface. Width drives sizing;
+// height is reported for future use but currently unread by the
+// resolver.
+export type Viewport = { cols: number; rows: number };
+
+const DEFAULT_VIEWPORT: Viewport = { cols: 80, rows: 24 };
+
+// Read terminal dimensions from process.stdout. Returns
+// DEFAULT_VIEWPORT (80×24) when stdout is not a TTY (piped, captured,
+// tests) — every call site that cares can override via the public
+// `render(tree, { viewport })` option.
+export function _viewport(): Viewport {
+  return {
+    cols: process.stdout.columns ?? DEFAULT_VIEWPORT.cols,
+    rows: process.stdout.rows    ?? DEFAULT_VIEWPORT.rows,
+  };
+}
+```
+
+Tests in `layout.test.ts`:
+- `_viewport()` returns `process.stdout.columns / rows` when set.
+- Falls back to 80×24 when `process.stdout.columns` is `undefined`.
+
+- [ ] **Step 2: `Width` discriminated type + parser**
+
+Lives in `lib/stdlib/layout/nodes.ts` so both `render.ts` and `table.ts` can import without forming a new cycle (nodes.ts is leaf).
+
+```ts
+// lib/stdlib/layout/nodes.ts
+
+// Width is one of: a plain number, "full", or a percentage like "50%".
+// Parsed by `parseWidth` into a tagged union the resolver consumes.
+export type Width =
+  | { kind: "cells";   value: number }
+  | { kind: "full" }
+  | { kind: "percent"; value: number };  // 0–100, may exceed
+
+export function parseWidth(raw: unknown): Width | null {
+  if (raw == null) return null;
+  if (typeof raw === "number") return { kind: "cells", value: raw };
+  if (raw === "full") return { kind: "full" };
+  if (typeof raw === "string") {
+    const m = raw.match(/^(\d+(?:\.\d+)?)%$/);
+    if (m) return { kind: "percent", value: parseFloat(m[1]) };
+  }
+  throw new Error(
+    `std::layout: invalid width ${JSON.stringify(raw)}. ` +
+    `Expected a number, "full", or "<n>%" (e.g. "50%").`,
+  );
+}
+```
+
+Tests:
+- `parseWidth(null)` → `null`, `parseWidth(undefined)` → `null`
+- `parseWidth(20)` → `{ kind: "cells", value: 20 }`
+- `parseWidth("full")` → `{ kind: "full" }`
+- `parseWidth("33%")` → `{ kind: "percent", value: 33 }`
+- `parseWidth("33.5%")` → `{ kind: "percent", value: 33.5 }`
+- `parseWidth("foo")` throws with a helpful message.
+- `parseWidth("100")` throws (no `%`, not a number).
+
+- [ ] **Step 3: `width` param on `box`, `row`, `column`, `table` + their `_add*` / builder mirrors**
+
+```agency
+// stdlib/layout.agency
+
+export type Width = number | "full" | string  // string carries "X%"
+
+export def box(
+  title: string = "",
+  titleColor: string = "",
+  borderStyle: BorderStyle = "rounded",
+  borderColor: string = "",
+  padding: number = 1,
+  width: Width = null,                       // NEW
+  children: LayoutNode[] = null,
+  block: (LayoutBuilder) -> void = null,
+): LayoutNode {
+  // ... unchanged body, plus `width: width` in attrs
+}
+```
+
+Apply the same `width: Width = null` insertion to:
+- `row`, `column`, `table`, and their `_addBox`, `_addRow`, `_addColumn` mirrors.
+- If the implementation branch already has a `LayoutBuilder.table` / `_addTable` helper, add `width` there too. The current stdlib does **not** have one, and adding nested-table builder support is out of scope for this plan.
+- The `TableBuilder.row(...)` / `TableBuilder.header(...)` / `TableBuilder.footer(...)` methods do NOT take width — row width comes from the table's column widths.
+
+Stored in `attrs.width` (raw — the resolver parses it).
+
+Test in `tests/agency/layout/width-sizing.agency`:
+- Build `box(width: "full")` and assert the returned node has `attrs.width === "full"`.
+- Build `table(width: 80)` and assert `attrs.width === 80`.
+
+- [ ] **Step 4: `width` field on `ColumnSpec`**
+
+```agency
+// stdlib/layout.agency
+
+export type ColumnSpec = {
+  align?: Alignment;
+  minWidth?: number;
+  width?: Width;            // NEW
+  fgColor?: string
+}
+```
+
+```ts
+// lib/stdlib/layout/nodes.ts
+
+export type ColumnSpec = {
+  align?: Align;
+  minWidth?: number;
+  width?: unknown;          // NEW — parsed by parseWidth at resolve time
+  fgColor?: string;
+};
+```
+
+Tests:
+- `_validateTable` already checks `columns` is an array of objects; verify that an `unknown` `width` field is accepted as-is (parsing happens later).
+- Build a `table({ columns: [{ width: "50%" }, { width: 10 }, {}] })` and assert the columns array is preserved on `attrs.columns`.
+
+---
+
+## Task 2: `resolveSizes` — top-down width resolution (non-table containers)
+
+**Files:**
+- Modify: `lib/stdlib/layout/render.ts`
+- Modify: `lib/stdlib/layout.test.ts`
+
+The core of the feature. A pure tree-walking function that takes a node tree + viewport and returns a new tree where every container has `attrs.resolvedWidth` (number | undefined) and every text leaf inside a width-constrained container has `attrs.wrapWidth` (number | undefined). The renderer reads these annotations; it does not call this function. Tables get a separate dispatch arm covered in Task 5.
+
+- [ ] **Step 1: Skeleton + root resolution**
+
+```ts
+// Resolve every node's width, top-down. Returns a new tree (does not
+// mutate). Caller passes the viewport so this stays a pure function.
+//
+// Resolved values:
+//   * resolvedWidth: number | undefined
+//     - undefined = content-driven (current behaviour)
+//     - number    = target width for this container; wrappable text is
+//                   constrained to fit it, while raw content remains
+//                   verbatim and may overflow visibly
+//   * wrapWidth: number | undefined  (text leaves only)
+//     - undefined = no wrap (current behaviour)
+//     - number    = wrap content to this column width
+export function resolveSizes(
+  node: LayoutNode,
+  viewport: Viewport,
+): LayoutNode {
+  const rootWidth = resolveRootWidth(node, viewport);
+  return resolveNode(node, rootWidth);
+}
+
+function resolveRootWidth(node: LayoutNode, viewport: Viewport): number | undefined {
+  const w = parseWidth(node.attrs.width);
+  if (w === null) return undefined;             // content-driven root
+  if (w.kind === "cells")   return w.value;
+  if (w.kind === "full")    return viewport.cols;
+  if (w.kind === "percent") {
+    // A percentage at the root is meaningless — there's no parent.
+    throw new Error(
+      `std::layout: width "${node.attrs.width}" on root has no parent ` +
+      `to take a percentage of. Use "full" or a number.`,
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Recursive resolve with chrome subtraction**
+
+```ts
+function resolveNode(node: LayoutNode, resolvedWidth: number | undefined): LayoutNode {
+  // Tables have their own width-distribution axis (per-column, not
+  // per-child). Delegate to the table-aware resolver.
+  if (node.type === "table") {
+    return _resolveTableWidths(node, resolvedWidth);
+  }
+
+  if (node.children.length === 0) {
+    return annotate(node, resolvedWidth, undefined);
+  }
+
+  // Available width for children = own width minus chrome (border + padding + gaps).
+  const available =
+    resolvedWidth !== undefined
+      ? Math.max(0, resolvedWidth - chromeWidth(node))
+      : undefined;
+
+  const resolvedChildren = node.children.map((child) =>
+    resolveChild(node, child, available),
+  );
+
+  return {
+    ...node,
+    attrs: { ...node.attrs, resolvedWidth },
+    children: resolvedChildren,
+  };
+}
+
+// Bytes the container itself eats out of resolvedWidth before children get any:
+//   * box border: 2 columns
+//   * box padding: 2 * padding columns
+//   * row gap:    (numChildren - 1) * gap columns  (column gap doesn't eat width)
+function chromeWidth(node: LayoutNode): number {
+  let chrome = 0;
+  if (node.type === "box") {
+    chrome += 2;                                     // left + right border
+    chrome += 2 * ((node.attrs.padding as number) ?? 0);
+  }
+  if (node.type === "row") {
+    const gap = (node.attrs.gap as number) ?? 0;
+    chrome += Math.max(0, node.children.length - 1) * gap;
+  }
+  return chrome;
+}
+```
+
+- [ ] **Step 3: Distribute available width to children**
+
+```ts
+function isContainer(node: LayoutNode): boolean {
+  return node.type === "box" || node.type === "row" || node.type === "column" || node.type === "table";
+}
+
+// Resolve one child using the parent's available width. Important rule:
+// an unsized *container* child inside a width-constrained parent inherits
+// the parent's available width as its resolution context. This is what
+// makes `box(width:"full") > row > [box(width:"33%"), ...]` work: the
+// unsized row is resolved against the box's inner width, so its percentage
+// children have a parent width to reference.
+function resolveChild(
+  node: LayoutNode,
+  child: LayoutNode,
+  available: number | undefined,
+): LayoutNode {
+  const childWidth = resolveChildWidth(node, child, available);
+
+  if (child.type === "text") {
+    // Explicit child width wins; otherwise text in a constrained parent wraps
+    // to the parent's available content width.
+    return annotate(child, undefined, childWidth ?? available);
+  }
+  if (child.type === "raw") {
+    return child;
+  }
+  if (isContainer(child)) {
+    // Unsized containers inherit the constrained context so their own
+    // percentage descendants can resolve. Content-driven parents still pass
+    // undefined and preserve today's behavior.
+    return resolveNode(child, childWidth ?? available);
+  }
+  return resolveNode(child, childWidth);
+}
+
+// Returns the explicit width requested by a child, if any.
+function resolveChildWidth(
+  node: LayoutNode,
+  child: LayoutNode,
+  available: number | undefined,
+): number | undefined {
+  const w = parseWidth(child.attrs.width);
+  if (w === null) return undefined;
+  if (w.kind === "cells") return w.value;
+  if (w.kind === "full") {
+    throw new Error(
+      `std::layout: width "full" is only valid at the root. ` +
+      `Use "100%" if you mean "fill the parent".`,
+    );
+  }
+  if (w.kind === "percent") {
+    if (available === undefined) {
+      throw new Error(
+        `std::layout: child uses width "${child.attrs.width}" but the ` +
+        `parent ${node.type} has no resolved width to take a percentage of. ` +
+        `Set a width on the parent or one of its ancestors.`,
+      );
+    }
+    return Math.floor((available * w.value) / 100);
+  }
+}
+```
+
+Decision check: for `column`, unsized children inherit the column's full available width because a column is single-axis, not horizontally distributing siblings. A column child with `width: "50%"` still resolves against the column's own available width.
+
+- [ ] **Step 4: Annotate text leaves with `wrapWidth`**
+
+```ts
+function annotate(
+  node: LayoutNode,
+  resolvedWidth: number | undefined,
+  wrapWidth: number | undefined,
+): LayoutNode {
+  return {
+    ...node,
+    attrs: {
+      ...node.attrs,
+      ...(resolvedWidth !== undefined ? { resolvedWidth } : {}),
+      ...(wrapWidth     !== undefined ? { wrapWidth }     : {}),
+    },
+  };
+}
+
+// `resolveChild` above annotates text leaves at the parent level because
+// that is where the parent's available content width is known. Raw leaves
+// do NOT receive wrapWidth (verbatim by contract).
+```
+
+Refactor the recursion so text-leaf annotation happens at the parent level (where the parent's `available` is known), not at the child level (where it would need to look up).
+
+- [ ] **Step 5: Tests**
+
+Tests in `layout.test.ts` for `resolveSizes` (non-table cases):
+- Single content-driven node: no annotations added.
+- `box(width: "full")` with viewport 100: root gets `resolvedWidth: 100`.
+- `box(width: 50)`: root gets `resolvedWidth: 50` regardless of viewport.
+- `box(width: "full") > row > [box(width:"33%"), box(width:"33%"), box(width:"34%")]`: each leaf box gets ~33 columns after chrome subtraction.
+- Same shape with an unsized intermediate `row`: the row inherits the box's inner width for resolution, so its percentage children do not throw.
+- `row(gap: 2)` with three 33% children: per-child width = floor((parentAvailable - 4) / 3).
+- `box(padding: 2, width: 20)`: inner child gets 20 - 2 (border) - 4 (padding) = 14 columns.
+- `box > text("long string")` with `box(width: 30)`: text node gets `wrapWidth: 28` (after border subtraction).
+- `raw` inside a width-constrained box does NOT receive `wrapWidth`.
+- Error: percentage at root → throws helpfully.
+- Error: `"full"` on non-root → throws.
+- Error: percentage child of a content-driven parent → throws.
+
+(Table-specific tests live in Task 5.)
+
+---
+
+## Task 3: `wrapText` — word-wrap with ANSI-aware char-break fallback
+
+**Files:**
+- Modify: `lib/stdlib/layout/ansi.ts` (lives next to `visualWidth` since both are pure ANSI string ops)
+- Modify: `lib/stdlib/layout.test.ts`
+
+A pure function: given a string and a target column width, return an array of wrapped lines. ANSI-aware (uses `visualWidth`). Preserves explicit `\n` boundaries — wraps each "paragraph" independently. Word-boundary preferred; single words longer than the column get char-broken.
+
+- [ ] **Step 1: `wrapText(content, width)` signature + line-by-line dispatch**
+
+```ts
+// Wrap `content` to fit within `width` columns. Returns an array of
+// wrapped lines suitable for `Block.of(wrapped)`. Preserves explicit
+// newlines in the input: each input line is wrapped independently.
+//
+// `width` is a hard limit measured in visual columns (ANSI-aware).
+// If `width <= 0`, returns an empty array (no room to render).
+export function wrapText(content: string, width: number): string[] {
+  if (width <= 0) return [];
+  return content.split("\n").flatMap((line) => wrapSingleLine(line, width));
+}
+```
+
+- [ ] **Step 2: `wrapSingleLine` — word-wrap with char-break fallback**
+
+```ts
+function wrapSingleLine(line: string, width: number): string[] {
+  if (visualWidth(line) <= width) return [line];
+
+  const words = line.split(/(\s+)/);  // keep whitespace as its own tokens
+  const out: string[] = [];
+  let current = "";
+
+  for (const token of words) {
+    const tentative = current + token;
+    if (visualWidth(tentative) <= width) {
+      current = tentative;
+      continue;
+    }
+    // Token doesn't fit. Flush current (if any), then handle token.
+    if (current.length > 0 && current.trim().length > 0) {
+      out.push(current);
+      current = "";
+    }
+    if (visualWidth(token) <= width) {
+      // Whole word fits on its own line
+      current = token;
+    } else {
+      // Word longer than column — char-break it
+      for (const chunk of breakLongToken(token, width)) {
+        if (visualWidth(current + chunk) <= width) {
+          current += chunk;
+        } else {
+          if (current.length > 0) out.push(current);
+          current = chunk;
+        }
+      }
+    }
+  }
+  if (current.length > 0) out.push(current);
+  return out;
+}
+
+// Break a string longer than `width` into `width`-sized chunks.
+// ANSI-aware: never splits inside a CSI escape sequence.
+function breakLongToken(token: string, width: number): string[] {
+  // Walk the string, accumulating visual columns. When an SGR sequence
+  // appears, copy it whole regardless of column count.
+  // Implementation: a small state machine. See test fixtures for
+  // expected behaviour with embedded SGR.
+  // ...
+}
+```
+
+- [ ] **Step 3: Tests for `wrapText`**
+
+- Plain short line: returns `[line]`.
+- Width 0: returns `[]`.
+- `"hello world", 5` → `["hello", "world"]`.
+- `"hello world", 8` → `["hello", "world"]` (won't fit both, even though sum is 11).
+- `"a b c d e", 4` → wraps greedily; locked-in convention: **trailing whitespace stripped per output line**.
+- Multiple paragraphs preserve newlines: `"foo\nbar baz", 5` → `["foo", "bar", "baz"]`.
+- Long single word: `"abcdefghij", 4` → `["abcd", "efgh", "ij"]`.
+- ANSI: `"\x1b[31mhello\x1b[0m world", 5` → `["\x1b[31mhello\x1b[0m", "world"]` (escape sequence stays attached to "hello").
+- Edge: empty string → `[""]` (preserves the one-row contract from the leaf renderer).
+- Width covers exactly the content: no wrap, no trailing whitespace.
+
+Decision locked in: **trailing whitespace on wrapped lines is stripped** (cleaner ASCII output, matches what user expects to see in a bordered panel). Document explicitly.
+
+---
+
+## Task 4: Wire `resolveSizes` + `wrapText` into the renderer (non-table)
+
+**Files:**
+- Modify: `lib/stdlib/layout/render.ts` (`render` entry point, `growToWidth` helper)
+- Modify: `lib/stdlib/layout/nodes.ts` (text renderer reads `attrs.wrapWidth`)
+- Modify: `lib/stdlib/layout/box.ts` (composeBox grows to `resolvedWidth`)
+- Modify: `lib/stdlib/layout/axis.ts` (composeRow/composeColumn grow to `resolvedWidth`)
+- Modify: `lib/stdlib/layout.test.ts`
+
+Connect the new pieces to the existing pipeline. `render` now calls `resolveSizes` first. Compose functions read `attrs.resolvedWidth` and grow their output. The `text` renderer reads `attrs.wrapWidth` and routes content through `wrapText` before building the block. The table renderer wiring is Task 5 (it shares `growToWidth` and `wrapText`).
+
+- [ ] **Step 1: `growToWidth` helper**
+
+```ts
+// lib/stdlib/layout/render.ts
+
+// Pad a block to at least `targetWidth` columns. If the block is
+// already wider, returns unchanged. (Wrap, not truncation, is the
+// overflow policy in this PR — but text wrap should mean the block
+// is already ≤ targetWidth, so this is just defensive padding for
+// containers whose resolved width exceeds their content.)
+export function growToWidth(block: Block, targetWidth: number): Block {
+  if (block.width >= targetWidth) return block;
+  return pad(block, targetWidth, block.height, "start", "start");
+}
+```
+
+- [ ] **Step 2: `text` renderer uses `wrapWidth`**
+
+```ts
+// In LEAF_RENDERERS in lib/stdlib/layout/nodes.ts:
+text: (n) => {
+  const content   = (n.attrs.content   as string)         ?? "";
+  const align     = (n.attrs.align     as Align)          ?? "start";
+  const wrapWidth = (n.attrs.wrapWidth as number | undefined);
+
+  const lines = wrapWidth !== undefined
+    ? wrapText(content, wrapWidth)
+    : content.split("\n");
+
+  const block = Block.of(lines);
+  const padded = pad(block, block.width, block.height, align, "start");
+  return styled(padded, styleOf(n.attrs));
+},
+```
+
+(Note: `alignedTextBlock` is no longer reusable as-is because we need to build from a pre-wrapped string array. Inline the logic; it's three lines. `alignedTextBlock` stays for the `raw` renderer.)
+
+- [ ] **Step 3: Compose functions grow to `resolvedWidth`**
+
+```ts
+// composeBox (lib/stdlib/layout/box.ts): after `bordered(...)`, grow if necessary.
+function composeBox(node: LayoutNode): Block {
+  // ... existing body builds `framed: Block` ...
+  const resolved = node.attrs.resolvedWidth as number | undefined;
+  return resolved !== undefined ? growToWidth(framed, resolved) : framed;
+}
+
+// composeAxis (lib/stdlib/layout/axis.ts): after joining children, grow if necessary.
+function composeAxis(node: LayoutNode, axis: Axis): Block {
+  // ... existing body builds `combined: Block` ...
+  const resolved = node.attrs.resolvedWidth as number | undefined;
+  return resolved !== undefined ? growToWidth(combined, resolved) : combined;
+}
+```
+
+- [ ] **Step 4: `render` entry point + viewport option**
+
+```ts
+// Public render: optionally accepts a viewport override (caller
+// knows better than process.stdout, e.g. snapshot tests).
+export function render(
+  node: LayoutNode,
+  opts?: { viewport?: Viewport },
+): string {
+  const viewport = opts?.viewport ?? _viewport();
+  const resolved = resolveSizes(node, viewport);
+  return renderNode(resolved).toString();
+}
+
+// _render (the Agency-side bridge) gains the same option:
+export function _render(
+  node: LayoutNode,
+  color: "auto" | boolean,
+  cols?: number,
+  rows?: number,
+): string {
+  const viewport: Viewport | undefined =
+    cols !== undefined && cols > 0 ? { cols, rows: rows ?? 24 } : undefined;
+  const out = render(node, { viewport });
+  // ... existing color stripping logic
+}
+```
+
+And in `stdlib/layout.agency`:
+
+```agency
+export safe def render(
+  node: LayoutNode,
+  color: "auto" | boolean = "auto",
+  cols: number = 0,        // 0 means "auto-detect from terminal"
+  rows: number = 0,
+): string {
+  return _render(node, color, cols, rows)
+}
+```
+
+Lock in the sentinel: `cols == 0` → use `_viewport()`. Document in the `render` docstring.
+
+- [ ] **Step 5: Integration tests**
+
+Tests in `layout.test.ts`:
+- `render(box(width:"full"), { viewport:{cols:40, rows:24} })` produces a 40-column-wide box (count visual chars on each output line).
+- `render(box(width:"full") containing row of three 33% boxes, viewport 40)` produces three boxes whose widths sum to ≤ 40 (after chrome).
+- `render(box(width:30) with text("long " * 20))` wraps the text and the output is exactly 30 columns wide.
+- `render(box(width:12, title:"a very long title"))` keeps the box width at 12 and wraps the title inside the frame instead of truncating or widening.
+- `raw` inside a width-constrained box overflows naturally (doesn't wrap).
+
+---
+
+## Task 5: Table width sizing + per-column sizing + cell wrap
+
+**Files:**
+- Modify: `lib/stdlib/layout/table.ts`
+- Modify: `lib/stdlib/layout.test.ts`
+
+Apply the same width-and-wrap machinery to tables. The resolver gets a table-specific dispatch arm (`_resolveTableWidths`) that distributes the table's resolved width across columns according to each `ColumnSpec.width`, then annotates each cell so the existing text wrap path (Task 4 Step 2) handles cell content.
+
+Design rationale: tables can't reuse `distributeChildWidths` because their "children" axis (rows) is orthogonal to the width-distribution axis (columns). The same per-column `Width` semantics from Task 2 apply, but the chrome model is different — interior column dividers and per-column `cellPadding` both eat into the table's inner width.
+
+- [ ] **Step 1: `_tableChromeWidth(columns, attrs)` helper**
+
+```ts
+// Width consumed by the table's frame + per-column padding + interior
+// dividers, before any cell content gets a single cell.
+//
+// Layout (columnDividers=true, 3 cols, cellPadding=1):
+//   │ <P><col0><P> │ <P><col1><P> │ <P><col2><P> │
+//   ^outer        ^div            ^div           ^outer
+//
+// chrome = 2 (outer borders) + nCols * 2 * cellPadding + (nCols-1)
+//          if columnDividers else 0.
+function _tableChromeWidth(
+  columnCount: number,
+  cellPadding: number,
+  columnDividers: boolean,
+): number {
+  const borders = 2;
+  const padding = columnCount * 2 * cellPadding;
+  const dividers = columnDividers ? Math.max(0, columnCount - 1) : 0;
+  return borders + padding + dividers;
+}
+```
+
+Tests:
+- `_tableChromeWidth(3, 1, true)` → 2 + 6 + 2 = 10.
+- `_tableChromeWidth(3, 0, false)` → 2.
+- `_tableChromeWidth(1, 2, true)` → 2 + 4 + 0 = 6.
+
+- [ ] **Step 2: `_resolveTableWidths(node, resolvedWidth)`**
+
+```ts
+// Top-down width resolver for tables. Called from the global
+// resolveNode dispatch when node.type === "table". Returns a new
+// table node with:
+//   * attrs.resolvedWidth         — the table's own resolved width (forwarded)
+//   * attrs.resolvedColumnWidths  — number[] of cell content widths per column
+//   * each cell in attrs.body/header/footer gets attrs.wrapWidth set
+//     if it is a text leaf in a width-constrained column.
+//
+// Behavior summary:
+//   * Always validates/coerces the table attrs first by calling
+//     `_validateTable`. The top-down resolver runs before `composeTable`,
+//     and raw Agency table attrs may still contain bare string cells.
+//   * resolvedWidth undefined → content-driven table. Fixed ColumnSpec.width
+//     values are honored; percentage columns throw because there is no table
+//     width to take a percentage from.
+//   * resolvedWidth set       → distribute inner = resolvedWidth - chrome
+//     across columns by spec.
+export function _resolveTableWidths(
+  node: LayoutNode,
+  resolvedWidth: number | undefined,
+): LayoutNode {
+  const attrs       = node.attrs;
+  const { header, body, footer, columnCount } = _validateTable(attrs);
+  const columns     = (attrs.columns as ColumnSpec[] | null | undefined) ?? [];
+  const cellPadding = clampCellPadding(attrs.cellPadding);
+  const columnDividers = (attrs.columnDividers as boolean) ?? true;
+
+  const sections = { header, body, footer };
+  const chrome = _tableChromeWidth(columnCount, cellPadding, columnDividers);
+
+  const resolvedColumnWidths = distributeColumnWidths({
+    columns,
+    columnCount,
+    sections,
+    resolvedWidth,
+    chrome,
+  });
+
+  const annotatedSections = annotateCellsWithWrap(sections, resolvedColumnWidths);
+
+  return {
+    ...node,
+    attrs: {
+      ...attrs,
+      ...(resolvedWidth !== undefined ? { resolvedWidth } : {}),
+      resolvedColumnWidths,
+      header: annotatedSections.header,
+      body:   annotatedSections.body,
+      footer: annotatedSections.footer,
+    },
+  };
+}
+```
+
+Notes:
+- `clampCellPadding` already exists in `table.ts` (or is inlined — extract it if not).
+- `_resolveTableWidths` must call `_validateTable` because it runs before `composeTable` and needs string cells coerced to `LayoutNode`s before wrap annotations. `composeTable` may still call `_validateTable` for backwards compatibility with tests that call `composeTable` directly.
+
+- [ ] **Step 3: `distributeColumnWidths` — per-column width math**
+
+```ts
+// Returns the per-column CONTENT width (excludes cellPadding — that's
+// added back by _layoutCell when rendering).
+//
+// Algorithm:
+//   1. For each column, compute its "ask":
+//        - fixed (cells): exact ask = w.value.
+//        - percent:       ask = floor((available - sumOfFixed - sumOfNatural) * w.value / 100)
+//          (only meaningful when `available` is finite)
+//        - none:          ask = natural content width
+//   2. If `available` is undefined (content-driven table):
+//        - Fixed columns get their fixed width.
+//        - Percent columns are an ERROR (no available width to take from)
+//          unless the table grows naturally — which we can't predict.
+//          Throw the same helpful error as resolveChildWidth.
+//        - Unsized columns get their natural width.
+//   3. If `available` is set:
+//        - Subtract chrome (already done — caller passes available = resolvedWidth - chrome).
+//        - Pay fixed columns first.
+//        - Pay unsized columns their natural width (capped at remaining space).
+//        - Distribute remaining space across percentage columns.
+//        - Clamp every result to >= 0; clamp to >= spec.minWidth if set.
+function distributeColumnWidths(args: {
+  columns: ColumnSpec[];
+  columnCount: number;
+  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] };
+  resolvedWidth: number | undefined;
+  chrome: number;
+}): number[] {
+  const { columns, columnCount, sections, resolvedWidth, chrome } = args;
+  const natural = measureNaturalColumnWidths(sections, columnCount);
+  const parsed = Array.from({ length: columnCount }, (_, c) =>
+    parseWidth(columns[c]?.width)
+  );
+
+  const available = resolvedWidth !== undefined
+    ? Math.max(0, resolvedWidth - chrome)
+    : undefined;
+
+  // Validate: no "full" allowed at column level.
+  for (let c = 0; c < columnCount; c++) {
+    if (parsed[c]?.kind === "full") {
+      throw new Error(
+        `std::layout: column[${c}].width "full" is not allowed. ` +
+        `Use a number or percentage.`,
+      );
+    }
+  }
+
+  // Validate: percentage columns need a table-level width.
+  if (available === undefined) {
+    for (let c = 0; c < columnCount; c++) {
+      if (parsed[c]?.kind === "percent") {
+        throw new Error(
+          `std::layout: column[${c}] uses a percentage width but the table ` +
+          `has no resolved width to take a percentage of. ` +
+          `Set width: on the table or one of its ancestors.`,
+        );
+      }
+    }
+  }
+
+  // Pay fixed and unsized.
+  const widths = new Array<number>(columnCount).fill(0);
+  let remaining = available ?? Infinity;
+  for (let c = 0; c < columnCount; c++) {
+    const p = parsed[c];
+    if (p?.kind === "cells") {
+      widths[c] = p.value;
+      remaining -= p.value;
+    } else if (p === null) {
+      widths[c] = natural[c];
+      remaining -= natural[c];
+    }
+  }
+  remaining = Math.max(0, remaining);
+
+  // Distribute remaining across percentage columns (proportional to their %).
+  const percentIndices = [] as number[];
+  let totalPct = 0;
+  for (let c = 0; c < columnCount; c++) {
+    if (parsed[c]?.kind === "percent") {
+      percentIndices.push(c);
+      totalPct += (parsed[c] as { kind: "percent"; value: number }).value;
+    }
+  }
+  for (const c of percentIndices) {
+    const pct = (parsed[c] as { kind: "percent"; value: number }).value;
+    // When percents sum to > 100, scale each by its share of the total so they
+    // collectively consume exactly `remaining` cells. When they sum to ≤ 100,
+    // each gets its literal share of the remaining width and slack stays at
+    // the right edge.
+    const share = totalPct > 100 ? pct / totalPct : pct / 100;
+    widths[c] = Math.floor(remaining * share);
+  }
+
+  // Apply per-column minWidth floor. If minWidth floors exceed the available
+  // table width, the table may grow past resolvedWidth; minWidth is the user's
+  // explicit floor knob and wins over the target-width request.
+  for (let c = 0; c < columnCount; c++) {
+    const min = columns[c]?.minWidth ?? 0;
+    if (widths[c] < min) widths[c] = min;
+  }
+
+  return widths;
+}
+```
+
+Lock in the percent math in the unit tests (a worked example for each):
+- 2 cols, both `"50%"`, inner = 20 → `[10, 10]`.
+- 3 cols, all `"33%"`, inner = 30 → `[9, 9, 9]` (one cell of slack to the right; matches box/row rounding loss).
+- 1 fixed (`width: 4`) + 1 percent (`"50%"`), inner = 20 → `[4, 8]` (50% of 16 remaining).
+- 2 cols, `"80%"` and `"40%"`, inner = 20 (sum > 100) → scaled to fit: `[13, 7]` (`floor(20 * 80/120)` and `floor(20 * 40/120)`).
+- Percent + no table width → throws.
+
+- [ ] **Step 4: `annotateCellsWithWrap` — set `wrapWidth` on text cells**
+
+```ts
+// For every cell across header/body/footer, if it's a text leaf and
+// its column has a resolved width, annotate it with wrapWidth so the
+// existing text renderer (Task 4 Step 2) wraps the content.
+//
+// Non-text cells (raw, nested box/row/column, nested table) are
+// recursed into via the global resolveNode — they participate in
+// width sizing as nested roots with resolvedWidth = column's content width.
+function annotateCellsWithWrap(
+  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] },
+  resolvedColumnWidths: number[],
+): { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] } {
+  const annotateCell = (cell: LayoutNode, colWidth: number): LayoutNode => {
+    if (cell.type === "text") {
+      return { ...cell, attrs: { ...cell.attrs, wrapWidth: colWidth } };
+    }
+    // raw → leave alone (verbatim contract).
+    if (cell.type === "raw") return cell;
+    // Anything else (nested container or table): recurse through the
+    // global resolver, treating colWidth as the child's resolved width.
+    return resolveNode(cell, colWidth);
+  };
+  return {
+    header: sections.header.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0)),
+    body:   sections.body.map((row) => row.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0))),
+    footer: sections.footer.map((row) => row.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0))),
+  };
+}
+```
+
+Forward declaration: `annotateCellsWithWrap` calls `resolveNode` from `render.ts`. To avoid a hard cycle, either (a) inject `resolveNode` as a parameter or (b) keep the existing `render.ts ↔ table.ts` cycle pattern (functions imported at module top, called inside function bodies — already how `renderNode` is used in `table.ts`).
+
+- [ ] **Step 5: `_computeColumnLayouts` honours resolved column widths**
+
+Today, `_computeColumnLayouts` measures the natural content width of each column. Update it to:
+
+```ts
+function _computeColumnLayouts(
+  rows: LayoutNode[][],
+  columnCount: number,
+  columns: ColumnSpec[],
+  cellPadding: number,
+  resolvedColumnWidths: number[] | undefined,   // NEW
+): { layouts: ColumnLayout[]; cellBlocks: Block[][] } {
+  // ... existing cell-rendering body ...
+  for (let c = 0; c < columnCount; c++) {
+    const measured = /* unchanged */;
+    const spec = columns[c] ?? {};
+    const resolved = resolvedColumnWidths?.[c];
+    layouts.push({
+      width:       resolved ?? Math.max(measured, spec.minWidth ?? 0),
+      align:       spec.align ?? "start",
+      cellPadding,
+      fgColor:     spec.fgColor ?? "",
+    });
+  }
+  return { layouts, cellBlocks };
+}
+```
+
+`composeTable` passes `attrs.resolvedColumnWidths` (set by `_resolveTableWidths`) into the call. When `resolveSizes` wasn't run (e.g. a TS-side unit test that builds a node by hand and calls `composeTable` directly), `resolvedColumnWidths` is undefined and the existing measured-content path runs — full backward compatibility.
+
+- [ ] **Step 6: `composeTable` grows to `resolvedWidth`**
+
+```ts
+function composeTable(node: LayoutNode): Block {
+  // ... existing body builds `framed: Block` ...
+  const resolved = node.attrs.resolvedWidth as number | undefined;
+  return resolved !== undefined ? growToWidth(framed, resolved) : framed;
+}
+```
+
+The natural cell grid already fills `_innerTableWidth(layouts)` cells when `resolvedColumnWidths` is set, so the framed block should already be exactly `resolvedWidth` wide — `growToWidth` is defensive padding for the case where the user set `width` smaller than the title floor (`minWidthForTitle`).
+
+- [ ] **Step 7: Tests**
+
+TS unit tests in `lib/stdlib/layout.test.ts` for `_resolveTableWidths`:
+- Content-driven table, no column widths → `resolvedColumnWidths` matches the natural content width, no cells annotated with `wrapWidth`.
+- Content-driven table, one column fixed (`width: 4`) → that column gets 4, others natural; text cell in that column gets `wrapWidth: 4`.
+- `table(width: 40)` with 2 columns, both `"50%"`, cellPadding 1, columnDividers true → chrome = 2 + 4 + 1 = 7, inner = 33, each column = floor(33 * 0.5) = 16.
+- `table(width: 20)` with cols `[{width: 2}, {}, {width: "50%"}]` → fixed pays 2 (col 0), unsized pays natural (col 1), col 2 gets 50% of remaining inner.
+- Percentage in column without table width → throws helpful error.
+- `"full"` in column → throws.
+- `minWidth: 5` on a column → column never drops below 5 even if percent math says less.
+
+TS unit tests for `_tableChromeWidth`:
+- See Step 1 (already enumerated).
+
+Integration tests live in Task 6.
+
+---
+
+## Task 6: User-facing integration tests + demo
+
+**Files:**
+- Create: `tests/agency/layout/width-sizing.agency` + `.test.json`
+- Create: `tests/agency/layout/text-wrap.agency` + `.test.json`
+- Create: `tests/agency/layout/table-width.agency` + `.test.json`
+- Modify: `examples/layoutDemo.agency`
+
+Lock the user-visible contract from Agency, not TS. These run the full pipeline and assert on the rendered string.
+
+- [ ] **Step 1: `width-sizing.agency`**
+
+Test cases:
+- `testFullWidth()` — `box(width: "full")` with explicit viewport via `render(..., cols: 60)`. Returns the rendered string; fixture asserts exact width of 60.
+- `testThreeColumn()` — full-width box with a row of three `33%` child boxes. Fixture asserts the rendered string matches a known layout.
+- `testFiftyFifty()` — full-width box with a row of two `50%` boxes.
+- `testPercentSummingTo80()` — three `25%` + one `5%`. Slack at right.
+- `testFixedWidthBox()` — `box(width: 30)` directly (no `"full"`). Fixture asserts exact width 30 regardless of viewport.
+- `testPercentageAtRootThrows()` — wrap in `try` block, assert the error message.
+
+- [ ] **Step 2: `text-wrap.agency`**
+
+Test cases:
+- `testWrapInsideBox()` — `box(width: 20)` with `text("the quick brown fox jumps over the lazy dog")`. Assert the rendered string has 4–5 lines all ≤ 18 cells (20 - 2 border).
+- `testLongWordBreaks()` — `box(width: 10)` with `text("supercalifragilisticexpialidocious")`. Assert the word is broken across lines.
+- `testRawDoesNotWrap()` — `box(width: 10)` with `raw("a very long banner string that should not be touched")`. Assert the raw content is on one line (overflowing the box visibly).
+- `testWrapPreservesExplicitNewlines()` — `text("line 1\nline 2 is much longer than the column")` with `width: 12`. Assert line 1 stays as-is and line 2 wraps.
+
+- [ ] **Step 3: `table-width.agency` (NEW)**
+
+Test cases:
+- `testTableFullWidth()` — `table(width: "full", columns: [{}, {}], header: ["a", "b"], body: [["x","y"]])` with viewport 40. Fixture: exact 40-cell-wide table.
+- `testTableFixedWidth()` — `table(width: 30, ...)`. Fixture: exact 30-cell-wide table regardless of viewport.
+- `testColumnFixedWidth()` — table with `columns: [{width: 2}, {width: 10}, {}]` and a row whose first cell is `"hello world"`. Fixture: first column's content is wrapped to 2 cells, rest renders naturally.
+- `testColumnPercentages()` — `table(width: 40, columns: [{width: "25%"}, {width: "75%"}], body: [...])`. Fixture: pinned column widths after chrome subtraction.
+- `testFixedAndPercentMix()` — `table(width: 40, columns: [{width: 4}, {}, {width: "50%"}])`. Fixture: column 0 = 4, column 1 = natural, column 2 = 50% of remaining inner.
+- `testCellWraps()` — column with `width: 8` containing `text("the quick brown fox")`. Fixture: cell content wraps to ≤ 8 cells over multiple visual lines, table row grows in height.
+- `testRawCellDoesNotWrap()` — column with `width: 8` containing `raw("ABCDEFGHIJKLMNOP")`. Fixture: raw content overflows the column visibly (no wrap).
+- `testColumnPercentWithoutTableWidthThrows()` — `table(columns: [{width: "50%"}], body: [["x"]])`. Wrap in `try`; assert error message names the column index.
+- `testColumnFullThrows()` — `table(columns: [{width: "full"}], ...)`. Assert error.
+- `testColumnMinWidthIsFloor()` — `table(width: 30, columns: [{width: "10%", minWidth: 5}, {}, {}])`. 10% of inner might be 2, but `minWidth: 5` floors it.
+
+- [ ] **Step 4: Update `examples/layoutDemo.agency`**
+
+Add a new section after the existing demos:
+
+```agency
+// 5) Full-width three-column splash, demonstrating top-down sizing
+//    and text wrap inside fixed-width cells.
+const splash = box(width: "full", title: "Status", padding: 1) as outer {
+  outer.row(gap: 2) as r {
+    r.box(width: "33%", title: "Commands") as b {
+      b.text("/help shows the help screen")
+      b.text("/exit quits the session")
+    }
+    r.box(width: "33%", title: "Shortcuts") as b {
+      b.text("Ctrl-C interrupts the current operation")
+      b.text("Ctrl-D submits the current input buffer")
+    }
+    r.box(width: "33%", title: "Tips") as b {
+      b.text("Long lines automatically wrap to fit the column width.")
+    }
+  }
+}
+print(render(splash))
+
+// 6) Sized table with a fixed first column and a percentage last column.
+const sized = table(
+  title: "Build summary",
+  width: "full",
+  columns: [
+    { width: 2, align: "end" },        // line numbers, exactly 2 cells
+    {},                                 // file path, content-driven
+    { width: "30%" },                   // notes column, 30% of inner
+  ],
+  header: ["#", "file", "notes"],
+  body: [
+    [text("1"), text("lib/foo.ts"), text("renamed; updated callers throughout the codebase")],
+    [text("2"), text("lib/bar.ts"), text("ok")],
+  ],
+)
+print(render(sized))
+```
+
+Manual smoke-check: `pnpm run agency examples/layoutDemo.agency` should render both demos correctly, with the "Tips" text wrapped across multiple lines and the "notes" cell in row 1 wrapped to ~30% of the terminal width.
+
+---
+
+## Task 7: Doc updates
+
+**Files:**
+- Modify: `stdlib/layout.agency` (module-level docstring + per-function docstrings)
+- Run: `make doc` (regenerates `docs/site/stdlib/layout.md`)
+
+- [ ] **Step 1: Module docstring section**
+
+Add a new "Sizing and wrap" section to the `@module` block in `stdlib/layout.agency`:
+
+```
+### Sizing and wrap
+
+Every container (`box`, `row`, `column`, `table`) accepts a `width`
+parameter:
+
+- `width: "full"` (root only) fills the terminal columns.
+- `width: 80` sets an exact column count.
+- `width: "50%"` takes 50% of the parent's available width.
+
+Inside a `table`, each `ColumnSpec` accepts the same `width` field —
+a percentage column is sized as a share of the table's inner width
+(after borders, cell padding, and interior dividers).
+
+Text inside a width-constrained container or column automatically
+wraps at word boundaries. Long single words are broken at the
+column width. `raw` content is never wrapped — use `text` if you
+want wrapping.
+
+Width is the only sized dimension. There is no height sizing and
+no truncation: content that overflows wraps, or (for `raw`) extends
+visibly past the container.
+```
+
+- [ ] **Step 2: Per-function docstring updates**
+
+`@param width` description on `box`, `row`, `column`, `table`:
+
+```
+@param width - Optional width constraint. `"full"` (root only) fills the
+   terminal columns. `"X%"` takes a percentage of the parent's
+   available width. A number sets an exact column count. Unset
+   (default) means content-driven width.
+```
+
+Add a `width` documentation paragraph to the `ColumnSpec` type docstring:
+
+```
+width - Optional per-column constraint. A number caps the column's
+   content width in cells (text wraps if the cap is exceeded). `"X%"`
+   takes a percentage of the table's inner width (after borders,
+   cell padding, and interior dividers). `"full"` is not allowed at
+   the column level. Unset means the column is content-driven; in a
+   width-constrained table, content-driven columns take their natural
+   width and slack flows to the percentage columns (if any) or to
+   trailing space.
+```
+
+- [ ] **Step 3: Regenerate site docs**
+
+```
+make doc
+```
+
+Verify the generated `docs/site/stdlib/layout.md` reflects the new params, new ColumnSpec field, and module section.
+
+---
+
+## Acceptance criteria
+
+This plan is complete when:
+
+- [ ] All unit tests in `lib/stdlib/layout.test.ts` pass (including new `parseWidth`, `wrapText`, `resolveSizes`, `_tableChromeWidth`, `_resolveTableWidths` tests).
+- [ ] All agency tests in `tests/agency/layout/` pass (existing + new `width-sizing`, `text-wrap`, `table-width`).
+- [ ] `pnpm run lint:structure` clean.
+- [ ] `make` (full build + doc regen) clean.
+- [ ] `examples/layoutDemo.agency` runs end-to-end and renders both the splash and the sized-table demos correctly in an interactive terminal.
+- [ ] `pnpm run agency examples/layoutDemo.agency 2>&1 | cat` (non-TTY path) also renders correctly using the 80-column fallback.
+- [ ] Manual check: a deeply nested width-constrained tree (e.g. `box(width:"full") > row > box(width:"50%") > table(width:"100%", columns:[{width:"50%"},{width:"50%"}])`) sizes correctly through 4+ levels.
+- [ ] Manual check: `table(width: 80)` with mixed fixed/percent/unsized columns + a cell containing a long sentence → cell wraps inside its column, table is exactly 80 cells wide, surrounding rows grow to the wrapped cell's height (this last bit is already how the row renderer composes — verify nothing regressed).
+
+## Risks / things to watch
+
+- **Cross-pass annotations on `attrs`.** Storing `resolvedWidth` / `wrapWidth` / `resolvedColumnWidths` on `attrs` mixes user data with resolver output. If this becomes painful (e.g. snapshot tests of node trees include the annotations), move to a side-channel `WeakMap<LayoutNode, ResolvedInfo>`. For now, the on-attrs approach is fine — easy to debug, easy to test.
+- **Wrap and styling interaction.** `text("...", bold: true)` is styled by the renderer after wrap. Confirm in the integration tests that every wrapped line is bolded, not just the first. The current `styled` helper wraps each line independently, which is the correct behaviour, but the test pins the contract.
+- **Percentage rounding loss.** Three `33%` children of a 100-cell parent → `floor(100 * 0.33) * 3 = 99`, one cell of slack. Document this; don't try to redistribute the lost cell (over-engineered for v1). Same rule applies to table columns.
+- **Column children with `width: "X%"`.** A `column` doesn't subdivide horizontally — `width: "50%"` on a column child takes 50% of the column's resolved width, NOT 50% of half the column's width. The resolver naturally does this; just make sure the integration test covers it.
+- **Test for wrapping with embedded ANSI** is the highest-risk unit test. The `breakLongToken` state machine for SGR-aware char-breaking is the most likely place for subtle bugs. Spend extra care there; include fixtures with adjacent SGR sequences, sequences spanning multiple line breaks, and bare CSI (no SGR) sequences.
+- **Table chrome math is easy to get wrong.** `_tableChromeWidth` is the single source of truth for "how much does the table frame eat". Don't inline the math anywhere else (don't reuse `chromeWidth` from `resolveSizes`). The most likely bug is forgetting that `columnDividers: false` removes `(N-1)` cells, or that `cellPadding` is applied **per column** not per row.
+- **Title floor vs. resolved width.** `minWidthForTitle` is a content-driven floor. If a user explicitly sets `table(width: 20, title: "A very long title")`, the resolved width wins and the title wraps inside the frame. Confirm with an integration test that this doesn't widen or crash.
+- **Cell wrap of nested non-text cells.** A cell that's a nested `box` with its own content needs to be resolved (recursive `resolveNode`) at the column's content width. The `annotateCellsWithWrap` helper does this. Confirm with an integration test that a `box` cell inside a width-constrained table column renders at the column's width, not its natural width.
+- **Backward compatibility for `composeTable` direct callers.** If anything in the codebase or tests calls `composeTable` without going through `render`/`resolveSizes`, `attrs.resolvedColumnWidths` will be undefined and `_computeColumnLayouts` falls back to natural measurement. Verify no existing tests regress.

--- a/packages/agency-lang/examples/layoutDemo.agency
+++ b/packages/agency-lang/examples/layoutDemo.agency
@@ -101,4 +101,42 @@ node main() {
     t.row("search",  text("yes", fgColor: "green"))
   }
   print(render(status))
+  print("")
+
+  // 8) Full-width three-column splash, demonstrating top-down sizing
+  // and text wrap inside percentage-width boxes.
+  const splash = box(width: "full", title: "Sized layout", padding: 1) as outer {
+    outer.row(gap: 2) as r {
+      r.box(width: "33%", title: "Commands") as b {
+        b.text("/help shows the help screen")
+        b.text("/exit quits the session")
+      }
+      r.box(width: "33%", title: "Shortcuts") as b {
+        b.text("Ctrl-C interrupts the current operation")
+        b.text("Ctrl-D submits the current input buffer")
+      }
+      r.box(width: "33%", title: "Tips") as b {
+        b.text("Long lines automatically wrap to fit the column width.")
+      }
+    }
+  }
+  print(render(splash))
+  print("")
+
+  // 9) Sized table with a fixed first column and a percentage notes column.
+  const sized = table(
+    title: "Build summary",
+    width: "full",
+    columns: [
+      { width: 2, align: "end" },
+      {},
+      { width: "30%" },
+    ],
+    header: ["#", "file", "notes"],
+    body: [
+      [text("1"), text("lib/foo.ts"), text("renamed; updated callers throughout the codebase")],
+      [text("2"), text("lib/bar.ts"), text("ok")],
+    ],
+  )
+  print(render(sized))
 }

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -33,6 +33,11 @@ describe("parseWidth", () => {
     expect(_internal.parseWidth(20)).toEqual({ kind: "cells", value: 20 });
   });
 
+  test("normalizes fixed cell widths to non-negative integer cells", () => {
+    expect(_internal.parseWidth(20.9)).toEqual({ kind: "cells", value: 20 });
+    expect(_internal.parseWidth(-5)).toEqual({ kind: "cells", value: 0 });
+  });
+
   test("parses full and percentage widths", () => {
     expect(_internal.parseWidth("full")).toEqual({ kind: "full" });
     expect(_internal.parseWidth("33%")).toEqual({ kind: "percent", value: 33 });
@@ -43,12 +48,22 @@ describe("parseWidth", () => {
     expect(() => _internal.parseWidth("foo")).toThrow(/invalid width/);
     expect(() => _internal.parseWidth("100")).toThrow(/invalid width/);
   });
+
+  test("rejects non-finite fixed cell widths", () => {
+    expect(() => _internal.parseWidth(Number.NaN)).toThrow(/invalid width/);
+    expect(() => _internal.parseWidth(Number.POSITIVE_INFINITY)).toThrow(/invalid width/);
+    expect(() => _internal.parseWidth(Number.NEGATIVE_INFINITY)).toThrow(/invalid width/);
+  });
 });
 
 describe("wrapText", () => {
   test("wraps on word boundaries", () => {
     expect(_internal.wrapText("hello world", 5)).toEqual(["hello", "world"]);
     expect(_internal.wrapText("hello world", 8)).toEqual(["hello", "world"]);
+  });
+
+  test("preserves trailing whitespace when no wrapping is needed", () => {
+    expect(_internal.wrapText("hello  ", 10)).toEqual(["hello  "]);
   });
 
   test("breaks long words", () => {
@@ -106,6 +121,19 @@ describe("resolveSizes", () => {
     const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
     expect(resolved.children[0].attrs.wrapWidth).toBeUndefined();
     expect(resolved.children[1].attrs.wrapWidth).toBeUndefined();
+  });
+
+  test("uses clamped integer padding and gap when resolving child width", () => {
+    const padded = _internal.resolveSizes(node("box", { width: 20, padding: 1.9 }, [
+      node("text", { content: "inside" }),
+    ]), { cols: 80, rows: 24 });
+    expect(padded.children[0].attrs.wrapWidth).toBe(16);
+
+    const negativeGap = _internal.resolveSizes(node("row", { width: 20, gap: -5 }, [
+      node("box", { width: "50%" }, []),
+      node("box", { width: "50%" }, []),
+    ]), { cols: 80, rows: 24 });
+    expect(negativeGap.children.map((child) => child.attrs.resolvedWidth)).toEqual([10, 10]);
   });
 
   test("rejects percentage root and nested full widths", () => {

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -83,6 +83,17 @@ describe("wrapText", () => {
     expect(_internal.wrapText("\x1b[31mhello\x1b[0m world", 5))
       .toEqual(["\x1b[31mhello\x1b[0m", "world"]);
   });
+
+  test("breaks a long colored word at the column boundary while keeping CSI escapes intact", () => {
+    // The break must happen at a visual-cell boundary (width=4), not
+    // mid-escape. Both pieces of the broken token must keep the
+    // CSI bytes that landed inside their span.
+    expect(_internal.wrapText("\x1b[31mabcdefghij\x1b[0m", 4)).toEqual([
+      "\x1b[31mabcd",
+      "efgh",
+      "ij\x1b[0m",
+    ]);
+  });
 });
 
 describe("resolveSizes", () => {
@@ -171,6 +182,31 @@ describe("resolveSizes", () => {
         { cols: 80, rows: 24 },
       ),
     ).toThrow(/requires a sized ancestor/);
+  });
+
+  test("sizeColumn propagates width to children (unlike row)", () => {
+    // Column children share the column's full width as their default
+    // (so unsized children fill) and as their percent basis. Distinct
+    // from row, which gives children no implicit width.
+    const tree = node("column", { width: 30 }, [
+      node("box", { width: "50%" }),
+      node("text", { content: "x" }),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect(resolved.attrs.resolvedWidth).toBe(30);
+    // Inner box's "50%" is taken against the column's own width (30).
+    expect(resolved.children[0].attrs.resolvedWidth).toBe(15);
+    // Unsized text child fills the column → wrapWidth = 30.
+    expect(resolved.children[1].attrs.wrapWidth).toBe(30);
+  });
+
+  test("box padding subtracts both sides from inner width", () => {
+    const tree = node("box", { width: 20, padding: 2 }, [
+      node("text", { content: "inside" }),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    // inner = 20 - 2 border - (2 padding * 2 sides) = 14.
+    expect(resolved.children[0].attrs.wrapWidth).toBe(14);
   });
 });
 
@@ -690,7 +726,7 @@ describe("box renderer", () => {
     const tree = node("box", { width: 20 }, [
       node("text", { content: "the quick brown fox jumps" }),
     ]);
-    const lines = render(tree, { viewport: { cols: 80, rows: 24 } }).split("\n");
+    const lines = render(tree, { cols: 80, rows: 24 }).split("\n");
     expect(lines.map(_internal.visualWidth)).toEqual([20, 20, 20, 20]);
     expect(lines).toContain("│the quick brown   │");
     expect(lines).toContain("│fox jumps         │");
@@ -699,7 +735,7 @@ describe("box renderer", () => {
     const tree = node("box", { width: 10 }, [
       node("raw", { content: "ABCDEFGHIJKLMNOP" }),
     ]);
-    const lines = render(tree, { viewport: { cols: 80, rows: 24 } }).split("\n");
+    const lines = render(tree, { cols: 80, rows: 24 }).split("\n");
     expect(_internal.visualWidth(lines[0])).toBe(10);
     expect(lines[1]).toBe("│ABCDEFGHIJKLMNOP│");
   });
@@ -707,7 +743,7 @@ describe("box renderer", () => {
     const tree = node("box", { width: 12, title: "a very long title" }, [
       node("text", { content: "ok" }),
     ]);
-    const lines = render(tree, { viewport: { cols: 80, rows: 24 } }).split("\n");
+    const lines = render(tree, { cols: 80, rows: 24 }).split("\n");
     expect(lines.map(_internal.visualWidth)).toEqual([12, 12, 12, 12, 12]);
     expect(lines[0]).toBe("╭──────────╮");
     expect(lines.slice(1, -1)).toContain("│a very    │");
@@ -860,14 +896,27 @@ describe("table — width resolution", () => {
   });
 
   test("renders fixed-width table and wraps text cells", () => {
+    // available = 24 - 2 border - 2*2*1 padding - 1 divider = 17.
+    // col0 fixed=6; remain=11; col1 "50%" → floor(11*0.5)=5. The
+    // natural cell grid is only 18 cells wide but the table was asked
+    // for 24, so each row is padded out to 24 with trailing space on
+    // the right (inside the right border).
     const lines = renderTablePlain({
       width: 24,
       columns: [{ width: 6 }, { width: "50%" }],
       body: [["abcdef", "the quick brown fox"]],
     }).split("\n");
     expect(lines.map(_internal.visualWidth)).toEqual([24, 24, 24, 24, 24, 24]);
-    expect(lines.some((line) => line.includes("abcdef") && line.includes("the"))).toBe(true);
-    expect(lines.some((line) => line.includes("quick"))).toBe(true);
+    expect(lines[0]).toMatch(/^╭─+╮$/);
+    expect(lines[lines.length - 1]).toMatch(/^╰─+╯$/);
+    // Exact body lines: "the quick brown fox" wraps in the 5-cell
+    // second column over four visual rows; the first column shows the
+    // word only once and is empty on the wrapped lines.
+    const body = lines.slice(1, -1);
+    expect(body[0]).toBe("│ abcdef │ the         │");
+    expect(body[1]).toBe("│        │ quick       │");
+    expect(body[2]).toBe("│        │ brown       │");
+    expect(body[3]).toBe("│        │ fox         │");
   });
 
   test("fixed-width table wraps over-long title inside the frame", () => {
@@ -880,6 +929,66 @@ describe("table — width resolution", () => {
     expect(lines[0]).toBe("╭──────────╮");
     expect(lines).toContain("│a very    │");
     expect(lines).toContain("│long title│");
+  });
+
+  test("minWidth floors a percentage column whose share rounds smaller", () => {
+    // Inner available = 30 - 2 border - 6 padding - 2 dividers = 20.
+    // Col 0 width "10%" → floor(20 * 0.1) = 2, but minWidth: 5 floors
+    // it back up to 5. Col 1/2 unsized → natural ("x" = 1 each).
+    const tree = tableNode({
+      width: 30,
+      columns: [{ width: "10%", minWidth: 5 }, {}, {}],
+      body: [["x", "x", "x"]],
+    });
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect((resolved.attrs.resolvedColumnWidths as number[])[0]).toBe(5);
+  });
+
+  test("rescales when column percentages sum to more than 100", () => {
+    // Two columns declared "80%" + "40%" → sum 120%. Each should get
+    // its proportional share of `available` (not its literal share).
+    // available = 40 - 2 - 4 - 1 = 33.
+    // share0 = 80/120 = 2/3 → floor(33 * 2/3) = 22.
+    // share1 = 40/120 = 1/3 → floor(33 * 1/3) = 11.
+    const tree = tableNode({
+      width: 40,
+      columns: [{ width: "80%" }, { width: "40%" }],
+      body: [["a", "b"]],
+    });
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect(resolved.attrs.resolvedColumnWidths).toEqual([22, 11]);
+  });
+
+  test("column width: 'full' behaves as 100% of the remaining space", () => {
+    // One fixed column eats 4 cells; "full" column takes everything
+    // left in `available`.
+    // available = 30 - 2 - 4 - 1 = 23. Col 0 fixed=4. Col 1 "full" = 19.
+    const tree = tableNode({
+      width: 30,
+      columns: [{ width: 4 }, { width: "full" }],
+      body: [["a", "b"]],
+    });
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect(resolved.attrs.resolvedColumnWidths).toEqual([4, 19]);
+  });
+
+  test("raw cells in a sized column are not annotated with wrapWidth", () => {
+    // Raw content keeps its literal form even when its column has a
+    // resolved width; only text cells get wrapWidth.
+    // available = 20 - 2 border - 2*2*1 padding - 1 divider = 13.
+    // Col 0 fixed=6 (claimed); remain=7; col 1 "50%" → floor(7*0.5)=3.
+    const tree = tableNode({
+      width: 20,
+      columns: [{ width: 6 }, { width: "50%" }],
+      body: [[{ type: "raw", attrs: { content: "ABCDEFGHIJ" }, children: [] }, "text"]],
+    });
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    const cell = (resolved.attrs.body as LayoutNode[][])[0][0];
+    expect(cell.type).toBe("raw");
+    expect(cell.attrs.wrapWidth).toBeUndefined();
+    // The neighbouring text cell still gets a wrapWidth.
+    const textCell = (resolved.attrs.body as LayoutNode[][])[0][1];
+    expect(textCell.attrs.wrapWidth).toBe(3);
   });
 });
 

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -136,12 +136,41 @@ describe("resolveSizes", () => {
     expect(negativeGap.children.map((child) => child.attrs.resolvedWidth)).toEqual([10, 10]);
   });
 
-  test("rejects percentage root and nested full widths", () => {
-    expect(() => _internal.resolveSizes(node("box", { width: "50%" }), { cols: 80, rows: 24 }))
-      .toThrow(/root has no parent/);
-    expect(() => _internal.resolveSizes(node("box", { width: 10 }, [
-      node("box", { width: "full" }, []),
-    ]), { cols: 80, rows: 24 })).toThrow(/only valid at the root/);
+  test("treats full and 100% as the same — at root, in children, anywhere", () => {
+    // At the root, both `"full"` and `"100%"` fill the viewport.
+    const full    = node("box", { width: "full" });
+    const hundred = node("box", { width: "100%" });
+    expect(_internal.resolveSizes(full,    { cols: 80, rows: 24 }).attrs.resolvedWidth).toBe(80);
+    expect(_internal.resolveSizes(hundred, { cols: 80, rows: 24 }).attrs.resolvedWidth).toBe(80);
+
+    // A nested `width: "full"` fills the parent's inner space (same as
+    // `width: "100%"` would). It no longer throws.
+    const nested = _internal.resolveSizes(
+      node("box", { width: 10 }, [node("box", { width: "full" })]),
+      { cols: 80, rows: 24 },
+    );
+    // outer inner = 10 - 2 border = 8 (no padding set at the raw-node
+    // level — Agency's `box()` defaults padding to 1, but a hand-built
+    // LayoutNode does not); inner box fills it.
+    expect(nested.children[0].attrs.resolvedWidth).toBe(8);
+
+    // Percentages at root resolve against the viewport.
+    const halfRoot = _internal.resolveSizes(
+      node("box", { width: "50%" }),
+      { cols: 100, rows: 24 },
+    );
+    expect(halfRoot.attrs.resolvedWidth).toBe(50);
+  });
+
+  test("rejects percentage child whose ancestors are all unsized", () => {
+    // Percent inside an unsized box has no basis to take a percentage
+    // of (the outer box does not itself have a resolved width).
+    expect(() =>
+      _internal.resolveSizes(
+        node("box", {}, [node("box", { width: "50%" })]),
+        { cols: 80, rows: 24 },
+      ),
+    ).toThrow(/requires a sized ancestor/);
   });
 });
 

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -23,6 +23,100 @@ function node(
 
 const { visualWidth, sgr, _coerceCell, _validateTable } = _internal;
 
+describe("parseWidth", () => {
+  test("parses empty width as content-driven", () => {
+    expect(_internal.parseWidth(null)).toBeNull();
+    expect(_internal.parseWidth(undefined)).toBeNull();
+  });
+
+  test("parses fixed cell widths", () => {
+    expect(_internal.parseWidth(20)).toEqual({ kind: "cells", value: 20 });
+  });
+
+  test("parses full and percentage widths", () => {
+    expect(_internal.parseWidth("full")).toEqual({ kind: "full" });
+    expect(_internal.parseWidth("33%")).toEqual({ kind: "percent", value: 33 });
+    expect(_internal.parseWidth("33.5%")).toEqual({ kind: "percent", value: 33.5 });
+  });
+
+  test("rejects invalid width strings", () => {
+    expect(() => _internal.parseWidth("foo")).toThrow(/invalid width/);
+    expect(() => _internal.parseWidth("100")).toThrow(/invalid width/);
+  });
+});
+
+describe("wrapText", () => {
+  test("wraps on word boundaries", () => {
+    expect(_internal.wrapText("hello world", 5)).toEqual(["hello", "world"]);
+    expect(_internal.wrapText("hello world", 8)).toEqual(["hello", "world"]);
+  });
+
+  test("breaks long words", () => {
+    expect(_internal.wrapText("abcdefghij", 4)).toEqual(["abcd", "efgh", "ij"]);
+  });
+
+  test("preserves explicit newlines", () => {
+    expect(_internal.wrapText("foo\nbar baz", 5)).toEqual(["foo", "bar", "baz"]);
+  });
+
+  test("handles zero width and empty strings", () => {
+    expect(_internal.wrapText("hello", 0)).toEqual([]);
+    expect(_internal.wrapText("", 5)).toEqual([""]);
+  });
+
+  test("keeps ANSI sequences attached while measuring visual width", () => {
+    expect(_internal.wrapText("\x1b[31mhello\x1b[0m world", 5))
+      .toEqual(["\x1b[31mhello\x1b[0m", "world"]);
+  });
+});
+
+describe("resolveSizes", () => {
+  test("resolves full root width from viewport", () => {
+    const tree = node("box", { width: "full" }, []);
+    const resolved = _internal.resolveSizes(tree, { cols: 100, rows: 24 });
+    expect(resolved.attrs.resolvedWidth).toBe(100);
+  });
+
+  test("wraps text to constrained box inner width", () => {
+    const tree = node("box", { width: 30 }, [
+      node("text", { content: "the quick brown fox" }),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBe(28);
+  });
+
+  test("unsized container inherits constrained parent context", () => {
+    const tree = node("box", { width: "full" }, [
+      node("row", {}, [
+        node("box", { width: "50%" }, []),
+        node("box", { width: "50%" }, []),
+      ]),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 42, rows: 24 });
+    const row = resolved.children[0];
+    expect(row.attrs.resolvedWidth).toBe(40);
+    expect(row.children.map((child) => child.attrs.resolvedWidth)).toEqual([20, 20]);
+  });
+
+  test("row does not give full width to every unsized child", () => {
+    const tree = node("row", { width: 20 }, [
+      node("text", { content: "first child is long" }),
+      node("text", { content: "second child is long" }),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBeUndefined();
+    expect(resolved.children[1].attrs.wrapWidth).toBeUndefined();
+  });
+
+  test("rejects percentage root and nested full widths", () => {
+    expect(() => _internal.resolveSizes(node("box", { width: "50%" }), { cols: 80, rows: 24 }))
+      .toThrow(/root has no parent/);
+    expect(() => _internal.resolveSizes(node("box", { width: 10 }, [
+      node("box", { width: "full" }, []),
+    ]), { cols: 80, rows: 24 })).toThrow(/only valid at the root/);
+  });
+});
+
 describe("visualWidth", () => {
   test("plain string", () => {
     expect(visualWidth("hello")).toBe(5);
@@ -535,6 +629,33 @@ describe("box renderer", () => {
     const out = render(tree);
     expect(out.split("\n")[0]).toBe("╭─ T ───────╮");
   });
+  test("fixed-width box wraps text content", () => {
+    const tree = node("box", { width: 20 }, [
+      node("text", { content: "the quick brown fox jumps" }),
+    ]);
+    const lines = render(tree, { viewport: { cols: 80, rows: 24 } }).split("\n");
+    expect(lines.map(_internal.visualWidth)).toEqual([20, 20, 20, 20]);
+    expect(lines).toContain("│the quick brown   │");
+    expect(lines).toContain("│fox jumps         │");
+  });
+  test("fixed-width box leaves raw content unwrapped", () => {
+    const tree = node("box", { width: 10 }, [
+      node("raw", { content: "ABCDEFGHIJKLMNOP" }),
+    ]);
+    const lines = render(tree, { viewport: { cols: 80, rows: 24 } }).split("\n");
+    expect(_internal.visualWidth(lines[0])).toBe(10);
+    expect(lines[1]).toBe("│ABCDEFGHIJKLMNOP│");
+  });
+  test("fixed-width box wraps over-long title inside the frame", () => {
+    const tree = node("box", { width: 12, title: "a very long title" }, [
+      node("text", { content: "ok" }),
+    ]);
+    const lines = render(tree, { viewport: { cols: 80, rows: 24 } }).split("\n");
+    expect(lines.map(_internal.visualWidth)).toEqual([12, 12, 12, 12, 12]);
+    expect(lines[0]).toBe("╭──────────╮");
+    expect(lines.slice(1, -1)).toContain("│a very    │");
+    expect(lines.slice(1, -1)).toContain("│long title│");
+  });
   test("box with padding=1", () => {
     const tree = node("box", { padding: 1 }, [node("text", { content: "x" })]);
     expect(render(tree)).toBe(
@@ -652,6 +773,58 @@ function tableNode(attrs: Record<string, unknown>): LayoutNode {
 function renderTablePlain(attrs: Record<string, unknown>): string {
   return stripAnsi(render(tableNode(attrs)));
 }
+
+describe("table — width resolution", () => {
+  test("computes table chrome width", () => {
+    expect(_internal._tableChromeWidth(3, 1, true)).toBe(10);
+    expect(_internal._tableChromeWidth(3, 0, false)).toBe(2);
+    expect(_internal._tableChromeWidth(1, 2, true)).toBe(6);
+  });
+
+  test("resolves fixed and percentage column widths", () => {
+    const tree = tableNode({
+      width: 40,
+      columns: [{ width: 4 }, {}, { width: "50%" }],
+      body: [["id", "name", "the quick brown fox"]],
+    });
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    expect(resolved.attrs.resolvedWidth).toBe(40);
+    expect(resolved.attrs.resolvedColumnWidths).toEqual([4, 4, 11]);
+    const body = resolved.attrs.body as LayoutNode[][];
+    expect(body[0][2].attrs.wrapWidth).toBe(11);
+  });
+
+  test("rejects percentage column without table width", () => {
+    const tree = tableNode({
+      columns: [{ width: "50%" }],
+      body: [["x"]],
+    });
+    expect(() => _internal.resolveSizes(tree, { cols: 80, rows: 24 })).toThrow(/column\[0\]/);
+  });
+
+  test("renders fixed-width table and wraps text cells", () => {
+    const lines = renderTablePlain({
+      width: 24,
+      columns: [{ width: 6 }, { width: "50%" }],
+      body: [["abcdef", "the quick brown fox"]],
+    }).split("\n");
+    expect(lines.map(_internal.visualWidth)).toEqual([24, 24, 24, 24, 24, 24]);
+    expect(lines.some((line) => line.includes("abcdef") && line.includes("the"))).toBe(true);
+    expect(lines.some((line) => line.includes("quick"))).toBe(true);
+  });
+
+  test("fixed-width table wraps over-long title inside the frame", () => {
+    const lines = renderTablePlain({
+      width: 12,
+      title: "a very long title",
+      body: [["x"]],
+    }).split("\n");
+    expect(lines.map(_internal.visualWidth)).toEqual([12, 12, 12, 12, 12]);
+    expect(lines[0]).toBe("╭──────────╮");
+    expect(lines).toContain("│a very    │");
+    expect(lines).toContain("│long title│");
+  });
+});
 
 describe("table — composeTable rendering", () => {
   test("2-col header + 2-row body, default settings", () => {

--- a/packages/agency-lang/lib/stdlib/layout.ts
+++ b/packages/agency-lang/lib/stdlib/layout.ts
@@ -27,8 +27,8 @@ import { parseWidth, styleOf } from "./layout/nodes.js";
 export { Style, wrapText } from "./layout/ansi.js";
 export { Align, Block, above, beside, pad, styled } from "./layout/block.js";
 export { BorderOpts, BorderStyle, bordered } from "./layout/border.js";
-export { Cell, ColumnSpec, LayoutNode, NodeType, Width } from "./layout/nodes.js";
-export { Viewport, _render, render, renderNode } from "./layout/render.js";
+export { Cell, ColumnSpec, LayoutNode, NodeType, Width, WidthInput } from "./layout/nodes.js";
+export { SizingContext, Viewport, _render, render, renderNode } from "./layout/render.js";
 
 // Internal exports for tests only — pinned here so the test surface
 // stays at a single import path even as implementation files move.

--- a/packages/agency-lang/lib/stdlib/layout.ts
+++ b/packages/agency-lang/lib/stdlib/layout.ts
@@ -18,17 +18,17 @@
 //   * render.ts  — RENDERERS dispatch table + renderNode + render + _render
 
 import { BORDER_CHARS, resolveBorderStyle } from "./layout/border.js";
-import { colorToRgb, sgr, stripAnsi, visualWidth } from "./layout/ansi.js";
+import { colorToRgb, sgr, stripAnsi, visualWidth, wrapText } from "./layout/ansi.js";
 import { padLine } from "./layout/block.js";
-import { RENDERERS } from "./layout/render.js";
-import { _coerceCell, _validateTable } from "./layout/table.js";
-import { styleOf } from "./layout/nodes.js";
+import { RENDERERS, _viewport, growToWidth, resolveSizes } from "./layout/render.js";
+import { _coerceCell, _tableChromeWidth, _validateTable } from "./layout/table.js";
+import { parseWidth, styleOf } from "./layout/nodes.js";
 
-export { Style } from "./layout/ansi.js";
+export { Style, wrapText } from "./layout/ansi.js";
 export { Align, Block, above, beside, pad, styled } from "./layout/block.js";
 export { BorderOpts, BorderStyle, bordered } from "./layout/border.js";
-export { Cell, ColumnSpec, LayoutNode, NodeType } from "./layout/nodes.js";
-export { _render, render, renderNode } from "./layout/render.js";
+export { Cell, ColumnSpec, LayoutNode, NodeType, Width } from "./layout/nodes.js";
+export { Viewport, _render, render, renderNode } from "./layout/render.js";
 
 // Internal exports for tests only — pinned here so the test surface
 // stays at a single import path even as implementation files move.
@@ -36,5 +36,6 @@ export const _internal = {
   visualWidth, sgr, padLine, stripAnsi, colorToRgb,
   BORDER_CHARS, resolveBorderStyle,
   styleOf, RENDERERS,
-  _coerceCell, _validateTable,
+  parseWidth, wrapText, _viewport, resolveSizes, growToWidth,
+  _coerceCell, _validateTable, _tableChromeWidth,
 };

--- a/packages/agency-lang/lib/stdlib/layout/ansi.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.ts
@@ -6,6 +6,7 @@
 // asking `stripAnsi` to remove them).
 
 const CSI_RE = /\x1b\[[\d;]*[A-Za-z]/g;
+const CSI_TOKEN_RE = /\x1b\[[\d;]*[A-Za-z]/y;
 
 export function visualWidth(s: string): number {
   return s.replace(CSI_RE, "").length;
@@ -13,6 +14,76 @@ export function visualWidth(s: string): number {
 
 export function stripAnsi(s: string): string {
   return s.replace(CSI_RE, "");
+}
+
+export function wrapText(content: string, width: number): string[] {
+  if (width <= 0) return [];
+  return content.split("\n").flatMap((line) => wrapSingleLine(line, width));
+}
+
+function wrapSingleLine(line: string, width: number): string[] {
+  if (line === "") return [""];
+  if (visualWidth(line) <= width) return [line.trimEnd()];
+
+  const tokens = line.split(/(\s+)/);
+  const out: string[] = [];
+  let current = "";
+
+  for (const token of tokens) {
+    if (token === "") continue;
+    const tentative = current + token;
+    if (visualWidth(tentative) <= width) {
+      current = tentative;
+      continue;
+    }
+    if (current.trim().length > 0) {
+      out.push(current.trimEnd());
+      current = "";
+    }
+    if (token.trim().length === 0) {
+      continue;
+    }
+    if (visualWidth(token) <= width) {
+      current = token;
+      continue;
+    }
+    const chunks = breakLongToken(token, width);
+    out.push(...chunks.slice(0, -1));
+    current = chunks[chunks.length - 1] ?? "";
+  }
+
+  if (current.length > 0) out.push(current.trimEnd());
+  return out;
+}
+
+function breakLongToken(token: string, width: number): string[] {
+  const chunks: string[] = [];
+  let current = "";
+  let currentWidth = 0;
+  let index = 0;
+
+  while (index < token.length) {
+    CSI_TOKEN_RE.lastIndex = index;
+    const escape = CSI_TOKEN_RE.exec(token);
+    if (escape && escape.index === index) {
+      current += escape[0];
+      index = CSI_TOKEN_RE.lastIndex;
+      continue;
+    }
+
+    const char = token[index];
+    if (currentWidth >= width) {
+      chunks.push(current);
+      current = "";
+      currentWidth = 0;
+    }
+    current += char;
+    currentWidth += 1;
+    index += 1;
+  }
+
+  if (current.length > 0) chunks.push(current);
+  return chunks;
 }
 
 export type Style = {

--- a/packages/agency-lang/lib/stdlib/layout/ansi.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.ts
@@ -23,7 +23,7 @@ export function wrapText(content: string, width: number): string[] {
 
 function wrapSingleLine(line: string, width: number): string[] {
   if (line === "") return [""];
-  if (visualWidth(line) <= width) return [line.trimEnd()];
+  if (visualWidth(line) <= width) return [line];
 
   const tokens = line.split(/(\s+)/);
   const out: string[] = [];

--- a/packages/agency-lang/lib/stdlib/layout/axis.ts
+++ b/packages/agency-lang/lib/stdlib/layout/axis.ts
@@ -8,7 +8,7 @@
 
 import { Align, Block, above, beside, pad } from "./block.js";
 import { LayoutNode } from "./nodes.js";
-import { renderNode } from "./render.js";
+import { growToWidth, renderNode } from "./render.js";
 
 type Axis = "row" | "column";
 
@@ -120,7 +120,9 @@ function composeAxis(node: LayoutNode, axis: Axis): Block {
   const aligned   = rendered.map((b) => ops.alignCross(b, crossSize, childAlign));
 
   const gapBlock = gapCells > 0 ? ops.spaceBlock(gapCells) : null;
-  return joinWithGap(aligned, gapBlock, ops.join);
+  const combined = joinWithGap(aligned, gapBlock, ops.join);
+  const resolved = node.attrs.resolvedWidth as number | undefined;
+  return resolved !== undefined ? growToWidth(combined, resolved) : combined;
 }
 
 export function composeRow(node: LayoutNode):    Block { return composeAxis(node, "row"); }

--- a/packages/agency-lang/lib/stdlib/layout/border.ts
+++ b/packages/agency-lang/lib/stdlib/layout/border.ts
@@ -5,8 +5,8 @@
 // `╭─ Title ───╮`). Title-driven width growth lives here too so
 // callers (box, table) get consistent sizing.
 
-import { Style, styledWrapper, visualWidth } from "./ansi.js";
-import { Align, Block, pad, padLine } from "./block.js";
+import { Style, styledWrapper, visualWidth, wrapText } from "./ansi.js";
+import { Align, Block, above, pad, padLine, styled } from "./block.js";
 
 export type BorderStyle = "rounded" | "heavy" | "double" | "light";
 
@@ -60,6 +60,7 @@ export type BorderOpts = {
   padding?: number;
   title?: string;
   titleColor?: string;
+  targetWidth?: number;
 };
 
 // Minimum inner width required to fit a title embedded in the top edge.
@@ -96,9 +97,23 @@ export function bordered(block: Block, opts: BorderOpts): Block {
   const borderChars = BORDER_CHARS[resolveBorderStyle(opts.borderStyle)];
   const padding     = opts.padding ?? 0;
   const titleText   = opts.title   ?? "";
+  const targetInnerWidth = opts.targetWidth !== undefined
+    ? Math.max(0, opts.targetWidth - 2)
+    : undefined;
 
   const padded = withPaddingApplied(block, padding);
-  const inner  = titleText !== "" ? growToFitTitle(padded, titleText, padding) : padded;
+  if (targetInnerWidth !== undefined) {
+    const titleFitsTop = titleText === "" || minWidthForTitle(titleText) <= targetInnerWidth;
+    const topTitle = titleFitsTop ? titleText : "";
+    const titleBlock = titleFitsTop
+      ? Block.empty()
+      : styled(Block.of(wrapText(titleText, targetInnerWidth)), opts.titleColor ? { fgColor: opts.titleColor } : {});
+    const content = above(titleBlock, padded);
+    const inner = pad(content, targetInnerWidth, content.height, "start", "start");
+    return frameWithBorder(inner, borderChars, targetInnerWidth, opts, topTitle);
+  }
+
+  const inner = titleText !== "" ? growToFitTitle(padded, titleText, padding) : padded;
 
   return frameWithBorder(inner, borderChars, inner.width, opts, titleText);
 }

--- a/packages/agency-lang/lib/stdlib/layout/border.ts
+++ b/packages/agency-lang/lib/stdlib/layout/border.ts
@@ -63,6 +63,10 @@ export type BorderOpts = {
   targetWidth?: number;
 };
 
+// Number of cells a single `│`-style side border takes (one on each
+// side, so a framed box is `BORDER_CELLS` wider than its inner content).
+export const BORDER_CELLS = 2;
+
 // Minimum inner width required to fit a title embedded in the top edge.
 // The top edge is `tl + h + " Title " + h*N + tr` — so we need at least
 // one `h` before the title, the title text plus two spaces of padding,
@@ -71,6 +75,31 @@ const TITLE_BORDER_OVERHEAD = 4;
 
 export function minWidthForTitle(titleText: string): number {
   return visualWidth(titleText) + TITLE_BORDER_OVERHEAD;
+}
+
+// Decide how to render a title given a fixed inner width.
+//
+// When the title fits on the top edge (`╭─ Title ───╮`), it goes there.
+// When it would overflow, it wraps inside the frame as its own block of
+// rows, and the top edge is drawn plain. This is the rule both `box`
+// (via `bordered`) and `table` (via `composeTable`) use, so it lives
+// here as a single source of truth.
+export type TitlePlacement =
+  | { kind: "top"; title: string }
+  | { kind: "wrapped"; block: Block };
+
+export function placeTitle(
+  title: string,
+  innerWidth: number,
+  titleStyle: Style,
+): TitlePlacement {
+  if (title === "" || minWidthForTitle(title) <= innerWidth) {
+    return { kind: "top", title };
+  }
+  return {
+    kind: "wrapped",
+    block: styled(Block.of(wrapText(title, innerWidth)), titleStyle),
+  };
 }
 
 // Grow `inner` horizontally so a title can fit. Padded children stay
@@ -97,24 +126,20 @@ export function bordered(block: Block, opts: BorderOpts): Block {
   const borderChars = BORDER_CHARS[resolveBorderStyle(opts.borderStyle)];
   const padding     = opts.padding ?? 0;
   const titleText   = opts.title   ?? "";
-  const targetInnerWidth = opts.targetWidth !== undefined
-    ? Math.max(0, opts.targetWidth - 2)
-    : undefined;
+  const padded      = withPaddingApplied(block, padding);
 
-  const padded = withPaddingApplied(block, padding);
-  if (targetInnerWidth !== undefined) {
-    const titleFitsTop = titleText === "" || minWidthForTitle(titleText) <= targetInnerWidth;
-    const topTitle = titleFitsTop ? titleText : "";
-    const titleBlock = titleFitsTop
-      ? Block.empty()
-      : styled(Block.of(wrapText(titleText, targetInnerWidth)), opts.titleColor ? { fgColor: opts.titleColor } : {});
+  if (opts.targetWidth !== undefined) {
+    const innerWidth = Math.max(0, opts.targetWidth - BORDER_CELLS);
+    const titleStyle: Style = opts.titleColor ? { fgColor: opts.titleColor } : {};
+    const placement = placeTitle(titleText, innerWidth, titleStyle);
+    const titleBlock = placement.kind === "wrapped" ? placement.block : Block.empty();
+    const topTitle   = placement.kind === "top"     ? placement.title : "";
     const content = above(titleBlock, padded);
-    const inner = pad(content, targetInnerWidth, content.height, "start", "start");
-    return frameWithBorder(inner, borderChars, targetInnerWidth, opts, topTitle);
+    const inner = pad(content, innerWidth, content.height, "start", "start");
+    return frameWithBorder(inner, borderChars, innerWidth, opts, topTitle);
   }
 
   const inner = titleText !== "" ? growToFitTitle(padded, titleText, padding) : padded;
-
   return frameWithBorder(inner, borderChars, inner.width, opts, titleText);
 }
 

--- a/packages/agency-lang/lib/stdlib/layout/box.ts
+++ b/packages/agency-lang/lib/stdlib/layout/box.ts
@@ -7,7 +7,7 @@
 import { Block } from "./block.js";
 import { BorderStyle, bordered } from "./border.js";
 import { LayoutNode } from "./nodes.js";
-import { renderNode } from "./render.js";
+import { growToWidth, renderNode } from "./render.js";
 
 export function composeBox(node: LayoutNode): Block {
   // Single-child box uses that child directly; multi-child (or empty)
@@ -16,11 +16,14 @@ export function composeBox(node: LayoutNode): Block {
   const inner: LayoutNode = node.children.length === 1
     ? node.children[0]
     : { type: "column", attrs: {}, children: node.children };
-  return bordered(renderNode(inner), {
+  const resolved = node.attrs.resolvedWidth as number | undefined;
+  const framed = bordered(renderNode(inner), {
     title:       node.attrs.title       as string | undefined,
     titleColor:  node.attrs.titleColor  as string | undefined,
     borderStyle: node.attrs.borderStyle as BorderStyle | undefined,
     borderColor: node.attrs.borderColor as string | undefined,
     padding:     node.attrs.padding     as number | undefined,
+    targetWidth: resolved,
   });
+  return resolved !== undefined ? growToWidth(framed, resolved) : framed;
 }

--- a/packages/agency-lang/lib/stdlib/layout/nodes.ts
+++ b/packages/agency-lang/lib/stdlib/layout/nodes.ts
@@ -26,15 +26,23 @@ export type LayoutNode = {
 // `_coerceCell` (table.ts) at the table-handler boundary.
 export type Cell = string | LayoutNode;
 
+// The on-the-wire `width` value users write in Agency code: a positive
+// number of cells, the literal `"full"`, or a `"<n>%"` string. Validated
+// at runtime by `parseWidth`.
+export type WidthInput = number | "full" | string;
+
 export type ColumnSpec = {
-  align?: Align;
+  align?:    Align;
   minWidth?: number;
-  width?: unknown;
-  fgColor?: string;
+  width?:    WidthInput;
+  fgColor?:  string;
 };
 
+// Result of `parseWidth`: a closed sum type that downstream sizers
+// pattern-match on. `"full"` is preserved as its own kind for clarity
+// at debug time, but the resolver treats it as a synonym for `100%`.
 export type Width =
-  | { kind: "cells"; value: number }
+  | { kind: "cells";   value: number }
   | { kind: "full" }
   | { kind: "percent"; value: number };
 

--- a/packages/agency-lang/lib/stdlib/layout/nodes.ts
+++ b/packages/agency-lang/lib/stdlib/layout/nodes.ts
@@ -40,7 +40,9 @@ export type Width =
 
 export function parseWidth(raw: unknown): Width | null {
   if (raw == null) return null;
-  if (typeof raw === "number") return { kind: "cells", value: raw };
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return { kind: "cells", value: Math.max(0, Math.floor(raw)) };
+  }
   if (raw === "full") return { kind: "full" };
   if (typeof raw === "string") {
     const match = raw.match(/^(\d+(?:\.\d+)?)%$/);

--- a/packages/agency-lang/lib/stdlib/layout/nodes.ts
+++ b/packages/agency-lang/lib/stdlib/layout/nodes.ts
@@ -5,7 +5,7 @@
 // recurse via `renderNode`; the leaves (text / raw / space / hline /
 // vline) live here.
 
-import { Style } from "./ansi.js";
+import { Style, wrapText } from "./ansi.js";
 import { Align, Block, pad, styled } from "./block.js";
 
 export type NodeType =
@@ -29,8 +29,28 @@ export type Cell = string | LayoutNode;
 export type ColumnSpec = {
   align?: Align;
   minWidth?: number;
+  width?: unknown;
   fgColor?: string;
 };
+
+export type Width =
+  | { kind: "cells"; value: number }
+  | { kind: "full" }
+  | { kind: "percent"; value: number };
+
+export function parseWidth(raw: unknown): Width | null {
+  if (raw == null) return null;
+  if (typeof raw === "number") return { kind: "cells", value: raw };
+  if (raw === "full") return { kind: "full" };
+  if (typeof raw === "string") {
+    const match = raw.match(/^(\d+(?:\.\d+)?)%$/);
+    if (match) return { kind: "percent", value: parseFloat(match[1]) };
+  }
+  throw new Error(
+    `std::layout: invalid width ${JSON.stringify(raw)}. ` +
+    `Expected a number, "full", or "<n>%" (e.g. "50%").`,
+  );
+}
 
 export function styleOf(attrs: Record<string, unknown>): Style {
   const s: Style = {};
@@ -62,9 +82,12 @@ export const LEAF_RENDERERS: Record<
   (n: LayoutNode) => Block
 > = {
   text: (n) => {
-    const content = (n.attrs.content as string) ?? "";
-    const align   = (n.attrs.align as Align) ?? "start";
-    return styled(alignedTextBlock(content, align), styleOf(n.attrs));
+    const content   = (n.attrs.content as string) ?? "";
+    const align     = (n.attrs.align as Align) ?? "start";
+    const wrapWidth = n.attrs.wrapWidth as number | undefined;
+    const lines = wrapWidth !== undefined ? wrapText(content, wrapWidth) : content.split("\n");
+    const block = Block.of(lines);
+    return styled(pad(block, block.width, block.height, align, "start"), styleOf(n.attrs));
   },
   raw: (n) => {
     const content = (n.attrs.content as string) ?? "";

--- a/packages/agency-lang/lib/stdlib/layout/render.ts
+++ b/packages/agency-lang/lib/stdlib/layout/render.ts
@@ -125,14 +125,18 @@ function isContainer(node: LayoutNode): boolean {
 
 function chromeWidth(node: LayoutNode): number {
   if (node.type === "box") {
-    const padding = (node.attrs.padding as number | undefined) ?? 0;
+    const padding = nonNegativeInteger((node.attrs.padding as number | undefined) ?? 0);
     return 2 + 2 * padding;
   }
   if (node.type === "row") {
-    const gap = (node.attrs.gap as number | undefined) ?? 0;
+    const gap = nonNegativeInteger((node.attrs.gap as number | undefined) ?? 0);
     return Math.max(0, node.children.length - 1) * gap;
   }
   return 0;
+}
+
+function nonNegativeInteger(value: number): number {
+  return Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
 }
 
 function annotate(

--- a/packages/agency-lang/lib/stdlib/layout/render.ts
+++ b/packages/agency-lang/lib/stdlib/layout/render.ts
@@ -13,6 +13,7 @@ import { stripAnsi } from "./ansi.js";
 import { Block, pad } from "./block.js";
 import { composeColumn, composeRow } from "./axis.js";
 import { composeBox } from "./box.js";
+import { BORDER_CELLS } from "./border.js";
 import { _resolveTableWidths, composeTable } from "./table.js";
 import { LEAF_RENDERERS, LayoutNode, NodeType, parseWidth } from "./nodes.js";
 
@@ -48,119 +49,164 @@ export function growToWidth(block: Block, targetWidth: number): Block {
   return pad(block, targetWidth, block.height, "start", "start");
 }
 
+// ---------------------------------------------------------------------------
+// Size resolution
+// ---------------------------------------------------------------------------
+//
+// The algorithm is a single top-down walk:
+//
+//   resolveSizes(node, viewport)
+//     = resolveNode(node, { defaultWidth, percentBasis })
+//     = SIZERS[node.type](node, ctx)
+//
+// Each sizer:
+//   1. Computes its own `resolvedWidth` from `attrs.width` + the parent's
+//      context (`resolveOwnWidth`).
+//   2. Derives the context to pass to its children — what default width
+//      an unsized child should fill to, and what basis a percentage child
+//      computes against.
+//   3. Recurses into children via `resolveNode`.
+//
+// `defaultWidth` is undefined for row children (so unsized siblings stay
+// content-driven) but equal to the inner width for box / column children
+// (so unsized children fill the parent). `percentBasis` is always the
+// container's inner width so percentages always mean "X% of the parent
+// I am inside of".
+//
+// "full" is treated as a synonym for "100%" everywhere — at the root the
+// percent basis is the viewport, so `width: "full"` and `width: "100%"`
+// both fill the terminal columns; nested they fill the parent's inner
+// space.
+//
+// Resolved values are written onto `attrs.resolvedWidth` (and on `text`
+// leaves, `attrs.wrapWidth`). Renderers in box.ts / axis.ts / table.ts
+// read these annotations.
+
+export type SizingContext = {
+  // The width an unsized node should adopt. Undefined when the parent
+  // does not impose a width on its children (e.g. row children).
+  defaultWidth: number | undefined;
+  // The width that percentages and "full" compute against. Undefined
+  // when no enclosing ancestor has a resolved width.
+  percentBasis: number | undefined;
+};
+
+type Sizer = (node: LayoutNode, ctx: SizingContext) => LayoutNode;
+
+const SIZERS: Record<NodeType, Sizer> = {
+  box:    sizeBox,
+  row:    sizeRow,
+  column: sizeColumn,
+  table:  sizeTable,
+  text:   sizeText,
+  raw:    passthrough,
+  space:  passthrough,
+  hline:  passthrough,
+  vline:  passthrough,
+};
+
 export function resolveSizes(node: LayoutNode, viewport: Viewport): LayoutNode {
-  const rootWidth = resolveRootWidth(node, viewport);
-  return resolveNode(node, rootWidth);
+  // The viewport is the implicit "parent" of the root: it provides the
+  // percent basis (so `width: "full"` / `width: "100%"` at the root mean
+  // "fill the terminal columns") but does not impose a default width
+  // (so unsized roots stay content-driven).
+  return resolveNode(node, { defaultWidth: undefined, percentBasis: viewport.cols });
 }
 
-export function resolveNode(node: LayoutNode, resolvedWidth: number | undefined): LayoutNode {
-  if (node.type === "table") {
-    return _resolveTableWidths(node, resolvedWidth);
-  }
-  if (node.children.length === 0) {
-    return annotate(node, resolvedWidth, undefined);
-  }
-
-  const available = resolvedWidth !== undefined
-    ? Math.max(0, resolvedWidth - chromeWidth(node))
-    : undefined;
-  const resolvedChildren = node.children.map((child) =>
-    resolveChild(node, child, available),
-  );
-
-  return {
-    ...node,
-    attrs: annotateAttrs(node.attrs, resolvedWidth, undefined),
-    children: resolvedChildren,
-  };
+export function resolveNode(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  return SIZERS[node.type](node, ctx);
 }
 
-function resolveRootWidth(node: LayoutNode, viewport: Viewport): number | undefined {
+// Resolve a node's `width` attribute against the parent's context.
+// Returns the concrete cell count the node should occupy, or undefined
+// if it is content-driven.
+function resolveOwnWidth(node: LayoutNode, ctx: SizingContext): number | undefined {
   const width = parseWidth(node.attrs.width);
-  if (width === null) return undefined;
+  if (width === null) return ctx.defaultWidth;
   if (width.kind === "cells") return width.value;
-  if (width.kind === "full") return viewport.cols;
-  throw new Error(
-    `std::layout: width "${node.attrs.width}" on root has no parent ` +
-    `to take a percentage of. Use "full" or a number.`,
-  );
-}
-
-function resolveChild(parent: LayoutNode, child: LayoutNode, available: number | undefined): LayoutNode {
-  const childWidth = resolveChildWidth(parent, child, available);
-  const implicitWidth = parent.type === "row" ? undefined : available;
-  if (child.type === "text") return annotate(child, undefined, childWidth ?? implicitWidth);
-  if (child.type === "raw") return child;
-  if (isContainer(child)) return resolveNode(child, childWidth ?? implicitWidth);
-  return resolveNode(child, childWidth);
-}
-
-function resolveChildWidth(
-  parent: LayoutNode,
-  child: LayoutNode,
-  available: number | undefined,
-): number | undefined {
-  const width = parseWidth(child.attrs.width);
-  if (width === null) return undefined;
-  if (width.kind === "cells") return width.value;
-  if (width.kind === "full") {
+  const pct = width.kind === "full" ? 100 : width.value;
+  if (ctx.percentBasis === undefined) {
     throw new Error(
-      `std::layout: width "full" is only valid at the root. ` +
-      `Use "100%" if you mean "fill the parent".`,
+      `std::layout: width "${node.attrs.width}" on this ${node.type} ` +
+      `requires a sized ancestor (set an explicit width on the parent ` +
+      `or one of its ancestors).`,
     );
   }
-  if (available === undefined) {
-    throw new Error(
-      `std::layout: child uses width "${child.attrs.width}" but the ` +
-      `parent ${parent.type} has no resolved width to take a percentage of. ` +
-      `Set a width on the parent or one of its ancestors.`,
-    );
-  }
-  return Math.floor((available * width.value) / 100);
+  return Math.floor((ctx.percentBasis * pct) / 100);
 }
 
-function isContainer(node: LayoutNode): boolean {
-  return node.type === "box" || node.type === "row" || node.type === "column" || node.type === "table";
+function sizeBox(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const own = resolveOwnWidth(node, ctx);
+  const padding = nonNegativeInteger(node.attrs.padding);
+  const inner = innerWidthAfterChrome(own, BORDER_CELLS + 2 * padding);
+  // Box children either occupy the inner width directly (single child)
+  // or are wrapped in an implicit column, which itself fills the inner
+  // width. Either way, children fill.
+  return resolveContainer(node, own, { defaultWidth: inner, percentBasis: inner });
 }
 
-function chromeWidth(node: LayoutNode): number {
-  if (node.type === "box") {
-    const padding = nonNegativeInteger((node.attrs.padding as number | undefined) ?? 0);
-    return 2 + 2 * padding;
-  }
-  if (node.type === "row") {
-    const gap = nonNegativeInteger((node.attrs.gap as number | undefined) ?? 0);
-    return Math.max(0, node.children.length - 1) * gap;
-  }
-  return 0;
+function sizeColumn(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const own = resolveOwnWidth(node, ctx);
+  // Columns stack vertically; horizontal width is shared with every child.
+  return resolveContainer(node, own, { defaultWidth: own, percentBasis: own });
 }
 
-function nonNegativeInteger(value: number): number {
+function sizeRow(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const own = resolveOwnWidth(node, ctx);
+  const gap = nonNegativeInteger(node.attrs.gap);
+  const gapTotal = Math.max(0, node.children.length - 1) * gap;
+  const inner = innerWidthAfterChrome(own, gapTotal);
+  // Row children stay natural width unless they declare their own
+  // width; percentages compute against the row's inner space.
+  return resolveContainer(node, own, { defaultWidth: undefined, percentBasis: inner });
+}
+
+function sizeText(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  // Text doesn't track a resolvedWidth; instead it gets a wrapWidth so
+  // its content wraps to the inline space the parent allocated.
+  const own = resolveOwnWidth(node, ctx);
+  if (own === undefined) return node;
+  return setAttr(node, "wrapWidth", own);
+}
+
+function sizeTable(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  // Tables have a custom column-width distribution; delegate to the
+  // table module after resolving the table's own outer width.
+  return _resolveTableWidths(node, resolveOwnWidth(node, ctx));
+}
+
+function passthrough(node: LayoutNode, _ctx: SizingContext): LayoutNode {
+  return node;
+}
+
+// Build a resolved container node: annotate it with its own width and
+// recurse on every child using `childCtx`.
+function resolveContainer(
+  node: LayoutNode,
+  ownWidth: number | undefined,
+  childCtx: SizingContext,
+): LayoutNode {
+  const children = node.children.map((child) => resolveNode(child, childCtx));
+  const annotated = ownWidth === undefined ? node : setAttr(node, "resolvedWidth", ownWidth);
+  return { ...annotated, children };
+}
+
+function innerWidthAfterChrome(own: number | undefined, chrome: number): number | undefined {
+  if (own === undefined) return undefined;
+  return Math.max(0, own - chrome);
+}
+
+function nonNegativeInteger(raw: unknown): number {
+  const value = typeof raw === "number" ? raw : 0;
   return Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
 }
 
-function annotate(
-  node: LayoutNode,
-  resolvedWidth: number | undefined,
-  wrapWidth: number | undefined,
-): LayoutNode {
-  return { ...node, attrs: annotateAttrs(node.attrs, resolvedWidth, wrapWidth) };
+function setAttr(node: LayoutNode, key: string, value: unknown): LayoutNode {
+  return { ...node, attrs: { ...node.attrs, [key]: value } };
 }
 
-function annotateAttrs(
-  attrs: Record<string, unknown>,
-  resolvedWidth: number | undefined,
-  wrapWidth: number | undefined,
-): Record<string, unknown> {
-  return {
-    ...attrs,
-    ...(resolvedWidth !== undefined ? { resolvedWidth } : {}),
-    ...(wrapWidth !== undefined ? { wrapWidth } : {}),
-  };
-}
-
-export function render(node: LayoutNode, opts?: { viewport?: Viewport }): string {
-  const resolved = resolveSizes(node, opts?.viewport ?? _viewport());
+export function render(node: LayoutNode, viewport?: Viewport): string {
+  const resolved = resolveSizes(node, viewport ?? _viewport());
   return renderNode(resolved).toString();
 }
 
@@ -185,11 +231,14 @@ function _autoUseColor(): boolean {
   return process.stdout.isTTY === true;
 }
 
+function buildViewport(cols?: number, rows?: number): Viewport | undefined {
+  if (cols === undefined || cols <= 0) return undefined;
+  const validRows = rows !== undefined && rows > 0 ? rows : DEFAULT_VIEWPORT.rows;
+  return { cols, rows: validRows };
+}
+
 export function _render(node: LayoutNode, color: "auto" | boolean, cols?: number, rows?: number): string {
   const useColor = color === "auto" ? _autoUseColor() : color === true;
-  const viewport = cols !== undefined && cols > 0
-    ? { cols, rows: rows !== undefined && rows > 0 ? rows : DEFAULT_VIEWPORT.rows }
-    : undefined;
-  const out = render(node, { viewport });
+  const out = render(node, buildViewport(cols, rows));
   return useColor ? out : stripAnsi(out);
 }

--- a/packages/agency-lang/lib/stdlib/layout/render.ts
+++ b/packages/agency-lang/lib/stdlib/layout/render.ts
@@ -10,11 +10,15 @@
 // function body, so module loading completes before any call happens.
 
 import { stripAnsi } from "./ansi.js";
-import { Block } from "./block.js";
+import { Block, pad } from "./block.js";
 import { composeColumn, composeRow } from "./axis.js";
 import { composeBox } from "./box.js";
-import { composeTable } from "./table.js";
-import { LEAF_RENDERERS, LayoutNode, NodeType } from "./nodes.js";
+import { _resolveTableWidths, composeTable } from "./table.js";
+import { LEAF_RENDERERS, LayoutNode, NodeType, parseWidth } from "./nodes.js";
+
+export type Viewport = { cols: number; rows: number };
+
+const DEFAULT_VIEWPORT: Viewport = { cols: 80, rows: 24 };
 
 export const RENDERERS: Record<NodeType, (n: LayoutNode) => Block> = {
   ...LEAF_RENDERERS,
@@ -32,8 +36,128 @@ export function renderNode(node: LayoutNode): Block {
   return renderer(node);
 }
 
-export function render(node: LayoutNode): string {
-  return renderNode(node).toString();
+export function _viewport(): Viewport {
+  return {
+    cols: process.stdout.columns ?? DEFAULT_VIEWPORT.cols,
+    rows: process.stdout.rows ?? DEFAULT_VIEWPORT.rows,
+  };
+}
+
+export function growToWidth(block: Block, targetWidth: number): Block {
+  if (block.width >= targetWidth) return block;
+  return pad(block, targetWidth, block.height, "start", "start");
+}
+
+export function resolveSizes(node: LayoutNode, viewport: Viewport): LayoutNode {
+  const rootWidth = resolveRootWidth(node, viewport);
+  return resolveNode(node, rootWidth);
+}
+
+export function resolveNode(node: LayoutNode, resolvedWidth: number | undefined): LayoutNode {
+  if (node.type === "table") {
+    return _resolveTableWidths(node, resolvedWidth);
+  }
+  if (node.children.length === 0) {
+    return annotate(node, resolvedWidth, undefined);
+  }
+
+  const available = resolvedWidth !== undefined
+    ? Math.max(0, resolvedWidth - chromeWidth(node))
+    : undefined;
+  const resolvedChildren = node.children.map((child) =>
+    resolveChild(node, child, available),
+  );
+
+  return {
+    ...node,
+    attrs: annotateAttrs(node.attrs, resolvedWidth, undefined),
+    children: resolvedChildren,
+  };
+}
+
+function resolveRootWidth(node: LayoutNode, viewport: Viewport): number | undefined {
+  const width = parseWidth(node.attrs.width);
+  if (width === null) return undefined;
+  if (width.kind === "cells") return width.value;
+  if (width.kind === "full") return viewport.cols;
+  throw new Error(
+    `std::layout: width "${node.attrs.width}" on root has no parent ` +
+    `to take a percentage of. Use "full" or a number.`,
+  );
+}
+
+function resolveChild(parent: LayoutNode, child: LayoutNode, available: number | undefined): LayoutNode {
+  const childWidth = resolveChildWidth(parent, child, available);
+  const implicitWidth = parent.type === "row" ? undefined : available;
+  if (child.type === "text") return annotate(child, undefined, childWidth ?? implicitWidth);
+  if (child.type === "raw") return child;
+  if (isContainer(child)) return resolveNode(child, childWidth ?? implicitWidth);
+  return resolveNode(child, childWidth);
+}
+
+function resolveChildWidth(
+  parent: LayoutNode,
+  child: LayoutNode,
+  available: number | undefined,
+): number | undefined {
+  const width = parseWidth(child.attrs.width);
+  if (width === null) return undefined;
+  if (width.kind === "cells") return width.value;
+  if (width.kind === "full") {
+    throw new Error(
+      `std::layout: width "full" is only valid at the root. ` +
+      `Use "100%" if you mean "fill the parent".`,
+    );
+  }
+  if (available === undefined) {
+    throw new Error(
+      `std::layout: child uses width "${child.attrs.width}" but the ` +
+      `parent ${parent.type} has no resolved width to take a percentage of. ` +
+      `Set a width on the parent or one of its ancestors.`,
+    );
+  }
+  return Math.floor((available * width.value) / 100);
+}
+
+function isContainer(node: LayoutNode): boolean {
+  return node.type === "box" || node.type === "row" || node.type === "column" || node.type === "table";
+}
+
+function chromeWidth(node: LayoutNode): number {
+  if (node.type === "box") {
+    const padding = (node.attrs.padding as number | undefined) ?? 0;
+    return 2 + 2 * padding;
+  }
+  if (node.type === "row") {
+    const gap = (node.attrs.gap as number | undefined) ?? 0;
+    return Math.max(0, node.children.length - 1) * gap;
+  }
+  return 0;
+}
+
+function annotate(
+  node: LayoutNode,
+  resolvedWidth: number | undefined,
+  wrapWidth: number | undefined,
+): LayoutNode {
+  return { ...node, attrs: annotateAttrs(node.attrs, resolvedWidth, wrapWidth) };
+}
+
+function annotateAttrs(
+  attrs: Record<string, unknown>,
+  resolvedWidth: number | undefined,
+  wrapWidth: number | undefined,
+): Record<string, unknown> {
+  return {
+    ...attrs,
+    ...(resolvedWidth !== undefined ? { resolvedWidth } : {}),
+    ...(wrapWidth !== undefined ? { wrapWidth } : {}),
+  };
+}
+
+export function render(node: LayoutNode, opts?: { viewport?: Viewport }): string {
+  const resolved = resolveSizes(node, opts?.viewport ?? _viewport());
+  return renderNode(resolved).toString();
 }
 
 // "auto" color resolution follows the de-facto ecosystem convention:
@@ -57,8 +181,11 @@ function _autoUseColor(): boolean {
   return process.stdout.isTTY === true;
 }
 
-export function _render(node: LayoutNode, color: "auto" | boolean): string {
+export function _render(node: LayoutNode, color: "auto" | boolean, cols?: number, rows?: number): string {
   const useColor = color === "auto" ? _autoUseColor() : color === true;
-  const out = render(node);
+  const viewport = cols !== undefined && cols > 0
+    ? { cols, rows: rows !== undefined && rows > 0 ? rows : DEFAULT_VIEWPORT.rows }
+    : undefined;
+  const out = render(node, { viewport });
   return useColor ? out : stripAnsi(out);
 }

--- a/packages/agency-lang/lib/stdlib/layout/table.ts
+++ b/packages/agency-lang/lib/stdlib/layout/table.ts
@@ -16,14 +16,14 @@
 // both consume the same `ColumnLayout[]`, so a change to one stays in
 // sync with the other automatically.
 
-import { Style, styledWrapper, visualWidth } from "./ansi.js";
+import { Style, styledWrapper, visualWidth, wrapText } from "./ansi.js";
 import { Align, Block, above, beside, pad, padLine, styled } from "./block.js";
 import {
   BORDER_CHARS, BorderChars, BorderStyle, buildTopEdge, minWidthForTitle,
   resolveBorderStyle,
 } from "./border.js";
-import { Cell, ColumnSpec, LayoutNode } from "./nodes.js";
-import { renderNode } from "./render.js";
+import { Cell, ColumnSpec, LayoutNode, parseWidth } from "./nodes.js";
+import { growToWidth, renderNode, resolveNode } from "./render.js";
 
 export { Cell, ColumnSpec };
 
@@ -173,6 +173,7 @@ function _computeColumnLayouts(
   columnCount: number,
   columns: ColumnSpec[],
   cellPadding: number,
+  resolvedColumnWidths?: number[],
 ): { layouts: ColumnLayout[]; cellBlocks: Block[][] } {
   const styledRows = rows.map((row) =>
     row.map((cell, c) => _applyColumnFg(cell, columns[c]?.fgColor)),
@@ -184,14 +185,161 @@ function _computeColumnLayouts(
       (m, row) => Math.max(m, row[c].width), 0,
     );
     const spec = columns[c] ?? {};
+    const resolved = resolvedColumnWidths?.[c];
     layouts.push({
-      width:       Math.max(measured, spec.minWidth ?? 0),
+      width:       resolved ?? Math.max(measured, spec.minWidth ?? 0),
       align:       spec.align ?? "start",
       cellPadding,
       fgColor:     spec.fgColor ?? "",
     });
   }
   return { layouts, cellBlocks };
+}
+
+function clampCellPadding(raw: unknown): number {
+  const value = (raw as number | undefined) ?? 1;
+  return Math.max(0, Math.floor(Number.isFinite(value) ? value : 1));
+}
+
+export function _tableChromeWidth(
+  columnCount: number,
+  cellPadding: number,
+  columnDividers: boolean,
+): number {
+  const borders = 2;
+  const padding = columnCount * 2 * cellPadding;
+  const dividers = columnDividers ? Math.max(0, columnCount - 1) : 0;
+  return borders + padding + dividers;
+}
+
+export function _resolveTableWidths(
+  node: LayoutNode,
+  resolvedWidth: number | undefined,
+): LayoutNode {
+  const attrs = node.attrs;
+  const { header, body, footer, columnCount } = _validateTable(attrs);
+  const columns = (attrs.columns as ColumnSpec[] | null | undefined) ?? [];
+  const cellPadding = clampCellPadding(attrs.cellPadding);
+  const columnDividers = (attrs.columnDividers as boolean | undefined) ?? true;
+  const sections = { header, body, footer };
+  const chrome = _tableChromeWidth(columnCount, cellPadding, columnDividers);
+  const resolvedColumnWidths = distributeColumnWidths({
+    columns,
+    columnCount,
+    sections,
+    resolvedWidth,
+    chrome,
+  });
+  const annotated = annotateCellsWithWrap(sections, resolvedColumnWidths);
+
+  return {
+    ...node,
+    attrs: {
+      ...attrs,
+      ...(resolvedWidth !== undefined ? { resolvedWidth } : {}),
+      resolvedColumnWidths,
+      header: attrs.header != null ? annotated.header : attrs.header,
+      body: annotated.body,
+      footer: annotated.footer,
+    },
+  };
+}
+
+function distributeColumnWidths(args: {
+  columns: ColumnSpec[];
+  columnCount: number;
+  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] };
+  resolvedWidth: number | undefined;
+  chrome: number;
+}): number[] {
+  const { columns, columnCount, sections, resolvedWidth, chrome } = args;
+  const natural = measureNaturalColumnWidths(sections, columnCount);
+  const parsed = Array.from({ length: columnCount }, (_, c) => parseWidth(columns[c]?.width));
+  const available = resolvedWidth !== undefined ? Math.max(0, resolvedWidth - chrome) : undefined;
+
+  for (let c = 0; c < columnCount; c++) {
+    if (parsed[c]?.kind === "full") {
+      throw new Error(
+        `std::layout: column[${c}].width "full" is not allowed. ` +
+        `Use a number or percentage.`,
+      );
+    }
+    if (available === undefined && parsed[c]?.kind === "percent") {
+      throw new Error(
+        `std::layout: column[${c}] uses a percentage width but the table ` +
+        `has no resolved width to take a percentage of. ` +
+        `Set width: on the table or one of its ancestors.`,
+      );
+    }
+  }
+
+  const widths = new Array<number>(columnCount).fill(0);
+  let remaining = available ?? Infinity;
+  for (let c = 0; c < columnCount; c++) {
+    const width = parsed[c];
+    if (width?.kind === "cells") {
+      widths[c] = width.value;
+      remaining -= width.value;
+    } else if (width === null) {
+      widths[c] = natural[c];
+      remaining -= natural[c];
+    }
+  }
+
+  const safeRemaining = Math.max(0, remaining);
+  const percentIndices = parsed
+    .map((width, index) => width?.kind === "percent" ? index : -1)
+    .filter((index) => index >= 0);
+  const totalPct = percentIndices.reduce((sum, index) => {
+    const width = parsed[index];
+    return sum + (width?.kind === "percent" ? width.value : 0);
+  }, 0);
+  for (const index of percentIndices) {
+    const width = parsed[index];
+    const pct = width?.kind === "percent" ? width.value : 0;
+    const share = totalPct > 100 ? pct / totalPct : pct / 100;
+    widths[index] = Math.floor(safeRemaining * share);
+  }
+
+  for (let c = 0; c < columnCount; c++) {
+    const min = columns[c]?.minWidth ?? 0;
+    if (widths[c] < min) widths[c] = min;
+  }
+  return widths;
+}
+
+function measureNaturalColumnWidths(
+  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] },
+  columnCount: number,
+): number[] {
+  const widths = new Array<number>(columnCount).fill(0);
+  const rows = [
+    ...(sections.header.length > 0 ? [sections.header] : []),
+    ...sections.body,
+    ...sections.footer,
+  ];
+  for (const row of rows) {
+    for (let c = 0; c < columnCount; c++) {
+      widths[c] = Math.max(widths[c], renderNode(row[c]).width);
+    }
+  }
+  return widths;
+}
+
+function annotateCellsWithWrap(
+  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] },
+  resolvedColumnWidths: number[],
+): { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] } {
+  const annotateCell = (cell: LayoutNode, columnWidth: number): LayoutNode => {
+    if (cell.type === "text") return { ...cell, attrs: { ...cell.attrs, wrapWidth: columnWidth } };
+    if (cell.type === "raw") return cell;
+    return resolveNode(cell, columnWidth);
+  };
+  return {
+    header: sections.header.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0)),
+    body: sections.body.map((row) => row.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0))),
+    footer: sections.footer.map((row) => row.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0))),
+  };
 }
 
 function _innerTableWidth(layouts: ColumnLayout[], columnDividers: boolean): number {
@@ -355,8 +503,7 @@ export function composeTable(node: LayoutNode): Block {
   // negative value would shrink dividers below the cell grid and
   // misalign the right border, while a fractional value would break
   // `" ".repeat(...)`.
-  const cellPaddingRaw = (attrs.cellPadding as number | undefined) ?? 1;
-  const cellPadding    = Math.max(0, Math.floor(Number.isFinite(cellPaddingRaw) ? cellPaddingRaw : 1));
+  const cellPadding    = clampCellPadding(attrs.cellPadding);
   const columns        = (attrs.columns        as ColumnSpec[] | null) ?? [];
   const columnDividers = (attrs.columnDividers as boolean) ?? true;
   const headerDivider  = (attrs.headerDivider  as boolean) ?? true;
@@ -370,6 +517,8 @@ export function composeTable(node: LayoutNode): Block {
   const titleColor  = (attrs.titleColor  as string | undefined) ?? "";
   const title       = (attrs.title       as string | undefined) ?? "";
   const caption     = (attrs.caption     as string | undefined) ?? "";
+  const resolved    = attrs.resolvedWidth as number | undefined;
+  const resolvedColumnWidths = attrs.resolvedColumnWidths as number[] | undefined;
   const wrapBorder  = styledWrapper(borderColor ? { fgColor: borderColor } : {});
   const titleStyle: Style = titleColor ? { fgColor: titleColor } : {};
 
@@ -386,7 +535,7 @@ export function composeTable(node: LayoutNode): Block {
     ...footer,
   ];
   const { layouts, cellBlocks } = _computeColumnLayouts(
-    allRows, columnCount, columns, cellPadding,
+    allRows, columnCount, columns, cellPadding, resolvedColumnWidths,
   );
   let idx = 0;
   const headerCells = styledHeader.length > 0 ? [cellBlocks[idx++]] : [];
@@ -396,10 +545,9 @@ export function composeTable(node: LayoutNode): Block {
   // A wide title may grow innerWidth beyond the cell grid; dividers and
   // row wrappers both honour that final width so everything lines up.
   const cellsWidth = _innerTableWidth(layouts, columnDividers);
-  const innerWidth = Math.max(
-    cellsWidth,
-    title !== "" ? minWidthForTitle(title) : 0,
-  );
+  const titleFloor = resolved === undefined && title !== "" ? minWidthForTitle(title) : 0;
+  const resolvedInner = resolved !== undefined ? Math.max(0, resolved - 2) : 0;
+  const innerWidth = Math.max(cellsWidth, titleFloor, resolvedInner);
 
   // Build flat declarative list of section parts, then render each
   // part into a Block in one place.
@@ -414,11 +562,15 @@ export function composeTable(node: LayoutNode): Block {
           _composeRowBlock(part.cells, layouts, columnDividers, ch.v, wrapBorder),
           innerWidth, ch, wrapBorder,
         );
-  const sectionBlocks = sectionParts.map(renderPart);
+  const titleFitsTop = title === "" || resolved === undefined || minWidthForTitle(title) <= innerWidth;
+  const titleRows = titleFitsTop
+    ? []
+    : [_wrapRowSides(styled(Block.of(wrapText(title, innerWidth)), titleStyle), innerWidth, ch, wrapBorder)];
+  const sectionBlocks = [...titleRows, ...sectionParts.map(renderPart)];
 
   // Outer frame (top + bottom edges).
   const topEdge    = Block.of(
-    buildTopEdge(ch, innerWidth, wrapBorder, title, titleStyle),
+    buildTopEdge(ch, innerWidth, wrapBorder, titleFitsTop ? title : "", titleStyle),
   );
   const bottomEdge = Block.of(
     wrapBorder(ch.bl + ch.h.repeat(innerWidth) + ch.br),
@@ -431,6 +583,8 @@ export function composeTable(node: LayoutNode): Block {
   // line, and routing it through `above` would re-pad it back out to
   // the framed width.
   const captionBlock = _composeCaption(caption, framed.width);
-  if (captionBlock === null) return framed;
-  return Block.of([...framed.lines, ...captionBlock.lines]);
+  const withCaption = captionBlock === null
+    ? framed
+    : Block.of([...framed.lines, ...captionBlock.lines]);
+  return resolved !== undefined ? growToWidth(withCaption, resolved) : withCaption;
 }

--- a/packages/agency-lang/lib/stdlib/layout/table.ts
+++ b/packages/agency-lang/lib/stdlib/layout/table.ts
@@ -16,13 +16,13 @@
 // both consume the same `ColumnLayout[]`, so a change to one stays in
 // sync with the other automatically.
 
-import { Style, styledWrapper, visualWidth, wrapText } from "./ansi.js";
+import { Style, styledWrapper, visualWidth } from "./ansi.js";
 import { Align, Block, above, beside, pad, padLine, styled } from "./block.js";
 import {
-  BORDER_CHARS, BorderChars, BorderStyle, buildTopEdge, minWidthForTitle,
-  resolveBorderStyle,
+  BORDER_CELLS, BORDER_CHARS, BorderChars, BorderStyle, buildTopEdge,
+  minWidthForTitle, placeTitle, resolveBorderStyle,
 } from "./border.js";
-import { Cell, ColumnSpec, LayoutNode, parseWidth } from "./nodes.js";
+import { Cell, ColumnSpec, LayoutNode, Width, parseWidth } from "./nodes.js";
 import { growToWidth, renderNode, resolveNode } from "./render.js";
 
 export { Cell, ColumnSpec };
@@ -206,11 +206,16 @@ export function _tableChromeWidth(
   cellPadding: number,
   columnDividers: boolean,
 ): number {
-  const borders = 2;
   const padding = columnCount * 2 * cellPadding;
   const dividers = columnDividers ? Math.max(0, columnCount - 1) : 0;
-  return borders + padding + dividers;
+  return BORDER_CELLS + padding + dividers;
 }
+
+type TableSections = {
+  header: LayoutNode[];
+  body:   LayoutNode[][];
+  footer: LayoutNode[][];
+};
 
 export function _resolveTableWidths(
   node: LayoutNode,
@@ -221,15 +226,12 @@ export function _resolveTableWidths(
   const columns = (attrs.columns as ColumnSpec[] | null | undefined) ?? [];
   const cellPadding = clampCellPadding(attrs.cellPadding);
   const columnDividers = (attrs.columnDividers as boolean | undefined) ?? true;
-  const sections = { header, body, footer };
+  const sections: TableSections = { header, body, footer };
   const chrome = _tableChromeWidth(columnCount, cellPadding, columnDividers);
-  const resolvedColumnWidths = distributeColumnWidths({
-    columns,
-    columnCount,
-    sections,
-    resolvedWidth,
-    chrome,
-  });
+  const available = resolvedWidth !== undefined ? Math.max(0, resolvedWidth - chrome) : undefined;
+
+  const plan = planColumns(columns, columnCount, sections);
+  const resolvedColumnWidths = computeColumnWidths(plan, available);
   const annotated = annotateCellsWithWrap(sections, resolvedColumnWidths);
 
   return {
@@ -245,100 +247,126 @@ export function _resolveTableWidths(
   };
 }
 
-function distributeColumnWidths(args: {
-  columns: ColumnSpec[];
-  columnCount: number;
-  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] };
-  resolvedWidth: number | undefined;
-  chrome: number;
-}): number[] {
-  const { columns, columnCount, sections, resolvedWidth, chrome } = args;
+// A single column's sizing inputs, gathered up front so the
+// width-distribution logic can read them as data rather than re-deriving
+// from the raw `ColumnSpec[]` mid-loop.
+type ColumnPlan = {
+  index:    number;
+  parsed:   Width | null;   // parsed `width` attribute, or null for unsized
+  natural:  number;         // measured content width
+  minWidth: number;         // explicit floor from `minWidth`
+};
+
+function planColumns(
+  columns: ColumnSpec[],
+  columnCount: number,
+  sections: TableSections,
+): ColumnPlan[] {
   const natural = measureNaturalColumnWidths(sections, columnCount);
-  const parsed = Array.from({ length: columnCount }, (_, c) => parseWidth(columns[c]?.width));
-  const available = resolvedWidth !== undefined ? Math.max(0, resolvedWidth - chrome) : undefined;
+  return Array.from({ length: columnCount }, (_, index) => ({
+    index,
+    parsed:   parseWidth(columns[index]?.width),
+    natural:  natural[index],
+    minWidth: columns[index]?.minWidth ?? 0,
+  }));
+}
 
-  for (let c = 0; c < columnCount; c++) {
-    if (parsed[c]?.kind === "full") {
-      throw new Error(
-        `std::layout: column[${c}].width "full" is not allowed. ` +
-        `Use a number or percentage.`,
-      );
-    }
-    if (available === undefined && parsed[c]?.kind === "percent") {
-      throw new Error(
-        `std::layout: column[${c}] uses a percentage width but the table ` +
-        `has no resolved width to take a percentage of. ` +
-        `Set width: on the table or one of its ancestors.`,
-      );
-    }
-  }
+// Compute the final width of every column.
+//
+// Allocation order:
+//   1. Fixed-cell columns claim their declared value.
+//   2. Unsized columns claim their natural content width.
+//   3. Percent / "full" columns share whatever is left of `available`.
+//      When their declared percentages sum to > 100, each gets its
+//      proportional share of the remainder; otherwise each gets its
+//      literal share and the slack stays at the right edge.
+//   4. `minWidth` is applied as a floor.
+function computeColumnWidths(
+  plan: ColumnPlan[],
+  available: number | undefined,
+): number[] {
+  assertPercentsHaveBasis(plan, available);
 
-  const widths = new Array<number>(columnCount).fill(0);
-  let remaining = available ?? Infinity;
-  for (let c = 0; c < columnCount; c++) {
-    const width = parsed[c];
-    if (width?.kind === "cells") {
-      widths[c] = width.value;
-      remaining -= width.value;
-    } else if (width === null) {
-      widths[c] = natural[c];
-      remaining -= natural[c];
-    }
-  }
+  const fixed    = plan.map(fixedWidthFor);
+  const claimed  = fixed.reduce<number>((sum, w) => sum + (w ?? 0), 0);
+  const remain   = Math.max(0, (available ?? Infinity) - claimed);
+  const totalPct = sumPercentages(plan);
 
-  const safeRemaining = Math.max(0, remaining);
-  const percentIndices = parsed
-    .map((width, index) => width?.kind === "percent" ? index : -1)
-    .filter((index) => index >= 0);
-  const totalPct = percentIndices.reduce((sum, index) => {
-    const width = parsed[index];
-    return sum + (width?.kind === "percent" ? width.value : 0);
-  }, 0);
-  for (const index of percentIndices) {
-    const width = parsed[index];
-    const pct = width?.kind === "percent" ? width.value : 0;
-    const share = totalPct > 100 ? pct / totalPct : pct / 100;
-    widths[index] = Math.floor(safeRemaining * share);
-  }
+  return plan.map((col, i) => {
+    const own = fixed[i] ?? percentWidthFor(col, remain, totalPct);
+    return Math.max(own, col.minWidth);
+  });
+}
 
-  for (let c = 0; c < columnCount; c++) {
-    const min = columns[c]?.minWidth ?? 0;
-    if (widths[c] < min) widths[c] = min;
-  }
-  return widths;
+function assertPercentsHaveBasis(plan: ColumnPlan[], available: number | undefined): void {
+  if (available !== undefined) return;
+  const percentCol = plan.find((col) => isPercentLike(col.parsed));
+  if (percentCol === undefined) return;
+  throw new Error(
+    `std::layout: column[${percentCol.index}] uses a percentage width ` +
+    `but the table has no resolved width to take a percentage of. ` +
+    `Set width: on the table or one of its ancestors.`,
+  );
+}
+
+// Width for a column whose own size doesn't depend on the leftover
+// space: fixed cells (declared count) or unsized (natural content
+// width). Returns null for percent/full columns, which are sized later.
+function fixedWidthFor(col: ColumnPlan): number | null {
+  if (col.parsed === null)            return col.natural;
+  if (col.parsed.kind === "cells")    return col.parsed.value;
+  return null;
+}
+
+function percentWidthFor(col: ColumnPlan, remaining: number, totalPct: number): number {
+  const pct = pctValue(col.parsed);
+  const share = totalPct > 100 ? pct / totalPct : pct / 100;
+  return Math.floor(remaining * share);
+}
+
+function isPercentLike(w: Width | null): boolean {
+  return w?.kind === "percent" || w?.kind === "full";
+}
+
+function pctValue(w: Width | null): number {
+  if (w?.kind === "percent") return w.value;
+  if (w?.kind === "full")    return 100;
+  return 0;
+}
+
+function sumPercentages(plan: ColumnPlan[]): number {
+  return plan.reduce((sum, col) => sum + pctValue(col.parsed), 0);
 }
 
 function measureNaturalColumnWidths(
-  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] },
+  sections: TableSections,
   columnCount: number,
 ): number[] {
-  const widths = new Array<number>(columnCount).fill(0);
   const rows = [
     ...(sections.header.length > 0 ? [sections.header] : []),
     ...sections.body,
     ...sections.footer,
   ];
-  for (const row of rows) {
-    for (let c = 0; c < columnCount; c++) {
-      widths[c] = Math.max(widths[c], renderNode(row[c]).width);
-    }
-  }
-  return widths;
+  return Array.from({ length: columnCount }, (_, c) =>
+    rows.reduce((max, row) => Math.max(max, renderNode(row[c]).width), 0),
+  );
 }
 
 function annotateCellsWithWrap(
-  sections: { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] },
+  sections: TableSections,
   resolvedColumnWidths: number[],
-): { header: LayoutNode[]; body: LayoutNode[][]; footer: LayoutNode[][] } {
+): TableSections {
   const annotateCell = (cell: LayoutNode, columnWidth: number): LayoutNode => {
     if (cell.type === "text") return { ...cell, attrs: { ...cell.attrs, wrapWidth: columnWidth } };
-    if (cell.type === "raw") return cell;
-    return resolveNode(cell, columnWidth);
+    if (cell.type === "raw")  return cell;
+    return resolveNode(cell, { defaultWidth: columnWidth, percentBasis: columnWidth });
   };
+  const annotateRow = (row: LayoutNode[]): LayoutNode[] =>
+    row.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0));
   return {
-    header: sections.header.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0)),
-    body: sections.body.map((row) => row.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0))),
-    footer: sections.footer.map((row) => row.map((cell, c) => annotateCell(cell, resolvedColumnWidths[c] ?? 0))),
+    header: annotateRow(sections.header),
+    body:   sections.body.map(annotateRow),
+    footer: sections.footer.map(annotateRow),
   };
 }
 
@@ -544,10 +572,10 @@ export function composeTable(node: LayoutNode): Block {
 
   // A wide title may grow innerWidth beyond the cell grid; dividers and
   // row wrappers both honour that final width so everything lines up.
-  const cellsWidth = _innerTableWidth(layouts, columnDividers);
-  const titleFloor = resolved === undefined && title !== "" ? minWidthForTitle(title) : 0;
-  const resolvedInner = resolved !== undefined ? Math.max(0, resolved - 2) : 0;
-  const innerWidth = Math.max(cellsWidth, titleFloor, resolvedInner);
+  const cellsWidth    = _innerTableWidth(layouts, columnDividers);
+  const titleFloor    = resolved === undefined && title !== "" ? minWidthForTitle(title) : 0;
+  const resolvedInner = resolved !== undefined ? Math.max(0, resolved - BORDER_CELLS) : 0;
+  const innerWidth    = Math.max(cellsWidth, titleFloor, resolvedInner);
 
   // Build flat declarative list of section parts, then render each
   // part into a Block in one place.
@@ -562,15 +590,22 @@ export function composeTable(node: LayoutNode): Block {
           _composeRowBlock(part.cells, layouts, columnDividers, ch.v, wrapBorder),
           innerWidth, ch, wrapBorder,
         );
-  const titleFitsTop = title === "" || resolved === undefined || minWidthForTitle(title) <= innerWidth;
-  const titleRows = titleFitsTop
-    ? []
-    : [_wrapRowSides(styled(Block.of(wrapText(title, innerWidth)), titleStyle), innerWidth, ch, wrapBorder)];
+  // A title that doesn't fit on the top edge gets wrapped inside the
+  // frame as its own section. Same rule the box renderer uses (via
+  // `placeTitle` in border.ts) — but only when the table has a resolved
+  // width; otherwise the table is free to grow to fit the title.
+  const placement = resolved === undefined
+    ? { kind: "top" as const, title }
+    : placeTitle(title, innerWidth, titleStyle);
+  const titleRows = placement.kind === "wrapped"
+    ? [_wrapRowSides(placement.block, innerWidth, ch, wrapBorder)]
+    : [];
+  const topTitle = placement.kind === "top" ? placement.title : "";
   const sectionBlocks = [...titleRows, ...sectionParts.map(renderPart)];
 
   // Outer frame (top + bottom edges).
   const topEdge    = Block.of(
-    buildTopEdge(ch, innerWidth, wrapBorder, titleFitsTop ? title : "", titleStyle),
+    buildTopEdge(ch, innerWidth, wrapBorder, topTitle, titleStyle),
   );
   const bottomEdge = Block.of(
     wrapBorder(ch.bl + ch.h.repeat(innerWidth) + ch.br),

--- a/packages/agency-lang/stdlib/layout.agency
+++ b/packages/agency-lang/stdlib/layout.agency
@@ -45,6 +45,29 @@ import { _render } from "agency-lang/stdlib-lib/layout.js"
 
   Both styles produce the same `LayoutNode` tree.
 
+  ### Sizing and wrap
+
+  Every container (`box`, `row`, `column`, `table`) accepts a `width`
+  parameter:
+
+  - `width: "full"` (root only) fills the terminal columns.
+  - `width: 80` sets a target column count.
+  - `width: "50%"` takes 50% of the parent's available width.
+
+  Inside a `table`, each `ColumnSpec` accepts the same `width` field.
+  A percentage column is sized as a share of the table's remaining
+  inner width after borders, cell padding, interior dividers, fixed
+  columns, and natural unsized columns.
+
+  Text inside a width-constrained container or column automatically
+  wraps at word boundaries. Long single words are broken at the column
+  width. `raw` content is never wrapped — use `text` if you want
+  wrapping.
+
+  Width is the only sized dimension. There is no height sizing and no
+  truncation: content that overflows wraps, or (for `raw`) extends
+  visibly past the container.
+
   ### See also
 
   `std::ui` exports `box`, `row`, `column` for interactive TUI
@@ -84,6 +107,8 @@ export type Alignment = "start" | "center" | "end"
 
 export type BorderStyle = "rounded" | "heavy" | "double" | "light"
 
+export type Width = number | "full" | string
+
 /**
  * A table cell. Either a bare string (auto-coerced to a styled `text`
  * leaf at render time) or any pre-built LayoutNode (e.g.
@@ -102,6 +127,10 @@ export type CellRow = Cell[]
  *
  * @param align - Horizontal alignment of every cell in this column
  * @param minWidth - Lower bound on column width; widens narrow columns
+ * @param width - Optional per-column constraint. A number caps the
+ *   column's content width in cells. `"X%"` takes a percentage of the
+ *   table's remaining inner width after fixed and natural unsized
+ *   columns. `"full"` is not allowed at the column level.
  * @param fgColor - Default foreground color applied to every cell in
  *   this column that doesn't carry its own `fgColor`. Cell-level
  *   `fgColor` always wins.
@@ -109,6 +138,7 @@ export type CellRow = Cell[]
 export type ColumnSpec = {
   align?: Alignment;
   minWidth?: number;
+  width?: Width;
   fgColor?: string
 }
 
@@ -349,10 +379,11 @@ def _addRow(
   kids: any[],
   gap: number = 0,
   align: Alignment = "start",
+  width: Width = null,
   children: LayoutNode[] = null,
   block: (LayoutBuilder) -> void = null,
 ): LayoutNode {
-  const n = row(gap: gap, align: align, children: children, block: block)
+  const n = row(gap: gap, align: align, width: width, children: children, block: block)
   kids.push(n)
   return n
 }
@@ -361,10 +392,11 @@ def _addColumn(
   kids: any[],
   gap: number = 0,
   align: Alignment = "start",
+  width: Width = null,
   children: LayoutNode[] = null,
   block: (LayoutBuilder) -> void = null,
 ): LayoutNode {
-  const n = column(gap: gap, align: align, children: children, block: block)
+  const n = column(gap: gap, align: align, width: width, children: children, block: block)
   kids.push(n)
   return n
 }
@@ -376,6 +408,7 @@ def _addBox(
   borderStyle: BorderStyle = "rounded",
   borderColor: string = "",
   padding: number = 1,
+  width: Width = null,
   children: LayoutNode[] = null,
   block: (LayoutBuilder) -> void = null,
 ): LayoutNode {
@@ -385,6 +418,7 @@ def _addBox(
     borderStyle: borderStyle,
     borderColor: borderColor,
     padding: padding,
+    width: width,
     children: children,
     block: block,
   )
@@ -416,12 +450,16 @@ def _makeBuilder(kids: any[]): LayoutBuilder {
  *
  * @param gap - Cells of blank space between siblings
  * @param align - Cross-axis (vertical) alignment of shorter children
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param children - Pre-built children (LLM / JSON construction)
  * @param block - Trailing builder block; appended after `children`
  */
 export def row(
   gap: number = 0,
   align: Alignment = "start",
+  width: Width = null,
   children: LayoutNode[] = null,
   block: (LayoutBuilder) -> void = null,
 ): LayoutNode {
@@ -434,12 +472,16 @@ export def row(
   if (block != null) {
     block(_makeBuilder(kids))
   }
+  const attrs: any = {
+    gap: gap,
+    align: align
+  }
+  if (width != null) {
+    attrs.width = width
+  }
   return {
     type: "row",
-    attrs: {
-      gap: gap,
-      align: align
-    },
+    attrs: attrs,
     children: kids
   }
 }
@@ -449,12 +491,16 @@ export def row(
  *
  * @param gap - Blank rows between siblings
  * @param align - Cross-axis (horizontal) alignment of narrower children
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param children - Pre-built children
  * @param block - Trailing builder block
  */
 export def column(
   gap: number = 0,
   align: Alignment = "start",
+  width: Width = null,
   children: LayoutNode[] = null,
   block: (LayoutBuilder) -> void = null,
 ): LayoutNode {
@@ -467,12 +513,16 @@ export def column(
   if (block != null) {
     block(_makeBuilder(kids))
   }
+  const attrs: any = {
+    gap: gap,
+    align: align
+  }
+  if (width != null) {
+    attrs.width = width
+  }
   return {
     type: "column",
-    attrs: {
-      gap: gap,
-      align: align
-    },
+    attrs: attrs,
     children: kids
   }
 }
@@ -488,6 +538,9 @@ export def column(
  * @param borderStyle - One of `"rounded"`, `"heavy"`, `"double"`, `"light"`
  * @param borderColor - Color of the border characters
  * @param padding - Cells of padding between border and content
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param children - Pre-built children
  * @param block - Trailing builder block
  */
@@ -497,6 +550,7 @@ export def box(
   borderStyle: BorderStyle = "rounded",
   borderColor: string = "",
   padding: number = 1,
+  width: Width = null,
   children: LayoutNode[] = null,
   block: (LayoutBuilder) -> void = null,
 ): LayoutNode {
@@ -509,15 +563,19 @@ export def box(
   if (block != null) {
     block(_makeBuilder(kids))
   }
+  const attrs: any = {
+    title: title,
+    titleColor: titleColor,
+    borderStyle: borderStyle,
+    borderColor: borderColor,
+    padding: padding
+  }
+  if (width != null) {
+    attrs.width = width
+  }
   return {
     type: "box",
-    attrs: {
-      title: title,
-      titleColor: titleColor,
-      borderStyle: borderStyle,
-      borderColor: borderColor,
-      padding: padding
-    },
+    attrs: attrs,
     children: kids
   }
 }
@@ -529,12 +587,17 @@ export def box(
  * @param color - `"auto"` (default) emits ANSI sequences only when stdout
  *   is a TTY. `true` always emits them. `false` strips all styling for
  *   plain ASCII output (logs, non-TTY consumers).
+ * @param cols - Optional viewport columns override. `0` auto-detects.
+ * @param rows - Optional viewport rows override. Reserved for future
+ *   height-aware layout; `0` uses the default.
  */
 export safe def render(
   node: LayoutNode,
   color: "auto" | boolean = "auto",
+  cols: number = 0,
+  rows: number = 0,
 ): string {
-  return _render(node, color)
+  return _render(node, color, cols, rows)
 }
 
 // ------------------------------------------------------------------
@@ -629,6 +692,9 @@ def _makeTableBuilder(state: any): TableBuilder {
  * @param borderColor - Color of the border characters
  * @param caption - Dim, centered single line drawn BELOW the bottom border
  * @param cellPadding - Spaces of horizontal padding inside each cell (default 1)
+ * @param width - Optional width constraint. `"full"` (root only)
+ *   fills the terminal columns. `"X%"` takes a percentage of the
+ *   parent's available width. A number sets a target column count.
  * @param columns - Per-column align / minWidth (length must equal column count)
  * @param header - Optional header row of cells
  * @param body - Optional body rows
@@ -646,6 +712,7 @@ export def table(
   borderColor: string = "",
   caption: string = "",
   cellPadding: number = 1,
+  width: Width = null,
   columns: ColumnSpec[] = null,
   header: Cell[] = null,
   body: CellRow[] = null,
@@ -682,24 +749,28 @@ export def table(
   if (block != null) {
     block(_makeTableBuilder(state))
   }
+  const attrs: any = {
+    title: title,
+    titleColor: titleColor,
+    borderStyle: borderStyle,
+    borderColor: borderColor,
+    caption: state.caption,
+    cellPadding: cellPadding,
+    columns: state.columns,
+    header: state.header,
+    body: state.body,
+    footer: state.footer,
+    headerDivider: headerDivider,
+    footerDivider: footerDivider,
+    rowDividers: rowDividers,
+    columnDividers: columnDividers
+  }
+  if (width != null) {
+    attrs.width = width
+  }
   return {
     type: "table",
-    attrs: {
-      title: title,
-      titleColor: titleColor,
-      borderStyle: borderStyle,
-      borderColor: borderColor,
-      caption: state.caption,
-      cellPadding: cellPadding,
-      columns: state.columns,
-      header: state.header,
-      body: state.body,
-      footer: state.footer,
-      headerDivider: headerDivider,
-      footerDivider: footerDivider,
-      rowDividers: rowDividers,
-      columnDividers: columnDividers
-    },
+    attrs: attrs,
     children: []
   }
 }

--- a/packages/agency-lang/stdlib/layout.agency
+++ b/packages/agency-lang/stdlib/layout.agency
@@ -532,8 +532,9 @@ export def column(
  * block with multiple builder calls), the children are stacked in an
  * implicit `column`.
  *
- * @param title - Text embedded in the top border (no truncation; box
- *   grows to fit). Empty string for no title.
+ * @param title - Text embedded in the top border. Without an explicit
+ *   width, the box grows to fit; with width set, over-long titles wrap
+ *   inside the frame. Empty string for no title.
  * @param titleColor - Color of the title text
  * @param borderStyle - One of `"rounded"`, `"heavy"`, `"double"`, `"light"`
  * @param borderColor - Color of the border characters
@@ -686,7 +687,9 @@ def _makeTableBuilder(state: any): TableBuilder {
  * emits it by default, so treating it as "set" would mean no
  * `text()` header cell ever got the auto-bold).
  *
- * @param title - Text embedded in the top border; box grows to fit
+ * @param title - Text embedded in the top border. Without an explicit
+ *   width, the table grows to fit; with width set, over-long titles wrap
+ *   inside the frame.
  * @param titleColor - Color of the title text
  * @param borderStyle - One of `"rounded"`, `"heavy"`, `"double"`, `"light"`
  * @param borderColor - Color of the border characters

--- a/packages/agency-lang/tests/agency/layout/width-sizing.agency
+++ b/packages/agency-lang/tests/agency/layout/width-sizing.agency
@@ -1,0 +1,32 @@
+import { box, render, table, text } from "std::layout"
+
+node testBoxWidthAttr() {
+  return box(width: "full")
+}
+
+node testTableWidthAttr() {
+  return table(width: 24, body: [["x"]])
+}
+
+node testRenderFullWidth(): string {
+  const panel = box(width: "full") as b {
+    b.text("hello")
+  }
+  return render(panel, color: false, cols: 20)
+}
+
+node testRenderWrap(): string {
+  const panel = box(width: 12) as b {
+    b.text("the quick brown fox")
+  }
+  return render(panel, color: false)
+}
+
+node testTableColumnWidth(): string {
+  const t = table(
+    width: 24,
+    columns: [{ width: 6 }, { width: "50%" }],
+    body: [[text("abcdef"), text("the quick brown fox")]],
+  )
+  return render(t, color: false)
+}

--- a/packages/agency-lang/tests/agency/layout/width-sizing.test.json
+++ b/packages/agency-lang/tests/agency/layout/width-sizing.test.json
@@ -1,0 +1,34 @@
+{
+  "tests": [
+    {
+      "nodeName": "testBoxWidthAttr",
+      "input": "",
+      "expectedOutput": "{\"type\":\"box\",\"attrs\":{\"title\":\"\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"padding\":1,\"width\":\"full\"},\"children\":[]}",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "testTableWidthAttr",
+      "input": "",
+      "expectedOutput": "{\"type\":\"table\",\"attrs\":{\"title\":\"\",\"titleColor\":\"\",\"borderStyle\":\"rounded\",\"borderColor\":\"\",\"caption\":\"\",\"cellPadding\":1,\"columns\":null,\"header\":null,\"body\":[[\"x\"]],\"footer\":[],\"headerDivider\":true,\"footerDivider\":true,\"rowDividers\":false,\"columnDividers\":true,\"width\":24},\"children\":[]}",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "testRenderFullWidth",
+      "input": "",
+      "expectedOutput": "\"╭──────────────────╮\\n│                  │\\n│ hello            │\\n│                  │\\n╰──────────────────╯\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "testRenderWrap",
+      "input": "",
+      "expectedOutput": "\"╭──────────╮\\n│          │\\n│ the      │\\n│ quick    │\\n│ brown    │\\n│ fox      │\\n│          │\\n╰──────────╯\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "testTableColumnWidth",
+      "input": "",
+      "expectedOutput": "\"╭──────────────────────╮\\n│ abcdef │ the         │\\n│        │ quick       │\\n│        │ brown       │\\n│        │ fox         │\\n╰──────────────────────╯\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add top-down width sizing for std::layout containers with fixed, full, and percentage widths.
- Wrap constrained text, preserve raw overflow, and support fixed/percentage table column sizing.
- Expose width and viewport options in the Agency stdlib, update docs, add demo coverage, and add layout tests.

## Test Plan
- [x] make
- [x] pnpm exec vitest run lib/stdlib/layout.test.ts
- [x] pnpm run agency test tests/agency/layout
- [x] pnpm run lint:structure
