### PR TITLE
Pluggable optimizer framework — Phase 3B (pointwise greedy migration)

### DIFF
--- a/packages/agency-lang/lib/agents/goalJudge.agency
+++ b/packages/agency-lang/lib/agents/goalJudge.agency
@@ -1,0 +1,16 @@
+type GoalVerdict = {
+  score: number # a score from 0.0 to 1.0 where 1.0 means the output fully satisfies the goal;
+  reasoning: string # brief explanation for the score
+}
+
+node main(goal: string, output: string): GoalVerdict {
+  result: GoalVerdict = llm("You are an evaluation judge. Score how well the agent output satisfies the goal.
+
+Goal: ${goal}
+
+Agent output: ${output}
+
+Provide a score from 0.0 to 1.0, where 1.0 means the output fully satisfies the goal and 0.0 means it does not satisfy the goal at all. Also provide brief reasoning for the score.")
+
+  return result
+}

--- a/packages/agency-lang/lib/cli/eval/optimize.test.ts
+++ b/packages/agency-lang/lib/cli/eval/optimize.test.ts
@@ -2,10 +2,10 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { getRuntimeContext } from "@/runtime/asyncContext.js";
-import type { OptimizeLoopConfig, OptimizeResult } from "@/optimize/types.js";
+import type { BaseOptimizerConfig, OptimizeTarget } from "@/optimize/optimizer.js";
+import type { OptimizeResult } from "@/optimize/types.js";
 
 import { evalOptimize, resolveVerbosity, type EvalOptimizeOptions } from "./optimize.js";
 
@@ -36,228 +36,99 @@ describe("eval optimize CLI", () => {
     return tasksFile;
   }
 
-  async function captureConfig(opts: Partial<EvalOptimizeOptions> & { agent: string }): Promise<OptimizeLoopConfig> {
-    const capture: { loopConfig?: OptimizeLoopConfig } = {};
+  type Captured = { name?: string; config?: BaseOptimizerConfig; target?: OptimizeTarget };
+
+  /** Run evalOptimize with a fake optimizer that captures the target + config it was built with. */
+  async function capture(opts: Partial<EvalOptimizeOptions> & { agent: string }): Promise<Captured> {
+    const captured: Captured = {};
     await evalOptimize(
       { config: {}, ...opts },
       {
         makeId: () => "task-id",
         makeRunId: () => "run-id",
-        optimizeLoop: async (config) => {
-          capture.loopConfig = config;
-          return optimizeResult(config);
+        getOptimizer: (name, config) => {
+          captured.name = name;
+          captured.config = config;
+          return {
+            name,
+            optimize: async (target) => {
+              captured.target = target;
+              return {} as OptimizeResult;
+            },
+          };
         },
       },
     );
-    if (!capture.loopConfig) throw new Error("optimize loop was not called");
-    return capture.loopConfig;
+    return captured;
   }
 
-  it("builds the loop config from a task suite with discovered targets", async () => {
+  it("desugars --goal into a single task-1 input with the goal in metadata", async () => {
     const agentFile = writeAgent();
-    const tasksFile = writeTasks([{ task_id: "first", goal: "be correct", args: { text: "hi" } }]);
-
-    const config = await captureConfig({
-      agent: `${agentFile}:main`,
-      tasks: tasksFile,
-      iterations: 3,
-      runsDir: path.join(tmpDir, "runs"),
-      runId: "run",
-    });
-
-    expect(config.runtime.tasks).toEqual([{ task_id: "first", goal: "be correct", args: { text: "hi" } }]);
-    expect(config.runtime.tasksSource).toBe(tasksFile);
-    expect(config.target.node).toBe("main");
-    expect(config.target.entryFile).toBe("agent.agency");
-    expect(config.target.targetSet.targets.map((target) => target.id)).toEqual([
-      "agent.agency:global:prompt",
-    ]);
-    expect(config.target.writeback).toBe(true);
-    expect(config.policy).toEqual({ iterations: 3, mutatorModel: undefined });
-    expect(config.artifacts).toEqual({ runsDir: path.join(tmpDir, "runs"), runId: "run" });
+    const { target } = await capture({ agent: agentFile, goal: "Return Paris" });
+    expect(target?.inputs).toEqual([{ id: "task-1", node: "main", args: {}, metadata: { goal: "Return Paris" } }]);
   });
 
-  it("desugars --goal into a single task-1 task", async () => {
+  it("builds one input per task from --tasks, carrying each goal in metadata", async () => {
     const agentFile = writeAgent();
-
-    const config = await captureConfig({ agent: agentFile, goal: "Return Paris" });
-
-    expect(config.runtime.tasks).toEqual([{ task_id: "task-1", goal: "Return Paris", args: {} }]);
-    expect(config.runtime.tasksSource).toBe("inline:--goal");
+    const tasksFile = writeTasks([{ task_id: "first", goal: "be correct", args: { text: "hi" } }]);
+    const { target } = await capture({ agent: `${agentFile}:main`, tasks: tasksFile });
+    expect(target?.inputs).toEqual([{ id: "first", node: "main", args: { text: "hi" }, metadata: { goal: "be correct" } }]);
   });
 
   it("requires exactly one of --tasks or --goal", async () => {
     const agentFile = writeAgent();
     const tasksFile = writeTasks([{ task_id: "first", goal: "g", args: {} }]);
-
     await expect(evalOptimize({ agent: agentFile, config: {} })).rejects.toThrow(/exactly one of --tasks or --goal/i);
-    await expect(
-      evalOptimize({ agent: agentFile, tasks: tasksFile, goal: "both", config: {} }),
-    ).rejects.toThrow(/exactly one of --tasks or --goal/i);
+    await expect(evalOptimize({ agent: agentFile, tasks: tasksFile, goal: "both", config: {} })).rejects.toThrow(/exactly one of --tasks or --goal/i);
   });
 
-  it("passes judge flags through to the judge policy with eval-judge defaults", async () => {
+  it("rejects --goal when the selected node requires arguments", async () => {
+    const agentFile = writeAgent("agent.agency", "optimize const prompt = \"hi\"\n\nnode main(text: string) {}\n");
+    await expect(evalOptimize({ agent: `${agentFile}:main`, goal: "g", config: {} }))
+      .rejects.toThrow(/requires arguments, but --goal creates a no-argument input/);
+  });
+
+  it("allows --goal when node parameters all have defaults", async () => {
+    const agentFile = writeAgent("agent.agency", "optimize const prompt = \"hi\"\n\nnode main(text: string = \"x\") {}\n");
+    const { target } = await capture({ agent: `${agentFile}:main`, goal: "g" });
+    expect(target?.inputs).toHaveLength(1);
+  });
+
+  it("configures a single goal LlmJudge grader plus run policy", async () => {
     const agentFile = writeAgent();
-
-    const defaulted = await captureConfig({ agent: agentFile, goal: "g" });
-    expect(defaulted.judgePolicy).toEqual({
-      samples: 3,
-      confidenceThreshold: 50,
-      marginThreshold: 0,
-      positionBias: "swap",
-    });
-
-    const custom = await captureConfig({
-      agent: agentFile,
-      goal: "g",
-      samples: 5,
-      confidenceThreshold: 80,
-      marginThreshold: 2,
-    });
-    expect(custom.judgePolicy).toEqual({
-      samples: 5,
-      confidenceThreshold: 80,
-      marginThreshold: 2,
-      positionBias: "swap",
-    });
+    const { config } = await capture({ agent: agentFile, goal: "g" });
+    expect(config?.graders.map((g) => g.name())).toEqual(["goal"]);
+    expect(config?.iterations).toBe(5);
+    expect(config?.writeback).toBe(true);
+    expect(config?.runId).toBe("run-id");
   });
 
   it("consumes Commander's writeback negation", async () => {
     const agentFile = writeAgent();
-
-    const config = await captureConfig({ agent: agentFile, goal: "g", writeback: false });
-
-    expect(config.target.writeback).toBe(false);
+    const { config } = await capture({ agent: agentFile, goal: "g", writeback: false });
+    expect(config?.writeback).toBe(false);
   });
 
-  it("rejects --goal when the selected node requires arguments", async () => {
-    const agentFile = writeAgent(
-      "agent.agency",
-      "optimize const prompt = \"hi\"\n\nnode main(text: string) {}\n",
-    );
-
-    await expect(evalOptimize({ agent: `${agentFile}:main`, goal: "g", config: {} }))
-      .rejects.toThrow(/requires arguments, but --goal creates a no-argument task/);
-  });
-
-  it("allows --goal when node parameters all have defaults", async () => {
-    const agentFile = writeAgent(
-      "agent.agency",
-      "optimize const prompt = \"hi\"\n\nnode main(text: string = \"x\") {}\n",
-    );
-
-    const config = await captureConfig({ agent: `${agentFile}:main`, goal: "g" });
-
-    expect(config.runtime.tasks).toHaveLength(1);
-  });
-
-  it("discovers the import closure and keys files off the discovery base dir", async () => {
-    fs.mkdirSync(path.join(tmpDir, "tools"), { recursive: true });
-    writeAgent("app/agent.agency", `
-import { helper } from "../shared/prompts.agency"
-node main() {}
-`);
-    writeAgent("shared/prompts.agency", "optimize const prompt = \"shared\"\n\ndef helper() {\n  return prompt\n}\n");
-    process.chdir(path.join(tmpDir, "tools"));
-
-    const config = await captureConfig({ agent: "../app/agent.agency:main", goal: "g" });
-
-    const realTmpDir = fs.realpathSync(tmpDir);
-    expect(config.target.targetSet.baseDir).toBe(realTmpDir);
-    expect(config.target.workingDir).toBe(realTmpDir);
-    expect(config.target.entryFile).toBe("app/agent.agency");
-    expect(Object.keys(config.target.targetSet.files).sort()).toEqual([
-      "app/agent.agency",
-      "shared/prompts.agency",
-    ]);
-  });
-
-  it("installs a CLI-only auto-approve handler around the loop", async () => {
+  it("resolves and runs the optimizer named by --optimizer", async () => {
     const agentFile = writeAgent();
-    let handlerCountDuringLoop = 0;
+    const { name } = await capture({ agent: agentFile, goal: "g", optimizer: "fake" });
+    expect(name).toBe("fake");
+  });
 
-    await evalOptimize(
-      { agent: agentFile, goal: "g", config: {} },
-      {
-        optimizeLoop: async (config) => {
-          handlerCountDuringLoop = getRuntimeContext().ctx.handlers.length;
-          return optimizeResult(config);
-        },
-      },
-    );
+  it("defaults to the greedy optimizer when --optimizer is omitted", async () => {
+    const agentFile = writeAgent();
+    const { name } = await capture({ agent: agentFile, goal: "g" });
+    expect(name).toBe("greedy");
+  });
 
-    expect(handlerCountDuringLoop).toBe(1);
+  it("uses configured optimize runs dir defaults", async () => {
+    const agentFile = writeAgent();
+    const { config } = await capture({ agent: agentFile, goal: "g", config: { eval: { optimizeRunsDir: path.join(tmpDir, "configured-runs") } } });
+    expect(config?.runsDir).toBe(path.join(tmpDir, "configured-runs"));
   });
 
   it("maps --silent to a verbosity", () => {
     expect(resolveVerbosity({})).toBe("default");
     expect(resolveVerbosity({ silent: true })).toBe("silent");
   });
-
-  it("uses configured optimize runs dir defaults", async () => {
-    const agentFile = writeAgent();
-
-    const config = await captureConfig({
-      agent: agentFile,
-      goal: "g",
-      config: { eval: { optimizeRunsDir: path.join(tmpDir, "configured-runs") } },
-    });
-
-    expect(config.artifacts).toEqual({
-      runsDir: path.join(tmpDir, "configured-runs"),
-      runId: "run-id",
-    });
-    expect(config.policy.iterations).toBe(5);
-  });
-
-  it("resolves and runs the optimizer named by --optimizer", async () => {
-    const agentFile = writeAgent();
-    const sentinel = { runId: "sentinel" } as OptimizeResult;
-    const optimizeSpy = vi.fn(async () => sentinel);
-    let requestedName: string | undefined;
-
-    const result = await evalOptimize(
-      { agent: agentFile, goal: "g", optimizer: "fake", silent: true, config: {} },
-      {
-        getOptimizer: (name) => {
-          requestedName = name;
-          return { name, optimize: optimizeSpy };
-        },
-      },
-    );
-
-    expect(requestedName).toBe("fake");
-    expect(optimizeSpy).toHaveBeenCalledTimes(1);
-    expect(result).toBe(sentinel);
-  });
-
-  it("defaults to the greedy optimizer when --optimizer is omitted", async () => {
-    const agentFile = writeAgent();
-    let requestedName: string | undefined;
-
-    await evalOptimize(
-      { agent: agentFile, goal: "g", silent: true, config: {} },
-      {
-        getOptimizer: (name) => {
-          requestedName = name;
-          return { name, optimize: async () => ({}) as OptimizeResult };
-        },
-      },
-    );
-
-    expect(requestedName).toBe("greedy");
-  });
 });
-
-function optimizeResult(config: OptimizeLoopConfig): OptimizeResult {
-  return {
-    runId: config.artifacts.runId,
-    runDir: path.join(config.artifacts.runsDir, config.artifacts.runId),
-    championIter: "baseline",
-    championFiles: {},
-    acceptedCount: 0,
-    rejectedCount: 0,
-    validationFailedCount: 0,
-    iterations: [],
-  };
-}

--- a/packages/agency-lang/lib/cli/eval/optimize.test.ts
+++ b/packages/agency-lang/lib/cli/eval/optimize.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { BaseOptimizerConfig, OptimizeTarget } from "@/optimize/optimizer.js";
 import type { OptimizeResult } from "@/optimize/types.js";
 
-import { evalOptimize, resolveVerbosity, type EvalOptimizeOptions } from "./optimize.js";
+import { evalOptimize, type EvalOptimizeOptions } from "./optimize.js";
 
 describe("eval optimize CLI", () => {
   let tmpDir: string;
@@ -125,10 +125,5 @@ describe("eval optimize CLI", () => {
     const agentFile = writeAgent();
     const { config } = await capture({ agent: agentFile, goal: "g", config: { eval: { optimizeRunsDir: path.join(tmpDir, "configured-runs") } } });
     expect(config?.runsDir).toBe(path.join(tmpDir, "configured-runs"));
-  });
-
-  it("maps --silent to a verbosity", () => {
-    expect(resolveVerbosity({})).toBe("default");
-    expect(resolveVerbosity({ silent: true })).toBe("silent");
   });
 });

--- a/packages/agency-lang/lib/cli/eval/optimize.ts
+++ b/packages/agency-lang/lib/cli/eval/optimize.ts
@@ -1,14 +1,13 @@
 import * as path from "path";
-import { fileURLToPath } from "url";
 
 import { nanoid } from "nanoid";
 
 import type { AgencyConfig } from "@/config.js";
 import { loadTasks } from "@/eval/loadTasks.js";
+import { getAgentsDir } from "@/importPaths.js";
 import { LlmJudge } from "@/optimize/grading/llmJudge.js";
 import type { Input, JSON as AgencyJSON } from "@/optimize/grading/types.js";
 import type { BaseOptimizerConfig, Optimizer, OptimizeTarget } from "@/optimize/optimizer.js";
-import { type OptimizeVerbosity } from "@/optimize/reporter.js";
 import { DEFAULT_OPTIMIZER, getOptimizer } from "@/optimize/registry.js";
 import { discoverOptimizeTargets, type OptimizeTargetSet } from "@/optimize/targets.js";
 import type { OptimizeResult } from "@/optimize/types.js";
@@ -30,10 +29,6 @@ export type EvalOptimizeOptions = {
   config?: AgencyConfig;
 };
 
-export function resolveVerbosity(opts: { silent?: boolean }): OptimizeVerbosity {
-  return opts.silent ? "silent" : "default";
-}
-
 export type EvalOptimizeDeps = {
   getOptimizer?: (name: string, config: BaseOptimizerConfig) => Optimizer;
   makeId?: () => string;
@@ -43,7 +38,7 @@ export type EvalOptimizeDeps = {
 const DEFAULT_ITERATIONS = 5;
 
 /** Bundled scalar goal judge: scores how well an output satisfies the input's goal. */
-const GOAL_JUDGE_FILE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../agents/goalJudge.agency");
+const GOAL_JUDGE_FILE = path.join(getAgentsDir(), "goalJudge.agency");
 
 export async function evalOptimize(
   opts: EvalOptimizeOptions,

--- a/packages/agency-lang/lib/cli/eval/optimize.ts
+++ b/packages/agency-lang/lib/cli/eval/optimize.ts
@@ -1,18 +1,18 @@
 import * as path from "path";
+import { fileURLToPath } from "url";
 
 import { nanoid } from "nanoid";
 
 import type { AgencyConfig } from "@/config.js";
-import { loadTasks, taskFromGoal } from "@/eval/loadTasks.js";
-import type { Optimizer } from "@/optimize/optimizer.js";
+import { loadTasks } from "@/eval/loadTasks.js";
+import { LlmJudge } from "@/optimize/grading/llmJudge.js";
+import type { Input, JSON as AgencyJSON } from "@/optimize/grading/types.js";
+import type { BaseOptimizerConfig, Optimizer, OptimizeTarget } from "@/optimize/optimizer.js";
+import { type OptimizeVerbosity } from "@/optimize/reporter.js";
 import { DEFAULT_OPTIMIZER, getOptimizer } from "@/optimize/registry.js";
-import { createOptimizeReporter, type OptimizeVerbosity } from "@/optimize/reporter.js";
 import { discoverOptimizeTargets, type OptimizeTargetSet } from "@/optimize/targets.js";
-import type { OptimizeLoopConfig, OptimizeResult } from "@/optimize/types.js";
+import type { OptimizeResult } from "@/optimize/types.js";
 import { parseAgency } from "@/parser.js";
-import { approve } from "@/runtime/interrupts.js";
-import { getRuntimeContext, runInBootstrapFrame } from "@/runtime/asyncContext.js";
-import { RuntimeContext } from "@/runtime/state/context.js";
 
 import { resolveEvalRunTarget, validateTaskSelection } from "./run.js";
 
@@ -21,9 +21,6 @@ export type EvalOptimizeOptions = {
   tasks?: string;
   goal?: string;
   iterations?: number;
-  samples?: number;
-  confidenceThreshold?: number;
-  marginThreshold?: number;
   writeback?: boolean;
   silent?: boolean;
   runsDir?: string;
@@ -38,88 +35,62 @@ export function resolveVerbosity(opts: { silent?: boolean }): OptimizeVerbosity 
 }
 
 export type EvalOptimizeDeps = {
-  optimizeLoop?: (config: OptimizeLoopConfig) => Promise<OptimizeResult>;
-  getOptimizer?: (name: string) => Optimizer;
+  getOptimizer?: (name: string, config: BaseOptimizerConfig) => Optimizer;
   makeId?: () => string;
   makeRunId?: () => string;
 };
 
 const DEFAULT_ITERATIONS = 5;
-const DEFAULT_JUDGE_SAMPLES = 3;
-const DEFAULT_CONFIDENCE_THRESHOLD = 50;
-const DEFAULT_MARGIN_THRESHOLD = 0;
+
+/** Bundled scalar goal judge: scores how well an output satisfies the input's goal. */
+const GOAL_JUDGE_FILE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../agents/goalJudge.agency");
 
 export async function evalOptimize(
   opts: EvalOptimizeOptions,
   deps: EvalOptimizeDeps = {},
 ): Promise<OptimizeResult> {
-  const verbosity = resolveVerbosity(opts);
-  const config = buildOptimizeLoopConfig(opts, deps);
-  const ctx = new RuntimeContext({
-    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
-    smoltalkDefaults: opts.config?.client ?? {},
-    dirname: config.target.workingDir,
-  });
-  return runInBootstrapFrame(ctx, async () => {
-    getRuntimeContext().ctx.pushHandler(async () => approve());
-    try {
-      if (deps.optimizeLoop) return await deps.optimizeLoop(config);
-      const resolve = deps.getOptimizer ?? getOptimizer;
-      const optimizer = resolve(opts.optimizer ?? DEFAULT_OPTIMIZER);
-      return await optimizer.optimize(config, { reporter: createOptimizeReporter(verbosity) });
-    } finally {
-      getRuntimeContext().ctx.popHandler();
-    }
-  }, { moduleDir: config.target.workingDir });
+  const target = buildTarget(opts, deps);
+  const config = buildConfig(opts, deps);
+  const resolve = deps.getOptimizer ?? getOptimizer;
+  const optimizer = resolve(opts.optimizer ?? DEFAULT_OPTIMIZER, config);
+  return optimizer.optimize(target);
 }
 
-function buildOptimizeLoopConfig(
-  opts: EvalOptimizeOptions,
-  deps: EvalOptimizeDeps,
-): OptimizeLoopConfig {
-  const taskSelection = validateTaskSelection(opts);
-  const target = resolveEvalRunTarget(opts.agent);
-  const tasks = taskSelection === "goal"
-    ? [taskFromGoal(opts.goal ?? "")]
-    : loadTasks(path.resolve(opts.tasks ?? ""), deps.makeId ?? nanoid);
-  const tasksSource = taskSelection === "goal"
-    ? "inline:--goal"
-    : path.resolve(opts.tasks ?? "");
-
-  const targetSet = discoverOptimizeTargets(target.agentFile);
-  if (taskSelection === "goal") {
-    rejectGoalForNodeWithRequiredArgs(targetSet, target.node);
+/** Build the optimize target: the agent plus the inputs to run it on (from --goal or --tasks). */
+export function buildTarget(opts: EvalOptimizeOptions, deps: EvalOptimizeDeps): OptimizeTarget {
+  const selection = validateTaskSelection(opts);
+  const resolved = resolveEvalRunTarget(opts.agent);
+  if (selection === "goal") {
+    const targetSet = discoverOptimizeTargets(resolved.agentFile);
+    rejectGoalForNodeWithRequiredArgs(targetSet, resolved.node);
+    return { agent: opts.agent, inputs: [{ id: "task-1", node: resolved.node, args: {}, metadata: { goal: opts.goal ?? "" } }] };
   }
+  const tasks = loadTasks(path.resolve(opts.tasks ?? ""), deps.makeId ?? nanoid);
+  const inputs: Input[] = tasks.map((t) => ({
+    id: t.task_id,
+    node: t.node ?? resolved.node,
+    args: t.args as Record<string, AgencyJSON>,
+    metadata: { goal: t.goal },
+  }));
+  return { agent: opts.agent, inputs };
+}
 
+/** Build the optimizer config: the goal-judge grader plus run policy/artifacts settings. */
+export function buildConfig(opts: EvalOptimizeOptions, deps: EvalOptimizeDeps): BaseOptimizerConfig {
   const config = opts.config ?? {};
   return {
-    runtime: { config, tasks, tasksSource },
-    target: {
-      entryFile: targetSet.entryFile,
-      node: target.node,
-      targetSet,
-      workingDir: targetSet.baseDir,
-      writeback: opts.writeback ?? true,
-    },
-    policy: {
-      iterations: opts.iterations ?? DEFAULT_ITERATIONS,
-      mutatorModel: opts.mutatorModel,
-    },
-    judgePolicy: {
-      samples: opts.samples ?? DEFAULT_JUDGE_SAMPLES,
-      confidenceThreshold: opts.confidenceThreshold ?? DEFAULT_CONFIDENCE_THRESHOLD,
-      marginThreshold: opts.marginThreshold ?? DEFAULT_MARGIN_THRESHOLD,
-      positionBias: "swap",
-    },
-    artifacts: {
-      runsDir: path.resolve(opts.runsDir ?? config.eval?.optimizeRunsDir ?? path.join(config.eval?.runsDir ?? "runs", "optimize")),
-      runId: opts.runId ?? (deps.makeRunId ?? nanoid)(),
-    },
+    graders: [new LlmJudge({ name: "goal", agencyFile: GOAL_JUDGE_FILE, goalPath: ["metadata", "goal"] })],
+    iterations: opts.iterations ?? DEFAULT_ITERATIONS,
+    config,
+    runsDir: path.resolve(opts.runsDir ?? config.eval?.optimizeRunsDir ?? path.join(config.eval?.runsDir ?? "runs", "optimize")),
+    runId: opts.runId ?? (deps.makeRunId ?? nanoid)(),
+    writeback: opts.writeback ?? true,
+    mutatorModel: opts.mutatorModel,
   };
 }
 
 /**
- * `--goal` desugars to a single no-argument task, so it cannot drive a node
+ * `--goal` desugars to a single no-argument input, so it cannot drive a node
  * that requires arguments. Task files can provide args; goals cannot.
  */
 function rejectGoalForNodeWithRequiredArgs(targetSet: OptimizeTargetSet, node: string): void {
@@ -131,7 +102,7 @@ function rejectGoalForNodeWithRequiredArgs(targetSet: OptimizeTargetSet, node: s
     const required = candidate.parameters.filter((parameter) => parameter.defaultValue === undefined);
     if (required.length > 0) {
       throw new Error(
-        `Node ${node} requires arguments, but --goal creates a no-argument task.\n` +
+        `Node ${node} requires arguments, but --goal creates a no-argument input.\n` +
         "Use --tasks tasks.json to provide args for this agent.",
       );
     }

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -69,6 +69,14 @@ export function getStdlibDir(): string {
 }
 
 /**
+ * Returns the absolute path to the bundled agents directory, resolved relative
+ * to this compiled module (`lib/agents` in dev, `dist/lib/agents` at runtime).
+ */
+export function getAgentsDir(): string {
+  return path.join(__dirname, "agents");
+}
+
+/**
  * Returns all .agency files in the stdlib directory as absolute paths.
  */
 export function getStdlibFiles(): string[] {

--- a/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
@@ -74,4 +74,11 @@ describe("BaseOptimizer.evaluate", () => {
     // input "a" scores 1; input "b" has no contributing grader → 0; mean = 0.5
     expect(sc.objective()).toBeCloseTo(0.5, 10);
   });
+
+  it("gives id-less inputs distinct cache keys so they do not collide", async () => {
+    const runInput = vi.fn(fixedRun);
+    const p = probe([new FixedGrader({ score: { kind: "scalar", value: 1 } })], runInput);
+    await p.evaluateAt(p.forkAt(src), "agent.agency", [{ args: {} }, { args: {} }]); // both omit id
+    expect(runInput).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
@@ -1,0 +1,77 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BaseGrader } from "./grading/baseGrader.js";
+import type { Grade, GraderInput, GraderOptions, Input } from "./grading/types.js";
+import type { Scorecard } from "./grading/scorecard.js";
+import { BaseOptimizer, type RunInput } from "./baseOptimizer.js";
+import type { OptimizeTarget } from "./optimizer.js";
+import type { OptimizeResult } from "./types.js";
+
+class FixedGrader extends BaseGrader {
+  protected readonly defaultName = "fixed";
+  constructor(private readonly grade: Grade, options: GraderOptions = {}) { super(options); }
+  protected _run(_input: GraderInput): Promise<Grade> { return Promise.resolve(this.grade); }
+}
+
+/** Concrete subclass exposing `evaluate` for testing. */
+class Probe extends BaseOptimizer {
+  readonly name = "probe";
+  async optimize(_t: OptimizeTarget): Promise<OptimizeResult> { return {} as OptimizeResult; }
+  evaluateAt(ws: ReturnType<Probe["fork"]>, entry: string, inputs: Input[]): Promise<Scorecard> {
+    return this.evaluate(ws, entry, inputs);
+  }
+  forkAt(dir: string) { return this.fork(dir); }
+}
+
+describe("BaseOptimizer.evaluate", () => {
+  let root: string;
+  let src: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "bo-"));
+    src = path.join(root, "src");
+    fs.mkdirSync(src);
+    fs.writeFileSync(path.join(src, "agent.agency"), "node main() {}\n");
+  });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  function probe(graders: BaseGrader[], runInput: RunInput): Probe {
+    return new Probe(
+      { graders, iterations: 1, config: {}, runsDir: root, runId: "r" },
+      { workspaceRoot: path.join(root, "ws"), runInput },
+    );
+  }
+
+  const inputs: Input[] = [{ id: "a", args: {} }, { id: "b", args: {} }];
+  const fixedRun: RunInput = async () => ({ output: "out", recordPath: "" });
+
+  it("runs the agent once per input (cached) and builds a gate-aware Scorecard", async () => {
+    const runInput = vi.fn(fixedRun);
+    const p = probe([new FixedGrader({ score: { kind: "scalar", value: 0.5 } })], runInput);
+    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", inputs);
+    expect(runInput).toHaveBeenCalledTimes(2);
+    expect(sc.objective()).toBeCloseTo(0.5, 10);
+    expect(sc.gatesPassed()).toBe(true);
+  });
+
+  it("short-circuits advisory graders when a gate fails for an input", async () => {
+    const gate = new FixedGrader({ score: { kind: "binary", pass: false } }, { mustPass: true });
+    const advisory = new FixedGrader({ score: { kind: "scalar", value: 1 } });
+    const advisorySpy = vi.spyOn(advisory as unknown as { _run: () => Promise<Grade> }, "_run");
+    const p = probe([gate, advisory], fixedRun);
+    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", [{ id: "a", args: {} }]);
+    expect(sc.gatesPassed()).toBe(false);
+    expect(advisorySpy).not.toHaveBeenCalled();
+  });
+
+  it("only runs graders whose inputScope matches the input", async () => {
+    const scoped = new FixedGrader({ score: { kind: "scalar", value: 1 } }, { inputScope: { ids: ["a"] } });
+    const p = probe([scoped], fixedRun);
+    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", inputs);
+    // input "a" scores 1; input "b" has no contributing grader → 0; mean = 0.5
+    expect(sc.objective()).toBeCloseTo(0.5, 10);
+  });
+});

--- a/packages/agency-lang/lib/optimize/baseOptimizer.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.ts
@@ -1,0 +1,108 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { evalRunLoadedTasks } from "@/cli/eval/run.js";
+import type { EvalTask } from "@/eval/runTypes.js";
+
+import { EvalCache } from "./evalCache.js";
+import { AgencyRunner } from "./grading/agencyRunner.js";
+import type { BaseGrader } from "./grading/baseGrader.js";
+import { Scorecard, type GraderGrade, type InputGrades } from "./grading/scorecard.js";
+import type { AgentRun, Input } from "./grading/types.js";
+import type { BaseOptimizerConfig, OptimizeTarget } from "./optimizer.js";
+import type { OptimizeResult } from "./types.js";
+import { WorkspaceManager, type Workspace } from "./workspace.js";
+
+/** A function that runs the agent for one input in a workspace and returns its run. */
+export type RunInput = (ws: Workspace, entryFile: string, input: Input) => Promise<AgentRun>;
+
+export type BaseOptimizerDeps = {
+  workspaceRoot?: string;
+  agencyRunner?: AgencyRunner;
+  cache?: EvalCache;
+  /** Override how the agent under test runs (tests inject a fake; default uses the eval-run path). */
+  runInput?: RunInput;
+};
+
+export abstract class BaseOptimizer {
+  protected readonly workspace: WorkspaceManager;
+  protected readonly agencyRunner: AgencyRunner;
+  protected readonly cache: EvalCache;
+  private readonly runInput: RunInput;
+  private runCounter = 0;
+
+  constructor(protected readonly config: BaseOptimizerConfig, deps: BaseOptimizerDeps = {}) {
+    this.workspace = new WorkspaceManager(deps.workspaceRoot ?? path.join(config.runsDir, config.runId, "ws"));
+    this.agencyRunner = deps.agencyRunner ?? new AgencyRunner(config.config);
+    this.cache = deps.cache ?? new EvalCache();
+    this.runInput = deps.runInput ?? ((ws, entryFile, input) => this.runInputViaEval(ws, entryFile, input));
+  }
+
+  abstract readonly name: string;
+  abstract optimize(target: OptimizeTarget): Promise<OptimizeResult>;
+
+  protected fork(sourceDir: string): Workspace {
+    return this.workspace.fork(sourceDir);
+  }
+
+  /** Run the agent once per input (cached by (workspace,input)), grade each, return a Scorecard. */
+  protected async evaluate(ws: Workspace, entryFile: string, inputs: Input[]): Promise<Scorecard> {
+    const perInput = await Promise.all(inputs.map((input) => this.gradeInput(ws, entryFile, input)));
+    return new Scorecard(perInput);
+  }
+
+  private async gradeInput(ws: Workspace, entryFile: string, input: Input): Promise<InputGrades> {
+    const run = await this.cache.get(ws.key, input.id ?? "", () => this.runInput(ws, entryFile, input));
+    const gates = this.config.graders.filter((g) => g.mustPass() && g.gradesInput(input));
+    const advisory = this.config.graders.filter((g) => !g.mustPass() && g.gradesInput(input));
+
+    const gateGrades: GraderGrade[] = [];
+    for (const grader of gates) {                                  // sequential: short-circuit
+      const grade = await grader.run({ input, run, runAgency: this.agencyRunner });
+      gateGrades.push({ grader, grade });
+      if (!grader.passes(grade)) return { input, run, grades: gateGrades, gatesPassed: false };
+    }
+    const advisoryGrades = await Promise.all(
+      advisory.map(async (grader) => ({ grader, grade: await grader.run({ input, run, runAgency: this.agencyRunner }) })),
+    );
+    return { input, run, grades: [...gateGrades, ...advisoryGrades], gatesPassed: true };
+  }
+
+  /** Default runInput: run the agent for one input via the eval-run subprocess path (named args). */
+  private async runInputViaEval(ws: Workspace, entryFile: string, input: Input): Promise<AgentRun> {
+    const task: EvalTask = {
+      task_id: input.id ?? "input",
+      goal: "",
+      args: input.args,
+      ...(input.node ? { node: input.node } : {}),
+    };
+    this.runCounter += 1;
+    const result = await evalRunLoadedTasks({
+      agent: path.join(ws.dir, entryFile),
+      tasks: [task],
+      tasksSource: "optimize",
+      runsDir: path.join(this.config.runsDir, this.config.runId, "agent-runs", ws.key),
+      runId: `run-${this.runCounter}`,
+      config: this.config.config,
+      continueOnError: true,
+      quietCompile: true,
+      pipeAgentOutput: false,
+    });
+    const taskResult = result.tasks[0];
+    if (!taskResult || taskResult.status !== "success") {
+      throw new Error(`agent run failed for input ${input.id ?? "(no id)"}: ${taskResult?.errorMessage ?? "unknown error"}`);
+    }
+    const record = JSON.parse(fs.readFileSync(taskResult.evalRecordPath, "utf8")) as { evalOutputs?: { value: unknown }[] };
+    const outputs = record.evalOutputs ?? [];
+    const output = outputs.length > 0 ? outputs[outputs.length - 1].value : null;
+    return { output: output as AgentRun["output"], recordPath: taskResult.evalRecordPath };
+  }
+
+  protected async eachIteration(step: (iter: number) => Promise<void>): Promise<void> {
+    for (let iter = 1; iter <= this.config.iterations; iter += 1) await step(iter);
+  }
+
+  protected get graders(): BaseGrader[] {
+    return this.config.graders;
+  }
+}

--- a/packages/agency-lang/lib/optimize/baseOptimizer.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.ts
@@ -14,7 +14,7 @@ import type { OptimizeResult } from "./types.js";
 import { WorkspaceManager, type Workspace } from "./workspace.js";
 
 /** A function that runs the agent for one input in a workspace and returns its run. */
-export type RunInput = (ws: Workspace, entryFile: string, input: Input) => Promise<AgentRun>;
+export type RunInput = (ws: Workspace, entryFile: string, input: Input, id: string) => Promise<AgentRun>;
 
 export type BaseOptimizerDeps = {
   workspaceRoot?: string;
@@ -35,7 +35,7 @@ export abstract class BaseOptimizer {
     this.workspace = new WorkspaceManager(deps.workspaceRoot ?? path.join(config.runsDir, config.runId, "ws"));
     this.agencyRunner = deps.agencyRunner ?? new AgencyRunner(config.config);
     this.cache = deps.cache ?? new EvalCache();
-    this.runInput = deps.runInput ?? ((ws, entryFile, input) => this.runInputViaEval(ws, entryFile, input));
+    this.runInput = deps.runInput ?? ((ws, entryFile, input, id) => this.runInputViaEval(ws, entryFile, input, id));
   }
 
   abstract readonly name: string;
@@ -47,12 +47,14 @@ export abstract class BaseOptimizer {
 
   /** Run the agent once per input (cached by (workspace,input)), grade each, return a Scorecard. */
   protected async evaluate(ws: Workspace, entryFile: string, inputs: Input[]): Promise<Scorecard> {
-    const perInput = await Promise.all(inputs.map((input) => this.gradeInput(ws, entryFile, input)));
+    const perInput = await Promise.all(
+      inputs.map((input, index) => this.gradeInput(ws, entryFile, input, inputId(input, index))),
+    );
     return new Scorecard(perInput);
   }
 
-  private async gradeInput(ws: Workspace, entryFile: string, input: Input): Promise<InputGrades> {
-    const run = await this.cache.get(ws.key, input.id ?? "", () => this.runInput(ws, entryFile, input));
+  private async gradeInput(ws: Workspace, entryFile: string, input: Input, id: string): Promise<InputGrades> {
+    const run = await this.cache.get(ws.key, id, () => this.runInput(ws, entryFile, input, id));
     const gates = this.config.graders.filter((g) => g.mustPass() && g.gradesInput(input));
     const advisory = this.config.graders.filter((g) => !g.mustPass() && g.gradesInput(input));
 
@@ -69,9 +71,9 @@ export abstract class BaseOptimizer {
   }
 
   /** Default runInput: run the agent for one input via the eval-run subprocess path (named args). */
-  private async runInputViaEval(ws: Workspace, entryFile: string, input: Input): Promise<AgentRun> {
+  private async runInputViaEval(ws: Workspace, entryFile: string, input: Input, id: string): Promise<AgentRun> {
     const task: EvalTask = {
-      task_id: input.id ?? "input",
+      task_id: id,
       goal: "",
       args: input.args,
       ...(input.node ? { node: input.node } : {}),
@@ -105,4 +107,9 @@ export abstract class BaseOptimizer {
   protected get graders(): BaseGrader[] {
     return this.config.graders;
   }
+}
+
+/** A stable id for an input: its own id when present, otherwise its position. */
+function inputId(input: Input, index: number): string {
+  return input.id && input.id.trim() !== "" ? input.id : `input-${index}`;
 }

--- a/packages/agency-lang/lib/optimize/grading/llmJudge.ts
+++ b/packages/agency-lang/lib/optimize/grading/llmJudge.ts
@@ -29,7 +29,10 @@ export class LlmJudge extends BaseGrader {
     if (raw === undefined || raw === null || String(raw).trim() === "") {
       throw new Error(`${this.name()}: no goal found at ${globalThis.JSON.stringify(goalPath)} on input ${input.id ?? "(no id)"}; an LLM judge needs a goal.`);
     }
-    const args = [String(raw), run.output];
+    // Judges take a string output; stringify structured outputs so they read as JSON
+    // rather than "[object Object]".
+    const output = typeof run.output === "string" ? run.output : globalThis.JSON.stringify(run.output);
+    const args = [String(raw), output];
     const node = this.options.node ?? "main";
     if (this.options.binary) {
       const v = await runAgency.runStructured(this.options.agencyFile, node, args, BinaryVerdict);

--- a/packages/agency-lang/lib/optimize/greedyReflective.test.ts
+++ b/packages/agency-lang/lib/optimize/greedyReflective.test.ts
@@ -1,29 +1,84 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
-vi.mock("./loop.js", () => ({ optimizeLoop: vi.fn() }));
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { optimizeLoop } from "./loop.js";
-import { GreedyReflective } from "./greedyReflective.js";
-import type { OptimizeLoopConfig, OptimizeResult } from "./types.js";
+import { BaseGrader } from "./grading/baseGrader.js";
+import type { Grade, GraderInput, GraderOptions } from "./grading/types.js";
+import { GreedyReflective, type GreedyDeps } from "./greedyReflective.js";
+import type { OptimizeMutationPreview } from "./sourceMutator.js";
+import type { OptimizeTargetSet } from "./targets.js";
 
-describe("GreedyReflective", () => {
+class ValueGrader extends BaseGrader {
+  protected readonly defaultName = "value";
+  constructor(private readonly next: () => number, options: GraderOptions = {}) { super(options); }
+  protected _run(_i: GraderInput): Promise<Grade> { return Promise.resolve({ score: { kind: "scalar", value: this.next() } }); }
+}
+
+describe("GreedyReflective (pointwise)", () => {
+  let root: string;
+  let src: string;
   beforeEach(() => {
-    vi.mocked(optimizeLoop).mockReset();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "greedy-"));
+    src = path.join(root, "src");
+    fs.mkdirSync(src);
+    fs.writeFileSync(path.join(src, "agent.agency"), 'optimize const prompt = "hi"\n\nnode main() {}\n');
+  });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  const fakeSource = (): OptimizeTargetSet => ({
+    baseDir: src,
+    entryFile: "agent.agency",
+    files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
+    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi" }],
   });
 
-  it("is named \"greedy\"", () => {
-    expect(new GreedyReflective().name).toBe("greedy");
+  const deps = (): GreedyDeps => ({
+    workspaceRoot: path.join(root, "ws"),
+    runInput: async () => ({ output: "out", recordPath: "" }),
+    discover: () => fakeSource(),
+    propose: async () => ({ rationale: "tighten", operations: [] }),
+    preview: (targetSet): OptimizeMutationPreview => ({ files: {}, changes: [], diff: "", diagnostics: [], targetSet }),
   });
 
-  it("delegates optimize() to optimizeLoop and returns its result", async () => {
-    const result = { runId: "r" } as OptimizeResult;
-    vi.mocked(optimizeLoop).mockResolvedValue(result);
-    const config = {} as OptimizeLoopConfig;
-    const deps = {};
+  it("accepts a candidate only when gates pass and the objective improves", async () => {
+    let n = 0;
+    const grader = new ValueGrader(() => 0.1 * ++n); // baseline 0.1, then 0.2, 0.3 ... each candidate beats champion
+    const opt = new GreedyReflective(
+      { graders: [grader], iterations: 2, config: {}, runsDir: root, runId: "r", writeback: false },
+      deps(),
+    );
+    const result = await opt.optimize({ agent: path.join(src, "agent.agency"), inputs: [{ id: "a", args: {} }] });
+    expect(result.acceptedCount).toBe(2);
+    expect(result.rejectedCount).toBe(0);
+  });
 
-    const returned = await new GreedyReflective().optimize(config, deps);
+  it("rejects a candidate whose objective does not improve", async () => {
+    const grader = new ValueGrader(() => 0.5); // constant — no candidate beats the champion
+    const opt = new GreedyReflective(
+      { graders: [grader], iterations: 2, config: {}, runsDir: root, runId: "r2", writeback: false },
+      deps(),
+    );
+    const result = await opt.optimize({ agent: path.join(src, "agent.agency"), inputs: [{ id: "a", args: {} }] });
+    expect(result.acceptedCount).toBe(0);
+    expect(result.rejectedCount).toBe(2);
+    expect(result.championIter).toBe("baseline");
+  });
 
-    expect(optimizeLoop).toHaveBeenCalledWith(config, deps);
-    expect(returned).toBe(result);
+  it("counts a candidate that fails a gate as rejected even if its objective is higher", async () => {
+    let n = 0;
+    const gate = new (class extends BaseGrader {
+      protected readonly defaultName = "gate";
+      protected _run(): Promise<Grade> { return Promise.resolve({ score: { kind: "binary", pass: ++n === 1 } }); }
+    })({ mustPass: true });
+    const scalar = new ValueGrader(() => 1); // would beat baseline, but the gate fails after baseline
+    const opt = new GreedyReflective(
+      { graders: [gate, scalar], iterations: 1, config: {}, runsDir: root, runId: "r3", writeback: false },
+      deps(),
+    );
+    const result = await opt.optimize({ agent: path.join(src, "agent.agency"), inputs: [{ id: "a", args: {} }] });
+    expect(result.acceptedCount).toBe(0);
+    expect(result.rejectedCount).toBe(1);
   });
 });

--- a/packages/agency-lang/lib/optimize/greedyReflective.ts
+++ b/packages/agency-lang/lib/optimize/greedyReflective.ts
@@ -1,15 +1,133 @@
-import { optimizeLoop, type OptimizeLoopDeps } from "./loop.js";
-import type { Optimizer } from "./optimizer.js";
-import type { OptimizeLoopConfig, OptimizeResult } from "./types.js";
+import * as fs from "fs";
 
-/**
- * The PR #283 champion–challenger hill-climb, exposed as an Optimizer. Phase 1 delegates
- * verbatim to optimizeLoop (its pairwise judge stays internal) — zero behavior change.
- */
-export class GreedyReflective implements Optimizer {
+import { resolveEvalRunTarget } from "@/cli/eval/run.js";
+import type { EvalTask } from "@/eval/runTypes.js";
+
+import { BaseOptimizer, type BaseOptimizerDeps } from "./baseOptimizer.js";
+import { proposeMutation, type ProposeMutationArgs } from "./mutator.js";
+import type { Scorecard } from "./grading/scorecard.js";
+import type { Input } from "./grading/types.js";
+import type { BaseOptimizerConfig, OptimizeTarget } from "./optimizer.js";
+import { OptimizeSourceMutator, type OptimizeMutationOperation, type OptimizeMutationPreview } from "./sourceMutator.js";
+import { discoverOptimizeTargets, sha256Text, type OptimizeTargetSet } from "./targets.js";
+import type { IterationResult, MutationProposal, OptimizeResult } from "./types.js";
+import type { Workspace } from "./workspace.js";
+
+/** Test seams: inject discovery / proposal / preview so the loop can run without real LLM or AST work. */
+export type GreedyDeps = BaseOptimizerDeps & {
+  discover?: (agentFile: string) => OptimizeTargetSet;
+  propose?: (args: ProposeMutationArgs) => Promise<MutationProposal>;
+  preview?: (targetSet: OptimizeTargetSet, operations: OptimizeMutationOperation[]) => OptimizeMutationPreview;
+};
+
+type Champion = {
+  iter: number | "baseline";
+  ws: Workspace;
+  scorecard: Scorecard;
+  targetSet: OptimizeTargetSet;
+  files: Record<string, string>;
+};
+
+type HistoryEntry = { iter: number; decision: string; rationale: string; objective: number };
+
+/** Champion–challenger hill-climb with pointwise grading (replaces the pairwise judge). */
+export class GreedyReflective extends BaseOptimizer {
   readonly name = "greedy";
-
-  optimize(config: OptimizeLoopConfig, deps: OptimizeLoopDeps = {}): Promise<OptimizeResult> {
-    return optimizeLoop(config, deps);
+  constructor(config: BaseOptimizerConfig, private readonly greedyDeps: GreedyDeps = {}) {
+    super(config, greedyDeps);
   }
+
+  async optimize(target: OptimizeTarget): Promise<OptimizeResult> {
+    const agentFile = resolveEvalRunTarget(target.agent).agentFile;
+    const source = (this.greedyDeps.discover ?? discoverOptimizeTargets)(agentFile);
+    if (source.targets.length === 0) {
+      throw new Error(`No optimize targets found in ${agentFile}. Mark a declaration with the optimize modifier.`);
+    }
+    const entry = source.entryFile;
+
+    const baselineWs = this.fork(source.baseDir);
+    const baselineScore = await this.evaluate(baselineWs, entry, target.inputs);
+    if (!baselineScore.gatesPassed()) {
+      throw new Error("Baseline fails a must-pass grader — fix the program or graders before optimizing.");
+    }
+
+    let champion: Champion = { iter: "baseline", ws: baselineWs, scorecard: baselineScore, targetSet: source, files: fileMap(source) };
+    const history: HistoryEntry[] = [];
+    const iterations: IterationResult[] = [{ iter: 0, decision: "baseline", winsA: 0, winsB: 0, ties: 0 }];
+    let accepted = 0; let rejected = 0; let validationFailed = 0;
+
+    await this.eachIteration(async (iter) => {
+      const proposal = await (this.greedyDeps.propose ?? proposeMutation)({
+        config: this.config.config,
+        targets: champion.targetSet.targets,
+        tasks: inputsAsTasks(target.inputs),
+        history: renderHistory(history),
+        model: this.config.mutatorModel,
+      });
+      const preview = (this.greedyDeps.preview ?? defaultPreview)(champion.targetSet, proposal.operations);
+      if (preview.diagnostics.length > 0) {
+        validationFailed += 1;
+        iterations.push({ iter, decision: "validation-failed", winsA: 0, winsB: 0, ties: 0 });
+        history.push({ iter, decision: "validation-failed", rationale: proposal.rationale, objective: NaN });
+        return;
+      }
+
+      const candidate = this.fork(champion.ws.dir);
+      this.workspace.applyFiles(candidate, preview.files);
+      const score = await this.evaluate(candidate, entry, target.inputs);
+      const wins = score.gatesPassed() && score.objective() > champion.scorecard.objective();
+      iterations.push({ iter, decision: wins ? "accepted" : "rejected", winsA: 0, winsB: 0, ties: 0 });
+      history.push({ iter, decision: wins ? "accepted" : "rejected", rationale: proposal.rationale, objective: score.objective() });
+      if (wins) {
+        champion = { iter, ws: candidate, scorecard: score, targetSet: preview.targetSet, files: preview.files };
+        accepted += 1;
+      } else {
+        rejected += 1;
+      }
+    });
+
+    this.writeBack(source, champion);
+    return {
+      runId: this.config.runId,
+      runDir: this.config.runsDir,
+      championIter: champion.iter,
+      championFiles: champion.files,
+      acceptedCount: accepted,
+      rejectedCount: rejected,
+      validationFailedCount: validationFailed,
+      iterations,
+    };
+  }
+
+  /** Write the champion file set back to the original sources, sha-checked (as PR #283). */
+  private writeBack(source: OptimizeTargetSet, champion: Champion): void {
+    if (!this.config.writeback || champion.iter === "baseline") return;
+    for (const sf of Object.values(source.files)) {
+      if (sha256Text(fs.readFileSync(sf.absoluteFile, "utf8")) !== sf.sha256) {
+        throw new Error(`Source file ${sf.absoluteFile} was modified externally; writeback aborted.`);
+      }
+    }
+    for (const [rel, contents] of Object.entries(champion.files)) {
+      if (contents !== source.files[rel]?.source) fs.writeFileSync(source.files[rel].absoluteFile, contents);
+    }
+  }
+}
+
+function defaultPreview(targetSet: OptimizeTargetSet, operations: OptimizeMutationOperation[]): OptimizeMutationPreview {
+  return new OptimizeSourceMutator({ targetSet }).preview(operations);
+}
+
+function fileMap(source: OptimizeTargetSet): Record<string, string> {
+  return Object.fromEntries(Object.entries(source.files).map(([rel, sf]) => [rel, sf.source]));
+}
+
+function inputsAsTasks(inputs: Input[]): EvalTask[] {
+  return inputs.map((input) => ({ task_id: input.id ?? "input", goal: String(input.metadata?.goal ?? ""), args: input.args }));
+}
+
+function renderHistory(history: HistoryEntry[]): string {
+  if (history.length === 0) return "";
+  return history
+    .map((h) => `- iter ${h.iter} [${h.decision}] objective=${Number.isNaN(h.objective) ? "n/a" : h.objective.toFixed(3)}: ${h.rationale}`)
+    .join("\n");
 }

--- a/packages/agency-lang/lib/optimize/greedyReflective.ts
+++ b/packages/agency-lang/lib/optimize/greedyReflective.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as path from "path";
 
 import { resolveEvalRunTarget } from "@/cli/eval/run.js";
 import type { EvalTask } from "@/eval/runTypes.js";
@@ -9,7 +9,7 @@ import type { Scorecard } from "./grading/scorecard.js";
 import type { Input } from "./grading/types.js";
 import type { BaseOptimizerConfig, OptimizeTarget } from "./optimizer.js";
 import { OptimizeSourceMutator, type OptimizeMutationOperation, type OptimizeMutationPreview } from "./sourceMutator.js";
-import { discoverOptimizeTargets, sha256Text, type OptimizeTargetSet } from "./targets.js";
+import { discoverOptimizeTargets, type OptimizeTargetSet } from "./targets.js";
 import type { IterationResult, MutationProposal, OptimizeResult } from "./types.js";
 import type { Workspace } from "./workspace.js";
 
@@ -20,7 +20,8 @@ export type GreedyDeps = BaseOptimizerDeps & {
   preview?: (targetSet: OptimizeTargetSet, operations: OptimizeMutationOperation[]) => OptimizeMutationPreview;
 };
 
-type Champion = {
+/** A fully-evaluated point in the search: a workspace + its grading + its target set/files. */
+type Candidate = {
   iter: number | "baseline";
   ws: Workspace;
   scorecard: Scorecard;
@@ -28,7 +29,9 @@ type Champion = {
   files: Record<string, string>;
 };
 
-type HistoryEntry = { iter: number; decision: string; rationale: string; objective: number };
+type Decision = "accepted" | "rejected" | "validation-failed";
+/** The immutable record of one iteration; all run stats are derived from these. */
+type Attempt = { iter: number; decision: Decision; rationale: string; objective?: number; candidate?: Candidate };
 
 /** Champion–challenger hill-climb with pointwise grading (replaces the pairwise judge). */
 export class GreedyReflective extends BaseOptimizer {
@@ -43,73 +46,88 @@ export class GreedyReflective extends BaseOptimizer {
     if (source.targets.length === 0) {
       throw new Error(`No optimize targets found in ${agentFile}. Mark a declaration with the optimize modifier.`);
     }
-    const entry = source.entryFile;
 
-    const baselineWs = this.fork(source.baseDir);
-    const baselineScore = await this.evaluate(baselineWs, entry, target.inputs);
-    if (!baselineScore.gatesPassed()) {
-      throw new Error("Baseline fails a must-pass grader — fix the program or graders before optimizing.");
+    const baseline = await this.makeCandidate("baseline", this.fork(source.baseDir), source, target.inputs);
+    this.requireBaselineGatesPass(baseline);
+
+    const attempts = await this.hillClimb(baseline, target.inputs);
+    const champion = lastAccepted(attempts)?.candidate ?? baseline;
+
+    if (this.config.writeback && champion.iter !== "baseline") {
+      this.workspace.writeBack(source, champion.files);
     }
-
-    let champion: Champion = { iter: "baseline", ws: baselineWs, scorecard: baselineScore, targetSet: source, files: fileMap(source) };
-    const history: HistoryEntry[] = [];
-    const iterations: IterationResult[] = [{ iter: 0, decision: "baseline", winsA: 0, winsB: 0, ties: 0 }];
-    let accepted = 0; let rejected = 0; let validationFailed = 0;
-
-    await this.eachIteration(async (iter) => {
-      const proposal = await (this.greedyDeps.propose ?? proposeMutation)({
-        config: this.config.config,
-        targets: champion.targetSet.targets,
-        tasks: inputsAsTasks(target.inputs),
-        history: renderHistory(history),
-        model: this.config.mutatorModel,
-      });
-      const preview = (this.greedyDeps.preview ?? defaultPreview)(champion.targetSet, proposal.operations);
-      if (preview.diagnostics.length > 0) {
-        validationFailed += 1;
-        iterations.push({ iter, decision: "validation-failed", winsA: 0, winsB: 0, ties: 0 });
-        history.push({ iter, decision: "validation-failed", rationale: proposal.rationale, objective: NaN });
-        return;
-      }
-
-      const candidate = this.fork(champion.ws.dir);
-      this.workspace.applyFiles(candidate, preview.files);
-      const score = await this.evaluate(candidate, entry, target.inputs);
-      const wins = score.gatesPassed() && score.objective() > champion.scorecard.objective();
-      iterations.push({ iter, decision: wins ? "accepted" : "rejected", winsA: 0, winsB: 0, ties: 0 });
-      history.push({ iter, decision: wins ? "accepted" : "rejected", rationale: proposal.rationale, objective: score.objective() });
-      if (wins) {
-        champion = { iter, ws: candidate, scorecard: score, targetSet: preview.targetSet, files: preview.files };
-        accepted += 1;
-      } else {
-        rejected += 1;
-      }
-    });
-
-    this.writeBack(source, champion);
-    return {
-      runId: this.config.runId,
-      runDir: this.config.runsDir,
-      championIter: champion.iter,
-      championFiles: champion.files,
-      acceptedCount: accepted,
-      rejectedCount: rejected,
-      validationFailedCount: validationFailed,
-      iterations,
-    };
+    return this.buildResult(champion, attempts);
   }
 
-  /** Write the champion file set back to the original sources, sha-checked (as PR #283). */
-  private writeBack(source: OptimizeTargetSet, champion: Champion): void {
-    if (!this.config.writeback || champion.iter === "baseline") return;
-    for (const sf of Object.values(source.files)) {
-      if (sha256Text(fs.readFileSync(sf.absoluteFile, "utf8")) !== sf.sha256) {
-        throw new Error(`Source file ${sf.absoluteFile} was modified externally; writeback aborted.`);
-      }
+  /** The one place the champion is threaded across iterations. */
+  private async hillClimb(baseline: Candidate, inputs: Input[]): Promise<Attempt[]> {
+    const attempts: Attempt[] = [];
+    let champion = baseline;
+    for (let iter = 1; iter <= this.config.iterations; iter += 1) {
+      const attempt = await this.attempt(champion, inputs, iter, attempts);
+      if (attempt.decision === "accepted" && attempt.candidate) champion = attempt.candidate;
+      attempts.push(attempt);
     }
-    for (const [rel, contents] of Object.entries(champion.files)) {
-      if (contents !== source.files[rel]?.source) fs.writeFileSync(source.files[rel].absoluteFile, contents);
+    return attempts;
+  }
+
+  /** Propose → apply → evaluate one candidate, deciding accept/reject against the champion. */
+  private async attempt(champion: Candidate, inputs: Input[], iter: number, history: Attempt[]): Promise<Attempt> {
+    const proposal = await (this.greedyDeps.propose ?? proposeMutation)({
+      config: this.config.config,
+      targets: champion.targetSet.targets,
+      tasks: inputsAsTasks(inputs),
+      history: renderHistory(history),
+      model: this.config.mutatorModel,
+    });
+    const preview = (this.greedyDeps.preview ?? defaultPreview)(champion.targetSet, proposal.operations);
+    if (preview.diagnostics.length > 0) {
+      return { iter, decision: "validation-failed", rationale: proposal.rationale };
     }
+    const candidate = await this.makeCandidate(iter, this.fork(champion.ws.dir), preview.targetSet, inputs, preview.files);
+    const decision: Decision = this.beats(candidate, champion) ? "accepted" : "rejected";
+    return { iter, decision, rationale: proposal.rationale, objective: candidate.scorecard.objective(), candidate };
+  }
+
+  /** Apply the candidate's file set (if any) into its forked workspace and grade it. */
+  private async makeCandidate(
+    iter: number | "baseline",
+    ws: Workspace,
+    targetSet: OptimizeTargetSet,
+    inputs: Input[],
+    files?: Record<string, string>,
+  ): Promise<Candidate> {
+    if (files) this.workspace.applyFiles(ws, files);
+    const scorecard = await this.evaluate(ws, targetSet.entryFile, inputs);
+    return { iter, ws, scorecard, targetSet, files: files ?? fileMap(targetSet) };
+  }
+
+  /** Greedy's acceptance policy: pass every gate AND beat the champion's objective. */
+  private beats(candidate: Candidate, champion: Candidate): boolean {
+    return candidate.scorecard.gatesPassed() && candidate.scorecard.objective() > champion.scorecard.objective();
+  }
+
+  private requireBaselineGatesPass(baseline: Candidate): void {
+    if (baseline.scorecard.gatesPassed()) return;
+    const failed = failingGraders(baseline.scorecard);
+    throw new Error(
+      `Baseline fails must-pass grader(s) [${failed.join(", ")}] — fix the program or those graders before optimizing.`,
+    );
+  }
+
+  private buildResult(champion: Candidate, attempts: Attempt[]): OptimizeResult {
+    const count = (decision: Decision): number => attempts.filter((a) => a.decision === decision).length;
+    const baselineIteration: IterationResult = { iter: 0, decision: "baseline", winsA: 0, winsB: 0, ties: 0 };
+    return {
+      runId: this.config.runId,
+      runDir: path.join(this.config.runsDir, this.config.runId),
+      championIter: champion.iter,
+      championFiles: champion.files,
+      acceptedCount: count("accepted"),
+      rejectedCount: count("rejected"),
+      validationFailedCount: count("validation-failed"),
+      iterations: [baselineIteration, ...attempts.map((a) => ({ iter: a.iter, decision: a.decision, winsA: 0, winsB: 0, ties: 0 }))],
+    };
   }
 }
 
@@ -125,9 +143,21 @@ function inputsAsTasks(inputs: Input[]): EvalTask[] {
   return inputs.map((input) => ({ task_id: input.id ?? "input", goal: String(input.metadata?.goal ?? ""), args: input.args }));
 }
 
-function renderHistory(history: HistoryEntry[]): string {
-  if (history.length === 0) return "";
-  return history
-    .map((h) => `- iter ${h.iter} [${h.decision}] objective=${Number.isNaN(h.objective) ? "n/a" : h.objective.toFixed(3)}: ${h.rationale}`)
+function lastAccepted(attempts: Attempt[]): Attempt | undefined {
+  return [...attempts].reverse().find((a) => a.decision === "accepted");
+}
+
+/** Names of the must-pass graders that failed on at least one input. */
+function failingGraders(scorecard: Scorecard): string[] {
+  const names = scorecard.perInput.flatMap((input) =>
+    input.grades.filter((g) => g.grader.mustPass() && !g.grader.passes(g.grade)).map((g) => g.grader.name()),
+  );
+  return names.filter((name, i) => names.indexOf(name) === i);
+}
+
+function renderHistory(attempts: Attempt[]): string {
+  if (attempts.length === 0) return "";
+  return attempts
+    .map((a) => `- iter ${a.iter} [${a.decision}] objective=${a.objective?.toFixed(3) ?? "n/a"}: ${a.rationale}`)
     .join("\n");
 }

--- a/packages/agency-lang/lib/optimize/optimizer.ts
+++ b/packages/agency-lang/lib/optimize/optimizer.ts
@@ -1,14 +1,28 @@
-import type { OptimizeLoopDeps } from "./loop.js";
-import type { OptimizeLoopConfig, OptimizeResult } from "./types.js";
+import type { AgencyConfig } from "@/config.js";
 
-/**
- * A pluggable optimization strategy. Phase 1 keeps the contract shaped around the existing
- * OptimizeLoopConfig/OptimizeResult; later phases generalize it (graders, inputs) per
- * docs/superpowers/specs/2026-06-17-pluggable-optimizer-framework-design.md.
- */
-export type Optimizer = {
-  readonly name: string;
-  optimize(config: OptimizeLoopConfig, deps?: OptimizeLoopDeps): Promise<OptimizeResult>;
+import type { BaseGrader } from "./grading/baseGrader.js";
+import type { Input } from "./grading/types.js";
+import type { OptimizeResult } from "./types.js";
+
+/** What to optimize: an agent (file[:node]) and the inputs to run it on. */
+export type OptimizeTarget = { agent: string; inputs: Input[] };
+
+/** Cross-cutting config every optimizer needs; each optimizer may extend it. */
+export type BaseOptimizerConfig = {
+  graders: BaseGrader[];
+  iterations: number;
+  seed?: number;
+  config: AgencyConfig;
+  runsDir: string;
+  runId: string;
+  writeback?: boolean;
+  mutatorModel?: string;
 };
 
-export type OptimizerFactory = () => Optimizer;
+/** A pluggable optimization strategy. */
+export type Optimizer = {
+  readonly name: string;
+  optimize(target: OptimizeTarget): Promise<OptimizeResult>;
+};
+
+export type OptimizerFactory = (config: BaseOptimizerConfig) => Optimizer;

--- a/packages/agency-lang/lib/optimize/registry.test.ts
+++ b/packages/agency-lang/lib/optimize/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { BaseOptimizerConfig } from "./optimizer.js";
 import {
   DEFAULT_OPTIMIZER,
   getOptimizer,
@@ -8,14 +9,16 @@ import {
 } from "./registry.js";
 import type { OptimizeResult } from "./types.js";
 
+const config: BaseOptimizerConfig = { graders: [], iterations: 1, config: {}, runsDir: ".", runId: "r" };
+
 describe("optimizer registry", () => {
   it("resolves the built-in greedy optimizer", () => {
-    expect(getOptimizer("greedy").name).toBe("greedy");
+    expect(getOptimizer("greedy", config).name).toBe("greedy");
   });
 
   it("defaults to greedy", () => {
     expect(DEFAULT_OPTIMIZER).toBe("greedy");
-    expect(getOptimizer(DEFAULT_OPTIMIZER).name).toBe("greedy");
+    expect(getOptimizer(DEFAULT_OPTIMIZER, config).name).toBe("greedy");
   });
 
   it("lists registered optimizers", () => {
@@ -23,7 +26,7 @@ describe("optimizer registry", () => {
   });
 
   it("throws a helpful error naming the unknown optimizer and the available ones", () => {
-    expect(() => getOptimizer("nope")).toThrow(/Unknown optimizer "nope".*greedy/);
+    expect(() => getOptimizer("nope", config)).toThrow(/Unknown optimizer "nope".*greedy/);
   });
 
   it("registers and resolves a custom optimizer", () => {
@@ -31,12 +34,12 @@ describe("optimizer registry", () => {
       name: "custom-test",
       optimize: async () => ({}) as OptimizeResult,
     }));
-    expect(getOptimizer("custom-test").name).toBe("custom-test");
+    expect(getOptimizer("custom-test", config).name).toBe("custom-test");
   });
 
   it("treats reserved object keys as unknown optimizers, not prototype lookups", () => {
     for (const reserved of ["__proto__", "constructor", "toString"]) {
-      expect(() => getOptimizer(reserved)).toThrow(/Unknown optimizer/);
+      expect(() => getOptimizer(reserved, config)).toThrow(/Unknown optimizer/);
     }
   });
 });

--- a/packages/agency-lang/lib/optimize/registry.ts
+++ b/packages/agency-lang/lib/optimize/registry.ts
@@ -1,5 +1,5 @@
 import { GreedyReflective } from "./greedyReflective.js";
-import type { Optimizer, OptimizerFactory } from "./optimizer.js";
+import type { BaseOptimizerConfig, Optimizer, OptimizerFactory } from "./optimizer.js";
 
 export const DEFAULT_OPTIMIZER = "greedy";
 
@@ -15,13 +15,13 @@ export function listOptimizers(): string[] {
   return Object.keys(registry).sort();
 }
 
-export function getOptimizer(name: string): Optimizer {
+export function getOptimizer(name: string, config: BaseOptimizerConfig): Optimizer {
   if (!Object.hasOwn(registry, name)) {
     throw new Error(
       `Unknown optimizer "${name}". Available optimizers: ${listOptimizers().join(", ")}.`,
     );
   }
-  return registry[name]();
+  return registry[name](config);
 }
 
-registerOptimizer("greedy", () => new GreedyReflective());
+registerOptimizer("greedy", (config) => new GreedyReflective(config));

--- a/packages/agency-lang/lib/optimize/workspace.test.ts
+++ b/packages/agency-lang/lib/optimize/workspace.test.ts
@@ -46,6 +46,17 @@ describe("WorkspaceManager", () => {
     expect(wsm.fork(src).key).not.toBe(wsm.fork(src).key);
   });
 
+  it("fork skips heavy directories like node_modules", () => {
+    const src = path.join(root, "src");
+    fs.mkdirSync(src);
+    fs.writeFileSync(path.join(src, "agent.agency"), "node main() {}\n");
+    fs.mkdirSync(path.join(src, "node_modules"));
+    fs.writeFileSync(path.join(src, "node_modules", "big.js"), "x");
+    const ws = new WorkspaceManager(path.join(root, "ws")).fork(src);
+    expect(fs.existsSync(path.join(ws.dir, "agent.agency"))).toBe(true);
+    expect(fs.existsSync(path.join(ws.dir, "node_modules"))).toBe(false);
+  });
+
   it("refuses paths that escape the workspace (traversal / absolute)", () => {
     const src = path.join(root, "src");
     fs.mkdirSync(src);

--- a/packages/agency-lang/lib/optimize/workspace.test.ts
+++ b/packages/agency-lang/lib/optimize/workspace.test.ts
@@ -4,12 +4,20 @@ import * as path from "path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { sha256Text, type OptimizeTargetSet } from "./targets.js";
 import { WorkspaceManager } from "./workspace.js";
 
 describe("WorkspaceManager", () => {
   let root: string;
   beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), "wsm-")); });
   afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  const sourceFor = (file: string, source: string, sha: string): OptimizeTargetSet => ({
+    baseDir: root,
+    entryFile: "a.agency",
+    targets: [],
+    files: { "a.agency": { file: "a.agency", absoluteFile: file, source, sha256: sha } },
+  });
 
   it("forks a source dir into an isolated copy; edits do not touch the source", () => {
     const src = path.join(root, "src");
@@ -45,5 +53,23 @@ describe("WorkspaceManager", () => {
     const ws = wsm.fork(src);
     expect(() => wsm.write(ws, "../escape.txt", "x")).toThrow(/escapes the workspace/);
     expect(() => wsm.read(ws, "../../etc/passwd")).toThrow(/escapes the workspace/);
+  });
+
+  it("writeBack writes changed champion files back to source", () => {
+    const file = path.join(root, "a.agency");
+    fs.writeFileSync(file, "original");
+    const wsm = new WorkspaceManager(path.join(root, "ws"));
+    wsm.writeBack(sourceFor(file, "original", sha256Text("original")), { "a.agency": "mutated" });
+    expect(fs.readFileSync(file, "utf8")).toBe("mutated");
+  });
+
+  it("writeBack aborts when a source file changed on disk since discovery", () => {
+    const file = path.join(root, "a.agency");
+    fs.writeFileSync(file, "original");
+    const wsm = new WorkspaceManager(path.join(root, "ws"));
+    // sha recorded at discovery no longer matches the on-disk content
+    expect(() => wsm.writeBack(sourceFor(file, "stale", sha256Text("stale")), { "a.agency": "mutated" }))
+      .toThrow(/modified externally/);
+    expect(fs.readFileSync(file, "utf8")).toBe("original");
   });
 });

--- a/packages/agency-lang/lib/optimize/workspace.ts
+++ b/packages/agency-lang/lib/optimize/workspace.ts
@@ -5,17 +5,23 @@ import { sha256Text, type OptimizeTargetSet } from "./targets.js";
 
 export type Workspace = { dir: string; key: string };
 
+/** Heavy/irrelevant directories never copied into a workspace fork. */
+const FORK_EXCLUDED = ["node_modules", ".git", "dist", "runs", ".worktrees"];
+
 /** Owns per-iteration workspace directories and resolves paths against them. */
 export class WorkspaceManager {
   private counter = 0;
   constructor(private readonly rootDir: string) {}
 
-  /** Copy `sourceDir` into a fresh workspace directory. */
+  /** Copy `sourceDir` into a fresh workspace directory, skipping heavy/irrelevant dirs. */
   fork(sourceDir: string): Workspace {
     this.counter += 1;
     const key = `ws-${this.counter}`;
     const dir = path.join(this.rootDir, key);
-    fs.cpSync(sourceDir, dir, { recursive: true });
+    fs.cpSync(sourceDir, dir, {
+      recursive: true,
+      filter: (src) => path.relative(sourceDir, src) === "" || !FORK_EXCLUDED.includes(path.basename(src)),
+    });
     return { dir, key };
   }
 

--- a/packages/agency-lang/lib/optimize/workspace.ts
+++ b/packages/agency-lang/lib/optimize/workspace.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import { sha256Text, type OptimizeTargetSet } from "./targets.js";
+
 export type Workspace = { dir: string; key: string };
 
 /** Owns per-iteration workspace directories and resolves paths against them. */
@@ -40,5 +42,21 @@ export class WorkspaceManager {
   /** Materialize a file map (e.g. OptimizeSourceMutator.preview().files) into the workspace. */
   applyFiles(ws: Workspace, files: Record<string, string>): void {
     for (const [rel, source] of Object.entries(files)) this.write(ws, rel, source);
+  }
+
+  /**
+   * Write a champion file set back to the original sources, sha-checked: every
+   * discovered file must still match its discovery-time hash, or the whole
+   * writeback aborts (as PR #283). Only changed files are written.
+   */
+  writeBack(source: OptimizeTargetSet, championFiles: Record<string, string>): void {
+    for (const sf of Object.values(source.files)) {
+      if (sha256Text(fs.readFileSync(sf.absoluteFile, "utf8")) !== sf.sha256) {
+        throw new Error(`Source file ${sf.absoluteFile} was modified externally; writeback aborted.`);
+      }
+    }
+    for (const [rel, contents] of Object.entries(championFiles)) {
+      if (contents !== source.files[rel]?.source) fs.writeFileSync(source.files[rel].absoluteFile, contents);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Phase 3B — the deferred **behavior change**: `greedy` now accepts a candidate when its
**pointwise objective improves and all gates pass**, instead of when the pairwise `judgeSuite`
declares it the winner.

- **Target-based `Optimizer` contract** — `optimize(target)` where `target = { agent, inputs }`; the registry builds optimizers from a `BaseOptimizerConfig` (graders, iterations, runsDir/runId, writeback).
- **`BaseOptimizer.evaluate()`** — runs the agent once per input (memoized by `EvalCache`) and grades each output into a `Scorecard`; gates run first and short-circuit. `runAgent` uses the **eval-run subprocess path** (named args, via `evalRunLoadedTasks`) and reads the answer from `EvalRecord.evalOutputs` — see "Design note" below.
- **`GreedyReflective`** — fork champion → `proposeMutation` → `OptimizeSourceMutator.preview` → `applyFiles` → `evaluate` → accept iff gates pass and objective improves. sha-checked writeback retained.
- **CLI desugaring** — `--goal`/`--tasks` become `Input[]` (goal carried in `metadata.goal`) plus a single bundled goal judge (`lib/agents/goalJudge.agency`, 0–1 score) as an `LlmJudge` grader.

## Design note (deviation from the plan, confirmed with the author)

The plan's `runAgent` called `AgencyRunner.run(positionalArgs)`. In reality the agent under test is invoked with **named** args via the eval-run subprocess bootstrap — turning optimize inputs positional would require parsing each node's parameter order. So `runAgent` reuses `evalRunLoadedTasks` (named args, produces eval records, reuses tested infra). `AgencyRunner` positional is still used for judges/proposers, where we control the arg order.

The pairwise `optimizeLoop`/`judgeSuite` remain in the tree (now unused by greedy) and can be removed in a follow-up.

## Test Plan

- [x] `pnpm test:run lib/optimize lib/cli/eval lib/cli/util.test.ts` — 199 passed across 25 files.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm run lint:structure` — clean.
- [x] `lib/agents/goalJudge.agency` compiles.
- **Coverage note:** the loop logic, evaluate/gates/scoring, greedy accept/reject, and CLI desugaring are unit-tested with **injected runners** (no LLM). The new `runInputViaEval` glue composes already-tested pieces (`evalRunLoadedTasks`, eval-record reading) but is **not exercised by a full live optimize run** here, since that needs LLM calls for the goal judge. Recommend a manual/CI live `agency eval optimize <agent> --goal ... --optimizer greedy` as the end-to-end validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
