### PR TITLE
Fix flaky guard-time-trip test: tolerate clock-source skew

### DIFF
--- a/packages/agency-lang/tests/agency/guards/guard-time-trip.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-trip.agency
@@ -6,7 +6,8 @@ import { guard } from "std::thread"
 // next runner step boundary then throws GuardExceededError("time",
 // ...). The stdlib guard's `try` converts it to a Failure with type
 // "timeoutFailure". Because sleep now wakes at the abort moment,
-// actualTime can be roughly equal to maxTime; we assert `>=`.
+// actualTime lands right around maxTime; we assert it reaches the
+// limit within a small tolerance.
 node main() {
   const result = guard(time: 20ms) as {
     sleep(150ms)
@@ -14,9 +15,14 @@ node main() {
     return "did not trip"
   }
   if (isFailure(result)) {
-    // actualTime >= maxTime catches a bug where actualTime is just set
-    // to 0 (or some sentinel); actualTime > 0 alone wouldn't.
-    return "tripped:${result.error.type}:${result.error.maxTime}:${result.error.actualTime >= result.error.maxTime}"
+    // actualTime is measured with performance.now(), while the guard's
+    // timer fires off libuv's coarser millisecond clock. Those two
+    // clocks can disagree by a fraction of a millisecond, so actualTime
+    // occasionally reads just under maxTime even though the limit was
+    // reached. Allow a 2ms tolerance: this still catches a bug where
+    // actualTime is left at 0 (or some sentinel), but no longer flakes
+    // on sub-millisecond clock skew.
+    return "tripped:${result.error.type}:${result.error.maxTime}:${result.error.actualTime >= result.error.maxTime - 2}"
   }
   return result.value
 }

--- a/packages/agency-lang/tests/agency/guards/guard-time-trip.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-time-trip.test.json
@@ -5,7 +5,7 @@
       "input": "",
       "expectedOutput": "\"tripped:timeoutFailure:20:true\"",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "A tiny time limit (20ms) wrapping sleeps that exceed it trips at the next runner step boundary. The stdlib guard catches GuardExceededError(\"time\", ...) and surfaces a Failure with type \"timeoutFailure\", maxTime equal to the configured limit, and actualTime >= maxTime (sleep is now abortable so it can wake at the abort moment)."
+      "description": "A tiny time limit (20ms) wrapping sleeps that exceed it trips at the next runner step boundary. The stdlib guard catches GuardExceededError(\"time\", ...) and surfaces a Failure with type \"timeoutFailure\", maxTime equal to the configured limit, and actualTime within 2ms of maxTime (sleep is now abortable so it can wake at the abort moment; the 2ms tolerance absorbs clock-source skew between performance.now() and the timer)."
     }
   ]
 }


### PR DESCRIPTION
## Problem

CI was failing on `tests/agency/guards/guard-time-trip.test.json` in the `real-llm-tests` job — it produced `"tripped:timeoutFailure:20:false"` instead of the expected `"tripped:timeoutFailure:20:true"`.

## Root cause

Since `sleep` became abortable (b37823f7), the 150ms sleep wrapped in a `guard(time: 20ms)` now wakes at the abort moment instead of running to completion. So `actualTime` lands right at the 20ms boundary rather than well past it (previously it was ~150ms, comfortably `>= maxTime`).

The assertion `actualTime >= maxTime` then flakes: `actualTime` is measured with `performance.now()`, while the guard's timer fires off libuv's coarser millisecond clock (`setTimeout` → `controller.abort()` in `guard.ts`). Those two clocks can disagree by a fraction of a millisecond, so `actualTime` occasionally reads ~19.95ms even though the limit was reached.

## Fix

Relax the assertion to `actualTime >= maxTime - 2` (a 2ms tolerance). This absorbs sub-millisecond clock skew but still fails hard if `actualTime` is left at a sentinel `0` — preserving the test's original intent. The runtime continues to report the true measured elapsed time rather than a clamped value, so user-facing `actualTime` stays truthful.

Verified locally: `pnpm run a test tests/agency/guards/guard-time-trip.test.json` → 1/1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
