### PR TITLE
Esc cancels the in-flight request in the agent REPL

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2548,6 +2548,13 @@ export class TypeScriptBuilder {
             ts.raw("__error instanceof GuardExceededError"),
             ts.statements([ts.throw("__error")]),
           ),
+          // A cancellation (Esc / abort) must propagate untouched rather
+          // than be logged + converted to a Failure here. Mirrors the
+          // function catch template.
+          ts.if(
+            ts.raw("__isAbortError(__error)"),
+            ts.statements([ts.throw("__error")]),
+          ),
           // Surface the underlying exception via logger + statelog
           // before converting to a Failure. Mirrors the function catch
           // template; see the recordAlwaysScoped bug in

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -77,5 +77,12 @@ export function isAbortError(error: unknown): boolean {
   if (error instanceof AgencyCancelledError) return true;
   if (error instanceof DOMException && error.name === "AbortError") return true;
   if (error instanceof Error && error.name === "AbortError") return true;
+  // Name-based fallback: `instanceof` fails when the error and this check
+  // resolve `AgencyCancelledError` from two different module instances
+  // (e.g. the spawned agent process under the resolver shim). The name is
+  // identity-independent, so a cancellation is still recognized as one.
+  if (error instanceof Error && error.name === "AgencyCancelledError") {
+    return true;
+  }
   return false;
 }

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -229,6 +229,19 @@ async function _runPrompt({
       stream,
     }));
   } catch (err) {
+    // Cancellation normalization. When WE aborted the request (user pressed
+    // Esc → ctx.cancel(), a race loser, a timeout), the provider SDK
+    // surfaces its OWN abort error — e.g. Anthropic throws a plain
+    // `Error("Request was aborted.")` whose name isn't "AbortError", so
+    // `isAbortError` can't recognize it by identity. Our cancellation state
+    // is authoritative: if the call threw while we're cancelled, it's a
+    // cancellation. Normalize to AgencyCancelledError so the rest of the
+    // runtime (function/node catches re-throw it, the REPL prints
+    // "cancelled") handles it as one — and skip the llmError log below,
+    // since a user cancel isn't a request failure worth recording.
+    if (ctx.isCancelled(stateStack) || isAbortError(err)) {
+      throw new AgencyCancelledError();
+    }
     // The success-path `promptCompletion` event below is the only place the
     // request payload (messages + tools) is logged, and it never runs when
     // the dispatch throws — so a provider rejection (e.g. a 400 over the
@@ -352,6 +365,30 @@ async function _runPrompt({
   });
 
   return { messages, toolCalls };
+}
+
+/**
+ * Leave a thread in a role-valid state after a hard cancellation
+ * (AgencyCancelledError / abort). A cancel can land mid-tool-round, so the
+ * thread may end on an assistant turn with unanswered `tool_calls` — which
+ * some providers reject on the next call. Truncate back to this turn's user
+ * message (within one runPrompt only assistant/tool messages follow it) and
+ * append a neutral marker so the next call sees the interruption and the
+ * thread alternates cleanly. `messages` is the live, persisted MessageThread
+ * (see agencyLlm.llm), so this repair sticks for the next turn.
+ */
+function markThreadCancelled(messages: MessageThread): void {
+  const all = messages.getMessages();
+  let lastUser = -1;
+  for (let i = all.length - 1; i >= 0; i--) {
+    if (all[i].role === "user") {
+      lastUser = i;
+      break;
+    }
+  }
+  const kept = lastUser >= 0 ? all.slice(0, lastUser + 1) : all.slice();
+  kept.push(smoltalk.assistantMessage("[Response cancelled.]"));
+  messages.setMessages(kept);
 }
 
 // eslint-disable-next-line max-lines-per-function -- core prompt execution loop; refactor tracked separately
@@ -1052,7 +1089,13 @@ export async function runPrompt(args: {
       shouldPop = false;
       return error.interrupts;
     }
-    if (isAbortError(error)) throw error;
+    if (isAbortError(error)) {
+      // Hard cancel (e.g. user pressed Esc): repair the live thread so the
+      // next turn starts from a clean, role-valid state, then re-throw so
+      // the cancellation still propagates to the caller / REPL.
+      markThreadCancelled(messages);
+      throw error;
+    }
     throw error;
   } finally {
     // Close any open llmCall span. This covers normal completion,

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -520,6 +520,18 @@ export class RuntimeContext<T> {
     }
   }
 
+  /**
+   * Swap in a fresh AbortController after a user-initiated cancel so the
+   * NEXT unit of work isn't immediately aborted. The REPL calls this once
+   * it has caught the AgencyCancelledError from a cancelled turn and is
+   * about to accept the next prompt. Safe only when nothing is in flight
+   * (the cancelled turn has fully unwound) — otherwise an in-flight call
+   * would keep a reference to the old, now-orphaned signal.
+   */
+  resetCancel(): void {
+    this.abortController = new AbortController();
+  }
+
   forkStack(): StateStack {
     return new StateStack();
   }

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -13,6 +13,7 @@ import { modifiers, RESET, styles } from "@/utils/termcolors.js"
 import { color, colors, bgColors } from "../utils/termcolors.js";
 import { _promptsAutocomplete } from "./ui.js";
 import { isFailure } from "../runtime/result.js";
+import { isAbortError } from "../runtime/errors.js";
 // ---------------------------------------------------------------------------
 // TS bridge for `std::cli` — the line-mode REPL.
 //
@@ -407,6 +408,58 @@ function installSlashTrigger(
 }
 
 /**
+ * While a turn is in flight, intercept a bare Esc keypress and invoke
+ * `onEscape` (which cancels the current request). Other keys pass through
+ * to readline as usual, so type-ahead still works. Returns a teardown that
+ * restores the original `_ttyWrite`; the caller MUST call it once the turn
+ * settles so idle-prompt Esc behaves normally again. No-op on non-TTY.
+ *
+ * Only a bare Esc fires: readline parses Esc to `key.name === "escape"`,
+ * while arrow keys and other escape sequences parse to their own names
+ * (`up`, `down`, ...), so they don't trip the cancel.
+ */
+function installCancelKey(
+  rl: readline.Interface,
+  useTTY: boolean,
+  onEscape: () => void,
+): () => void {
+  if (!useTTY) return () => { };
+  const rlAny = rl as unknown as {
+    _ttyWrite: (s: unknown, key: { name?: string; sequence?: string }) => void;
+  };
+  const originalTtyWrite = rlAny._ttyWrite;
+  rlAny._ttyWrite = function (
+    this: typeof rlAny,
+    s: unknown,
+    key: { name?: string; sequence?: string },
+  ): void {
+    if (key && key.name === "escape") {
+      onEscape();
+      return;
+    }
+    originalTtyWrite.call(this, s, key);
+  };
+  return (): void => {
+    rlAny._ttyWrite = originalTtyWrite;
+  };
+}
+
+/** Safely fetch the active RuntimeContext, or null when none is bound
+ *  (e.g. tests drive `_runLineRepl` without a runtime). */
+function activeCtxOrNull(): {
+  cancel: (r?: string) => void;
+  resetCancel: () => void;
+  readonly aborted: boolean;
+} | null {
+  try {
+    const { ctx } = getRuntimeContext();
+    return (ctx as any) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Snapshot of the per-turn stats `_runLineRepl` collects before
  * calling `onSubmit` and after it returns. `printFooter` projects the
  * delta into the footer so the user can see at a glance how many
@@ -534,6 +587,13 @@ export async function _runLineRepl(
     history: initialHistory,
     historySize: historyMax,
     removeHistoryDuplicates: true,
+    // A lone Esc is ambiguous (it's also the lead byte of escape sequences
+    // like arrow keys), so readline waits `escapeCodeTimeout` ms before
+    // delivering it as the `escape` key. The 500ms default made Esc-to-
+    // cancel feel laggy (~1s). 50ms keeps cancellation snappy while still
+    // leaving ample time for a real escape sequence's bytes — which arrive
+    // in one burst on a local TTY — to be parsed as a sequence.
+    escapeCodeTimeout: 50,
     // Tab completion fallback for the slash-command palette.
     // Submitting a bare `/` opens the `prompts.autocomplete` picker
     // (see `openSlashPalette`); the completer is the "Tab to fill"
@@ -667,16 +727,37 @@ export async function _runLineRepl(
       const tokensBefore = readTokenSnapshot();
       activeStopSpinner = startSpinner(useTTY);
 
+      // Esc cancels the in-flight request. The watcher calls `ctx.cancel`,
+      // which aborts the active LLM fetch; an AgencyCancelledError then
+      // propagates out of `onSubmit` and is caught below. Torn down in the
+      // `finally` so idle-prompt Esc is unaffected.
+      const turnCtx = activeCtxOrNull();
+      const teardownCancelKey = installCancelKey(rl, useTTY, () => {
+        // Stop the spinner the instant Esc is pressed so the user gets
+        // immediate feedback, then abort the in-flight request. The
+        // AgencyCancelledError propagates out and the catch below prints
+        // "cancelled".
+        stopActiveSpinner();
+        turnCtx?.cancel("cancelled by user");
+      });
+
       try {
         reply = await callBridgeFn(onSubmit, line);
       } catch (err: any) {
         stopActiveSpinner();
-        const msg = err?.message ?? String(err);
-        process.stdout.write(`Error: ${msg}\n`);
-        // Still print the footer on error so the user sees how long
-        // the failed turn ran and whether tokens flowed. Useful when
-        // the turn died after a partial LLM response.
         const tokensAfter = readTokenSnapshot();
+        if (isAbortError(err)) {
+          // User pressed Esc: the turn was cancelled, not a real failure.
+          // The thread was already repaired in runPrompt; the abort
+          // controller is reset in the `finally` below. Just print a
+          // notice and reprompt.
+          process.stdout.write(`${DIM}cancelled${COLOR_RESET}\n`);
+        } else {
+          const msg = err?.message ?? String(err);
+          process.stdout.write(`Error: ${msg}\n`);
+        }
+        // Still print the footer so the user sees how long the turn ran
+        // and whether tokens flowed (useful on both cancel and error).
         await printFooter(status, useColor, {
           elapsedMs: Date.now() - turnStartMs,
           inputTokens: tokensAfter.inputTokens - tokensBefore.inputTokens,
@@ -684,6 +765,14 @@ export async function _runLineRepl(
           model: tokensAfter.model,
         });
         continue;
+      } finally {
+        teardownCancelKey();
+        // Reset the abort controller whenever this turn left it aborted —
+        // covers both the cancelled-with-error path above AND the race
+        // where Esc fired but the turn finished before hitting a
+        // cancellation checkpoint. Without this, the next turn's first LLM
+        // call would see an already-aborted signal and fail immediately.
+        if (turnCtx?.aborted) turnCtx.resetCancel();
       }
       stopActiveSpinner();
       if (reply === false) break;

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
@@ -9,6 +9,15 @@ if (__error instanceof RestoreSignal) {
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
@@ -14,6 +14,15 @@ export const template = `if (__error instanceof RestoreSignal) {
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -21,6 +21,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -218,6 +219,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -17,6 +17,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -231,6 +232,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -384,6 +394,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -520,6 +539,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -229,6 +230,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -269,6 +270,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -218,6 +219,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -237,6 +238,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -394,6 +404,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -229,6 +230,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -238,6 +239,15 @@ if (hasInterrupts(__funcResult)) {
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -396,6 +406,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -242,6 +243,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -377,6 +387,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -226,6 +227,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -361,6 +371,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -215,6 +216,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -248,6 +249,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -410,6 +420,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -259,6 +260,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -432,6 +442,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -233,6 +234,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -234,6 +235,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -390,6 +400,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -244,6 +245,15 @@ if (hasInterrupts(__funcResult)) {
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -230,6 +231,15 @@ await callHook({
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -368,6 +378,15 @@ await callHook({
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before
@@ -509,6 +528,15 @@ await callHook({
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -647,6 +675,15 @@ await callHook({
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -765,6 +802,15 @@ await callHook({
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -221,6 +222,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -236,6 +237,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -220,6 +221,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -259,6 +260,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -410,6 +420,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -251,6 +252,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -404,6 +414,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -543,6 +562,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -222,6 +223,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -292,6 +293,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -432,6 +442,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -355,6 +356,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -512,6 +522,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -239,6 +240,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -292,6 +293,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -432,6 +442,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -272,6 +273,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -252,6 +253,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -411,6 +421,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before
@@ -574,6 +593,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -735,6 +763,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -890,6 +927,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -1018,6 +1064,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {
@@ -1157,6 +1206,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -217,6 +218,15 @@ __stack.locals.foo = 1;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -353,6 +363,15 @@ await callHook({
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -483,6 +502,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -226,6 +227,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -362,6 +372,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before
@@ -522,6 +541,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -666,6 +694,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -243,6 +244,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -380,6 +390,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -211,6 +212,9 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
+    if (__isAbortError(__error)) {
+      throw __error
+    }
     {
               const __errMsg = __error instanceof Error ? __error.message : String(__error);
               const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
@@ -285,6 +289,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -214,6 +215,9 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
+    if (__isAbortError(__error)) {
+      throw __error
+    }
     {
               const __errMsg = __error instanceof Error ? __error.message : String(__error);
               const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
@@ -290,6 +294,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -233,6 +234,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -376,6 +377,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -31,6 +31,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -248,6 +249,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -410,6 +420,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -254,6 +255,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -420,6 +430,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -246,6 +247,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -232,6 +233,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -273,6 +274,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -457,6 +467,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -639,6 +658,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -268,6 +269,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -273,6 +274,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -439,6 +449,9 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
+    if (__isAbortError(__error)) {
+      throw __error
+    }
     {
               const __errMsg = __error instanceof Error ? __error.message : String(__error);
               const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
@@ -536,6 +549,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -260,6 +261,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -447,6 +448,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -220,6 +221,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -229,6 +230,9 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
+    if (__isAbortError(__error)) {
+      throw __error
+    }
     {
               const __errMsg = __error instanceof Error ? __error.message : String(__error);
               const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
@@ -332,6 +336,9 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
+    if (__isAbortError(__error)) {
+      throw __error
+    }
     {
               const __errMsg = __error instanceof Error ? __error.message : String(__error);
               const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
@@ -406,6 +413,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -251,6 +252,15 @@ if (hasInterrupts(__funcResult)) {
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -238,6 +239,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -422,6 +432,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -229,6 +230,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -232,6 +233,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -244,6 +245,15 @@ if (hasInterrupts(__funcResult)) {
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -226,6 +227,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -368,6 +378,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before
@@ -532,6 +551,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before
@@ -704,6 +732,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -238,6 +239,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -238,6 +239,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -238,6 +239,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -205,6 +206,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -228,6 +229,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -17,6 +17,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -220,6 +221,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -240,6 +241,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -384,6 +394,15 @@ return;
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before
@@ -638,6 +657,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -17,6 +17,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -236,6 +237,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -229,6 +230,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -218,6 +219,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -222,6 +223,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -207,6 +208,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -243,6 +244,15 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -374,6 +384,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -222,6 +223,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -268,6 +269,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -198,6 +199,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -237,6 +238,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -379,6 +380,15 @@ if (hasInterrupts(__funcResult)) {
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -675,6 +685,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -266,6 +267,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -234,6 +235,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -264,6 +265,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -236,6 +237,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -234,6 +235,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -223,6 +224,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -238,6 +239,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -238,6 +239,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -240,6 +241,15 @@ if (hasInterrupts(__funcResult)) {
 // the trip and every guarded block would appear to succeed even
 // over budget. See lib/runtime/guard.ts.
 if (__error instanceof GuardExceededError) {
+  throw __error;
+}
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
   throw __error;
 }
 // Surface the underlying exception via logger + statelog before

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -255,6 +256,15 @@ if (__response) {
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// A cancellation (user pressed Esc / an abort fired) must propagate
+// untouched: converting it to a Failure here would (a) let the agent
+// limp onward through more soon-to-abort calls instead of stopping
+// promptly, and (b) surface the abort as a logged ERROR + a Failure the
+// REPL can't recognize as a cancel. The runtime is built to propagate
+// AgencyCancelledError (see prompt.ts / hooks.ts / result.ts); honor that.
+if (__isAbortError(__error)) {
+  throw __error;
+}
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
 // inspect the result (the common case for void side-effect calls)
@@ -379,6 +389,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -16,6 +16,7 @@ import {
   rewindFrom as _rewindFrom,
   RestoreSignal,
   GuardExceededError,
+  isAbortError as __isAbortError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
@@ -232,6 +233,9 @@ await callHook({
       throw __error
     }
     if (__error instanceof GuardExceededError) {
+      throw __error
+    }
+    if (__isAbortError(__error)) {
       throw __error
     }
     {


### PR DESCRIPTION
## What

Pressing <kbd>Esc</kbd> during a turn in the agency agent now **cancels the in-flight request**, prints `cancelled`, and returns you to the prompt — instead of forcing you to wait for the LLM call to finish.

## How

```text
Esc → ctx.cancel() (spinner stops at once) → in-flight LLM fetch aborts
   → _runPrompt: thrown while cancelled → AgencyCancelledError
   → runPrompt: repair the live thread, re-throw
   → per-function/node catch: re-throw (don't convert to Failure)
   → REPL catch: print "cancelled", reset AbortController, reprompt
```

- **`lib/stdlib/cli.ts`** — a turn-scoped Esc watcher (the same `_ttyWrite` hijack `/paste` uses) calls `ctx.cancel()` and stops the spinner immediately. `escapeCodeTimeout` is lowered to **50ms** so a lone Esc registers promptly (the 500ms default made cancel feel ~1s laggy). The turn's `catch` recognizes the cancel, prints `cancelled`, and the `finally` resets the abort controller so the next turn starts clean.
- **`lib/runtime/state/context.ts`** — `resetCancel()` swaps in a fresh `AbortController` after a user-initiated cancel (otherwise the next turn's first LLM call sees an already-aborted signal).
- **`lib/runtime/prompt.ts`** — when an LLM dispatch throws *while we're cancelled*, normalize the provider's own abort error (e.g. Anthropic throws a plain `Error("Request was aborted")`) to `AgencyCancelledError`. `markThreadCancelled()` repairs the live thread — truncate the partial round back to the turn's user message and append a `[Response cancelled.]` marker — so the next turn starts role-valid (no dangling `tool_calls`).
- **`lib/runtime/errors.ts`** — `isAbortError` also matches by `name === "AgencyCancelledError"`, so a cancellation thrown from a different module instance is still recognized.
- **Codegen** (`functionCatchFailure` template + the `typescriptBuilder` node catch) — re-throw a cancellation (`isAbortError`) instead of logging it and converting it to a `Failure`. The runtime is built to propagate `AgencyCancelledError` (prompt.ts / hooks.ts / result.ts); the per-function catch was the one place that swallowed it — which is what caused both the lag (the agent limped onward through converted failures) and a leaked `ERROR … converted to Failure` dump. Regenerated codegen fixtures (86 files).

## History handling

The cancelled exchange is **kept, marked interrupted** (`[Response cancelled.]`) so the model knows it was cut off and the thread stays valid. Double-Esc (rewind) is intentionally out of scope for now.

## Testing

- `pnpm run build` clean; 340 unit tests pass across `lib/backends` (codegen fixtures), `lib/runtime` (prompt/context/errors), and `lib/stdlib/cli`.
- Deterministic checks confirmed `resetCancel()` clears the aborted state, the thread repair drops a dangling tool-call round and appends the marker, and the abort normalization recognizes provider errors via our cancellation state.
- The actual Esc keypress in a live TTY is terminal behavior (not CI-testable, like the prior raw-mode fix) — verified manually: Esc now cancels near-instantly with a dim `cancelled` line and no error output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
