### PR TITLE
Fix: allow re-exports above an @module doc comment

### DIFF
--- a/packages/agency-lang/lib/preprocessors/resolveReExports.test.ts
+++ b/packages/agency-lang/lib/preprocessors/resolveReExports.test.ts
@@ -450,7 +450,7 @@ describe("resolveReExports: leading preamble ordering", () => {
     } as unknown as AgencyNode;
     const moduleDoc = {
       type: "multiLineComment",
-      value: "@module\n  docs",
+      content: "\n  module docs\n",
       isDoc: true,
       isModuleDoc: true,
     } as unknown as AgencyNode;
@@ -507,5 +507,63 @@ describe("resolveReExports: leading preamble ordering", () => {
     expect(
       result.nodes.slice(0, docIdx).every((n) => preamble.has(n.type)),
     ).toBe(true);
+  });
+
+  it("does not split a regular doc comment from the declaration it documents", () => {
+    const sourcePath = "/project/source.agency";
+    const reexporterPath = "/project/reexporter.agency";
+    // A non-`@module` doc comment binds to the next declaration. Synthesized
+    // re-export nodes must not be inserted between them.
+    const docComment = {
+      type: "multiLineComment",
+      content: " docs for foo ",
+      isDoc: true,
+      isModuleDoc: false,
+    } as unknown as AgencyNode;
+    const fooDef = {
+      type: "function",
+      functionName: "foo",
+      exported: true,
+      safe: false,
+      parameters: [],
+      body: [],
+    } as unknown as AgencyNode;
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        docComment,
+        fooDef,
+        makeExportFromStmt({
+          modulePath: "./source.agency",
+          body: {
+            kind: "namedExport",
+            names: ["search"],
+            aliases: {},
+            safeNames: [],
+          },
+        }),
+      ],
+    };
+    const symbolTable = table({
+      [sourcePath]: { search: fn({ name: "search" }) },
+      [reexporterPath]: {
+        foo: fn({ name: "foo" }),
+        search: fn({
+          name: "search",
+          reExportedFrom: { sourceFile: sourcePath, originalName: "search" },
+        }),
+      },
+    });
+
+    const result = resolveReExports(program, symbolTable, reexporterPath);
+
+    // The doc comment is immediately followed by `foo` (the declaration it
+    // documents) — nothing synthesized was spliced between them.
+    const docIdx = result.nodes.findIndex((n) => n.type === "multiLineComment");
+    expect(docIdx).toBeGreaterThanOrEqual(0);
+    expect(result.nodes[docIdx + 1]).toMatchObject({
+      type: "function",
+      functionName: "foo",
+    });
   });
 });

--- a/packages/agency-lang/lib/preprocessors/resolveReExports.test.ts
+++ b/packages/agency-lang/lib/preprocessors/resolveReExports.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolveReExports } from "./resolveReExports.js";
-import type { AgencyProgram } from "../types.js";
+import type { AgencyNode, AgencyProgram } from "../types.js";
 import {
   SymbolTable,
   type FileSymbols,
@@ -435,5 +435,77 @@ describe("resolveReExports: coalescing and star", () => {
     ) as FunctionDefinition[];
     const names = fns.map((f) => f.functionName).sort();
     expect(names).toEqual(["bar", "foo"]);
+  });
+});
+
+describe("resolveReExports: leading preamble ordering", () => {
+  it("keeps a leading @module doc comment and imports ahead of synthesized nodes", () => {
+    const sourcePath = "/project/source.agency";
+    const reexporterPath = "/project/reexporter.agency";
+    const userImport = {
+      type: "importStatement",
+      modulePath: "./other.agency",
+      isAgencyImport: true,
+      importedNames: [],
+    } as unknown as AgencyNode;
+    const moduleDoc = {
+      type: "multiLineComment",
+      value: "@module\n  docs",
+      isDoc: true,
+      isModuleDoc: true,
+    } as unknown as AgencyNode;
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        userImport,
+        moduleDoc,
+        makeExportFromStmt({
+          modulePath: "./source.agency",
+          body: {
+            kind: "namedExport",
+            names: ["search"],
+            aliases: {},
+            safeNames: [],
+          },
+        }),
+      ],
+    };
+    const symbolTable = table({
+      [sourcePath]: { search: fn({ name: "search" }) },
+      [reexporterPath]: {
+        search: fn({
+          name: "search",
+          reExportedFrom: { sourceFile: sourcePath, originalName: "search" },
+        }),
+      },
+    });
+
+    const result = resolveReExports(program, symbolTable, reexporterPath);
+
+    const docIdx = result.nodes.findIndex((n) => n.type === "multiLineComment");
+    const wrapperIdx = result.nodes.findIndex((n) => n.type === "function");
+    const synthImportIdx = result.nodes.findIndex(
+      (n) =>
+        n.type === "importStatement" &&
+        (n as ImportStatement).modulePath === "./source.agency",
+    );
+
+    // The module doc must precede every synthesized node so the
+    // preprocessor's "module doc must precede code" check still passes.
+    expect(docIdx).toBeGreaterThanOrEqual(0);
+    expect(wrapperIdx).toBeGreaterThan(docIdx);
+    expect(synthImportIdx).toBeGreaterThan(docIdx);
+
+    // Nothing non-preamble appears before the module doc.
+    const preamble = new Set([
+      "comment",
+      "newLine",
+      "multiLineComment",
+      "importStatement",
+      "importNodeStatement",
+    ]);
+    expect(
+      result.nodes.slice(0, docIdx).every((n) => preamble.has(n.type)),
+    ).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/preprocessors/resolveReExports.ts
+++ b/packages/agency-lang/lib/preprocessors/resolveReExports.ts
@@ -90,9 +90,35 @@ export function resolveReExports(
     }
   }
 
-  // Synthesized imports go before kept nodes (matches normal import positioning).
-  return { ...program, nodes: [...synthesized, ...kept] };
+  // Insert the synthesized nodes after the file's leading preamble —
+  // comments (including the `@module` doc), blank lines, and imports —
+  // rather than at the absolute front. A function/constant/type re-export
+  // desugars to a wrapper `def` / `static const` / `type`, which is
+  // non-preamble code; placing it before a leading `@module` doc comment
+  // would trip the preprocessor's "module doc must precede code" check.
+  // Keeping the leading preamble first preserves both behaviours: imports
+  // stay at the top, and `@module` keeps documenting the module.
+  let head = 0;
+  while (head < kept.length && LEADING_PREAMBLE_TYPES.has(kept[head].type)) {
+    head++;
+  }
+  return {
+    ...program,
+    nodes: [...kept.slice(0, head), ...synthesized, ...kept.slice(head)],
+  };
 }
+
+// Node types that may legally precede a `@module` doc comment, and so form
+// the "leading preamble" that synthesized re-export nodes are inserted
+// after. Mirrors the preprocessor's preamble notion (comments, blank
+// lines, imports).
+const LEADING_PREAMBLE_TYPES: ReadonlySet<string> = new Set([
+  "comment",
+  "newLine",
+  "multiLineComment",
+  "importStatement",
+  "importNodeStatement",
+]);
 
 function hasReExportedFrom(
   sym: SymbolInfo,

--- a/packages/agency-lang/lib/preprocessors/resolveReExports.ts
+++ b/packages/agency-lang/lib/preprocessors/resolveReExports.ts
@@ -1,4 +1,4 @@
-import type { AgencyNode, AgencyProgram } from "../types.js";
+import type { AgencyMultiLineComment, AgencyNode, AgencyProgram } from "../types.js";
 import type {
   ConstantSymbol,
   FunctionSymbol,
@@ -91,7 +91,7 @@ export function resolveReExports(
   }
 
   // Insert the synthesized nodes after the file's leading preamble —
-  // comments (including the `@module` doc), blank lines, and imports —
+  // blank lines, comments (including the `@module` doc), and imports —
   // rather than at the absolute front. A function/constant/type re-export
   // desugars to a wrapper `def` / `static const` / `type`, which is
   // non-preamble code; placing it before a leading `@module` doc comment
@@ -99,7 +99,7 @@ export function resolveReExports(
   // Keeping the leading preamble first preserves both behaviours: imports
   // stay at the top, and `@module` keeps documenting the module.
   let head = 0;
-  while (head < kept.length && LEADING_PREAMBLE_TYPES.has(kept[head].type)) {
+  while (head < kept.length && isLeadingPreamble(kept[head])) {
     head++;
   }
   return {
@@ -108,17 +108,29 @@ export function resolveReExports(
   };
 }
 
-// Node types that may legally precede a `@module` doc comment, and so form
-// the "leading preamble" that synthesized re-export nodes are inserted
-// after. Mirrors the preprocessor's preamble notion (comments, blank
-// lines, imports).
-const LEADING_PREAMBLE_TYPES: ReadonlySet<string> = new Set([
-  "comment",
-  "newLine",
-  "multiLineComment",
-  "importStatement",
-  "importNodeStatement",
-]);
+// Whether a node belongs to the file's leading preamble — the run that
+// synthesized re-export nodes are inserted *after*. Mirrors the
+// preprocessor's preamble notion (blank lines, comments, imports), with
+// one crucial exception: a regular doc comment (`/** ... */` that is not
+// `@module`) binds to the declaration that follows it, so it must NOT be
+// treated as preamble — otherwise synthesized nodes would be spliced
+// between the doc comment and its declaration, breaking doc attachment.
+// The `@module` doc and plain block comments are safe to keep ahead.
+function isLeadingPreamble(node: AgencyNode): boolean {
+  switch (node.type) {
+    case "comment":
+    case "newLine":
+    case "importStatement":
+    case "importNodeStatement":
+      return true;
+    case "multiLineComment": {
+      const mc = node as AgencyMultiLineComment;
+      return mc.isModuleDoc || !mc.isDoc;
+    }
+    default:
+      return false;
+  }
+}
 
 function hasReExportedFrom(
   sym: SymbolInfo,


### PR DESCRIPTION
## Allow re-exports above an `@module` doc comment

### Problem

A module that both re-exports a symbol **and** has an `@module` doc comment fails to compile:

```ts
import { x } from "std::foo"

/** @module
  ...
*/

export { x } from "std::foo"
```

```
Error: @module doc comment must appear before any code. Move it to the top
of the file or right after the imports.
```

This surfaced while extracting `std::table` (Part B of the chart work): `std::table` wanted to re-export `render` from `std::layout` for one-import convenience, but couldn't while also carrying an `@module` doc.

### Root cause

The check itself is fine — the problem is upstream. `resolveReExports` (which runs before the preprocessor) **desugars** a function/constant/type re-export into a synthesized `import` **plus a wrapper** (`buildFunctionWrapper` returns a `FunctionDefinition`, constants a `static const`, types a `type`). It then placed every synthesized node at the absolute front:

```ts
return { ...program, nodes: [...synthesized, ...kept] };
```

The wrapper is non-preamble code, so it landed *before* the `@module` comment in `kept`, tripping the preprocessor's "module doc must precede code" check. (The literal `exportFromStatement` is already gone by then, which is why relaxing the check to allow it wouldn't have worked.)

### Fix

Insert the synthesized nodes **after the file's leading preamble** (comments incl. `@module`, blank lines, imports) rather than at the absolute front. Imports stay at the top and `@module` keeps documenting the module:

```ts
let head = 0;
while (head < kept.length && LEADING_PREAMBLE_TYPES.has(kept[head].type)) head++;
return { ...program, nodes: [...kept.slice(0, head), ...synthesized, ...kept.slice(head)] };
```

### Verification

- **New unit test** in `resolveReExports.test.ts`: a leading `@module` comment + imports stay ahead of the synthesized import/wrapper.
- `resolveReExports.test.ts` (9) + `typescriptPreprocessor.core.test.ts` (22) → **31 pass**.
- **End-to-end**: the repro above now compiles cleanly.
- **No regression**: `tests/agency/reexport-node` (3/3) and `tests/agency/topsort/reexport-main` (1/1) still pass; full `make stdlib` compiles (including `cli.agency`'s re-export).
- `tsc --noEmit` and `lint:structure` clean.

### Follow-up

With this in, `std::table` (and `std::chart` in Part C) can re-export `render` from `std::layout` again if desired — though consumers importing `render` directly from `std::layout` also works fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
