### PR TITLE
Esc at the approval menu cancels the request

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -641,7 +641,7 @@ _handler(intr: any): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L775))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L779))
 
 ### cliPolicyHandler
 
@@ -722,4 +722,4 @@ CLI sugar for an interactive policy handler. Owns load + save +
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L897))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L902))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -597,7 +597,7 @@ Line-mode arrow-key picker, backed by the `prompts` package. Returns
 ### autocomplete
 
 ```ts
-autocomplete(message: string, items: ChoiceItem[], allowFreeText: boolean, hint: string): Result<string>
+autocomplete(message: string, items: ChoiceItem[], allowFreeText: boolean, hint: string, cancelOnEscape: boolean): Result<string>
 ```
 
 Line-mode type-to-filter picker, backed by `prompts.autocomplete`.
@@ -615,6 +615,10 @@ Line-mode type-to-filter picker, backed by `prompts.autocomplete`.
   @param items - The {key, label} rows
   @param allowFreeText - Allow returning the typed input verbatim when no item matches
   @param hint - Dim hint shown after the message
+  @param cancelOnEscape - When true, pressing Escape raises a cancellation
+    (AgencyCancelledError) that unwinds the current run instead of
+    returning `failure("cancelled")`. Use for prompts where Escape should
+    abort the whole request rather than be re-asked.
 
 **Parameters:**
 
@@ -624,6 +628,7 @@ Line-mode type-to-filter picker, backed by `prompts.autocomplete`.
 | items | `ChoiceItem[]` |  |
 | allowFreeText | `boolean` | false |
 | hint | `string` | "" |
+| cancelOnEscape | `boolean` | false |
 
 **Returns:** `Result<string>`
 
@@ -667,7 +672,7 @@ Line-mode free-form text prompt, backed by `prompts.text`. Returns
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1068))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1073))
 
 ### confirm
 
@@ -693,12 +698,12 @@ Line-mode yes/no toggle, backed by `prompts.toggle`. Returns
 
 **Returns:** `Result<boolean>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1099))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1104))
 
 ### chooseOption
 
 ```ts
-chooseOption(title: string, body: string, items: ChoiceItem[], allowFreeText: boolean): string
+chooseOption(title: string, body: string, items: ChoiceItem[], allowFreeText: boolean, allowCancel: boolean): string
 ```
 
 Show a modal choice prompt over the active repl() and block until
@@ -725,6 +730,10 @@ Show a modal choice prompt over the active repl() and block until
   @param body - Multi-line context shown above the choices (or "")
   @param items - The set of {key, label} choices to pick from
   @param allowFreeText - Accept free-form text in addition to item keys
+  @param allowCancel - When true, Escape cancels the whole request
+    (raises a cancellation that unwinds the run) instead of re-prompting,
+    and the menu shows an "Esc to cancel" hint. Default false preserves
+    the "must answer" contract for callers where skipping isn't safe.
 
 **Parameters:**
 
@@ -734,10 +743,11 @@ Show a modal choice prompt over the active repl() and block until
 | body | `string` |  |
 | items | `ChoiceItem[]` |  |
 | allowFreeText | `boolean` | false |
+| allowCancel | `boolean` | false |
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1140))
 
 ### repl
 
@@ -779,4 +789,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1890))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1909))

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -689,6 +689,16 @@ export async function runPrompt(args: {
           )
           : await invokeAsTool();
       } catch (error: unknown) {
+        // A cancellation (user pressed Esc, race-loser, timeout) is not a
+        // tool crash. Let it propagate so the turn unwinds cleanly —
+        // logging it as an error and feeding a bogus failure message back
+        // to the model (as the crash path below does) would both spam
+        // "Tool call X crashed" for every tool on the stack and corrupt
+        // the thread. Mirrors the function/node catch re-throws.
+        if (isAbortError(error)) {
+          stack.deleteBranch(branchKey);
+          throw error;
+        }
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         console.error(

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -15,6 +15,7 @@ import { withBottomCursor, installRegion, resetRegion } from "./ui-region.js";
 import { __call } from "../runtime/call.js";
 import { __ctx } from "../runtime/asyncContext.js";
 import { isFailure, success, failure } from "../runtime/result.js";
+import { AgencyCancelledError } from "../runtime/errors.js";
 import prompts from "prompts";
 import { color } from "@/utils/termcolors.js";
 
@@ -841,6 +842,7 @@ export async function _promptsAutocomplete(
   items: PromptsChoiceItem[],
   allowFreeText: boolean,
   hint: string = "",
+  cancelOnEscape: boolean = false,
 ): Promise<any> {
   _assertLineModeAvailable("autocomplete");
   const result = await _runPrompt({
@@ -851,7 +853,18 @@ export async function _promptsAutocomplete(
     choices: items.map((it) => ({ title: `${color.cyan(it.key)} - ${it.label}`, value: it.key })),
     suggest: _buildSuggest(items, allowFreeText),
   });
-  if (isFailure(result)) return result;
+  if (isFailure(result)) {
+    // When the caller opts in (e.g. a policy approval menu), Escape means
+    // "cancel the whole request" rather than "re-prompt". Escalate the
+    // cancellation to AgencyCancelledError: __tryCall and the generated
+    // function catches both re-throw it, so it unwinds to the REPL exactly
+    // like an Esc during the thinking phase. (Ctrl+C still exits the
+    // process inside _runPrompt before we get here.)
+    if (cancelOnEscape) {
+      throw new AgencyCancelledError("cancelled by user");
+    }
+    return result;
+  }
 
   const raw = String(result.value);
   if (raw.startsWith(AUTOCOMPLETE_FREE_TEXT_PREFIX)) {

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -735,8 +735,12 @@ def askUser(intr: any): AskUserResult {
     label: "reject always"
   })
 
+  // `allowCancel: true` makes Escape cancel the whole request (raises a
+  // cancellation that unwinds the turn back to the REPL prompt) instead of
+  // re-prompting. Rejecting a single action (and optionally telling the
+  // agent what to do instead) is still available via the "r" option.
   const answer = withLock("std::tty") as {
-    return chooseOption(title, body, items, allowFreeText: true)
+    return chooseOption(title, body, items, allowFreeText: true, allowCancel: true)
   }
   match(answer) {
     "a" => return {
@@ -834,9 +838,10 @@ export def _handler(intr: any): any {
     return reject(answer.reason)
   }
 
-  // Interactive reject (user picked "r"): ask for an optional reason
-  // so the LLM sees concrete feedback as the tool's return value.
-  const reason = input("Why are you rejecting? (press enter to skip) ")
+  // Interactive reject (user picked "r"): ask for optional guidance so
+  // the LLM sees concrete feedback as the tool's return value and the
+  // agent can course-correct without ending the turn.
+  const reason = input("What should the agent do instead? (press enter to skip) ")
   if (reason == "") {
     return reject()
   }

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -1044,6 +1044,7 @@ export def autocomplete(
   items: ChoiceItem[],
   allowFreeText: boolean = false,
   hint: string = "",
+  cancelOnEscape: boolean = false,
 ): Result<string> {
   """
   Line-mode type-to-filter picker, backed by `prompts.autocomplete`.
@@ -1061,8 +1062,12 @@ export def autocomplete(
   @param items - The {key, label} rows
   @param allowFreeText - Allow returning the typed input verbatim when no item matches
   @param hint - Dim hint shown after the message
+  @param cancelOnEscape - When true, pressing Escape raises a cancellation
+    (AgencyCancelledError) that unwinds the current run instead of
+    returning `failure("cancelled")`. Use for prompts where Escape should
+    abort the whole request rather than be re-asked.
   """
-  return _promptsAutocomplete(message, items, allowFreeText, hint)
+  return _promptsAutocomplete(message, items, allowFreeText, hint, cancelOnEscape)
 }
 
 export def prompt(
@@ -1137,6 +1142,7 @@ export def chooseOption(
   body: string,
   items: ChoiceItem[],
   allowFreeText: boolean = false,
+  allowCancel: boolean = false,
 ): string {
   """
   Show a modal choice prompt over the active repl() and block until
@@ -1163,6 +1169,10 @@ export def chooseOption(
   @param body - Multi-line context shown above the choices (or "")
   @param items - The set of {key, label} choices to pick from
   @param allowFreeText - Accept free-form text in addition to item keys
+  @param allowCancel - When true, Escape cancels the whole request
+    (raises a cancellation that unwinds the run) instead of re-prompting,
+    and the menu shows an "Esc to cancel" hint. Default false preserves
+    the "must answer" contract for callers where skipping isn't safe.
   """
   if (_activeRepl != null) {
     return _openChoicePrompt(
@@ -1224,11 +1234,20 @@ export def chooseOption(
     print(indent(body))
   }
   print("\n")
+  let cancelHint = ""
+  if (allowCancel) {
+    cancelHint = "Esc to cancel"
+  }
   while (true) {
+    // With `allowCancel`, autocomplete raises a cancellation on Escape
+    // (it never returns failure("cancelled") here), so the re-prompt loop
+    // below only runs for the must-answer callers.
     const result = autocomplete(
       message: "Do you want to continue?",
       items: items,
       allowFreeText: allowFreeText,
+      hint: cancelHint,
+      cancelOnEscape: allowCancel,
     )
     if (!isFailure(result)) {
       return result.value


### PR DESCRIPTION
## What

Pressing <kbd>Esc</kbd> on the interrupt-approval menu (`a / r / aa / ap / rr`) now **cancels the whole request** and returns you to the prompt — instead of re-showing the menu with `(answer required)`, which was a dead end.

This makes Esc mean the same thing everywhere in the agent: **cancel the current request**. (The thinking-phase Esc-cancel shipped previously; this extends it to the approval menu.)

Rejecting a *single* action — and optionally telling the agent what to do instead, **without ending the turn** — is still available via **`r` (reject once)**, whose prompt is now the forward-looking *"What should the agent do instead?"*. So the two are complementary:

| Input | Meaning |
|-------|---------|
| `r` | reject this action, give optional guidance, agent **continues** |
| `Esc` | **cancel** the whole request, back to the prompt |

After an Esc-cancel the thread history is preserved (the partial turn is truncated and marked `[Response cancelled.]`), so your next message — a redirection or a brand-new topic — still has full context.

## How

```text
Esc at menu → autocomplete raises AgencyCancelledError (cancelOnEscape)
   → __tryCall / generated function-catch re-throw it
   → runHandlerChain propagates it (try/finally)
   → tool-loop → runPrompt catch: markThreadCancelled, re-throw
   → REPL: print "cancelled", back to prompt
```

- **`lib/stdlib/ui.ts` + `stdlib/ui.agency`** — `autocomplete` / `chooseOption` gain a `cancelOnEscape` / `allowCancel` option. When set, Esc raises `AgencyCancelledError` instead of returning `failure("cancelled")` and re-prompting, reusing the exact unwind path as the thinking-phase Esc-cancel. The menu shows an `Esc to cancel` hint. Default is `false`, preserving the "must answer" contract for other callers (slash palette, etc.).
- **`stdlib/policy.agency`** — the approval menu passes `allowCancel: true`. Cancelling is safe: Esc can only ever lead to an unwind, never an approval. Reworded the `r` reason prompt to "What should the agent do instead?".

## Testing

- `pnpm run build` + `make stdlib` clean; `lib/stdlib/ui` vitest (28) and the policy agency-js tests (`cli-policy-handler`, `policy-prompt-array-data`, `ui-policy-integration`) all pass — the menu's normal/free-text/non-TTY paths are unchanged.
- Confirmed the compiled stdlib re-throws cancellation through every layer (`__isAbortError` in `ui.js`/`policy.js`) and that `_promptsAutocomplete` throws on `cancelOnEscape`.
- The actual Esc keypress is terminal-only behavior (the menu requires a TTY, so it can't be unit-tested — same as the prior Esc work). Worth a quick manual confirm: Esc on the approval menu should print `cancelled` and drop you back at the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
