### PR TITLE
Per-agent scoped LLM mocks and vitest runs/ exclude

### DIFF
--- a/packages/agency-lang/docs/misc/TESTING.md
+++ b/packages/agency-lang/docs/misc/TESTING.md
@@ -207,6 +207,20 @@ Each `llm()` call in the agency code consumes one entry from `llmMocks`, in orde
 - `{ "return": <value> }` — the LLM returns `<value>`. Strings are returned as-is; non-strings are JSON-stringified (the agency runtime parses them back per the response type annotation).
 - `{ "toolCall": { "name": "...", "args": { ... } } }` — the LLM emits a tool call. Use this when an `llm(..., { tools: [...] })` call should invoke a function. Tool-using flows usually need a sequence like `[toolCall, toolCall, ..., return]` — one mock per LLM round-trip.
 
+**Per-agent scoped mocks:**
+
+When a test spans several agents (e.g. a main agent that invokes the bundled mutator or judge), a single ordered list forces you to predict the exact global interleaving of `llm()` calls across all of them. Instead, pass `llmMocks` as an object of independent queues keyed by agent:
+
+```json
+"llmMocks": {
+  "mutatePrompt": [{ "return": { "operations": [], "rationale": "..." } }],
+  "judgePairwise": [{ "return": { "winner": "B", "confidence": 90, "reasoning": "..." } }],
+  "*": [{ "return": "task agent response" }]
+}
+```
+
+Keys are matched against the module making the `llm()` call: the exact module id (`lib/agents/mutatePrompt.agency`), then its basename without the extension (`mutatePrompt`), then the `"*"` fallback queue. Each queue is consumed in order independently of the others. The env var inherits into eval/agent subprocesses, so scoping works across process boundaries too. See `tests/agency/llm-mock-scoping.test.json` for a working example.
+
 **Behavior under deterministic mode:**
 
 - Tests with `evaluationCriteria.type === "llmJudge"` are auto-skipped (the judge itself is an LLM call without a mock).

--- a/packages/agency-lang/lib/cli/runAgencyAgent.ts
+++ b/packages/agency-lang/lib/cli/runAgencyAgent.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url";
 import type { AgencyConfig } from "@/config.js";
 import { parseAgency } from "@/parser.js";
 import type { GraphNodeDefinition } from "@/types.js";
-import type { LLMMock } from "@/runtime/deterministicClient.js";
+import type { LLMMock, ScopedLLMMocks } from "@/runtime/deterministicClient.js";
 
 import { executeNodeAsync } from "./util.js";
 
@@ -26,7 +26,7 @@ export type RunAgencyAgentArgs = {
   scratchDir?: string;
   statelogPath?: string;
   limits?: AgencyAgentLimits;
-  llmMocks?: LLMMock[];
+  llmMocks?: LLMMock[] | ScopedLLMMocks;
   useTestLLMProvider?: boolean;
   argv?: string[];
 };

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -20,7 +20,7 @@ import { formatDiff } from "@/utils/diff.js";
 import { AgencyConfig } from "@/config.js";
 import path from "path";
 import { compile, loadConfig } from "./commands.js";
-import type { LLMMock } from "../runtime/deterministicClient.js";
+import type { LLMMock, ScopedLLMMocks } from "../runtime/deterministicClient.js";
 type Exact = { type: "exact" };
 type LLMJudge = {
   type: "llmJudge";
@@ -49,7 +49,7 @@ type TestCase = {
   // Ordered list of LLM mocks consumed by the deterministic LLM client
   // when running under AGENCY_USE_TEST_LLM_PROVIDER=1. Each entry maps to
   // one llm() call in the agency code, in source order.
-  llmMocks?: LLMMock[];
+  llmMocks?: LLMMock[] | ScopedLLMMocks;
   // Force the deterministic LLM provider even when the suite is not
   // launched with AGENCY_USE_TEST_LLM_PROVIDER=1. Use for tests whose
   // assertions depend on the deterministic client's fixed per-call cost /

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -26,7 +26,7 @@ import { compile } from "./commands.js";
 import { RunStrategy } from "../importStrategy.js";
 import { AgencyConfig } from "@/config.js";
 import { parseAgency } from "@/parser.js";
-import type { LLMMock } from "../runtime/deterministicClient.js";
+import type { LLMMock, ScopedLLMMocks } from "../runtime/deterministicClient.js";
 export function parseTarget(target: string): {
   filename: string;
   nodeName: string;
@@ -202,7 +202,7 @@ type ExecuteNodeArgs = {
   // when AGENCY_USE_TEST_LLM_PROVIDER is set OR when useTestLLMProvider
   // is true. The compiled module's imports template auto-activates
   // DeterministicClient when this env var is present.
-  llmMocks?: LLMMock[];
+  llmMocks?: LLMMock[] | ScopedLLMMocks;
   // Force the deterministic LLM provider for this run even when the
   // suite-level AGENCY_USE_TEST_LLM_PROVIDER env var is unset. Use for
   // tests whose assertions depend on the deterministic client's fixed

--- a/packages/agency-lang/lib/runtime/deterministicClient.test.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.test.ts
@@ -187,4 +187,20 @@ describe("DeterministicClient scoped mocks", () => {
       inModule("agents/taskAgent.agency", () => client.text(baseConfig)),
     ).rejects.toThrow(/no llmMocks queue.*taskAgent.*mutatePrompt/s);
   });
+
+  it("does not treat user-controlled scope keys as prototype properties", async () => {
+    // "__proto__" must behave as an ordinary queue key (no prototype
+    // mutation), and unmatched modules must not falsely resolve against
+    // inherited Object.prototype names like "constructor".
+    const client = new DeterministicClient(
+      JSON.parse('{"__proto__": [{"return": "proto queue"}]}'),
+    );
+
+    const result = await inModule("agents/__proto__.agency", () => client.text(baseConfig));
+    expect(result.success && result.value.output).toBe("proto queue");
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    await expect(
+      inModule("agents/constructor.agency", () => client.text(baseConfig)),
+    ).rejects.toThrow(/no llmMocks queue/);
+  });
 });

--- a/packages/agency-lang/lib/runtime/deterministicClient.test.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.test.ts
@@ -1,10 +1,26 @@
 import { describe, it, expect } from "vitest";
+import { agencyStore } from "./asyncContext.js";
 import { DeterministicClient } from "./deterministicClient.js";
 import type { PromptConfig } from "./llmClient.js";
 
 const baseConfig: PromptConfig = {
   messages: [],
 };
+
+/** Runs `fn` inside a minimal ALS frame whose callsite names `moduleId`,
+ *  mimicking what `Runner.runInScope` seeds for a step body. */
+function inModule<T>(moduleId: string, fn: () => T): T {
+  return agencyStore.run(
+    {
+      ctx: {} as any,
+      stack: {} as any,
+      threads: {} as any,
+      globals: {} as any,
+      callsite: { moduleId, scopeName: "main", stepPath: "" },
+    },
+    fn,
+  );
+}
 
 describe("DeterministicClient", () => {
   it("returns a return mock as output", async () => {
@@ -92,5 +108,83 @@ describe("DeterministicClient", () => {
     }
     expect(chunks).toHaveLength(1);
     expect(chunks[0].type).toBe("done");
+  });
+});
+
+describe("DeterministicClient scoped mocks", () => {
+  it("selects the queue matching the executing module id exactly", async () => {
+    const client = new DeterministicClient({
+      "lib/agents/mutatePrompt.agency": [{ return: "from mutator queue" }],
+      "*": [{ return: "from fallback" }],
+    });
+
+    const result = await inModule("lib/agents/mutatePrompt.agency", () => client.text(baseConfig));
+
+    expect(result.success && result.value.output).toBe("from mutator queue");
+  });
+
+  it("selects the queue matching the module basename", async () => {
+    const client = new DeterministicClient({
+      mutatePrompt: [{ return: "from mutator queue" }],
+      "*": [{ return: "from fallback" }],
+    });
+
+    const result = await inModule("lib/agents/mutatePrompt.agency", () => client.text(baseConfig));
+
+    expect(result.success && result.value.output).toBe("from mutator queue");
+  });
+
+  it("falls back to the * queue when no scope matches", async () => {
+    const client = new DeterministicClient({
+      mutatePrompt: [{ return: "from mutator queue" }],
+      "*": [{ return: "from fallback" }],
+    });
+
+    const result = await inModule("agents/taskAgent.agency", () => client.text(baseConfig));
+
+    expect(result.success && result.value.output).toBe("from fallback");
+  });
+
+  it("falls back to the * queue outside any execution frame", async () => {
+    const client = new DeterministicClient({ "*": [{ return: "from fallback" }] });
+
+    const result = await client.text(baseConfig);
+
+    expect(result.success && result.value.output).toBe("from fallback");
+  });
+
+  it("consumes each scope's queue independently of interleaving", async () => {
+    const client = new DeterministicClient({
+      mutatePrompt: [{ return: "m1" }, { return: "m2" }],
+      judgePairwise: [{ return: "j1" }, { return: "j2" }],
+    });
+
+    const m1 = await inModule("lib/agents/mutatePrompt.agency", () => client.text(baseConfig));
+    const j1 = await inModule("lib/agents/judgePairwise.agency", () => client.text(baseConfig));
+    const m2 = await inModule("lib/agents/mutatePrompt.agency", () => client.text(baseConfig));
+    const j2 = await inModule("lib/agents/judgePairwise.agency", () => client.text(baseConfig));
+
+    expect(m1.success && m1.value.output).toBe("m1");
+    expect(j1.success && j1.value.output).toBe("j1");
+    expect(m2.success && m2.value.output).toBe("m2");
+    expect(j2.success && j2.value.output).toBe("j2");
+  });
+
+  it("names the scope when its queue is exhausted", async () => {
+    const client = new DeterministicClient({ mutatePrompt: [{ return: "only" }] });
+
+    await inModule("lib/agents/mutatePrompt.agency", () => client.text(baseConfig));
+
+    await expect(
+      inModule("lib/agents/mutatePrompt.agency", () => client.text(baseConfig)),
+    ).rejects.toThrow(/call #2.*"mutatePrompt"/);
+  });
+
+  it("lists available scopes when nothing matches and there is no fallback", async () => {
+    const client = new DeterministicClient({ mutatePrompt: [{ return: "only" }] });
+
+    await expect(
+      inModule("agents/taskAgent.agency", () => client.text(baseConfig)),
+    ).rejects.toThrow(/no llmMocks queue.*taskAgent.*mutatePrompt/s);
   });
 });

--- a/packages/agency-lang/lib/runtime/deterministicClient.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.ts
@@ -1,5 +1,6 @@
 import type { PromptResult, StreamChunk, Result } from "smoltalk";
 import { ToolCall } from "smoltalk";
+import { agencyStore } from "./asyncContext.js";
 import type {
   EmbedConfig,
   EmbedResult,
@@ -26,6 +27,19 @@ export type MultiToolCallMock = {
 
 export type LLMMock = ReturnMock | ToolCallMock | MultiToolCallMock;
 
+/**
+ * Per-agent mock queues. Keys are matched against the executing module:
+ * the exact module id ("lib/agents/mutatePrompt.agency"), then its
+ * basename without the extension ("mutatePrompt"), then the "*" fallback
+ * queue. Each queue is consumed in order, independently of the others,
+ * so tests that span several agents (e.g. a full optimize iteration:
+ * task agent + mutator + judge) don't have to predict the global
+ * interleaving of llm() calls.
+ */
+export type ScopedLLMMocks = Record<string, LLMMock[]>;
+
+const FALLBACK_SCOPE = "*";
+
 // Synthetic non-zero usage/cost so tests that only assert "value is
 // nonzero" still pass under the deterministic client. Tests that assert
 // on exact token counts or precise costs are using a real LLM and won't
@@ -43,27 +57,73 @@ const SYNTHETIC_COST = {
   currency: "USD",
 };
 
-export class DeterministicClient implements LLMClient {
-  private mocks: LLMMock[];
-  private callIndex = 0;
+type MockQueue = {
+  mocks: LLMMock[];
+  callIndex: number;
+};
 
-  constructor(mocks: LLMMock[]) {
-    this.mocks = mocks;
+export class DeterministicClient implements LLMClient {
+  private queues: Record<string, MockQueue>;
+  /** Array form: one anonymous queue, original error messages. */
+  private readonly scoped: boolean;
+
+  constructor(mocks: LLMMock[] | ScopedLLMMocks) {
+    this.scoped = !Array.isArray(mocks);
+    this.queues = {};
+    if (Array.isArray(mocks)) {
+      this.queues[FALLBACK_SCOPE] = { mocks, callIndex: 0 };
+    } else {
+      for (const [scope, queueMocks] of Object.entries(mocks)) {
+        this.queues[scope] = { mocks: queueMocks, callIndex: 0 };
+      }
+    }
+  }
+
+  /**
+   * Picks the mock queue for the currently-executing module. The module
+   * id comes from the ALS frame's callsite (seeded by `Runner.runInScope`
+   * for every step body); outside any frame — or when no scope matches —
+   * the "*" queue applies.
+   */
+  private resolveQueue(): { scope: string; queue: MockQueue } {
+    if (!this.scoped) {
+      return { scope: FALLBACK_SCOPE, queue: this.queues[FALLBACK_SCOPE] };
+    }
+    const moduleId = agencyStore.getStore()?.callsite?.moduleId;
+    if (moduleId !== undefined) {
+      if (this.queues[moduleId]) {
+        return { scope: moduleId, queue: this.queues[moduleId] };
+      }
+      const basename = moduleId.split("/").pop()?.replace(/\.agency$/, "") ?? moduleId;
+      if (this.queues[basename]) {
+        return { scope: basename, queue: this.queues[basename] };
+      }
+    }
+    if (this.queues[FALLBACK_SCOPE]) {
+      return { scope: FALLBACK_SCOPE, queue: this.queues[FALLBACK_SCOPE] };
+    }
+    throw new Error(
+      `DeterministicClient: no llmMocks queue matches module ${moduleId ?? "(no execution frame)"}. ` +
+      `Available scopes: ${Object.keys(this.queues).join(", ")}. Add a "*" queue as a fallback.`
+    );
   }
 
   async text(_config: PromptConfig): Promise<Result<PromptResult>> {
+    const { scope, queue } = this.resolveQueue();
     // NOTE: increment-then-check is intentional. callIndex tracks the
     // 1-based index of the *current* call so error messages say
     // "call #N" where N matches what a user would expect when reading
     // their llmMocks list (call #1 = first mock, call #2 = second, ...).
-    this.callIndex++;
-    if (this.callIndex > this.mocks.length) {
+    queue.callIndex++;
+    if (queue.callIndex > queue.mocks.length) {
+      const where = this.scoped ? ` in scope "${scope}"` : "";
       throw new Error(
-        `DeterministicClient: no mock provided for llm() call #${this.callIndex}. Add an entry to llmMocks in your test.json.`
+        `DeterministicClient: no mock provided for llm() call #${queue.callIndex}${where}. Add an entry to llmMocks in your test.json.`
       );
     }
 
-    const mock = this.mocks[this.callIndex - 1];
+    const mock = queue.mocks[queue.callIndex - 1];
+    const callIndex = queue.callIndex;
 
     if ("return" in mock) {
       const output =
@@ -87,7 +147,7 @@ export class DeterministicClient implements LLMClient {
       // mocks for tools that take no arguments can omit it cleanly.
       const calls = mock.toolCalls.map(
         (tc, i) =>
-          new ToolCall(`mock-tool-${this.callIndex}-${i}`, tc.name, tc.args ?? {}),
+          new ToolCall(`mock-tool-${callIndex}-${i}`, tc.name, tc.args ?? {}),
       );
       return {
         success: true,
@@ -109,7 +169,7 @@ export class DeterministicClient implements LLMClient {
       success: true,
       value: {
         output: null,
-        toolCalls: [new ToolCall(`mock-tool-${this.callIndex}`, name, args ?? {})],
+        toolCalls: [new ToolCall(`mock-tool-${callIndex}`, name, args ?? {})],
         model: "deterministic",
         usage: SYNTHETIC_USAGE,
         cost: SYNTHETIC_COST,

--- a/packages/agency-lang/lib/runtime/deterministicClient.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.ts
@@ -69,7 +69,11 @@ export class DeterministicClient implements LLMClient {
 
   constructor(mocks: LLMMock[] | ScopedLLMMocks) {
     this.scoped = !Array.isArray(mocks);
-    this.queues = {};
+    // Null prototype: scope keys come from user-controlled JSON
+    // (AGENCY_LLM_MOCKS / test.json), so a plain `{}` would let
+    // "__proto__" pollute the prototype and would falsely match scope
+    // lookups against inherited names like "constructor".
+    this.queues = Object.create(null);
     if (Array.isArray(mocks)) {
       this.queues[FALLBACK_SCOPE] = { mocks, callIndex: 0 };
     } else {

--- a/packages/agency-lang/tests/agency/llm-mock-scoping.agency
+++ b/packages/agency-lang/tests/agency/llm-mock-scoping.agency
@@ -1,0 +1,17 @@
+import node { mutatePrompt } from "../../lib/agents/mutatePrompt.agency"
+
+// Scoped-mock routing test. Each queue holds exactly one mock, so this
+// only passes when BOTH llm() calls draw from their own module's queue:
+// if routing collapsed to a single queue, the second call would exhaust
+// it; if the queues were swapped, the mutator's structured-output schema
+// would reject the plain string.
+node main() {
+  const summary: string = llm("Summarize: hello")
+  const proposal = mutatePrompt(
+    "- id: foo.agency:global:prompt\n  kind: variable\n  current value: " + summary,
+    "- [task-1] Improve accuracy",
+    "",
+    "",
+  )
+  return proposal.data
+}

--- a/packages/agency-lang/tests/agency/llm-mock-scoping.agency
+++ b/packages/agency-lang/tests/agency/llm-mock-scoping.agency
@@ -1,10 +1,11 @@
-import node { mutatePrompt } from "../../lib/agents/mutatePrompt.agency"
+import { mutatePrompt } from "../../lib/agents/mutatePrompt.agency"
 
 // Scoped-mock routing test. Each queue holds exactly one mock, so this
 // only passes when BOTH llm() calls draw from their own module's queue:
-// if routing collapsed to a single queue, the second call would exhaust
-// it; if the queues were swapped, the mutator's structured-output schema
-// would reject the plain string.
+// any misrouting either exhausts a queue or feeds the mutator's
+// structured-output schema a plain string, and the test fails. Calling
+// a node transitions to it, so the mutator call is the last statement
+// and its proposal is the run's result.
 node main() {
   const summary: string = llm("Summarize: hello")
   const proposal = mutatePrompt(
@@ -13,5 +14,5 @@ node main() {
     "",
     "",
   )
-  return proposal.data
+  return proposal
 }

--- a/packages/agency-lang/tests/agency/llm-mock-scoping.test.json
+++ b/packages/agency-lang/tests/agency/llm-mock-scoping.test.json
@@ -5,10 +5,16 @@
       "description": "Scoped llmMocks route each agent's llm() calls to its own queue.",
       "input": "",
       "expectedOutput": "{\"operations\":[{\"target\":\"foo.agency:global:prompt\",\"kind\":\"variable\",\"op\":\"replaceInitializer\",\"value\":\"\\\"hello there\\\"\",\"rationale\":\"Friendlier.\"}],\"rationale\":\"mutator-rationale\"}",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "llmMocks": {
         "llm-mock-scoping": [
-          { "return": "main-summary" }
+          {
+            "return": "main-summary"
+          }
         ],
         "mutatePrompt": [
           {

--- a/packages/agency-lang/tests/agency/llm-mock-scoping.test.json
+++ b/packages/agency-lang/tests/agency/llm-mock-scoping.test.json
@@ -1,0 +1,33 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Scoped llmMocks route each agent's llm() calls to its own queue.",
+      "input": "",
+      "expectedOutput": "{\"operations\":[{\"target\":\"foo.agency:global:prompt\",\"kind\":\"variable\",\"op\":\"replaceInitializer\",\"value\":\"\\\"hello there\\\"\",\"rationale\":\"Friendlier.\"}],\"rationale\":\"mutator-rationale\"}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "llmMocks": {
+        "llm-mock-scoping": [
+          { "return": "main-summary" }
+        ],
+        "mutatePrompt": [
+          {
+            "return": {
+              "operations": [
+                {
+                  "target": "foo.agency:global:prompt",
+                  "kind": "variable",
+                  "op": "replaceInitializer",
+                  "value": "\"hello there\"",
+                  "rationale": "Friendlier."
+                }
+              ],
+              "rationale": "mutator-rationale"
+            }
+          }
+        ]
+      },
+      "retry": 1
+    }
+  ]
+}

--- a/packages/agency-lang/vitest.config.ts
+++ b/packages/agency-lang/vitest.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['**/*.test.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**', 'tests', '.worktrees/**'],
+    // runs/ holds eval/optimize run output; optimize copies the whole
+    // working dir (test files included) into iter-N/workspace/, so without
+    // this exclude a local optimize session pollutes the test run.
+    exclude: ['**/node_modules/**', '**/dist/**', 'tests', '.worktrees/**', 'runs/**'],
     setupFiles: ['./lib/parsers/vitest.setup.ts'],
   },
   resolve: {


### PR DESCRIPTION
Follow-up from the optimize pipeline work (#283): per-agent scoping for deterministic LLM mocks, plus the `runs/` vitest exclude.

## Per-agent scoped LLM mocks

`AGENCY_LLM_MOCKS` / `llmMocks` in test.json now accepts an object of independent queues keyed by agent, alongside the existing ordered-array form:

```json
"llmMocks": {
  "mutatePrompt": [{ "return": { "operations": [...], "rationale": "..." } }],
  "judgePairwise": [{ "return": { "winner": "B", ... } }],
  "*": [{ "return": "task agent response" }]
}
```

**Why:** with one global ordered list, a test spanning several agents (a full optimize iteration interleaves the task agent, the mutator, and the judge — across processes) has to predict the exact global order of `llm()` calls; any internal reorder silently feeds the wrong mock to the wrong agent, and the failure surfaces downstream as a confusing shape error. Scoped queues make such tests order-independent — this unblocks a future full-iteration optimize integration test.

**How:** `DeterministicClient` resolves the queue at call time from the ALS frame's `callsite.moduleId` (seeded by `Runner.runInScope` for every step body): exact module id → basename without `.agency` → `"*"` fallback. Each queue keeps its own index. The env var inherits into eval/agent subprocesses, so scoping crosses process boundaries unchanged. Runtime-only change — no codegen, templates, or production LLM paths touched; the activation site already `JSON.parse`s the env var and now accepts either shape. The array form's behavior and error messages are byte-identical.

**Tests:** 7 new unit tests (exact/basename/fallback resolution, no-frame fallback, independent interleaved consumption, scope-named exhaustion errors, helpful no-match error) and an end-to-end agency test (`tests/agency/llm-mock-scoping`) where the main agent and the imported `mutatePrompt` agent each consume their own single-entry queue — it can only pass if both calls route to their own module's queue. Docs added to `docs/misc/TESTING.md`.

## vitest `runs/` exclude

`agency eval optimize` copies the whole working dir — test files included — into `runs/optimize/<id>/iter-N/workspace/`, so a local optimize session previously made `pnpm test` pick up and run stale test copies. `runs/**` is now excluded.

## Note for reviewers

The end-to-end test calls the bundled mutator node as its last statement: calling a node is a graph transition (the called node's value becomes the run's result), so call-and-continue does not apply. An earlier draft of this description flagged that as a possible bug — it isn't; it's node semantics. The test uses a plain `import` (not the dead `import node` form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
