### PR TITLE
Restore recursive-ls cap and tool-result size cap

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -79,13 +79,16 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 ### ls
 
 ```ts
-ls(dir: string, recursive: boolean, allowedPaths: string[]): Result
+ls(dir: string, recursive: boolean, maxResults: number, allowedPaths: string[]): Result
 ```
 
 List entries in a directory. Each entry includes name, path, type ("file", "dir", "symlink", "other"), and size. Set recursive to true to walk subdirectories. Fails if the directory cannot be read (missing, not a directory, permission denied). Set allowedPaths to restrict which directories may be listed.
 
+  A recursive listing skips the heavyweight dirs (node_modules, .git, dist, build, .next, .cache) entirely and stops at `maxResults` entries (default 1000), so listing a project root can't return a multi-million-entry tree. A non-recursive listing still shows those dirs. If you suspect entries were truncated, narrow `dir` or raise `maxResults`.
+
   @param dir - The directory to list (relative paths resolve against the module directory)
   @param recursive - Whether to walk subdirectories
+  @param maxResults - Maximum number of entries to return
   @param allowedPaths - Only allow listing directories under these prefixes
 
 **Parameters:**
@@ -94,6 +97,7 @@ List entries in a directory. Each entry includes name, path, type ("file", "dir"
 |---|---|---|
 | dir | `string` | "." |
 | recursive | `boolean` | false |
+| maxResults | `number` | 1000 |
 | allowedPaths | `string[]` | [] |
 
 **Returns:** `Result`
@@ -134,7 +138,7 @@ Search for a regex pattern in files under a directory. Returns matches with file
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L142))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L147))
 
 ### glob
 
@@ -162,7 +166,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Stops at maxRe
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L177))
 
 ### stat
 
@@ -188,7 +192,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L202))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L207))
 
 ### exists
 
@@ -214,7 +218,7 @@ Return true if a file or directory exists at the given path. Set allowedPaths to
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L219))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L224))
 
 ### which
 
@@ -232,4 +236,4 @@ Locate an executable in PATH and return its absolute path. Returns an empty stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L236))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L241))

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3447,6 +3447,11 @@ export class TypeScriptBuilder {
         String(this.agencyConfig.checkpoints.maxRestores),
       );
     }
+    if (cfg.client?.maxToolResultChars !== undefined) {
+      runtimeCtxArgs.maxToolResultChars = ts.raw(
+        String(cfg.client.maxToolResultChars),
+      );
+    }
 
     const traceConfigFields: Record<string, TsNode> = {
       program: ts.str(this.moduleId),

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -117,6 +117,15 @@ export interface AgencyConfig {
     defaultModel: string;
     openAiApiKey: string;
     googleApiKey: string;
+    /**
+     * Max characters of a single tool result fed back to the LLM.
+     * Results longer than this are truncated (with a marker) in what
+     * the model sees — the full value is still returned to Agency code.
+     * Prevents one tool (e.g. a recursive `ls`) from blowing the
+     * context window. Default 100000; `0` disables the cap. Override
+     * per call with `llm(..., { maxToolResultChars })`.
+     */
+    maxToolResultChars: number;
     statelog?: Partial<{
       host: string;
       projectId: string;
@@ -326,6 +335,7 @@ export const AgencyConfigSchema = z
         defaultModel: z.string(),
         openAiApiKey: z.string(),
         googleApiKey: z.string(),
+        maxToolResultChars: z.number(),
         statelog: z
           .object({
             host: z.string(),

--- a/packages/agency-lang/lib/runtime/configOverrides.ts
+++ b/packages/agency-lang/lib/runtime/configOverrides.ts
@@ -9,6 +9,7 @@ import type { TraceConfig } from "./trace/types.js";
 export type RuntimeContextConstructorArgs = {
   statelogConfig: StatelogConfig;
   smoltalkDefaults: Partial<SmolConfig>;
+  maxToolResultChars?: number;
   dirname: string;
   maxRestores?: number;
   traceConfig?: TraceConfig;

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { _internal } from "./prompt.js";
+
+const { DEFAULT_TOOL_RESULT_CHARS, stringifyToolResult, capToolResultForLlm } =
+  _internal;
+
+describe("stringifyToolResult", () => {
+  it("passes strings through unchanged", () => {
+    expect(stringifyToolResult("hello")).toBe("hello");
+  });
+
+  it("JSON-stringifies objects/arrays", () => {
+    expect(stringifyToolResult({ a: 1 })).toBe('{"a":1}');
+    expect(stringifyToolResult([1, 2])).toBe("[1,2]");
+  });
+
+  it("falls back to String() on circular structures", () => {
+    const a: any = {};
+    a.self = a;
+    // Does not throw; returns some string representation.
+    expect(typeof stringifyToolResult(a)).toBe("string");
+  });
+});
+
+describe("capToolResultForLlm", () => {
+  it("returns the original value untouched when within the cap", () => {
+    const obj = { big: "x".repeat(100) };
+    // Object under cap → returned as-is (object identity), so smoltalk
+    // serializes it exactly as before — no behavior change.
+    expect(capToolResultForLlm(obj, 1000)).toBe(obj);
+    expect(capToolResultForLlm("short", 1000)).toBe("short");
+  });
+
+  it("truncates an over-cap string and appends a marker", () => {
+    const out = capToolResultForLlm("a".repeat(5000), 100) as string;
+    expect(typeof out).toBe("string");
+    expect(out.startsWith("a".repeat(100))).toBe(true);
+    expect(out).toContain("truncated");
+    // Marker reports the original length.
+    expect(out).toContain("of 5000");
+    // First `cap` chars are preserved verbatim before the marker.
+    expect(out.slice(0, 100)).toBe("a".repeat(100));
+  });
+
+  it("truncates an over-cap object (by its serialized form)", () => {
+    const big = { data: "y".repeat(5000) };
+    const out = capToolResultForLlm(big, 100);
+    expect(typeof out).toBe("string");
+    expect(out).toContain("truncated");
+  });
+
+  it("cap of 0 disables the cap (returns original)", () => {
+    const huge = "z".repeat(1_000_000);
+    expect(capToolResultForLlm(huge, 0)).toBe(huge);
+  });
+
+  it("non-finite cap (Infinity) disables the cap", () => {
+    const huge = "z".repeat(1_000_000);
+    expect(capToolResultForLlm(huge, Infinity)).toBe(huge);
+  });
+
+  it("default cap is 100000 characters", () => {
+    expect(DEFAULT_TOOL_RESULT_CHARS).toBe(100_000);
+    const justOver = "q".repeat(DEFAULT_TOOL_RESULT_CHARS + 1);
+    const out = capToolResultForLlm(justOver, DEFAULT_TOOL_RESULT_CHARS) as string;
+    expect(out.slice(0, DEFAULT_TOOL_RESULT_CHARS)).toBe(
+      "q".repeat(DEFAULT_TOOL_RESULT_CHARS),
+    );
+    expect(out).toContain("truncated");
+  });
+});

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -83,6 +83,48 @@ async function dispatchLLMRequest({
   };
 }
 
+/** Default cap on characters of a single tool result fed back to the
+ *  LLM. A recursive `ls`/`grep` can return megabytes; without a cap one
+ *  tool call can blow the context window. The FULL result is still
+ *  returned to Agency code — only what the model sees is truncated. */
+const DEFAULT_TOOL_RESULT_CHARS = 100_000;
+
+/** Coerce an arbitrary tool result to the string the LLM would see.
+ *  Strings pass through; everything else is JSON-stringified, with a
+ *  `String()` fallback for values JSON can't represent (e.g. circular). */
+function stringifyToolResult(result: any): string {
+  if (typeof result === "string") return result;
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return String(result);
+  }
+}
+
+/** Truncate a tool result for the LLM if its serialized form exceeds
+ *  `cap` characters. Returns the ORIGINAL value untouched when within
+ *  the cap (so smoltalk serializes it exactly as before) or when the cap
+ *  is disabled (`cap <= 0` or non-finite). Over the cap, returns the
+ *  first `cap` characters plus a marker noting the original length, so
+ *  the model knows it was cut. */
+function capToolResultForLlm(result: any, cap: number): any {
+  if (!Number.isFinite(cap) || cap <= 0) return result;
+  const text = stringifyToolResult(result);
+  if (text.length <= cap) return result;
+  return (
+    text.slice(0, cap) +
+    `\n\n[tool result truncated: showing ${cap} of ${text.length} chars]`
+  );
+}
+
+/** Test-only surface for the pure tool-result-cap helpers. Not part of
+ *  the supported runtime API. */
+export const _internal = {
+  DEFAULT_TOOL_RESULT_CHARS,
+  stringifyToolResult,
+  capToolResultForLlm,
+};
+
 async function _runPrompt({
   ctx,
   messages,
@@ -336,12 +378,22 @@ export async function runPrompt(args: {
   const {
     tools: _extractedTools,
     memory: memoryOption,
+    maxToolResultChars: callMaxToolResultChars,
     ...restClientConfig
   } = (args.clientConfig || {}) as Partial<smoltalk.SmolConfig> & {
     tools?: any[];
     memory?: boolean | { model?: string };
+    maxToolResultChars?: number;
   };
   const clientConfig = ctx.getSmoltalkConfig(restClientConfig);
+
+  // Cap on characters of a single tool result fed back to the LLM. The
+  // full result is still cached for Agency code via `setResultOnBranch`;
+  // only what the model sees is truncated. Resolution precedence:
+  // per-call `llm(..., { maxToolResultChars })` > agency.json
+  // (`ctx.maxToolResultChars`) > default. `0`/non-finite disables.
+  const toolResultCap =
+    callMaxToolResultChars ?? ctx.maxToolResultChars ?? DEFAULT_TOOL_RESULT_CHARS;
 
   // Restore or initialize messages.
   //
@@ -541,7 +593,7 @@ export async function runPrompt(args: {
           (toolErrorCounts[handler.name] || 0) + 1;
         messages.push(
           smoltalk.toolMessage(
-            `Error: ${errorMessage}. This tool failed after performing side effects and cannot be retried.`,
+            `Error: ${String(capToolResultForLlm(errorMessage, toolResultCap))}. This tool failed after performing side effects and cannot be retried.`,
             { tool_call_id: toolCall.id, name: toolCall.name },
           ),
         );
@@ -557,6 +609,10 @@ export async function runPrompt(args: {
           typeof toolResult.error === "string"
             ? toolResult.error
             : String(toolResult.error);
+        // Cap only what the LLM sees; statelog keeps the full message.
+        const cappedError = String(
+          capToolResultForLlm(errorMessage, toolResultCap),
+        );
         toolErrorCounts[handler.name] =
           (toolErrorCounts[handler.name] || 0) + 1;
         ctx.statelogClient.error({
@@ -568,14 +624,14 @@ export async function runPrompt(args: {
         if (toolResult.retryable && toolErrorCounts[handler.name] < 5) {
           messages.push(
             smoltalk.toolMessage(
-              `Error: ${errorMessage}. You may retry this tool call with corrected arguments.`,
+              `Error: ${cappedError}. You may retry this tool call with corrected arguments.`,
               { tool_call_id: toolCall.id, name: toolCall.name },
             ),
           );
         } else if (toolResult.retryable) {
           messages.push(
             smoltalk.toolMessage(
-              `Error: ${errorMessage}. This tool has failed too many times and can no longer be called.`,
+              `Error: ${cappedError}. This tool has failed too many times and can no longer be called.`,
               { tool_call_id: toolCall.id, name: toolCall.name },
             ),
           );
@@ -583,7 +639,7 @@ export async function runPrompt(args: {
         } else {
           messages.push(
             smoltalk.toolMessage(
-              `Error: ${errorMessage}. This operation failed and cannot be retried.`,
+              `Error: ${cappedError}. This operation failed and cannot be retried.`,
               { tool_call_id: toolCall.id, name: toolCall.name },
             ),
           );
@@ -599,7 +655,7 @@ export async function runPrompt(args: {
             ? toolResult.value
             : "Tool call rejected by policy";
         messages.push(
-          smoltalk.toolMessage(message, {
+          smoltalk.toolMessage(capToolResultForLlm(message, toolResultCap), {
             tool_call_id: toolCall.id,
             name: toolCall.name,
           }),
@@ -628,7 +684,7 @@ export async function runPrompt(args: {
         `${handler.name} ran successfully but did not return a value`;
       stack.setResultOnBranch(branchKey, toolResult);
       messages.push(
-        smoltalk.toolMessage(toolResult, {
+        smoltalk.toolMessage(capToolResultForLlm(toolResult, toolResultCap), {
           tool_call_id: toolCall.id,
           name: toolCall.name,
         }),

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -115,6 +115,11 @@ export class RuntimeContext<T> {
   // so that all the logs share the same traceId, so they all show up in the same trace in the Statelog dashboard.
   statelogClient: StatelogClient;
   smoltalkDefaults: Partial<SmolConfig>;
+  /** Max characters of a single tool result fed back to the LLM (the
+   *  full result is still returned to Agency code). `undefined` falls
+   *  back to the runtime default in `runPrompt`. Baked in from
+   *  `agency.json` `client.maxToolResultChars` at compile time. */
+  maxToolResultChars?: number;
   private _llmClient: LLMClient;
   private _interruptResponses: Record<string, { response: InterruptResponse }> = {};
 
@@ -181,6 +186,7 @@ export class RuntimeContext<T> {
   constructor(args: {
     statelogConfig: StatelogConfig;
     smoltalkDefaults: Partial<SmolConfig>;
+    maxToolResultChars?: number;
     dirname: string;
     maxRestores?: number;
     traceConfig?: TraceConfig;
@@ -236,6 +242,7 @@ export class RuntimeContext<T> {
     this.graph = new SimpleMachine<T>(graphConfig);
 
     this.smoltalkDefaults = args.smoltalkDefaults;
+    this.maxToolResultChars = args.maxToolResultChars;
     this._llmClient = new SmoltalkClient();
     this.abortController = new AbortController();
 
@@ -265,6 +272,7 @@ export class RuntimeContext<T> {
     ) as RuntimeContext<T>;
     execCtx.graph = this.graph;
     execCtx.smoltalkDefaults = this.smoltalkDefaults;
+    execCtx.maxToolResultChars = this.maxToolResultChars;
     execCtx._llmClient = this._llmClient;
     execCtx.dirname = this.dirname;
     execCtx.statelogConfig = this.statelogConfig;

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -227,17 +227,28 @@ export async function _ls(
   // dir as `dir`". All policy lives in `resolveDir` so future rules
   // (env vars, normalization, etc.) propagate automatically.
   const root = await resolveDir(dir, allowedPaths ?? []);
+  // Coerce the cap so a non-finite value (e.g. NaN) can't silently
+  // disable the bound and reintroduce unbounded recursion. `0` (and any
+  // value <= 0) is a valid request that yields an empty result.
+  const cap = Number.isFinite(maxResults) ? maxResults : DEFAULT_LS_MAX_RESULTS;
   const out: LsEntry[] = [];
 
-  // Returns false to signal "stop walking" (cap reached).
-  async function walk(current: string): Promise<boolean> {
+  // Returns false to signal "stop walking" (cap reached). `isRoot`
+  // surfaces a readdir failure on the scanned dir itself — matching the
+  // documented "fails if the directory cannot be read" contract — while
+  // an unreadable *subdirectory* during a recursive walk is skipped
+  // rather than failing the whole listing.
+  async function walk(current: string, isRoot: boolean): Promise<boolean> {
     let names: string[];
     try {
       names = await fs.readdir(current);
-    } catch {
+    } catch (err) {
+      if (isRoot) throw err;
       return true;
     }
     for (const name of names) {
+      // Check the cap before pushing so `cap <= 0` yields an empty result.
+      if (out.length >= cap) return false;
       // On a recursive walk, skip the heavyweight dirs entirely — don't
       // list them and don't descend. A non-recursive `ls` still shows
       // them (the user asked for exactly this directory's contents).
@@ -261,15 +272,14 @@ export async function _ls(
         type,
         size: st.size,
       });
-      if (out.length >= maxResults) return false;
       if (recursive && type === "dir") {
-        if (!(await walk(full))) return false;
+        if (!(await walk(full, false))) return false;
       }
     }
     return true;
   }
 
-  await walk(root);
+  await walk(root, true);
   return out;
 }
 

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -206,10 +206,18 @@ export type LsEntry = {
   size: number;
 };
 
+// Cap on how many entries a single `ls` returns. Without this, a
+// recursive listing of a project root could return a multi-million
+// entry tree (which once produced a ~48MB / ~12M-token blob fed back to
+// an LLM). The Agency `ls` wrapper passes an explicit value; this is a
+// safety default for direct callers.
+const DEFAULT_LS_MAX_RESULTS = 1000;
+
 export async function _ls(
   dir: string,
   recursive: boolean,
   allowedPaths?: string[],
+  maxResults: number = DEFAULT_LS_MAX_RESULTS,
 ): Promise<LsEntry[]> {
   // Resolve relative `dir` against the calling module's directory (same
   // policy as `read`/`write`), so co-located resource folders work no
@@ -221,9 +229,19 @@ export async function _ls(
   const root = await resolveDir(dir, allowedPaths ?? []);
   const out: LsEntry[] = [];
 
-  async function walk(current: string): Promise<void> {
-    const names = await fs.readdir(current);
+  // Returns false to signal "stop walking" (cap reached).
+  async function walk(current: string): Promise<boolean> {
+    let names: string[];
+    try {
+      names = await fs.readdir(current);
+    } catch {
+      return true;
+    }
     for (const name of names) {
+      // On a recursive walk, skip the heavyweight dirs entirely — don't
+      // list them and don't descend. A non-recursive `ls` still shows
+      // them (the user asked for exactly this directory's contents).
+      if (recursive && SKIP_DIRS.has(name)) continue;
       const full = path.join(current, name);
       let st: Awaited<ReturnType<typeof fs.lstat>>;
       try {
@@ -243,10 +261,12 @@ export async function _ls(
         type,
         size: st.size,
       });
+      if (out.length >= maxResults) return false;
       if (recursive && type === "dir") {
-        await walk(full);
+        if (!(await walk(full))) return false;
       }
     }
+    return true;
   }
 
   await walk(root);

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -58,6 +58,9 @@ const llmOptions: VariableType = {
     // The object form is reserved for future config (e.g. per-call
     // model override); for now only the boolean form is wired.
     { key: "memory", value: optional(boolean) },
+    // Per-call cap on characters of a tool result fed back to the LLM
+    // (overrides agency.json `client.maxToolResultChars`). `0` disables.
+    { key: "maxToolResultChars", value: optional(number) },
     // `any` already accepts undefined, so no need to wrap in optional.
     { key: "metadata", value: ANY_T },
   ],

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -116,21 +116,26 @@ type LsEntry = {
 export def ls(
   dir: string = ".",
   recursive: boolean = false,
+  maxResults: number = 1000,
   allowedPaths: string[] = [],
 ): Result {
   """
   List entries in a directory. Each entry includes name, path, type ("file", "dir", "symlink", "other"), and size. Set recursive to true to walk subdirectories. Fails if the directory cannot be read (missing, not a directory, permission denied). Set allowedPaths to restrict which directories may be listed.
 
+  A recursive listing skips the heavyweight dirs (node_modules, .git, dist, build, .next, .cache) entirely and stops at `maxResults` entries (default 1000), so listing a project root can't return a multi-million-entry tree. A non-recursive listing still shows those dirs. If you suspect entries were truncated, narrow `dir` or raise `maxResults`.
+
   @param dir - The directory to list (relative paths resolve against the module directory)
   @param recursive - Whether to walk subdirectories
+  @param maxResults - Maximum number of entries to return
   @param allowedPaths - Only allow listing directories under these prefixes
   """
   return interrupt std::ls("Are you sure you want to list this directory?", {
     dir: dir,
-    recursive: recursive
+    recursive: recursive,
+    maxResults: maxResults
   })
 
-  return try _ls(dir, recursive, allowedPaths)
+  return try _ls(dir, recursive, allowedPaths, maxResults)
 }
 
 type GrepMatch = {

--- a/packages/agency-lang/tests/agency-js/ls-recursive-cap/agent.agency
+++ b/packages/agency-lang/tests/agency-js/ls-recursive-cap/agent.agency
@@ -1,0 +1,36 @@
+import { ls } from "std::shell"
+
+// Regression: a recursive `ls` must skip the heavyweight dirs
+// (node_modules, .git, ...) and honor `maxResults`, so listing a
+// project root can't return a multi-million-entry tree (which once fed
+// a 48MB / ~12M-token blob back to an LLM).
+node main(args: { dir: string }): any {
+  let total = 0
+  let hasNodeModules = false
+  let hasGit = false
+  const r = ls(args.dir, recursive: true) with approve
+  if (r is success(entries)) {
+    for (e in entries) {
+      total = total + 1
+      if (e.path.includes("node_modules")) {
+        hasNodeModules = true
+      }
+      if (e.path.includes(".git")) {
+        hasGit = true
+      }
+    }
+  }
+
+  let cappedCount = 0
+  const capped = ls(args.dir, recursive: true, maxResults: 2) with approve
+  if (capped is success(c)) {
+    cappedCount = c.length
+  }
+
+  return {
+    total: total,
+    hasNodeModules: hasNodeModules,
+    hasGit: hasGit,
+    cappedCount: cappedCount
+  }
+}

--- a/packages/agency-lang/tests/agency-js/ls-recursive-cap/agent.agency
+++ b/packages/agency-lang/tests/agency-js/ls-recursive-cap/agent.agency
@@ -27,10 +27,28 @@ node main(args: { dir: string }): any {
     cappedCount = c.length
   }
 
+  // maxResults: 0 is a valid request for "no entries" — must yield an
+  // empty result, not one entry (cap is checked before each push).
+  let zeroCount = -1
+  const zero = ls(args.dir, recursive: true, maxResults: 0) with approve
+  if (zero is success(z)) {
+    zeroCount = z.length
+  }
+
+  // An unreadable / missing root must surface as a failure (matches the
+  // documented contract), not silently succeed with an empty list.
+  let missingFailed = false
+  const missing = ls("__agency_no_such_dir__", recursive: true) with approve
+  if (isFailure(missing)) {
+    missingFailed = true
+  }
+
   return {
     total: total,
     hasNodeModules: hasNodeModules,
     hasGit: hasGit,
-    cappedCount: cappedCount
+    cappedCount: cappedCount,
+    zeroCount: zeroCount,
+    missingFailed: missingFailed
   }
 }

--- a/packages/agency-lang/tests/agency-js/ls-recursive-cap/fixture.json
+++ b/packages/agency-lang/tests/agency-js/ls-recursive-cap/fixture.json
@@ -1,0 +1,6 @@
+{
+  "total": 4,
+  "hasNodeModules": false,
+  "hasGit": false,
+  "cappedCount": 2
+}

--- a/packages/agency-lang/tests/agency-js/ls-recursive-cap/fixture.json
+++ b/packages/agency-lang/tests/agency-js/ls-recursive-cap/fixture.json
@@ -2,5 +2,7 @@
   "total": 4,
   "hasNodeModules": false,
   "hasGit": false,
-  "cappedCount": 2
+  "cappedCount": 2,
+  "zeroCount": 0,
+  "missingFailed": true
 }

--- a/packages/agency-lang/tests/agency-js/ls-recursive-cap/test.js
+++ b/packages/agency-lang/tests/agency-js/ls-recursive-cap/test.js
@@ -1,0 +1,25 @@
+import { main } from "./agent.js";
+import { writeFileSync, mkdtempSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Build a tree with real source files plus the heavyweight dirs a
+// recursive `ls` must skip (node_modules with many files, .git).
+const dir = mkdtempSync(join(tmpdir(), "ls-cap-"));
+mkdirSync(join(dir, "src"));
+writeFileSync(join(dir, "src", "a.ts"), "a");
+writeFileSync(join(dir, "src", "b.ts"), "b");
+writeFileSync(join(dir, "src", "c.ts"), "c");
+mkdirSync(join(dir, "node_modules", "pkg"), { recursive: true });
+for (let i = 0; i < 50; i++) {
+  writeFileSync(join(dir, "node_modules", "pkg", `f${i}.js`), "x");
+}
+mkdirSync(join(dir, ".git"));
+writeFileSync(join(dir, ".git", "config"), "x");
+
+try {
+  const result = await main({ dir });
+  writeFileSync("__result.json", JSON.stringify(result.data, null, 2));
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Restores two safety fixes that bound how much data a single tool call can feed back to the LLM. Both had been implemented earlier but were lost (uncommitted changes reverted); this re-creates them cleanly with their tests.

### 1. Cap and prune recursive `ls` (`fix(shell)`)

A recursive `ls` walked into `node_modules`/`.git` and returned unbounded results — once producing a ~48MB / ~12M-token blob fed back to an LLM.

- Recursive listings now skip the heavyweight dirs (`node_modules`, `.git`, `dist`, `build`, `.next`, `.cache`) entirely — not listed, not descended.
- Recursive listings stop at `maxResults` entries (default `1000`).
- Non-recursive listings are unchanged (still show those dirs).
- New `maxResults` param on `std::shell`'s `ls`.

### 2. Cap tool-result size fed to the LLM (`feat(runtime)`)

Any single tool call (not just `ls`) could return megabytes and blow the context window.

- Tool results are truncated to a character cap in **what the model sees** — with a marker noting the original length — while the **full** result is still cached for Agency code via `setResultOnBranch`.
- Applied at the success, crash, failure, and rejected tool-message sites. Statelog keeps full error text.
- Resolution precedence: per-call `llm(..., { maxToolResultChars })` > `agency.json` `client.maxToolResultChars` > default (`100000`). `0` or non-finite disables.
- Wired through config (type + zod), codegen (baked into `RuntimeContext` args, mirroring `maxRestores`), the runtime context (incl. `createExecutionContext` propagation), and the typechecker `llm` options.

## Testing

- `lib/runtime/prompt.test.ts` — 9 unit tests for the pure cap helpers (`stringifyToolResult`, `capToolResultForLlm`, default constant).
- `tests/agency-js/ls-recursive-cap/` — regression test: recursive `ls` skips `node_modules`/`.git` and honors `maxResults`.
- Verified config→codegen wiring bakes `maxToolResultChars` into generated `RuntimeContext` args.
- Full `make` clean; related unit suites green (`config`, `context`, `configOverrides`, `agencyLlm`, `shell`, typechecker builtins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
