### PR TITLE
Roll subagent (tool-dispatch) LLM cost up to the parent stack

### DIFF
--- a/packages/agency-lang/lib/runtime/promptRunner.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.ts
@@ -3,7 +3,12 @@ import { hasInterrupts, type Interrupt } from "./interrupts.js";
 import { runBatch, type RunBatchResult } from "./runBatch.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
-import type { State, StateStack } from "./state/stateStack.js";
+import {
+  seedBranchCost,
+  propagateBranchCost,
+  type State,
+  type StateStack,
+} from "./state/stateStack.js";
 
 /**
  * Thrown by {@link PromptRunner.step} when a step body returns interrupts.
@@ -205,6 +210,18 @@ export class PromptRunner {
         },
       })),
       hooks: {
+        // Roll each tool branch's LLM cost/tokens up to the parent stack,
+        // just like fork/parallel/race do (see Runner). Subagents run as
+        // tools in their own branch stacks; without these hooks their
+        // spend (e.g. an oracle on a pricier model) never propagated back,
+        // so `getCost()`/`getTokens()` under-reported the turn. seed is
+        // idempotent across interrupt/resume; propagate fires only on the
+        // no-interrupt completion path (runBatch.ts), and the delta math
+        // is correct across resume because the seed baseline is per-branch.
+        seedBranchCost: (childStack, parentStack) =>
+          seedBranchCost(childStack, parentStack),
+        propagateBranchCost: (branches, parentStack) =>
+          propagateBranchCost(branches, parentStack),
         // Snapshot the message thread INTO `self.messagesJSON` BEFORE
         // runBatch calls `ctx.checkpoints.create`. The checkpoint deep-
         // clones `self.locals` synchronously, so mutating messagesJSON

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -10,7 +10,11 @@ import { runBatch } from "./runBatch.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { BranchState, State } from "./state/stateStack.js";
-import { StateStack } from "./state/stateStack.js";
+import {
+  StateStack,
+  seedBranchCost as seedBranchCostImpl,
+  propagateBranchCost as propagateBranchCostImpl,
+} from "./state/stateStack.js";
 import type { ThreadStore } from "./state/threadStore.js";
 import type { HandlerFn } from "./types.js";
 
@@ -344,21 +348,8 @@ export class Runner {
    *  before the winner resumes. See docs/superpowers/specs/2026-05-20-
    *  thread-builtins-and-stdlib-design.md. */
   private seedBranchCost(branchStack: StateStack, parentStack: StateStack): void {
-    // Fresh-branch detection: seedBranchCost can be called more than
-    // once for the same branch (e.g. a branch interrupts mid-flight
-    // and the parent resumes runBatch on the next response cycle).
-    // We must not clobber state the branch has already accumulated.
-    // A branch is "fresh" iff it has no cost AND no tokens. Guards are
-    // handled separately by `rehydrateInheritedGuards` in runBatch.ts —
-    // they have their own idempotency tracking via BranchState.
-    const isFresh =
-      branchStack.localCost === 0 && branchStack.localTokens === 0;
-    if (!isFresh) return;
-
-    branchStack.localCost = parentStack.localCost;
-    branchStack.localTokens = parentStack.localTokens;
-    branchStack.seedCost = parentStack.localCost;
-    branchStack.seedTokens = parentStack.localTokens;
+    // Shared with PromptRunner's tool-dispatch batches (see stateStack.ts).
+    seedBranchCostImpl(branchStack, parentStack);
   }
 
   /** Propagate cost/token deltas from a set of branches back to the
@@ -373,14 +364,8 @@ export class Runner {
     branches: BranchState[],
     parentStack: StateStack,
   ): void {
-    let costDelta = 0;
-    let tokensDelta = 0;
-    for (const branch of branches) {
-      costDelta += branch.stack.localCost - branch.stack.seedCost;
-      tokensDelta += branch.stack.localTokens - branch.stack.seedTokens;
-    }
-    parentStack.localCost += costDelta;
-    parentStack.localTokens += tokensDelta;
+    // Shared with PromptRunner's tool-dispatch batches (see stateStack.ts).
+    propagateBranchCostImpl(branches, parentStack);
   }
 
   // ── Core step method ──

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -745,3 +745,44 @@ export class StateStack {
     return stateStack;
   }
 }
+
+/** Seed a child branch's `localCost` / `localTokens` from the parent stack
+ *  unless they're already populated (e.g. restored from a checkpoint on
+ *  resume). Idempotent — a branch is "fresh" iff it has zero cost AND zero
+ *  tokens. Also records the immutable `seedCost` / `seedTokens` baseline so
+ *  `propagateBranchCost` can compute this branch's delta independently of
+ *  the parent's later mutations (sibling branches may fold their spend into
+ *  the parent first). Shared by `Runner` (fork/parallel/race) and
+ *  `PromptRunner` (LLM tool dispatch) so `getCost()`/`getTokens()` are
+ *  cumulative across ALL child branches, including subagent tools. */
+export function seedBranchCost(
+  branchStack: StateStack,
+  parentStack: StateStack,
+): void {
+  const isFresh =
+    branchStack.localCost === 0 && branchStack.localTokens === 0;
+  if (!isFresh) return;
+  branchStack.localCost = parentStack.localCost;
+  branchStack.localTokens = parentStack.localTokens;
+  branchStack.seedCost = parentStack.localCost;
+  branchStack.seedTokens = parentStack.localTokens;
+}
+
+/** Propagate cost/token deltas from a set of branches back to the parent
+ *  stack. Delta = `branch.localCost - branch.seedCost` (the baseline
+ *  captured at seed time). Using the per-branch seed rather than the
+ *  parent's current totals keeps the math correct when sibling branches
+ *  already folded their spend in. Call BEFORE popBranches/deleteBranch. */
+export function propagateBranchCost(
+  branches: BranchState[],
+  parentStack: StateStack,
+): void {
+  let costDelta = 0;
+  let tokensDelta = 0;
+  for (const branch of branches) {
+    costDelta += branch.stack.localCost - branch.stack.seedCost;
+    tokensDelta += branch.stack.localTokens - branch.stack.seedTokens;
+  }
+  parentStack.localCost += costDelta;
+  parentStack.localTokens += tokensDelta;
+}

--- a/packages/agency-lang/tests/agency/subagent-cost-propagation.agency
+++ b/packages/agency-lang/tests/agency/subagent-cost-propagation.agency
@@ -1,0 +1,20 @@
+import { getTokens } from "std::thread"
+
+// A tool that itself makes an LLM call. When the outer llm() dispatches
+// this as a tool, it runs in its own branch stack — so its token/cost
+// spend must propagate back to the parent for getTokens()/getCost() to be
+// cumulative.
+def innerTool(): string {
+  """Calls the LLM from inside a tool."""
+  return llm("inner")
+}
+
+// Three LLM calls happen: (1) the outer call returns a tool call, (2) the
+// tool's own llm() runs, (3) the outer call resumes and returns. The
+// deterministic provider bills 2 synthetic tokens per call, so a correct
+// cumulative total is 6 — proving the tool (subagent) branch's spend rolled
+// up. Before the fix this returned 4 (the tool branch's 2 were dropped).
+node main(): number {
+  llm("outer", { tools: [innerTool] })
+  return getTokens()
+}

--- a/packages/agency-lang/tests/agency/subagent-cost-propagation.agency
+++ b/packages/agency-lang/tests/agency/subagent-cost-propagation.agency
@@ -32,6 +32,14 @@ def nestedOuter(): string {
   return llm("mid", { tools: [nestedInner] })
 }
 
+def interruptingTool(): string {
+  """Calls the LLM, pauses for approval, then calls the LLM again."""
+  const before = llm("before")
+  interrupt("approve to continue")
+  const after = llm("after")
+  return "done"
+}
+
 // One tool, one round → 3 LLM calls → 6 tokens. (Was 4 before the fix.)
 node toolTokensRollUp(): number {
   llm("outer", { tools: [innerTool] })
@@ -59,5 +67,15 @@ node parallelToolTokensRollUp(): number {
 // top-continues = 5 calls → 10 tokens.
 node nestedToolTokensRollUp(): number {
   llm("top", { tools: [nestedOuter] })
+  return getTokens()
+}
+
+// A tool that pauses for an approval interrupt and resumes. Its spend must
+// be counted EXACTLY ONCE across the interrupt/resume cycle — the seed is
+// idempotent on resume (the branch isn't re-seeded) and its seed baseline
+// survives the checkpoint, so the delta math doesn't double-count or drop.
+// Calls: outer + before + after + outer-continues = 4 → 8 tokens.
+node interruptResumeTokensRollUp(): number {
+  llm("outer", { tools: [interruptingTool] })
   return getTokens()
 }

--- a/packages/agency-lang/tests/agency/subagent-cost-propagation.agency
+++ b/packages/agency-lang/tests/agency/subagent-cost-propagation.agency
@@ -1,20 +1,63 @@
-import { getTokens } from "std::thread"
+import { getCost, getTokens } from "std::thread"
 
-// A tool that itself makes an LLM call. When the outer llm() dispatches
-// this as a tool, it runs in its own branch stack — so its token/cost
-// spend must propagate back to the parent for getTokens()/getCost() to be
-// cumulative.
+// Tools/subagents are dispatched by an LLM tool call, which runs each tool
+// in its own branch stack. Their LLM spend must roll up into the parent so
+// getCost()/getTokens() are cumulative. The deterministic test provider
+// bills 2 tokens + $0.000002 per LLM call, so the expected totals below are
+// just (number of LLM calls) × that. Before the fix, tool-branch spend was
+// dropped, so every total collapsed to just the outer (coordinator) calls.
+
 def innerTool(): string {
   """Calls the LLM from inside a tool."""
   return llm("inner")
 }
 
-// Three LLM calls happen: (1) the outer call returns a tool call, (2) the
-// tool's own llm() runs, (3) the outer call resumes and returns. The
-// deterministic provider bills 2 synthetic tokens per call, so a correct
-// cumulative total is 6 — proving the tool (subagent) branch's spend rolled
-// up. Before the fix this returned 4 (the tool branch's 2 were dropped).
-node main(): number {
+def toolA(): string {
+  """Tool A — calls the LLM."""
+  return llm("a")
+}
+
+def toolB(): string {
+  """Tool B — calls the LLM."""
+  return llm("b")
+}
+
+def nestedInner(): string {
+  """Deepest tool — calls the LLM."""
+  return llm("deep")
+}
+
+def nestedOuter(): string {
+  """Mid tool — calls the LLM with its OWN nested tool."""
+  return llm("mid", { tools: [nestedInner] })
+}
+
+// One tool, one round → 3 LLM calls → 6 tokens. (Was 4 before the fix.)
+node toolTokensRollUp(): number {
   llm("outer", { tools: [innerTool] })
+  return getTokens()
+}
+
+// Same flow, asserting COST (the user-facing figure) rolled up too: 3
+// calls' cost ($0.000006) exceeds the 2 outer calls' worth ($0.000004).
+// Before the fix getCost() was exactly $0.000004, so `>` is false.
+node toolCostRollsUp(): boolean {
+  llm("outer", { tools: [innerTool] })
+  return getCost() > 0.000004
+}
+
+// Two tools dispatched in ONE round (parallel branches). BOTH branch
+// deltas must sum into the parent: outer + a + b + outer-continues = 4
+// calls → 8 tokens. Exercises propagateBranchCost's sum over all branches.
+node parallelToolTokensRollUp(): number {
+  llm("outer", { tools: [toolA, toolB] })
+  return getTokens()
+}
+
+// Nested tools (two levels): top → nestedOuter → nestedInner. Spend must
+// chain up through every level: top + mid + deep + mid-continues +
+// top-continues = 5 calls → 10 tokens.
+node nestedToolTokensRollUp(): number {
+  llm("top", { tools: [nestedOuter] })
   return getTokens()
 }

--- a/packages/agency-lang/tests/agency/subagent-cost-propagation.test.json
+++ b/packages/agency-lang/tests/agency/subagent-cost-propagation.test.json
@@ -1,8 +1,8 @@
 {
   "tests": [
     {
-      "nodeName": "main",
-      "description": "A tool's own LLM spend propagates to the parent stack, so getTokens() is cumulative across subagent/tool branches",
+      "nodeName": "toolTokensRollUp",
+      "description": "A tool's own LLM spend rolls up to the parent (getTokens cumulative across the tool branch)",
       "input": "",
       "expectedOutput": "6",
       "evaluationCriteria": [{ "type": "exact" }],
@@ -11,6 +11,48 @@
         { "toolCall": { "name": "innerTool" } },
         { "return": "inner result" },
         { "return": "done" }
+      ]
+    },
+    {
+      "nodeName": "toolCostRollsUp",
+      "description": "Cost (not just tokens) rolls up from the tool branch",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCall": { "name": "innerTool" } },
+        { "return": "inner result" },
+        { "return": "done" }
+      ]
+    },
+    {
+      "nodeName": "parallelToolTokensRollUp",
+      "description": "Two tools in one round: both branch deltas sum into the parent",
+      "input": "",
+      "expectedOutput": "8",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "toolA" }, { "name": "toolB" }] },
+        { "return": "a result" },
+        { "return": "b result" },
+        { "return": "done" }
+      ]
+    },
+    {
+      "nodeName": "nestedToolTokensRollUp",
+      "description": "Nested tools: spend chains up through every level",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCall": { "name": "nestedOuter" } },
+        { "toolCall": { "name": "nestedInner" } },
+        { "return": "deep result" },
+        { "return": "mid done" },
+        { "return": "top done" }
       ]
     }
   ]

--- a/packages/agency-lang/tests/agency/subagent-cost-propagation.test.json
+++ b/packages/agency-lang/tests/agency/subagent-cost-propagation.test.json
@@ -54,6 +54,21 @@
         { "return": "mid done" },
         { "return": "top done" }
       ]
+    },
+    {
+      "nodeName": "interruptResumeTokensRollUp",
+      "description": "A tool that pauses for approval and resumes counts its spend exactly once (seed idempotent + survives checkpoint)",
+      "input": "",
+      "expectedOutput": "8",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCall": { "name": "interruptingTool" } },
+        { "return": "before result" },
+        { "return": "after result" },
+        { "return": "done" }
+      ],
+      "interruptHandlers": [{ "action": "approve" }]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/subagent-cost-propagation.test.json
+++ b/packages/agency-lang/tests/agency/subagent-cost-propagation.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "A tool's own LLM spend propagates to the parent stack, so getTokens() is cumulative across subagent/tool branches",
+      "input": "",
+      "expectedOutput": "6",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCall": { "name": "innerTool" } },
+        { "return": "inner result" },
+        { "return": "done" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

The agent footer's cost (and `/cost`) under-reported any turn that used a subagent — e.g. the oracle/explorer running on a pricier model. Those costs are now included.

## Root cause

`getCost()` / `getTokens()` read the active stack's per-branch `localCost` / `localTokens`, which is meant to be cumulative across a stack **and its child branches**. `fork`/`parallel`/`race` make that true by wiring `seedBranchCost` + `propagateBranchCost` (via the node `Runner`), so a branch's spend is seeded from the parent and its delta propagates back on join.

But **LLM tool dispatches** run each tool in its own branch stack via `PromptRunner.parallel` (`runBatch.ts:358`), and that call site passed **neither** hook. So a subagent's spend accumulated only on its branch stack and was discarded at join — never reaching `getCost()`/`getTokens()`. Since subagents are invoked as tools, all of their cost was missing from the totals.

## Fix

- Extract `seedBranchCost` / `propagateBranchCost` into shared functions in `state/stateStack.ts`.
- `Runner` now delegates to them (no behavior change; removes the duplicated logic).
- Wire both into `PromptRunner.parallel`'s `runBatch` call, so tool branches seed + propagate exactly like fork/race. The seed is idempotent across the approval-interrupt/resume cycle, and propagate only fires on the no-interrupt completion path, so the per-branch delta math stays correct across resumes.

## Testing

- 117 unit tests pass across `runner` / `runBatch` / `stateStack` (these exercise the now-shared seed/propagate logic for fork/race).
- New deterministic regression test (`tests/agency/subagent-cost-propagation.*`): an outer `llm()` calls a tool that itself calls `llm()` (3 calls total). With the fix `getTokens()` reports **6** synthetic tokens (all three calls); before it reported **4** (the tool branch's spend was dropped).

Note: `getCost()` remains cumulative (per the design intent) — it now reflects the coordinator's calls plus every subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
