### PR TITLE
Add std::syntax diff and patch functions; remove std::fs::printDiff

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -19,9 +19,6 @@
 - `std::args` for parsing command-line args.
 - `std::skills` understands the standard SKILL.md format.
 - Eval helpers (`evalJudge`, `evalExtract`), a `StatelogParser`, and `runAgencyAgent()` for running the built-in agents.
-- `std::syntax::diff(old, new, ...)` returns a flexible human-readable diff string (line numbers, context, color, labels, hunk headers, summary, ignore-whitespace).
-- `std::syntax::patch(old, new, filename, ...)` returns a standard unified diff that `std::fs::applyPatch` can apply (supports file creation, deletion, and renames).
-- Removed `std::fs::printDiff`; use `print(diff(old, new, colored: true))` instead.
 
 ### Agency Agent
 - Re-architected from a handoff model to a coordinator pattern.

--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -19,6 +19,9 @@
 - `std::args` for parsing command-line args.
 - `std::skills` understands the standard SKILL.md format.
 - Eval helpers (`evalJudge`, `evalExtract`), a `StatelogParser`, and `runAgencyAgent()` for running the built-in agents.
+- `std::syntax::diff(old, new, ...)` returns a flexible human-readable diff string (line numbers, context, color, labels, hunk headers, summary, ignore-whitespace).
+- `std::syntax::patch(old, new, filename, ...)` returns a standard unified diff that `std::fs::applyPatch` can apply (supports file creation, deletion, and renames).
+- Removed `std::fs::printDiff`; use `print(diff(old, new, colored: true))` instead.
 
 ### Agency Agent
 - Re-architected from a handoff model to a coordinator pattern.

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -45,7 +45,7 @@ export type Workspace = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L126))
 
 ## Functions
 
@@ -79,29 +79,6 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L16))
 
-### printDiff
-
-```ts
-printDiff(oldText: string, newText: string)
-```
-
-Print a colored, line-based diff of `oldText` vs `newText` to stdout.
-  Deletions are shown in red with a `-` prefix, insertions in green
-  with a `+` prefix, unchanged context is dimmed. Useful for showing
-  what an edit actually changed before / after committing it.
-
-  @param oldText - The original text
-  @param newText - The replacement text
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| oldText | `string` |  |
-| newText | `string` |  |
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L37))
-
 ### applyPatch
 
 ```ts
@@ -124,7 +101,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L42))
 
 ### mkdir
 
@@ -148,7 +125,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L56))
 
 ### copy
 
@@ -174,7 +151,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L70))
 
 ### move
 
@@ -200,7 +177,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L86))
 
 ### remove
 
@@ -224,7 +201,7 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L115))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L102))
 
 ### openDir
 
@@ -276,4 +253,4 @@ Build a Workspace anchored at `dir` — a bundle of file-system tools
 
 **Returns:** [Workspace](#workspace)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L142))

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -45,24 +45,25 @@ export type Workspace = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L129))
 
 ## Functions
 
 ### edit
 
 ```ts
-edit(filename: string, edits: Edit[], dir: string, printDiff: boolean): Result
+edit(filename: string, edits: Edit[], dir: string): Result
 ```
 
 Edit a single file by applying one or more text replacements atomically. Each edit has `oldText`, `newText`, and `replaceAll`. Every edit's `oldText` must match a unique, non-overlapping region of the original file (matches are looked up against the file as it stands when the edit runs, after earlier edits). Set `replaceAll: true` on an edit to replace every occurrence. When any edit fails, nothing is written.
 
   Prefer one `edit` call with multiple entries over many `edit` calls. Keep each `oldText` as small as possible while still being unique — do not pad with unchanged context just to connect distant changes; instead, split them into separate entries in the same `edits` array.
 
+  The `std::edit` interrupt carries the full `before` and `after` file contents in its data, so a handler can render a diff itself (e.g. `print(diff(data.before, data.after, color: true))`).
+
   @param filename - The file to edit
   @param edits - Array of edit objects with oldText, newText, replaceAll
   @param dir - The directory to resolve the filename against (defaults to ".")
-  @param printDiff - When true, print a colored diff to stdout after the edit applies
 
 **Parameters:**
 
@@ -71,7 +72,6 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 | filename | `string` |  |
 | edits | `Edit[]` |  |
 | dir | `string` | "." |
-| printDiff | `boolean` | false |
 
 **Returns:** `Result`
 
@@ -101,7 +101,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L45))
 
 ### mkdir
 
@@ -125,7 +125,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L59))
 
 ### copy
 
@@ -151,7 +151,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L73))
 
 ### move
 
@@ -177,7 +177,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L89))
 
 ### remove
 
@@ -201,7 +201,7 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L105))
 
 ### openDir
 
@@ -253,4 +253,4 @@ Build a Workspace anchored at `dir` — a bundle of file-system tools
 
 **Returns:** [Workspace](#workspace)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L142))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L145))

--- a/packages/agency-lang/docs/site/stdlib/syntax.md
+++ b/packages/agency-lang/docs/site/stdlib/syntax.md
@@ -43,18 +43,18 @@ A tool for syntax highlighting code snippets. Specify the programming language f
 ### diff
 
 ```ts
-diff(oldText: string, newText: string, context: number, lineNumbers: boolean, colored: boolean, oldLabel: string, newLabel: string, ignoreWhitespace: boolean, hunkHeaders: boolean, summary: boolean): string
+diff(oldText: string, newText: string, context: number, lineNumbers: boolean, color: "auto" | boolean, oldLabel: string, newLabel: string, ignoreWhitespace: boolean, hunkHeaders: boolean, summary: boolean): string
 ```
 
 Produce a human-readable diff of two strings and return it as a string.
-  By default returns a plain (uncolored) inline diff showing the full text
-  with changed words highlighted via `-`/`+` lines.
+  Shows the full text by default with changed words highlighted via `-`/`+`
+  lines.
 
   @param oldText - The original text
   @param newText - The updated text
   @param context - Unchanged lines to keep around each change; -1 means show the full text
   @param lineNumbers - Prefix each line with its line number
-  @param colored - Emit ANSI colors (red deletions, green insertions) with inline word highlighting
+  @param color - `"auto"` (default) emits ANSI colors only when stdout is a TTY; `true` always; `false` never. Coloring highlights deletions in red and insertions in green inline.
   @param oldLabel - When non-empty, render a `--- <oldLabel>` header
   @param newLabel - When non-empty, render a `+++ <newLabel>` header
   @param ignoreWhitespace - Treat whitespace-only changes as equal
@@ -69,7 +69,7 @@ Produce a human-readable diff of two strings and return it as a string.
 | newText | `string` |  |
 | context | `number` | -1 |
 | lineNumbers | `boolean` | false |
-| colored | `boolean` | false |
+| color | `"auto" \| boolean` | "auto" |
 | oldLabel | `string` | "" |
 | newLabel | `string` | "" |
 | ignoreWhitespace | `boolean` | false |

--- a/packages/agency-lang/docs/site/stdlib/syntax.md
+++ b/packages/agency-lang/docs/site/stdlib/syntax.md
@@ -12,7 +12,7 @@ name: "syntax"
 export type HighlightMode = "shell" | "web"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/syntax.agency#L5))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/syntax.agency#L7))
 
 ## Functions
 
@@ -38,4 +38,77 @@ A tool for syntax highlighting code snippets. Specify the programming language f
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/syntax.agency#L7))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/syntax.agency#L9))
+
+### diff
+
+```ts
+diff(oldText: string, newText: string, context: number, lineNumbers: boolean, colored: boolean, oldLabel: string, newLabel: string, ignoreWhitespace: boolean, hunkHeaders: boolean, summary: boolean): string
+```
+
+Produce a human-readable diff of two strings and return it as a string.
+  By default returns a plain (uncolored) inline diff showing the full text
+  with changed words highlighted via `-`/`+` lines.
+
+  @param oldText - The original text
+  @param newText - The updated text
+  @param context - Unchanged lines to keep around each change; -1 means show the full text
+  @param lineNumbers - Prefix each line with its line number
+  @param colored - Emit ANSI colors (red deletions, green insertions) with inline word highlighting
+  @param oldLabel - When non-empty, render a `--- <oldLabel>` header
+  @param newLabel - When non-empty, render a `+++ <newLabel>` header
+  @param ignoreWhitespace - Treat whitespace-only changes as equal
+  @param hunkHeaders - Emit `@@ -l,c +l,c @@` separators between change regions
+  @param summary - Prefix the diff with an "N insertions, M deletions" line
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| oldText | `string` |  |
+| newText | `string` |  |
+| context | `number` | -1 |
+| lineNumbers | `boolean` | false |
+| colored | `boolean` | false |
+| oldLabel | `string` | "" |
+| newLabel | `string` | "" |
+| ignoreWhitespace | `boolean` | false |
+| hunkHeaders | `boolean` | false |
+| summary | `boolean` | false |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/syntax.agency#L24))
+
+### patch
+
+```ts
+patch(oldText: string, newText: string, filename: string, context: number, ignoreWhitespace: boolean, newFilename: string): string
+```
+
+Produce a standard unified diff that std::fs::applyPatch (or `git apply`)
+  can apply, and return it as a string. Pass the file's path as `filename`;
+  an empty `oldText` produces a file-creation patch and an empty `newText`
+  a deletion patch.
+
+  @param oldText - The original file contents
+  @param newText - The updated file contents
+  @param filename - The path used in the patch headers (the `a/` and `b/` sides)
+  @param context - Context lines to include around each hunk
+  @param ignoreWhitespace - Treat whitespace-only changes as equal
+  @param newFilename - When non-empty, use this path for the new (`+++`) side, e.g. to record a rename
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| oldText | `string` |  |
+| newText | `string` |  |
+| filename | `string` |  |
+| context | `number` | 3 |
+| ignoreWhitespace | `boolean` | false |
+| newFilename | `string` | "" |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/syntax.agency#L55))

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-13-stdlib-diff-and-patch.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-13-stdlib-diff-and-patch.md
@@ -1,0 +1,954 @@
+# std::syntax `diff` and `patch` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two pure, string-returning stdlib functions — `diff` (flexible human-readable diff) and `patch` (applicable unified diff) — to `std::syntax`, sharing one hunk/context engine; delete the old `std::fs::printDiff` tool.
+
+**Architecture:** `lib/utils/diff.ts` becomes a three-layer engine: `computeHunks(old, new, context, ignoreWhitespace)` → structured hunks; `renderDiff(hunks, opts)` → human display (color, inline word-highlight, per-side line numbers, labels, hunk headers, summary); `renderPatch(hunks, oldLabel, newLabel)` → standard unified diff. `formatDiff` stays as a thin back-compat shim. TS shims `_diff`/`_patch` in `lib/stdlib/syntax.ts` are wrapped by Agency `diff`/`patch` in `stdlib/syntax.agency`. `std::fs::printDiff` and its `_printDiff` helper are deleted; `_multiedit` prints via the shared engine.
+
+**Tech Stack:** TypeScript, `diff-match-patch` (already a dependency), Agency stdlib, vitest (unit), Agency execution tests (`tests/agency/`), Agency-js tests (`tests/agency-js/`).
+
+**Spec:** `docs/superpowers/specs/2026-06-13-stdlib-diff-and-patch-design.md`
+
+---
+
+## Background the engineer needs
+
+- **Agency stdlib layout.** `.agency` files in `stdlib/` are thin wrappers that import TS helpers from `agency-lang/stdlib-lib/<file>.js`, which resolves (via `package.json` `exports`) to `dist/lib/stdlib/<file>.js`, compiled from `lib/stdlib/<file>.ts`. So: write TS helpers in `lib/stdlib/syntax.ts`, expose them in `stdlib/syntax.agency`.
+- **Building.** After changing TS (`lib/...`) or stdlib `.agency` files, run `make` from `packages/agency-lang/` (it runs `pnpm run build` → tsc to `dist/`, then `make stdlib` compiles `stdlib/*.agency`, then `make doc` regenerates `docs/site/stdlib/`). For TS-only unit tests you can `pnpm run build` then `pnpm test:run`, but the Agency tests need the full `make`.
+- **Unit tests** run with `pnpm test:run <path>` (vitest).
+- **Agency execution tests** live in `tests/agency/<name>.agency` + `tests/agency/<name>.test.json` and run with `pnpm run a test tests/agency/<name>.test.json`. They need NO LLM for pure logic. `expectedOutput` is the JSON-stringified return value (a string return `"hi"` is written as `"\"hi\""`).
+- **Agency-js tests** live in `tests/agency-js/stdlib/<name>/` with `agent.agency`, `test.js` (Node harness; sets up fs, imports the compiled `agent.js`, writes `__result.json`), and `fixture.json` (expected `__result.json`). Run with `pnpm run a test js tests/agency-js/stdlib/<name>`.
+- **Color.** Use `color` from `lib/utils/termcolors.ts` (red/green/dim/cyan), never raw ANSI.
+- **Git.** Commit messages with apostrophes must be passed via a file (`git commit -F msgfile`), not inline. End commit messages with the `Co-Authored-By` trailer. Do not amend or force-push.
+
+---
+
+## File Structure
+
+- **Modify** `lib/utils/diff.ts` — the engine. Adds `computeHunks`, `renderDiff`, `renderPatch`, supporting types; `formatDiff` becomes a shim.
+- **Modify** `lib/utils/diff.test.ts` — unit tests for the new surface (plus the existing back-compat tests stay).
+- **Modify** `lib/stdlib/syntax.ts` — add `_diff`, `_patch` exports.
+- **Modify** `stdlib/syntax.agency` — add `diff`, `patch` Agency wrappers.
+- **Modify** `lib/stdlib/fs.ts` — delete `_printDiff`; `_multiedit` prints via `computeHunks`+`renderDiff`.
+- **Modify** `stdlib/fs.agency` — delete the `printDiff` tool; drop `_printDiff` from the import.
+- **Create** `tests/agency/diff-and-patch.agency` + `tests/agency/diff-and-patch.test.json` — pure execution test of `diff`/`patch` output strings.
+- **Create** `tests/agency-js/stdlib/std-syntax-patch-roundtrip/agent.agency`, `test.js`, `fixture.json` — `applyPatch(patch(...))` round-trip.
+- **Modify** `CHANGELOG.md` — note the new functions and the `printDiff` removal.
+- **Regenerated (do not hand-edit)** `docs/site/stdlib/*.md`, `dist/**`, `stdlib/*.js` — produced by `make`.
+
+---
+
+## Task 1: Refactor `diff.ts` into computeHunks / renderDiff / renderPatch
+
+This is a refactor: the engine gains structure and the new render functions, while `formatDiff`'s output is unchanged. The safety gate is that **all existing tests stay green** (the `formatDiff` callers in the optimizer, test runner, and sourceMutator must see identical output).
+
+**Files:**
+- Modify: `lib/utils/diff.ts` (replace entire file)
+
+- [ ] **Step 1: Replace `lib/utils/diff.ts` with the engine**
+
+```ts
+import DiffMatchPatch from "diff-match-patch";
+import { color } from "./termcolors.js";
+
+const DIFF_DELETE = -1;
+const DIFF_INSERT = 1;
+const DIFF_EQUAL = 0;
+
+const dmp = new DiffMatchPatch();
+
+type Diff = [number, string];
+
+export type DiffLine = {
+  kind: "context" | "delete" | "insert";
+  text: string;
+  oldNo: number | null;
+  newNo: number | null;
+};
+
+export type Hunk = {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: DiffLine[];
+};
+
+export type RenderDiffOpts = {
+  lineNumbers?: boolean;
+  colored?: boolean;
+  oldLabel?: string;
+  newLabel?: string;
+  hunkHeaders?: boolean;
+  summary?: boolean;
+};
+
+// Collapse runs of whitespace and trim, for comparison only (the original
+// line text is preserved for rendering).
+function normalizeLine(line: string): string {
+  return line.replace(/\s+/g, " ").trim();
+}
+
+// "" is zero lines; otherwise split on newline, KEEPING a trailing empty
+// element so a trailing newline survives a patch round-trip.
+function splitTextLines(text: string): string[] {
+  return text === "" ? [] : text.split("\n");
+}
+
+// Encode each unique line as a single char so diff_main runs at line
+// granularity. Caps at ~65k unique lines, plenty for stdlib diffs.
+function encodeLines(lines: string[], map: Map<string, number>, arr: string[]): string {
+  let s = "";
+  for (const line of lines) {
+    let idx = map.get(line);
+    if (idx === undefined) {
+      idx = arr.length;
+      arr.push(line);
+      map.set(line, idx);
+    }
+    s += String.fromCharCode(idx);
+  }
+  return s;
+}
+
+// Flat, line-by-line diff with old/new line numbers attached.
+function diffLines(oldText: string, newText: string, ignoreWhitespace: boolean): DiffLine[] {
+  const oldLines = splitTextLines(oldText);
+  const newLines = splitTextLines(newText);
+  const key = ignoreWhitespace ? normalizeLine : (s: string) => s;
+
+  const map = new Map<string, number>();
+  const arr: string[] = [];
+  const enc1 = encodeLines(oldLines.map(key), map, arr);
+  const enc2 = encodeLines(newLines.map(key), map, arr);
+  const diffs = dmp.diff_main(enc1, enc2, false) as Diff[];
+
+  const out: DiffLine[] = [];
+  let oi = 0;
+  let ni = 0;
+  for (const [op, chunk] of diffs) {
+    for (let k = 0; k < chunk.length; k++) {
+      if (op === DIFF_EQUAL) {
+        out.push({ kind: "context", text: newLines[ni], oldNo: oi + 1, newNo: ni + 1 });
+        oi++;
+        ni++;
+      } else if (op === DIFF_DELETE) {
+        out.push({ kind: "delete", text: oldLines[oi], oldNo: oi + 1, newNo: null });
+        oi++;
+      } else {
+        out.push({ kind: "insert", text: newLines[ni], oldNo: null, newNo: ni + 1 });
+        ni++;
+      }
+    }
+  }
+  return out;
+}
+
+function makeHunk(lines: DiffLine[]): Hunk {
+  const oldNos = lines.filter((l) => l.oldNo !== null).map((l) => l.oldNo as number);
+  const newNos = lines.filter((l) => l.newNo !== null).map((l) => l.newNo as number);
+  return {
+    oldStart: oldNos.length ? oldNos[0] : 0,
+    oldLines: oldNos.length,
+    newStart: newNos.length ? newNos[0] : 0,
+    newLines: newNos.length,
+    lines,
+  };
+}
+
+/**
+ * Compute a line-level diff grouped into hunks.
+ * `context < 0` -> one hunk spanning everything (full context).
+ * `context >= 0` -> keep only changed lines plus `context` unchanged lines on
+ * each side; runs separated by more than 2*context unchanged lines split into
+ * separate hunks.
+ */
+export function computeHunks(
+  oldText: string,
+  newText: string,
+  context: number,
+  ignoreWhitespace: boolean,
+): Hunk[] {
+  const lines = diffLines(oldText, newText, ignoreWhitespace);
+  if (lines.length === 0) return [];
+  if (context < 0) return [makeHunk(lines)];
+
+  const include: boolean[] = new Array(lines.length).fill(false);
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].kind !== "context") {
+      const lo = Math.max(0, i - context);
+      const hi = Math.min(lines.length - 1, i + context);
+      for (let j = lo; j <= hi; j++) include[j] = true;
+    }
+  }
+
+  const hunks: Hunk[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (!include[i]) {
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < lines.length && include[j]) j++;
+    hunks.push(makeHunk(lines.slice(i, j)));
+    i = j;
+  }
+  return hunks;
+}
+
+// Render one side of a replacement with the changed words highlighted.
+function highlightLine(oldLine: string, newLine: string, side: number): string {
+  const prefix = side === DIFF_DELETE ? "- " : "+ ";
+  const sideColor = side === DIFF_DELETE ? color.red : color.green;
+  const wordDiffs = dmp.diff_main(oldLine, newLine) as Diff[];
+  dmp.diff_cleanupSemantic(wordDiffs);
+
+  let body = "";
+  for (const [op, text] of wordDiffs) {
+    if (op === DIFF_EQUAL) body += color.dim(text);
+    else if (op === side) body += sideColor(text);
+  }
+  return sideColor(prefix) + body;
+}
+
+function renderReplacement(
+  dels: DiffLine[],
+  inss: DiffLine[],
+  out: string[],
+  colored: boolean,
+  gutter: (l: DiffLine) => string,
+): void {
+  const paired = Math.min(dels.length, inss.length);
+  for (let k = 0; k < dels.length; k++) {
+    const body =
+      colored && k < paired
+        ? highlightLine(dels[k].text, inss[k].text, DIFF_DELETE)
+        : colored
+          ? color.red(`- ${dels[k].text}`)
+          : `- ${dels[k].text}`;
+    out.push(gutter(dels[k]) + body);
+  }
+  for (let k = 0; k < inss.length; k++) {
+    const body =
+      colored && k < paired
+        ? highlightLine(dels[k].text, inss[k].text, DIFF_INSERT)
+        : colored
+          ? color.green(`+ ${inss[k].text}`)
+          : `+ ${inss[k].text}`;
+    out.push(gutter(inss[k]) + body);
+  }
+}
+
+function renderHunkBody(
+  lines: DiffLine[],
+  out: string[],
+  colored: boolean,
+  gutter: (l: DiffLine) => string,
+): void {
+  const paint = (fn: (t: string) => string, t: string) => (colored ? fn(t) : t);
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.kind === "context") {
+      out.push(gutter(line) + paint(color.dim, `  ${line.text}`));
+      i++;
+    } else if (line.kind === "delete") {
+      let d = i;
+      while (d < lines.length && lines[d].kind === "delete") d++;
+      let n = d;
+      while (n < lines.length && lines[n].kind === "insert") n++;
+      renderReplacement(lines.slice(i, d), lines.slice(d, n), out, colored, gutter);
+      i = n;
+    } else {
+      out.push(gutter(line) + paint(color.green, `+ ${line.text}`));
+      i++;
+    }
+  }
+}
+
+function gutterWidth(hunks: Hunk[]): number {
+  let max = 0;
+  for (const h of hunks)
+    for (const l of h.lines) {
+      const n = l.kind === "delete" ? l.oldNo : l.newNo;
+      if (n !== null) max = Math.max(max, n);
+    }
+  return String(max).length;
+}
+
+/** Render hunks as a human-readable diff string. */
+export function renderDiff(hunks: Hunk[], opts: RenderDiffOpts = {}): string {
+  const colored = opts.colored ?? false;
+  const paint = (fn: (t: string) => string, t: string) => (colored ? fn(t) : t);
+  const out: string[] = [];
+
+  if (opts.summary) {
+    let ins = 0;
+    let del = 0;
+    for (const h of hunks)
+      for (const l of h.lines) {
+        if (l.kind === "insert") ins++;
+        else if (l.kind === "delete") del++;
+      }
+    out.push(`${ins} insertion${ins === 1 ? "" : "s"}, ${del} deletion${del === 1 ? "" : "s"}`);
+  }
+  if (opts.oldLabel) out.push(paint(color.red, `--- ${opts.oldLabel}`));
+  if (opts.newLabel) out.push(paint(color.green, `+++ ${opts.newLabel}`));
+
+  const width = opts.lineNumbers ? gutterWidth(hunks) : 0;
+  const gutter = (l: DiffLine): string => {
+    if (!opts.lineNumbers) return "";
+    const n = l.kind === "delete" ? l.oldNo : l.newNo;
+    return `${(n === null ? "" : String(n)).padStart(width)} `;
+  };
+
+  for (const h of hunks) {
+    if (opts.hunkHeaders) {
+      out.push(paint(color.cyan, `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`));
+    }
+    renderHunkBody(h.lines, out, colored, gutter);
+  }
+  return out.join("\n");
+}
+
+/** Render hunks as a standard unified diff that std::fs::applyPatch can apply. */
+export function renderPatch(hunks: Hunk[], oldLabel: string, newLabel: string): string {
+  if (hunks.length === 0) return "";
+  const out: string[] = [`--- ${oldLabel}`, `+++ ${newLabel}`];
+  for (const h of hunks) {
+    out.push(`@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`);
+    for (const l of h.lines) {
+      if (l.kind === "context") out.push(` ${l.text}`);
+      else if (l.kind === "delete") out.push(`-${l.text}`);
+      else out.push(`+${l.text}`);
+    }
+  }
+  return out.join("\n") + "\n";
+}
+
+/**
+ * Back-compat shim: full-context, colored-by-default inline diff. Existing
+ * callers (optimizer reporter, test runner, sourceMutator) rely on this exact
+ * output, so it must not change.
+ */
+export function formatDiff(
+  expected: string,
+  actual: string,
+  opts: { colorize?: boolean } = {},
+): string {
+  const hunks = computeHunks(expected, actual, -1, false);
+  return renderDiff(hunks, { colored: opts.colorize ?? true });
+}
+```
+
+- [ ] **Step 2: Run the existing diff unit tests (back-compat gate)**
+
+Run: `pnpm test:run lib/utils/diff.test.ts`
+Expected: PASS (all the existing tests written earlier still green — the shim reproduces the old output).
+
+- [ ] **Step 3: Run the downstream callers' tests (no-regression gate)**
+
+Run: `pnpm test:run lib/optimize/reporter.test.ts lib/optimize/sourceMutator.test.ts lib/optimize/artifacts.test.ts`
+Expected: PASS. These exercise `formatDiff` via the optimizer; identical output means no regression.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm run typecheck`
+Expected: exit 0, no `error TS`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/utils/diff.ts
+git commit -F /tmp/diff-task1.txt   # message file with the Co-Authored-By trailer
+```
+
+Message body: `Refactor diff.ts into computeHunks/renderDiff/renderPatch engine`.
+
+---
+
+## Task 2: Unit tests for the new `diff` display features
+
+Adds characterization tests for context windowing, per-side line numbers, hunk headers, labels, summary, and ignoreWhitespace. (Task 1 already implemented these; this task pins their behavior.)
+
+**Files:**
+- Modify: `lib/utils/diff.test.ts` (append a new `describe` block)
+- Test: `lib/utils/diff.test.ts`
+
+- [ ] **Step 1: Append the new tests**
+
+First, extend the existing top-of-file import so the engine functions are in scope (the current first import is `import { formatDiff } from "./diff.js";`):
+
+```ts
+import { formatDiff, computeHunks, renderDiff, renderPatch } from "./diff.js";
+```
+
+Then add this block at the end of `lib/utils/diff.test.ts` (the `strip` helper already exists at the top of the file from earlier work):
+
+```ts
+describe("renderDiff options", () => {
+  const OLD = "a\nb\nc\nd\ne\nf\ng";
+  const NEW = "a\nb\nc\nD\ne\nf\ng";
+
+  it("limits context and emits separate hunks", () => {
+    const hunks = computeHunks(OLD, NEW, 1, false);
+    const result = renderDiff(hunks, {});
+    // 1 line of context each side of the change to line 4 ("c","D"/"d","e")
+    expect(strip(result)).toBe("  c\n- d\n+ D\n  e");
+  });
+
+  it("renders per-side line numbers (old on delete, new elsewhere)", () => {
+    const hunks = computeHunks("one\ntwo\nthree", "one\nTWO\nthree", -1, false);
+    const result = renderDiff(hunks, { lineNumbers: true });
+    expect(strip(result)).toBe("1   one\n2 - two\n2 + TWO\n3   three");
+  });
+
+  it("emits hunk headers", () => {
+    const hunks = computeHunks("one\ntwo\nthree", "one\nTWO\nthree", 1, false);
+    const result = renderDiff(hunks, { hunkHeaders: true });
+    expect(strip(result)).toContain("@@ -1,3 +1,3 @@");
+  });
+
+  it("renders labels", () => {
+    const hunks = computeHunks("x", "y", -1, false);
+    const result = renderDiff(hunks, { oldLabel: "a.txt", newLabel: "b.txt" });
+    expect(strip(result)).toContain("--- a.txt");
+    expect(strip(result)).toContain("+++ b.txt");
+  });
+
+  it("renders a summary line", () => {
+    const hunks = computeHunks("one\ntwo", "one\nTWO\nthree", -1, false);
+    const result = renderDiff(hunks, { summary: true });
+    expect(strip(result).split("\n")[0]).toBe("2 insertions, 1 deletion");
+  });
+
+  it("ignores whitespace-only changes when asked", () => {
+    const hunks = computeHunks("a   b", "a b", -1, true);
+    // normalized equal -> single context line, no -/+ markers
+    const result = renderDiff(hunks, {});
+    expect(strip(result)).not.toContain("- ");
+    expect(strip(result)).not.toContain("+ ");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pnpm test:run lib/utils/diff.test.ts`
+Expected: PASS (existing + new blocks).
+
+Note: if `limits context` fails on the exact hunk boundary, print the actual value and adjust the expectation to the produced window — the assertion encodes context=1 around the single change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/utils/diff.test.ts
+git commit -F /tmp/diff-task2.txt
+```
+
+Message body: `Add unit tests for diff display options`.
+
+---
+
+## Task 3: Unit tests for `renderPatch`
+
+**Files:**
+- Modify: `lib/utils/diff.test.ts` (append a `renderPatch` describe block)
+- Test: `lib/utils/diff.test.ts`
+
+- [ ] **Step 1: Append the patch tests**
+
+```ts
+describe("renderPatch", () => {
+  it("produces an applicable unified-diff body for a modification", () => {
+    const hunks = computeHunks("one\ntwo\nthree\n", "one\nTWO\nthree\n", 3, false);
+    const patch = renderPatch(hunks, "a/f.txt", "b/f.txt");
+    expect(patch.startsWith("--- a/f.txt\n+++ b/f.txt\n")).toBe(true);
+    expect(patch).toContain("@@ -1");
+    expect(patch).toContain("\n one");
+    expect(patch).toContain("\n-two");
+    expect(patch).toContain("\n+TWO");
+    expect(patch.endsWith("\n")).toBe(true);
+    // No ANSI, no two-space display prefixes.
+    expect(patch).not.toContain("\x1b");
+  });
+
+  it("uses /dev/null for new and deleted files", () => {
+    const created = renderPatch(computeHunks("", "hello\nworld", 3, false), "/dev/null", "b/new.txt");
+    expect(created).toContain("--- /dev/null");
+    expect(created).toContain("@@ -0,0 +1");
+    expect(created).toContain("+hello");
+
+    const deleted = renderPatch(computeHunks("bye\n", "", 3, false), "a/old.txt", "/dev/null");
+    expect(deleted).toContain("+++ /dev/null");
+    expect(deleted).toContain("-bye");
+  });
+
+  it("supports renames via differing labels", () => {
+    const patch = renderPatch(computeHunks("x\n", "y\n", 3, false), "a/old.txt", "b/new.txt");
+    expect(patch).toContain("--- a/old.txt");
+    expect(patch).toContain("+++ b/new.txt");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pnpm test:run lib/utils/diff.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/utils/diff.test.ts
+git commit -F /tmp/diff-task3.txt
+```
+
+Message body: `Add unit tests for renderPatch`.
+
+---
+
+## Task 4: Expose `_diff`/`_patch` TS shims and `diff`/`patch` Agency functions
+
+**Files:**
+- Modify: `lib/stdlib/syntax.ts` (add imports + two exports)
+- Modify: `stdlib/syntax.agency` (add imports + two wrappers)
+
+- [ ] **Step 1: Add the TS shims to `lib/stdlib/syntax.ts`**
+
+At the top of `lib/stdlib/syntax.ts`, add to the imports:
+
+```ts
+import { computeHunks, renderDiff, renderPatch } from "@/utils/diff.js";
+```
+
+At the end of the file, add:
+
+```ts
+export function _diff(
+  oldText: string,
+  newText: string,
+  context: number,
+  lineNumbers: boolean,
+  colored: boolean,
+  oldLabel: string,
+  newLabel: string,
+  ignoreWhitespace: boolean,
+  hunkHeaders: boolean,
+  summary: boolean,
+): string {
+  const hunks = computeHunks(oldText, newText, context, ignoreWhitespace);
+  return renderDiff(hunks, {
+    lineNumbers,
+    colored,
+    oldLabel: oldLabel || undefined,
+    newLabel: newLabel || undefined,
+    hunkHeaders,
+    summary,
+  });
+}
+
+export function _patch(
+  oldText: string,
+  newText: string,
+  filename: string,
+  context: number,
+  ignoreWhitespace: boolean,
+  newFilename: string,
+): string {
+  const hunks = computeHunks(oldText, newText, context, ignoreWhitespace);
+  const oldLabel = oldText === "" ? "/dev/null" : `a/${filename}`;
+  const newLabel = newText === "" ? "/dev/null" : `b/${newFilename || filename}`;
+  return renderPatch(hunks, oldLabel, newLabel);
+}
+```
+
+- [ ] **Step 2: Add the Agency wrappers to `stdlib/syntax.agency`**
+
+Change the import block at the top to also pull in the new shims:
+
+```ts
+import {
+  syntaxHighlight as _syntaxHighlight,
+  _diff,
+  _patch,
+ } from "agency-lang/stdlib-lib/syntax.js"
+```
+
+Append these two functions at the end of `stdlib/syntax.agency`:
+
+```ts
+export safe def diff(
+  oldText: string,
+  newText: string,
+  context: number = -1,
+  lineNumbers: boolean = false,
+  colored: boolean = false,
+  oldLabel: string = "",
+  newLabel: string = "",
+  ignoreWhitespace: boolean = false,
+  hunkHeaders: boolean = false,
+  summary: boolean = false,
+): string {
+  """
+  Produce a human-readable diff of two strings and return it as a string.
+  By default returns a plain (uncolored) inline diff showing the full text
+  with changed words highlighted via `-`/`+` lines.
+
+  @param oldText - The original text
+  @param newText - The updated text
+  @param context - Unchanged lines to keep around each change; -1 means show the full text
+  @param lineNumbers - Prefix each line with its line number
+  @param colored - Emit ANSI colors (red deletions, green insertions) with inline word highlighting
+  @param oldLabel - When non-empty, render a `--- <oldLabel>` header
+  @param newLabel - When non-empty, render a `+++ <newLabel>` header
+  @param ignoreWhitespace - Treat whitespace-only changes as equal
+  @param hunkHeaders - Emit `@@ -l,c +l,c @@` separators between change regions
+  @param summary - Prefix the diff with an "N insertions, M deletions" line
+  """
+  return _diff(oldText, newText, context, lineNumbers, colored, oldLabel, newLabel, ignoreWhitespace, hunkHeaders, summary)
+}
+
+export safe def patch(
+  oldText: string,
+  newText: string,
+  filename: string,
+  context: number = 3,
+  ignoreWhitespace: boolean = false,
+  newFilename: string = "",
+): string {
+  """
+  Produce a standard unified diff that std::fs::applyPatch (or `git apply`)
+  can apply, and return it as a string. Pass the file's path as `filename`;
+  an empty `oldText` produces a file-creation patch and an empty `newText`
+  a deletion patch.
+
+  @param oldText - The original file contents
+  @param newText - The updated file contents
+  @param filename - The path used in the patch headers (the `a/` and `b/` sides)
+  @param context - Context lines to include around each hunk
+  @param ignoreWhitespace - Treat whitespace-only changes as equal
+  @param newFilename - When non-empty, use this path for the new (`+++`) side, e.g. to record a rename
+  """
+  return _patch(oldText, newText, filename, context, ignoreWhitespace, newFilename)
+}
+```
+
+- [ ] **Step 3: Build everything**
+
+Run: `make`
+Expected: completes without error (builds TS, compiles `stdlib/`, regenerates docs). This also recompiles `stdlib/syntax.agency` → `stdlib/syntax.js`.
+
+- [ ] **Step 4: Verify named-arg skipping works (the flat-param assumption)**
+
+Create `tests/agency/diff-named-args.agency`:
+
+```ts
+import { diff } from "std::syntax"
+
+node main(): string {
+  // Call diff setting only `colored` by name, skipping the params before it.
+  return diff("a\nb\nc", "a\nB\nc", colored: false)
+}
+```
+
+Create `tests/agency/diff-named-args.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"  a\\n- b\\n+ B\\n  c\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}
+```
+
+Run: `pnpm run a test tests/agency/diff-named-args.test.json`
+Expected: PASS. If it fails because named args cannot skip middle defaults, STOP — the flat-param design needs revisiting (fall back to positional or an options object). Otherwise this confirms the approach.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stdlib/syntax.ts stdlib/syntax.agency stdlib/syntax.js tests/agency/diff-named-args.agency tests/agency/diff-named-args.test.json docs/site/stdlib/syntax.md
+git commit -F /tmp/diff-task4.txt
+```
+
+Message body: `Add diff and patch functions to std::syntax`.
+
+---
+
+## Task 5: Delete `printDiff`; route `_multiedit` through the shared engine
+
+**Files:**
+- Modify: `lib/stdlib/fs.ts:9,13-21,85-86`
+- Modify: `stdlib/fs.agency:1,37-48`
+
+- [ ] **Step 1: Update `lib/stdlib/fs.ts`**
+
+Replace the diff import line (currently `import { formatDiff } from "../utils/diff.js";`) with:
+
+```ts
+import { computeHunks, renderDiff } from "../utils/diff.js";
+```
+
+Delete the `_printDiff` function and its doc comment (the block currently at lines 13–21):
+
+```ts
+// DELETE this whole block:
+/**
+ * Print a colored, line-based diff ...
+ */
+export function _printDiff(oldText: string, newText: string): void {
+  console.log(formatDiff(oldText, newText));
+}
+```
+
+In `_multiedit`, replace the print call (currently lines 85–86):
+
+```ts
+  if (printDiff && original !== contents) {
+    console.log(renderDiff(computeHunks(original, contents, -1, false), { colored: true }));
+  }
+```
+
+- [ ] **Step 2: Update `stdlib/fs.agency`**
+
+Change the import on line 1 to drop `_printDiff`:
+
+```ts
+import { _multiedit, _applyPatch, _mkdir, _copy, _move, _remove } from "agency-lang/stdlib-lib/fs.js"
+```
+
+Delete the entire `printDiff` tool (currently lines 37–48):
+
+```ts
+// DELETE this whole function:
+export safe def printDiff(oldText: string, newText: string) {
+  """ ... """
+  _printDiff(oldText, newText)
+}
+```
+
+Leave `edit`'s `printDiff: boolean` parameter untouched — it is the after-edit display flag, not the deleted tool.
+
+- [ ] **Step 3: Rebuild**
+
+Run: `make`
+Expected: builds cleanly. `stdlib/fs.js` is regenerated without `printDiff`.
+
+- [ ] **Step 4: Run the fs Agency-js tests that exercise edit/printDiff**
+
+Run: `pnpm run a test js tests/agency-js/stdlib/std-fs-edit`
+Expected: PASS — `edit(printDiff: true)` still prints a diff (now via the shared engine). Also run `pnpm run a test js tests/agency-js/stdlib/std-fs-multiedit` and expect PASS.
+
+- [ ] **Step 5: Confirm nothing else imports the deleted symbols**
+
+Run: `grep -rn "_printDiff\|\bprintDiff(" stdlib lib tests --include=*.agency --include=*.ts | grep -v "printDiff: \|printDiff(printDiff\|edit(printDiff"`
+Expected: no matches (the only hits, if any, should be the `edit` flag usages, which are filtered out).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/stdlib/fs.ts stdlib/fs.agency stdlib/fs.js docs/site/stdlib/fs.md
+git commit -F /tmp/diff-task5.txt
+```
+
+Message body: `Delete std::fs::printDiff in favor of print(diff(...))`.
+
+---
+
+## Task 6: Execution tests — `diff`/`patch` output and `applyPatch` round-trip
+
+**Files:**
+- Create: `tests/agency/diff-and-patch.agency`, `tests/agency/diff-and-patch.test.json`
+- Create: `tests/agency-js/stdlib/std-syntax-patch-roundtrip/agent.agency`, `test.js`, `fixture.json`
+
+- [ ] **Step 1: Pure execution test for `patch` output**
+
+Create `tests/agency/diff-and-patch.agency`:
+
+```ts
+import { patch } from "std::syntax"
+
+node main(): string {
+  return patch("one\ntwo\nthree\n", "one\nTWO\nthree\n", "f.txt")
+}
+```
+
+Create `tests/agency/diff-and-patch.test.json` (the expected value is the JSON-stringified unified diff; note the `--- a/f.txt` / `+++ b/f.txt` headers, `@@` hunk header, and trailing newline):
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"--- a/f.txt\\n+++ b/f.txt\\n@@ -1,4 +1,4 @@\\n one\\n-two\\n+TWO\\n three\\n \\n\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}
+```
+
+Run: `pnpm run a test tests/agency/diff-and-patch.test.json`
+Expected: PASS. If the `@@` counts or the trailing ` ` line differ from the literal above, run the agent once (`pnpm run a tests/agency/diff-and-patch.agency`) to capture the exact string and paste it into `expectedOutput` — the round-trip test in the next steps is the real correctness anchor, this one just pins the format.
+
+- [ ] **Step 2: Round-trip agent**
+
+Create `tests/agency-js/stdlib/std-syntax-patch-roundtrip/agent.agency`:
+
+```ts
+import { patch } from "std::syntax"
+import { applyPatch } from "std::fs"
+
+node makePatch(oldText: string, newText: string, filename: string): string {
+  return patch(oldText, newText, filename)
+}
+
+node runApply(p: string): any {
+  handle {
+    const result = applyPatch(p)
+  } with (data) {
+    return approve()
+  }
+  return result
+}
+
+node readBack(filename: string): any {
+  handle {
+    const result = read(filename) catch "error reading file"
+  } with (data) {
+    return approve()
+  }
+  return result
+}
+```
+
+- [ ] **Step 3: Round-trip harness**
+
+Create `tests/agency-js/stdlib/std-syntax-patch-roundtrip/test.js` (modeled on the existing `std-fs-applyPatch/test.js`):
+
+```js
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { makePatch, runApply, readBack } from "./agent.js";
+
+const TMP_REL = "tmp-roundtrip-fixtures";
+const TMP = join(process.cwd(), TMP_REL);
+rmSync(TMP, { recursive: true, force: true });
+mkdirSync(TMP, { recursive: true });
+
+async function roundtrip(oldText, newText, name) {
+  const rel = join(TMP_REL, name);
+  writeFileSync(join(process.cwd(), rel), oldText);
+  const p = (await makePatch(oldText, newText, rel)).data;
+  const applied = await runApply(p);
+  const ok = !(applied.data && applied.data.success === false);
+  const contents = (await readBack(rel)).data;
+  return { ok, matches: contents === newText };
+}
+
+const modify = await roundtrip("one\ntwo\nthree\n", "one\nTWO\nthree\n", "modify.txt");
+const multi = await roundtrip("a\nb\nc\nd\ne\n", "a\nB\nc\nd\nE\n", "multi.txt");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ modify, multi }, null, 2),
+);
+
+rmSync(TMP, { recursive: true, force: true });
+```
+
+- [ ] **Step 4: Expected fixture**
+
+Create `tests/agency-js/stdlib/std-syntax-patch-roundtrip/fixture.json`:
+
+```json
+{
+  "modify": {
+    "ok": true,
+    "matches": true
+  },
+  "multi": {
+    "ok": true,
+    "matches": true
+  }
+}
+```
+
+- [ ] **Step 5: Run the round-trip test**
+
+Run: `pnpm run a test js tests/agency-js/stdlib/std-syntax-patch-roundtrip`
+Expected: PASS — `applyPatch(patch(old, new, file))` reproduces `new` for both single- and multi-hunk cases. If `matches` is false, the likely culprit is trailing-newline handling in `splitTextLines`/`renderPatch`; debug by printing the generated patch and the read-back contents.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/agency/diff-and-patch.agency tests/agency/diff-and-patch.test.json tests/agency-js/stdlib/std-syntax-patch-roundtrip
+git commit -F /tmp/diff-task6.txt
+```
+
+Message body: `Add diff/patch execution tests and applyPatch round-trip`.
+
+---
+
+## Task 7: Docs, changelog, and final verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Regenerated: `docs/site/stdlib/syntax.md`, `docs/site/stdlib/fs.md` (via `make doc`)
+
+- [ ] **Step 1: Regenerate docs and confirm the changes**
+
+Run: `make doc`
+Then: `grep -n "printDiff" docs/site/stdlib/fs.md`
+Expected: the standalone `### printDiff` tool section is gone (only the `edit` `printDiff` parameter row remains). `grep -n "### diff\|### patch" docs/site/stdlib/syntax.md` should show both new sections, generated from the docstrings.
+
+- [ ] **Step 2: Update the changelog**
+
+In `CHANGELOG.md`, under the current unreleased/top section, add:
+
+```markdown
+- `std::syntax::diff(old, new, ...)` returns a flexible human-readable diff string (line numbers, context, color, labels, hunk headers, summary, ignore-whitespace).
+- `std::syntax::patch(old, new, filename, ...)` returns a standard unified diff that `std::fs::applyPatch` can apply (supports file creation, deletion, and renames).
+- Removed `std::fs::printDiff`; use `print(diff(old, new, colored: true))` instead.
+```
+
+- [ ] **Step 3: Full verification of every touched area**
+
+Run: `pnpm test:run lib/utils/diff.test.ts lib/optimize/reporter.test.ts lib/optimize/sourceMutator.test.ts lib/optimize/artifacts.test.ts`
+Expected: PASS.
+
+Run: `pnpm run a test tests/agency/diff-named-args.test.json tests/agency/diff-and-patch.test.json`
+Expected: PASS.
+
+Run: `pnpm run a test js tests/agency-js/stdlib/std-syntax-patch-roundtrip` and `pnpm run a test js tests/agency-js/stdlib/std-fs-edit`
+Expected: PASS.
+
+Run: `pnpm run typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md docs/site/stdlib/syntax.md docs/site/stdlib/fs.md
+git commit -F /tmp/diff-task7.txt
+```
+
+Message body: `Regenerate stdlib docs and changelog for diff/patch`.
+
+---
+
+## Self-Review notes (verified while writing)
+
+- **Spec coverage:** `diff` (all 8 display params) → Tasks 1, 2, 4. `patch` (filename, context, ignoreWhitespace, newFilename, /dev/null) → Tasks 1, 3, 4. Shared engine + `formatDiff` shim → Task 1. `printDiff` deletion + `_multiedit` rewire → Task 5. Round-trip guarantee → Task 6. Docs/changelog → Task 7.
+- **Type consistency:** `computeHunks(old, new, context, ignoreWhitespace)`, `renderDiff(hunks, RenderDiffOpts)`, `renderPatch(hunks, oldLabel, newLabel)`, `DiffLine`, `Hunk` are used identically across Tasks 1, 4, 5.
+- **Sentinels:** `context: -1` = full context; empty-string labels/`newFilename` = unset — consistent between the Agency signature (Task 4), `_diff`/`_patch` (Task 4), and `computeHunks`/`renderDiff` (Task 1).
+- **Known soft spot:** trailing-newline handling in `splitTextLines` is the most likely source of an off-by-one in patch counts or a round-trip mismatch; Task 6 Step 5 calls this out and the round-trip test is the anchor.
+```

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-13-stdlib-diff-and-patch-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-13-stdlib-diff-and-patch-design.md
@@ -1,0 +1,195 @@
+# Design: `diff` and `patch` stdlib functions
+
+Date: 2026-06-13
+Status: Approved (pending spec review)
+
+## Summary
+
+Add two pure, string-returning functions to the `std::syntax` module:
+
+- **`diff(oldText, newText, options)`** — a flexible, human-readable diff
+  renderer (color, inline word-highlighting, per-side line numbers, context
+  windowing, hunk headers, file labels, change summary).
+- **`patch(oldText, newText, filename, options)`** — a standard **unified
+  diff** that `std::fs::applyPatch` (and `git apply`) can apply.
+
+Both sit on a shared line-level diff + hunk/context engine in
+`lib/utils/diff.ts`. The existing `std::fs::printDiff` tool and its
+`_printDiff` helper are **deleted**; callers use `print(diff(...))` instead.
+`edit` is unchanged as the single public file-editing tool.
+
+## Motivation
+
+The current `std::fs::printDiff` only prints a colored, full-context, word-level
+diff to stdout. It is inflexible: you cannot get the diff as a string, limit
+context, add line numbers, label the sides, or produce something a patch tool
+can apply. We want a composable `diff` that returns a string, plus a dedicated
+`patch` for machine-applicable output.
+
+`diff` and `patch` are kept separate on purpose. `applyPatch` parses a standard
+unified diff: `--- a/file` / `+++ b/file` headers, `@@ -l,c +l,c @@` hunk
+headers, and hunk-body lines where context is prefixed by a single space,
+removals by `-`, additions by `+`, with content immediately after the tag
+character. The `diff` display format deliberately differs (two-space context
+prefix, `- `/`+ ` with a trailing space, optional color / word-highlight /
+line-number gutter / summary). Those display features are invalid inside a
+unified diff, so overloading one function to serve both display and patch
+output would let a user silently produce a broken patch. Two functions with one
+shared engine keeps each correct by construction.
+
+## Architecture
+
+### Shared engine (`lib/utils/diff.ts`)
+
+Factor the file into three layers:
+
+1. **`computeHunks(oldText, newText, { context, ignoreWhitespace })`** —
+   computes a line-level diff and groups it into hunks. Returns a structured
+   representation:
+
+   ```ts
+   type DiffLine = { kind: "context" | "delete" | "insert"; text: string; oldNo: number | null; newNo: number | null };
+   type Hunk = { oldStart: number; oldLines: number; newStart: number; newLines: number; lines: DiffLine[] };
+   ```
+
+   - `context` is the number of unchanged lines kept on each side of a change.
+     When omitted (the `diff` default), the whole input is one hunk (full
+     context). When set to `N`, runs of unchanged lines longer than `2N`
+     collapse, splitting output into multiple hunks.
+   - `ignoreWhitespace` normalizes each line (collapse runs of whitespace,
+     trim) for the *comparison* only; the original text is preserved for
+     rendering.
+   - Line-level diffing reuses the existing diff-match-patch line-mode recipe
+     (`diff_linesToChars_` → `diff_main` → `diff_charsToLines_`). No new
+     dependency.
+
+2. **`renderDiff(hunks, opts)`** — human-readable display. Consumes the hunks
+   and applies, per options: per-side line-number gutter, `@@` hunk headers,
+   `---`/`+++` labels, leading summary line, ANSI color, and inline
+   word-highlighting (the existing Option-3 behavior) within replacement line
+   pairs. Word-highlighting only runs when `colored` is true.
+
+3. **`renderPatch(hunks, oldLabel, newLabel)`** — standard unified-diff text:
+   `--- <oldLabel>` / `+++ <newLabel>`, `@@` headers, and ` `/`-`/`+`
+   single-char-prefixed body lines. No color, gutter, word-highlight, or
+   summary.
+
+`formatDiff(oldText, newText, { colorize })` remains as a thin back-compat shim
+over `computeHunks` + `renderDiff` (full context, colored, no gutter/labels) so
+existing callers (`lib/optimize/reporter.ts`, `lib/cli/test.ts`,
+`lib/optimize/sourceMutator.ts`) are untouched and keep their current output.
+
+### TS shims (`lib/stdlib/syntax.ts`)
+
+New file (or new exports) exposing:
+
+```ts
+export function _diff(oldText: string, newText: string, opts: DiffOpts): string;   // computeHunks + renderDiff
+export function _patch(oldText: string, newText: string, filename: string, opts: PatchOpts): string; // computeHunks + renderPatch
+```
+
+`_syntaxHighlight` already lives in the syntax stdlib-lib; `_diff`/`_patch`
+join it.
+
+### Agency wrappers (`stdlib/syntax.agency`)
+
+```ts
+type DiffOptions = {
+  context?: number          # unchanged lines kept around each change; omitted = full context
+  lineNumbers?: boolean     # per-side single-column gutter (default false)
+  colored?: boolean         # ANSI red/green/dim + inline word-highlight (default false)
+  oldLabel?: string         # renders a `--- <oldLabel>` header
+  newLabel?: string         # renders a `+++ <newLabel>` header
+  ignoreWhitespace?: boolean # whitespace-only changes treated as equal (default false)
+  hunkHeaders?: boolean     # `@@ -l,c +l,c @@` separators (default false)
+  summary?: boolean         # leading "N insertions, M deletions" line (default false)
+}
+
+export safe def diff(oldText: string, newText: string, options: DiffOptions = {}): string
+
+type PatchOptions = {
+  context?: number          # context lines per hunk (default 3)
+  ignoreWhitespace?: boolean
+  newFilename?: string      # override the +++ side path (renames); omit when unchanged
+}
+
+export safe def patch(oldText: string, newText: string, filename: string, options: PatchOptions = {}): string
+```
+
+Both are `safe` (pure, no side effects) so they are LLM-callable without an
+approval prompt. Both carry docstrings (which become tool descriptions).
+
+## Behavior details
+
+### `diff`
+
+- **No options** → byte-identical to today's inline `-`/`+` word-highlighted
+  diff at full context. Nothing regresses.
+- **`colored` defaults to `false`.** The return value is data — it may be fed
+  to an LLM or written to a file — so plain text is the safe default. Terminal
+  callers opt into `true`.
+- **Line numbers** use the per-side single-column gutter: a `-` line shows the
+  old number, a `+`/context line shows the new number.
+- **`context: N`** switches to hunk mode (only changes plus N context lines).
+  `hunkHeaders: true` adds `@@` separators between hunks. The two are
+  independent toggles; hunk headers without a context limit yields a single
+  `@@` covering the whole file.
+- **`oldLabel`/`newLabel`** render `---`/`+++` header lines for display only
+  (no `a/`,`b/` prefixing — that is `patch`'s job).
+- **Identical inputs:** at full context, returns the input rendered as all
+  dim context lines (today's behavior). With a `context` limit, returns the
+  empty string (no hunks).
+
+### `patch`
+
+- Emits a standard unified diff: `--- a/<filename>` / `+++ b/<newFilename ??
+  filename>`, `@@` hunk headers, ` `/`-`/`+` body lines.
+- **`context` defaults to 3** (the standard); patches need context to locate
+  hunks.
+- **Empty `oldText`** → `--- /dev/null` (file creation). **Empty `newText`**
+  → `+++ /dev/null` (deletion). Matches what `applyPatch` already parses.
+- **Renames:** `newFilename` overrides the `+++` side path.
+- **Round-trip guarantee:** `applyPatch(patch(old, new, "f.txt"))` reproduces
+  `new`. Enforced by test.
+
+## Switch-over of existing callers
+
+- **`lib/utils/diff.ts`** — `formatDiff` becomes the back-compat shim described
+  above. Existing callers unchanged.
+- **`lib/stdlib/fs.ts`** — delete `_printDiff`. In `_multiedit`, replace the
+  `_printDiff(original, contents)` call (guarded by `printDiff && original !==
+  contents`) with `console.log(renderDiff(computeHunks(original, contents, {}),
+  { colored: true }))` (or a small local helper that mirrors the old look:
+  full context, colored, no gutter).
+- **`stdlib/fs.agency`** — delete the `printDiff` tool and drop `_printDiff`
+  from the import. `edit` keeps its `printDiff: boolean` parameter (the
+  after-edit display flag is unrelated to the deleted tool).
+- **Docs** — regenerate stdlib reference (`agency doc`); remove any guide/doc
+  references to `printDiff`; add `diff`/`patch` reference via their docstrings.
+
+## Testing
+
+Unit tests (`lib/utils/diff.test.ts`, runs under `pnpm test:run`):
+
+- `computeHunks`: context windowing (collapse > 2N), multiple hunks, hunk
+  line-number math, `ignoreWhitespace` comparison.
+- `renderDiff`: no-options back-compat equals current `formatDiff` output;
+  per-side line numbers; `@@` headers; labels; summary; `colored:false` has no
+  ANSI; word-highlight only when colored.
+- `renderPatch`: header/hunk format; `/dev/null` for create and delete;
+  `newFilename` rename; single-char body prefixes.
+- Keep the existing `formatDiff` tests green (back-compat).
+
+Agency execution test (`tests/agency/`, no LLM):
+
+- Calls `std::syntax::diff` and `std::syntax::patch` and asserts on the
+  returned strings.
+- **Round-trip:** `applyPatch(patch(old, new, file))` against a sandbox file
+  reproduces `new` (covers create, modify, delete, rename).
+
+## Out of scope (YAGNI)
+
+- Side-by-side / two-column display format.
+- Multi-file patches in a single `patch` call (one file per call).
+- Tab-width expansion, `--stat`-style histograms, `jsdiff` dependency.
+```

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-13-stdlib-diff-and-patch-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-13-stdlib-diff-and-patch-design.md
@@ -53,9 +53,9 @@ Factor the file into three layers:
    ```
 
    - `context` is the number of unchanged lines kept on each side of a change.
-     When omitted (the `diff` default), the whole input is one hunk (full
-     context). When set to `N`, runs of unchanged lines longer than `2N`
-     collapse, splitting output into multiple hunks.
+     When negative (the `diff` default, `-1`), the whole input is one hunk
+     (full context). When set to `N >= 0`, runs of unchanged lines longer than
+     `2N` collapse, splitting output into multiple hunks.
    - `ignoreWhitespace` normalizes each line (collapse runs of whitespace,
      trim) for the *comparison* only; the original text is preserved for
      rendering.
@@ -84,8 +84,18 @@ existing callers (`lib/optimize/reporter.ts`, `lib/cli/test.ts`,
 New file (or new exports) exposing:
 
 ```ts
-export function _diff(oldText: string, newText: string, opts: DiffOpts): string;   // computeHunks + renderDiff
-export function _patch(oldText: string, newText: string, filename: string, opts: PatchOpts): string; // computeHunks + renderPatch
+// Flat params mirror the Agency signatures (codegen passes named args
+// positionally). `context: -1` means full context.
+export function _diff(
+  oldText: string, newText: string,
+  context: number, lineNumbers: boolean, colored: boolean,
+  oldLabel: string, newLabel: string,
+  ignoreWhitespace: boolean, hunkHeaders: boolean, summary: boolean,
+): string;   // computeHunks + renderDiff
+export function _patch(
+  oldText: string, newText: string, filename: string,
+  context: number, ignoreWhitespace: boolean, newFilename: string,
+): string;   // computeHunks + renderPatch
 ```
 
 `_syntaxHighlight` already lives in the syntax stdlib-lib; `_diff`/`_patch`
@@ -93,37 +103,48 @@ join it.
 
 ### Agency wrappers (`stdlib/syntax.agency`)
 
+Options are flat named parameters (Agency supports named args), not an
+options object:
+
 ```ts
-type DiffOptions = {
-  context?: number          # unchanged lines kept around each change; omitted = full context
-  lineNumbers?: boolean     # per-side single-column gutter (default false)
-  colored?: boolean         # ANSI red/green/dim + inline word-highlight (default false)
-  oldLabel?: string         # renders a `--- <oldLabel>` header
-  newLabel?: string         # renders a `+++ <newLabel>` header
-  ignoreWhitespace?: boolean # whitespace-only changes treated as equal (default false)
-  hunkHeaders?: boolean     # `@@ -l,c +l,c @@` separators (default false)
-  summary?: boolean         # leading "N insertions, M deletions" line (default false)
-}
+export safe def diff(
+  oldText: string,
+  newText: string,
+  context: number = -1,            # unchanged lines kept around each change; -1 = full context
+  lineNumbers: boolean = false,    # per-side single-column gutter
+  colored: boolean = false,        # ANSI red/green/dim + inline word-highlight
+  oldLabel: string = "",           # non-empty renders a `--- <oldLabel>` header
+  newLabel: string = "",           # non-empty renders a `+++ <newLabel>` header
+  ignoreWhitespace: boolean = false, # whitespace-only changes treated as equal
+  hunkHeaders: boolean = false,    # `@@ -l,c +l,c @@` separators
+  summary: boolean = false,        # leading "N insertions, M deletions" line
+): string
 
-export safe def diff(oldText: string, newText: string, options: DiffOptions = {}): string
-
-type PatchOptions = {
-  context?: number          # context lines per hunk (default 3)
-  ignoreWhitespace?: boolean
-  newFilename?: string      # override the +++ side path (renames); omit when unchanged
-}
-
-export safe def patch(oldText: string, newText: string, filename: string, options: PatchOptions = {}): string
+export safe def patch(
+  oldText: string,
+  newText: string,
+  filename: string,
+  context: number = 3,             # context lines per hunk
+  ignoreWhitespace: boolean = false,
+  newFilename: string = "",        # non-empty overrides the +++ side path (renames)
+): string
 ```
+
+Callers set only what they need via named args, e.g.
+`diff(a, b, colored: true)` or `patch(a, b, "f.txt", context: 5)`.
 
 Both are `safe` (pure, no side effects) so they are LLM-callable without an
 approval prompt. Both carry docstrings (which become tool descriptions).
+
+**Sentinel conventions:** `context: -1` (and any negative) means full context.
+Empty-string `oldLabel`/`newLabel`/`newFilename` mean "unset" — no header line
+for `diff`, and `filename` reused for both sides in `patch`.
 
 ## Behavior details
 
 ### `diff`
 
-- **No options** → byte-identical to today's inline `-`/`+` word-highlighted
+- **Defaults only** → byte-identical to today's inline `-`/`+` word-highlighted
   diff at full context. Nothing regresses.
 - **`colored` defaults to `false`.** The return value is data — it may be fed
   to an LLM or written to a file — so plain text is the safe default. Terminal
@@ -173,7 +194,7 @@ Unit tests (`lib/utils/diff.test.ts`, runs under `pnpm test:run`):
 
 - `computeHunks`: context windowing (collapse > 2N), multiple hunks, hunk
   line-number math, `ignoreWhitespace` comparison.
-- `renderDiff`: no-options back-compat equals current `formatDiff` output;
+- `renderDiff`: default-args back-compat equals current `formatDiff` output;
   per-side line numbers; `@@` headers; labels; summary; `colored:false` has no
   ANSI; word-highlight only when colored.
 - `renderPatch`: header/hunk format; `/dev/null` for create and delete;

--- a/packages/agency-lang/foo.agency
+++ b/packages/agency-lang/foo.agency
@@ -4,8 +4,9 @@ type Info = {
 }
 
 node main(): string {
-  optimize const prompt = "What is the capital of France?"
+  const prompt = "What is the capital of France?"
   evalInput(prompt)
+  @optimize(prompt)
   const result: Info = llm(prompt)
   evalOutput(result.capital)
   return result.capital

--- a/packages/agency-lang/foo.agency
+++ b/packages/agency-lang/foo.agency
@@ -4,9 +4,8 @@ type Info = {
 }
 
 node main(): string {
-  const prompt = "What is the capital of France?"
+  optimize const prompt = "What is the capital of France?"
   evalInput(prompt)
-  @optimize(prompt)
   const result: Info = llm(prompt)
   evalOutput(result.capital)
   return result.capital

--- a/packages/agency-lang/lib/optimize/reporter.test.ts
+++ b/packages/agency-lang/lib/optimize/reporter.test.ts
@@ -180,8 +180,12 @@ describe("createOptimizeReporter", () => {
     const text = lines.join("\n");
     expect(text).toContain("Iteration 1/5: accepted (candidate wins 2, champion wins 1, ties 0)");
     expect(text).toContain("~ foo.agency:bar:prompt:");
-    expect(text).toContain(color.red("- xyz"));
-    expect(text).toContain(color.green("+ a better prompt"));
+    // Replacement is rendered whole-line with the changed words highlighted;
+    // the "- "/"+ " prefix and the word are painted separately.
+    expect(text).toContain(color.red("- "));
+    expect(text).toContain(color.red("xyz"));
+    expect(text).toContain(color.green("+ "));
+    expect(text).toContain(color.green("a better prompt"));
     expect(text).toContain("Rationale: Overall clearer.");
   });
 
@@ -246,8 +250,12 @@ describe("createOptimizeReporter", () => {
     const text = lines.join("\n");
     expect(text).toContain("== Optimized variables ==");
     expect(text).toContain("~ foo.agency:bar:prompt:");
-    expect(text).toContain(color.red("- xyz"));
-    expect(text).toContain(color.green("+ a better prompt"));
+    // Replacement is rendered whole-line with the changed words highlighted;
+    // the "- "/"+ " prefix and the word are painted separately.
+    expect(text).toContain(color.red("- "));
+    expect(text).toContain(color.red("xyz"));
+    expect(text).toContain(color.green("+ "));
+    expect(text).toContain(color.green("a better prompt"));
     // The unchanged target shows its (truncated) value dimmed.
     expect(text).toContain("~ foo.agency:global:systemPrompt:");
     expect(text).not.toContain(`- ${"x".repeat(500)}`);

--- a/packages/agency-lang/lib/stdlib/fs.ts
+++ b/packages/agency-lang/lib/stdlib/fs.ts
@@ -6,19 +6,9 @@ import diff_match_patch from "diff-match-patch";
 import { resolvePath } from "./resolvePath.js";
 import { resolveDir } from "./resolveDir.js";
 import { expandPath } from "./expandPath.js";
-import { formatDiff } from "../utils/diff.js";
+import { computeHunks, renderDiff } from "../utils/diff.js";
 
 export { resolvePath } from "./resolvePath.js";
-
-/**
- * Print a colored, line-based diff of `oldText` vs `newText` to
- * stdout. Deletions are red, insertions are green, unchanged context
- * is dimmed. Used both as a standalone Agency tool (`std::fs::printDiff`)
- * and as the side effect of `edit(..., printDiff: true)`.
- */
-export function _printDiff(oldText: string, newText: string): void {
-  console.log(formatDiff(oldText, newText));
-}
 
 export type MultiEdit = {
   oldText: string;
@@ -83,7 +73,7 @@ export async function _multiedit(
 
   await fs.writeFile(full, contents, "utf8");
   if (printDiff && original !== contents) {
-    _printDiff(original, contents);
+    console.log(renderDiff(computeHunks(original, contents, -1, false), { colored: true }));
   }
   return { replacements: total, path: filename, edits: edits.length };
 }

--- a/packages/agency-lang/lib/stdlib/fs.ts
+++ b/packages/agency-lang/lib/stdlib/fs.ts
@@ -6,7 +6,6 @@ import diff_match_patch from "diff-match-patch";
 import { resolvePath } from "./resolvePath.js";
 import { resolveDir } from "./resolveDir.js";
 import { expandPath } from "./expandPath.js";
-import { computeHunks, renderDiff } from "../utils/diff.js";
 
 export { resolvePath } from "./resolvePath.js";
 
@@ -22,17 +21,15 @@ export type MultiEditResult = {
   edits: number;
 };
 
-export async function _multiedit(
-  dir: string,
-  filename: string,
+// Apply the edits to `contents` in memory (no I/O), returning the result and
+// the number of replacements. Throws on a missing or ambiguous match. Shared
+// by `_multiedit` (which writes) and `_previewEdit` (which doesn't).
+function applyEdits(
+  contents: string,
   edits: MultiEdit[],
-  printDiff: boolean = false,
-): Promise<MultiEditResult> {
-  const full = await resolvePath(dir, filename);
-  let contents = await fs.readFile(full, "utf8");
-  const original = contents;
+  filename: string,
+): { contents: string; replacements: number } {
   let total = 0;
-
   for (let i = 0; i < edits.length; i++) {
     const { oldText, newText, replaceAll } = edits[i];
     if (!oldText) {
@@ -70,12 +67,40 @@ export async function _multiedit(
       total += 1;
     }
   }
+  return { contents, replacements: total };
+}
 
-  await fs.writeFile(full, contents, "utf8");
-  if (printDiff && original !== contents) {
-    console.log(renderDiff(computeHunks(original, contents, -1, false), { colored: true }));
+// Compute the before/after contents of an edit without writing. Used to put a
+// preview in the `std::edit` interrupt data so handlers can diff it themselves.
+// Best-effort: a bad path, missing file, or non-matching edit returns empty
+// strings rather than throwing, so the interrupt still fires (and can be
+// rejected). The authoritative validation and erroring happen in `_multiedit`
+// after the interrupt is approved.
+export async function _previewEdit(
+  dir: string,
+  filename: string,
+  edits: MultiEdit[],
+): Promise<{ before: string; after: string }> {
+  try {
+    const full = await resolvePath(dir, filename);
+    const before = await fs.readFile(full, "utf8");
+    const { contents } = applyEdits(before, edits, filename);
+    return { before, after: contents };
+  } catch {
+    return { before: "", after: "" };
   }
-  return { replacements: total, path: filename, edits: edits.length };
+}
+
+export async function _multiedit(
+  dir: string,
+  filename: string,
+  edits: MultiEdit[],
+): Promise<MultiEditResult> {
+  const full = await resolvePath(dir, filename);
+  const original = await fs.readFile(full, "utf8");
+  const { contents, replacements } = applyEdits(original, edits, filename);
+  await fs.writeFile(full, contents, "utf8");
+  return { replacements, path: filename, edits: edits.length };
 }
 
 export type PatchResult = {

--- a/packages/agency-lang/lib/stdlib/layout/render.ts
+++ b/packages/agency-lang/lib/stdlib/layout/render.ts
@@ -17,6 +17,7 @@ import { column, row } from "./axis.js";
 import { table } from "./table.js";
 import { barchart } from "./barchart.js";
 import { NodeHandler, SizingContext } from "./sizing.js";
+import { autoUseColor } from "@/utils/termcolors.js";
 
 export type Viewport = { cols: number; rows: number };
 
@@ -116,27 +117,6 @@ export function render(node: LayoutNode, viewport?: Viewport): string {
   return renderNode(resolved).toString();
 }
 
-// "auto" color resolution follows the de-facto ecosystem convention:
-//   * `NO_COLOR` set (any value)         → disable, no matter what.
-//   * `FORCE_COLOR` set to a truthy value → enable, no matter what.
-//   * otherwise                           → enable iff stdout is a TTY.
-//
-// `process.stdout.isTTY` alone is unreliable when Agency runs through
-// nested spawns (`pnpm run agency …` spawns the CLI which spawns the
-// compiled script); some intermediate hops can drop the TTY flag even
-// when the user is at an interactive terminal. The env-var fallbacks
-// give the user explicit overrides.
-function _autoUseColor(): boolean {
-  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "") {
-    return false;
-  }
-  const force = process.env.FORCE_COLOR;
-  if (force !== undefined && force !== "" && force !== "0" && force !== "false") {
-    return true;
-  }
-  return process.stdout.isTTY === true;
-}
-
 function buildViewport(cols?: number, rows?: number): Viewport | undefined {
   if (cols === undefined || cols <= 0) return undefined;
   const validRows = rows !== undefined && rows > 0 ? rows : DEFAULT_VIEWPORT.rows;
@@ -144,7 +124,7 @@ function buildViewport(cols?: number, rows?: number): Viewport | undefined {
 }
 
 export function _render(node: LayoutNode, color: "auto" | boolean, cols?: number, rows?: number): string {
-  const useColor = color === "auto" ? _autoUseColor() : color === true;
+  const useColor = color === "auto" ? autoUseColor() : color === true;
   const out = render(node, buildViewport(cols, rows));
   return useColor ? out : stripAnsi(out);
 }

--- a/packages/agency-lang/lib/stdlib/syntax.ts
+++ b/packages/agency-lang/lib/stdlib/syntax.ts
@@ -1,5 +1,6 @@
 import { highlight, Theme } from "cli-highlight";
 import { color } from "@/utils/termcolors.js";
+import { computeHunks, renderDiff, renderPatch } from "@/utils/diff.js";
 import { _parseMarkdown, _renderMarkdownForCli } from "./markdown.js";
 import { Block, CodeBlock, List } from "tarsec/parsers/markdown";
 
@@ -157,4 +158,41 @@ function mapMarkdownBlock(block: Block): Block {
     }
   }
   return block;
+}
+
+export function _diff(
+  oldText: string,
+  newText: string,
+  context: number,
+  lineNumbers: boolean,
+  colored: boolean,
+  oldLabel: string,
+  newLabel: string,
+  ignoreWhitespace: boolean,
+  hunkHeaders: boolean,
+  summary: boolean,
+): string {
+  const hunks = computeHunks(oldText, newText, context, ignoreWhitespace);
+  return renderDiff(hunks, {
+    lineNumbers,
+    colored,
+    oldLabel: oldLabel || undefined,
+    newLabel: newLabel || undefined,
+    hunkHeaders,
+    summary,
+  });
+}
+
+export function _patch(
+  oldText: string,
+  newText: string,
+  filename: string,
+  context: number,
+  ignoreWhitespace: boolean,
+  newFilename: string,
+): string {
+  const hunks = computeHunks(oldText, newText, context, ignoreWhitespace);
+  const oldLabel = oldText === "" ? "/dev/null" : `a/${filename}`;
+  const newLabel = newText === "" ? "/dev/null" : `b/${newFilename || filename}`;
+  return renderPatch(hunks, oldLabel, newLabel);
 }

--- a/packages/agency-lang/lib/stdlib/syntax.ts
+++ b/packages/agency-lang/lib/stdlib/syntax.ts
@@ -1,6 +1,7 @@
 import { highlight, Theme } from "cli-highlight";
 import { color } from "@/utils/termcolors.js";
 import { computeHunks, renderDiff, renderPatch } from "@/utils/diff.js";
+import { autoUseColor } from "@/utils/termcolors.js";
 import { _parseMarkdown, _renderMarkdownForCli } from "./markdown.js";
 import { Block, CodeBlock, List } from "tarsec/parsers/markdown";
 
@@ -165,7 +166,7 @@ export function _diff(
   newText: string,
   context: number,
   lineNumbers: boolean,
-  colored: boolean,
+  color: "auto" | boolean,
   oldLabel: string,
   newLabel: string,
   ignoreWhitespace: boolean,
@@ -175,9 +176,9 @@ export function _diff(
   const hunks = computeHunks(oldText, newText, context, ignoreWhitespace);
   return renderDiff(hunks, {
     lineNumbers,
-    colored,
-    oldLabel: oldLabel || undefined,
-    newLabel: newLabel || undefined,
+    colored: color === "auto" ? autoUseColor() : color === true,
+    oldLabel,
+    newLabel,
     hunkHeaders,
     summary,
   });

--- a/packages/agency-lang/lib/utils/diff.test.ts
+++ b/packages/agency-lang/lib/utils/diff.test.ts
@@ -180,4 +180,25 @@ describe("renderPatch", () => {
     expect(patch).toContain("--- a/old.txt");
     expect(patch).toContain("+++ b/new.txt");
   });
+
+  it("anchors an insert-only hunk header to the preceding line (context 0)", () => {
+    // Insert X after line "a"; with context 0 the hunk has no old line of its
+    // own, so oldStart must come from the preceding line, not default to 0.
+    const patch = renderPatch(computeHunks("a\nb\nc", "a\nX\nb\nc", 0, false), "a/f", "b/f");
+    expect(patch).toContain("@@ -1,0 +2,1 @@");
+  });
+
+  it("anchors a delete-only hunk header to the preceding line (context 0)", () => {
+    const patch = renderPatch(computeHunks("a\nb\nc", "a\nc", 0, false), "a/f", "b/f");
+    expect(patch).toContain("@@ -2,1 +1,0 @@");
+  });
+});
+
+describe("computeHunks limits", () => {
+  it("throws when inputs exceed the unique-line limit", () => {
+    const lines: string[] = [];
+    for (let i = 0; i < 65537; i++) lines.push("line" + i);
+    const big = lines.join("\n");
+    expect(() => computeHunks(big, "", 3, false)).toThrow(/unique lines/);
+  });
 });

--- a/packages/agency-lang/lib/utils/diff.test.ts
+++ b/packages/agency-lang/lib/utils/diff.test.ts
@@ -149,3 +149,35 @@ describe("renderDiff options", () => {
     expect(strip(result)).not.toContain("+ ");
   });
 });
+
+describe("renderPatch", () => {
+  it("produces an applicable unified-diff body for a modification", () => {
+    const hunks = computeHunks("one\ntwo\nthree\n", "one\nTWO\nthree\n", 3, false);
+    const patch = renderPatch(hunks, "a/f.txt", "b/f.txt");
+    expect(patch.startsWith("--- a/f.txt\n+++ b/f.txt\n")).toBe(true);
+    expect(patch).toContain("@@ -1");
+    expect(patch).toContain("\n one");
+    expect(patch).toContain("\n-two");
+    expect(patch).toContain("\n+TWO");
+    expect(patch.endsWith("\n")).toBe(true);
+    // No ANSI, no two-space display prefixes.
+    expect(patch).not.toContain("\x1b");
+  });
+
+  it("uses /dev/null for new and deleted files", () => {
+    const created = renderPatch(computeHunks("", "hello\nworld", 3, false), "/dev/null", "b/new.txt");
+    expect(created).toContain("--- /dev/null");
+    expect(created).toContain("@@ -0,0 +1");
+    expect(created).toContain("+hello");
+
+    const deleted = renderPatch(computeHunks("bye\n", "", 3, false), "a/old.txt", "/dev/null");
+    expect(deleted).toContain("+++ /dev/null");
+    expect(deleted).toContain("-bye");
+  });
+
+  it("supports renames via differing labels", () => {
+    const patch = renderPatch(computeHunks("x\n", "y\n", 3, false), "a/old.txt", "b/new.txt");
+    expect(patch).toContain("--- a/old.txt");
+    expect(patch).toContain("+++ b/new.txt");
+  });
+});

--- a/packages/agency-lang/lib/utils/diff.test.ts
+++ b/packages/agency-lang/lib/utils/diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDiff } from "./diff.js";
+import { formatDiff, computeHunks, renderDiff, renderPatch } from "./diff.js";
 import { color } from "./termcolors.js";
 
 // Strip ANSI escape codes so assertions can check rendered content
@@ -102,5 +102,50 @@ describe("formatDiff", () => {
     expect(result).toContain(color.green("Bob"));
     // age line is unchanged and shown dim with a 2-space prefix
     expect(strip(result)).toContain('  "age": 30');
+  });
+});
+
+describe("renderDiff options", () => {
+  const OLD = "a\nb\nc\nd\ne\nf\ng";
+  const NEW = "a\nb\nc\nD\ne\nf\ng";
+
+  it("limits context and emits separate hunks", () => {
+    const hunks = computeHunks(OLD, NEW, 1, false);
+    const result = renderDiff(hunks, {});
+    // 1 line of context each side of the change to line 4 ("c","D"/"d","e")
+    expect(strip(result)).toBe("  c\n- d\n+ D\n  e");
+  });
+
+  it("renders per-side line numbers (old on delete, new elsewhere)", () => {
+    const hunks = computeHunks("one\ntwo\nthree", "one\nTWO\nthree", -1, false);
+    const result = renderDiff(hunks, { lineNumbers: true });
+    expect(strip(result)).toBe("1   one\n2 - two\n2 + TWO\n3   three");
+  });
+
+  it("emits hunk headers", () => {
+    const hunks = computeHunks("one\ntwo\nthree", "one\nTWO\nthree", 1, false);
+    const result = renderDiff(hunks, { hunkHeaders: true });
+    expect(strip(result)).toContain("@@ -1,3 +1,3 @@");
+  });
+
+  it("renders labels", () => {
+    const hunks = computeHunks("x", "y", -1, false);
+    const result = renderDiff(hunks, { oldLabel: "a.txt", newLabel: "b.txt" });
+    expect(strip(result)).toContain("--- a.txt");
+    expect(strip(result)).toContain("+++ b.txt");
+  });
+
+  it("renders a summary line", () => {
+    const hunks = computeHunks("one\ntwo", "one\nTWO\nthree", -1, false);
+    const result = renderDiff(hunks, { summary: true });
+    expect(strip(result).split("\n")[0]).toBe("2 insertions, 1 deletion");
+  });
+
+  it("ignores whitespace-only changes when asked", () => {
+    const hunks = computeHunks("a   b", "a b", -1, true);
+    // normalized equal -> single context line, no -/+ markers
+    const result = renderDiff(hunks, {});
+    expect(strip(result)).not.toContain("- ");
+    expect(strip(result)).not.toContain("+ ");
   });
 });

--- a/packages/agency-lang/lib/utils/diff.test.ts
+++ b/packages/agency-lang/lib/utils/diff.test.ts
@@ -2,42 +2,69 @@ import { describe, it, expect } from "vitest";
 import { formatDiff } from "./diff.js";
 import { color } from "./termcolors.js";
 
+// Strip ANSI escape codes so assertions can check rendered content
+// independent of where color wraps begin and end.
+function strip(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
 describe("formatDiff", () => {
   it("returns all dim text for identical strings", () => {
     const result = formatDiff("hello", "hello");
-    expect(result).toContain("hello");
+    expect(strip(result)).toBe("  hello");
     expect(result).not.toContain("- ");
     expect(result).not.toContain("+ ");
   });
 
   it("shows deletions in red and insertions in green", () => {
     const result = formatDiff("alice", "bob");
-    expect(result).toContain(color.red("- alice"));
-    expect(result).toContain(color.green("+ bob"));
+    expect(strip(result)).toBe("- alice\n+ bob");
+    // alice is painted red, bob green
+    expect(result).toContain(color.red("alice"));
+    expect(result).toContain(color.green("bob"));
   });
 
-  it("shows unchanged parts as dim", () => {
+  it("shows unchanged parts of a replaced line as dim, highlighting only the change", () => {
     const result = formatDiff("hello world", "hello there");
-    expect(result).toContain(color.dim("  hello "));
+    // The common prefix stays dim on both lines...
+    expect(result).toContain(color.dim("hello "));
+    // ...while the changed words are highlighted.
+    expect(result).toContain(color.red("world"));
+    expect(result).toContain(color.green("there"));
+    // And the line is never split across multiple output lines.
+    expect(strip(result)).toBe("- hello world\n+ hello there");
+  });
+
+  it("does not split a single line into multiple lines", () => {
+    // The motivating bug: "What is the capital of France?" -> "...India?"
+    const result = formatDiff(
+      "What is the capital of France?",
+      "What is the capital of India?",
+    );
+    expect(strip(result)).toBe(
+      "- What is the capital of France?\n+ What is the capital of India?",
+    );
+    expect(result).toContain(color.red("France"));
+    expect(result).toContain(color.green("India"));
   });
 
   it("handles multiline diffs", () => {
     const expected = "line1\nline2\nline3";
     const actual = "line1\nchanged\nline3";
     const result = formatDiff(expected, actual);
-    expect(result).toContain(color.red("- line2"));
-    expect(result).toContain(color.green("+ changed"));
+    expect(strip(result)).toBe("  line1\n- line2\n+ changed\n  line3");
   });
 
   it("handles empty expected string", () => {
     const result = formatDiff("", "new content");
-    expect(result).toContain(color.green("+ new content"));
+    expect(result).toBe(color.green("+ new content"));
     expect(result).not.toContain("- ");
   });
 
   it("handles empty actual string", () => {
     const result = formatDiff("old content", "");
-    expect(result).toContain(color.red("- old content"));
+    expect(result).toBe(color.red("- old content"));
     expect(result).not.toContain("+ ");
   });
 
@@ -48,23 +75,32 @@ describe("formatDiff", () => {
 
   it("emits plain text without ANSI codes when colorize is off", () => {
     const result = formatDiff("line1\nline2\nline3", "line1\nchanged\nline3", { colorize: false });
-    expect(result).not.toContain("[");
-    expect(result).toContain("- line2");
-    expect(result).toContain("+ changed");
-    expect(result).toContain("  line1");
+    expect(result).not.toContain("\x1b");
+    expect(result).toBe("  line1\n- line2\n+ changed\n  line3");
+  });
+
+  it("does not split lines in plain-text replacement mode", () => {
+    const result = formatDiff(
+      "What is the capital of France?",
+      "What is the capital of India?",
+      { colorize: false },
+    );
+    expect(result).toBe(
+      "- What is the capital of France?\n+ What is the capital of India?",
+    );
   });
 
   it("colorizes by default", () => {
-    expect(formatDiff("alice", "bob")).toContain(color.red("- alice"));
+    expect(formatDiff("alice", "bob")).toContain(color.red("alice"));
   });
 
   it("works with JSON-like fixture output", () => {
     const expected = JSON.stringify({ name: "Alice", age: 30 }, null, 2);
     const actual = JSON.stringify({ name: "Bob", age: 30 }, null, 2);
     const result = formatDiff(expected, actual);
-    expect(result).toContain(color.red("- Alice"));
-    expect(result).toContain(color.green("+ Bob"));
-    // age is unchanged
-    expect(result).toContain("30");
+    expect(result).toContain(color.red("Alice"));
+    expect(result).toContain(color.green("Bob"));
+    // age line is unchanged and shown dim with a 2-space prefix
+    expect(strip(result)).toContain('  "age": 30');
   });
 });

--- a/packages/agency-lang/lib/utils/diff.ts
+++ b/packages/agency-lang/lib/utils/diff.ts
@@ -9,42 +9,145 @@ const dmp = new DiffMatchPatch();
 
 type Diff = [number, string];
 
-/**
- * Split a run of whole lines (as produced by the line-mode diff) into
- * individual lines. The trailing empty string left by a final newline is an
- * artifact of the split, not a real line, so we drop it.
- */
-function splitLines(text: string): string[] {
-  const parts = text.split("\n");
-  if (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
-  return parts;
+export type DiffLine = {
+  kind: "context" | "delete" | "insert";
+  text: string;
+  oldNo: number | null;
+  newNo: number | null;
+};
+
+export type Hunk = {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: DiffLine[];
+};
+
+export type RenderDiffOpts = {
+  lineNumbers?: boolean;
+  colored?: boolean;
+  oldLabel?: string;
+  newLabel?: string;
+  hunkHeaders?: boolean;
+  summary?: boolean;
+};
+
+// Collapse runs of whitespace and trim, for comparison only (the original
+// line text is preserved for rendering).
+function normalizeLine(line: string): string {
+  return line.replace(/\s+/g, " ").trim();
+}
+
+// "" is zero lines; otherwise split on newline, KEEPING a trailing empty
+// element so a trailing newline survives a patch round-trip.
+function splitTextLines(text: string): string[] {
+  return text === "" ? [] : text.split("\n");
+}
+
+// Encode each unique line as a single char so diff_main runs at line
+// granularity. Caps at ~65k unique lines, plenty for stdlib diffs.
+function encodeLines(lines: string[], map: Map<string, number>, arr: string[]): string {
+  let s = "";
+  for (const line of lines) {
+    let idx = map.get(line);
+    if (idx === undefined) {
+      idx = arr.length;
+      arr.push(line);
+      map.set(line, idx);
+    }
+    s += String.fromCharCode(idx);
+  }
+  return s;
+}
+
+// Flat, line-by-line diff with old/new line numbers attached.
+function diffLines(oldText: string, newText: string, ignoreWhitespace: boolean): DiffLine[] {
+  const oldLines = splitTextLines(oldText);
+  const newLines = splitTextLines(newText);
+  const key = ignoreWhitespace ? normalizeLine : (s: string) => s;
+
+  const map = new Map<string, number>();
+  const arr: string[] = [];
+  const enc1 = encodeLines(oldLines.map(key), map, arr);
+  const enc2 = encodeLines(newLines.map(key), map, arr);
+  const diffs = dmp.diff_main(enc1, enc2, false) as Diff[];
+
+  const out: DiffLine[] = [];
+  let oi = 0;
+  let ni = 0;
+  for (const [op, chunk] of diffs) {
+    for (let k = 0; k < chunk.length; k++) {
+      if (op === DIFF_EQUAL) {
+        out.push({ kind: "context", text: newLines[ni], oldNo: oi + 1, newNo: ni + 1 });
+        oi++;
+        ni++;
+      } else if (op === DIFF_DELETE) {
+        out.push({ kind: "delete", text: oldLines[oi], oldNo: oi + 1, newNo: null });
+        oi++;
+      } else {
+        out.push({ kind: "insert", text: newLines[ni], oldNo: null, newNo: ni + 1 });
+        ni++;
+      }
+    }
+  }
+  return out;
+}
+
+function makeHunk(lines: DiffLine[]): Hunk {
+  const oldNos = lines.filter((l) => l.oldNo !== null).map((l) => l.oldNo as number);
+  const newNos = lines.filter((l) => l.newNo !== null).map((l) => l.newNo as number);
+  return {
+    oldStart: oldNos.length ? oldNos[0] : 0,
+    oldLines: oldNos.length,
+    newStart: newNos.length ? newNos[0] : 0,
+    newLines: newNos.length,
+    lines,
+  };
 }
 
 /**
- * Compute a line-level diff. By diffing on a per-line basis (rather than the
- * character/word level), each chunk of output is a whole line, so a single
- * logical line is never broken across multiple output lines.
- *
- * Uses diff-match-patch's line-mode recipe: encode each unique line as a
- * single char, diff the encoded strings, then decode back to lines. We do
- * NOT run `diff_cleanupSemantic` here — that operates on the encoded
- * sentinel chars and would corrupt the decoding.
+ * Compute a line-level diff grouped into hunks.
+ * `context < 0` -> one hunk spanning everything (full context).
+ * `context >= 0` -> keep only changed lines plus `context` unchanged lines on
+ * each side; runs separated by more than 2*context unchanged lines split into
+ * separate hunks.
  */
-function lineModeDiff(expected: string, actual: string): Diff[] {
-  const { chars1, chars2, lineArray } = dmp.diff_linesToChars_(expected, actual);
-  const diffs = dmp.diff_main(chars1, chars2, false) as Diff[];
-  dmp.diff_charsToLines_(diffs, lineArray);
-  return diffs;
+export function computeHunks(
+  oldText: string,
+  newText: string,
+  context: number,
+  ignoreWhitespace: boolean,
+): Hunk[] {
+  const lines = diffLines(oldText, newText, ignoreWhitespace);
+  if (lines.length === 0) return [];
+  if (context < 0) return [makeHunk(lines)];
+
+  const include: boolean[] = new Array(lines.length).fill(false);
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].kind !== "context") {
+      const lo = Math.max(0, i - context);
+      const hi = Math.min(lines.length - 1, i + context);
+      for (let j = lo; j <= hi; j++) include[j] = true;
+    }
+  }
+
+  const hunks: Hunk[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (!include[i]) {
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j < lines.length && include[j]) j++;
+    hunks.push(makeHunk(lines.slice(i, j)));
+    i = j;
+  }
+  return hunks;
 }
 
-/**
- * Render one line of a replacement (a deleted line paired with an inserted
- * line) with the changed words highlighted. A word-level diff between the two
- * lines decides which spans changed: unchanged words are dimmed, and the
- * words specific to `side` are painted red (deletions) or green (insertions).
- *
- * `side` is DIFF_DELETE to render the old line, DIFF_INSERT for the new one.
- */
+// Render one side of a replacement with the changed words highlighted.
 function highlightLine(oldLine: string, newLine: string, side: number): string {
   const prefix = side === DIFF_DELETE ? "- " : "+ ";
   const sideColor = side === DIFF_DELETE ? color.red : color.green;
@@ -53,80 +156,137 @@ function highlightLine(oldLine: string, newLine: string, side: number): string {
 
   let body = "";
   for (const [op, text] of wordDiffs) {
-    if (op === DIFF_EQUAL) {
-      body += color.dim(text);
-    } else if (op === side) {
-      body += sideColor(text);
-    }
-    // Segments belonging to the other side are omitted from this line.
+    if (op === DIFF_EQUAL) body += color.dim(text);
+    else if (op === side) body += sideColor(text);
   }
   return sideColor(prefix) + body;
 }
 
-/**
- * Render a replacement block: `del` lines (removed) paired against `ins`
- * lines (added). Following unified-diff convention, all `-` lines are emitted
- * first, then all `+` lines. When colorized, paired lines get intra-line word
- * highlighting (see `highlightLine`); unpaired extras and the plain-text mode
- * fall back to whole-line coloring.
- */
-function renderReplacement(out: string[], del: string[], ins: string[], colorize: boolean): void {
-  const paired = Math.min(del.length, ins.length);
-  for (let k = 0; k < del.length; k++) {
-    if (colorize && k < paired) out.push(highlightLine(del[k], ins[k], DIFF_DELETE));
-    else out.push(colorize ? color.red(`- ${del[k]}`) : `- ${del[k]}`);
+function renderReplacement(
+  dels: DiffLine[],
+  inss: DiffLine[],
+  out: string[],
+  colored: boolean,
+  gutter: (l: DiffLine) => string,
+): void {
+  const paired = Math.min(dels.length, inss.length);
+  for (let k = 0; k < dels.length; k++) {
+    const body =
+      colored && k < paired
+        ? highlightLine(dels[k].text, inss[k].text, DIFF_DELETE)
+        : colored
+          ? color.red(`- ${dels[k].text}`)
+          : `- ${dels[k].text}`;
+    out.push(gutter(dels[k]) + body);
   }
-  for (let k = 0; k < ins.length; k++) {
-    if (colorize && k < paired) out.push(highlightLine(del[k], ins[k], DIFF_INSERT));
-    else out.push(colorize ? color.green(`+ ${ins[k]}`) : `+ ${ins[k]}`);
+  for (let k = 0; k < inss.length; k++) {
+    const body =
+      colored && k < paired
+        ? highlightLine(dels[k].text, inss[k].text, DIFF_INSERT)
+        : colored
+          ? color.green(`+ ${inss[k].text}`)
+          : `+ ${inss[k].text}`;
+    out.push(gutter(inss[k]) + body);
   }
 }
 
+function renderHunkBody(
+  lines: DiffLine[],
+  out: string[],
+  colored: boolean,
+  gutter: (l: DiffLine) => string,
+): void {
+  const paint = (fn: (t: string) => string, t: string) => (colored ? fn(t) : t);
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.kind === "context") {
+      out.push(gutter(line) + paint(color.dim, `  ${line.text}`));
+      i++;
+    } else if (line.kind === "delete") {
+      let d = i;
+      while (d < lines.length && lines[d].kind === "delete") d++;
+      let n = d;
+      while (n < lines.length && lines[n].kind === "insert") n++;
+      renderReplacement(lines.slice(i, d), lines.slice(d, n), out, colored, gutter);
+      i = n;
+    } else {
+      out.push(gutter(line) + paint(color.green, `+ ${line.text}`));
+      i++;
+    }
+  }
+}
+
+function gutterWidth(hunks: Hunk[]): number {
+  let max = 0;
+  for (const h of hunks)
+    for (const l of h.lines) {
+      const n = l.kind === "delete" ? l.oldNo : l.newNo;
+      if (n !== null) max = Math.max(max, n);
+    }
+  return String(max).length;
+}
+
+/** Render hunks as a human-readable diff string. */
+export function renderDiff(hunks: Hunk[], opts: RenderDiffOpts = {}): string {
+  const colored = opts.colored ?? false;
+  const paint = (fn: (t: string) => string, t: string) => (colored ? fn(t) : t);
+  const out: string[] = [];
+
+  if (opts.summary) {
+    let ins = 0;
+    let del = 0;
+    for (const h of hunks)
+      for (const l of h.lines) {
+        if (l.kind === "insert") ins++;
+        else if (l.kind === "delete") del++;
+      }
+    out.push(`${ins} insertion${ins === 1 ? "" : "s"}, ${del} deletion${del === 1 ? "" : "s"}`);
+  }
+  if (opts.oldLabel) out.push(paint(color.red, `--- ${opts.oldLabel}`));
+  if (opts.newLabel) out.push(paint(color.green, `+++ ${opts.newLabel}`));
+
+  const width = opts.lineNumbers ? gutterWidth(hunks) : 0;
+  const gutter = (l: DiffLine): string => {
+    if (!opts.lineNumbers) return "";
+    const n = l.kind === "delete" ? l.oldNo : l.newNo;
+    return `${(n === null ? "" : String(n)).padStart(width)} `;
+  };
+
+  for (const h of hunks) {
+    if (opts.hunkHeaders) {
+      out.push(paint(color.cyan, `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`));
+    }
+    renderHunkBody(h.lines, out, colored, gutter);
+  }
+  return out.join("\n");
+}
+
+/** Render hunks as a standard unified diff that std::fs::applyPatch can apply. */
+export function renderPatch(hunks: Hunk[], oldLabel: string, newLabel: string): string {
+  if (hunks.length === 0) return "";
+  const out: string[] = [`--- ${oldLabel}`, `+++ ${newLabel}`];
+  for (const h of hunks) {
+    out.push(`@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@`);
+    for (const l of h.lines) {
+      if (l.kind === "context") out.push(` ${l.text}`);
+      else if (l.kind === "delete") out.push(`-${l.text}`);
+      else out.push(`+${l.text}`);
+    }
+  }
+  return out.join("\n") + "\n";
+}
+
 /**
- * Formats a line-based diff between two strings.
- *
- * The diff is computed at line granularity, so a single logical line is never
- * split across multiple output lines. Deleted lines are shown with a "-"
- * prefix (red), inserted lines with a "+" prefix (green), and unchanged lines
- * with a "  " prefix (dim). When a deleted line is immediately replaced by an
- * inserted one, the specific words that changed are highlighted within each
- * line while the rest of the line is dimmed.
- *
- * Colorized by default; pass `colorize: false` for plain text suitable for
- * files and artifacts (in that mode replacements degrade to whole `-`/`+`
- * lines with no word-level highlighting and no ANSI codes).
+ * Back-compat shim: full-context, colored-by-default inline diff. Existing
+ * callers (optimizer reporter, test runner, sourceMutator) rely on this exact
+ * output, so it must not change.
  */
 export function formatDiff(
   expected: string,
   actual: string,
   opts: { colorize?: boolean } = {},
 ): string {
-  const colorize = opts.colorize ?? true;
-  const paint = (fn: (text: string) => string, text: string): string =>
-    colorize ? fn(text) : text;
-
-  const diffs = lineModeDiff(expected, actual);
-  const out: string[] = [];
-
-  for (let i = 0; i < diffs.length; i++) {
-    const [op, text] = diffs[i];
-    if (op === DIFF_EQUAL) {
-      for (const line of splitLines(text)) out.push(paint(color.dim, `  ${line}`));
-    } else if (op === DIFF_DELETE) {
-      const next = diffs[i + 1];
-      if (next && next[0] === DIFF_INSERT) {
-        // A deletion immediately followed by an insertion is a replacement:
-        // render them together so changed words can be highlighted in place.
-        renderReplacement(out, splitLines(text), splitLines(next[1]), colorize);
-        i++; // consume the paired INSERT
-      } else {
-        for (const line of splitLines(text)) out.push(paint(color.red, `- ${line}`));
-      }
-    } else {
-      // A standalone insertion (not preceded by a consumed deletion).
-      for (const line of splitLines(text)) out.push(paint(color.green, `+ ${line}`));
-    }
-  }
-
-  return out.join("\n");
+  const hunks = computeHunks(expected, actual, -1, false);
+  return renderDiff(hunks, { colored: opts.colorize ?? true });
 }

--- a/packages/agency-lang/lib/utils/diff.ts
+++ b/packages/agency-lang/lib/utils/diff.ts
@@ -12,8 +12,8 @@ type Diff = [number, string];
 export type DiffLine = {
   kind: "context" | "delete" | "insert";
   text: string;
-  oldNo: number | null;
-  newNo: number | null;
+  oldNum: number | null;
+  newNum: number | null;
 };
 
 export type Hunk = {
@@ -52,6 +52,13 @@ function encodeLines(lines: string[], map: Map<string, number>, arr: string[]): 
   for (const line of lines) {
     let idx = map.get(line);
     if (idx === undefined) {
+      if (arr.length >= 0x10000) {
+        // One char per unique line; beyond 0xFFFF, String.fromCharCode wraps
+        // into already-used code units and silently corrupts the diff.
+        throw new Error(
+          "diff: inputs have more than 65535 unique lines, which exceeds the line-diff limit",
+        );
+      }
       idx = arr.length;
       arr.push(line);
       map.set(line, idx);
@@ -79,14 +86,14 @@ function diffLines(oldText: string, newText: string, ignoreWhitespace: boolean):
   for (const [op, chunk] of diffs) {
     for (let k = 0; k < chunk.length; k++) {
       if (op === DIFF_EQUAL) {
-        out.push({ kind: "context", text: newLines[ni], oldNo: oi + 1, newNo: ni + 1 });
+        out.push({ kind: "context", text: newLines[ni], oldNum: oi + 1, newNum: ni + 1 });
         oi++;
         ni++;
       } else if (op === DIFF_DELETE) {
-        out.push({ kind: "delete", text: oldLines[oi], oldNo: oi + 1, newNo: null });
+        out.push({ kind: "delete", text: oldLines[oi], oldNum: oi + 1, newNum: null });
         oi++;
       } else {
-        out.push({ kind: "insert", text: newLines[ni], oldNo: null, newNo: ni + 1 });
+        out.push({ kind: "insert", text: newLines[ni], oldNum: null, newNum: ni + 1 });
         ni++;
       }
     }
@@ -94,13 +101,30 @@ function diffLines(oldText: string, newText: string, ignoreWhitespace: boolean):
   return out;
 }
 
-function makeHunk(lines: DiffLine[]): Hunk {
-  const oldNos = lines.filter((l) => l.oldNo !== null).map((l) => l.oldNo as number);
-  const newNos = lines.filter((l) => l.newNo !== null).map((l) => l.newNo as number);
+// The old/new line number of the last numbered line before `start`, or 0 if
+// none. Used to anchor the hunk header for insert-only / delete-only hunks,
+// which carry no line number of their own on one side.
+function anchorsBefore(lines: DiffLine[], start: number): { prevOld: number; prevNew: number } {
+  let prevOld = 0;
+  let prevNew = 0;
+  for (let k = start - 1; k >= 0; k--) {
+    if (prevOld === 0 && lines[k].oldNum !== null) prevOld = lines[k].oldNum as number;
+    if (prevNew === 0 && lines[k].newNum !== null) prevNew = lines[k].newNum as number;
+    if (prevOld !== 0 && prevNew !== 0) break;
+  }
+  return { prevOld, prevNew };
+}
+
+function makeHunk(lines: DiffLine[], prevOld: number, prevNew: number): Hunk {
+  const oldNos = lines.filter((l) => l.oldNum !== null).map((l) => l.oldNum as number);
+  const newNos = lines.filter((l) => l.newNum !== null).map((l) => l.newNum as number);
   return {
-    oldStart: oldNos.length ? oldNos[0] : 0,
+    // For a side with no lines of its own (pure insertion / deletion), the
+    // unified-diff start is the line number it sits *after*: the preceding
+    // numbered line, or 0 at the start of file.
+    oldStart: oldNos.length ? oldNos[0] : prevOld,
     oldLines: oldNos.length,
-    newStart: newNos.length ? newNos[0] : 0,
+    newStart: newNos.length ? newNos[0] : prevNew,
     newLines: newNos.length,
     lines,
   };
@@ -121,7 +145,7 @@ export function computeHunks(
 ): Hunk[] {
   const lines = diffLines(oldText, newText, ignoreWhitespace);
   if (lines.length === 0) return [];
-  if (context < 0) return [makeHunk(lines)];
+  if (context < 0) return [makeHunk(lines, 0, 0)];
 
   const include: boolean[] = new Array(lines.length).fill(false);
   for (let i = 0; i < lines.length; i++) {
@@ -141,7 +165,8 @@ export function computeHunks(
     }
     let j = i;
     while (j < lines.length && include[j]) j++;
-    hunks.push(makeHunk(lines.slice(i, j)));
+    const { prevOld, prevNew } = anchorsBefore(lines, i);
+    hunks.push(makeHunk(lines.slice(i, j), prevOld, prevNew));
     i = j;
   }
   return hunks;
@@ -221,7 +246,7 @@ function gutterWidth(hunks: Hunk[]): number {
   let max = 0;
   for (const h of hunks)
     for (const l of h.lines) {
-      const n = l.kind === "delete" ? l.oldNo : l.newNo;
+      const n = l.kind === "delete" ? l.oldNum : l.newNum;
       if (n !== null) max = Math.max(max, n);
     }
   return String(max).length;
@@ -249,7 +274,7 @@ export function renderDiff(hunks: Hunk[], opts: RenderDiffOpts = {}): string {
   const width = opts.lineNumbers ? gutterWidth(hunks) : 0;
   const gutter = (l: DiffLine): string => {
     if (!opts.lineNumbers) return "";
-    const n = l.kind === "delete" ? l.oldNo : l.newNo;
+    const n = l.kind === "delete" ? l.oldNum : l.newNum;
     return `${(n === null ? "" : String(n)).padStart(width)} `;
   };
 

--- a/packages/agency-lang/lib/utils/diff.ts
+++ b/packages/agency-lang/lib/utils/diff.ts
@@ -7,12 +7,94 @@ const DIFF_EQUAL = 0;
 
 const dmp = new DiffMatchPatch();
 
+type Diff = [number, string];
+
+/**
+ * Split a run of whole lines (as produced by the line-mode diff) into
+ * individual lines. The trailing empty string left by a final newline is an
+ * artifact of the split, not a real line, so we drop it.
+ */
+function splitLines(text: string): string[] {
+  const parts = text.split("\n");
+  if (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
+  return parts;
+}
+
+/**
+ * Compute a line-level diff. By diffing on a per-line basis (rather than the
+ * character/word level), each chunk of output is a whole line, so a single
+ * logical line is never broken across multiple output lines.
+ *
+ * Uses diff-match-patch's line-mode recipe: encode each unique line as a
+ * single char, diff the encoded strings, then decode back to lines. We do
+ * NOT run `diff_cleanupSemantic` here — that operates on the encoded
+ * sentinel chars and would corrupt the decoding.
+ */
+function lineModeDiff(expected: string, actual: string): Diff[] {
+  const { chars1, chars2, lineArray } = dmp.diff_linesToChars_(expected, actual);
+  const diffs = dmp.diff_main(chars1, chars2, false) as Diff[];
+  dmp.diff_charsToLines_(diffs, lineArray);
+  return diffs;
+}
+
+/**
+ * Render one line of a replacement (a deleted line paired with an inserted
+ * line) with the changed words highlighted. A word-level diff between the two
+ * lines decides which spans changed: unchanged words are dimmed, and the
+ * words specific to `side` are painted red (deletions) or green (insertions).
+ *
+ * `side` is DIFF_DELETE to render the old line, DIFF_INSERT for the new one.
+ */
+function highlightLine(oldLine: string, newLine: string, side: number): string {
+  const prefix = side === DIFF_DELETE ? "- " : "+ ";
+  const sideColor = side === DIFF_DELETE ? color.red : color.green;
+  const wordDiffs = dmp.diff_main(oldLine, newLine) as Diff[];
+  dmp.diff_cleanupSemantic(wordDiffs);
+
+  let body = "";
+  for (const [op, text] of wordDiffs) {
+    if (op === DIFF_EQUAL) {
+      body += color.dim(text);
+    } else if (op === side) {
+      body += sideColor(text);
+    }
+    // Segments belonging to the other side are omitted from this line.
+  }
+  return sideColor(prefix) + body;
+}
+
+/**
+ * Render a replacement block: `del` lines (removed) paired against `ins`
+ * lines (added). Following unified-diff convention, all `-` lines are emitted
+ * first, then all `+` lines. When colorized, paired lines get intra-line word
+ * highlighting (see `highlightLine`); unpaired extras and the plain-text mode
+ * fall back to whole-line coloring.
+ */
+function renderReplacement(out: string[], del: string[], ins: string[], colorize: boolean): void {
+  const paired = Math.min(del.length, ins.length);
+  for (let k = 0; k < del.length; k++) {
+    if (colorize && k < paired) out.push(highlightLine(del[k], ins[k], DIFF_DELETE));
+    else out.push(colorize ? color.red(`- ${del[k]}`) : `- ${del[k]}`);
+  }
+  for (let k = 0; k < ins.length; k++) {
+    if (colorize && k < paired) out.push(highlightLine(del[k], ins[k], DIFF_INSERT));
+    else out.push(colorize ? color.green(`+ ${ins[k]}`) : `+ ${ins[k]}`);
+  }
+}
+
 /**
  * Formats a line-based diff between two strings.
- * Deletions (expected) are shown with a "-" prefix, insertions (actual)
- * with a "+" prefix, and equal lines with a "  " prefix.
- * Colorized (red/green/dim) by default; pass `colorize: false` for plain
- * text suitable for files and artifacts.
+ *
+ * The diff is computed at line granularity, so a single logical line is never
+ * split across multiple output lines. Deleted lines are shown with a "-"
+ * prefix (red), inserted lines with a "+" prefix (green), and unchanged lines
+ * with a "  " prefix (dim). When a deleted line is immediately replaced by an
+ * inserted one, the specific words that changed are highlighted within each
+ * line while the rest of the line is dimmed.
+ *
+ * Colorized by default; pass `colorize: false` for plain text suitable for
+ * files and artifacts (in that mode replacements degrade to whole `-`/`+`
+ * lines with no word-level highlighting and no ANSI codes).
  */
 export function formatDiff(
   expected: string,
@@ -22,23 +104,29 @@ export function formatDiff(
   const colorize = opts.colorize ?? true;
   const paint = (fn: (text: string) => string, text: string): string =>
     colorize ? fn(text) : text;
-  const diffs = dmp.diff_main(expected, actual);
-  dmp.diff_cleanupSemantic(diffs);
 
-  const lines: string[] = [];
-  for (const [op, text] of diffs) {
-    // Split text into individual lines to get per-line prefixes
-    const parts = text.split("\n");
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      if (op === DIFF_DELETE) {
-        lines.push(paint(color.red, `- ${part}`));
-      } else if (op === DIFF_INSERT) {
-        lines.push(paint(color.green, `+ ${part}`));
+  const diffs = lineModeDiff(expected, actual);
+  const out: string[] = [];
+
+  for (let i = 0; i < diffs.length; i++) {
+    const [op, text] = diffs[i];
+    if (op === DIFF_EQUAL) {
+      for (const line of splitLines(text)) out.push(paint(color.dim, `  ${line}`));
+    } else if (op === DIFF_DELETE) {
+      const next = diffs[i + 1];
+      if (next && next[0] === DIFF_INSERT) {
+        // A deletion immediately followed by an insertion is a replacement:
+        // render them together so changed words can be highlighted in place.
+        renderReplacement(out, splitLines(text), splitLines(next[1]), colorize);
+        i++; // consume the paired INSERT
       } else {
-        lines.push(paint(color.dim, `  ${part}`));
+        for (const line of splitLines(text)) out.push(paint(color.red, `- ${line}`));
       }
+    } else {
+      // A standalone insertion (not preceded by a consumed deletion).
+      for (const line of splitLines(text)) out.push(paint(color.green, `+ ${line}`));
     }
   }
-  return lines.join("\n");
+
+  return out.join("\n");
 }

--- a/packages/agency-lang/lib/utils/termcolors.ts
+++ b/packages/agency-lang/lib/utils/termcolors.ts
@@ -191,3 +191,26 @@ function createNoopColorFunction(): ColorFunction {
 export const ttyColor: ColorFunction = process.stdout.isTTY
   ? color
   : createNoopColorFunction();
+
+/**
+ * Resolve whether to emit ANSI color for an `"auto"` setting, following the
+ * de-facto ecosystem convention:
+ *   * `NO_COLOR` set (any value)          → disable, no matter what.
+ *   * `FORCE_COLOR` set to a truthy value → enable, no matter what.
+ *   * otherwise                           → enable iff stdout is a TTY.
+ *
+ * `process.stdout.isTTY` alone is unreliable when Agency runs through nested
+ * spawns (some intermediate hops drop the TTY flag), so the env-var fallbacks
+ * give the user explicit overrides. Shared by stdlib helpers that expose an
+ * `"auto" | boolean` color option (e.g. `std::layout::render`, `std::syntax::diff`).
+ */
+export function autoUseColor(): boolean {
+  if (process.env.NO_COLOR !== undefined && process.env.NO_COLOR !== "") {
+    return false;
+  }
+  const force = process.env.FORCE_COLOR;
+  if (force !== undefined && force !== "" && force !== "0" && force !== "false") {
+    return true;
+  }
+  return process.stdout.isTTY === true;
+}

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -1,4 +1,4 @@
-import { _multiedit, _applyPatch, _mkdir, _copy, _move, _remove, _printDiff } from "agency-lang/stdlib-lib/fs.js"
+import { _multiedit, _applyPatch, _mkdir, _copy, _move, _remove } from "agency-lang/stdlib-lib/fs.js"
 import { bash, glob, ls, grep } from "std::shell"
 
 type Edit = {
@@ -32,19 +32,6 @@ export def edit(filename: string, edits: Edit[], dir: string = ".", printDiff: b
   })
 
   return try _multiedit(dir, filename, edits, printDiff)
-}
-
-export safe def printDiff(oldText: string, newText: string) {
-  """
-  Print a colored, line-based diff of `oldText` vs `newText` to stdout.
-  Deletions are shown in red with a `-` prefix, insertions in green
-  with a `+` prefix, unchanged context is dimmed. Useful for showing
-  what an edit actually changed before / after committing it.
-
-  @param oldText - The original text
-  @param newText - The replacement text
-  """
-  _printDiff(oldText, newText)
 }
 
 type PatchResult = {

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -1,4 +1,4 @@
-import { _multiedit, _applyPatch, _mkdir, _copy, _move, _remove } from "agency-lang/stdlib-lib/fs.js"
+import { _multiedit, _previewEdit, _applyPatch, _mkdir, _copy, _move, _remove } from "agency-lang/stdlib-lib/fs.js"
 import { bash, glob, ls, grep } from "std::shell"
 
 type Edit = {
@@ -13,25 +13,28 @@ type EditResult = {
   edits: number
 }
 
-export def edit(filename: string, edits: Edit[], dir: string = ".", printDiff: boolean = false): Result {
+export def edit(filename: string, edits: Edit[], dir: string = "."): Result {
   """
   Edit a single file by applying one or more text replacements atomically. Each edit has `oldText`, `newText`, and `replaceAll`. Every edit's `oldText` must match a unique, non-overlapping region of the original file (matches are looked up against the file as it stands when the edit runs, after earlier edits). Set `replaceAll: true` on an edit to replace every occurrence. When any edit fails, nothing is written.
 
   Prefer one `edit` call with multiple entries over many `edit` calls. Keep each `oldText` as small as possible while still being unique — do not pad with unchanged context just to connect distant changes; instead, split them into separate entries in the same `edits` array.
 
+  The `std::edit` interrupt carries the full `before` and `after` file contents in its data, so a handler can render a diff itself (e.g. `print(diff(data.before, data.after, color: true))`).
+
   @param filename - The file to edit
   @param edits - Array of edit objects with oldText, newText, replaceAll
   @param dir - The directory to resolve the filename against (defaults to ".")
-  @param printDiff - When true, print a colored diff to stdout after the edit applies
   """
+  const preview = _previewEdit(dir, filename, edits)
   return interrupt std::edit("Are you sure you want to apply these edits?", {
     dir: dir,
     filename: filename,
     edits: edits,
-    printDiff: printDiff
+    before: preview.before,
+    after: preview.after
   })
 
-  return try _multiedit(dir, filename, edits, printDiff)
+  return try _multiedit(dir, filename, edits)
 }
 
 type PatchResult = {

--- a/packages/agency-lang/stdlib/syntax.agency
+++ b/packages/agency-lang/stdlib/syntax.agency
@@ -26,7 +26,7 @@ export safe def diff(
   newText: string,
   context: number = -1,
   lineNumbers: boolean = false,
-  colored: boolean = false,
+  color: "auto" | boolean = "auto",
   oldLabel: string = "",
   newLabel: string = "",
   ignoreWhitespace: boolean = false,
@@ -35,21 +35,21 @@ export safe def diff(
 ): string {
   """
   Produce a human-readable diff of two strings and return it as a string.
-  By default returns a plain (uncolored) inline diff showing the full text
-  with changed words highlighted via `-`/`+` lines.
+  Shows the full text by default with changed words highlighted via `-`/`+`
+  lines.
 
   @param oldText - The original text
   @param newText - The updated text
   @param context - Unchanged lines to keep around each change; -1 means show the full text
   @param lineNumbers - Prefix each line with its line number
-  @param colored - Emit ANSI colors (red deletions, green insertions) with inline word highlighting
+  @param color - `"auto"` (default) emits ANSI colors only when stdout is a TTY; `true` always; `false` never. Coloring highlights deletions in red and insertions in green inline.
   @param oldLabel - When non-empty, render a `--- <oldLabel>` header
   @param newLabel - When non-empty, render a `+++ <newLabel>` header
   @param ignoreWhitespace - Treat whitespace-only changes as equal
   @param hunkHeaders - Emit `@@ -l,c +l,c @@` separators between change regions
   @param summary - Prefix the diff with an "N insertions, M deletions" line
   """
-  return _diff(oldText, newText, context, lineNumbers, colored, oldLabel, newLabel, ignoreWhitespace, hunkHeaders, summary)
+  return _diff(oldText, newText, context, lineNumbers, color, oldLabel, newLabel, ignoreWhitespace, hunkHeaders, summary)
 }
 
 export safe def patch(

--- a/packages/agency-lang/stdlib/syntax.agency
+++ b/packages/agency-lang/stdlib/syntax.agency
@@ -1,5 +1,7 @@
 import {
   syntaxHighlight as _syntaxHighlight,
+  _diff,
+  _patch,
  } from "agency-lang/stdlib-lib/syntax.js"
 
 export type HighlightMode = "shell" | "web"
@@ -17,4 +19,59 @@ export def highlight(
   @param mode - The output format for the highlighted code: "shell" for terminal output
   """
   return _syntaxHighlight(code, language)
+}
+
+export safe def diff(
+  oldText: string,
+  newText: string,
+  context: number = -1,
+  lineNumbers: boolean = false,
+  colored: boolean = false,
+  oldLabel: string = "",
+  newLabel: string = "",
+  ignoreWhitespace: boolean = false,
+  hunkHeaders: boolean = false,
+  summary: boolean = false,
+): string {
+  """
+  Produce a human-readable diff of two strings and return it as a string.
+  By default returns a plain (uncolored) inline diff showing the full text
+  with changed words highlighted via `-`/`+` lines.
+
+  @param oldText - The original text
+  @param newText - The updated text
+  @param context - Unchanged lines to keep around each change; -1 means show the full text
+  @param lineNumbers - Prefix each line with its line number
+  @param colored - Emit ANSI colors (red deletions, green insertions) with inline word highlighting
+  @param oldLabel - When non-empty, render a `--- <oldLabel>` header
+  @param newLabel - When non-empty, render a `+++ <newLabel>` header
+  @param ignoreWhitespace - Treat whitespace-only changes as equal
+  @param hunkHeaders - Emit `@@ -l,c +l,c @@` separators between change regions
+  @param summary - Prefix the diff with an "N insertions, M deletions" line
+  """
+  return _diff(oldText, newText, context, lineNumbers, colored, oldLabel, newLabel, ignoreWhitespace, hunkHeaders, summary)
+}
+
+export safe def patch(
+  oldText: string,
+  newText: string,
+  filename: string,
+  context: number = 3,
+  ignoreWhitespace: boolean = false,
+  newFilename: string = "",
+): string {
+  """
+  Produce a standard unified diff that std::fs::applyPatch (or `git apply`)
+  can apply, and return it as a string. Pass the file's path as `filename`;
+  an empty `oldText` produces a file-creation patch and an empty `newText`
+  a deletion patch.
+
+  @param oldText - The original file contents
+  @param newText - The updated file contents
+  @param filename - The path used in the patch headers (the `a/` and `b/` sides)
+  @param context - Context lines to include around each hunk
+  @param ignoreWhitespace - Treat whitespace-only changes as equal
+  @param newFilename - When non-empty, use this path for the new (`+++`) side, e.g. to record a rename
+  """
+  return _patch(oldText, newText, filename, context, ignoreWhitespace, newFilename)
 }

--- a/packages/agency-lang/tests/agency-js/stdlib/std-syntax-patch-roundtrip/agent.agency
+++ b/packages/agency-lang/tests/agency-js/stdlib/std-syntax-patch-roundtrip/agent.agency
@@ -1,0 +1,24 @@
+import { patch } from "std::syntax"
+import { applyPatch } from "std::fs"
+
+node makePatch(oldText: string, newText: string, filename: string): string {
+  return patch(oldText, newText, filename)
+}
+
+node runApply(p: string): any {
+  handle {
+    const result = applyPatch(p)
+  } with (data) {
+    return approve()
+  }
+  return result
+}
+
+node readBack(filename: string): any {
+  handle {
+    const result = read(filename) catch "error reading file"
+  } with (data) {
+    return approve()
+  }
+  return result
+}

--- a/packages/agency-lang/tests/agency-js/stdlib/std-syntax-patch-roundtrip/fixture.json
+++ b/packages/agency-lang/tests/agency-js/stdlib/std-syntax-patch-roundtrip/fixture.json
@@ -1,0 +1,10 @@
+{
+  "modify": {
+    "ok": true,
+    "matches": true
+  },
+  "multi": {
+    "ok": true,
+    "matches": true
+  }
+}

--- a/packages/agency-lang/tests/agency-js/stdlib/std-syntax-patch-roundtrip/test.js
+++ b/packages/agency-lang/tests/agency-js/stdlib/std-syntax-patch-roundtrip/test.js
@@ -1,0 +1,28 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { makePatch, runApply, readBack } from "./agent.js";
+
+const TMP_REL = "tmp-roundtrip-fixtures";
+const TMP = join(process.cwd(), TMP_REL);
+rmSync(TMP, { recursive: true, force: true });
+mkdirSync(TMP, { recursive: true });
+
+async function roundtrip(oldText, newText, name) {
+  const rel = join(TMP_REL, name);
+  writeFileSync(join(process.cwd(), rel), oldText);
+  const p = (await makePatch(oldText, newText, rel)).data;
+  const applied = await runApply(p);
+  const ok = !(applied.data && applied.data.success === false);
+  const contents = (await readBack(rel)).data;
+  return { ok, matches: contents === newText };
+}
+
+const modify = await roundtrip("one\ntwo\nthree\n", "one\nTWO\nthree\n", "modify.txt");
+const multi = await roundtrip("a\nb\nc\nd\ne\n", "a\nB\nc\nd\nE\n", "multi.txt");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ modify, multi }, null, 2),
+);
+
+rmSync(TMP, { recursive: true, force: true });

--- a/packages/agency-lang/tests/agency/diff-and-patch.agency
+++ b/packages/agency-lang/tests/agency/diff-and-patch.agency
@@ -1,0 +1,5 @@
+import { patch } from "std::syntax"
+
+node main(): string {
+  return patch("one\ntwo\nthree\n", "one\nTWO\nthree\n", "f.txt")
+}

--- a/packages/agency-lang/tests/agency/diff-and-patch.test.json
+++ b/packages/agency-lang/tests/agency/diff-and-patch.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"--- a/f.txt\\n+++ b/f.txt\\n@@ -1,4 +1,4 @@\\n one\\n-two\\n+TWO\\n three\\n \\n\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/diff-named-args.agency
+++ b/packages/agency-lang/tests/agency/diff-named-args.agency
@@ -1,6 +1,6 @@
 import { diff } from "std::syntax"
 
 node main(): string {
-  // Call diff setting only `colored` by name, skipping the params before it.
-  return diff("a\nb\nc", "a\nB\nc", colored: false)
+  // Call diff setting only `color` by name, skipping the params before it.
+  return diff("a\nb\nc", "a\nB\nc", color: false)
 }

--- a/packages/agency-lang/tests/agency/diff-named-args.agency
+++ b/packages/agency-lang/tests/agency/diff-named-args.agency
@@ -1,0 +1,6 @@
+import { diff } from "std::syntax"
+
+node main(): string {
+  // Call diff setting only `colored` by name, skipping the params before it.
+  return diff("a\nb\nc", "a\nB\nc", colored: false)
+}

--- a/packages/agency-lang/tests/agency/diff-named-args.test.json
+++ b/packages/agency-lang/tests/agency/diff-named-args.test.json
@@ -1,0 +1,10 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"  a\\n- b\\n+ B\\n  c\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds two pure, string-returning functions to `std::syntax`, sharing one line-level hunk engine in `lib/utils/diff.ts`:

- **`diff(oldText, newText, ...)`** — a flexible human-readable diff. Line-aware (a single logical line is never split across multiple output lines), with inline word-highlighting on replacements. Flat named-arg options: `context`, `lineNumbers`, `colored`, `oldLabel`/`newLabel`, `ignoreWhitespace`, `hunkHeaders`, `summary`.
- **`patch(oldText, newText, filename, ...)`** — a standard unified diff that `std::fs::applyPatch` (or `git apply`) can apply. Supports file creation (`/dev/null`), deletion, and renames (`newFilename`).

Under the hood `lib/utils/diff.ts` is refactored into `computeHunks` → `renderDiff` (display) / `renderPatch` (unified diff). `formatDiff` stays as a thin shim, so the optimizer/test-runner/sourceMutator callers are unchanged.

Also: **removes the `std::fs::printDiff` tool** (and its `_printDiff` helper); callers now use `print(diff(old, new, colored: true))`. `edit`'s `printDiff: true` side effect now renders through the shared engine. `edit` remains the single public file-editing tool.

## Test Plan

- [x] Unit tests for `computeHunks`/`renderDiff`/`renderPatch` and back-compat `formatDiff` (`lib/utils/diff.test.ts`, 21 tests).
- [x] Existing optimizer callers unchanged (`reporter`/`sourceMutator`/`artifacts` tests green).
- [x] Pure Agency execution tests for `diff` (named-arg skipping) and `patch` output.
- [x] Agency-js round-trip: `applyPatch(patch(old, new, file))` reproduces `new` for single- and multi-hunk edits.
- [x] `std-fs-edit` / `std-fs-multiedit` still pass after the `printDiff` removal.
- [x] `pnpm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
