### PR TITLE
Part C: std::chart horizontal bar charts

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/chart.md
+++ b/packages/agency-lang/docs/site/stdlib/chart.md
@@ -1,0 +1,142 @@
+---
+name: "chart"
+---
+
+# chart
+
+## Module: std::chart
+
+  Horizontal bar charts for terminal output. A `barChart(...)` returns a
+  layout node; render it with `render` from `std::layout`, so a chart
+  nests inside `box` / `row` / `column`.
+
+  Two construction styles, same result:
+
+  - **Data form (LLM-callable, JSON-friendly):** pass `keys` and `data`
+    arrays. `data[i].values` aligns to `keys` by index.
+
+    ```ts
+    import { barChart } from "std::chart"
+    import { render } from "std::layout"
+
+    const c = barChart(
+      title: "Revenue by quarter",
+      mode: "stacked",
+      keys: [{ name: "web", color: "blue" }, { name: "app", color: "green" }],
+      data: [
+        { label: "Q1", values: [120, 80] },
+        { label: "Q2", values: [98, 90] },
+      ],
+    )
+    print(render(c))
+    ```
+
+  - **Block form (Agency-author ergonomics):**
+
+    ```ts
+    const c = barChart(title: "Revenue", mode: "stacked") as ch {
+      ch.key("web", color: "blue")
+      ch.key("app", color: "green")
+      ch.bar("Q1", 120, 80)
+      ch.bar("Q2", 98, 90)
+    }
+    ```
+
+  Keys get a distinct color and fill symbol automatically when omitted,
+  so charts stay readable even when color is disabled. Negative values
+  draw left of a zero baseline; stacked bars must be uniform-sign.
+
+## Types
+
+### BarKey
+
+A series. `color`/`symbol` auto-assign if omitted.
+
+```ts
+/** A series. `color`/`symbol` auto-assign if omitted. */
+export type BarKey = {
+  name: string;
+  color?: string;
+  symbol?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/chart.agency#L48))
+
+### Bar
+
+One category. `values` aligns to `keys` by index.
+
+```ts
+/** One category. `values` aligns to `keys` by index. */
+export type Bar = {
+  label: string;
+  values: number[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/chart.agency#L55))
+
+### BarMode
+
+```ts
+export type BarMode = "stacked" | "grouped"
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/chart.agency#L60))
+
+### ChartBuilder
+
+Methods inside a `barChart` trailing `as c { ... }` block.
+
+```ts
+/** Methods inside a `barChart` trailing `as c { ... }` block. */
+export type ChartBuilder = {
+  key: any;
+  bar: any
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/chart.agency#L63))
+
+## Functions
+
+### barChart
+
+```ts
+barChart(title: string, mode: BarMode, keys: BarKey[], data: Bar[], showValues: boolean, legend: boolean, max: number, barChar: string, width: Width, block: (ChartBuilder) => void): LayoutNode
+```
+
+Render a horizontal bar chart as a layout node. When calling this as
+  an LLM tool, use the data form: pass `keys` (one per series) and
+  `data` (one entry per category, whose `values` array lines up with
+  `keys` by index). Render the result with `render` from `std::layout`.
+
+  @param title - Heading shown above the chart
+  @param mode - "grouped" draws one bar per key; "stacked" stacks the keys into one bar
+  @param keys - Series definitions. Each key may set a color (a termcolors name like "blue" or a hex string like "#cc7a4a") and a fill symbol; both auto-assign when omitted
+  @param data - Categories to plot. Each has a `label` and a positional `values` array aligned to `keys`
+  @param showValues - Show the numeric value beside each bar
+  @param legend - Show a legend listing the named keys
+  @param max - Fix the axis maximum; 0 derives it from the data
+  @param barChar - Default fill cell for the first / single series
+  @param width - Chart width in cells, or "full" / "N%"
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| title | `string` | "" |
+| mode | [BarMode](#barmode) | "grouped" |
+| keys | `BarKey[]` | null |
+| data | `Bar[]` | null |
+| showValues | `boolean` | true |
+| legend | `boolean` | true |
+| max | `number` | 0 |
+| barChar | `string` | "█" |
+| width | [Width](layout.md#width) | null |
+| block | `(ChartBuilder) => void` | null |
+
+**Returns:** [LayoutNode](layout.md#layoutnode)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/chart.agency#L92))

--- a/packages/agency-lang/docs/site/stdlib/chart.md
+++ b/packages/agency-lang/docs/site/stdlib/chart.md
@@ -118,7 +118,7 @@ Render a horizontal bar chart as a layout node. When calling this as
   @param data - Categories to plot. Each has a `label` and a positional `values` array aligned to `keys`
   @param showValues - Show the numeric value beside each bar
   @param legend - Show a legend listing the named keys
-  @param max - Fix the axis maximum; 0 derives it from the data
+  @param max - Fix the axis maximum (a positive number; values beyond it saturate at a full bar). 0 derives it from the data
   @param barChar - Default fill cell for the first / single series
   @param width - Chart width in cells, or "full" / "N%"
 

--- a/packages/agency-lang/lib/stdlib/layout.ts
+++ b/packages/agency-lang/lib/stdlib/layout.ts
@@ -24,6 +24,10 @@ import { padLine } from "./layout/block.js";
 import { HANDLERS, RENDERERS, _viewport, growToWidth, resolveSizes } from "./layout/render.js";
 import { _coerceCell, _tableChromeWidth, _validateTable } from "./layout/table.js";
 import { parseWidth, styleOf } from "./layout/nodes.js";
+import {
+  barCells, baselineColumn, dataRange, renderBarChart, resolveColor, resolveKeys,
+  stackSegments, validateChart,
+} from "./layout/barchart.js";
 
 export { Style, wrapText } from "./layout/ansi.js";
 export { Align, Block, above, beside, pad, styled } from "./layout/block.js";
@@ -40,4 +44,6 @@ export const _internal = {
   styleOf, RENDERERS, HANDLERS,
   parseWidth, wrapText, _viewport, resolveSizes, growToWidth,
   _coerceCell, _validateTable, _tableChromeWidth,
+  barCells, baselineColumn, dataRange, resolveKeys, stackSegments, renderBarChart,
+  resolveColor, validateChart,
 };

--- a/packages/agency-lang/lib/stdlib/layout/barchart.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout/barchart.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "vitest";
-import {
+// Import through the public layout entry (not ./barchart.js directly) so the
+// module graph initializes in the same order as production. Importing
+// barchart.js first would evaluate it before render.js builds HANDLERS,
+// leaving its handler entry undefined mid-cycle.
+import { _internal, _render, LayoutNode } from "../layout.js";
+import { color } from "../../utils/termcolors.js";
+
+const {
   barCells,
   baselineColumn,
   dataRange,
@@ -7,8 +14,7 @@ import {
   resolveKeys,
   stackSegments,
   validateChart,
-} from "./barchart.js";
-import { color } from "../../utils/termcolors.js";
+} = _internal;
 
 describe("barCells", () => {
   test("scales magnitude to cells", () => {
@@ -88,6 +94,63 @@ describe("validateChart", () => {
         [{ label: "Q1", values: [10, -5] }],
         "stacked",
       ),
+    ).toThrow(/mixes positive and negative/);
+  });
+});
+
+function chartNode(attrs: Record<string, unknown>): LayoutNode {
+  return { type: "barchart", attrs, children: [] };
+}
+
+function renderPlain(attrs: Record<string, unknown>): string {
+  // color: false → deterministic, ANSI stripped.
+  return _render(chartNode(attrs), false);
+}
+
+describe("renderBarChart", () => {
+  test("single-series bar fills proportionally and shows value + label", () => {
+    const out = renderPlain({
+      mode: "grouped",
+      data: [
+        { label: "North", values: [10] },
+        { label: "South", values: [5] },
+      ],
+      barChar: "#",
+      showValues: true,
+      legend: false,
+      // chrome = labelW(5) + 1 + valueW(2) + 1 = 9, so barArea = 9.
+      // Asserts relative bar length + containment, not exact width.
+      resolvedWidth: 18,
+    });
+    const lines = out.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain("North");
+    expect(lines[0]).toContain("10");
+    const northBars = (lines[0].match(/#/g) ?? []).length;
+    const southBars = (lines[1].match(/#/g) ?? []).length;
+    expect(northBars).toBeGreaterThan(southBars);
+  });
+
+  test("legend lists each named key", () => {
+    const out = renderPlain({
+      mode: "stacked",
+      keys: [{ name: "web" }, { name: "app" }],
+      data: [{ label: "Q1", values: [3, 1] }],
+      legend: true,
+      showValues: false,
+      resolvedWidth: 30,
+    });
+    expect(out).toContain("web");
+    expect(out).toContain("app");
+  });
+
+  test("rejects mixed-sign stacked bars at render time", () => {
+    expect(() =>
+      renderPlain({
+        mode: "stacked",
+        keys: [{ name: "a" }, { name: "b" }],
+        data: [{ label: "Q1", values: [5, -2] }],
+      }),
     ).toThrow(/mixes positive and negative/);
   });
 });

--- a/packages/agency-lang/lib/stdlib/layout/barchart.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout/barchart.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+import {
+  barCells,
+  baselineColumn,
+  dataRange,
+  resolveColor,
+  resolveKeys,
+  stackSegments,
+  validateChart,
+} from "./barchart.js";
+import { color } from "../../utils/termcolors.js";
+
+describe("barCells", () => {
+  test("scales magnitude to cells", () => {
+    expect(barCells(50, 100, 20)).toBe(10);
+    expect(barCells(82, 91, 20)).toBe(18);
+  });
+  test("uses absolute value and guards zero span", () => {
+    expect(barCells(-50, 100, 20)).toBe(10);
+    expect(barCells(5, 0, 20)).toBe(0);
+  });
+});
+
+describe("baselineColumn", () => {
+  test("is 0 when all data is non-negative", () => {
+    expect(baselineColumn(0, 100, 20)).toBe(0);
+  });
+  test("places zero at the interior when data has negatives", () => {
+    expect(baselineColumn(-50, 100, 30)).toBe(10);
+  });
+});
+
+describe("dataRange", () => {
+  test("stacked ranges over row sums and includes zero", () => {
+    expect(dataRange([{ label: "a", values: [120, 80, 30] }], "stacked")).toEqual({ min: 0, max: 230 });
+  });
+  test("grouped ranges over individual values", () => {
+    expect(dataRange([{ label: "a", values: [82, -41] }], "grouped")).toEqual({ min: -41, max: 82 });
+  });
+});
+
+describe("stackSegments", () => {
+  test("largest-remainder distribution sums exactly to total cells", () => {
+    const segs = stackSegments([120, 80, 30], 230, 20);
+    expect(segs).toEqual([10, 7, 3]);
+    expect(segs.reduce((a, b) => a + b, 0)).toBe(20);
+  });
+});
+
+describe("resolveKeys", () => {
+  test("auto-assigns colors and symbols round-robin", () => {
+    expect(resolveKeys([{ name: "a" }, { name: "b" }], "█")).toEqual([
+      { name: "a", color: "blue", symbol: "█" },
+      { name: "b", color: "green", symbol: "▓" },
+    ]);
+  });
+  test("supplies one implicit key when none given", () => {
+    expect(resolveKeys(null, "█")).toEqual([{ name: "", color: "blue", symbol: "█" }]);
+  });
+});
+
+describe("resolveColor", () => {
+  test("named color matches termcolors", () => {
+    expect(resolveColor("blue")("x")).toBe(color.blue("x"));
+  });
+  test("empty name is identity", () => {
+    expect(resolveColor("")("x")).toBe("x");
+  });
+});
+
+describe("validateChart", () => {
+  test("rejects values/keys length mismatch", () => {
+    expect(() =>
+      validateChart(
+        [{ name: "a", color: "blue", symbol: "█" }],
+        [{ label: "Q1", values: [1, 2] }],
+        "grouped",
+      ),
+    ).toThrow(/Q1/);
+  });
+  test("rejects mixed-sign stacked bar", () => {
+    expect(() =>
+      validateChart(
+        [
+          { name: "a", color: "blue", symbol: "█" },
+          { name: "b", color: "green", symbol: "▓" },
+        ],
+        [{ label: "Q1", values: [10, -5] }],
+        "stacked",
+      ),
+    ).toThrow(/mixes positive and negative/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/layout/barchart.ts
+++ b/packages/agency-lang/lib/stdlib/layout/barchart.ts
@@ -1,0 +1,244 @@
+// std::layout — horizontal bar chart renderer for std::chart.
+//
+// Value→cell scaling and the largest-remainder rounding in
+// `stackSegments` (so stacked segments sum exactly to the bar length)
+// are adapted from chartscii (MIT, https://github.com/tool3/chartscii).
+import { color } from "../../utils/termcolors.js";
+import { Block, above, beside, pad } from "./block.js";
+import { visualWidth } from "./ansi.js";
+import { LayoutNode } from "./nodes.js";
+import { NodeHandler, SizingContext, resolveOwnWidth, setAttr } from "./sizing.js";
+
+export type BarKey = { name: string; color?: string; symbol?: string };
+export type Bar = { label: string; values: number[] };
+export type BarMode = "stacked" | "grouped";
+
+export type ResolvedKey = { name: string; color: string; symbol: string };
+
+export const DEFAULT_COLORS = ["blue", "green", "brightYellow", "magenta", "cyan", "red"];
+export const DEFAULT_SYMBOLS = ["█", "▓", "▒", "░"];
+const DEFAULT_BAR_AREA = 40;
+const TRACK_CHAR = "·";
+
+export function resolveColor(name: string): (s: string) => string {
+  if (!name) return (s) => s;
+  if (name.startsWith("#")) return (s) => (color as any).hex(name)(s);
+  const fn = (color as any)[name];
+  return typeof fn === "function" ? (s) => fn(s) : (s) => s;
+}
+
+export function resolveKeys(keys: BarKey[] | null, barChar: string): ResolvedKey[] {
+  const list = keys && keys.length > 0 ? keys : [{ name: "" } as BarKey];
+  return list.map((k, i) => ({
+    name: k.name ?? "",
+    color: k.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+    symbol: k.symbol ?? (i === 0 ? barChar : DEFAULT_SYMBOLS[i % DEFAULT_SYMBOLS.length]),
+  }));
+}
+
+export function dataRange(data: Bar[], mode: BarMode): { min: number; max: number } {
+  const quantities =
+    mode === "stacked"
+      ? data.map((b) => b.values.reduce((a, c) => a + c, 0))
+      : data.flatMap((b) => b.values);
+  let min = 0;
+  let max = 0;
+  for (const q of quantities) {
+    if (q < min) min = q;
+    if (q > max) max = q;
+  }
+  return { min, max };
+}
+
+export function barCells(value: number, rangeSpan: number, barArea: number): number {
+  if (rangeSpan <= 0) return 0;
+  return Math.round((Math.abs(value) / rangeSpan) * barArea);
+}
+
+export function baselineColumn(rangeMin: number, rangeMax: number, barArea: number): number {
+  const span = rangeMax - rangeMin;
+  if (rangeMin >= 0 || span <= 0) return 0;
+  return Math.round(((0 - rangeMin) / span) * barArea);
+}
+
+export function stackSegments(values: number[], rangeSpan: number, barArea: number): number[] {
+  const total = values.reduce((a, b) => a + Math.abs(b), 0);
+  const totalCells = barCells(total, rangeSpan, barArea);
+  if (total <= 0 || totalCells <= 0) return values.map(() => 0);
+  const raw = values.map((v) => (Math.abs(v) / total) * totalCells);
+  const result = raw.map((x) => Math.floor(x));
+  let remaining = totalCells - result.reduce((a, b) => a + b, 0);
+  const order = raw
+    .map((x, i) => ({ i, frac: x - Math.floor(x) }))
+    .sort((a, b) => b.frac - a.frac);
+  for (let k = 0; k < order.length && remaining > 0; k++) {
+    result[order[k].i] += 1;
+    remaining--;
+  }
+  return result;
+}
+
+export function validateChart(keys: ResolvedKey[], data: Bar[], mode: BarMode): void {
+  const expected = keys.length;
+  for (const bar of data) {
+    if (bar.values.length !== expected) {
+      throw new Error(
+        `std::chart: bar "${bar.label}" has ${bar.values.length} value(s) but there are ${expected} key(s).`,
+      );
+    }
+    for (const v of bar.values) {
+      if (!Number.isFinite(v)) {
+        throw new Error(`std::chart: bar "${bar.label}" has a non-finite value.`);
+      }
+    }
+    if (mode === "stacked") {
+      const hasPos = bar.values.some((v) => v > 0);
+      const hasNeg = bar.values.some((v) => v < 0);
+      if (hasPos && hasNeg) {
+        throw new Error(
+          `std::chart: stacked bar "${bar.label}" mixes positive and negative values; uniform sign required.`,
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function fmtValue(v: number): string {
+  return Number.isInteger(v) ? String(v) : String(Math.round(v * 100) / 100);
+}
+
+function track(n: number): string {
+  return n > 0 ? color.dim(TRACK_CHAR.repeat(n)) : "";
+}
+
+function drawBar(
+  cells: number,
+  baseline: number,
+  barArea: number,
+  sign: number,
+  fill: string,
+  colorFn: (s: string) => string,
+): string {
+  if (sign >= 0) {
+    const c = Math.min(cells, barArea - baseline);
+    return track(baseline) + colorFn(fill.repeat(c)) + track(barArea - baseline - c);
+  }
+  const c = Math.min(cells, baseline);
+  return track(baseline - c) + colorFn(fill.repeat(c)) + track(barArea - baseline);
+}
+
+function drawStack(
+  segs: number[],
+  keys: ResolvedKey[],
+  baseline: number,
+  barArea: number,
+  sign: number,
+): string {
+  const total = segs.reduce((a, b) => a + b, 0);
+  const body = segs.map((n, i) => resolveColor(keys[i].color)(keys[i].symbol.repeat(n))).join("");
+  if (sign >= 0) {
+    return track(baseline) + body + track(barArea - baseline - total);
+  }
+  return track(baseline - total) + body + track(barArea - baseline);
+}
+
+type ChartRow = { label: string; bar: string; value: string };
+
+// "What" each data entry becomes: in grouped mode one row per key (label
+// + value only on the first); in stacked mode a single row. No padding or
+// layout concerns here.
+function chartRows(
+  data: Bar[],
+  keys: ResolvedKey[],
+  mode: BarMode,
+  valueStrings: string[],
+  span: number,
+  barArea: number,
+  baseline: number,
+): ChartRow[] {
+  return data.flatMap((bar, bi) => {
+    if (mode === "stacked") {
+      const sign = bar.values.some((v) => v < 0) ? -1 : 1;
+      const segs = stackSegments(bar.values, span, barArea);
+      return [{ label: bar.label, bar: drawStack(segs, keys, baseline, barArea, sign), value: valueStrings[bi] }];
+    }
+    return keys.map((k, ki) => {
+      const v = bar.values[ki];
+      const bar_ = drawBar(barCells(v, span, barArea), baseline, barArea, Math.sign(v) || 1, k.symbol, resolveColor(k.color));
+      return { label: ki === 0 ? bar.label : "", bar: bar_, value: ki === 0 ? valueStrings[bi] : "" };
+    });
+  });
+}
+
+// Stack non-empty blocks vertically. Used for title / legend / body.
+function stackBlocks(blocks: Block[]): Block {
+  return blocks
+    .filter((b) => b.height > 0)
+    .reduce((acc, b) => (acc.height === 0 ? b : above(acc, b)), Block.empty());
+}
+
+export function renderBarChart(node: LayoutNode): Block {
+  const a = node.attrs as any;
+  const mode: BarMode = a.mode === "stacked" ? "stacked" : "grouped";
+  const data: Bar[] = Array.isArray(a.data) ? a.data : [];
+  const keys = resolveKeys(
+    Array.isArray(a.keys) ? a.keys : null,
+    typeof a.barChar === "string" && a.barChar ? a.barChar : "█",
+  );
+  validateChart(keys, data, mode);
+
+  const showValues: boolean = a.showValues !== false;
+  const wantLegend: boolean = a.legend !== false;
+  const resolvedWidth: number | undefined = typeof a.resolvedWidth === "number" ? a.resolvedWidth : undefined;
+
+  const valueStrings = data.map((b) =>
+    mode === "stacked"
+      ? fmtValue(b.values.reduce((s, v) => s + v, 0))
+      : fmtValue(b.values.reduce((m, v) => (Math.abs(v) > Math.abs(m) ? v : m), 0)),
+  );
+  const labelW = data.length ? Math.max(...data.map((b) => visualWidth(b.label))) : 0;
+  const valueW = showValues && valueStrings.length ? Math.max(...valueStrings.map((s) => s.length)) : 0;
+
+  const chrome = labelW + 1 + (showValues ? valueW + 1 : 0);
+  const totalW = resolvedWidth ?? chrome + DEFAULT_BAR_AREA;
+  const barArea = Math.max(1, totalW - chrome);
+
+  const { min, max: autoMax } = dataRange(data, mode);
+  const max = typeof a.max === "number" && a.max > autoMax ? a.max : autoMax;
+  const span = max - min;
+  const baseline = baselineColumn(min, max, barArea);
+
+  const rows = chartRows(data, keys, mode, valueStrings, span, barArea, baseline);
+
+  // "How" — three aligned columns combined with the Block algebra, the
+  // same pad/beside/above approach composeRow and composeTable use. No
+  // hand-rolled padding or string concatenation.
+  const gap = Block.of(rows.map(() => " "));
+  const labelCol = pad(Block.of(rows.map((r) => r.label)), labelW, rows.length, "start", "start");
+  const barCol = Block.of(rows.map((r) => r.bar));
+  const valueCol = pad(Block.of(rows.map((r) => r.value)), valueW, rows.length, "end", "start");
+
+  const body = showValues
+    ? beside(beside(beside(beside(labelCol, gap), barCol), gap), valueCol)
+    : beside(beside(labelCol, gap), barCol);
+
+  const title = typeof a.title === "string" && a.title ? Block.of(a.title) : Block.empty();
+  const legend =
+    wantLegend && keys.some((k) => k.name)
+      ? Block.of(keys.map((k) => resolveColor(k.color)(k.symbol) + " " + k.name).join("  "))
+      : Block.empty();
+
+  return stackBlocks([title, legend, body]);
+}
+
+export function sizeBarChart(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const own = resolveOwnWidth(node, ctx);
+  if (own === undefined) return node; // unsized: render falls back to DEFAULT_BAR_AREA
+  return setAttr(node, "resolvedWidth", own);
+}
+
+export const barchart: NodeHandler = { size: sizeBarChart, render: renderBarChart };

--- a/packages/agency-lang/lib/stdlib/layout/barchart.ts
+++ b/packages/agency-lang/lib/stdlib/layout/barchart.ts
@@ -147,8 +147,18 @@ function drawStack(
   barArea: number,
   sign: number,
 ): string {
-  const total = segs.reduce((a, b) => a + b, 0);
-  const body = segs.map((n, i) => resolveColor(keys[i].color)(keys[i].symbol.repeat(n))).join("");
+  // Clamp the cumulative run to the width available on this side of the
+  // baseline, so a stack whose total exceeds the axis maximum saturates
+  // the bar instead of overflowing the chart.
+  const avail = sign >= 0 ? barArea - baseline : baseline;
+  let used = 0;
+  const clamped = segs.map((n) => {
+    const c = Math.max(0, Math.min(n, avail - used));
+    used += c;
+    return c;
+  });
+  const total = clamped.reduce((a, b) => a + b, 0);
+  const body = clamped.map((n, i) => resolveColor(keys[i].color)(keys[i].symbol.repeat(n))).join("");
   if (sign >= 0) {
     return track(baseline) + body + track(barArea - baseline - total);
   }
@@ -157,28 +167,35 @@ function drawStack(
 
 type ChartRow = { label: string; bar: string; value: string };
 
+// The value shown beside a bar: in stacked mode the category total; in
+// grouped mode each key's own value (one per bar).
+function barValue(bar: Bar, mode: BarMode, ki: number): string {
+  return mode === "stacked"
+    ? fmtValue(bar.values.reduce((s, v) => s + v, 0))
+    : fmtValue(bar.values[ki]);
+}
+
 // "What" each data entry becomes: in grouped mode one row per key (label
-// + value only on the first); in stacked mode a single row. No padding or
-// layout concerns here.
+// on the first, its own value on each); in stacked mode a single row. No
+// padding or layout concerns here.
 function chartRows(
   data: Bar[],
   keys: ResolvedKey[],
   mode: BarMode,
-  valueStrings: string[],
   span: number,
   barArea: number,
   baseline: number,
 ): ChartRow[] {
-  return data.flatMap((bar, bi) => {
+  return data.flatMap((bar) => {
     if (mode === "stacked") {
       const sign = bar.values.some((v) => v < 0) ? -1 : 1;
       const segs = stackSegments(bar.values, span, barArea);
-      return [{ label: bar.label, bar: drawStack(segs, keys, baseline, barArea, sign), value: valueStrings[bi] }];
+      return [{ label: bar.label, bar: drawStack(segs, keys, baseline, barArea, sign), value: barValue(bar, "stacked", 0) }];
     }
     return keys.map((k, ki) => {
       const v = bar.values[ki];
       const bar_ = drawBar(barCells(v, span, barArea), baseline, barArea, Math.sign(v) || 1, k.symbol, resolveColor(k.color));
-      return { label: ki === 0 ? bar.label : "", bar: bar_, value: ki === 0 ? valueStrings[bi] : "" };
+      return { label: ki === 0 ? bar.label : "", bar: bar_, value: barValue(bar, "grouped", ki) };
     });
   });
 }
@@ -204,24 +221,33 @@ export function renderBarChart(node: LayoutNode): Block {
   const wantLegend: boolean = a.legend !== false;
   const resolvedWidth: number | undefined = typeof a.resolvedWidth === "number" ? a.resolvedWidth : undefined;
 
-  const valueStrings = data.map((b) =>
+  if (typeof a.max === "number" && (!Number.isFinite(a.max) || a.max < 0)) {
+    throw new Error(`std::chart: max must be a non-negative number, got ${a.max}.`);
+  }
+
+  // Value shown per row (grouped → one per key; stacked → category total).
+  const allValues = data.flatMap((bar) =>
     mode === "stacked"
-      ? fmtValue(b.values.reduce((s, v) => s + v, 0))
-      : fmtValue(b.values.reduce((m, v) => (Math.abs(v) > Math.abs(m) ? v : m), 0)),
+      ? [barValue(bar, "stacked", 0)]
+      : keys.map((_k, ki) => barValue(bar, "grouped", ki)),
   );
   const labelW = data.length ? Math.max(...data.map((b) => visualWidth(b.label))) : 0;
-  const valueW = showValues && valueStrings.length ? Math.max(...valueStrings.map((s) => s.length)) : 0;
+  const valueW = showValues ? Math.max(0, ...allValues.map((s) => s.length)) : 0;
 
   const chrome = labelW + 1 + (showValues ? valueW + 1 : 0);
   const totalW = resolvedWidth ?? chrome + DEFAULT_BAR_AREA;
-  const barArea = Math.max(1, totalW - chrome);
+  // Clamp to 0 (not 1) so an explicit `width` is never exceeded; a chart
+  // with no room left simply renders an empty bar region.
+  const barArea = Math.max(0, totalW - chrome);
 
   const { min, max: autoMax } = dataRange(data, mode);
-  const max = typeof a.max === "number" && a.max > autoMax ? a.max : autoMax;
+  // A positive `max` fixes the axis maximum (values beyond it saturate);
+  // 0 / unset derives it from the data.
+  const max = typeof a.max === "number" && a.max > 0 ? a.max : autoMax;
   const span = max - min;
   const baseline = baselineColumn(min, max, barArea);
 
-  const rows = chartRows(data, keys, mode, valueStrings, span, barArea, baseline);
+  const rows = chartRows(data, keys, mode, span, barArea, baseline);
 
   // "How" — three aligned columns combined with the Block algebra, the
   // same pad/beside/above approach composeRow and composeTable use. No

--- a/packages/agency-lang/lib/stdlib/layout/barchart.ts
+++ b/packages/agency-lang/lib/stdlib/layout/barchart.ts
@@ -20,8 +20,17 @@ export const DEFAULT_SYMBOLS = ["█", "▓", "▒", "░"];
 const DEFAULT_BAR_AREA = 40;
 const TRACK_CHAR = "·";
 
-export function resolveColor(name: string): (s: string) => string {
-  if (!name) return (s) => s;
+// True only for a non-empty string. Used to decide whether an optional
+// key field was explicitly set. The Agency block builder leaves omitted
+// optional params as a runtime sentinel (not "" or undefined), so we
+// can't trust `?? default` / truthiness on the raw value — only a real
+// string counts as an explicit color/symbol; everything else auto-assigns.
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+export function resolveColor(name: unknown): (s: string) => string {
+  if (!isNonEmptyString(name)) return (s) => s;
   if (name.startsWith("#")) return (s) => (color as any).hex(name)(s);
   const fn = (color as any)[name];
   return typeof fn === "function" ? (s) => fn(s) : (s) => s;
@@ -30,9 +39,9 @@ export function resolveColor(name: string): (s: string) => string {
 export function resolveKeys(keys: BarKey[] | null, barChar: string): ResolvedKey[] {
   const list = keys && keys.length > 0 ? keys : [{ name: "" } as BarKey];
   return list.map((k, i) => ({
-    name: k.name ?? "",
-    color: k.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length],
-    symbol: k.symbol ?? (i === 0 ? barChar : DEFAULT_SYMBOLS[i % DEFAULT_SYMBOLS.length]),
+    name: isNonEmptyString(k.name) ? k.name : "",
+    color: isNonEmptyString(k.color) ? k.color : DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+    symbol: isNonEmptyString(k.symbol) ? k.symbol : (i === 0 ? barChar : DEFAULT_SYMBOLS[i % DEFAULT_SYMBOLS.length]),
   }));
 }
 

--- a/packages/agency-lang/lib/stdlib/layout/nodes.ts
+++ b/packages/agency-lang/lib/stdlib/layout/nodes.ts
@@ -12,7 +12,7 @@ import { NodeHandler, SizingContext, resolveOwnWidth, setAttr } from "./sizing.j
 export type NodeType =
   | "box" | "row" | "column"
   | "text" | "raw" | "space" | "hline" | "vline"
-  | "table";
+  | "table" | "barchart";
 
 export type LayoutNode = {
   type: NodeType;

--- a/packages/agency-lang/lib/stdlib/layout/render.ts
+++ b/packages/agency-lang/lib/stdlib/layout/render.ts
@@ -15,6 +15,7 @@ import { LayoutNode, NodeType, hline, raw, space, text, vline } from "./nodes.js
 import { box } from "./box.js";
 import { column, row } from "./axis.js";
 import { table } from "./table.js";
+import { barchart } from "./barchart.js";
 import { NodeHandler, SizingContext } from "./sizing.js";
 
 export type Viewport = { cols: number; rows: number };
@@ -84,7 +85,7 @@ export function growToWidth(block: Block, targetWidth: number): Block {
 // Single dispatch table: each node type's size + render paired, sourced
 // from the per-concern files that own them.
 export const HANDLERS: Record<NodeType, NodeHandler> = {
-  box, row, column, table,
+  box, row, column, table, barchart,
   text, raw, space, hline, vline,
 };
 

--- a/packages/agency-lang/stdlib/chart.agency
+++ b/packages/agency-lang/stdlib/chart.agency
@@ -113,7 +113,7 @@ export safe def barChart(
   @param data - Categories to plot. Each has a `label` and a positional `values` array aligned to `keys`
   @param showValues - Show the numeric value beside each bar
   @param legend - Show a legend listing the named keys
-  @param max - Fix the axis maximum; 0 derives it from the data
+  @param max - Fix the axis maximum (a positive number; values beyond it saturate at a full bar). 0 derives it from the data
   @param barChar - Default fill cell for the first / single series
   @param width - Chart width in cells, or "full" / "N%"
   """

--- a/packages/agency-lang/stdlib/chart.agency
+++ b/packages/agency-lang/stdlib/chart.agency
@@ -1,0 +1,157 @@
+import { LayoutNode, Width } from "std::layout"
+
+/** @module
+  ## Module: std::chart
+
+  Horizontal bar charts for terminal output. A `barChart(...)` returns a
+  layout node; render it with `render` from `std::layout`, so a chart
+  nests inside `box` / `row` / `column`.
+
+  Two construction styles, same result:
+
+  - **Data form (LLM-callable, JSON-friendly):** pass `keys` and `data`
+    arrays. `data[i].values` aligns to `keys` by index.
+
+    ```ts
+    import { barChart } from "std::chart"
+    import { render } from "std::layout"
+
+    const c = barChart(
+      title: "Revenue by quarter",
+      mode: "stacked",
+      keys: [{ name: "web", color: "blue" }, { name: "app", color: "green" }],
+      data: [
+        { label: "Q1", values: [120, 80] },
+        { label: "Q2", values: [98, 90] },
+      ],
+    )
+    print(render(c))
+    ```
+
+  - **Block form (Agency-author ergonomics):**
+
+    ```ts
+    const c = barChart(title: "Revenue", mode: "stacked") as ch {
+      ch.key("web", color: "blue")
+      ch.key("app", color: "green")
+      ch.bar("Q1", 120, 80)
+      ch.bar("Q2", 98, 90)
+    }
+    ```
+
+  Keys get a distinct color and fill symbol automatically when omitted,
+  so charts stay readable even when color is disabled. Negative values
+  draw left of a zero baseline; stacked bars must be uniform-sign.
+*/
+
+/** A series. `color`/`symbol` auto-assign if omitted. */
+export type BarKey = {
+  name: string;
+  color?: string;
+  symbol?: string
+}
+
+/** One category. `values` aligns to `keys` by index. */
+export type Bar = {
+  label: string;
+  values: number[]
+}
+
+export type BarMode = "stacked" | "grouped"
+
+/** Methods inside a `barChart` trailing `as c { ... }` block. */
+export type ChartBuilder = {
+  key: any;
+  bar: any
+}
+
+def _addKey(state: any, name: string, color: string = "", symbol: string = ""): any {
+  const k: any = { name: name }
+  if (color != "") {
+    k.color = color
+  }
+  if (symbol != "") {
+    k.symbol = symbol
+  }
+  state.keys.push(k)
+  return null
+}
+
+def _addBar(state: any, label: string, ...values: number[]): any {
+  state.data.push({ label: label, values: values })
+  return null
+}
+
+def _makeChartBuilder(state: any): ChartBuilder {
+  return {
+    key: _addKey.partial(state: state),
+    bar: _addBar.partial(state: state)
+  }
+}
+
+export safe def barChart(
+  title: string = "",
+  mode: BarMode = "grouped",
+  keys: BarKey[] = null,
+  data: Bar[] = null,
+  showValues: boolean = true,
+  legend: boolean = true,
+  max: number = 0,
+  barChar: string = "█",
+  width: Width = null,
+  block: (ChartBuilder) -> void = null,
+): LayoutNode {
+  """
+  Render a horizontal bar chart as a layout node. When calling this as
+  an LLM tool, use the data form: pass `keys` (one per series) and
+  `data` (one entry per category, whose `values` array lines up with
+  `keys` by index). Render the result with `render` from `std::layout`.
+
+  @param title - Heading shown above the chart
+  @param mode - "grouped" draws one bar per key; "stacked" stacks the keys into one bar
+  @param keys - Series definitions. Each key may set a color (a termcolors name like "blue" or a hex string like "#cc7a4a") and a fill symbol; both auto-assign when omitted
+  @param data - Categories to plot. Each has a `label` and a positional `values` array aligned to `keys`
+  @param showValues - Show the numeric value beside each bar
+  @param legend - Show a legend listing the named keys
+  @param max - Fix the axis maximum; 0 derives it from the data
+  @param barChar - Default fill cell for the first / single series
+  @param width - Chart width in cells, or "full" / "N%"
+  """
+  const keysArr: any[] = []
+  if (keys != null) {
+    for (k in keys) {
+      keysArr.push(k)
+    }
+  }
+  const dataArr: any[] = []
+  if (data != null) {
+    for (d in data) {
+      dataArr.push(d)
+    }
+  }
+  const state: any = {
+    keys: keysArr,
+    data: dataArr
+  }
+  if (block != null) {
+    block(_makeChartBuilder(state))
+  }
+  const attrs: any = {
+    title: title,
+    mode: mode,
+    keys: state.keys,
+    data: state.data,
+    showValues: showValues,
+    legend: legend,
+    max: max,
+    barChar: barChar
+  }
+  if (width != null) {
+    attrs.width = width
+  }
+  return {
+    type: "barchart",
+    attrs: attrs,
+    children: []
+  }
+}

--- a/packages/agency-lang/tests/agency/chart/basic.agency
+++ b/packages/agency-lang/tests/agency/chart/basic.agency
@@ -1,0 +1,28 @@
+import { barChart } from "std::chart"
+import { render } from "std::layout"
+
+// Data-param form.
+node testDataForm() {
+  const c = barChart(
+    title: "Q",
+    mode: "stacked",
+    keys: [{ name: "web" }, { name: "app" }],
+    data: [
+      { label: "Q1", values: [3, 1] },
+      { label: "Q2", values: [2, 2] },
+    ],
+    width: 24,
+  )
+  return render(c, color: false)
+}
+
+// Block form — must produce identical output.
+node testBlockForm() {
+  const c = barChart(title: "Q", mode: "stacked", width: 24) as ch {
+    ch.key("web")
+    ch.key("app")
+    ch.bar("Q1", 3, 1)
+    ch.bar("Q2", 2, 2)
+  }
+  return render(c, color: false)
+}

--- a/packages/agency-lang/tests/agency/chart/basic.test.json
+++ b/packages/agency-lang/tests/agency/chart/basic.test.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    {
+      "nodeName": "testDataForm",
+      "input": "",
+      "expectedOutput": "\"Q                       \\n█ web  ▓ app            \\nQ1 ██████████████▓▓▓▓▓ 4\\nQ2 ██████████▓▓▓▓▓▓▓▓▓ 4\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "testBlockForm",
+      "input": "",
+      "expectedOutput": "\"Q                       \\n█ web  ▓ app            \\nQ1 ██████████████▓▓▓▓▓ 4\\nQ2 ██████████▓▓▓▓▓▓▓▓▓ 4\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Part C of 3 — `std::chart` horizontal bar charts

The feature itself: a new `std::chart` module that renders **horizontal bar charts** in the terminal as a first-class layout node, building on the Part A handler refactor and the Part B `std::table` split.

```ts
import { barChart } from "std::chart"
import { render } from "std::layout"

const c = barChart(
  title: "Revenue by quarter",
  mode: "stacked",
  keys: [{ name: "web", color: "blue" }, { name: "app", color: "green" }],
  data: [
    { label: "Q1", values: [120, 80] },
    { label: "Q2", values: [98, 90] },
  ],
)
print(render(c))
```

### What's included

- **`lib/stdlib/layout/barchart.ts`** — a new `barchart` node handler registered in the layout `HANDLERS` table. Grouped + stacked modes, keyed series with auto color/symbol assignment, a legend, value labels, and **negative values via a zero baseline** (uniform-sign stacks enforced). Value→cell scaling + largest-remainder rounding adapted from chartscii (MIT). Coloring uses `lib/utils/termcolors.ts`.
- **`stdlib/chart.agency`** — the `std::chart` module: `barChart(...)` with both the data-param form (LLM-callable) and the block form (`as ch { ch.key(...); ch.bar(...) }`), plus an in-function docstring with `@param` lines for PFA-aware tool descriptions.
- Wiring: `barchart` added to the `NodeType` union and `HANDLERS`; chart helpers exposed on `_internal`.

### Render assembly (declarative)

The renderer keeps the chart-specific math in small pure helpers (`barCells`, `baselineColumn`, `stackSegments`, `drawBar`, `drawStack`) and assembles the chart by mapping data into rows, then combining three column `Block`s via the existing `pad`/`beside`/`above` algebra — the same approach `composeRow`/`composeTable` use, rather than hand-rolling padding.

### Notable fix along the way

The block builder exposed a runtime quirk: Agency leaves omitted optional params (e.g. `color`/`symbol` in `ch.key("web")`) as an internal sentinel rather than the declared `""` default, which is invisible to `printJSON` but a non-string in memory. The renderer now treats only a non-empty **string** as an explicit color/symbol and auto-assigns otherwise, so the block and data forms render identically. (No `render` re-export from `std::chart` — consumers import `render` from `std::layout`, since the re-export-above-`@module` fix isn't on `main` yet.)

### Verification

- **TS unit + render tests** (`barchart.test.ts`, 16): scaling, baseline, largest-remainder sum, color/symbol auto-assignment, legend, error cases (length mismatch, mixed-sign stack), and `_render` smoke tests. Full layout suite stays green (**200 passed**).
- **Agency execution test** (`tests/agency/chart/basic.agency`): block form and data-param form produce **byte-identical** output (2/2 exact-match).
- `tsc --noEmit`, `lint:structure`, and `make doc` (adds `chart.md`) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
