### PR TITLE
User-selectable models: std::llm (setModel/setLlmOptions/pickProvider) + agent CLI flags

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -4,21 +4,41 @@ name: "llm"
 
 # llm
 
+Pick which model and options `llm()` calls use at runtime.
+
+`setModel` / `setLlmOptions` set defaults for subsequent `llm()` calls;
+`pickProvider` detects an available provider from API-key env vars.
+
+Defaults are branch-scoped — a `fork`/`race` branch inherits the
+run-wide default, but a `setModel` inside the branch stays local — and
+they survive interrupt/resume. A per-call `llm(..., { ... })` option
+always overrides these defaults.
+
 ## Types
 
 ### LlmDefaults
 
+Default options for `llm()` calls. Every field is optional; only the
+ *  fields you pass are changed. `provider` is normally derived from the
+ *  model name — set it only when the name doesn't imply a provider (e.g.
+ *  a custom or local model).
+
 ```ts
+/** Default options for `llm()` calls. Every field is optional; only the
+ *  fields you pass are changed. `provider` is normally derived from the
+ *  model name — set it only when the name doesn't imply a provider (e.g.
+ *  a custom or local model). */
 export type LlmDefaults = {
   model?: string;
+  provider?: string;
   temperature?: number;
-  reasoningEffort?: string;
+  reasoningEffort?: "low" | "medium" | "high";
   maxTokens?: number;
   maxToolResultChars?: number
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L10))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L20))
 
 ## Functions
 
@@ -28,14 +48,8 @@ export type LlmDefaults = {
 setLlmOptions(opts: LlmDefaults)
 ```
 
-Set default options for subsequent `llm()` calls. Only the fields you
-  pass are changed; others keep their current value. A per-call
-  `llm(..., { ... })` option still overrides these defaults.
-
-  Branch-scoped: a `fork`/`race` branch inherits the defaults active at
-  fork time, but a `setLlmOptions(...)` inside a branch affects only that
-  branch — it does not leak to siblings or the parent after join. The
-  defaults survive interrupt/resume.
+Set default options for subsequent llm() calls. Only the fields you
+  pass are changed; a per-call llm(..., { ... }) option overrides them.
 
   @param opts - The default LLM options to merge in
 
@@ -45,7 +59,7 @@ Set default options for subsequent `llm()` calls. Only the fields you
 |---|---|---|
 | opts | [LlmDefaults](#llmdefaults) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L29))
 
 ### setModel
 
@@ -53,13 +67,9 @@ Set default options for subsequent `llm()` calls. Only the fields you
 setModel(name: string)
 ```
 
-Set the default model for subsequent `llm()` calls. Convenience
-  wrapper for `setLlmOptions({ model: name })`.
+Set the default model for subsequent llm() calls.
 
-  A per-call `llm(..., { model })` option still overrides this, and it is
-  branch-scoped the same way `setLlmOptions` is.
-
-  @param name - The model name (e.g. "gpt-4o-mini", "claude-opus-4-8")
+  @param name - The model name, e.g. "gpt-4o-mini" or "claude-opus-4-8"
 
 **Parameters:**
 
@@ -67,24 +77,18 @@ Set the default model for subsequent `llm()` calls. Convenience
 |---|---|---|
 | name | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L39))
 
 ### pickProvider
 
 ```ts
-pickProvider(order: string[]): Result
+pickProvider(order: string[]): Result<string>
 ```
 
-Detect which LLM provider is available based on API-key environment
-  variables, in your preferred order. Returns `success(provider)` with
-  the first provider in `order` whose key env var is set, or a
-  `failure(message)` listing the variables it checked if none are.
-
-  Recognized providers and their env vars: "anthropic"
+Return the first provider in `order` whose API-key environment variable
+  is set, or a failure if none are. Recognized providers: "anthropic"
   (ANTHROPIC_API_KEY), "google" (GEMINI_API_KEY), "openai"
-  (OPENAI_API_KEY). Unrecognized names in `order` are skipped. This only
-  detects the provider; mapping a provider to a concrete model is the
-  caller's job.
+  (OPENAI_API_KEY).
 
   @param order - Providers to check, highest preference first
 
@@ -94,6 +98,6 @@ Detect which LLM provider is available based on API-key environment
 |---|---|---|
 | order | `string[]` | ["anthropic", "google", "openai"] |
 
-**Returns:** `Result`
+**Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L63))

--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -1,0 +1,99 @@
+---
+name: "llm"
+---
+
+# llm
+
+## Types
+
+### LlmDefaults
+
+```ts
+export type LlmDefaults = {
+  model?: string;
+  temperature?: number;
+  reasoningEffort?: string;
+  maxTokens?: number;
+  maxToolResultChars?: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L10))
+
+## Functions
+
+### setLlmOptions
+
+```ts
+setLlmOptions(opts: LlmDefaults)
+```
+
+Set default options for subsequent `llm()` calls. Only the fields you
+  pass are changed; others keep their current value. A per-call
+  `llm(..., { ... })` option still overrides these defaults.
+
+  Branch-scoped: a `fork`/`race` branch inherits the defaults active at
+  fork time, but a `setLlmOptions(...)` inside a branch affects only that
+  branch — it does not leak to siblings or the parent after join. The
+  defaults survive interrupt/resume.
+
+  @param opts - The default LLM options to merge in
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| opts | [LlmDefaults](#llmdefaults) |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L18))
+
+### setModel
+
+```ts
+setModel(name: string)
+```
+
+Set the default model for subsequent `llm()` calls. Convenience
+  wrapper for `setLlmOptions({ model: name })`.
+
+  A per-call `llm(..., { model })` option still overrides this, and it is
+  branch-scoped the same way `setLlmOptions` is.
+
+  @param name - The model name (e.g. "gpt-4o-mini", "claude-opus-4-8")
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L34))
+
+### pickProvider
+
+```ts
+pickProvider(order: string[]): Result
+```
+
+Detect which LLM provider is available based on API-key environment
+  variables, in your preferred order. Returns `success(provider)` with
+  the first provider in `order` whose key env var is set, or a
+  `failure(message)` listing the variables it checked if none are.
+
+  Recognized providers and their env vars: "anthropic"
+  (ANTHROPIC_API_KEY), "google" (GEMINI_API_KEY), "openai"
+  (OPENAI_API_KEY). Unrecognized names in `order` are skipped. This only
+  detects the provider; mapping a provider to a concrete model is the
+  caller's job.
+
+  @param order - Providers to check, highest preference first
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| order | `string[]` | ["anthropic", "google", "openai"] |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L60))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -16,7 +16,9 @@ import { highlight, diff } from "std::syntax"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
 import { getCost, getTokens, systemMessage } from "std::thread"
 import { chooseOption, ChoiceItem } from "std::ui"
+import { setModel, pickProvider } from "std::llm"
 
+import { MODELS, setSlowModel } from "./shared.agency"
 import { figs, title } from "./images/images.agency"
 import { POLICY_PATH, HISTORY_PATH, ALWAYS_FIELDS } from "./lib/config.agency"
 import {
@@ -588,6 +590,18 @@ node main() {
       verbose: {
         type: "boolean",
         description: "Echo tool-call starts to stdout in non-interactive mode"
+      },
+      model: {
+        type: "string",
+        description: "Model for all LLM calls (overrides provider auto-detection)"
+      },
+      fastmodel: {
+        type: "string",
+        description: "Model for ordinary work (default: per detected provider)"
+      },
+      slowmodel: {
+        type: "string",
+        description: "Model for deep reasoning, e.g. the oracle/explorer subagents"
       }
     }
   },
@@ -598,6 +612,48 @@ node main() {
   }
   if (args.flags.verbose) {
     VERBOSE = true
+  }
+
+  // Resolve which models to use. Explicit flags win; otherwise detect a
+  // provider from API-key env vars and use that provider's defaults. The
+  // fast model becomes the run-wide default via `setModel`; the slow
+  // model is read by the deep-reasoning subagents (oracle, explorer).
+  let provider = "openai"
+  // Absent string flags read as `undefined` (NOT null), and agency's
+  // `== null` does not match `undefined`. Normalize via `??` (which does
+  // treat `undefined` as nullish) to "" and compare strings.
+  const modelFlag = args.flags.model ?? ""
+  const fastFlag = args.flags.fastmodel ?? ""
+  const slowFlag = args.flags.slowmodel ?? ""
+  // A provider is only needed when fast OR slow can't be derived from
+  // flags (so `--model X` alone never requires an API key / detection).
+  const needFast = fastFlag == "" && modelFlag == ""
+  const needSlow = slowFlag == "" && modelFlag == ""
+  if (needFast || needSlow) {
+    const picked = pickProvider()
+    if (isSuccess(picked)) {
+      provider = picked.value
+    } else {
+      print(picked.error)
+      process.exit(1)
+    }
+  }
+  let fast = MODELS[provider].fast
+  if (fastFlag != "") {
+    fast = fastFlag
+  } else if (modelFlag != "") {
+    fast = modelFlag
+  }
+  setModel(fast)
+  // Slow model: an explicit flag wins (with empty provider so smoltalk
+  // resolves the provider from the model name); otherwise use the
+  // detected provider's slow model + its pinned provider.
+  if (slowFlag != "") {
+    setSlowModel(slowFlag, "")
+  } else if (modelFlag != "") {
+    setSlowModel(modelFlag, "")
+  } else {
+    setSlowModel(MODELS[provider].slow, MODELS[provider].slowProvider)
   }
 
   // Positional args (everything after flags) are joined with spaces to

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -16,9 +16,8 @@ import { highlight, diff } from "std::syntax"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
 import { getCost, getTokens, systemMessage } from "std::thread"
 import { chooseOption, ChoiceItem } from "std::ui"
-import { setModel, pickProvider } from "std::llm"
 
-import { MODELS, setSlowModel } from "./shared.agency"
+import { configureModels } from "./shared.agency"
 import { figs, title } from "./images/images.agency"
 import { POLICY_PATH, HISTORY_PATH, ALWAYS_FIELDS } from "./lib/config.agency"
 import {
@@ -602,6 +601,10 @@ node main() {
       slowmodel: {
         type: "string",
         description: "Model for deep reasoning, e.g. the oracle/explorer subagents"
+      },
+      provider: {
+        type: "string",
+        description: "Force the LLM provider (use when a model name doesn't imply one)"
       }
     }
   },
@@ -618,43 +621,15 @@ node main() {
   // provider from API-key env vars and use that provider's defaults. The
   // fast model becomes the run-wide default via `setModel`; the slow
   // model is read by the deep-reasoning subagents (oracle, explorer).
-  let provider = "openai"
-  // Absent string flags read as `undefined` (NOT null), and agency's
-  // `== null` does not match `undefined`. Normalize via `??` (which does
-  // treat `undefined` as nullish) to "" and compare strings.
-  const modelFlag = args.flags.model ?? ""
-  const fastFlag = args.flags.fastmodel ?? ""
-  const slowFlag = args.flags.slowmodel ?? ""
-  // A provider is only needed when fast OR slow can't be derived from
-  // flags (so `--model X` alone never requires an API key / detection).
-  const needFast = fastFlag == "" && modelFlag == ""
-  const needSlow = slowFlag == "" && modelFlag == ""
-  if (needFast || needSlow) {
-    const picked = pickProvider()
-    if (isSuccess(picked)) {
-      provider = picked.value
-    } else {
-      print(picked.error)
-      process.exit(1)
-    }
-  }
-  let fast = MODELS[provider].fast
-  if (fastFlag != "") {
-    fast = fastFlag
-  } else if (modelFlag != "") {
-    fast = modelFlag
-  }
-  setModel(fast)
-  // Slow model: an explicit flag wins (with empty provider so smoltalk
-  // resolves the provider from the model name); otherwise use the
-  // detected provider's slow model + its pinned provider.
-  if (slowFlag != "") {
-    setSlowModel(slowFlag, "")
-  } else if (modelFlag != "") {
-    setSlowModel(modelFlag, "")
-  } else {
-    setSlowModel(MODELS[provider].slow, MODELS[provider].slowProvider)
-  }
+  // Resolve + apply the fast/slow models. Absent string flags read as
+  // `undefined`, and agency's `== null` does not match `undefined`, so
+  // normalize via `??` (which does treat `undefined` as nullish) to "".
+  configureModels(
+    args.flags.model ?? "",
+    args.flags.fastmodel ?? "",
+    args.flags.slowmodel ?? "",
+    args.flags.provider ?? "",
+  )
 
   // Positional args (everything after flags) are joined with spaces to
   // form the one-shot prompt. `--` ends flag parsing if a positional

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -11,6 +11,7 @@
  */
 import { enableMemory } from "std::memory"
 import { env } from "std::system"
+import { setLlmOptions, pickProvider } from "std::llm"
 
 // Per-user state directory for the agent (persistent memory + saved
 // policy). We expand `~` ourselves via `env("HOME")` because
@@ -55,7 +56,7 @@ static const _memoryReady = enableMemory({
 // Default models per provider. `slowProvider` pins the provider for the
 // deep-reasoning call: OpenAI needs the Responses API for reasoning /
 // extended thinking; native providers use their own. Used as fallbacks
-// when the user doesn't pass --model / --fast-model / --slow-model.
+// when the user doesn't pass --model / --fastmodel / --slowmodel.
 type ProviderModels = { fast: string; slow: string; slowProvider: string }
 
 export static const MODELS: Record<string, ProviderModels> = {
@@ -64,23 +65,62 @@ export static const MODELS: Record<string, ProviderModels> = {
   google: { fast: "gemini-2.5-flash", slow: "gemini-2.5-pro", slowProvider: "google" }
 }
 
-// The slow ("deep reasoning") model + its provider, set once in main()
-// from the CLI flags / detected provider. The deep subagents (oracle,
-// explorer) read these instead of hardcoding a model. An empty
-// slowProvider means "let smoltalk resolve the provider from the model
-// name" — used when the user overrides --slow-model.
-let _slowModel: string = "gpt-5.5"
-let _slowProvider: string = "openai-responses"
-
-export def setSlowModel(model: string, provider: string) {
-  _slowModel = model
-  _slowProvider = provider
-}
+// The slow ("deep reasoning") model + its provider, set once by
+// `configureModels()`. The deep subagents (oracle, explorer) read these.
+// An empty slowProvider means "let smoltalk resolve the provider from
+// the model name".
+let slowModel: string = "gpt-5.5"
+let slowProvider: string = "openai-responses"
 
 export def getSlowModel(): string {
-  return _slowModel
+  return slowModel
 }
 
 export def getSlowProvider(): string {
-  return _slowProvider
+  return slowProvider
+}
+
+/** Resolve and apply the agent's models from CLI flag values (each
+ *  already normalized to "" when absent). The fast model becomes the
+ *  run-wide default; the slow model is stored for the deep subagents.
+ *  Explicit flags win; otherwise a provider is detected from API-key env
+ *  vars and its defaults are used (exits the process if none is found).
+ *  `provider` forces the provider when a model name doesn't imply one
+ *  (e.g. a custom or local model). */
+export def configureModels(model: string, fast: string, slow: string, provider: string) {
+  let detected = "openai"
+  const needFast = fast == "" && model == ""
+  const needSlow = slow == "" && model == ""
+  if (needFast || needSlow) {
+    const picked = pickProvider()
+    if (isSuccess(picked)) {
+      detected = picked.value
+    } else {
+      print(picked.error)
+      process.exit(1)
+    }
+  }
+
+  let fastModel = MODELS[detected].fast
+  if (fast != "") {
+    fastModel = fast
+  } else if (model != "") {
+    fastModel = model
+  }
+  setLlmOptions({ model: fastModel, provider: provider })
+
+  if (slow != "") {
+    slowModel = slow
+    slowProvider = provider
+  } else if (model != "") {
+    slowModel = model
+    slowProvider = provider
+  } else {
+    slowModel = MODELS[detected].slow
+    if (provider != "") {
+      slowProvider = provider
+    } else {
+      slowProvider = MODELS[detected].slowProvider
+    }
+  }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -51,3 +51,36 @@ static const _memoryReady = enableMemory({
     model: "text-embedding-3-small"
   }
 }) with approve
+
+// Default models per provider. `slowProvider` pins the provider for the
+// deep-reasoning call: OpenAI needs the Responses API for reasoning /
+// extended thinking; native providers use their own. Used as fallbacks
+// when the user doesn't pass --model / --fast-model / --slow-model.
+type ProviderModels = { fast: string; slow: string; slowProvider: string }
+
+export static const MODELS: Record<string, ProviderModels> = {
+  openai: { fast: "gpt-4o-mini", slow: "gpt-5.5", slowProvider: "openai-responses" },
+  anthropic: { fast: "claude-haiku-4-5-20251001", slow: "claude-opus-4-8", slowProvider: "anthropic" },
+  google: { fast: "gemini-2.5-flash", slow: "gemini-2.5-pro", slowProvider: "google" }
+}
+
+// The slow ("deep reasoning") model + its provider, set once in main()
+// from the CLI flags / detected provider. The deep subagents (oracle,
+// explorer) read these instead of hardcoding a model. An empty
+// slowProvider means "let smoltalk resolve the provider from the model
+// name" — used when the user overrides --slow-model.
+let _slowModel: string = "gpt-5.5"
+let _slowProvider: string = "openai-responses"
+
+export def setSlowModel(model: string, provider: string) {
+  _slowModel = model
+  _slowProvider = provider
+}
+
+export def getSlowModel(): string {
+  return _slowModel
+}
+
+export def getSlowProvider(): string {
+  return _slowProvider
+}

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
@@ -15,6 +15,7 @@ import { Workspace, openDir } from "std::fs"
 import { skillsDir } from "std::skills"
 import { cwd } from "std::system"
 import { systemMessage } from "std::thread"
+import { getSlowModel, getSlowProvider } from "../shared.agency"
 
 // explorer gets its own read-only view of the project. Mirrors the
 // workspace setup in `code.agency` but only the read-side tools are
@@ -153,8 +154,8 @@ export def explorerAgent(userMsg: string, allowHandoff: boolean): string {
       userMsg,
       {
       tools: explorerTools,
-      model: "gpt-5.5",
-      provider: "openai-responses",
+      model: getSlowModel(),
+      provider: getSlowProvider(),
       reasoningEffort: "high",
       thinking: {
         enabled: true

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
@@ -3,6 +3,7 @@ import { Workspace, openDir } from "std::fs"
 import { skillsDir } from "std::skills"
 import { cwd } from "std::system"
 import { systemMessage } from "std::thread"
+import { getSlowModel, getSlowProvider } from "../shared.agency"
 
 // Oracle gets its own read-only view of the project. Mirrors the
 // workspace setup in `code.agency` but only the read-side tools are
@@ -115,8 +116,8 @@ export def oracleAgent(userMsg: string, allowHandoff: boolean): string {
       userMsg,
       {
       tools: oracleTools,
-      model: "gpt-5.5",
-      provider: "openai-responses",
+      model: getSlowModel(),
+      provider: getSlowProvider(),
       reasoningEffort: "high",
       thinking: {
         enabled: true

--- a/packages/agency-lang/lib/backends/anthropicApiKey.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/anthropicApiKey.codegen.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypeScriptBuilder } from "./typescriptBuilder.js";
+import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { printTs } from "../ir/prettyPrint.js";
+import type { AgencyConfig } from "@/config.js";
+
+// Codegen wiring: anthropicApiKey must be emitted into smoltalkDefaults
+// alongside openAiApiKey/googleApiKey — from the agency.json value when
+// set, else falling back to the ANTHROPIC_API_KEY env var. Without this,
+// Anthropic models can't be used as run-wide defaults the same way the
+// other providers can.
+function generate(source: string, config?: Partial<AgencyConfig>): string {
+  const parseResult = parseAgency(source, {}, false);
+  if (!parseResult.success) {
+    throw new Error(`Failed to parse: ${parseResult.message}`);
+  }
+  const info = buildCompilationUnit(parseResult.result);
+  const preprocessor = new TypescriptPreprocessor(parseResult.result, {}, info);
+  const pre = preprocessor.preprocess();
+  const builder = new TypeScriptBuilder(config as AgencyConfig, info, "test.agency");
+  return printTs(builder.build(pre));
+}
+
+const PROGRAM = "node main() {\n  const x = 1\n}\n";
+
+describe("anthropicApiKey codegen", () => {
+  it("emits anthropicApiKey with an ANTHROPIC_API_KEY env fallback by default", () => {
+    const out = generate(PROGRAM);
+    expect(out).toContain("anthropicApiKey");
+    expect(out).toContain("ANTHROPIC_API_KEY");
+  });
+
+  it("bakes a literal client.anthropicApiKey when configured", () => {
+    const out = generate(PROGRAM, { client: { anthropicApiKey: "sk-ant-test" } });
+    expect(out).toContain("sk-ant-test");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3417,6 +3417,9 @@ export class TypeScriptBuilder {
       googleApiKey: cfg.client?.googleApiKey
         ? ts.str(cfg.client.googleApiKey)
         : ts.binOp(ts.env("GEMINI_API_KEY"), "||", ts.str("")),
+      anthropicApiKey: cfg.client?.anthropicApiKey
+        ? ts.str(cfg.client.anthropicApiKey)
+        : ts.binOp(ts.env("ANTHROPIC_API_KEY"), "||", ts.str("")),
       model: ts.str(cfg.client?.defaultModel || "gpt-4o-mini"),
       logLevel: ts.str(cfg.client?.logLevel || "warn"),
       statelog: ts.obj({

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -117,6 +117,7 @@ export interface AgencyConfig {
     defaultModel: string;
     openAiApiKey: string;
     googleApiKey: string;
+    anthropicApiKey: string;
     /**
      * Max characters of a single tool result fed back to the LLM.
      * Results longer than this are truncated (with a marker) in what
@@ -335,6 +336,7 @@ export const AgencyConfigSchema = z
         defaultModel: z.string(),
         openAiApiKey: z.string(),
         googleApiKey: z.string(),
+        anthropicApiKey: z.string(),
         maxToolResultChars: z.number(),
         statelog: z
           .object({

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -385,15 +385,35 @@ export async function runPrompt(args: {
     memory?: boolean | { model?: string };
     maxToolResultChars?: number;
   };
-  const clientConfig = ctx.getSmoltalkConfig(restClientConfig);
+
+  // Run-wide LLM defaults set at runtime via `std::llm`
+  // (setLlmOptions/setModel) live on the ACTIVE branch stack's
+  // `other.llmDefaults` (branch-scoped, serialized; seeded from the
+  // parent at fork time). Layer them BETWEEN the baked
+  // `smoltalkDefaults` and the per-call options, so precedence is
+  // baked agency.json < stack defaults < per-call `llm({...})`.
+  const stackDefaults = (stateStack?.other?.llmDefaults ?? {}) as {
+    maxToolResultChars?: number;
+    [k: string]: unknown;
+  };
+  const { maxToolResultChars: stackMaxToolResultChars, ...stackSmolDefaults } =
+    stackDefaults;
+  const clientConfig = ctx.getSmoltalkConfig({
+    ...stackSmolDefaults,
+    ...restClientConfig,
+  });
 
   // Cap on characters of a single tool result fed back to the LLM. The
   // full result is still cached for Agency code via `setResultOnBranch`;
   // only what the model sees is truncated. Resolution precedence:
-  // per-call `llm(..., { maxToolResultChars })` > agency.json
-  // (`ctx.maxToolResultChars`) > default. `0`/non-finite disables.
+  // per-call `llm(..., { maxToolResultChars })` > runtime
+  // `setLlmOptions` (active stack) > agency.json (`ctx.maxToolResultChars`)
+  // > default. `0`/non-finite disables.
   const toolResultCap =
-    callMaxToolResultChars ?? ctx.maxToolResultChars ?? DEFAULT_TOOL_RESULT_CHARS;
+    callMaxToolResultChars ??
+    stackMaxToolResultChars ??
+    ctx.maxToolResultChars ??
+    DEFAULT_TOOL_RESULT_CHARS;
 
   // Restore or initialize messages.
   //

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -14,6 +14,7 @@ import { PromptBailout, PromptRunner } from "./promptRunner.js";
 import { isFailure } from "./result.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
+import type { LlmDefaults } from "../stdlib/llm.js";
 import { MessageThread } from "./state/messageThread.js";
 import { StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
@@ -392,10 +393,8 @@ export async function runPrompt(args: {
   // parent at fork time). Layer them BETWEEN the baked
   // `smoltalkDefaults` and the per-call options, so precedence is
   // baked agency.json < stack defaults < per-call `llm({...})`.
-  const stackDefaults = (stateStack?.other?.llmDefaults ?? {}) as {
-    maxToolResultChars?: number;
-    [k: string]: unknown;
-  };
+  const stackDefaults: Partial<LlmDefaults> =
+    stateStack?.other?.llmDefaults ?? {};
   const { maxToolResultChars: stackMaxToolResultChars, ...stackSmolDefaults } =
     stackDefaults;
   const clientConfig = ctx.getSmoltalkConfig({

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -239,20 +239,22 @@ function rehydrateInheritedGuards(
   branch.guardsRehydrated = true;
 }
 
-/** Seed a fresh branch's memory state (active id + frame stack) from the
- *  parent so the branch inherits the run-wide memory config, while its
- *  own later `setMemoryId`/`enableMemory`/`disableMemory` stay branch-
- *  local. Fresh-branch detection mirrors `seedBranchCost`: a value-based
- *  check (resume-safe — does not rely on a live-only flag) so a resumed
- *  branch, whose stack was restored from JSON with its own serialized
- *  memory state, is never re-seeded from the parent. */
+/** Seed a fresh branch's dynamic state (memory id + frame stack, and the
+ *  `std::llm` defaults) from the parent so the branch inherits the
+ *  run-wide config, while its own later `setMemoryId`/`enableMemory`/
+ *  `disableMemory`/`setLlmOptions` stay branch-local. Fresh-branch
+ *  detection mirrors `seedBranchCost`: a value-based check (resume-safe —
+ *  does not rely on a live-only flag) so a resumed branch, whose stack
+ *  was restored from JSON with its own serialized state, is never
+ *  re-seeded from the parent. */
 function inheritBranchMemory(
   branchStack: StateStack,
   parentStack: StateStack,
 ): void {
   const fresh =
     !branchStack.hasMemoryFrameStack() &&
-    branchStack.other.memoryId === undefined;
+    branchStack.other.memoryId === undefined &&
+    branchStack.other.llmDefaults === undefined;
   if (!fresh) return;
   branchStack.inheritMemoryFrom(parentStack);
 }

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -446,6 +446,14 @@ export class StateStack {
     if (pframes !== undefined) {
       this.other.memoryFrames = [...pframes];
     }
+    // Run-wide LLM defaults set via `std::llm` (setLlmOptions/setModel)
+    // ride the same branch inheritance: a fork branch inherits the
+    // parent's defaults at fork time, then its own setLlmOptions mutates
+    // this shallow copy — never the parent's object.
+    const pllm = parent.other.llmDefaults;
+    if (pllm !== undefined) {
+      this.other.llmDefaults = { ...pllm };
+    }
   }
 
   /** Pop the top memory frame, including the JSON-seeded bottom frame.

--- a/packages/agency-lang/lib/stdlib/llm.test.ts
+++ b/packages/agency-lang/lib/stdlib/llm.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { _setLlmOptions } from "./llm.js";
+import { agencyStore } from "../runtime/asyncContext.js";
+
+// _setLlmOptions writes the ACTIVE stack's `other.llmDefaults`. A bare
+// `{ other: {} }` stand-in stack is enough to exercise the merge.
+function withStack<T>(stack: any, fn: () => T): T {
+  return agencyStore.run({ stack } as any, fn);
+}
+
+describe("_setLlmOptions", () => {
+  it("writes model into stack.other.llmDefaults", () => {
+    const stack = { other: {} as any };
+    withStack(stack, () => _setLlmOptions({ model: "gpt-5.5" }));
+    expect(stack.other.llmDefaults.model).toBe("gpt-5.5");
+  });
+
+  it("merges multiple fields and leaves existing ones intact", () => {
+    const stack = { other: { llmDefaults: { model: "old", temperature: 0.1 } } as any };
+    withStack(stack, () =>
+      _setLlmOptions({ model: "m2", reasoningEffort: "high", maxTokens: 42 }),
+    );
+    expect(stack.other.llmDefaults).toEqual({
+      model: "m2",
+      temperature: 0.1,
+      reasoningEffort: "high",
+      maxTokens: 42,
+    });
+  });
+
+  it("carries maxToolResultChars in the same bag", () => {
+    const stack = { other: {} as any };
+    withStack(stack, () => _setLlmOptions({ maxToolResultChars: 5 }));
+    expect(stack.other.llmDefaults.maxToolResultChars).toBe(5);
+  });
+
+  it("ignores undefined fields (no overwrite with undefined)", () => {
+    const stack = { other: { llmDefaults: { model: "keep" } } as any };
+    withStack(stack, () => _setLlmOptions({ temperature: 0.5 }));
+    expect(stack.other.llmDefaults.model).toBe("keep");
+    expect(stack.other.llmDefaults.temperature).toBe(0.5);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -1,0 +1,44 @@
+import { getRuntimeContext } from "../runtime/asyncContext.js";
+
+/**
+ * Fields that may be set as LLM defaults via `setLlmOptions`. A
+ * deliberately small subset of the per-call `llm()` options. All ride
+ * the same `stack.other.llmDefaults` bag; `runPrompt` routes
+ * model/temperature/reasoningEffort/maxTokens into the smoltalk config
+ * and `maxToolResultChars` into the tool-result cap.
+ */
+export type LlmDefaults = {
+  model?: string;
+  temperature?: number;
+  reasoningEffort?: string;
+  maxTokens?: number;
+  maxToolResultChars?: number;
+};
+
+/**
+ * Merge `opts` into the ACTIVE branch stack's LLM defaults
+ * (`stack.other.llmDefaults`). Only present (non-undefined) keys are
+ * written, so a partial update never clears an existing default.
+ *
+ * Branch-scoped: inside a fork/race/tool branch this writes that
+ * branch's own slice (seeded from the parent at fork time by
+ * `runBatch.inheritBranchMemory`), so the change is visible in-branch
+ * and does not leak to siblings or the parent after join. It rides the
+ * serialized `stack.other`, so it survives interrupt/resume. `runPrompt`
+ * merges it over the baked `smoltalkDefaults` and under any per-call
+ * `llm({...})` option.
+ */
+export function _setLlmOptions(opts: LlmDefaults): void {
+  const { stack } = getRuntimeContext();
+  if (!stack) return;
+  // The branch's own llmDefaults object (seeded as a shallow copy of the
+  // parent's at fork time), so mutating it here never touches the parent.
+  const current = (stack.other.llmDefaults ?? {}) as Record<string, unknown>;
+  for (const key of Object.keys(opts)) {
+    const value = (opts as Record<string, unknown>)[key];
+    if (value !== undefined) {
+      current[key] = value;
+    }
+  }
+  stack.other.llmDefaults = current;
+}

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -9,8 +9,9 @@ import { getRuntimeContext } from "../runtime/asyncContext.js";
  */
 export type LlmDefaults = {
   model?: string;
+  provider?: string;
   temperature?: number;
-  reasoningEffort?: string;
+  reasoningEffort?: "low" | "medium" | "high";
   maxTokens?: number;
   maxToolResultChars?: number;
 };

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -1,30 +1,35 @@
-// Runtime control over which model `llm()` calls use, and which
-// provider is available. `_*` helpers read ctx/stack from
-// AsyncLocalStorage (see `lib/runtime/asyncContext.ts`).
 import { _setLlmOptions } from "agency-lang/stdlib-lib/llm.js"
 import { env } from "std::system"
 
-// LLM defaults that can be set at runtime. Mirrors a subset of the
-// per-call `llm()` options. Every field is optional; only provided
-// fields are changed.
+/** @module
+Pick which model and options `llm()` calls use at runtime.
+
+`setModel` / `setLlmOptions` set defaults for subsequent `llm()` calls;
+`pickProvider` detects an available provider from API-key env vars.
+
+Defaults are branch-scoped — a `fork`/`race` branch inherits the
+run-wide default, but a `setModel` inside the branch stays local — and
+they survive interrupt/resume. A per-call `llm(..., { ... })` option
+always overrides these defaults.
+*/
+
+/** Default options for `llm()` calls. Every field is optional; only the
+ *  fields you pass are changed. `provider` is normally derived from the
+ *  model name — set it only when the name doesn't imply a provider (e.g.
+ *  a custom or local model). */
 export type LlmDefaults = {
   model?: string;
+  provider?: string;
   temperature?: number;
-  reasoningEffort?: string;
+  reasoningEffort?: "low" | "medium" | "high";
   maxTokens?: number;
   maxToolResultChars?: number
 }
 
 export def setLlmOptions(opts: LlmDefaults) {
   """
-  Set default options for subsequent `llm()` calls. Only the fields you
-  pass are changed; others keep their current value. A per-call
-  `llm(..., { ... })` option still overrides these defaults.
-
-  Branch-scoped: a `fork`/`race` branch inherits the defaults active at
-  fork time, but a `setLlmOptions(...)` inside a branch affects only that
-  branch — it does not leak to siblings or the parent after join. The
-  defaults survive interrupt/resume.
+  Set default options for subsequent llm() calls. Only the fields you
+  pass are changed; a per-call llm(..., { ... }) option overrides them.
 
   @param opts - The default LLM options to merge in
   """
@@ -33,17 +38,15 @@ export def setLlmOptions(opts: LlmDefaults) {
 
 export def setModel(name: string) {
   """
-  Set the default model for subsequent `llm()` calls. Convenience
-  wrapper for `setLlmOptions({ model: name })`.
+  Set the default model for subsequent llm() calls.
 
-  A per-call `llm(..., { model })` option still overrides this, and it is
-  branch-scoped the same way `setLlmOptions` is.
-
-  @param name - The model name (e.g. "gpt-4o-mini", "claude-opus-4-8")
+  @param name - The model name, e.g. "gpt-4o-mini" or "claude-opus-4-8"
   """
   _setLlmOptions({ model: name })
 }
 
+/** Map a recognized provider name to the env var that holds its API key.
+ *  Returns "" for unrecognized names. */
 def envVarFor(provider: string): string {
   if (provider == "anthropic") {
     return "ANTHROPIC_API_KEY"
@@ -57,18 +60,12 @@ def envVarFor(provider: string): string {
   return ""
 }
 
-export def pickProvider(order: string[] = ["anthropic", "google", "openai"]): Result {
+export def pickProvider(order: string[] = ["anthropic", "google", "openai"]): Result<string, string> {
   """
-  Detect which LLM provider is available based on API-key environment
-  variables, in your preferred order. Returns `success(provider)` with
-  the first provider in `order` whose key env var is set, or a
-  `failure(message)` listing the variables it checked if none are.
-
-  Recognized providers and their env vars: "anthropic"
+  Return the first provider in `order` whose API-key environment variable
+  is set, or a failure if none are. Recognized providers: "anthropic"
   (ANTHROPIC_API_KEY), "google" (GEMINI_API_KEY), "openai"
-  (OPENAI_API_KEY). Unrecognized names in `order` are skipped. This only
-  detects the provider; mapping a provider to a concrete model is the
-  caller's job.
+  (OPENAI_API_KEY).
 
   @param order - Providers to check, highest preference first
   """
@@ -86,6 +83,9 @@ export def pickProvider(order: string[] = ["anthropic", "google", "openai"]): Re
         return success(provider)
       }
     }
+  }
+  if (checked == "") {
+    return failure("pickProvider: no recognized providers given (expected anthropic, google, or openai)")
   }
   return failure("No LLM API key found. Set one of: ${checked}")
 }

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -1,0 +1,91 @@
+// Runtime control over which model `llm()` calls use, and which
+// provider is available. `_*` helpers read ctx/stack from
+// AsyncLocalStorage (see `lib/runtime/asyncContext.ts`).
+import { _setLlmOptions } from "agency-lang/stdlib-lib/llm.js"
+import { env } from "std::system"
+
+// LLM defaults that can be set at runtime. Mirrors a subset of the
+// per-call `llm()` options. Every field is optional; only provided
+// fields are changed.
+export type LlmDefaults = {
+  model?: string;
+  temperature?: number;
+  reasoningEffort?: string;
+  maxTokens?: number;
+  maxToolResultChars?: number
+}
+
+export def setLlmOptions(opts: LlmDefaults) {
+  """
+  Set default options for subsequent `llm()` calls. Only the fields you
+  pass are changed; others keep their current value. A per-call
+  `llm(..., { ... })` option still overrides these defaults.
+
+  Branch-scoped: a `fork`/`race` branch inherits the defaults active at
+  fork time, but a `setLlmOptions(...)` inside a branch affects only that
+  branch — it does not leak to siblings or the parent after join. The
+  defaults survive interrupt/resume.
+
+  @param opts - The default LLM options to merge in
+  """
+  _setLlmOptions(opts)
+}
+
+export def setModel(name: string) {
+  """
+  Set the default model for subsequent `llm()` calls. Convenience
+  wrapper for `setLlmOptions({ model: name })`.
+
+  A per-call `llm(..., { model })` option still overrides this, and it is
+  branch-scoped the same way `setLlmOptions` is.
+
+  @param name - The model name (e.g. "gpt-4o-mini", "claude-opus-4-8")
+  """
+  _setLlmOptions({ model: name })
+}
+
+def envVarFor(provider: string): string {
+  if (provider == "anthropic") {
+    return "ANTHROPIC_API_KEY"
+  }
+  if (provider == "google") {
+    return "GEMINI_API_KEY"
+  }
+  if (provider == "openai") {
+    return "OPENAI_API_KEY"
+  }
+  return ""
+}
+
+export def pickProvider(order: string[] = ["anthropic", "google", "openai"]): Result {
+  """
+  Detect which LLM provider is available based on API-key environment
+  variables, in your preferred order. Returns `success(provider)` with
+  the first provider in `order` whose key env var is set, or a
+  `failure(message)` listing the variables it checked if none are.
+
+  Recognized providers and their env vars: "anthropic"
+  (ANTHROPIC_API_KEY), "google" (GEMINI_API_KEY), "openai"
+  (OPENAI_API_KEY). Unrecognized names in `order` are skipped. This only
+  detects the provider; mapping a provider to a concrete model is the
+  caller's job.
+
+  @param order - Providers to check, highest preference first
+  """
+  let checked = ""
+  for (provider in order) {
+    const varName = envVarFor(provider)
+    if (varName != "") {
+      if (checked == "") {
+        checked = varName
+      } else {
+        checked = "${checked}, ${varName}"
+      }
+      const value = env(varName)
+      if (value != null && value != "") {
+        return success(provider)
+      }
+    }
+  }
+  return failure("No LLM API key found. Set one of: ${checked}")
+}

--- a/packages/agency-lang/tests/agency-js/llm-fork-scoped/agent.agency
+++ b/packages/agency-lang/tests/agency-js/llm-fork-scoped/agent.agency
@@ -1,0 +1,14 @@
+import { setModel } from "std::llm"
+
+// Each branch sets its own model and dispatches with it; the parent's
+// model is unaffected after the fork joins (no leak, no cross-branch
+// races). The parent's llm() call runs after the fork, so it is the
+// last LLM call.
+node main() {
+  setModel("base-model")
+  fork(["a", "b"]) as item {
+    setModel("model-${item}")
+    return llm("ping")
+  }
+  return llm("ping-parent")
+}

--- a/packages/agency-lang/tests/agency-js/llm-fork-scoped/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-fork-scoped/fixture.json
@@ -1,0 +1,5 @@
+{
+  "parentModel": "base-model",
+  "branchModels": ["model-a", "model-b"],
+  "callCount": 3
+}

--- a/packages/agency-lang/tests/agency-js/llm-fork-scoped/test.js
+++ b/packages/agency-lang/tests/agency-js/llm-fork-scoped/test.js
@@ -1,0 +1,38 @@
+import { main, __setLLMClient } from "./agent.js";
+import { writeFileSync } from "fs";
+
+// Record the model of every LLM call. Branch calls run concurrently
+// (order nondeterministic); the parent call runs after the fork joins,
+// so it is the LAST call.
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+const models = [];
+
+const client = {
+  async text(config) {
+    models.push(config.model ?? null);
+    return {
+      success: true,
+      value: { output: "ok", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "captureClient does not implement embed" };
+  },
+};
+
+__setLLMClient(client);
+
+await main();
+
+const parentModel = models[models.length - 1]; // parent call, after join
+const branchModels = models.slice(0, -1).sort(); // the two branch calls
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ parentModel, branchModels, callCount: models.length }, null, 2),
+);

--- a/packages/agency-lang/tests/agency-js/llm-pick-provider/agent.agency
+++ b/packages/agency-lang/tests/agency-js/llm-pick-provider/agent.agency
@@ -1,0 +1,19 @@
+import { pickProvider } from "std::llm"
+
+// Returns the picked provider, or "FAIL:<msg>" so the JS side can assert
+// both the success and the no-key failure paths.
+def describe(order: string[]): string {
+  const r = pickProvider(order)
+  if (isFailure(r)) {
+    return "FAIL:${r.error}"
+  }
+  return r.value
+}
+
+node main(): any {
+  return {
+    defaultOrder: describe(["anthropic", "google", "openai"]),
+    openaiFirst: describe(["openai", "anthropic"]),
+    noneAvailable: describe(["anthropic"])
+  }
+}

--- a/packages/agency-lang/tests/agency-js/llm-pick-provider/agent.agency
+++ b/packages/agency-lang/tests/agency-js/llm-pick-provider/agent.agency
@@ -14,6 +14,7 @@ node main(): any {
   return {
     defaultOrder: describe(["anthropic", "google", "openai"]),
     openaiFirst: describe(["openai", "anthropic"]),
-    noneAvailable: describe(["anthropic"])
+    noneAvailable: describe(["anthropic"]),
+    emptyOrder: describe([])
   }
 }

--- a/packages/agency-lang/tests/agency-js/llm-pick-provider/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-pick-provider/fixture.json
@@ -1,0 +1,5 @@
+{
+  "defaultOrder": "google",
+  "openaiFirst": "openai",
+  "noneAvailable": "FAIL:No LLM API key found. Set one of: ANTHROPIC_API_KEY"
+}

--- a/packages/agency-lang/tests/agency-js/llm-pick-provider/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-pick-provider/fixture.json
@@ -1,5 +1,6 @@
 {
   "defaultOrder": "google",
   "openaiFirst": "openai",
-  "noneAvailable": "FAIL:No LLM API key found. Set one of: ANTHROPIC_API_KEY"
+  "noneAvailable": "FAIL:No LLM API key found. Set one of: ANTHROPIC_API_KEY",
+  "emptyOrder": "FAIL:pickProvider: no recognized providers given (expected anthropic, google, or openai)"
 }

--- a/packages/agency-lang/tests/agency-js/llm-pick-provider/test.js
+++ b/packages/agency-lang/tests/agency-js/llm-pick-provider/test.js
@@ -1,0 +1,13 @@
+import { main } from "./agent.js";
+import { writeFileSync } from "node:fs";
+
+// Control which keys are "set": GEMINI + OPENAI set, ANTHROPIC unset.
+delete process.env.ANTHROPIC_API_KEY;
+process.env.GEMINI_API_KEY = "test-google-key";
+process.env.OPENAI_API_KEY = "test-openai-key";
+
+const result = await main({});
+writeFileSync(
+  new URL("./__result.json", import.meta.url),
+  JSON.stringify(result.data, null, 2),
+);

--- a/packages/agency-lang/tests/agency-js/llm-set-model/agent.agency
+++ b/packages/agency-lang/tests/agency-js/llm-set-model/agent.agency
@@ -1,0 +1,8 @@
+import { setModel } from "std::llm"
+
+// setModel at the top level changes the model the next llm() call
+// dispatches with.
+node main() {
+  setModel("test-model-x")
+  return llm("ping")
+}

--- a/packages/agency-lang/tests/agency-js/llm-set-model/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-set-model/fixture.json
@@ -1,0 +1,4 @@
+{
+  "reply": "ok",
+  "modelUsed": "test-model-x"
+}

--- a/packages/agency-lang/tests/agency-js/llm-set-model/test.js
+++ b/packages/agency-lang/tests/agency-js/llm-set-model/test.js
@@ -1,0 +1,34 @@
+import { main, __setLLMClient } from "./agent.js";
+import { writeFileSync } from "fs";
+
+// Capture the model each LLM call dispatches with, to assert setModel
+// flowed through (stack.other.llmDefaults -> runPrompt merge -> client).
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+const models = [];
+
+const client = {
+  async text(config) {
+    models.push(config.model ?? null);
+    return {
+      success: true,
+      value: { output: "ok", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "captureClient does not implement embed" };
+  },
+};
+
+__setLLMClient(client);
+
+const result = await main();
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ reply: result.data, modelUsed: models[0] }, null, 2),
+);


### PR DESCRIPTION
## Summary

Lets users pick which model `llm()` calls use — for the Agency agent and any Agency program — via a new `std::llm` module. Model defaults are **branch-scoped** (a `fork`/`race` branch inherits the run-wide default, but its own `setModel` stays local) and **resume-durable** (they ride the serialized `stack.other`). Builds on the branch-scoped-memory work (#298).

## `std::llm`

- **`setLlmOptions(opts)` / `setModel(name)`** — write the active branch stack's `other.llmDefaults`. `runPrompt` merges these **between** the baked `smoltalkDefaults` and per-call `llm({...})` options (precedence: baked `agency.json` < runtime `setLlmOptions` < per-call), and into the tool-result-cap resolution.
- **`pickProvider(order)`** — returns a `Result` naming the first provider whose API-key env var is set (`anthropic`→`ANTHROPIC_API_KEY`, `google`→`GEMINI_API_KEY`, `openai`→`OPENAI_API_KEY`), else a `failure` listing the checked vars.

Branch inheritance/isolation reuses #298's seam: `StateStack.inheritMemoryFrom` now also seeds `other.llmDefaults`, and `runBatch.inheritBranchMemory`'s fresh-detection includes it (resume-safe).

## Config

`anthropicApiKey` plumbed through `agency.json` (`client.anthropicApiKey`) and emitted into `smoltalkDefaults` (literal when set, else `ANTHROPIC_API_KEY` env), parallel to OpenAI/Google.

## Agent

- `--model` / `--fastmodel` / `--slowmodel` flags.
- A provider→models table + `setSlowModel`/`getSlowModel`/`getSlowProvider` in `shared.agency`.
- `main()` resolves: explicit flags win; otherwise `pickProvider` detects a provider and uses its defaults. The fast model becomes the run-wide default via `setModel`; the slow model is read by the oracle/explorer deep-reasoning calls (replacing hardcoded `gpt-5.5`/`openai-responses`).

## Testing

- Unit: `lib/stdlib/llm.test.ts` (setLlmOptions merge), `lib/backends/anthropicApiKey.codegen.test.ts` (baked / env fallback).
- agency-js: `llm-pick-provider` (env detection + failure), `llm-set-model` (e2e — dispatched model = `setModel` value, via a capturing client), `llm-fork-scoped` (each branch dispatches its own model; the parent's post-fork call is unaffected — no leak/race).
- Manual: `--help` lists the flags; no-key run errors cleanly via `pickProvider`; `--model X` alone skips provider detection.
- No regressions across the memory-fork and runtime unit suites.

## Notes for review

- **Flag names are `--fastmodel`/`--slowmodel`, not `--fast-model`/`--fastModel`.** Agency object literals reject hyphenated/quoted keys and `std::args` rejects uppercase flag names, so kebab/camel forms are unexpressible; a single lowercase token is the closest valid form. Easy to switch to `--fast`/`--slow` if preferred.
- Spotted an agency-semantics gotcha while wiring `main()`: an absent string flag reads as `undefined`, and `undefined == null` is **false** in agency (though `undefined ?? x` does fall back). The resolution normalizes flags via `?? ""` and compares strings to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
