### PR TITLE
Characterize memory/setMemoryId behavior inside forks (+ getMemoryId)

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -18,7 +18,7 @@ export type MemoryConfig = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L40))
 
 ## Functions
 
@@ -40,7 +40,7 @@ Return `true` iff there is an active memory frame on the current
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L48))
 
 ### setMemoryId
 
@@ -68,7 +68,23 @@ Set the memory scope for this agent run. Call this before other
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L63))
+
+### getMemoryId
+
+```ts
+getMemoryId(): string
+```
+
+Return the current memory scope id (the value last passed to
+  `setMemoryId`, or "default" if it was never set or memory is not
+  active). Reads the scope visible to the current execution branch.
+
+  @returns The active memory scope id
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L82))
 
 ### enableMemory
 
@@ -107,7 +123,7 @@ Turn memory on for the current execution branch using `config`.
 
 **Throws:** `std::memory::enableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L93))
 
 ### disableMemory
 
@@ -128,7 +144,7 @@ Pop the top memory frame from the current branch's stateStack.
 
 **Throws:** `std::memory::disableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L125))
 
 ### memory
 
@@ -168,7 +184,7 @@ Run `block` with `config` pushed as the active memory frame; pop
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L143))
 
 ### remember
 
@@ -195,7 +211,7 @@ Extract and store structured facts from the given text into the
 
 **Throws:** `std::memory::remember`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L176))
 
 ### recall
 
@@ -222,7 +238,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Throws:** `std::memory::recall`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L190))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L202))
 
 ### forget
 
@@ -248,4 +264,4 @@ Soft-delete facts matching the query from the knowledge graph.
 
 **Throws:** `std::memory::forget`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L208))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L220))

--- a/packages/agency-lang/lib/stdlib/memory.ts
+++ b/packages/agency-lang/lib/stdlib/memory.ts
@@ -135,6 +135,12 @@ export async function _setMemoryId(id: string): Promise<void> {
   manager.setMemoryId(id);
 }
 
+export function _getMemoryId(): string {
+  const { ctx } = getRuntimeContext();
+  const manager = ctx?.getActiveMemoryManager?.();
+  return manager?.getMemoryId?.() ?? "default";
+}
+
 export function _shouldRunMemory(): boolean {
   const { ctx } = getRuntimeContext();
   return ctx?.getActiveMemoryManager?.() !== undefined;

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -9,6 +9,7 @@
 // `lib/stdlib/memory.ts` for the migration window.
 import {
   _setMemoryId,
+  _getMemoryId,
   _shouldRunMemory,
   _buildExtractionPrompt,
   _applyExtractionResult,
@@ -76,6 +77,17 @@ export def setMemoryId(id: string) {
   @param id - A unique identifier for the memory scope (e.g. user ID)
   """
   _setMemoryId(id)
+}
+
+export def getMemoryId(): string {
+  """
+  Return the current memory scope id (the value last passed to
+  `setMemoryId`, or "default" if it was never set or memory is not
+  active). Reads the scope visible to the current execution branch.
+
+  @returns The active memory scope id
+  """
+  return _getMemoryId()
 }
 
 export def enableMemory(config: MemoryConfig) {

--- a/packages/agency-lang/tests/agency/memory-fork/branch-enable-invisible.agency
+++ b/packages/agency-lang/tests/agency/memory-fork/branch-enable-invisible.agency
@@ -1,0 +1,17 @@
+import { enableMemory, isMemoryActive } from "std::memory"
+
+// CHARACTERIZATION (documents current behavior, which may be surprising):
+// Enabling memory INSIDE a branch is not observable in that branch.
+// `enableMemory` pushes a frame onto the branch's own stack (the ALS
+// slice), but `isMemoryActive` reads the top-level stack, so the
+// branch's freshly-pushed frame is invisible here. (This is the
+// `fork(range(10)) as i { if (i % 2 == 0) { enableMemory() } }` case.)
+node main() {
+  const results = fork([0, 1, 2, 3]) as i {
+    if (i % 2 == 0) {
+      enableMemory({ dir: ".agency-tmp/memory-fork-branch-${i}" }) with approve
+    }
+    return isMemoryActive()
+  }
+  return results
+}

--- a/packages/agency-lang/tests/agency/memory-fork/branch-enable-invisible.test.json
+++ b/packages/agency-lang/tests/agency/memory-fork/branch-enable-invisible.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Branch-local enableMemory is invisible to isMemoryActive in that branch",
+      "input": "",
+      "expectedOutput": "[false,false,false,false]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/memory-fork/branch-enable-no-leak.agency
+++ b/packages/agency-lang/tests/agency/memory-fork/branch-enable-no-leak.agency
@@ -1,0 +1,12 @@
+import { enableMemory, isMemoryActive } from "std::memory"
+
+// CHARACTERIZATION: a branch-local enableMemory does not affect the
+// parent after the fork joins (the branch frame lived on the branch's
+// own stack, which is discarded at join).
+node main(): boolean {
+  fork([0]) as i {
+    enableMemory({ dir: ".agency-tmp/memory-fork-no-leak" }) with approve
+    return isMemoryActive()
+  }
+  return isMemoryActive()
+}

--- a/packages/agency-lang/tests/agency/memory-fork/branch-enable-no-leak.test.json
+++ b/packages/agency-lang/tests/agency/memory-fork/branch-enable-no-leak.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Branch-local enableMemory does not leak to the parent after join",
+      "input": "",
+      "expectedOutput": "false",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/memory-fork/enable-inherits.agency
+++ b/packages/agency-lang/tests/agency/memory-fork/enable-inherits.agency
@@ -1,0 +1,13 @@
+import { enableMemory, isMemoryActive } from "std::memory"
+
+// CHARACTERIZATION (documents current behavior, which may be surprising):
+// With memory enabled at the top level, each fork branch observes it as
+// active. Branch memory reads resolve through ctx.stateStack (the
+// top-level stack), so branches inherit the top-level frame.
+node main() {
+  enableMemory({ dir: ".agency-tmp/memory-fork-enable-inherits" }) with approve
+  const results = fork([1, 2, 3]) as i {
+    return isMemoryActive()
+  }
+  return results
+}

--- a/packages/agency-lang/tests/agency/memory-fork/enable-inherits.test.json
+++ b/packages/agency-lang/tests/agency/memory-fork/enable-inherits.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Branches inherit top-level enableMemory (isMemoryActive true in each)",
+      "input": "",
+      "expectedOutput": "[true,true,true]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/memory-fork/setid-inherits.agency
+++ b/packages/agency-lang/tests/agency/memory-fork/setid-inherits.agency
@@ -1,0 +1,12 @@
+import { enableMemory, setMemoryId, getMemoryId } from "std::memory"
+
+// CHARACTERIZATION: each fork branch inherits the memory id set at the
+// top level (id reads resolve through the top-level stack).
+node main() {
+  enableMemory({ dir: ".agency-tmp/memory-fork-setid-inherits" }) with approve
+  setMemoryId("base")
+  const results = fork([1, 2, 3]) as i {
+    return getMemoryId()
+  }
+  return results
+}

--- a/packages/agency-lang/tests/agency/memory-fork/setid-inherits.test.json
+++ b/packages/agency-lang/tests/agency/memory-fork/setid-inherits.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Branches inherit the top-level memory id via getMemoryId",
+      "input": "",
+      "expectedOutput": "[\"base\",\"base\",\"base\"]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/memory-fork/setid-leaks.agency
+++ b/packages/agency-lang/tests/agency/memory-fork/setid-leaks.agency
@@ -1,0 +1,16 @@
+import { enableMemory, setMemoryId, getMemoryId } from "std::memory"
+
+// CHARACTERIZATION (documents current behavior, which may be surprising):
+// setMemoryId inside a branch writes the shared top-level scope, so the
+// change LEAKS to the parent after the fork. (This is the
+// `fork(range(10)) as i { setMemoryId(i) }` case — with many branches it
+// also races; a single branch keeps the assertion deterministic.)
+node main(): string {
+  enableMemory({ dir: ".agency-tmp/memory-fork-setid-leaks" }) with approve
+  setMemoryId("base")
+  fork([0]) as i {
+    setMemoryId("branch")
+    return getMemoryId()
+  }
+  return getMemoryId()
+}

--- a/packages/agency-lang/tests/agency/memory-fork/setid-leaks.test.json
+++ b/packages/agency-lang/tests/agency/memory-fork/setid-leaks.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "setMemoryId inside a branch leaks the id to the parent after join",
+      "input": "",
+      "expectedOutput": "\"branch\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Characterization tests that pin down how memory behaves across `fork` branches today. We were unsure of the actual semantics (forks share `ctx` but get their own stacks, and memory helpers split between the two), so these tests establish ground truth before any change. **They document current behavior — including the surprising parts — they do not endorse it.**

Also adds `getMemoryId()` to `std::memory` (symmetric with `setMemoryId`) as the no-LLM observable the `setMemoryId` tests need.

## What the tests show

| Test | Result | Meaning |
|---|---|---|
| `enable-inherits` | `[true,true,true]` | A branch **inherits** top-level `enableMemory` (`isMemoryActive()` true in each branch). |
| `branch-enable-invisible` | `[false,false,false,false]` | ⚠️ `enableMemory` **inside** a branch is **not observable** in that branch — the frame lands on the branch's own stack, but `isMemoryActive`/manager lookup reads the top-level stack. |
| `branch-enable-no-leak` | `false` | A branch-local enable does not leak to the parent after join. |
| `setid-inherits` | `["base","base","base"]` | Branches **inherit** the top-level memory id. |
| `setid-leaks` | `"branch"` | ⚠️ `setMemoryId` **inside** a branch **leaks** to the parent (it writes the shared top-level scope; with many branches it also races). |

The two ⚠️ rows are the surprising behaviors: memory frame/id reads resolve through the top-level stack (`ctx.stateStack`), so a branch can't establish its own memory scope, and a branch-local `setMemoryId` mutates shared state.

## Why

Captured ahead of a planned move to **branch-scoped** memory/model config (so `setModel`/`setMemoryId`/`memory{}` inside a fork affect only that branch, inheriting the parent's default at fork time). These tests will flip from "documents the quirk" to "guards the fix" when that lands.

## Testing

- 5 new agency execution tests under `tests/agency/memory-fork/` (no LLM calls).
- Existing memory tests (`tests/agency/memory-code/*`) and 97 memory unit tests still pass.
- `getMemoryId` reference doc regenerated via `agency doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
