### PR TITLE
Fix two pre-existing CI failures on main

### DIFF
--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -351,7 +351,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
       },
     );
 
-  // Registered under both `agency eval optimize` and the top-level `agency optimize`.
+  // Registered under `agency eval optimize` only; the legacy top-level
+  // `agency optimize` command has been removed.
   const addOptimizeCommand = (parent: Command): void => {
     parent
     .command("optimize")
@@ -395,7 +396,6 @@ export function createProgram(deps: CliDependencies = {}): Command {
     });
   };
   addOptimizeCommand(evalCmd);
-  addOptimizeCommand(program);
 
   program
     .command("format")

--- a/packages/agency-lang/tests/agency/llm-mock-scoping.agency
+++ b/packages/agency-lang/tests/agency/llm-mock-scoping.agency
@@ -1,4 +1,4 @@
-import { mutatePrompt } from "../../lib/agents/mutatePrompt.agency"
+import { mutatePrompt } from "../../lib/agents/optimize/mutatePrompt.agency"
 
 // Scoped-mock routing test. Each queue holds exactly one mock, so this
 // only passes when BOTH llm() calls draw from their own module's queue:

--- a/packages/agency-lang/tests/agency/optimize-mutator.agency
+++ b/packages/agency-lang/tests/agency/optimize-mutator.agency
@@ -1,4 +1,4 @@
-import node { mutatePrompt } from "../../lib/agents/mutatePrompt.agency"
+import node { mutatePrompt } from "../../lib/agents/optimize/mutatePrompt.agency"
 
 type OptimizeMutationOperation = {
   target: string;


### PR DESCRIPTION
## Summary

Fixes two CI failures on `main`. **Both pre-existed at `605888dd`** (the base the inputs-terminology PR branched from) and are unrelated to the tasks→inputs rename — they were just never caught locally because the `scripts/agency.test.ts` unit test and the agency execution fixtures only run in CI, and surfaced when #309 merged.

### 1. `scripts/agency.test.ts` — top-level `optimize` command

The test `exposes eval optimize and not the legacy top-level optimize command` asserts the top-level command tree has no `optimize`, but `addOptimizeCommand` was still registered on both `program` (top-level) and `evalCmd`. Dropped the top-level registration so `optimize` lives only under `agency eval optimize`, matching the test's intent; updated the stale comment.

### 2. `mutatePrompt.agency` import path in two fixtures

`tests/agency/optimize-mutator.agency` and `tests/agency/llm-mock-scoping.agency` imported `../../lib/agents/mutatePrompt.agency`, but the bundled agent lives at `lib/agents/optimize/mutatePrompt.agency` (the path `lib/optimize/mutator.ts` actually resolves). Fixed both imports → resolves the `Input file ... mutatePrompt.agency not found` error in the real-LLM job. The deterministic mock key is the basename `mutatePrompt`, so scoping is unaffected.

## Testing

- `make` (tsc) clean, `pnpm run lint:structure` clean.
- `scripts/agency.test.ts` passes (5 tests).
- `tests/agency/optimize-mutator.agency` and `tests/agency/llm-mock-scoping.agency` pass (deterministic mocks, no real LLM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
