### PR TITLE
Rename interrupt "kind" to "effect"

### DIFF
--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -168,7 +168,7 @@ else:
 
 ```ts
 handle { ... } with (data) {
-  if (data.kind == "std::read" && data.params.dir == "/private") {
+  if (data.effect == "std::read" && data.params.dir == "/private") {
     return reject()
   }
   return consultPolicy()
@@ -184,7 +184,7 @@ keeps the "every handler always runs" guarantee intact.
 
 ### The diagnostic
 
-The error names the handler and the interrupt kinds:
+The error names the handler and the interrupt effects:
 
 ```
 Handler 'defaultHandler' may raise interrupts [std::read]. That would

--- a/packages/agency-lang/docs/site/guide/policies.md
+++ b/packages/agency-lang/docs/site/guide/policies.md
@@ -31,7 +31,7 @@ handle {
 }
 ```
 
-Policies are a structured way to respond to interrupts of different kinds. They don't magically get applied, you need to call the `checkPolicy()` function yourself. The rules of handlers still apply, so if a policy approves an interrupt, but a different handler rejects it, that interrupt will still get rejected.
+Policies are a structured way to respond to interrupts based on their effect. They don't magically get applied, you need to call the `checkPolicy()` function yourself. The rules of handlers still apply, so if a policy approves an interrupt, but a different handler rejects it, that interrupt will still get rejected.
 
 Here I've defined the policy as a variable, but its just an object. It could just as easily come from a JSON file, or a database.
 

--- a/packages/agency-lang/docs/site/guide/policies.md
+++ b/packages/agency-lang/docs/site/guide/policies.md
@@ -1,6 +1,6 @@
 ---
 name: Policies
-description: Explains how to define structured policies — rules matching on interrupt kind and data — to auto-approve or reject interrupts inside handler blocks.
+description: Explains how to define structured policies — rules matching on interrupt effect and data — to auto-approve or reject interrupts inside handler blocks.
 ---
 
 # Policies
@@ -35,7 +35,7 @@ Policies are a structured way to respond to interrupts of different kinds. They 
 
 Here I've defined the policy as a variable, but its just an object. It could just as easily come from a JSON file, or a database.
 
-In this example, I am matching on the interrupt kind, but I can additionally match on the interrupt data too. For example, here is a policy that approves all reads from the `/tmp` directory, and rejects all other reads.
+In this example, I am matching on the interrupt effect, but I can additionally match on the interrupt data too. For example, here is a policy that approves all reads from the `/tmp` directory, and rejects all other reads.
 
 ```json
 {

--- a/packages/agency-lang/docs/site/guide/serving.md
+++ b/packages/agency-lang/docs/site/guide/serving.md
@@ -113,7 +113,7 @@ If a node triggers an interrupt during execution, the response includes the inte
   "success": true,
   "value": {
     "interrupts": [
-      { "type": "interrupt", "kind": "std::read", "message": "Do you approve?" }
+      { "type": "interrupt", "effect": "std::read", "message": "Do you approve?" }
     ],
     "state": "..."
   }

--- a/packages/agency-lang/docs/site/guide/structured-interrupts.md
+++ b/packages/agency-lang/docs/site/guide/structured-interrupts.md
@@ -1,6 +1,6 @@
 ---
 name: Structured Interrupts
-description: Explains the structured interrupt syntax for tagging interrupts with an `effect`, letting handlers dispatch on different kinds of interrupts.
+description: Explains the structured interrupt syntax for tagging interrupts with an `effect`, letting handlers dispatch on different effects.
 ---
 
 # Structured Interrupts
@@ -21,7 +21,7 @@ return interrupt foo::write(
 
 In this example, `foo::write` is the effect of the interrupt. You can set this to anything you want. Interrupts in the standard library are prefixed with `std::`.
 
-What are effects good for? They're useful if you want specific responses for different kinds of interrupts in handlers:
+What are effects good for? They're useful if you want specific responses for different effects in handlers:
 
 ```ts
 def deleteEmail(numEmails: number) {
@@ -46,4 +46,4 @@ handle {
 
 Effects give you a way to programmatically identify and handle different interrupts in handler blocks. If you don't specify the effect, it is automatically set to `"unknown"`.
 
-Effects are also useful if you want to write [policies](./policies) that apply to specific kinds of interrupts.
+Effects are also useful if you want to write [policies](./policies) that apply to specific effects.

--- a/packages/agency-lang/docs/site/guide/structured-interrupts.md
+++ b/packages/agency-lang/docs/site/guide/structured-interrupts.md
@@ -1,6 +1,6 @@
 ---
 name: Structured Interrupts
-description: Explains the structured interrupt syntax for tagging interrupts with a `kind`, letting handlers dispatch on different kinds of interrupts.
+description: Explains the structured interrupt syntax for tagging interrupts with an `effect`, letting handlers dispatch on different kinds of interrupts.
 ---
 
 # Structured Interrupts
@@ -8,9 +8,9 @@ description: Explains the structured interrupt syntax for tagging interrupts wit
 All interrupts contain three fields:
 - message,
 - data, and
-- kind.
+- effect.
 
-We've already seen how you can pass the message and data as the first and second parameters to the `interrupt()` function. To pass in the kind, use the structured interrupt format.
+We've already seen how you can pass the message and data as the first and second parameters to the `interrupt()` function. To pass in the effect, use the structured interrupt format.
 
 ```ts
 return interrupt foo::write(
@@ -19,9 +19,9 @@ return interrupt foo::write(
 )
 ```
 
-In this example, `foo::write` is the kind of the interrupt. You can set this to anything you want. Interrupts in the standard library are prefixed with `std::`.
+In this example, `foo::write` is the effect of the interrupt. You can set this to anything you want. Interrupts in the standard library are prefixed with `std::`.
 
-What are kinds good for? They're useful if you want specific responses for different kinds of interrupts in handlers:
+What are effects good for? They're useful if you want specific responses for different kinds of interrupts in handlers:
 
 ```ts
 def deleteEmail(numEmails: number) {
@@ -37,13 +37,13 @@ handle {
 } with (data) {
   // Reject any interrupt for deleting email.
   // Approve all other interrupts.
-  if (data.kind == "foo::deleteEmail") {
+  if (data.effect == "foo::deleteEmail") {
     return reject()
   }
   return approve()
 }
 ```
 
-Kinds give you a way to programmatically identify and handle different interrupts in handler blocks. If you don't specify the kind, it is automatically set to `"unknown"`.
+Effects give you a way to programmatically identify and handle different interrupts in handler blocks. If you don't specify the effect, it is automatically set to `"unknown"`.
 
-Kinds are also useful if you want to write [policies](./policies) that apply to specific kinds of interrupts.
+Effects are also useful if you want to write [policies](./policies) that apply to specific kinds of interrupts.

--- a/packages/agency-lang/docs/site/guide/ts-interop.md
+++ b/packages/agency-lang/docs/site/guide/ts-interop.md
@@ -90,7 +90,7 @@ agency.thread.user("Please proofread the following.");
 
 // Install a scoped handler
 await agency.withHandler(
-  (intr) => intr.kind === "std::read" ? approve("auto-y") : undefined,
+  (intr) => intr.effect === "std::read" ? approve("auto-y") : undefined,
   () => doWork(),
 );
 

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -6,7 +6,7 @@ name: "policy"
 
 ## Overview
 
-  A `Policy` is an ordered list of rules per interrupt kind that decides,
+  A `Policy` is an ordered list of rules per interrupt effect that decides,
   without prompting the user, whether to approve or reject each interrupt
   an agent raises. Rules use glob patterns ("match objects") against the
   interrupt's `data` fields. Evaluation is first-match-wins.
@@ -22,7 +22,7 @@ name: "policy"
   2. **CLI sugar** — `cliPolicyHandler` — drops in as a handler for
      interactive agents. It loads `policy.json` on first use, prompts
      the user with (a)/(r)/(aa)/(ap)/(rr) for each new interrupt
-     kind, records "always" decisions to disk, and replays matching
+     effect, records "always" decisions to disk, and replays matching
      rules on subsequent interrupts so the user is only asked once
      per pattern.
 
@@ -31,8 +31,8 @@ name: "policy"
   ```ts
   import { cliPolicyHandler, ScopedRuleFields } from "std::policy"
 
-  // Per-kind config controlling the "approve always here (ap)" option.
-  // For every kind you list, the (ap) prompt offers to pin the listed
+  // Per-effect config controlling the "approve always here (ap)" option.
+  // For every effect you list, the (ap) prompt offers to pin the listed
   // data fields. `matchSubpaths: true` brace-expands the value so
   // `/tmp/x` also matches `/tmp/x/anything`.
   const FIELDS: ScopedRuleFields = {
@@ -53,7 +53,7 @@ name: "policy"
     )
     handle {
       // Every interrupt the inner code raises is filtered through the
-      // policy. New kinds prompt the user; "aa" / "ap" decisions are
+      // policy. New effects prompt the user; "aa" / "ap" decisions are
       // persisted so the next run starts pre-approved.
       llm("hi", { tools: [...] })
     } with handler
@@ -77,7 +77,7 @@ name: "policy"
     // decision.type == "propagate" -- no rule matches. Ask your UI:
     const choice = askUserSomehow(intr)
     if (choice == "always-approve") {
-      myPolicy = recordRule(myPolicy, intr.kind, "approve")
+      myPolicy = recordRule(myPolicy, intr.effect, "approve")
       return approve()
     }
     return choice == "approve" ? approve() : reject()
@@ -89,7 +89,7 @@ name: "policy"
   Each rule has an optional `match` map. The values are glob patterns
   (via picomatch); evaluation passes when every key in `match` exists
   in `intr.data` and its value matches the pattern. A rule with no
-  `match` is a catch-all for that kind.
+  `match` is a catch-all for that effect.
 
   Example: this rule auto-approves reads under `/tmp` (and any subdir):
 
@@ -108,7 +108,7 @@ name: "policy"
 
   `recordRule` **appends** a catch-all rule. Because evaluation is
   first-match-wins, a new approve rule will be ignored if an earlier
-  catch-all already covers the kind:
+  catch-all already covers the effect:
 
   ```ts
   let p = recordRule({}, "std::read", "reject")
@@ -152,17 +152,17 @@ export type InterruptDataVal = string
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L142))
 
-### InterruptKind
+### InterruptEffect
 
-* Identifier for an interrupt's kind (e.g. `"std::read"`,
+* Identifier for an interrupt's effect (e.g. `"std::read"`,
  * `"myapp::deploy"`).
 
 ```ts
 /**
- * Identifier for an interrupt's kind (e.g. `"std::read"`,
+ * Identifier for an interrupt's effect (e.g. `"std::read"`,
  * `"myapp::deploy"`).
  */
-export type InterruptKind = string
+export type InterruptEffect = string
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L148))
@@ -172,14 +172,14 @@ export type InterruptKind = string
 * One row of a `Policy`. A rule passes if every key in `match` is
  * present in the interrupt's `data` and its value matches the glob
  * pattern. Omit `match` (or set it to `{}`) for a catch-all that
- * applies to every interrupt of the parent kind.
+ * applies to every interrupt of the parent effect.
 
 ```ts
 /**
  * One row of a `Policy`. A rule passes if every key in `match` is
  * present in the interrupt's `data` and its value matches the glob
  * pattern. Omit `match` (or set it to `{}`) for a catch-all that
- * applies to every interrupt of the parent kind.
+ * applies to every interrupt of the parent effect.
  */
 export type PolicyRule = {
   match?: Record<InterruptDataKey, InterruptDataVal>;
@@ -191,19 +191,19 @@ export type PolicyRule = {
 
 ### Policy
 
-* A policy: ordered rules per interrupt kind. `checkPolicy` walks
- * the array for `intr.kind` in order and returns on the first
- * matching rule. If no rule for the kind exists, evaluation falls
+* A policy: ordered rules per interrupt effect. `checkPolicy` walks
+ * the array for `intr.effect` in order and returns on the first
+ * matching rule. If no rule for the effect exists, evaluation falls
  * through to `propagate` (i.e. ask the next handler in the chain).
 
 ```ts
 /**
- * A policy: ordered rules per interrupt kind. `checkPolicy` walks
- * the array for `intr.kind` in order and returns on the first
- * matching rule. If no rule for the kind exists, evaluation falls
+ * A policy: ordered rules per interrupt effect. `checkPolicy` walks
+ * the array for `intr.effect` in order and returns on the first
+ * matching rule. If no rule for the effect exists, evaluation falls
  * through to `propagate` (i.e. ask the next handler in the chain).
  */
-export type Policy = Record<InterruptKind, PolicyRule[]>
+export type Policy = Record<InterruptEffect, PolicyRule[]>
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L167))
@@ -213,22 +213,22 @@ export type Policy = Record<InterruptKind, PolicyRule[]>
 * The five answers `cliPolicyHandler`'s prompt accepts:
  * - `"approve"` / `"reject"` — one-off (a) / (r).
  * - `"approve-always"` / `"reject-always"` — (aa) / (rr); records a
- *   catch-all rule for the kind so future interrupts of this kind
+ *   catch-all rule for the effect so future interrupts of this effect
  *   resolve without prompting.
  * - `"approve-always-here"` — (ap); records a scoped rule pinned to
- *   whichever fields you listed in `ScopedRuleFields` for this kind.
- *   Only offered when the kind has an entry in the config.
+ *   whichever fields you listed in `ScopedRuleFields` for this effect.
+ *   Only offered when the effect has an entry in the config.
 
 ```ts
 /**
  * The five answers `cliPolicyHandler`'s prompt accepts:
  * - `"approve"` / `"reject"` — one-off (a) / (r).
  * - `"approve-always"` / `"reject-always"` — (aa) / (rr); records a
- *   catch-all rule for the kind so future interrupts of this kind
+ *   catch-all rule for the effect so future interrupts of this effect
  *   resolve without prompting.
  * - `"approve-always-here"` — (ap); records a scoped rule pinned to
- *   whichever fields you listed in `ScopedRuleFields` for this kind.
- *   Only offered when the kind has an entry in the config.
+ *   whichever fields you listed in `ScopedRuleFields` for this effect.
+ *   Only offered when the effect has an entry in the config.
  */
 export type Decision =
   | "approve"
@@ -274,9 +274,9 @@ export type ScopedField = {
 
 ### ScopedRuleFields
 
-* Per-kind configuration consumed by `buildScopedMatch` and the
- * `cliPolicyHandler`. Maps each interrupt kind to the fields its
- * "approve-always-here" rule should pin. Kinds not present in this
+* Per-effect configuration consumed by `buildScopedMatch` and the
+ * `cliPolicyHandler`. Maps each interrupt effect to the fields its
+ * "approve-always-here" rule should pin. Effects not present in this
  * map don't offer the (ap) prompt option — the user falls back to
  * (a) / (r) / (aa) / (rr).
  *
@@ -293,9 +293,9 @@ export type ScopedField = {
 
 ````ts
 /**
- * Per-kind configuration consumed by `buildScopedMatch` and the
- * `cliPolicyHandler`. Maps each interrupt kind to the fields its
- * "approve-always-here" rule should pin. Kinds not present in this
+ * Per-effect configuration consumed by `buildScopedMatch` and the
+ * `cliPolicyHandler`. Maps each interrupt effect to the fields its
+ * "approve-always-here" rule should pin. Effects not present in this
  * map don't offer the (ap) prompt option — the user falls back to
  * (a) / (r) / (aa) / (rr).
  *
@@ -310,7 +310,7 @@ export type ScopedField = {
  * }
  * ```
  */
-export type ScopedRuleFields = Record<InterruptKind, ScopedField[]>
+export type ScopedRuleFields = Record<InterruptEffect, ScopedField[]>
 ````
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L220))
@@ -346,12 +346,12 @@ export type ParsePolicyFailure = {
 checkPolicy(policy: Record<string, any>, interrupt: Record<string, any>)
 ```
 
-Evaluate a policy against an interrupt. Returns approve(), reject(), or propagate() based on the first matching rule. Policy is a JSON object keyed by interrupt kind, where each kind maps to an ordered array of rules with optional match fields (glob patterns) and an action.
+Evaluate a policy against an interrupt. Returns approve(), reject(), or propagate() based on the first matching rule. Policy is a JSON object keyed by interrupt effect, where each effect maps to an ordered array of rules with optional match fields (glob patterns) and an action.
 
 * Evaluate a policy against a single interrupt. Returns the result
  * of `approve()`, `reject()`, or `propagate()` corresponding to the
- * first matching rule for `interrupt.kind`. If no rule matches
- * (no rules for the kind, or every rule's `match` failed), returns
+ * first matching rule for `interrupt.effect`. If no rule matches
+ * (no rules for the effect, or every rule's `match` failed), returns
  * `propagate()` so the next handler in the chain runs.
  *
  * Designed for use inside a custom handler. The CLI sugar
@@ -398,8 +398,8 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 buildScopedMatch(intr: Record<string, any>, fields: ScopedRuleFields): Record<string, string>
 ```
 
-Given the per-kind ScopedField[] config, build a match object pinned
-  to the meaningful fields of this interrupt. Returns {} when the kind
+Given the per-effect ScopedField[] config, build a match object pinned
+  to the meaningful fields of this interrupt. Returns {} when the effect
   isn't in the fields map. Pure.
 
 * Build the `match` map for a scoped rule by reading the configured
@@ -411,7 +411,7 @@ Given the per-kind ScopedField[] config, build a match object pinned
  * const rule: PolicyRule = { match: match, action: "approve" }
  * ```
  *
- * For each `ScopedField` configured for `intr.kind`:
+ * For each `ScopedField` configured for `intr.effect`:
  * - The field's value is read from `intr.data`.
  * - If `matchSubpaths: true`, the value is wrapped as
  *   `"{value,value/**}"` so the resulting glob matches both the
@@ -420,7 +420,7 @@ Given the per-kind ScopedField[] config, build a match object pinned
  *   match).
  *
  * Fields that are absent from `intr.data` (`null` / `undefined`)
- * are skipped silently. Kinds not present in `fields` return `{}`.
+ * are skipped silently. Effects not present in `fields` return `{}`.
  *
  * Most callers should use `recordScopedRule` instead, which calls
  * this internally; `buildScopedMatch` is exposed for callers
@@ -441,24 +441,24 @@ Given the per-kind ScopedField[] config, build a match object pinned
 ### recordRule
 
 ```ts
-recordRule(policy: Policy, kind: InterruptKind, action: "approve" | "reject"): Policy
+recordRule(policy: Policy, effect: InterruptEffect, action: "approve" | "reject"): Policy
 ```
 
-Return a new policy with a catch-all rule for `kind` appended.
+Return a new policy with a catch-all rule for `effect` appended.
   First-match-wins inside `checkPolicy`, so a single bare rule covers
-  every future interrupt of that kind. Pure — no I/O.
+  every future interrupt of that effect. Pure — no I/O.
 
-  WARNING: append order matters. A second call for the same kind with
-  a different action is dead — the earlier rule wins. Reset the kind's
+  WARNING: append order matters. A second call for the same effect with
+  a different action is dead — the earlier rule wins. Reset the effect's
   rules first if you want to flip a previous decision.
 
 * Return a new policy with a catch-all rule (`{ action }` with no
- * `match`) for `kind` appended. Pure — does not mutate the input.
+ * `match`) for `effect` appended. Pure — does not mutate the input.
  *
  * ## Precedence trap
  *
  * Evaluation is first-match-wins, so **append order matters**. A
- * second call for the same kind with a different action is dead
+ * second call for the same effect with a different action is dead
  * code:
  *
  * ```ts
@@ -467,9 +467,9 @@ Return a new policy with a catch-all rule for `kind` appended.
  * ```
  *
  * If you're flipping a previously-recorded decision, decide
- * explicitly: either reset the kind's rules first
+ * explicitly: either reset the effect's rules first
  * (`{ ...policy, "std::read": [] }` and re-record), or hand-edit
- * `policy[kind]` to replace the offending rule. This function does
+ * `policy[effect]` to replace the offending rule. This function does
  * not try to detect or warn about shadowing on your behalf.
 
 **Parameters:**
@@ -477,7 +477,7 @@ Return a new policy with a catch-all rule for `kind` appended.
 | Name | Type | Default |
 |---|---|---|
 | policy | [Policy](#policy) |  |
-| kind | [InterruptKind](#interruptkind) |  |
+| effect | [InterruptEffect](#interrupteffect) |  |
 | action | `"approve" \| "reject"` |  |
 
 **Returns:** [Policy](#policy)
@@ -491,16 +491,16 @@ recordScopedRule(policy: Policy, intr: Record<string, any>, fields: ScopedRuleFi
 ```
 
 Return a new policy with a scoped approve rule prepended for the
-  interrupt's kind. Prepended (not appended) so the more-specific
+  interrupt's effect. Prepended (not appended) so the more-specific
   rule wins over any later catch-all in first-match-wins order. Pure.
 
 * Return a new policy with a scoped approve rule prepended for
- * `intr.kind`. The rule's `match` is built by `buildScopedMatch`,
- * so it pins whichever fields are configured for the kind. Pure.
+ * `intr.effect`. The rule's `match` is built by `buildScopedMatch`,
+ * so it pins whichever fields are configured for the effect. Pure.
  *
  * Prepended (not appended) so the new, more-specific rule wins
  * over any pre-existing catch-all in first-match-wins order. This
- * makes scoped rules safe to add even if the kind already has a
+ * makes scoped rules safe to add even if the effect already has a
  * broader rejection: the scoped approval applies first when it
  * matches, otherwise the catch-all takes over.
  *
@@ -661,7 +661,7 @@ CLI sugar for an interactive policy handler. Owns load + save +
   handle { ... } with handler
 
   @param file - Path to the on-disk policy file
-  @param fields - Per-kind config controlling the "approve-always-here" option
+  @param fields - Per-effect config controlling the "approve-always-here" option
 
 * Drop-in policy handler for interactive CLI agents. Returns a
  * function ref you bind to a local variable and install on a `handle`
@@ -685,7 +685,7 @@ CLI sugar for an interactive policy handler. Owns load + save +
  *    matches, approves or rejects without prompting.
  * 3. **Prompts the user** when no rule applies, showing
  *    (a)/(r)/(aa)/(ap)/(rr). The (ap) option appears only when
- *    `fields` has an entry for the interrupt's kind.
+ *    `fields` has an entry for the interrupt's effect.
  * 4. **Records "always" decisions** in memory and flushes them to
  *    disk at the top of the next interrupt. Use `flushPolicy()` if
  *    you need the final decision of a session persisted before
@@ -710,8 +710,8 @@ CLI sugar for an interactive policy handler. Owns load + save +
  *
  * @param file - Path to the on-disk policy file. Created on first
  *   save; the containing directory must already exist.
- * @param fields - Per-kind config controlling the (ap) prompt
- *   option. Kinds not present here don't offer (ap).
+ * @param fields - Per-effect config controlling the (ap) prompt
+ *   option. Effects not present here don't offer (ap).
 
 **Parameters:**
 

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -60,7 +60,7 @@ import { reviewAgent } from "./subagents/review.agency"
  * This file's responsibilities collapse to:
  *   1. Per-turn callback (`_runTurn`) wiring the user message into
  *      `mainAgent` and printing the reply into the scroll output.
- *   2. Per-kind ALWAYS_FIELDS map for the policy handler's
+ *   2. Per-effect ALWAYS_FIELDS map for the policy handler's
  *      "approve-always-here" option.
  *   3. Wire the two specialists into one `RouterConfig`.
  *
@@ -529,10 +529,10 @@ def setupSession(interactive: boolean): any {
 
 // Show a colored diff for an incoming `std::edit` interrupt. Shared by
 // the interactive and one-shot handlers. The handler receives the whole
-// interrupt object ({kind, message, data, origin}); the edit's
+// interrupt object ({effect, message, data, origin}); the edit's
 // filename / before / after live under `data.data`.
 def renderEditDiff(data: any) {
-  if (data.kind == "std::edit") {
+  if (data.effect == "std::edit") {
     print(color.yellow("⏺ Edit: ${data.data.filename}"))
     print(
       diff(

--- a/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
@@ -9,10 +9,10 @@ export static const POLICY_DIR = path.join(os.homedir(), ".agency-agent")
 export static const POLICY_PATH = path.join(POLICY_DIR, POLICY_FILE)
 export static const HISTORY_PATH = path.join(POLICY_DIR, HISTORY_FILE)
 
-// Per-kind config driving the "approve-always-here" option. For each
-// kind we list the data fields the scoped rule should pin, plus a
+// Per-effect config driving the "approve-always-here" option. For each
+// effect we list the data fields the scoped rule should pin, plus a
 // flag that turns a directory value into a brace-expanded glob so the
-// rule matches `dir` AND `dir/**`. Kinds not present in this map
+// rule matches `dir` AND `dir/**`. Effects not present in this map
 // don't offer the option — the user falls back to (a)/(r)/(aa)/(rr).
 export static const ALWAYS_FIELDS: ScopedRuleFields = {
   "std::read": [{

--- a/packages/agency-lang/lib/agents/policy/agent.agency
+++ b/packages/agency-lang/lib/agents/policy/agent.agency
@@ -2,7 +2,7 @@ import { map } from "std::array"
 import {
   writePolicyFile,
   Policy,
-  InterruptKind,
+  InterruptEffect,
   InterruptDataKey,
   InterruptDataVal,
  } from "std::policy"
@@ -36,23 +36,23 @@ type PolicyAction = "approve" | "reject" | "propagate"
 let currentPolicy: Policy = {}
 
 def addToPolicy(
-  interruptKind: InterruptKind,
+  interruptEffect: InterruptEffect,
   matchArgName: InterruptDataKey,
   matchArgValue: InterruptDataVal,
   action: PolicyAction!,
 ): Result<Policy> {
   """
-  Add a rule to the current policy for the given interrupt kind, matching on the specified argument and value, with the specified action.
+  Add a rule to the current policy for the given interrupt effect, matching on the specified argument and value, with the specified action.
   Use only "approve", "reject", or "propagate" as the action. DO NOT use "allow" or "deny".
   Returns the current policy after adding the rule.
   """
   const match = {
     [matchArgName]: matchArgValue
   }
-  if (!currentPolicy[interruptKind]) {
-    currentPolicy[interruptKind] = []
+  if (!currentPolicy[interruptEffect]) {
+    currentPolicy[interruptEffect] = []
   }
-  currentPolicy[interruptKind].push({
+  currentPolicy[interruptEffect].push({
     match: match,
     action: action
   })
@@ -77,13 +77,13 @@ def setPolicy(newPolicy: Policy): Policy {
   return currentPolicy
 }
 
-def deleteFromPolicy(interruptKind: InterruptKind, index: number): boolean {
+def deleteFromPolicy(interruptEffect: InterruptEffect, index: number): boolean {
   """
-  Delete the rule at the specified index for the given interrupt kind from the current policy.
+  Delete the rule at the specified index for the given interrupt effect from the current policy.
   Returns true if the rule was successfully deleted, or false if the index was out of bounds.
   """
-  if (currentPolicy[interruptKind] && index < currentPolicy[interruptKind].length) {
-    currentPolicy[interruptKind].splice(index, 1)
+  if (currentPolicy[interruptEffect] && index < currentPolicy[interruptEffect].length) {
+    currentPolicy[interruptEffect].splice(index, 1)
     return true
   }
   return false
@@ -116,16 +116,16 @@ node main() {
     return
   }
 
-  const interruptKinds = cliArgs[0] |> parseJSON
+  const interruptEffects = cliArgs[0] |> parseJSON
   const outputPath = cliArgs[1]
   const existingPolicy = get(cliArgs, 2) |> parseJSON
 
-  if (interruptKinds is failure(error)) {
-    print("Failed to parse interrupt kinds: ${error}")
+  if (interruptEffects is failure(error)) {
+    print("Failed to parse interrupt effects: ${error}")
     return
   }
 
-  let contextMessage = "This agent can produce the following interrupts:\n${map(interruptKinds.value, \kind -> "- ${kind}\n").join("")}"
+  let contextMessage = "This agent can produce the following interrupts:\n${map(interruptEffects.value, \effect -> "- ${effect}\n").join("")}"
 
   if (existingPolicy is success(thePolicy)) {
     currentPolicy = thePolicy

--- a/packages/agency-lang/lib/analysis/interrupts.test.ts
+++ b/packages/agency-lang/lib/analysis/interrupts.test.ts
@@ -29,7 +29,7 @@ node main() {
         const result = analyzeInterrupts(file, {});
         expect(result.sites).toHaveLength(1);
         const s = result.sites[0];
-        expect(s.site.kind).toBe("std::read");
+        expect(s.site.effect).toBe("std::read");
         expect(s.site.file).toBe(file);
         expect(s.site.line).toBe(4); // 1-indexed line of `interrupt std::read(...)`
         expect(s.handlers).toHaveLength(1);
@@ -71,7 +71,7 @@ node main() {
       (file) => {
         const result = analyzeInterrupts(file, {});
         expect(result.sites).toHaveLength(1);
-        expect(result.sites[0].site.kind).toBe("unknown");
+        expect(result.sites[0].site.effect).toBe("unknown");
       },
     );
   });
@@ -194,7 +194,7 @@ node main() {
 `,
       (file) => {
         const result = analyzeInterrupts(file, {});
-        const site = result.sites.find((s) => s.site.kind === "std::write");
+        const site = result.sites.find((s) => s.site.effect === "std::write");
         expect(site).toBeDefined();
         expect(site!.handlers).toHaveLength(1);
         expect(site!.handlers[0].line).toBe(7);
@@ -262,7 +262,7 @@ node main() {
         expect(result.sites).toHaveLength(2);
         // Sites are sorted by line, so std::write (line 4) comes first.
         expect(result.sites.map((s) => s.site.line)).toEqual([4, 5]);
-        expect(result.sites.map((s) => s.site.kind)).toEqual(["std::write", "std::read"]);
+        expect(result.sites.map((s) => s.site.effect)).toEqual(["std::write", "std::read"]);
       },
     );
   });
@@ -431,7 +431,7 @@ node main() {
       const result = analyzeInterrupts(mainFile, {});
       // Both same-named helpers are reported with their own interrupt
       // sites; neither overwrites the other in the merged graph.
-      const kinds = result.sites.map((s) => s.site.kind).sort();
+      const kinds = result.sites.map((s) => s.site.effect).sort();
       expect(kinds).toEqual(["std::read", "std::write"]);
       const files = new Set(result.sites.map((s) => s.site.file));
       expect(files).toEqual(
@@ -463,7 +463,7 @@ def b() {
       (file) => {
         const result = analyzeInterrupts(file, {});
         expect(result.sites).toHaveLength(1);
-        expect(result.sites[0].site.kind).toBe("std::read");
+        expect(result.sites[0].site.effect).toBe("std::read");
         expect(result.sites[0].site.file).toBe(file);
       },
     );

--- a/packages/agency-lang/lib/analysis/interrupts.ts
+++ b/packages/agency-lang/lib/analysis/interrupts.ts
@@ -18,16 +18,16 @@ import type { InterruptStatement } from "@/types/interruptStatement.js";
 
 /**
  * One interrupt site: a single `interruptStatement` AST node, located by
- * (file, line, kind). `line` is **1-indexed** for human consumption (the
+ * (file, line, effect). `line` is **1-indexed** for human consumption (the
  * parser stores 0-indexed lines, so we add 1 when building this shape).
  */
 export type InterruptSite = {
   file: string;
   /** 1-indexed line number of the `interrupt …` statement. */
   line: number;
-  /** Interrupt kind, e.g. `"std::read"`. `"unknown"` for the bare
+  /** Interrupt effect, e.g. `"std::read"`. `"unknown"` for the bare
    *  `interrupt(...)` form. */
-  kind: string;
+  effect: string;
 };
 
 /**
@@ -271,7 +271,7 @@ function buildSiteResult(rec: SiteRecord, handlers: HandlerSet): SiteResult {
     site: {
       file: rec.file,
       line: toDisplayLine(rec.site.loc?.line),
-      kind: rec.site.kind,
+      effect: rec.site.effect,
     },
     handlers: Array.from(handlers.values()).map(toHandlerRef).sort(compareHandlerRefs),
   };

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -516,10 +516,10 @@ export class AgencyGenerator {
 
   protected processInterruptStatement(node: InterruptStatement): string {
     const args = this.renderArgList(node.arguments);
-    if (node.kind === "unknown") {
+    if (node.effect === "unknown") {
       return this.indentStr(`interrupt${args}`);
     }
-    return this.indentStr(`interrupt ${node.kind}${args}`);
+    return this.indentStr(`interrupt ${node.effect}${args}`);
   }
 
   protected needsParensLeft(child: BinOpArgument, parentOp: Operator): boolean {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1891,21 +1891,21 @@ export class TypeScriptBuilder {
     return this.processNode(node);
   }
 
-  private interruptTemplateArgs(kind: string, message: string, data: string, origin: string) {
+  private interruptTemplateArgs(effect: string, message: string, data: string, origin: string) {
     return {
-      kind: JSON.stringify(kind),
+      effect: JSON.stringify(effect),
       message,
       data,
       origin: JSON.stringify(origin),
     };
   }
 
-  private buildInterruptReturnStructured(kind: string, messageExpr: string, dataExpr: string): TsNode {
+  private buildInterruptReturnStructured(effect: string, messageExpr: string, dataExpr: string): TsNode {
     const origin = moduleIdToOrigin(this.moduleId);
     const opts = this.checkpointOpts();
     return ts.raw(
       renderInterruptReturn.default({
-        ...this.interruptTemplateArgs(kind, messageExpr, dataExpr, origin),
+        ...this.interruptTemplateArgs(effect, messageExpr, dataExpr, origin),
         nodeContext: this.scopes.current().type === "node",
         interruptIdKey: `__interruptId_${this.steps.joined("_")}`,
         ...opts,
@@ -1913,9 +1913,9 @@ export class TypeScriptBuilder {
     );
   }
 
-  private extractInterruptFields(node: InterruptStatement): { kind: string; messageExpr: string; dataExpr: string } {
+  private extractInterruptFields(node: InterruptStatement): { effect: string; messageExpr: string; dataExpr: string } {
     return {
-      kind: node.kind,
+      effect: node.effect,
       messageExpr: node.arguments && node.arguments.length > 0
         ? this.str(this.processCallArg(node.arguments[0]))
         : '""',
@@ -1930,8 +1930,8 @@ export class TypeScriptBuilder {
   }
 
   private processInterruptStatement(node: InterruptStatement): TsNode {
-    const { kind, messageExpr, dataExpr } = this.extractInterruptFields(node);
-    return this.buildInterruptReturnStructured(kind, messageExpr, dataExpr);
+    const { effect, messageExpr, dataExpr } = this.extractInterruptFields(node);
+    return this.buildInterruptReturnStructured(effect, messageExpr, dataExpr);
   }
 
   private processFunctionCallAsStatement(node: FunctionCall): TsNode {
@@ -2721,7 +2721,7 @@ export class TypeScriptBuilder {
     if (value.type === "functionCall" && value.functionName === "llm") {
       return this.processLlmCall(variableName, typeHint, value, node.scope!);
     } else if (this.isInterruptExpression(value)) {
-      const { kind, messageExpr, dataExpr } = this.extractInterruptFields(value as InterruptStatement);
+      const { effect, messageExpr, dataExpr } = this.extractInterruptFields(value as InterruptStatement);
       const origin = moduleIdToOrigin(this.moduleId);
       const makeAssign = (val: string) =>
         this.str(
@@ -2738,7 +2738,7 @@ export class TypeScriptBuilder {
           assignResolve: makeAssign("__response.value"),
           assignApprove: makeAssign("true"),
           handlerApprove: makeAssign("__handlerResult.value"),
-          ...this.interruptTemplateArgs(kind, messageExpr, dataExpr, origin),
+          ...this.interruptTemplateArgs(effect, messageExpr, dataExpr, origin),
           nodeContext: this.scopes.current().type === "node",
           interruptIdKey: `__interruptId_${this.steps.joined("_")}`,
           ...opts,

--- a/packages/agency-lang/lib/cli/doc.ts
+++ b/packages/agency-lang/lib/cli/doc.ts
@@ -11,7 +11,7 @@ import { GraphNodeDefinition } from "@/types/graphNode.js";
 import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
 import { buildCompilationUnit, GLOBAL_SCOPE_KEY } from "@/compilationUnit.js";
 import { typeCheck } from "@/typeChecker/index.js";
-import type { InterruptKind } from "@/symbolTable.js";
+import type { InterruptEffect } from "@/symbolTable.js";
 import {
   heading,
   codeFence,
@@ -142,13 +142,13 @@ function generateDocForFile(
   const info = buildCompilationUnit(program);
 
   // Run the type checker (without a SymbolTable) to compute the
-  // transitive interrupt kinds each function/node may throw. We
+  // transitive interrupt effects each function/node may throw. We
   // intentionally ignore type errors here — the doc command should
   // produce output even for files that don't fully type-check.
-  let interruptKindsByFunction: Record<string, InterruptKind[]> = {};
+  let interruptEffectsByFunction: Record<string, InterruptEffect[]> = {};
   try {
     const result = typeCheck(program, ctx.config, info);
-    interruptKindsByFunction = result.interruptKindsByFunction;
+    interruptEffectsByFunction = result.interruptEffectsByFunction;
   } catch {
     // Fall back to no interrupt info if the type checker crashes.
   }
@@ -185,14 +185,14 @@ function generateDocForFile(
   const functionSection = generateFunctionSection(
     functions,
     ctx,
-    interruptKindsByFunction,
+    interruptEffectsByFunction,
   );
   if (functionSection) sections.push(functionSection);
 
   const nodeSection = generateNodeSection(
     info.graphNodes,
     ctx,
-    interruptKindsByFunction,
+    interruptEffectsByFunction,
   );
   if (nodeSection) sections.push(nodeSection);
   const generatedOutput = sections.join("\n\n") + "\n";
@@ -387,10 +387,10 @@ function generateConstantSection(
   );
 }
 
-function formatThrows(kinds: InterruptKind[] | undefined): string | null {
+function formatThrows(kinds: InterruptEffect[] | undefined): string | null {
   if (!kinds || kinds.length === 0) return null;
   const formatted = kinds
-    .map((k) => "`" + (k.kind || "unknown") + "`")
+    .map((k) => "`" + (k.effect || "unknown") + "`")
     .join(", ");
   return `${bold("Throws:")} ${formatted}`;
 }
@@ -398,7 +398,7 @@ function formatThrows(kinds: InterruptKind[] | undefined): string | null {
 function generateFunctionSection(
   fns: FunctionDefinition[],
   ctx: DocContext,
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
 ): string | null {
   if (fns.length === 0) return null;
   const _parts = fns.map((fn) => {
@@ -413,7 +413,7 @@ function generateFunctionSection(
       fn.returnType
         ? `${bold("Returns:")} ${formatTypeLinked(fn.returnType, ctx)}`
         : null,
-      formatThrows(interruptKindsByFunction[fn.functionName]),
+      formatThrows(interruptEffectsByFunction[fn.functionName]),
       sourceLink(fn.loc, ctx),
     );
   });
@@ -424,7 +424,7 @@ function generateFunctionSection(
 function generateNodeSection(
   nodes: GraphNodeDefinition[],
   ctx: DocContext,
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
 ): string | null {
   if (nodes.length === 0) return null;
   const parts = nodes.map((node) => {
@@ -442,7 +442,7 @@ function generateNodeSection(
       node.returnType
         ? `${bold("Returns:")} ${formatTypeLinked(node.returnType, ctx)}`
         : null,
-      formatThrows(interruptKindsByFunction[node.nodeName]),
+      formatThrows(interruptEffectsByFunction[node.nodeName]),
       sourceLink(node.loc, ctx),
     );
   });

--- a/packages/agency-lang/lib/cli/interrupts.test.ts
+++ b/packages/agency-lang/lib/cli/interrupts.test.ts
@@ -6,32 +6,32 @@ describe("renderInterrupts", () => {
   it("renders a site with no handlers as (none) under the standard header", () => {
     const r: AnalysisResult = {
       sites: [{
-        site: { file: "/x/a.agency", line: 5, kind: "std::read" },
+        site: { file: "/x/a.agency", line: 5, effect: "std::read" },
         handlers: [],
       }],
     };
     const out = renderInterrupts(r);
-    expect(out).toContain("/x/a.agency:5  interrupt of kind std::read");
+    expect(out).toContain("/x/a.agency:5  interrupt of effect std::read");
     expect(out).toContain("Possible enclosing handlers:");
     expect(out).toContain("(none)");
   });
 
-  it("omits the kind clause when kind is unknown", () => {
+  it("omits the effect clause when effect is unknown", () => {
     const r: AnalysisResult = {
       sites: [{
-        site: { file: "/x/a.agency", line: 5, kind: "unknown" },
+        site: { file: "/x/a.agency", line: 5, effect: "unknown" },
         handlers: [],
       }],
     };
     const out = renderInterrupts(r);
     expect(out).toContain("/x/a.agency:5  interrupt");
-    expect(out).not.toContain("of kind");
+    expect(out).not.toContain("of effect");
   });
 
   it("renders inline and functionRef handlers in the right format", () => {
     const r: AnalysisResult = {
       sites: [{
-        site: { file: "/x/a.agency", line: 5, kind: "std::read" },
+        site: { file: "/x/a.agency", line: 5, effect: "std::read" },
         handlers: [
           { file: "/x/m.agency", line: 10, shape: "inline" },
           { file: "/x/m.agency", line: 18, shape: "functionRef", functionName: "approveReads" },
@@ -46,8 +46,8 @@ describe("renderInterrupts", () => {
   it("emits one block per site, separated by blank lines", () => {
     const r: AnalysisResult = {
       sites: [
-        { site: { file: "/x/a.agency", line: 1, kind: "std::read" }, handlers: [] },
-        { site: { file: "/x/a.agency", line: 5, kind: "std::write" }, handlers: [] },
+        { site: { file: "/x/a.agency", line: 1, effect: "std::read" }, handlers: [] },
+        { site: { file: "/x/a.agency", line: 5, effect: "std::write" }, handlers: [] },
       ],
     };
     const out = renderInterrupts(r);
@@ -58,7 +58,7 @@ describe("renderInterrupts", () => {
   it("ends the output with a single trailing newline", () => {
     const r: AnalysisResult = {
       sites: [{
-        site: { file: "/x/a.agency", line: 5, kind: "std::read" },
+        site: { file: "/x/a.agency", line: 5, effect: "std::read" },
         handlers: [],
       }],
     };

--- a/packages/agency-lang/lib/cli/interrupts.ts
+++ b/packages/agency-lang/lib/cli/interrupts.ts
@@ -26,9 +26,9 @@ export function renderInterrupts(result: AnalysisResult): string {
   for (const s of result.sites) {
     const lines: string[] = [];
     const header =
-      s.site.kind === "unknown"
+      s.site.effect === "unknown"
         ? `${s.site.file}:${s.site.line}  interrupt`
-        : `${s.site.file}:${s.site.line}  interrupt of kind ${s.site.kind}`;
+        : `${s.site.file}:${s.site.line}  interrupt of effect ${s.site.effect}`;
     lines.push(header);
     lines.push("  Possible enclosing handlers:");
     if (s.handlers.length === 0) {

--- a/packages/agency-lang/lib/cli/policy.ts
+++ b/packages/agency-lang/lib/cli/policy.ts
@@ -1,7 +1,7 @@
 import { AgencyConfig } from "@/config.js";
 import { runBundledAgent } from "./runBundledAgent.js";
 import { SymbolTable } from "../symbolTable.js";
-import type { FileSymbols, InterruptKind } from "../symbolTable.js";
+import type { FileSymbols, InterruptEffect } from "../symbolTable.js";
 import { existsSync, readFileSync } from "fs";
 import { validatePolicy } from "../runtime/policy.js";
 import { parseAgency } from "../parser.js";
@@ -9,9 +9,9 @@ import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck } from "../typeChecker/index.js";
 import path from "path";
 
-function uniqueInterruptKinds(
+function uniqueInterruptEffects(
   fileSymbols: FileSymbols | undefined,
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
 ): string[] {
   // The symbol table only records *direct* interrupts (literal `interrupt`
   // statements in a function/node body). Transitive interrupts — e.g. a node
@@ -20,9 +20,9 @@ function uniqueInterruptKinds(
   const kinds: string[] = [];
   for (const sym of Object.values(fileSymbols ?? {})) {
     if (sym.kind !== "function" && sym.kind !== "node") continue;
-    const transitive = interruptKindsByFunction[sym.name] ?? sym.interruptKinds ?? [];
+    const transitive = interruptEffectsByFunction[sym.name] ?? sym.interruptEffects ?? [];
     for (const ik of transitive) {
-      if (!kinds.includes(ik.kind)) kinds.push(ik.kind);
+      if (!kinds.includes(ik.effect)) kinds.push(ik.effect);
     }
   }
   return kinds;
@@ -48,21 +48,21 @@ export function policyGen(
   const symbolTable = SymbolTable.build(absoluteFile, config);
   const fileSymbols = symbolTable.getFile(absoluteFile);
 
-  // Run the type checker so we get *transitive* interrupt kinds (the symbol
+  // Run the type checker so we get *transitive* interrupt effects (the symbol
   // table only knows about direct `interrupt` statements; calls into stdlib
   // functions like `read()` need the type checker's transitive analysis).
   const source = readFileSync(absoluteFile, "utf-8");
   const parseResult = parseAgency(source, config);
-  let interruptKindsByFunction: Record<string, InterruptKind[]> = {};
+  let interruptEffectsByFunction: Record<string, InterruptEffect[]> = {};
   if (parseResult.success) {
     const info = buildCompilationUnit(parseResult.result, symbolTable, absoluteFile, source);
     const result = typeCheck(parseResult.result, config, info);
-    interruptKindsByFunction = result.interruptKindsByFunction;
+    interruptEffectsByFunction = result.interruptEffectsByFunction;
   }
-  const interruptKinds = uniqueInterruptKinds(fileSymbols, interruptKindsByFunction);
+  const interruptEffects = uniqueInterruptEffects(fileSymbols, interruptEffectsByFunction);
 
-  if (interruptKinds.length === 0) {
-    console.log("No interrupt kinds found in this agent. No policy needed.");
+  if (interruptEffects.length === 0) {
+    console.log("No interrupt effects found in this agent. No policy needed.");
     return;
   }
 
@@ -82,7 +82,7 @@ export function policyGen(
   }
 
   const agentArgs = [
-    JSON.stringify(interruptKinds),
+    JSON.stringify(interruptEffects),
     outputPath,
     ...(existingPolicyJson ? [existingPolicyJson] : []),
   ];

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -19,7 +19,7 @@ import { DEFAULT_HOST } from "../serve/http/security.js";
 import { createLogger } from "../logger.js";
 import { VERSION } from "../stdlib/version.js";
 import type { ExportedItem } from "../serve/types.js";
-import type { InterruptKind } from "../symbolTable.js";
+import type { InterruptEffect } from "../symbolTable.js";
 import type { InterruptHandlers } from "../serve/mcp/interruptLoop.js";
 import { PolicyStore } from "../serve/policyStore.js";
 import * as esbuild from "esbuild";
@@ -31,7 +31,7 @@ type CompileResult = {
   outputPath: string;
   moduleId: string;
   exportedNodeNames: string[];
-  interruptKindsByName: Record<string, InterruptKind[]>;
+  interruptEffectsByName: Record<string, InterruptEffect[]>;
 };
 
 function compileForServe(file: string): CompileResult {
@@ -49,10 +49,10 @@ function compileForServe(file: string): CompileResult {
     .filter((sym) => sym.kind === "node" && sym.exported)
     .map((sym) => sym.name);
 
-  // Run type checker to get transitive interrupt kinds and report errors
+  // Run type checker to get transitive interrupt effects and report errors
   const source = fs.readFileSync(absoluteFile, "utf-8");
   const parseResult = parseAgency(source, config);
-  const interruptKindsByName: Record<string, InterruptKind[]> = {};
+  const interruptEffectsByName: Record<string, InterruptEffect[]> = {};
   if (parseResult.success) {
     const info = buildCompilationUnit(parseResult.result, symbolTable, absoluteFile, source);
     const result = typeCheck(parseResult.result, config, info);
@@ -64,11 +64,11 @@ function compileForServe(file: string): CompileResult {
     if (warnings.length > 0) {
       console.error(formatErrors(warnings, "warning"));
     }
-    Object.assign(interruptKindsByName, result.interruptKindsByFunction);
+    Object.assign(interruptEffectsByName, result.interruptEffectsByFunction);
   }
 
   const moduleId = path.relative(process.cwd(), absoluteFile);
-  return { outputPath, moduleId, exportedNodeNames, interruptKindsByName };
+  return { outputPath, moduleId, exportedNodeNames, interruptEffectsByName };
 }
 
 async function loadAndDiscover(
@@ -87,7 +87,7 @@ async function loadAndDiscover(
     moduleExports,
     moduleId: compileResult.moduleId,
     exportedNodeNames: compileResult.exportedNodeNames,
-    interruptKindsByName: compileResult.interruptKindsByName,
+    interruptEffectsByName: compileResult.interruptEffectsByName,
   });
 
   return { exports, moduleExports };
@@ -373,7 +373,7 @@ function buildHttpEntrypoint(
     loggerPath: JSON.stringify(distPath("lib/logger.js")),
     moduleId: JSON.stringify(compileResult.moduleId),
     exportedNodeNamesJson: JSON.stringify(compileResult.exportedNodeNames),
-    interruptKindsByNameJson: JSON.stringify(compileResult.interruptKindsByName),
+    interruptEffectsByNameJson: JSON.stringify(compileResult.interruptEffectsByName),
     defaultPort: JSON.stringify(String(options.port)),
     defaultHost: JSON.stringify(options.host),
     apiKeyEnv: JSON.stringify(options.apiKeyEnv),
@@ -393,7 +393,7 @@ function buildMcpEntrypoint(
     policyStorePath: JSON.stringify(distPath("lib/serve/policyStore.js")),
     moduleId: JSON.stringify(compileResult.moduleId),
     exportedNodeNamesJson: JSON.stringify(compileResult.exportedNodeNames),
-    interruptKindsByNameJson: JSON.stringify(compileResult.interruptKindsByName),
+    interruptEffectsByNameJson: JSON.stringify(compileResult.interruptEffectsByName),
     serverName: JSON.stringify(options.serverName),
     serverVersion: JSON.stringify(serverVersion),
   });
@@ -414,7 +414,7 @@ function buildMcpHttpEntrypoint(
     loggerPath: JSON.stringify(distPath("lib/logger.js")),
     moduleId: JSON.stringify(compileResult.moduleId),
     exportedNodeNamesJson: JSON.stringify(compileResult.exportedNodeNames),
-    interruptKindsByNameJson: JSON.stringify(compileResult.interruptKindsByName),
+    interruptEffectsByNameJson: JSON.stringify(compileResult.interruptEffectsByName),
     serverName: JSON.stringify(options.serverName),
     serverVersion: JSON.stringify(serverVersion),
     defaultPort: JSON.stringify(String(options.port)),

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -15,7 +15,7 @@ import type {
   ImportStatement,
 } from "./types/importStatement.js";
 import { getImportedNames } from "./types/importStatement.js";
-import type { SymbolTable, InterruptKind } from "./symbolTable.js";
+import type { SymbolTable, InterruptEffect } from "./symbolTable.js";
 import { collectTypeAliasTags } from "./symbolTable.js";
 import { walkNodes } from "./utils/node.js";
 import { resultTypeForValidation } from "./typeChecker/validation.js";
@@ -121,8 +121,8 @@ export type CompilationUnit = {
    * `// @tc-nocheck` / `// @tc-ignore` directives. Optional because
    * many callers (including most tests) construct the AST directly. */
   sourceText?: string;
-  /** Transitive interrupt kinds per function/node, populated from the symbol table. */
-  interruptKindsByFunction?: Record<string, InterruptKind[]>;
+  /** Transitive interrupt effects per function/node, populated from the symbol table. */
+  interruptEffectsByFunction?: Record<string, InterruptEffect[]>;
   /** Symbol table used to build this unit. Forwarded so downstream
    *  consumers (e.g. the typechecker) can use it for cross-file lookups
    *  like resolving the file a function/node lives in. Optional because
@@ -298,30 +298,30 @@ export function buildCompilationUnit(
     // was never imported.
     pullTransitiveAliases(unit, symbolTable, aliasSeeds);
 
-    const interruptKindsByFunction: Record<string, InterruptKind[]> = {};
+    const interruptEffectsByFunction: Record<string, InterruptEffect[]> = {};
     const fileSymbols = symbolTable.getFile(fromFile);
     if (fileSymbols) {
       for (const [name, sym] of Object.entries(fileSymbols)) {
-        if ((sym.kind === "function" || sym.kind === "node") && sym.interruptKinds) {
-          interruptKindsByFunction[name] = sym.interruptKinds;
+        if ((sym.kind === "function" || sym.kind === "node") && sym.interruptEffects) {
+          interruptEffectsByFunction[name] = sym.interruptEffects;
         }
       }
     }
     for (const stmt of unit.importStatements) {
       for (const r of symbolTable.resolveImport(stmt, fromFile)) {
-        if ((r.symbol.kind === "function" || r.symbol.kind === "node") && r.symbol.interruptKinds) {
-          interruptKindsByFunction[r.localName] = r.symbol.interruptKinds;
+        if ((r.symbol.kind === "function" || r.symbol.kind === "node") && r.symbol.interruptEffects) {
+          interruptEffectsByFunction[r.localName] = r.symbol.interruptEffects;
         }
       }
     }
     for (const stmt of unit.importedNodes) {
       for (const r of symbolTable.resolveImportedNodes(stmt, fromFile)) {
-        if (r.symbol.kind === "node" && r.symbol.interruptKinds) {
-          interruptKindsByFunction[r.localName] = r.symbol.interruptKinds;
+        if (r.symbol.kind === "node" && r.symbol.interruptEffects) {
+          interruptEffectsByFunction[r.localName] = r.symbol.interruptEffects;
         }
       }
     }
-    unit.interruptKindsByFunction = interruptKindsByFunction;
+    unit.interruptEffectsByFunction = interruptEffectsByFunction;
     unit.symbolTable = symbolTable;
     unit.fromFile = fromFile;
   }

--- a/packages/agency-lang/lib/logsViewer/summary.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.ts
@@ -143,8 +143,10 @@ function stringifyValue(v: unknown): string {
  *  attached to `handlerDecision` / `interruptResolved` events. The
  *  runtime started attaching this so log readers can see *what* was
  *  being approved/rejected without correlating against a separate
- *  `interruptThrown` event. Returns "" when no summary is present
- *  (preserves prior format for older traces). */
+ *  `interruptThrown` event. Returns "" when no `effect` summary is
+ *  present. Note: pre-rename traces carried this field as `kind`; by
+ *  design (see the kind->effect rename) such older traces render
+ *  without the effect label rather than being read back-compatibly. */
 function formatInterruptSummary(intr: any): string {
   if (!intr || typeof intr !== "object") return "";
   const effect = intr.effect ? String(intr.effect) : null;

--- a/packages/agency-lang/lib/logsViewer/summary.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.ts
@@ -139,7 +139,7 @@ function stringifyValue(v: unknown): string {
   return typeof v === "string" ? v : JSON.stringify(v ?? null) ?? "undefined";
 }
 
-/** Format the optional `{kind, message, data}` interrupt summary
+/** Format the optional `{effect, message, data}` interrupt summary
  *  attached to `handlerDecision` / `interruptResolved` events. The
  *  runtime started attaching this so log readers can see *what* was
  *  being approved/rejected without correlating against a separate
@@ -147,10 +147,10 @@ function stringifyValue(v: unknown): string {
  *  (preserves prior format for older traces). */
 function formatInterruptSummary(intr: any): string {
   if (!intr || typeof intr !== "object") return "";
-  const kind = intr.kind ? String(intr.kind) : null;
+  const effect = intr.effect ? String(intr.effect) : null;
   const msg = intr.message ? truncate(String(intr.message), 50) : null;
-  if (kind && msg) return ` — ${kind}: "${msg}"`;
-  if (kind) return ` — ${kind}`;
+  if (effect && msg) return ` — ${effect}: "${msg}"`;
+  if (effect) return ` — ${effect}`;
   if (msg) return ` — "${msg}"`;
   return "";
 }

--- a/packages/agency-lang/lib/lsp/builtinHover.ts
+++ b/packages/agency-lang/lib/lsp/builtinHover.ts
@@ -28,9 +28,9 @@ function formatSig(sig: BuiltinSignature): string {
  */
 const KEYWORD_BUILTIN_HOVERS: Record<string, { sig: string; description: string }> = {
   interrupt: {
-    sig: "interrupt <kind>(message: string, payload?: Record<string, any>)",
+    sig: "interrupt <effect>(message: string, payload?: Record<string, any>)",
     description:
-      "Throw an interrupt of the given kind. The current execution state is captured so that, once responded to, execution resumes from exactly this point.",
+      "Throw an interrupt of the given effect. The current execution state is captured so that, once responded to, execution resumes from exactly this point.",
   },
   schema: {
     sig: "schema(T)",

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -131,7 +131,7 @@ export function runDiagnostics(
   }
 
   const info = buildCompilationUnit(program, symbolTable, fsPath, source);
-  const { errors, scopes, interruptKindsByFunction } = typeCheck(program, config, info);
+  const { errors, scopes, interruptEffectsByFunction } = typeCheck(program, config, info);
 
   for (const err of errors) {
     const range = err.loc
@@ -152,7 +152,7 @@ export function runDiagnostics(
     diagnostics,
     program,
     info,
-    semanticIndex: buildSemanticIndex(program, fsPath, symbolTable, interruptKindsByFunction),
+    semanticIndex: buildSemanticIndex(program, fsPath, symbolTable, interruptEffectsByFunction),
     scopes,
   };
 }

--- a/packages/agency-lang/lib/lsp/semantics.ts
+++ b/packages/agency-lang/lib/lsp/semantics.ts
@@ -1,6 +1,6 @@
 import { getWordAtPosition } from "../cli/definition.js";
 import { formatTypeHint } from "../utils/formatType.js";
-import type { FileSymbols, InterruptKind, SymbolInfo, SymbolKind, SymbolTable } from "../symbolTable.js";
+import type { FileSymbols, InterruptEffect, SymbolInfo, SymbolKind, SymbolTable } from "../symbolTable.js";
 import type {
   AgencyProgram,
   FunctionDefinition,
@@ -21,7 +21,7 @@ export type SemanticSymbol = {
   returnType?: VariableType | null;
   aliasedType?: VariableType;
   importPath?: string;
-  interruptKinds?: InterruptKind[];
+  interruptEffects?: InterruptEffect[];
 };
 
 export type SemanticIndex = Record<string, SemanticSymbol>;
@@ -30,9 +30,9 @@ function addSymbol(index: SemanticIndex, symbol: SemanticSymbol): void {
   index[symbol.name] = symbol;
 }
 
-function interruptKindsFor(fileSymbols: FileSymbols | undefined, name: string): InterruptKind[] | undefined {
+function interruptEffectsFor(fileSymbols: FileSymbols | undefined, name: string): InterruptEffect[] | undefined {
   const sym = fileSymbols?.[name];
-  if (sym?.kind === "function" || sym?.kind === "node") return sym.interruptKinds;
+  if (sym?.kind === "function" || sym?.kind === "node") return sym.interruptEffects;
   return undefined;
 }
 
@@ -53,7 +53,7 @@ function addLocalDefinition(
         loc: node.loc,
         parameters: node.parameters,
         returnType: node.returnType,
-        interruptKinds: interruptKindsFor(fileSymbols, node.functionName),
+        interruptEffects: interruptEffectsFor(fileSymbols, node.functionName),
       });
       break;
     case "graphNode":
@@ -66,7 +66,7 @@ function addLocalDefinition(
         loc: node.loc,
         parameters: node.parameters,
         returnType: node.returnType,
-        interruptKinds: interruptKindsFor(fileSymbols, node.nodeName),
+        interruptEffects: interruptEffectsFor(fileSymbols, node.nodeName),
       });
       break;
     case "typeAlias":
@@ -106,7 +106,7 @@ function addImportedSymbol(
     returnType: isCallable ? sym.returnType : undefined,
     aliasedType: sym.kind === "type" ? sym.aliasedType : undefined,
     importPath: opts.importPath,
-    interruptKinds: isCallable ? sym.interruptKinds : undefined,
+    interruptEffects: isCallable ? sym.interruptEffects : undefined,
   });
 }
 
@@ -160,10 +160,10 @@ export function buildSemanticIndex(
   program: AgencyProgram,
   fsPath: string,
   symbolTable: SymbolTable,
-  interruptKindsByFunction?: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction?: Record<string, InterruptEffect[]>,
 ): SemanticIndex {
   const index: SemanticIndex = {};
-  const fileSymbols = enrichWithInterruptKinds(symbolTable.getFile(fsPath), interruptKindsByFunction);
+  const fileSymbols = enrichWithInterruptEffects(symbolTable.getFile(fsPath), interruptEffectsByFunction);
 
   for (const node of program.nodes) {
     if (
@@ -177,11 +177,11 @@ export function buildSemanticIndex(
 
   Object.assign(index, collectImportedSymbols(program, fsPath, symbolTable));
 
-  // Overlay transitive interrupt kinds onto imported symbols
-  if (interruptKindsByFunction) {
+  // Overlay transitive interrupt effects onto imported symbols
+  if (interruptEffectsByFunction) {
     for (const [name, sym] of Object.entries(index)) {
-      if (sym.source === "imported" && interruptKindsByFunction[name]) {
-        index[name] = { ...sym, interruptKinds: interruptKindsByFunction[name] };
+      if (sym.source === "imported" && interruptEffectsByFunction[name]) {
+        index[name] = { ...sym, interruptEffects: interruptEffectsByFunction[name] };
       }
     }
   }
@@ -189,16 +189,16 @@ export function buildSemanticIndex(
   return index;
 }
 
-/** Merge transitive interrupt kinds into a copy of file symbols. */
-function enrichWithInterruptKinds(
+/** Merge transitive interrupt effects into a copy of file symbols. */
+function enrichWithInterruptEffects(
   fileSymbols: FileSymbols | undefined,
-  interruptKindsByFunction?: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction?: Record<string, InterruptEffect[]>,
 ): FileSymbols | undefined {
-  if (!fileSymbols || !interruptKindsByFunction) return fileSymbols;
+  if (!fileSymbols || !interruptEffectsByFunction) return fileSymbols;
   const enriched: FileSymbols = {};
   for (const [name, sym] of Object.entries(fileSymbols)) {
-    if ((sym.kind === "function" || sym.kind === "node") && interruptKindsByFunction[name]) {
-      enriched[name] = { ...sym, interruptKinds: interruptKindsByFunction[name] };
+    if ((sym.kind === "function" || sym.kind === "node") && interruptEffectsByFunction[name]) {
+      enriched[name] = { ...sym, interruptEffects: interruptEffectsByFunction[name] };
     } else {
       enriched[name] = sym;
     }
@@ -258,16 +258,16 @@ function formatSignature(symbol: SemanticSymbol): string {
   }
 }
 
-function formatInterruptKinds(interruptKinds: InterruptKind[] | undefined): string {
-  if (!interruptKinds || interruptKinds.length === 0) return "";
-  const kinds = interruptKinds.map((ik) => `\`${ik.kind}\``).join(", ");
+function formatInterruptEffects(interruptEffects: InterruptEffect[] | undefined): string {
+  if (!interruptEffects || interruptEffects.length === 0) return "";
+  const kinds = interruptEffects.map((ik) => `\`${ik.effect}\``).join(", ");
   return `\n\n**Interrupts:** ${kinds}`;
 }
 
 export function formatSemanticHover(symbol: SemanticSymbol): string {
   const signature = formatSignature(symbol);
   const codeBlock = `\`\`\`typescript\n${signature}\n\`\`\``;
-  const interrupts = formatInterruptKinds(symbol.interruptKinds);
+  const interrupts = formatInterruptEffects(symbol.interruptEffects);
   if (symbol.source === "local") {
     return `${codeBlock}${interrupts}`;
   }

--- a/packages/agency-lang/lib/parsers/interruptStatement.test.ts
+++ b/packages/agency-lang/lib/parsers/interruptStatement.test.ts
@@ -8,7 +8,7 @@ describe("interruptStatementParser", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.result.type).toBe("interruptStatement");
-    expect(result.result.kind).toBe("std::read");
+    expect(result.result.effect).toBe("std::read");
     expect(result.result.arguments).toHaveLength(2);
   });
 
@@ -17,7 +17,7 @@ describe("interruptStatementParser", () => {
     const result = interruptStatementParser(input);
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.result.kind).toBe("std::read");
+    expect(result.result.effect).toBe("std::read");
     expect(result.result.arguments).toHaveLength(1);
   });
 
@@ -26,7 +26,7 @@ describe("interruptStatementParser", () => {
     const result = interruptStatementParser(input);
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.result.kind).toBe("myapp::deploy");
+    expect(result.result.effect).toBe("myapp::deploy");
     expect(result.result.arguments).toHaveLength(2);
   });
 
@@ -35,7 +35,7 @@ describe("interruptStatementParser", () => {
     const result = interruptStatementParser(input);
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.result.kind).toBe("std::http::fetch");
+    expect(result.result.effect).toBe("std::http::fetch");
     expect(result.result.arguments).toHaveLength(1);
   });
 
@@ -45,7 +45,7 @@ describe("interruptStatementParser", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.result.type).toBe("interruptStatement");
-    expect(result.result.kind).toBe("unknown");
+    expect(result.result.effect).toBe("unknown");
     expect(result.result.arguments).toHaveLength(1);
   });
 
@@ -55,7 +55,7 @@ describe("interruptStatementParser", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.result.type).toBe("interruptStatement");
-    expect(result.result.kind).toBe("unknown");
+    expect(result.result.effect).toBe("unknown");
     expect(result.result.arguments).toHaveLength(2);
   });
 });
@@ -67,7 +67,7 @@ describe("interruptExprParser", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.result.type).toBe("interruptStatement");
-    expect(result.result.kind).toBe("std::read");
+    expect(result.result.effect).toBe("std::read");
   });
 
   it("parses bare interrupt expression", () => {
@@ -76,6 +76,6 @@ describe("interruptExprParser", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.result.type).toBe("interruptStatement");
-    expect(result.result.kind).toBe("unknown");
+    expect(result.result.effect).toBe("unknown");
   });
 });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2527,30 +2527,30 @@ const namespaceIdentifier: Parser<string> = (input: string) => {
   const result = parser(input);
   if (!result.success) return result;
   if (!result.result.includes("::")) {
-    return failure("expected interrupt kind with ::, e.g. std::read or myapp::deploy", input);
+    return failure("expected interrupt effect with ::, e.g. std::read or myapp::deploy", input);
   }
   return result;
 };
 
 // Core interrupt parser without trailing whitespace/semicolons (for use in expressions)
 // Handles both structured `interrupt std::read("msg")` and bare `interrupt("msg")` forms.
-// Bare form gets kind "unknown".
+// Bare form gets effect "unknown".
 const _interruptExprParser: Parser<InterruptStatement> = (input: string) => {
   // Try structured form first: interrupt <namespace>(<args>)
   const structured = seqC(
     set("type", "interruptStatement"),
     str("interrupt"),
     spaces,
-    capture(namespaceIdentifier, "kind"),
+    capture(namespaceIdentifier, "effect"),
     captureCaptures(argumentListParser),
   )(input);
   if (structured.success) return success(structured.result as InterruptStatement, structured.rest);
 
-  // Bare form: interrupt(<args>) — no namespace, kind defaults to "unknown"
+  // Bare form: interrupt(<args>) — no namespace, effect defaults to "unknown"
   const bare = seqC(
     set("type", "interruptStatement"),
     str("interrupt"),
-    set("kind", "unknown"),
+    set("effect", "unknown"),
     captureCaptures(argumentListParser),
   )(input);
   if (!bare.success) return bare;

--- a/packages/agency-lang/lib/runtime/agencyInterrupt.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyInterrupt.test.ts
@@ -30,7 +30,7 @@ describe("agency.interrupt — handler approves", () => {
             async () => approve("handler-value"),
             async () => {
               result = await agency.interrupt({
-                kind: "test",
+                effect: "test",
                 message: "needs approval",
                 data: { foo: 1 },
               });
@@ -58,7 +58,7 @@ describe("agency.interrupt — handler rejects", () => {
             async () => reject("nope"),
             async () => {
               result = await agency.interrupt({
-                kind: "test",
+                effect: "test",
                 message: "needs approval",
                 data: {},
               });
@@ -81,7 +81,7 @@ describe("agency.interrupt — no handler", () => {
       agency.withResumableScope({ name: "halt" }, async (s) => {
         await s.step(async () => {
           await agency.interrupt({
-            kind: "test",
+            effect: "test",
             message: "propagated",
             data: { foo: 42 },
           });
@@ -96,7 +96,7 @@ describe("agency.interrupt — no handler", () => {
     expect(interrupts).toHaveLength(1);
     const intr = interrupts[0];
     expect(intr.type).toBe("interrupt");
-    expect(intr.kind).toBe("test");
+    expect(intr.effect).toBe("test");
     expect(intr.message).toBe("propagated");
     expect(intr.data).toEqual({ foo: 42 });
     // The codegen path attaches both id and the full snapshot.
@@ -115,7 +115,7 @@ describe("agency.interrupt — no handler", () => {
       agency.withResumableScope({ name: "no-after" }, async (s) => {
         await s.step(async () => {
           await agency.interrupt({
-            kind: "test",
+            effect: "test",
             message: "halt me",
             data: {},
           });
@@ -135,7 +135,7 @@ describe("agency.interrupt — no handler", () => {
         await s.step(async () => {
           order.push("first");
           await agency.interrupt({
-            kind: "test",
+            effect: "test",
             message: "halt",
             data: {},
           });
@@ -160,7 +160,7 @@ describe("agency.interrupt — resume idempotency", () => {
       agency.withResumableScope({ name: "resume" }, async (s) => {
         await s.step(async () => {
           await agency.interrupt({
-            kind: "test",
+            effect: "test",
             message: "first pass",
             data: { round: 1 },
           });
@@ -171,7 +171,7 @@ describe("agency.interrupt — resume idempotency", () => {
 
     expect(Array.isArray(firstResult)).toBe(true);
     const intr = firstResult[0];
-    expect(intr.kind).toBe("test");
+    expect(intr.effect).toBe("test");
     const persistedId = intr.interruptId;
 
     // Stamp a user response for the persisted interrupt id, mirroring
@@ -218,7 +218,7 @@ describe("agency.interrupt — resume idempotency", () => {
             },
             async () => {
               observed = await agency.interrupt({
-                kind: "test",
+                effect: "test",
                 message: "ignored on resume",
                 data: { round: 2 },
               });
@@ -245,7 +245,7 @@ describe("agency.interrupt — option defaults", () => {
           await agency.withHandler(
             // eslint-disable-next-line @typescript-eslint/require-await
             async (i) => {
-              observedKind = i.kind;
+              observedKind = i.effect;
               return approve("ok");
             },
             async () => {
@@ -263,7 +263,7 @@ describe("agency.interrupt — option defaults", () => {
     const ret = (await inFrame(ctx, () =>
       agency.withResumableScope({ name: "no-data" }, async (s) => {
         await s.step(async () => {
-          await agency.interrupt({ kind: "x", message: "no data" });
+          await agency.interrupt({ effect: "x", message: "no data" });
         });
       }),
     )) as unknown as Interrupt[];
@@ -276,7 +276,7 @@ describe("agency.interrupt — frame requirements", () => {
     const ctx = makeMockCtx();
     await expect(
       inFrame(ctx, () =>
-        agency.interrupt({ kind: "test", message: "x", data: {} }),
+        agency.interrupt({ effect: "test", message: "x", data: {} }),
       ),
     ).rejects.toThrow(/without an active Runner/);
   });
@@ -298,7 +298,7 @@ describe("agency.interrupt — recursive-handler guard", () => {
     // again — infinite recursion without the depth guard.
     const selfRecursingHandler = async () => {
       await agency.interrupt({
-        kind: "inner",
+        effect: "inner",
         message: "raised from inside handler",
         data: {},
       });
@@ -310,7 +310,7 @@ describe("agency.interrupt — recursive-handler guard", () => {
           await s.step(async () => {
             await agency.withHandler(selfRecursingHandler, async () => {
               await agency.interrupt({
-                kind: "outer",
+                effect: "outer",
                 message: "trips the chain the first time",
                 data: {},
               });
@@ -326,7 +326,7 @@ describe("agency.interrupt — recursive-handler guard", () => {
     const ctx = makeMockCtx();
     const selfRecursingHandler = async () => {
       await agency.interrupt({
-        kind: "deep-recursion-kind",
+        effect: "deep-recursion-kind",
         message: "raised from inside handler",
         data: {},
       });
@@ -338,7 +338,7 @@ describe("agency.interrupt — recursive-handler guard", () => {
           await s.step(async () => {
             await agency.withHandler(selfRecursingHandler, async () => {
               await agency.interrupt({
-                kind: "outer",
+                effect: "outer",
                 message: "trips first",
                 data: {},
               });
@@ -358,7 +358,7 @@ describe("agency.interrupt — recursive-handler guard", () => {
     const ctx = makeMockCtx();
     const selfRecursingHandler = async () => {
       await agency.interrupt({
-        kind: "inner",
+        effect: "inner",
         message: "x",
         data: {},
       });
@@ -369,7 +369,7 @@ describe("agency.interrupt — recursive-handler guard", () => {
         agency.withResumableScope({ name: "cleanup" }, async (s) => {
           await s.step(async () => {
             await agency.withHandler(selfRecursingHandler, async () => {
-              await agency.interrupt({ kind: "outer", message: "x", data: {} });
+              await agency.interrupt({ effect: "outer", message: "x", data: {} });
             });
           });
           return "unreachable";

--- a/packages/agency-lang/lib/runtime/agencyInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/agencyInterrupt.ts
@@ -103,12 +103,12 @@ import {
 } from "./interrupts.js";
 
 export type InterruptOpts<T = unknown> = {
-  /** Stable identifier for the interrupt kind. Mirrors the kind a
+  /** Stable identifier for the interrupt effect. Mirrors the effect a
    *  generated `interrupt foo` statement would emit. Used by handlers
    *  to decide whether to intercept. Optional — defaults to
    *  `"unknown"` so quick TS scripts can call `agency.interrupt({message:...})`
-   *  without inventing a kind name. */
-  kind?: string;
+   *  without inventing an effect name. */
+  effect?: string;
   /** Human-readable description shown to the user / dashboards when
    *  the interrupt propagates. */
   message: string;
@@ -158,11 +158,11 @@ export async function interrupt<T = unknown>(
   }
 
   // First-time propagation: consult handlers.
-  const kind = opts.kind ?? "unknown";
+  const effect = opts.effect ?? "unknown";
   const data = opts.data;
   const origin = callsite.moduleId;
   const handlerResult = await interruptWithHandlers(
-    kind,
+    effect,
     opts.message,
     data,
     origin,

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -52,15 +52,15 @@ export class AgencyCancelledError extends Error {
  *  handler-chain dispatch depth exceeds `MAX_HANDLER_CHAIN_DEPTH`. Almost
  *  always indicates a handler raised an interrupt that re-enters the same
  *  handler (directly or via the chain dispatcher visiting every handler).
- *  Carries the interrupt kind that tripped the limit so the diagnostic
+ *  Carries the interrupt effect that tripped the limit so the diagnostic
  *  points at the right place. */
 export class HandlerRecursionError extends Error {
-  readonly kind: string;
+  readonly effect: string;
   readonly depth: number;
-  constructor(kind: string, depth: number) {
+  constructor(effect: string, depth: number) {
     super(
       `Handler chain dispatch nested ${depth} levels deep while handling ` +
-        `interrupt of kind "${kind}". This usually means a handler raised an ` +
+        `interrupt of effect "${effect}". This usually means a handler raised an ` +
         `interrupt that re-entered itself (the chain dispatcher visits every ` +
         `handler, even after one approves). Check whether the handler's body ` +
         `calls anything that raises an interrupt (\`with approve\`, file I/O, ` +
@@ -68,7 +68,7 @@ export class HandlerRecursionError extends Error {
         `flag BEFORE the call, not after.`,
     );
     this.name = "HandlerRecursionError";
-    this.kind = kind;
+    this.effect = effect;
     this.depth = depth;
   }
 }

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -4,14 +4,14 @@ import { interrupt, hasInterrupts } from "./interrupts.js";
 describe("hasInterrupts", () => {
   it("returns true for an array of interrupts", () => {
     const interrupts = [
-      interrupt({ kind: "unknown", message: "test1", data: {}, origin: "", runId: "run1" }),
-      interrupt({ kind: "unknown", message: "test2", data: {}, origin: "", runId: "run1" }),
+      interrupt({ effect: "unknown", message: "test1", data: {}, origin: "", runId: "run1" }),
+      interrupt({ effect: "unknown", message: "test2", data: {}, origin: "", runId: "run1" }),
     ];
     expect(hasInterrupts(interrupts)).toBe(true);
   });
 
   it("returns true for a single-element array", () => {
-    expect(hasInterrupts([interrupt({ kind: "unknown", message: "test", data: {}, origin: "", runId: "run1" })])).toBe(true);
+    expect(hasInterrupts([interrupt({ effect: "unknown", message: "test", data: {}, origin: "", runId: "run1" })])).toBe(true);
   });
 
   it("returns false for null/undefined", () => {

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -52,7 +52,7 @@ export type InterruptState = {
 
 export type Interrupt<T = any> = {
   type: "interrupt";
-  kind: string;           // e.g. "std::read", "unknown"
+  effect: string;         // e.g. "std::read", "unknown"
   message: string;        // human-readable description
   origin: string;         // compiler-injected module origin
   interruptId: string; // nanoid — globally unique
@@ -66,7 +66,7 @@ export type Interrupt<T = any> = {
 };
 
 export function interrupt<T = any>(opts: {
-  kind: string;
+  effect: string;
   message: string;
   data: T;
   origin: string;
@@ -75,7 +75,7 @@ export function interrupt<T = any>(opts: {
 }): Interrupt<T> {
   return {
     type: "interrupt",
-    kind: opts.kind,
+    effect: opts.effect,
     message: opts.message,
     origin: opts.origin,
     interruptId: opts.interruptId || nanoid(),
@@ -92,7 +92,7 @@ export function createDebugInterrupt<T = any>(
 ): Interrupt<T> {
   return {
     type: "interrupt",
-    kind: "debug",
+    effect: "debug",
     message: "",
     origin: "",
     interruptId: nanoid(),
@@ -147,7 +147,7 @@ async function runHandlerChain(
   ctx: RuntimeContext<any>,
   stack: StateStack | undefined,
   interruptId: string,
-  interruptObj: { kind: string; message: string; data: any; origin: string },
+  interruptObj: { effect: string; message: string; data: any; origin: string },
 ): Promise<HandlerChainOutcome> {
   let approvedValue: any = undefined;
   let hasApproval = false;
@@ -161,7 +161,7 @@ async function runHandlerChain(
     // the stack — otherwise a caller that catches this error would see a
     // stale +1 and trip the limit on the next legitimate dispatch.
     ctx._handlerChainDepth -= 1;
-    throw new HandlerRecursionError(interruptObj.kind, MAX_HANDLER_CHAIN_DEPTH);
+    throw new HandlerRecursionError(interruptObj.effect, MAX_HANDLER_CHAIN_DEPTH);
   }
   const chainSpanId = ctx.statelogClient.startSpan("handlerChain");
   try {
@@ -177,12 +177,12 @@ async function runHandlerChain(
       }
       // Pre-bind the interrupt summary once so all handlerDecision /
       // interruptResolved events from this dispatch carry the same
-      // {kind, message, data} payload — lets log readers see *what*
+      // {effect, message, data} payload — lets log readers see *what*
       // is being approved/rejected without needing a separate
       // interruptThrown event (which doesn't fire for synchronously-
       // resolved interrupts like `with approve`).
       const interruptSummary = {
-        kind: interruptObj.kind,
+        effect: interruptObj.effect,
         message: interruptObj.message,
         data: interruptObj.data,
       };
@@ -222,14 +222,14 @@ async function runHandlerChain(
 }
 
 export async function interruptWithHandlers<T = any>(
-  kind: string,
+  effect: string,
   message: string,
   data: T,
   origin: string,
   ctx: RuntimeContext<any>,
   stack?: StateStack,
 ): Promise<Interrupt<T>[] | Approved | Rejected> {
-  const interruptObj = { kind, message, data, origin };
+  const interruptObj = { effect, message, data, origin };
   const interruptId = nanoid();
   const outcome = await runHandlerChain(ctx, stack, interruptId, interruptObj);
 
@@ -242,10 +242,10 @@ export async function interruptWithHandlers<T = any>(
   // IPC mode: always consult parent (unless local handler rejected — that already returned above)
   if (isIpcMode()) {
     const parentDecision = await sendInterruptToParent(
-      { kind, message, data, origin },
+      { effect, message, data, origin },
       { propagated: hasPropagation },
     );
-    const interruptSummary = { kind, message, data };
+    const interruptSummary = { effect, message, data };
     if (parentDecision.type === "approve") {
       ctx.statelogClient.interruptResolved({
         interruptId,
@@ -271,7 +271,7 @@ export async function interruptWithHandlers<T = any>(
   // from the runtime. A future improvement could add checkpoint events to
   // the generated templates.
   if (hasPropagation) {
-    const intr = interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId });
+    const intr = interrupt({ effect, message, data, origin, runId: ctx.getRunId(), interruptId });
     ctx.statelogClient.interruptThrown({
       interruptId: intr.interruptId,
       interruptData: data,
@@ -283,12 +283,12 @@ export async function interruptWithHandlers<T = any>(
       interruptId,
       outcome: "approved",
       resolvedBy: "handler",
-      interrupt: { kind, message, data },
+      interrupt: { effect, message, data },
     });
     return { type: "approve", value: approvedValue };
   }
   // No handler responded — propagate to user
-  const intr = interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId });
+  const intr = interrupt({ effect, message, data, origin, runId: ctx.getRunId(), interruptId });
   ctx.statelogClient.interruptThrown({
     interruptId: intr.interruptId,
     interruptData: data,

--- a/packages/agency-lang/lib/runtime/ipc.configOverrides.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.configOverrides.test.ts
@@ -62,11 +62,11 @@ describe("subprocess interrupt IPC", () => {
     }) as any;
 
     const first = sendInterruptToParent(
-      { kind: "test", message: "first", data: {}, origin: "test" },
+      { effect: "test", message: "first", data: {}, origin: "test" },
       { propagated: false },
     );
     const second = sendInterruptToParent(
-      { kind: "test", message: "second", data: {}, origin: "test" },
+      { effect: "test", message: "second", data: {}, origin: "test" },
       { propagated: false },
     );
 
@@ -101,7 +101,7 @@ describe("subprocess interrupt IPC", () => {
     setSubprocessIpcPayloadLimit(1);
 
     await expect(sendInterruptToParent(
-      { kind: "test", message: "too large", data: { value: "é" }, origin: "test" },
+      { effect: "test", message: "too large", data: { value: "é" }, origin: "test" },
       { propagated: false },
     )).resolves.toEqual({ type: "reject", value: expect.stringContaining("ipc_payload") });
 
@@ -125,7 +125,7 @@ describe("subprocess interrupt IPC", () => {
     circular.self = circular;
 
     await expect(sendInterruptToParent(
-      { kind: "test", message: "bad", data: circular, origin: "test" },
+      { effect: "test", message: "bad", data: circular, origin: "test" },
       { propagated: false },
     )).resolves.toEqual({ type: "reject", value: expect.stringContaining("Failed to serialize interrupt payload") });
 

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -137,7 +137,7 @@ export function ipcLog(direction: "send" | "recv", msg: any): void {
   const ts = new Date().toISOString().slice(11, 23); // HH:MM:SS.mmm
   const type = msg?.type ?? "unknown";
   let detail: string;
-  if (type === "interrupt") detail = `kind=${msg.interrupt?.kind}`;
+  if (type === "interrupt") detail = `effect=${msg.interrupt?.effect}`;
   else if (type === "decision") detail = `approved=${msg.approved}`;
   else if (type === "result") detail = `data=${truncate(msg.value?.data)}`;
   else if (type === "error") detail = `error=${truncate(msg.error)}`;
@@ -154,7 +154,7 @@ export type IpcInterruptMessage = {
   type: "interrupt";
   interruptId: string;
   interrupt: {
-    kind: string;
+    effect: string;
     message: string;
     data: any;
     origin: string;
@@ -259,7 +259,7 @@ export function cleanupSessionLocks(
  */
 export async function sendInterruptToParent(
   interruptData: {
-    kind: string;
+    effect: string;
     message: string;
     data: any;
     origin: string;
@@ -539,9 +539,9 @@ function attachStdoutForwarder(
 }
 
 async function handleInterruptMessage(s: RunSession, msg: any): Promise<void> {
-  const { kind, message, data, origin } = msg.interrupt;
+  const { effect, message, data, origin } = msg.interrupt;
   try {
-    const handlerResult = await interruptWithHandlers(kind, message, data, origin, s.ctx, s.stateStack);
+    const handlerResult = await interruptWithHandlers(effect, message, data, origin, s.ctx, s.stateStack);
     let decision: any;
     if (isApproved(handlerResult)) {
       decision = { type: "decision", interruptId: msg.interruptId, approved: true, value: (handlerResult as any).value };

--- a/packages/agency-lang/lib/runtime/isDebugger.test.ts
+++ b/packages/agency-lang/lib/runtime/isDebugger.test.ts
@@ -5,13 +5,13 @@ const RUN_ID = "test-run-id";
 
 describe("isDebugger", () => {
   it("returns true for an interrupt with debugger: true", () => {
-    const i = interrupt({ kind: "debug", message: "breakpoint", data: {}, origin: "", runId: RUN_ID });
+    const i = interrupt({ effect: "debug", message: "breakpoint", data: {}, origin: "", runId: RUN_ID });
     i.debugger = true;
     expect(isDebugger(i)).toBe(true);
   });
 
   it("returns false for a regular interrupt", () => {
-    const i = interrupt({ kind: "unknown", message: "regular", data: {}, origin: "", runId: RUN_ID });
+    const i = interrupt({ effect: "unknown", message: "regular", data: {}, origin: "", runId: RUN_ID });
     expect(isDebugger(i)).toBe(false);
   });
 
@@ -23,7 +23,7 @@ describe("isDebugger", () => {
   });
 
   it("returns false for interrupt with debugger: false", () => {
-    const i = interrupt({ kind: "debug", message: "breakpoint", data: {}, origin: "", runId: RUN_ID });
+    const i = interrupt({ effect: "debug", message: "breakpoint", data: {}, origin: "", runId: RUN_ID });
     i.debugger = false;
     expect(isDebugger(i)).toBe(false);
   });

--- a/packages/agency-lang/lib/runtime/policy.test.ts
+++ b/packages/agency-lang/lib/runtime/policy.test.ts
@@ -4,7 +4,7 @@ import { checkPolicy, validatePolicy } from "./policy.js";
 describe("checkPolicy", () => {
   it("returns propagate when no rules exist for the kind", () => {
     const policy = {};
-    const interrupt = { kind: "std::read", message: "msg", data: { filename: "foo" }, origin: "std::fs" };
+    const interrupt = { effect: "std::read", message: "msg", data: { filename: "foo" }, origin: "std::fs" };
     const result = checkPolicy(policy, interrupt);
     expect(result).toEqual({ type: "propagate" });
   });
@@ -16,9 +16,9 @@ describe("checkPolicy", () => {
         { action: "reject" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "test::greet", message: "", data: { name: "Alice" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::greet", message: "", data: { name: "Alice" }, origin: "" }))
       .toEqual({ type: "approve" });
-    expect(checkPolicy(policy, { kind: "test::greet", message: "", data: { name: "Bob" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::greet", message: "", data: { name: "Bob" }, origin: "" }))
       .toEqual({ type: "reject" });
   });
 
@@ -29,9 +29,9 @@ describe("checkPolicy", () => {
         { action: "reject" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "test::cmd", message: "", data: { command: "ls -la" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::cmd", message: "", data: { command: "ls -la" }, origin: "" }))
       .toEqual({ type: "approve" });
-    expect(checkPolicy(policy, { kind: "test::cmd", message: "", data: { command: "rm -rf" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::cmd", message: "", data: { command: "rm -rf" }, origin: "" }))
       .toEqual({ type: "reject" });
   });
 
@@ -42,9 +42,9 @@ describe("checkPolicy", () => {
         { action: "reject" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "test::read", message: "", data: { path: "src/foo/bar.ts" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::read", message: "", data: { path: "src/foo/bar.ts" }, origin: "" }))
       .toEqual({ type: "approve" });
-    expect(checkPolicy(policy, { kind: "test::read", message: "", data: { path: "dist/foo.js" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::read", message: "", data: { path: "dist/foo.js" }, origin: "" }))
       .toEqual({ type: "reject" });
   });
 
@@ -55,7 +55,7 @@ describe("checkPolicy", () => {
         { match: { name: "Ali*" }, action: "approve" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "test::greet", message: "", data: { name: "Alice" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::greet", message: "", data: { name: "Alice" }, origin: "" }))
       .toEqual({ type: "reject" });
   });
 
@@ -66,7 +66,7 @@ describe("checkPolicy", () => {
         { action: "approve" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "test::greet", message: "", data: { name: "Alice" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::greet", message: "", data: { name: "Alice" }, origin: "" }))
       .toEqual({ type: "approve" });
   });
 
@@ -77,9 +77,9 @@ describe("checkPolicy", () => {
         { action: "reject" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "std::read", message: "", data: {}, origin: "std::fs" }))
+    expect(checkPolicy(policy, { effect: "std::read", message: "", data: {}, origin: "std::fs" }))
       .toEqual({ type: "approve" });
-    expect(checkPolicy(policy, { kind: "std::read", message: "", data: {}, origin: "./myfile.agency" }))
+    expect(checkPolicy(policy, { effect: "std::read", message: "", data: {}, origin: "./myfile.agency" }))
       .toEqual({ type: "reject" });
   });
 
@@ -90,7 +90,7 @@ describe("checkPolicy", () => {
         { action: "reject" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "test::x", message: "Are you sure about this?", data: {}, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::x", message: "Are you sure about this?", data: {}, origin: "" }))
       .toEqual({ type: "approve" });
   });
 
@@ -101,9 +101,9 @@ describe("checkPolicy", () => {
         { action: "reject" as const },
       ],
     };
-    expect(checkPolicy(policy, { kind: "test::cmd", message: "", data: { command: "rm foo", dir: "/tmp/x" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::cmd", message: "", data: { command: "rm foo", dir: "/tmp/x" }, origin: "" }))
       .toEqual({ type: "approve" });
-    expect(checkPolicy(policy, { kind: "test::cmd", message: "", data: { command: "rm foo", dir: "/home/x" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::cmd", message: "", data: { command: "rm foo", dir: "/home/x" }, origin: "" }))
       .toEqual({ type: "reject" });
   });
 
@@ -111,7 +111,7 @@ describe("checkPolicy", () => {
     const policy = {
       "test::x": [{ action: "approve" as const }],
     };
-    expect(checkPolicy(policy, { kind: "test::x", message: "", data: { anything: "whatever" }, origin: "" }))
+    expect(checkPolicy(policy, { effect: "test::x", message: "", data: { anything: "whatever" }, origin: "" }))
       .toEqual({ type: "approve" });
   });
 
@@ -119,7 +119,7 @@ describe("checkPolicy", () => {
     const policy = {
       "test::x": [{ action: "reject" as const }],
     };
-    const result = checkPolicy(policy, { kind: "test::x", message: "", data: {}, origin: "" });
+    const result = checkPolicy(policy, { effect: "test::x", message: "", data: {}, origin: "" });
     expect(result).toEqual({ type: "reject" });
   });
 
@@ -141,7 +141,7 @@ describe("checkPolicy", () => {
       };
       expect(
         checkPolicy(policy, {
-          kind: "std::read",
+          effect: "std::read",
           message: "",
           data: { dir: "./docs/guide" },
           origin: "",
@@ -158,7 +158,7 @@ describe("checkPolicy", () => {
       };
       expect(
         checkPolicy(policy, {
-          kind: "std::read",
+          effect: "std::read",
           message: "",
           data: { dir: "./docs/guide/sub" },
           origin: "",
@@ -175,7 +175,7 @@ describe("checkPolicy", () => {
       };
       expect(
         checkPolicy(policy, {
-          kind: "std::read",
+          effect: "std::read",
           message: "",
           data: { dir: "docs" },
           origin: "",
@@ -194,7 +194,7 @@ describe("checkPolicy", () => {
       };
       expect(
         checkPolicy(policy, {
-          kind: "std::read",
+          effect: "std::read",
           message: "",
           data: { dir: "./docs/guidance" },
           origin: "",
@@ -211,7 +211,7 @@ describe("checkPolicy", () => {
       };
       expect(
         checkPolicy(policy, {
-          kind: "std::read",
+          effect: "std::read",
           message: "",
           data: { dir: "./src" },
           origin: "",
@@ -228,7 +228,7 @@ describe("checkPolicy", () => {
       };
       expect(
         checkPolicy(policy, {
-          kind: "std::read",
+          effect: "std::read",
           message: "",
           data: { dir: "/abs/path/x" },
           origin: "",

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -19,9 +19,9 @@ type PolicyResult =
 
 export function checkPolicy(
   policy: Policy,
-  interrupt: { kind: string; message: string; data: any; origin: string },
+  interrupt: { effect: string; message: string; data: any; origin: string },
 ): PolicyResult {
-  const rules = policy[interrupt.kind];
+  const rules = policy[interrupt.effect];
   if (!rules) {
     return { type: "propagate" };
   }
@@ -45,7 +45,7 @@ function stripDotSlash(s: string): string {
 
 function matchesRule(
   rule: PolicyRule,
-  interrupt: { kind: string; message: string; data: any; origin: string },
+  interrupt: { effect: string; message: string; data: any; origin: string },
 ): boolean {
   if (!rule.match) return true; // catch-all
 

--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -18,7 +18,7 @@ function fakeLeafCheckpoint(id: number): any {
 function fakeInterrupt(idSuffix = "1", checkpointId = 100): Interrupt {
   return {
     type: "interrupt",
-    kind: "test",
+    effect: "test",
     message: "test",
     origin: "test",
     runId: "r-1",

--- a/packages/agency-lang/lib/runtime/types.ts
+++ b/packages/agency-lang/lib/runtime/types.ts
@@ -37,7 +37,7 @@ export type Approved = { type: "approve"; value?: any };
 export type Propagated = { type: "propagate" };
 
 export type HandlerFn = (
-  interrupt: { kind: string; message: string; data: any; origin: string },
+  interrupt: { effect: string; message: string; data: any; origin: string },
 ) => Promise<Approved | Rejected | Propagated | undefined>;
 
 /* tokenstats

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -99,7 +99,7 @@ describe("discoverExports", () => {
     expect(nodes[0].name).toBe("main");
     if (nodes[0].kind === "node") {
       expect(nodes[0].parameters).toEqual([{ name: "message" }]);
-      expect(nodes[0].interruptKinds).toEqual([]);
+      expect(nodes[0].interruptEffects).toEqual([]);
     }
   });
 
@@ -127,7 +127,7 @@ describe("discoverExports", () => {
     ).toEqual([]);
   });
 
-  it("attaches interruptKinds from interruptKindsByName", () => {
+  it("attaches interruptEffects from interruptEffectsByName", () => {
     const registry: Record<string, AgencyFunction> = {};
     AgencyFunction.create(
       {
@@ -150,19 +150,19 @@ describe("discoverExports", () => {
       },
       moduleId: "test",
       exportedNodeNames: ["checkout"],
-      interruptKindsByName: {
-        deploy: [{ kind: "myapp::deploy" }],
-        checkout: [{ kind: "payment::charge" }, { kind: "payment::refund" }],
+      interruptEffectsByName: {
+        deploy: [{ effect: "myapp::deploy" }],
+        checkout: [{ effect: "payment::charge" }, { effect: "payment::refund" }],
       },
     });
 
     const fn = exports.find((e) => e.name === "deploy")!;
-    expect(fn.interruptKinds).toEqual([{ kind: "myapp::deploy" }]);
+    expect(fn.interruptEffects).toEqual([{ effect: "myapp::deploy" }]);
 
     const node = exports.find((e) => e.name === "checkout")!;
-    expect(node.interruptKinds).toEqual([
-      { kind: "payment::charge" },
-      { kind: "payment::refund" },
+    expect(node.interruptEffects).toEqual([
+      { effect: "payment::charge" },
+      { effect: "payment::refund" },
     ]);
   });
 });

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { AgencyFunction } from "../runtime/agencyFunction.js";
-import type { InterruptKind } from "../symbolTable.js";
+import type { InterruptEffect } from "../symbolTable.js";
 import type { ExportedFunction, ExportedNode, ExportedItem } from "./types.js";
 
 export type DiscoverOptions = {
@@ -8,27 +8,27 @@ export type DiscoverOptions = {
   moduleExports: Record<string, unknown>;
   moduleId: string;
   exportedNodeNames?: string[];
-  interruptKindsByName?: Record<string, InterruptKind[]>;
+  interruptEffectsByName?: Record<string, InterruptEffect[]>;
 };
 
 function isExportedFromModule(fn: AgencyFunction, moduleId: string): boolean {
   return !!fn.exported && !!fn.toolDefinition && fn.module === moduleId;
 }
 
-function toExportedFunction(fn: AgencyFunction, interruptKinds: InterruptKind[]): ExportedFunction {
+function toExportedFunction(fn: AgencyFunction, interruptEffects: InterruptEffect[]): ExportedFunction {
   return {
     kind: "function",
     name: fn.name,
     description: fn.toolDefinition!.description,
     agencyFunction: fn,
-    interruptKinds,
+    interruptEffects,
   };
 }
 
 function toExportedNode(
   nodeName: string,
   moduleExports: Record<string, unknown>,
-  interruptKinds: InterruptKind[],
+  interruptEffects: InterruptEffect[],
 ): ExportedNode | null {
   const nodeFn = moduleExports[nodeName];
   if (typeof nodeFn !== "function") return null;
@@ -39,19 +39,19 @@ function toExportedNode(
     name: nodeName,
     parameters: params.map((name) => ({ name })),
     invoke: nodeFn as (...args: unknown[]) => Promise<unknown>,
-    interruptKinds,
+    interruptEffects,
   };
 }
 
 export function discoverExports(options: DiscoverOptions): ExportedItem[] {
-  const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [], interruptKindsByName = {} } = options;
+  const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [], interruptEffectsByName = {} } = options;
 
   const functions = Object.values(toolRegistry)
     .filter((fn) => isExportedFromModule(fn, moduleId))
-    .map((fn) => toExportedFunction(fn, interruptKindsByName[fn.name] ?? []));
+    .map((fn) => toExportedFunction(fn, interruptEffectsByName[fn.name] ?? []));
 
   const nodes = exportedNodeNames
-    .map((name) => toExportedNode(name, moduleExports, interruptKindsByName[name] ?? []))
+    .map((name) => toExportedNode(name, moduleExports, interruptEffectsByName[name] ?? []))
     .filter((n): n is ExportedNode => n !== null);
 
   return [...functions, ...nodes];

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -36,7 +36,7 @@ function makeExports(): {
       name: "add",
       description: "Add two numbers",
       agencyFunction: addFn,
-      interruptKinds: [],
+      interruptEffects: [],
     },
     {
       kind: "node",
@@ -46,7 +46,7 @@ function makeExports(): {
         data: { echo: message },
         messages: {},
       }),
-      interruptKinds: [],
+      interruptEffects: [],
     },
   ];
 
@@ -115,10 +115,10 @@ describe("HTTP adapter", () => {
     const body = result.body as any;
     expect(body.functions).toHaveLength(1);
     expect(body.functions[0].name).toBe("add");
-    expect(body.functions[0].interruptKinds).toEqual([]);
+    expect(body.functions[0].interruptEffects).toEqual([]);
     expect(body.nodes).toHaveLength(1);
     expect(body.nodes[0].name).toBe("main");
-    expect(body.nodes[0].interruptKinds).toEqual([]);
+    expect(body.nodes[0].interruptEffects).toEqual([]);
   });
 
   it("POST /function/:name calls function", async () => {
@@ -170,7 +170,7 @@ describe("HTTP adapter", () => {
     expect(result.status).toBe(404);
   });
 
-  it("GET /list includes interruptKinds as string arrays", async () => {
+  it("GET /list includes interruptEffects as string arrays", async () => {
     const registry: Record<string, AgencyFunction> = {};
     const deployFn = AgencyFunction.create(
       {
@@ -191,7 +191,7 @@ describe("HTTP adapter", () => {
           name: "deploy",
           description: "Deploy",
           agencyFunction: deployFn,
-          interruptKinds: [{ kind: "myapp::deploy" }],
+          interruptEffects: [{ effect: "myapp::deploy" }],
         },
       ],
       port: 3545,
@@ -201,7 +201,7 @@ describe("HTTP adapter", () => {
     });
     const result = await h("GET", "/list", undefined);
     const body = result.body as any;
-    expect(body.functions[0].interruptKinds).toEqual(["myapp::deploy"]);
+    expect(body.functions[0].interruptEffects).toEqual(["myapp::deploy"]);
   });
 });
 
@@ -311,7 +311,7 @@ describe("startHttpServer auth and host validation", () => {
         name: "fail",
         description: "",
         agencyFunction: failFn,
-        interruptKinds: [],
+        interruptEffects: [],
       },
     ];
     await withServer(baseConfig({ exports: exportsWithFail }), async (port) => {

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -145,12 +145,12 @@ export function createHttpHandler(config: HttpConfig): (
             name: f.name,
             description: f.description,
             safe: f.agencyFunction.safe,
-            interruptKinds: f.interruptKinds.map((ik) => ik.kind),
+            interruptEffects: f.interruptEffects.map((ik) => ik.effect),
           })),
           nodes: Object.values(nodes).map((n) => ({
             name: n.name,
             parameters: n.parameters.map((p) => p.name),
-            interruptKinds: n.interruptKinds.map((ik) => ik.kind),
+            interruptEffects: n.interruptEffects.map((ik) => ik.effect),
           })),
         },
       };

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -36,14 +36,14 @@ function makeTestExports(): ExportedItem[] {
       name: "add",
       description: "Add two numbers",
       agencyFunction: addFn,
-      interruptKinds: [],
+      interruptEffects: [],
     },
     {
       kind: "node",
       name: "main",
       parameters: [{ name: "city" }, { name: "country" }],
       invoke: async (...args: unknown[]) => ({ data: `${args[0]}, ${args[1]}` }),
-      interruptKinds: [],
+      interruptEffects: [],
     },
   ];
 }
@@ -151,7 +151,7 @@ describe("MCP adapter", () => {
     expect(response!.error.code).toBe(-32601);
   });
 
-  it("appends interrupt kinds to tool description (no policy)", async () => {
+  it("appends interrupt effects to tool description (no policy)", async () => {
     const registry: Record<string, AgencyFunction> = {};
     const deployFn = AgencyFunction.create(
       {
@@ -174,7 +174,7 @@ describe("MCP adapter", () => {
           name: "deploy",
           description: "Deploy app",
           agencyFunction: deployFn,
-          interruptKinds: [{ kind: "myapp::deploy" }, { kind: "myapp::approve" }],
+          interruptEffects: [{ effect: "myapp::deploy" }, { effect: "myapp::approve" }],
         },
       ],
     });
@@ -185,7 +185,7 @@ describe("MCP adapter", () => {
     });
     const tools = response!.result.tools;
     expect(tools[0].description).toBe(
-      "Deploy app\n\nInterrupt kinds: myapp::deploy, myapp::approve",
+      "Deploy app\n\nInterrupt effects: myapp::deploy, myapp::approve",
     );
   });
 });
@@ -241,7 +241,7 @@ describe("MCP adapter — policy tools", () => {
       jsonrpc: "2.0",
       id: 3,
       method: "tools/call",
-      params: { name: "agencyAddRule", arguments: { kind: "email::send", action: "approve", match: { recipient: "*@co.com" } } },
+      params: { name: "agencyAddRule", arguments: { effect: "email::send", action: "approve", match: { recipient: "*@co.com" } } },
     });
     expect(addResponse!.result.isError).toBe(false);
 
@@ -261,20 +261,20 @@ describe("MCP adapter — policy tools", () => {
       jsonrpc: "2.0",
       id: 5,
       method: "tools/call",
-      params: { name: "agencyAddRule", arguments: { kind: "x::y", action: "approve" } },
+      params: { name: "agencyAddRule", arguments: { effect: "x::y", action: "approve" } },
     });
     await handler({
       jsonrpc: "2.0",
       id: 6,
       method: "tools/call",
-      params: { name: "agencyAddRule", arguments: { kind: "x::y", action: "reject" } },
+      params: { name: "agencyAddRule", arguments: { effect: "x::y", action: "reject" } },
     });
 
     const removeResponse = await handler({
       jsonrpc: "2.0",
       id: 7,
       method: "tools/call",
-      params: { name: "agencyRemoveRule", arguments: { kind: "x::y", ruleIndex: 0 } },
+      params: { name: "agencyRemoveRule", arguments: { effect: "x::y", ruleIndex: 0 } },
     });
     expect(removeResponse!.result.isError).toBe(false);
 
@@ -294,7 +294,7 @@ describe("MCP adapter — policy tools", () => {
       jsonrpc: "2.0",
       id: 9,
       method: "tools/call",
-      params: { name: "agencyRemoveRule", arguments: { kind: "x::y", ruleIndex: 0 } },
+      params: { name: "agencyRemoveRule", arguments: { effect: "x::y", ruleIndex: 0 } },
     });
     expect(response!.result.isError).toBe(true);
   });
@@ -304,7 +304,7 @@ describe("MCP adapter — policy tools", () => {
       jsonrpc: "2.0",
       id: 10,
       method: "tools/call",
-      params: { name: "agencyAddRule", arguments: { kind: "x::y", action: "approve" } },
+      params: { name: "agencyAddRule", arguments: { effect: "x::y", action: "approve" } },
     });
 
     const clearResponse = await handler({
@@ -342,7 +342,7 @@ describe("MCP adapter — policy tools", () => {
         name: "greet",
         module: "test",
         fn: async () => [
-          { type: "interrupt", kind: "test::greet", message: "Greet?", data: {}, origin: "test", interruptId: "i1", runId: "r1" },
+          { type: "interrupt", effect: "test::greet", message: "Greet?", data: {}, origin: "test", interruptId: "i1", runId: "r1" },
         ],
         params: [{ name: "name", hasDefault: false, defaultValue: undefined, variadic: false }],
         toolDefinition: { name: "greet", description: "Greet someone", schema: z.object({ name: z.string() }) },
@@ -357,7 +357,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptKinds: [{ kind: "test::greet" }] },
+        { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }] },
       ],
       policyConfig: {
         policyStore: new PolicyStore("test", tmpDir),
@@ -391,7 +391,7 @@ describe("MCP adapter — policy tools", () => {
         name: "sendEmail",
         module: "test",
         fn: async () => [
-          { type: "interrupt", kind: "email::send", message: "Send?", data: { recipient: "alice@company.com" }, origin: "test", interruptId: "i2", runId: "r2" },
+          { type: "interrupt", effect: "email::send", message: "Send?", data: { recipient: "alice@company.com" }, origin: "test", interruptId: "i2", runId: "r2" },
         ],
         params: [],
         toolDefinition: { name: "sendEmail", description: "Send an email", schema: z.object({}) },
@@ -408,7 +408,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptKinds: [{ kind: "email::send" }] },
+        { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }] },
       ],
       policyConfig: {
         policyStore: store,

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -1,15 +1,15 @@
 import process from "process";
-import type { InterruptKind } from "../../symbolTable.js";
+import type { InterruptEffect } from "../../symbolTable.js";
 import type { ExportedFunction, ExportedNode, ExportedItem } from "../types.js";
 import type { PolicyStore } from "../policyStore.js";
 import type { InterruptHandlers } from "./interruptLoop.js";
 import { runWithPolicy } from "./interruptLoop.js";
 import { errorMessage } from "../util.js";
 
-function formatToolDescription(description: string, interruptKinds: InterruptKind[]): string {
-  if (interruptKinds.length === 0) return description;
-  const kinds = interruptKinds.map((ik) => ik.kind).join(", ");
-  return `${description}\n\nInterrupt kinds: ${kinds}`;
+function formatToolDescription(description: string, interruptEffects: InterruptEffect[]): string {
+  if (interruptEffects.length === 0) return description;
+  const effects = interruptEffects.map((ie) => ie.effect).join(", ");
+  return `${description}\n\nInterrupt effects: ${effects}`;
 }
 
 type JsonRpcId = string | number | null;
@@ -65,20 +65,20 @@ const POLICY_TOOL_NAMES = {
 const POLICY_TOOL_DEFINITIONS = [
   {
     name: POLICY_TOOL_NAMES.GET,
-    description: "Get the current interrupt policy for this agent. Returns a JSON object keyed by interrupt kind, where each kind maps to an ordered array of rules.",
+    description: "Get the current interrupt policy for this agent. Returns a JSON object keyed by interrupt effect, where each effect maps to an ordered array of rules.",
     inputSchema: { type: "object" as const, properties: {} },
   },
   {
     name: POLICY_TOOL_NAMES.ADD_RULE,
-    description: "Add a rule to the interrupt policy. Rules control which actions the agent can take autonomously. Each tool lists its interrupt kinds — use those as the 'kind' parameter. Rules are evaluated in order; the first match wins. A rule with no 'match' field is a catch-all.",
+    description: "Add a rule to the interrupt policy. Rules control which actions the agent can take autonomously. Each tool lists its interrupt effects — use those as the 'effect' parameter. Rules are evaluated in order; the first match wins. A rule with no 'match' field is a catch-all.",
     inputSchema: {
       type: "object" as const,
       properties: {
-        kind: { type: "string" as const, description: "The interrupt kind to add a rule for (e.g. 'email::send')" },
+        effect: { type: "string" as const, description: "The interrupt effect to add a rule for (e.g. 'email::send')" },
         action: { type: "string" as const, enum: ["approve", "reject"], description: "What to do when this rule matches" },
         match: { type: "object" as const, additionalProperties: { type: "string" as const }, description: "Optional. Keys are interrupt data field names, values are glob patterns (e.g. '*@company.com'). If omitted, the rule is a catch-all." },
       },
-      required: ["kind", "action"],
+      required: ["effect", "action"],
     },
   },
   {
@@ -87,10 +87,10 @@ const POLICY_TOOL_DEFINITIONS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        kind: { type: "string" as const, description: "The interrupt kind to remove a rule from" },
+        effect: { type: "string" as const, description: "The interrupt effect to remove a rule from" },
         ruleIndex: { type: "integer" as const, minimum: 0, description: "Zero-based index of the rule to remove" },
       },
-      required: ["kind", "ruleIndex"],
+      required: ["effect", "ruleIndex"],
     },
   },
   {
@@ -110,15 +110,15 @@ function handlePolicyTool(
       return { content: [{ type: "text", text: JSON.stringify(policyStore.get(), null, 2) }], isError: false };
     case POLICY_TOOL_NAMES.ADD_RULE:
       try {
-        policyStore.addRule(args.kind, { action: args.action, ...(args.match && { match: args.match }) });
-        return { content: [{ type: "text", text: `Rule added for '${args.kind}'.` }], isError: false };
+        policyStore.addRule(args.effect, { action: args.action, ...(args.match && { match: args.match }) });
+        return { content: [{ type: "text", text: `Rule added for '${args.effect}'.` }], isError: false };
       } catch (err) {
         return { content: [{ type: "text", text: errorMessage(err) }], isError: true };
       }
     case POLICY_TOOL_NAMES.REMOVE_RULE:
       try {
-        policyStore.removeRule(args.kind, args.ruleIndex);
-        return { content: [{ type: "text", text: `Rule removed from '${args.kind}'.` }], isError: false };
+        policyStore.removeRule(args.effect, args.ruleIndex);
+        return { content: [{ type: "text", text: `Rule removed from '${args.effect}'.` }], isError: false };
       } catch (err) {
         return { content: [{ type: "text", text: errorMessage(err) }], isError: true };
       }
@@ -210,14 +210,14 @@ export function createMcpHandler(config: McpConfig): McpHandler {
 
   const functionToolEntries = functions.map((f) => ({
     name: f.name,
-    description: formatToolDescription(f.description, f.interruptKinds),
+    description: formatToolDescription(f.description, f.interruptEffects),
     inputSchema: schemaToJsonSchema(f.agencyFunction.toolDefinition?.schema),
     ...(f.agencyFunction.safe ? { annotations: { readOnlyHint: true } } : {}),
   }));
 
   const nodeToolEntries = nodes.map((n) => ({
     name: n.name,
-    description: formatToolDescription(`Run the '${n.name}' node`, n.interruptKinds),
+    description: formatToolDescription(`Run the '${n.name}' node`, n.interruptEffects),
     inputSchema: {
       type: "object",
       properties: Object.fromEntries(n.parameters.map((p) => [p.name, { type: "string" }])),

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -30,7 +30,7 @@ function makeHandler() {
       name: "add",
       description: "Add two numbers",
       agencyFunction: addFn,
-      interruptKinds: [],
+      interruptEffects: [],
     },
   ];
   return createMcpHandler({

--- a/packages/agency-lang/lib/serve/mcp/interruptLoop.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/interruptLoop.test.ts
@@ -12,8 +12,8 @@ function makeTmpStore(policy: Record<string, any> = {}): { store: PolicyStore; c
   return { store, cleanup: () => rmSync(tmpDir, { recursive: true, force: true }) };
 }
 
-function makeInterrupt(kind: string, data: Record<string, any> = {}): any {
-  return { type: "interrupt", kind, message: "", data, origin: "test", interruptId: "test-id", runId: "test-run" };
+function makeInterrupt(effect: string, data: Record<string, any> = {}): any {
+  return { type: "interrupt", effect, message: "", data, origin: "test", interruptId: "test-id", runId: "test-run" };
 }
 
 const isInterrupts = (data: unknown) =>

--- a/packages/agency-lang/lib/serve/mcp/interruptLoop.ts
+++ b/packages/agency-lang/lib/serve/mcp/interruptLoop.ts
@@ -8,7 +8,7 @@ export type InterruptHandlers = {
 };
 
 function applyPolicy(
-  interrupts: Array<{ kind: string; message: string; data: any; origin: string }>,
+  interrupts: Array<{ effect: string; message: string; data: any; origin: string }>,
   policy: Record<string, any>,
 ) {
   return interrupts.map((interrupt) => {
@@ -25,7 +25,7 @@ export async function runWithPolicy(
   let result = await invoke();
 
   while (handlers.hasInterrupts(result)) {
-    const interrupts = result as Array<{ kind: string; message: string; data: any; origin: string }>;
+    const interrupts = result as Array<{ effect: string; message: string; data: any; origin: string }>;
     const responses = applyPolicy(interrupts, policyStore.get());
     result = await handlers.respondToInterrupts(interrupts, responses);
   }

--- a/packages/agency-lang/lib/serve/types.ts
+++ b/packages/agency-lang/lib/serve/types.ts
@@ -1,12 +1,12 @@
 import type { AgencyFunction } from "../runtime/agencyFunction.js";
-import type { InterruptKind } from "../symbolTable.js";
+import type { InterruptEffect } from "../symbolTable.js";
 
 export type ExportedFunction = {
   kind: "function";
   name: string;
   description: string;
   agencyFunction: AgencyFunction;
-  interruptKinds: InterruptKind[];
+  interruptEffects: InterruptEffect[];
 };
 
 export type ExportedNode = {
@@ -14,7 +14,7 @@ export type ExportedNode = {
   name: string;
   parameters: Array<{ name: string }>;
   invoke: (...args: unknown[]) => Promise<unknown>;
-  interruptKinds: InterruptKind[];
+  interruptEffects: InterruptEffect[];
 };
 
 export type ExportedItem = ExportedFunction | ExportedNode;

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -782,11 +782,11 @@ export class StatelogClient {
     decision: "approve" | "reject" | "propagate" | "none";
     value?: any;
     /** Optional summary of the interrupt being decided on. Carries
-     *  `kind`, `message`, and `data` so log consumers can see *what*
+     *  `effect`, `message`, and `data` so log consumers can see *what*
      *  was being approved/rejected without having to correlate with
      *  a separate `interruptThrown` event (which doesn't fire for
      *  synchronously-resolved interrupts like `with approve`). */
-    interrupt?: { kind: string; message: string; data: any };
+    interrupt?: { effect: string; message: string; data: any };
   }): Promise<void> {
     await this.post({
       type: "handlerDecision",
@@ -811,7 +811,7 @@ export class StatelogClient {
     timeTaken?: number;
     /** Optional summary of the interrupt being resolved. See
      *  `handlerDecision.interrupt` for rationale. */
-    interrupt?: { kind: string; message: string; data: any };
+    interrupt?: { effect: string; message: string; data: any };
   }): Promise<void> {
     await this.post({
       type: "interruptResolved",

--- a/packages/agency-lang/lib/symbolTable.test.ts
+++ b/packages/agency-lang/lib/symbolTable.test.ts
@@ -109,7 +109,7 @@ type NumberInRange(low: number, high: number) = number
 });
 
 describe("SymbolTable direct interrupt collection", () => {
-  it("populates direct interruptKinds on function and node symbols", () => {
+  it("populates direct interruptEffects on function and node symbols", () => {
     const file = path.join(os.tmpdir(), `st-int-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`);
     writeFileSync(
       file,
@@ -132,15 +132,15 @@ describe("SymbolTable direct interrupt collection", () => {
       // Only direct interrupt kinds — no transitive propagation
       expect(symbols["deploy"]).toMatchObject({
         kind: "function",
-        interruptKinds: [{ kind: "myapp::deploy" }],
+        interruptEffects: [{ effect: "myapp::deploy" }],
       });
       expect(symbols["orchestrate"]).toMatchObject({
         kind: "function",
-        interruptKinds: [],
+        interruptEffects: [],
       });
       expect(symbols["main"]).toMatchObject({
         kind: "node",
-        interruptKinds: [],
+        interruptEffects: [],
       });
     } finally {
       unlinkSync(file);
@@ -172,11 +172,11 @@ describe("SymbolTable direct interrupt collection", () => {
       const st = SymbolTable.build(mainFile);
       const libSymbols = st.getFile(path.resolve(libFile))!;
       expect(libSymbols["deploy"].kind).toBe("function");
-      expect((libSymbols["deploy"] as any).interruptKinds).toEqual([{ kind: "myapp::deploy" }]);
+      expect((libSymbols["deploy"] as any).interruptEffects).toEqual([{ effect: "myapp::deploy" }]);
       // main has no direct interrupts — transitive propagation happens in type checker
       const mainSymbols = st.getFile(path.resolve(mainFile))!;
       expect(mainSymbols["main"].kind).toBe("node");
-      expect((mainSymbols["main"] as any).interruptKinds).toEqual([]);
+      expect((mainSymbols["main"] as any).interruptEffects).toEqual([]);
     } finally {
       unlinkSync(mainFile);
       unlinkSync(libFile);

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -24,8 +24,8 @@ import {
   getStdlibDir,
 } from "./importPaths.js";
 
-export type InterruptKind = {
-  kind: string;
+export type InterruptEffect = {
+  effect: string;
 };
 
 /** Type-alias names that resolve to built-in types. */
@@ -46,7 +46,7 @@ export type FunctionSymbol = {
   parameters: FunctionParameter[];
   returnType: VariableType | null;
   returnTypeValidated?: boolean;
-  interruptKinds?: InterruptKind[];
+  interruptEffects?: InterruptEffect[];
   reExportedFrom?: ReExportedFrom;
 };
 
@@ -58,7 +58,7 @@ export type NodeSymbol = {
   returnType: VariableType | null;
   returnTypeValidated?: boolean;
   exported?: boolean;
-  interruptKinds?: InterruptKind[];
+  interruptEffects?: InterruptEffect[];
   reExportedFrom?: ReExportedFrom;
 };
 
@@ -327,7 +327,7 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
           returnType: node.returnType ?? null,
           returnTypeValidated: node.returnTypeValidated,
           exported: !!node.exported,
-          interruptKinds: collectDirectInterruptKinds(node.body),
+          interruptEffects: collectDirectInterruptEffects(node.body),
         };
         break;
       case "function":
@@ -340,7 +340,7 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
           parameters: node.parameters,
           returnType: node.returnType ?? null,
           returnTypeValidated: node.returnTypeValidated,
-          interruptKinds: collectDirectInterruptKinds(node.body),
+          interruptEffects: collectDirectInterruptEffects(node.body),
         };
         break;
       case "typeAlias":
@@ -378,14 +378,14 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
   return symbols;
 }
 
-function collectDirectInterruptKinds(body: AgencyNode[]): InterruptKind[] {
-  const kinds: string[] = [];
+function collectDirectInterruptEffects(body: AgencyNode[]): InterruptEffect[] {
+  const effects: string[] = [];
   for (const { node } of walkNodes(body)) {
-    if (node.type === "interruptStatement" && !kinds.includes(node.kind)) {
-      kinds.push(node.kind);
+    if (node.type === "interruptStatement" && !effects.includes(node.effect)) {
+      effects.push(node.effect);
     }
   }
-  return kinds.map((k) => ({ kind: k }));
+  return effects.map((e) => ({ effect: e }));
 }
 
 function isExportedSymbol(sym: SymbolInfo): boolean {

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
@@ -19,7 +19,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
+  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
@@ -24,7 +24,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
+  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -59,7 +59,7 @@ export type TemplateType = {
   assignResolve: string | boolean | number;
   assignApprove: string | boolean | number;
   nodeContext: boolean;
-  kind: string | boolean | number;
+  effect: string | boolean | number;
   message: string | boolean | number;
   data: string | boolean | number;
   origin: string | boolean | number;

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.mustache
@@ -15,7 +15,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
+  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.ts
@@ -20,7 +20,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
+  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -52,7 +52,7 @@ if (__response) {
 export type TemplateType = {
   interruptIdKey: string;
   nodeContext: boolean;
-  kind: string | boolean | number;
+  effect: string | boolean | number;
   message: string | boolean | number;
   data: string | boolean | number;
   origin: string | boolean | number;

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
@@ -4,14 +4,14 @@ import { startHttpServer } from {{{httpAdapterPath:string}}};
 import { createLogger } from {{{loggerPath:string}}};
 
 const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
-const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+const interruptEffectsByName = {{{interruptEffectsByNameJson:string}}};
 
 const exports = discoverExports({
   toolRegistry: mod.__toolRegistry ?? {},
   moduleExports: mod,
   moduleId: {{{moduleId:string}}},
   exportedNodeNames,
-  interruptKindsByName,
+  interruptEffectsByName,
 });
 
 const rawPort = process.env.PORT ?? {{{defaultPort:string}}};

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
@@ -9,14 +9,14 @@ import { startHttpServer } from {{{httpAdapterPath:string}}};
 import { createLogger } from {{{loggerPath:string}}};
 
 const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
-const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+const interruptEffectsByName = {{{interruptEffectsByNameJson:string}}};
 
 const exports = discoverExports({
   toolRegistry: mod.__toolRegistry ?? {},
   moduleExports: mod,
   moduleId: {{{moduleId:string}}},
   exportedNodeNames,
-  interruptKindsByName,
+  interruptEffectsByName,
 });
 
 const rawPort = process.env.PORT ?? {{{defaultPort:string}}};
@@ -50,7 +50,7 @@ export type TemplateType = {
   httpAdapterPath: string;
   loggerPath: string;
   exportedNodeNamesJson: string;
-  interruptKindsByNameJson: string;
+  interruptEffectsByNameJson: string;
   moduleId: string;
   defaultPort: string;
   defaultHost: string;

--- a/packages/agency-lang/lib/templates/cli/standaloneMcp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcp.mustache
@@ -4,14 +4,14 @@ import { createMcpHandler, startStdioServer } from {{{mcpAdapterPath:string}}};
 import { PolicyStore } from {{{policyStorePath:string}}};
 
 const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
-const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+const interruptEffectsByName = {{{interruptEffectsByNameJson:string}}};
 
 const exports = discoverExports({
   toolRegistry: mod.__toolRegistry ?? {},
   moduleExports: mod,
   moduleId: {{{moduleId:string}}},
   exportedNodeNames,
-  interruptKindsByName,
+  interruptEffectsByName,
 });
 
 const serverName = {{{serverName:string}}};

--- a/packages/agency-lang/lib/templates/cli/standaloneMcp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcp.ts
@@ -9,14 +9,14 @@ import { createMcpHandler, startStdioServer } from {{{mcpAdapterPath:string}}};
 import { PolicyStore } from {{{policyStorePath:string}}};
 
 const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
-const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+const interruptEffectsByName = {{{interruptEffectsByNameJson:string}}};
 
 const exports = discoverExports({
   toolRegistry: mod.__toolRegistry ?? {},
   moduleExports: mod,
   moduleId: {{{moduleId:string}}},
   exportedNodeNames,
-  interruptKindsByName,
+  interruptEffectsByName,
 });
 
 const serverName = {{{serverName:string}}};
@@ -46,7 +46,7 @@ export type TemplateType = {
   mcpAdapterPath: string;
   policyStorePath: string;
   exportedNodeNamesJson: string;
-  interruptKindsByNameJson: string;
+  interruptEffectsByNameJson: string;
   moduleId: string;
   serverName: string;
   serverVersion: string;

--- a/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.mustache
@@ -6,14 +6,14 @@ import { PolicyStore } from {{{policyStorePath:string}}};
 import { createLogger } from {{{loggerPath:string}}};
 
 const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
-const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+const interruptEffectsByName = {{{interruptEffectsByNameJson:string}}};
 
 const exports = discoverExports({
   toolRegistry: mod.__toolRegistry ?? {},
   moduleExports: mod,
   moduleId: {{{moduleId:string}}},
   exportedNodeNames,
-  interruptKindsByName,
+  interruptEffectsByName,
 });
 
 const serverName = {{{serverName:string}}};

--- a/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.ts
@@ -11,14 +11,14 @@ import { PolicyStore } from {{{policyStorePath:string}}};
 import { createLogger } from {{{loggerPath:string}}};
 
 const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
-const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+const interruptEffectsByName = {{{interruptEffectsByNameJson:string}}};
 
 const exports = discoverExports({
   toolRegistry: mod.__toolRegistry ?? {},
   moduleExports: mod,
   moduleId: {{{moduleId:string}}},
   exportedNodeNames,
-  interruptKindsByName,
+  interruptEffectsByName,
 });
 
 const serverName = {{{serverName:string}}};
@@ -72,7 +72,7 @@ export type TemplateType = {
   policyStorePath: string;
   loggerPath: string;
   exportedNodeNamesJson: string;
-  interruptKindsByNameJson: string;
+  interruptEffectsByNameJson: string;
   moduleId: string;
   serverName: string;
   serverVersion: string;

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -3,7 +3,7 @@ import type {
   CompilationUnit,
   ImportedFunctionSignature,
 } from "../compilationUnit.js";
-import type { InterruptKind } from "../symbolTable.js";
+import type { InterruptEffect } from "../symbolTable.js";
 import {
   GLOBAL_SCOPE_KEY,
   ScopedTypeAliases,
@@ -61,7 +61,7 @@ export class TypeChecker {
   private nodeDefs: Record<string, GraphNodeDefinition> = {};
   private importedFunctions: Record<string, ImportedFunctionSignature> = {};
   private jsImportedNames: Record<string, true> = {};
-  private interruptKindsByFunction: Record<string, InterruptKind[]> = {};
+  private interruptEffectsByFunction: Record<string, InterruptEffect[]> = {};
   private symbolTable?: SymbolTable;
   private currentFile?: string;
   private errors: TypeCheckError[] = [];
@@ -84,7 +84,7 @@ export class TypeChecker {
     );
     this.importedFunctions = { ...resolved.importedFunctions };
     this.jsImportedNames = { ...resolved.jsImportedNames };
-    this.interruptKindsByFunction = resolved.interruptKindsByFunction ?? {};
+    this.interruptEffectsByFunction = resolved.interruptEffectsByFunction ?? {};
     this.symbolTable = resolved.symbolTable;
     this.currentFile = resolved.fromFile;
     this.sourceText = resolved.sourceText;
@@ -113,7 +113,7 @@ export class TypeChecker {
       nodeDefs: this.nodeDefs,
       importedFunctions: this.importedFunctions,
       jsImportedNames: this.jsImportedNames,
-      interruptKindsByFunction: this.interruptKindsByFunction,
+      interruptEffectsByFunction: this.interruptEffectsByFunction,
       symbolTable: this.symbolTable,
       currentFile: this.currentFile,
       errors: this.errors,
@@ -293,7 +293,7 @@ export class TypeChecker {
     checkScopes(scopes, ctx);
 
     // 5. Analyze interrupts using functionRefType
-    const interruptKindsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
+    const interruptEffectsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
 
     // 5a. Build the per-function interrupt call graph used by
     // `agency interrupts` for static handler-set analysis. The
@@ -302,15 +302,15 @@ export class TypeChecker {
     const interruptCallGraph = buildInterruptCallGraph(scopes, ctx);
 
     // 6. Check for unhandled interrupt warnings (uses transitive results)
-    checkUnhandledInterruptWarnings(scopes, interruptKindsByFunction, ctx);
+    checkUnhandledInterruptWarnings(scopes, interruptEffectsByFunction, ctx);
 
     // 6a. Reject `interrupt` inside any callback body. Callbacks fire as
     // side effects; their body cannot pause execution.
-    checkCallbackBodyInterrupts(scopes, interruptKindsByFunction, ctx);
+    checkCallbackBodyInterrupts(scopes, interruptEffectsByFunction, ctx);
 
     // 6b. Reject handlers whose body may itself raise an interrupt — that
     // re-enters the handler chain and recurses (see HandlerRecursionError).
-    checkHandlerBodyInterrupts(scopes, interruptKindsByFunction, ctx);
+    checkHandlerBodyInterrupts(scopes, interruptEffectsByFunction, ctx);
 
     // 7. Check for undefined function calls (config-controlled severity).
     checkUndefinedFunctions(scopes, ctx);
@@ -337,7 +337,7 @@ export class TypeChecker {
     return {
       errors: this.applySuppressions(this.deduplicateErrors()),
       scopes,
-      interruptKindsByFunction,
+      interruptEffectsByFunction,
       interruptCallGraph,
     };
   }

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.test.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.test.ts
@@ -7,7 +7,7 @@ import { SymbolTable } from "../symbolTable.js";
 import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck } from "./index.js";
 
-function interruptKindsFor(source: string, funcName: string): string[] {
+function interruptEffectsFor(source: string, funcName: string): string[] {
   const file = path.join(
     os.tmpdir(),
     `int-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
@@ -19,8 +19,8 @@ function interruptKindsFor(source: string, funcName: string): string[] {
     const parseResult = parseAgency(source, {});
     if (!parseResult.success) throw new Error("Parse failed");
     const info = buildCompilationUnit(parseResult.result, symbolTable, absPath, source);
-    const { interruptKindsByFunction } = typeCheck(parseResult.result, {}, info);
-    return (interruptKindsByFunction[funcName] ?? []).map((ik) => ik.kind).sort();
+    const { interruptEffectsByFunction } = typeCheck(parseResult.result, {}, info);
+    return (interruptEffectsByFunction[funcName] ?? []).map((ik) => ik.effect).sort();
   } finally {
     unlinkSync(file);
   }
@@ -29,7 +29,7 @@ function interruptKindsFor(source: string, funcName: string): string[] {
 describe("interrupt analysis via type checker", () => {
   it("collects direct interrupt kinds", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def deploy() {
         interrupt myapp::deploy("Deploy?")
@@ -42,7 +42,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("propagates transitively through calls", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def deploy() {
         interrupt myapp::deploy("Deploy?")
@@ -57,7 +57,7 @@ describe("interrupt analysis via type checker", () => {
   });
 
   it("handles cycles without infinite loop", () => {
-    const kinds = interruptKindsFor(
+    const kinds = interruptEffectsFor(
       `
       def ping() {
         interrupt myapp::ping("Ping")
@@ -75,7 +75,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("resolves function refs in llm tools arrays", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def deploy() {
         interrupt myapp::deploy("Deploy?")
@@ -91,7 +91,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("resolves function refs via variable assignment", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def deploy() {
         interrupt myapp::deploy("Deploy?")
@@ -108,7 +108,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("resolves function refs via spread", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def deploy() {
         interrupt myapp::deploy("Deploy?")
@@ -128,7 +128,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("returns empty for functions with no interrupts", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def add(a: number, b: number): number {
         return a + b
@@ -141,7 +141,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("collects multiple interrupt kinds from one function", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def riskyOp() {
         interrupt myapp::deploy("Deploy?")
@@ -155,7 +155,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("propagates through goto statements", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       node checkout() {
         interrupt payment::charge("Charge?")
@@ -171,7 +171,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("collects from node definitions", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       node checkout() {
         interrupt payment::charge("Charge?")
@@ -204,8 +204,8 @@ describe("interrupt analysis via type checker", () => {
       const parseResult = parseAgency(mainSource, {});
       if (!parseResult.success) throw new Error("Parse failed");
       const info = buildCompilationUnit(parseResult.result, symbolTable, absPath, mainSource);
-      const { interruptKindsByFunction } = typeCheck(parseResult.result, {}, info);
-      const kinds = (interruptKindsByFunction["main"] ?? []).map((ik) => ik.kind).sort();
+      const { interruptEffectsByFunction } = typeCheck(parseResult.result, {}, info);
+      const kinds = (interruptEffectsByFunction["main"] ?? []).map((ik) => ik.effect).sort();
       expect(kinds).toEqual(["myapp::deploy"]);
     } finally {
       unlinkSync(mainFile);
@@ -215,7 +215,7 @@ describe("interrupt analysis via type checker", () => {
 
   it("propagates through multiple levels", () => {
     expect(
-      interruptKindsFor(
+      interruptEffectsFor(
         `
       def deploy() {
         interrupt myapp::deploy("Deploy?")

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -1,4 +1,4 @@
-import type { InterruptKind } from "../symbolTable.js";
+import type { InterruptEffect } from "../symbolTable.js";
 import type { TypeCheckerContext, ScopeInfo } from "./types.js";
 import { synthType } from "./synthesizer.js";
 import { walkNodes, type WalkAncestor } from "../utils/node.js";
@@ -70,7 +70,7 @@ type FunctionProfile = {
 export function analyzeInterruptsFromScopes(
   scopes: ScopeInfo[],
   ctx: TypeCheckerContext,
-): Record<string, InterruptKind[]> {
+): Record<string, InterruptEffect[]> {
   const profiles = collectProfiles(scopes, ctx);
   propagateTransitively(profiles);
   return formatResult(profiles);
@@ -85,8 +85,8 @@ function collectProfiles(
   const profiles: Record<string, FunctionProfile> = {};
 
   // Seed imported functions' direct kinds
-  for (const [name, importedKinds] of Object.entries(ctx.interruptKindsByFunction)) {
-    profiles[name] = { kinds: importedKinds.map((ik) => ik.kind), callees: [] };
+  for (const [name, importedKinds] of Object.entries(ctx.interruptEffectsByFunction)) {
+    profiles[name] = { kinds: importedKinds.map((ik) => ik.effect), callees: [] };
   }
 
   // Analyze each scope (skip the top-level scope — it has no function name
@@ -125,7 +125,7 @@ function collectFromBody(
   const callees: string[] = [];
   for (const { node } of walkNodes(body)) {
     if (node.type === "interruptStatement") {
-      addUnique(kinds, node.kind);
+      addUnique(kinds, node.effect);
     } else if (node.type === "functionCall") {
       addUnique(callees, node.functionName);
       for (const name of functionRefsInArgs(node.arguments, scope, ctx)) {
@@ -171,11 +171,11 @@ function propagateFromCallees(
 
 function formatResult(
   profiles: Record<string, FunctionProfile>,
-): Record<string, InterruptKind[]> {
-  const result: Record<string, InterruptKind[]> = {};
+): Record<string, InterruptEffect[]> {
+  const result: Record<string, InterruptEffect[]> = {};
   for (const [name, profile] of Object.entries(profiles)) {
     if (profile.kinds.length > 0) {
-      result[name] = profile.kinds.map((k) => ({ kind: k }));
+      result[name] = profile.kinds.map((k) => ({ effect: k }));
     }
   }
   return result;
@@ -355,7 +355,7 @@ function enclosingHandleBlocks(
  */
 export function checkUnhandledInterruptWarnings(
   scopes: ScopeInfo[],
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
   ctx: TypeCheckerContext,
 ): void {
   for (const info of scopes) {
@@ -366,10 +366,10 @@ export function checkUnhandledInterruptWarnings(
     if (!ctx.nodeDefs[info.name]) continue;
     for (const { node, ancestors } of walkNodes(info.body)) {
       if (node.type !== "functionCall") continue;
-      const kinds = interruptKindsByFunction[node.functionName];
+      const kinds = interruptEffectsByFunction[node.functionName];
       if (!kinds || kinds.length === 0) continue;
       if (isInsideHandler(ancestors)) continue;
-      const kindList = kinds.map((ik) => ik.kind).join(", ");
+      const kindList = kinds.map((ik) => ik.effect).join(", ");
       ctx.errors.push({
         message: `Function '${node.functionName}' may throw interrupts [${kindList}] but is not inside a handler.`,
         severity: "warning",
@@ -397,7 +397,7 @@ export function checkUnhandledInterruptWarnings(
  */
 export function checkHandlerBodyInterrupts(
   scopes: ScopeInfo[],
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
   ctx: TypeCheckerContext,
 ): void {
   for (const info of scopes) {
@@ -407,7 +407,7 @@ export function checkHandlerBodyInterrupts(
         const kinds = collectHandlerOffenderKinds(
           node,
           info,
-          interruptKindsByFunction,
+          interruptEffectsByFunction,
           ctx,
         );
         if (kinds.length === 0) continue;
@@ -433,28 +433,28 @@ export function checkHandlerBodyInterrupts(
   }
 }
 
-/** Collect every interrupt kind a handle block's handler may raise,
+/** Collect every interrupt effect a handle block's handler may raise,
  *  transitively. For a `functionRef` handler we read the already-propagated
  *  kinds directly. For an inline handler we reuse `collectFromBody` (the
  *  same walker Phase 1 uses for every scope) and then resolve its callees
- *  through `interruptKindsByFunction`, so transitive interrupts via tool
+ *  through `interruptEffectsByFunction`, so transitive interrupts via tool
  *  calls, function refs in args, or `goto` targets are caught with no
  *  duplicated walker logic. */
 function collectHandlerOffenderKinds(
   node: { handler: { kind: string; functionName?: string; body?: any[] } },
   info: ScopeInfo,
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
   ctx: TypeCheckerContext,
 ): string[] {
   if (node.handler.kind === "functionRef") {
-    const ks = interruptKindsByFunction[node.handler.functionName!] ?? [];
-    return ks.map((k) => k.kind);
+    const ks = interruptEffectsByFunction[node.handler.functionName!] ?? [];
+    return ks.map((k) => k.effect);
   }
   const profile = collectFromBody(node.handler.body ?? [], info.scope, ctx);
   const kinds = [...profile.kinds];
   for (const callee of profile.callees) {
-    for (const k of interruptKindsByFunction[callee] ?? []) {
-      addUnique(kinds, k.kind);
+    for (const k of interruptEffectsByFunction[callee] ?? []) {
+      addUnique(kinds, k.effect);
     }
   }
   return kinds;
@@ -494,12 +494,12 @@ function extractStaticString(expr: Expression): string | null {
  * `callback(...) { ... }` block becomes
  * `callback("hookName", __cb_scope_N)` — a 2-arg call whose second
  * argument is a `variableName` referencing a lifted top-level
- * function. We look that function up in `interruptKindsByFunction`
+ * function. We look that function up in `interruptEffectsByFunction`
  * (transitively populated) and emit an error if it may interrupt.
  */
 export function checkCallbackBodyInterrupts(
   scopes: ScopeInfo[],
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
   ctx: TypeCheckerContext,
 ): void {
   for (const info of scopes) {
@@ -517,10 +517,10 @@ export function checkCallbackBodyInterrupts(
       const fnName = fnArg && fnArg.type === "variableName" ? fnArg.value : null;
       if (!fnName) continue;
 
-      const kinds = interruptKindsByFunction[fnName];
+      const kinds = interruptEffectsByFunction[fnName];
       if (!kinds || kinds.length === 0) continue;
 
-      const kindList = kinds.map((ik) => ik.kind).join(", ");
+      const kindList = kinds.map((ik) => ik.effect).join(", ");
       ctx.errors.push({
         message:
           `\`interrupt\` is not allowed inside a callback body ` +

--- a/packages/agency-lang/lib/typeChecker/interruptCallGraph.test.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptCallGraph.test.ts
@@ -60,7 +60,7 @@ node main() {
     expect(main.file).toMatch(/\.agency$/);
     expect(main.interruptSites).toHaveLength(1);
     const site = main.interruptSites[0];
-    expect(site.site.kind).toBe("std::read");
+    expect(site.site.effect).toBe("std::read");
     expect(site.file).toBe(main.file); // site file matches enclosing function's file
     expect(site.enclosingHandlers).toHaveLength(1);
     // Identity check: the captured handler is the `handle {` on the third
@@ -181,6 +181,6 @@ node main() {
 `);
     const main = entry(cg, "main");
     expect(main.interruptSites).toHaveLength(2);
-    expect(main.interruptSites.map((s) => s.site.kind)).toEqual(["std::read", "std::write"]);
+    expect(main.interruptSites.map((s) => s.site.effect)).toEqual(["std::read", "std::write"]);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -12,7 +12,7 @@ import type {
   ImportedFunctionSignature,
   ScopedTypeAliases,
 } from "../compilationUnit.js";
-import type { InterruptKind, SymbolTable } from "../symbolTable.js";
+import type { InterruptEffect, SymbolTable } from "../symbolTable.js";
 import type { InterruptCallGraph } from "./interruptAnalysis.js";
 
 export type TypeCheckError = {
@@ -27,7 +27,7 @@ export type TypeCheckError = {
 export type TypeCheckResult = {
   errors: TypeCheckError[];
   scopes: ScopeInfo[];
-  interruptKindsByFunction: Record<string, InterruptKind[]>;
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>;
   interruptCallGraph: InterruptCallGraph;
 };
 
@@ -75,7 +75,7 @@ export type TypeCheckerContext = {
   importedFunctions: Record<string, ImportedFunctionSignature>;
   /** Names brought in by non-Agency JS imports — see CompilationUnit. */
   jsImportedNames: Record<string, true>;
-  interruptKindsByFunction: Record<string, InterruptKind[]>;
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>;
   errors: TypeCheckError[];
   inferredReturnTypes: Record<string, VariableType | "any">;
   inferringReturnType: Set<string>;

--- a/packages/agency-lang/lib/types/interruptStatement.ts
+++ b/packages/agency-lang/lib/types/interruptStatement.ts
@@ -4,6 +4,6 @@ import { SplatExpression, NamedArgument } from "./dataStructures.js";
 
 export type InterruptStatement = BaseNode & {
   type: "interruptStatement";
-  kind: string; // e.g. "std::read", "myapp::deploy"
+  effect: string; // e.g. "std::read", "myapp::deploy"
   arguments: (Expression | SplatExpression | NamedArgument)[];
 };

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -132,7 +132,7 @@ export function expressionToString(expr: Expression): string {
       return `schema(${variableTypeToString(expr.typeArg, {})})`;
     case "interruptStatement": {
       const args = expr.arguments.map(callArgToString).join(", ");
-      return `interrupt ${expr.kind}(${args})`;
+      return `interrupt ${expr.effect}(${args})`;
     }
     case "blockArgument": {
       const params = expr.params.map(p => p.typeHint ? `${p.name}: ${variableTypeToString(p.typeHint, {})}` : p.name).join(", ");

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -15,7 +15,7 @@ import {
 /** @module
   ## Overview
 
-  A `Policy` is an ordered list of rules per interrupt kind that decides,
+  A `Policy` is an ordered list of rules per interrupt effect that decides,
   without prompting the user, whether to approve or reject each interrupt
   an agent raises. Rules use glob patterns ("match objects") against the
   interrupt's `data` fields. Evaluation is first-match-wins.
@@ -31,7 +31,7 @@ import {
   2. **CLI sugar** — `cliPolicyHandler` — drops in as a handler for
      interactive agents. It loads `policy.json` on first use, prompts
      the user with (a)/(r)/(aa)/(ap)/(rr) for each new interrupt
-     kind, records "always" decisions to disk, and replays matching
+     effect, records "always" decisions to disk, and replays matching
      rules on subsequent interrupts so the user is only asked once
      per pattern.
 
@@ -40,8 +40,8 @@ import {
   ```ts
   import { cliPolicyHandler, ScopedRuleFields } from "std::policy"
 
-  // Per-kind config controlling the "approve always here (ap)" option.
-  // For every kind you list, the (ap) prompt offers to pin the listed
+  // Per-effect config controlling the "approve always here (ap)" option.
+  // For every effect you list, the (ap) prompt offers to pin the listed
   // data fields. `matchSubpaths: true` brace-expands the value so
   // `/tmp/x` also matches `/tmp/x/anything`.
   const FIELDS: ScopedRuleFields = {
@@ -62,7 +62,7 @@ import {
     )
     handle {
       // Every interrupt the inner code raises is filtered through the
-      // policy. New kinds prompt the user; "aa" / "ap" decisions are
+      // policy. New effects prompt the user; "aa" / "ap" decisions are
       // persisted so the next run starts pre-approved.
       llm("hi", { tools: [...] })
     } with handler
@@ -86,7 +86,7 @@ import {
     // decision.type == "propagate" -- no rule matches. Ask your UI:
     const choice = askUserSomehow(intr)
     if (choice == "always-approve") {
-      myPolicy = recordRule(myPolicy, intr.kind, "approve")
+      myPolicy = recordRule(myPolicy, intr.effect, "approve")
       return approve()
     }
     return choice == "approve" ? approve() : reject()
@@ -98,7 +98,7 @@ import {
   Each rule has an optional `match` map. The values are glob patterns
   (via picomatch); evaluation passes when every key in `match` exists
   in `intr.data` and its value matches the pattern. A rule with no
-  `match` is a catch-all for that kind.
+  `match` is a catch-all for that effect.
 
   Example: this rule auto-approves reads under `/tmp` (and any subdir):
 
@@ -117,7 +117,7 @@ import {
 
   `recordRule` **appends** a catch-all rule. Because evaluation is
   first-match-wins, a new approve rule will be ignored if an earlier
-  catch-all already covers the kind:
+  catch-all already covers the effect:
 
   ```ts
   let p = recordRule({}, "std::read", "reject")
@@ -142,16 +142,16 @@ export type InterruptDataKey = string
 export type InterruptDataVal = string
 
 /**
- * Identifier for an interrupt's kind (e.g. `"std::read"`,
+ * Identifier for an interrupt's effect (e.g. `"std::read"`,
  * `"myapp::deploy"`).
  */
-export type InterruptKind = string
+export type InterruptEffect = string
 
 /**
  * One row of a `Policy`. A rule passes if every key in `match` is
  * present in the interrupt's `data` and its value matches the glob
  * pattern. Omit `match` (or set it to `{}`) for a catch-all that
- * applies to every interrupt of the parent kind.
+ * applies to every interrupt of the parent effect.
  */
 export type PolicyRule = {
   match?: Record<InterruptDataKey, InterruptDataVal>;
@@ -159,22 +159,22 @@ export type PolicyRule = {
 }
 
 /**
- * A policy: ordered rules per interrupt kind. `checkPolicy` walks
- * the array for `intr.kind` in order and returns on the first
- * matching rule. If no rule for the kind exists, evaluation falls
+ * A policy: ordered rules per interrupt effect. `checkPolicy` walks
+ * the array for `intr.effect` in order and returns on the first
+ * matching rule. If no rule for the effect exists, evaluation falls
  * through to `propagate` (i.e. ask the next handler in the chain).
  */
-export type Policy = Record<InterruptKind, PolicyRule[]>
+export type Policy = Record<InterruptEffect, PolicyRule[]>
 
 /**
  * The five answers `cliPolicyHandler`'s prompt accepts:
  * - `"approve"` / `"reject"` — one-off (a) / (r).
  * - `"approve-always"` / `"reject-always"` — (aa) / (rr); records a
- *   catch-all rule for the kind so future interrupts of this kind
+ *   catch-all rule for the effect so future interrupts of this effect
  *   resolve without prompting.
  * - `"approve-always-here"` — (ap); records a scoped rule pinned to
- *   whichever fields you listed in `ScopedRuleFields` for this kind.
- *   Only offered when the kind has an entry in the config.
+ *   whichever fields you listed in `ScopedRuleFields` for this effect.
+ *   Only offered when the effect has an entry in the config.
  */
 export type Decision =
   | "approve"
@@ -200,9 +200,9 @@ export type ScopedField = {
 }
 
 /**
- * Per-kind configuration consumed by `buildScopedMatch` and the
- * `cliPolicyHandler`. Maps each interrupt kind to the fields its
- * "approve-always-here" rule should pin. Kinds not present in this
+ * Per-effect configuration consumed by `buildScopedMatch` and the
+ * `cliPolicyHandler`. Maps each interrupt effect to the fields its
+ * "approve-always-here" rule should pin. Effects not present in this
  * map don't offer the (ap) prompt option — the user falls back to
  * (a) / (r) / (aa) / (rr).
  *
@@ -217,7 +217,7 @@ export type ScopedField = {
  * }
  * ```
  */
-export type ScopedRuleFields = Record<InterruptKind, ScopedField[]>
+export type ScopedRuleFields = Record<InterruptEffect, ScopedField[]>
 
 type CliPolicyOpts = {
   file: string;
@@ -245,8 +245,8 @@ let _internalIo: boolean = false
 /**
  * Evaluate a policy against a single interrupt. Returns the result
  * of `approve()`, `reject()`, or `propagate()` corresponding to the
- * first matching rule for `interrupt.kind`. If no rule matches
- * (no rules for the kind, or every rule's `match` failed), returns
+ * first matching rule for `interrupt.effect`. If no rule matches
+ * (no rules for the effect, or every rule's `match` failed), returns
  * `propagate()` so the next handler in the chain runs.
  *
  * Designed for use inside a custom handler. The CLI sugar
@@ -257,7 +257,7 @@ export def checkPolicy(
   interrupt: Record<string, any>,
 ) {
   """
-  Evaluate a policy against an interrupt. Returns approve(), reject(), or propagate() based on the first matching rule. Policy is a JSON object keyed by interrupt kind, where each kind maps to an ordered array of rules with optional match fields (glob patterns) and an action.
+  Evaluate a policy against an interrupt. Returns approve(), reject(), or propagate() based on the first matching rule. Policy is a JSON object keyed by interrupt effect, where each effect maps to an ordered array of rules with optional match fields (glob patterns) and an action.
   """
   return _checkPolicy(policy, interrupt)
 }
@@ -288,7 +288,7 @@ export def validatePolicy(policy: Record<string, any>): Result<void> {
  * const rule: PolicyRule = { match: match, action: "approve" }
  * ```
  *
- * For each `ScopedField` configured for `intr.kind`:
+ * For each `ScopedField` configured for `intr.effect`:
  * - The field's value is read from `intr.data`.
  * - If `matchSubpaths: true`, the value is wrapped as
  *   `"{value,value/**}"` so the resulting glob matches both the
@@ -297,7 +297,7 @@ export def validatePolicy(policy: Record<string, any>): Result<void> {
  *   match).
  *
  * Fields that are absent from `intr.data` (`null` / `undefined`)
- * are skipped silently. Kinds not present in `fields` return `{}`.
+ * are skipped silently. Effects not present in `fields` return `{}`.
  *
  * Most callers should use `recordScopedRule` instead, which calls
  * this internally; `buildScopedMatch` is exposed for callers
@@ -309,13 +309,13 @@ export def buildScopedMatch(
   fields: ScopedRuleFields,
 ): Record<string, string> {
   """
-  Given the per-kind ScopedField[] config, build a match object pinned
-  to the meaningful fields of this interrupt. Returns {} when the kind
+  Given the per-effect ScopedField[] config, build a match object pinned
+  to the meaningful fields of this interrupt. Returns {} when the effect
   isn't in the fields map. Pure.
   """
   let specs: ScopedField[] = []
-  if (fields[intr.kind] != undefined) {
-    specs = fields[intr.kind]
+  if (fields[intr.effect] != undefined) {
+    specs = fields[intr.effect]
   }
   let match: Record<string, string> = {}
   for (spec in specs) {
@@ -334,12 +334,12 @@ export def buildScopedMatch(
 
 /**
  * Return a new policy with a catch-all rule (`{ action }` with no
- * `match`) for `kind` appended. Pure — does not mutate the input.
+ * `match`) for `effect` appended. Pure — does not mutate the input.
  *
  * ## Precedence trap
  *
  * Evaluation is first-match-wins, so **append order matters**. A
- * second call for the same kind with a different action is dead
+ * second call for the same effect with a different action is dead
  * code:
  *
  * ```ts
@@ -348,29 +348,29 @@ export def buildScopedMatch(
  * ```
  *
  * If you're flipping a previously-recorded decision, decide
- * explicitly: either reset the kind's rules first
+ * explicitly: either reset the effect's rules first
  * (`{ ...policy, "std::read": [] }` and re-record), or hand-edit
- * `policy[kind]` to replace the offending rule. This function does
+ * `policy[effect]` to replace the offending rule. This function does
  * not try to detect or warn about shadowing on your behalf.
  */
 export def recordRule(
   policy: Policy,
-  kind: InterruptKind,
+  effect: InterruptEffect,
   action: "approve" | "reject",
 ): Policy {
   """
-  Return a new policy with a catch-all rule for `kind` appended.
+  Return a new policy with a catch-all rule for `effect` appended.
   First-match-wins inside `checkPolicy`, so a single bare rule covers
-  every future interrupt of that kind. Pure — no I/O.
+  every future interrupt of that effect. Pure — no I/O.
 
-  WARNING: append order matters. A second call for the same kind with
-  a different action is dead — the earlier rule wins. Reset the kind's
+  WARNING: append order matters. A second call for the same effect with
+  a different action is dead — the earlier rule wins. Reset the effect's
   rules first if you want to flip a previous decision.
   """
-  const existing = policy[kind] || []
+  const existing = policy[effect] || []
   const next: Policy = {
     ...policy,
-    [kind]: [...existing, {
+    [effect]: [...existing, {
       action: action
     }]
   }
@@ -379,12 +379,12 @@ export def recordRule(
 
 /**
  * Return a new policy with a scoped approve rule prepended for
- * `intr.kind`. The rule's `match` is built by `buildScopedMatch`,
- * so it pins whichever fields are configured for the kind. Pure.
+ * `intr.effect`. The rule's `match` is built by `buildScopedMatch`,
+ * so it pins whichever fields are configured for the effect. Pure.
  *
  * Prepended (not appended) so the new, more-specific rule wins
  * over any pre-existing catch-all in first-match-wins order. This
- * makes scoped rules safe to add even if the kind already has a
+ * makes scoped rules safe to add even if the effect already has a
  * broader rejection: the scoped approval applies first when it
  * matches, otherwise the catch-all takes over.
  *
@@ -399,14 +399,14 @@ export def recordScopedRule(
 ): Policy {
   """
   Return a new policy with a scoped approve rule prepended for the
-  interrupt's kind. Prepended (not appended) so the more-specific
+  interrupt's effect. Prepended (not appended) so the more-specific
   rule wins over any later catch-all in first-match-wins order. Pure.
   """
   const match = buildScopedMatch(intr, fields)
-  const existing = policy[intr.kind] || []
+  const existing = policy[intr.effect] || []
   const next: Policy = {
     ...policy,
-    [intr.kind]: [{
+    [intr.effect]: [{
       match: match,
       action: "approve"
     }, ...existing]
@@ -633,7 +633,7 @@ def prettyPrintInterruptData(data: any): string {
 
 // Present the (a)/(r)/(aa)/(ap)/(rr) menu for one interrupt and
 // return the user's choice as an `AskUserResult`. `(ap)` is offered
-// only when `globalCliPolicyOpts.fields` has an entry for `intr.kind`.
+// only when `globalCliPolicyOpts.fields` has an entry for `intr.effect`.
 // Renders as a modal over the active repl(); falls back to plain print
 // + input when no REPL is running (e.g. headless agent runs).
 //
@@ -643,11 +643,11 @@ def prettyPrintInterruptData(data: any): string {
 def askUser(intr: any): AskUserResult {
   // `!= null` compiles to `!== null` (Agency strict equality), so an
   // undefined entry would slip through. Use the explicit existence check.
-  let kindFields: ScopedField[] = []
-  if (globalCliPolicyOpts.fields[intr.kind] != undefined) {
-    kindFields = globalCliPolicyOpts.fields[intr.kind]
+  let effectFields: ScopedField[] = []
+  if (globalCliPolicyOpts.fields[intr.effect] != undefined) {
+    effectFields = globalCliPolicyOpts.fields[intr.effect]
   }
-  const scopedAvailable = kindFields.length > 0
+  const scopedAvailable = effectFields.length > 0
 
   const title = intr.message
   const body = prettyPrintInterruptData(intr.data)
@@ -663,7 +663,7 @@ def askUser(intr: any): AskUserResult {
   },
     {
     key: "aa",
-    label: "approve always (every future ${intr.kind})"
+    label: "approve always (every future ${intr.effect})"
   },
   ]
   if (scopedAvailable) {
@@ -747,7 +747,7 @@ export def _handler(intr: any): any {
 
   const answer = askUser(intr)
   if (answer.action == "approve-always") {
-    _policy = recordRule(_policy, intr.kind, "approve")
+    _policy = recordRule(_policy, intr.effect, "approve")
     _pendingSave = true
     return approve()
   }
@@ -757,7 +757,7 @@ export def _handler(intr: any): any {
     return approve()
   }
   if (answer.action == "reject-always") {
-    _policy = recordRule(_policy, intr.kind, "reject")
+    _policy = recordRule(_policy, intr.effect, "reject")
     _pendingSave = true
     return reject()
   }
@@ -804,7 +804,7 @@ export def _handler(intr: any): any {
  *    matches, approves or rejects without prompting.
  * 3. **Prompts the user** when no rule applies, showing
  *    (a)/(r)/(aa)/(ap)/(rr). The (ap) option appears only when
- *    `fields` has an entry for the interrupt's kind.
+ *    `fields` has an entry for the interrupt's effect.
  * 4. **Records "always" decisions** in memory and flushes them to
  *    disk at the top of the next interrupt. Use `flushPolicy()` if
  *    you need the final decision of a session persisted before
@@ -829,8 +829,8 @@ export def _handler(intr: any): any {
  *
  * @param file - Path to the on-disk policy file. Created on first
  *   save; the containing directory must already exist.
- * @param fields - Per-kind config controlling the (ap) prompt
- *   option. Kinds not present here don't offer (ap).
+ * @param fields - Per-effect config controlling the (ap) prompt
+ *   option. Effects not present here don't offer (ap).
  */
 export def cliPolicyHandler(file: string, fields: ScopedRuleFields): any {
   """
@@ -846,7 +846,7 @@ export def cliPolicyHandler(file: string, fields: ScopedRuleFields): any {
   handle { ... } with handler
 
   @param file - Path to the on-disk policy file
-  @param fields - Per-kind config controlling the "approve-always-here" option
+  @param fields - Per-effect config controlling the "approve-always-here" option
   """
   globalCliPolicyOpts = {
     file: file,

--- a/packages/agency-lang/tests/agency-js/subprocess-no-handler/fixture.json
+++ b/packages/agency-lang/tests/agency-js/subprocess-no-handler/fixture.json
@@ -1,4 +1,4 @@
 {
   "type": "interrupt",
-  "kind": "std::run"
+  "effect": "std::run"
 }

--- a/packages/agency-lang/tests/agency-js/subprocess-no-handler/test.js
+++ b/packages/agency-lang/tests/agency-js/subprocess-no-handler/test.js
@@ -16,5 +16,5 @@ const interrupt = result.data[0];
 
 writeFileSync("__result.json", JSON.stringify({
   type: interrupt.type,
-  kind: interrupt.kind,
+  effect: interrupt.effect,
 }, null, 2));

--- a/packages/agency-lang/tests/agency/handlers/handle-mixed-approve-reject.agency
+++ b/packages/agency-lang/tests/agency/handlers/handle-mixed-approve-reject.agency
@@ -36,9 +36,9 @@ node main() {
     const res1 = foo()
     log.push("foo returned ${res1}")
   } with (interrupt) {
-    if (interrupt.kind == "test::safe") {
+    if (interrupt.effect == "test::safe") {
       return approve("Alice")
-    } else if (interrupt.kind == "test::read") {
+    } else if (interrupt.effect == "test::read") {
       return reject("not allowed")
     }
   }
@@ -50,9 +50,9 @@ node bothRejected() {
     const res1 = foo()
     log.push("foo returned ${res1}")
   } with (interrupt) {
-    if (interrupt.kind == "test::safe") {
+    if (interrupt.effect == "test::safe") {
       return reject()
-    } else if (interrupt.kind == "test::read") {
+    } else if (interrupt.effect == "test::read") {
       return reject("not allowed")
     }
   }

--- a/packages/agency-lang/tests/agency/policy-build-scoped-match/main.agency
+++ b/packages/agency-lang/tests/agency/policy-build-scoped-match/main.agency
@@ -9,7 +9,7 @@ node main() {
     ],
   }
   const readIntr = {
-    kind: "std::read",
+    effect: "std::read",
     data: { dir: "/Users/x/project", filename: "foo.ts" }
   }
   const m1 = buildScopedMatch(readIntr, fields)
@@ -19,7 +19,7 @@ node main() {
   }
 
   const execIntr = {
-    kind: "std::exec",
+    effect: "std::exec",
     data: { command: "git", subcommand: "log", args: ["log"] }
   }
   const m2 = buildScopedMatch(execIntr, fields)
@@ -27,7 +27,7 @@ node main() {
   if (m2.subcommand != "log") { return "FAIL: subcommand not pinned" }
 
   // Kind not in the fields map → empty match
-  const otherIntr = { kind: "myapp::deploy", data: { env: "prod" } }
+  const otherIntr = { effect: "myapp::deploy", data: { env: "prod" } }
   const m3 = buildScopedMatch(otherIntr, fields)
   if (keys(m3).length != 0) { return "FAIL: should be empty for unknown kind" }
 

--- a/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.agency
+++ b/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.agency
@@ -5,7 +5,7 @@ node main() {
     "std::read": [{ field: "dir", matchSubpaths: true }],
   }
   const intr = {
-    kind: "std::read",
+    effect: "std::read",
     data: { dir: "/Users/x/project", filename: "foo.ts" }
   }
   const policy = recordScopedRule({}, intr, fields)
@@ -16,7 +16,7 @@ node main() {
 
   // Should NOT auto-approve a non-matching read.
   const otherIntr = {
-    kind: "std::read",
+    effect: "std::read",
     data: { dir: "/Users/x/secrets", filename: "passwd" }
   }
   const d2 = checkPolicy(policy, otherIntr)
@@ -24,7 +24,7 @@ node main() {
 
   // Subpath of the original dir should still match (brace-expansion).
   const subIntr = {
-    kind: "std::read",
+    effect: "std::read",
     data: { dir: "/Users/x/project/sub", filename: "a.ts" }
   }
   const d3 = checkPolicy(policy, subIntr)

--- a/packages/agency-lang/tests/agency/structured-interrupts/bare-interrupt-backward-compat.agency
+++ b/packages/agency-lang/tests/agency/structured-interrupts/bare-interrupt-backward-compat.agency
@@ -7,7 +7,7 @@ node main() {
   handle {
     return check()
   } with (interrupt) {
-    if (interrupt.kind == "unknown") {
+    if (interrupt.effect == "unknown") {
       return approve()
     }
     return reject()

--- a/packages/agency-lang/tests/agency/structured-interrupts/structured-interrupt-assign.agency
+++ b/packages/agency-lang/tests/agency/structured-interrupts/structured-interrupt-assign.agency
@@ -7,7 +7,7 @@ node main() {
   handle {
     return askName()
   } with (interrupt) {
-    if (interrupt.kind == "mytest::ask") {
+    if (interrupt.effect == "mytest::ask") {
       return approve("Alice")
     }
     return reject()

--- a/packages/agency-lang/tests/agency/structured-interrupts/structured-interrupt-handler.agency
+++ b/packages/agency-lang/tests/agency/structured-interrupts/structured-interrupt-handler.agency
@@ -7,7 +7,7 @@ node main() {
   handle {
     return check("Alice")
   } with (interrupt) {
-    if (interrupt.kind == "mytest::greet") {
+    if (interrupt.effect == "mytest::greet") {
       if (interrupt.data.name == "Alice") {
         return approve()
       }

--- a/packages/agency-lang/tests/agency/subprocess/handler-reject.agency
+++ b/packages/agency-lang/tests/agency/subprocess/handler-reject.agency
@@ -26,7 +26,7 @@ node main() {
     }
     return "run failed: " + result.error
   } with (data) {
-    if (data.kind == "std::run") {
+    if (data.effect == "std::run") {
       return approve()
     }
     return reject()

--- a/packages/agency-lang/tests/typescriptPreprocessor/interrupt.json
+++ b/packages/agency-lang/tests/typescriptPreprocessor/interrupt.json
@@ -23,7 +23,7 @@
           "type": "returnStatement",
           "value": {
             "type": "interruptStatement",
-            "kind": "unknown",
+            "effect": "unknown",
             "arguments": [
               {
                 "type": "string",


### PR DESCRIPTION
## Summary

Renames the interrupt-categorization field from `kind` to `effect` throughout the language, runtime, and tooling.

`kind` was one of the most overloaded identifiers in the codebase (IR/AST discriminants, symbol kinds, `RunBatchResult`, handler shapes), so this is a **targeted** rename of only the interrupt-effect uses — every unrelated `kind` discriminant is left untouched.

## Breaking change (no backward-compat shim, by request)

- Handler code reading `intr.kind` / `data.kind` must now use `.effect`.
- The serialized interrupt wire format uses `"effect"` (IPC, checkpoints, traces). Old persisted snapshots that carry `"kind"` will not match.
- The MCP policy tool parameter `kind` is renamed to `effect`.

## What changed

- **Core / AST / parser / codegen:** `InterruptStatement.effect`, `Interrupt.effect`, `InterruptOpts.effect`, the parser capture, both mustache templates (regenerated), and the TypeScript builder.
- **Runtime:** `interruptWithHandlers`, the handler chain, `HandlerFn`, `policy.ts`, the IPC payload, the statelog summary, `HandlerRecursionError`, and the log/summary readers.
- **Static-analysis subsystem:** `InterruptKind` → `InterruptEffect`, `interruptKinds` → `interruptEffects` across the type checker, LSP, symbol table, CLI, and HTTP/MCP adapters — including the user-facing MCP policy parameter and the HTTP wire field.
- **Agency source:** `stdlib/policy.agency`, the policy agent, and the agency-agent's edit-diff handler.
- **Docs:** guide code examples and prose, hover text, and the generated `stdlib/policy.md`.
- **Tests / fixtures:** interrupt unit tests, the subprocess fixtures, and the preprocessor `interrupt.json` AST snapshot.

## Verification

- `pnpm run typecheck`: **0 errors**
- `make` (build + stdlib + agents): **passes**
- `pnpm run lint:structure`: **clean**
- Full unit suite: **green**. The only two failures are **pre-existing and unrelated** (verified against a clean tree): a `@/` dist module-resolution issue in `mutator.test.ts`, and an uncommitted layout `REPRO:` test on `main`.

## Notes

- `agency doc` could not be run in this environment (pre-existing `@/cli` alias-resolution error in the compiled `dist`), so `docs/site/stdlib/policy.md` was hand-synced to match the source; regenerate via `make doc` when that tooling works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
