### PR TITLE
Per-model cost attribution in footer + /cost

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -6,6 +6,19 @@ name: "thread"
 
 ## Types
 
+### ModelCost
+
+```ts
+export type ModelCost = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L78))
+
 ### GuardFailureData
 
 ```ts
@@ -18,7 +31,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L101))
 
 ## Functions
 
@@ -40,7 +53,7 @@ Add a system message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L17))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L18))
 
 ### userMessage
 
@@ -60,7 +73,7 @@ Add a user message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L28))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L29))
 
 ### assistantMessage
 
@@ -80,7 +93,7 @@ Add an assistant message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L40))
 
 ### getCost
 
@@ -104,7 +117,7 @@ Get the cumulative cost (USD, floating point) of all LLM calls
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L50))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L51))
 
 ### getTokens
 
@@ -117,7 +130,28 @@ Get the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L70))
+
+### getModelCosts
+
+```ts
+getModelCosts(): ModelCost[]
+```
+
+Get a per-model breakdown of cumulative LLM usage, one entry per
+  model that has been called, sorted by cost descending.
+
+  Unlike getCost()/getTokens() (which read the per-branch accumulator),
+  this reads the process-wide totals across every branch — including
+  subagents and tool calls that run on a different model. Useful for a
+  cost summary that attributes spend per model.
+
+  Each entry has `model` (the model name), `inputTokens`,
+  `outputTokens`, and `cost` (USD).
+
+**Returns:** `ModelCost[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L85))
 
 ### guard
 
@@ -191,4 +225,4 @@ Run a block under a cost limit, a time limit, or both. The block
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L113))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -15,7 +15,7 @@ import { exists } from "std::shell"
 import { commandsDir, expandSlash } from "std::skills"
 import { highlight } from "std::syntax"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
-import { getCost, getTokens, getModelCosts, systemMessage } from "std::thread"
+import { getCost, getModelCosts, systemMessage } from "std::thread"
 import { chooseOption, ChoiceItem } from "std::ui"
 
 import { figs, title } from "./images/images.agency"
@@ -232,12 +232,22 @@ def _runTurn(msg: string): boolean {
     return true
   }
   if (trimmed == "/cost") {
-    pushMessage("Cost:   $${getCost().toFixed(4)}")
-    pushMessage("Tokens: ${getTokens()}")
-    // Per-model breakdown so a turn that delegated to a subagent on a
-    // pricier model (e.g. the oracle on opus-4.8) shows where the spend
-    // went. Sorted by cost descending by getModelCosts().
+    // Derive BOTH the header total and the per-model breakdown from the
+    // same process-wide accumulator (getModelCosts), so the `Cost:` /
+    // `Tokens:` lines and the rows below them can never visibly disagree.
+    // (getCost()/getTokens() read the per-branch accumulator, a different
+    // scope — adjacent in the output, they could in principle diverge.)
+    // Rows are sorted by cost descending by getModelCosts(); a subagent
+    // on a pricier model (e.g. the oracle on opus-4.8) shows up here.
     const byModel = getModelCosts()
+    let totalCost = 0.0
+    let totalTokens = 0
+    for (m in byModel) {
+      totalCost = totalCost + m.cost
+      totalTokens = totalTokens + m.inputTokens + m.outputTokens
+    }
+    pushMessage("Cost:   $${totalCost.toFixed(4)}")
+    pushMessage("Tokens: ${totalTokens}")
     if (byModel.length > 0) {
       pushMessage("")
       pushMessage("By model:")

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -15,7 +15,7 @@ import { exists } from "std::shell"
 import { commandsDir, expandSlash } from "std::skills"
 import { highlight } from "std::syntax"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
-import { getCost, getTokens, systemMessage } from "std::thread"
+import { getCost, getTokens, getModelCosts, systemMessage } from "std::thread"
 import { chooseOption, ChoiceItem } from "std::ui"
 
 import { figs, title } from "./images/images.agency"
@@ -234,6 +234,17 @@ def _runTurn(msg: string): boolean {
   if (trimmed == "/cost") {
     pushMessage("Cost:   $${getCost().toFixed(4)}")
     pushMessage("Tokens: ${getTokens()}")
+    // Per-model breakdown so a turn that delegated to a subagent on a
+    // pricier model (e.g. the oracle on opus-4.8) shows where the spend
+    // went. Sorted by cost descending by getModelCosts().
+    const byModel = getModelCosts()
+    if (byModel.length > 0) {
+      pushMessage("")
+      pushMessage("By model:")
+      for (m in byModel) {
+        pushMessage("  ${m.model}  ↑${m.inputTokens} ↓${m.outputTokens}  $${m.cost.toFixed(4)}")
+      }
+    }
     return true
   }
   // Hand the message to the agent. `agentReply` does the slash-command

--- a/packages/agency-lang/lib/runtime/state/globalStore.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.ts
@@ -46,9 +46,12 @@ export class GlobalStore {
   static withTokenStats(): GlobalStore {
     const gs = new GlobalStore();
     gs.set(GlobalStore.INTERNAL_MODULE, "__tokenStats", {
-      // Model of the most recent LLM call; updated by updateTokenStats and
-      // read by the REPL footer. Empty until the first call.
-      lastModel: "",
+      // Per-model usage breakdown, keyed by model name. Accumulated by
+      // updateTokenStats on every LLM call (across all branches, which
+      // pointer-share this object), so subagent spend lands here too.
+      // Read by the REPL footer (distinct models used this turn) and
+      // `/cost` (cumulative per-model breakdown).
+      models: {},
       usage: {
         inputTokens: 0,
         outputTokens: 0,

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { deepFreeze } from "./utils.js";
+import { deepFreeze, updateTokenStats } from "./utils.js";
+import { GlobalStore } from "./state/globalStore.js";
+
+const usage = (i: number, o: number) => ({
+  inputTokens: i,
+  outputTokens: o,
+  totalTokens: i + o,
+});
+const cost = (c: number) => ({ inputCost: 0, outputCost: 0, totalCost: c });
 
 describe("deepFreeze", () => {
   it("freezes a plain object", () => {
@@ -60,5 +68,62 @@ describe("deepFreeze", () => {
     expect(Object.isFrozen(obj.data)).toBe(true);
     // Map internal state still mutable (known limitation)
     expect(() => obj.data.set("b", 2)).not.toThrow();
+  });
+});
+
+describe("updateTokenStats per-model breakdown", () => {
+  it("records a new model on first call", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
+    const stats = globals.getTokenStats();
+    expect(stats.models["opus-4.8"]).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalCost: 0.001,
+    });
+    // The aggregate totals still accumulate independently.
+    expect(stats.usage.inputTokens).toBe(10);
+    expect(stats.cost.totalCost).toBe(0.001);
+  });
+
+  it("accumulates repeated calls to the same model", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "opus-4.8" });
+    updateTokenStats({ globals, usage: usage(2, 3), cost: cost(0.0005), model: "opus-4.8" });
+    expect(globals.getTokenStats().models["opus-4.8"]).toEqual({
+      inputTokens: 12,
+      outputTokens: 8,
+      totalCost: 0.0015,
+    });
+  });
+
+  it("tracks multiple models separately (e.g. a subagent on a different model)", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001), model: "gpt-5-mini" });
+    updateTokenStats({ globals, usage: usage(20, 10), cost: cost(0.03), model: "opus-4.8" });
+    const models = globals.getTokenStats().models;
+    expect(models["gpt-5-mini"]).toEqual({ inputTokens: 10, outputTokens: 5, totalCost: 0.001 });
+    expect(models["opus-4.8"]).toEqual({ inputTokens: 20, outputTokens: 10, totalCost: 0.03 });
+  });
+
+  it("does not record a model entry when no model name is supplied", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(10, 5), cost: cost(0.001) });
+    expect(globals.getTokenStats().models).toEqual({});
+    // Aggregate totals still update even without a model name.
+    expect(globals.getTokenStats().usage.totalTokens).toBe(15);
+  });
+
+  it("backfills the models slot for token-stats restored from older checkpoints", () => {
+    const globals = GlobalStore.withTokenStats();
+    // Simulate a checkpoint written before per-model tracking existed.
+    const stats = globals.getTokenStats();
+    delete stats.models;
+    updateTokenStats({ globals, usage: usage(1, 1), cost: cost(0.0002), model: "opus-4.8" });
+    expect(globals.getTokenStats().models["opus-4.8"]).toEqual({
+      inputTokens: 1,
+      outputTokens: 1,
+      totalCost: 0.0002,
+    });
   });
 });

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -120,10 +120,19 @@ export function updateTokenStats(args: {
   const { globals, usage, cost, model } = args;
   if (!usage || !cost) return;
   const tokenStats = globals.get(GlobalStore.INTERNAL_MODULE, "__tokenStats");
-  // Record the model of the most recent LLM call so the REPL footer can
-  // show which model produced the turn. Purely informational; doesn't
-  // affect billing/usage accumulation.
-  if (model) tokenStats.lastModel = model;
+  // Accumulate a per-model usage breakdown. Every LLM call (including
+  // subagent/tool branches, which pointer-share this object) lands here,
+  // so the footer can list which models a turn touched and `/cost` can
+  // attribute spend per model. Defensive against an absent `models` slot
+  // for token-stats objects restored from older checkpoints.
+  if (model) {
+    if (!tokenStats.models) tokenStats.models = {};
+    const m = tokenStats.models[model] ??
+      (tokenStats.models[model] = { inputTokens: 0, outputTokens: 0, totalCost: 0 });
+    m.inputTokens += usage.inputTokens || 0;
+    m.outputTokens += usage.outputTokens || 0;
+    m.totalCost += cost.totalCost || 0;
+  }
   tokenStats.usage.inputTokens += usage.inputTokens || 0;
   tokenStats.usage.outputTokens += usage.outputTokens || 0;
   tokenStats.usage.cachedInputTokens += usage.cachedInputTokens || 0;

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -111,6 +111,35 @@ export function createReturnObject<T>({
   );
 }
 
+export type ModelUsage = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+};
+
+/**
+ * Normalize the raw `__tokenStats.models` map into a typed, defensively
+ * narrowed array sorted by cost descending (model name as the tiebreak).
+ * Single source of truth for reading the per-model breakdown — shared by
+ * std::thread's `getModelCosts` and the REPL footer's token snapshot so
+ * the field narrowing and ordering live in one place.
+ */
+export function normalizeModelUsage(rawModels: unknown): ModelUsage[] {
+  if (!rawModels || typeof rawModels !== "object") return [];
+  const out: ModelUsage[] = [];
+  for (const [model, v] of Object.entries(rawModels as Record<string, any>)) {
+    out.push({
+      model,
+      inputTokens: typeof v?.inputTokens === "number" ? v.inputTokens : 0,
+      outputTokens: typeof v?.outputTokens === "number" ? v.outputTokens : 0,
+      cost: typeof v?.totalCost === "number" ? v.totalCost : 0,
+    });
+  }
+  out.sort((a, b) => b.cost - a.cost || (a.model < b.model ? -1 : 1));
+  return out;
+}
+
 export function updateTokenStats(args: {
   globals: GlobalStore;
   usage: any;

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -9,7 +9,18 @@ const {
   pasteJoin,
   classifyPasteKey,
   readMultiline,
+  modelsUsedThisTurn,
 } = _internal;
+
+/** Build a snapshot shaped like `readTokenSnapshot`'s return value from
+ *  a `{model: [tokens, cost]}` shorthand. */
+function snap(entries: Record<string, [number, number]>) {
+  const models: Record<string, { tokens: number; cost: number }> = {};
+  for (const [name, [tokens, cost]] of Object.entries(entries)) {
+    models[name] = { tokens, cost };
+  }
+  return { inputTokens: 0, outputTokens: 0, models };
+}
 
 // The readMultiline tests spy on process.stdout.write; restore after
 // every test so the global spy never leaks into other tests/files.
@@ -170,5 +181,44 @@ describe("readMultiline editor (drives the hijacked _ttyWrite)", () => {
     // Simulate a stdin EOF / readline close while editing.
     (fakeRl as unknown as { emitClose: () => void }).emitClose();
     expect(await promise).toBe("partial");
+  });
+});
+
+describe("modelsUsedThisTurn (footer model attribution)", () => {
+  it("returns nothing when no model did work this turn", () => {
+    const before = snap({ "opus-4.8": [10, 0.01] });
+    const after = snap({ "opus-4.8": [10, 0.01] });
+    expect(modelsUsedThisTurn(before, after)).toEqual([]);
+  });
+
+  it("lists the single model that grew this turn", () => {
+    const before = snap({});
+    const after = snap({ "opus-4.8": [100, 0.03] });
+    expect(modelsUsedThisTurn(before, after)).toEqual(["opus-4.8"]);
+  });
+
+  it("orders multiple models by cost spent this turn, descending", () => {
+    const before = snap({});
+    const after = snap({ "gpt-5-mini": [400, 0.011], "opus-4.8": [800, 0.03] });
+    expect(modelsUsedThisTurn(before, after)).toEqual(["opus-4.8", "gpt-5-mini"]);
+  });
+
+  it("uses the per-turn delta, not cumulative totals, to order", () => {
+    // opus has a bigger cumulative cost, but gpt spent more THIS turn.
+    const before = snap({ "opus-4.8": [1000, 0.50], "gpt-5-mini": [0, 0] });
+    const after = snap({ "opus-4.8": [1010, 0.505], "gpt-5-mini": [500, 0.40] });
+    expect(modelsUsedThisTurn(before, after)).toEqual(["gpt-5-mini", "opus-4.8"]);
+  });
+
+  it("excludes a model that was used in a prior turn but not this one", () => {
+    const before = snap({ "opus-4.8": [100, 0.03], "gpt-5-mini": [50, 0.005] });
+    const after = snap({ "opus-4.8": [100, 0.03], "gpt-5-mini": [80, 0.008] });
+    expect(modelsUsedThisTurn(before, after)).toEqual(["gpt-5-mini"]);
+  });
+
+  it("breaks cost ties by model name", () => {
+    const before = snap({});
+    const after = snap({ "model-b": [100, 0.01], "model-a": [100, 0.01] });
+    expect(modelsUsedThisTurn(before, after)).toEqual(["model-a", "model-b"]);
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -10,6 +10,7 @@ const {
   classifyPasteKey,
   readMultiline,
   modelsUsedThisTurn,
+  fmtModels,
 } = _internal;
 
 /** Build a snapshot shaped like `readTokenSnapshot`'s return value from
@@ -220,5 +221,25 @@ describe("modelsUsedThisTurn (footer model attribution)", () => {
     const before = snap({});
     const after = snap({ "model-b": [100, 0.01], "model-a": [100, 0.01] });
     expect(modelsUsedThisTurn(before, after)).toEqual(["model-a", "model-b"]);
+  });
+
+  it("includes a model whose cost grew even if its token count didn't", () => {
+    const before = snap({ "opus-4.8": [100, 0.01] });
+    const after = snap({ "opus-4.8": [100, 0.02] });
+    expect(modelsUsedThisTurn(before, after)).toEqual(["opus-4.8"]);
+  });
+});
+
+describe("fmtModels (footer cap)", () => {
+  it("joins up to three models in full", () => {
+    expect(fmtModels(["a", "b", "c"])).toBe("a, b, c");
+  });
+
+  it("collapses the tail to `+N more` past the cap", () => {
+    expect(fmtModels(["a", "b", "c", "d", "e"])).toBe("a, b, c +2 more");
+  });
+
+  it("renders a single model plainly", () => {
+    expect(fmtModels(["opus-4.8"])).toBe("opus-4.8");
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -480,42 +480,71 @@ type TurnStats = {
   elapsedMs: number;
   inputTokens: number;
   outputTokens: number;
-  model: string;
+  // Distinct models that did work during the turn, ordered by spend
+  // descending (most expensive first). Empty when no model is known.
+  models: string[];
 };
 
-/** Read the cumulative input/output token counts from the active
- *  RuntimeContext's GlobalStore. Returns zeros when no context is
- *  active or the token-stats slot is missing (defensive — `_runLineRepl`
- *  always runs inside a context, but tests sometimes don't). */
-function readTokenSnapshot(): {
+/** Cumulative per-model token+cost totals, keyed by model name. */
+type ModelTotals = Record<string, { tokens: number; cost: number }>;
+
+type TokenSnapshot = {
   inputTokens: number;
   outputTokens: number;
-  model: string;
-} {
+  models: ModelTotals;
+};
+
+/** Read the cumulative input/output token counts (and per-model
+ *  breakdown) from the active RuntimeContext's GlobalStore. Returns
+ *  zeros when no context is active or the token-stats slot is missing
+ *  (defensive — `_runLineRepl` always runs inside a context, but tests
+ *  sometimes don't). */
+function readTokenSnapshot(): TokenSnapshot {
+  const empty: TokenSnapshot = { inputTokens: 0, outputTokens: 0, models: {} };
   try {
     const { ctx } = getRuntimeContext();
     const stats = ctx?.globals?.getTokenStats?.();
-    if (!stats || typeof stats !== "object") {
-      return { inputTokens: 0, outputTokens: 0, model: "" };
+    if (!stats || typeof stats !== "object") return empty;
+    // Per-model breakdown (updateTokenStats). Snapshotted so the footer
+    // can diff before/after and list the models used *this turn*.
+    const models: ModelTotals = {};
+    const rawModels = (stats as { models?: Record<string, unknown> }).models;
+    if (rawModels && typeof rawModels === "object") {
+      for (const [name, v] of Object.entries(rawModels)) {
+        const e = v as { inputTokens?: unknown; outputTokens?: unknown; totalCost?: unknown };
+        const inTok = typeof e?.inputTokens === "number" ? e.inputTokens : 0;
+        const outTok = typeof e?.outputTokens === "number" ? e.outputTokens : 0;
+        const cost = typeof e?.totalCost === "number" ? e.totalCost : 0;
+        models[name] = { tokens: inTok + outTok, cost };
+      }
     }
     const usage = (stats as { usage?: Record<string, unknown> }).usage;
-    // `lastModel` is the model of the most recent LLM call (set in
-    // updateTokenStats). It's cumulative, not a delta — the footer uses
-    // the post-turn value to label which model produced the reply.
-    const lastModel = (stats as { lastModel?: unknown }).lastModel;
-    const model = typeof lastModel === "string" ? lastModel : "";
     if (!usage || typeof usage !== "object") {
-      return { inputTokens: 0, outputTokens: 0, model };
+      return { inputTokens: 0, outputTokens: 0, models };
     }
     return {
       inputTokens: typeof usage.inputTokens === "number" ? usage.inputTokens : 0,
       outputTokens:
         typeof usage.outputTokens === "number" ? usage.outputTokens : 0,
-      model,
+      models,
     };
   } catch {
-    return { inputTokens: 0, outputTokens: 0, model: "" };
+    return empty;
   }
+}
+
+/** Distinct models whose token count grew between two snapshots, ordered
+ *  by cost spent during the turn (descending), name as tiebreak. This is
+ *  what the footer lists after the per-turn token/time stats. */
+function modelsUsedThisTurn(before: TokenSnapshot, after: TokenSnapshot): string[] {
+  const used: { name: string; cost: number }[] = [];
+  for (const [name, a] of Object.entries(after.models)) {
+    const b = before.models[name];
+    const tokenDelta = a.tokens - (b?.tokens ?? 0);
+    if (tokenDelta > 0) used.push({ name, cost: a.cost - (b?.cost ?? 0) });
+  }
+  used.sort((x, y) => y.cost - x.cost || (x.name < y.name ? -1 : 1));
+  return used.map((u) => u.name);
 }
 
 /** Format a token count as a short, human-readable string. Below 1000
@@ -562,7 +591,7 @@ async function printFooter(
   // model is appended only when known.
   if (turn) {
     let stats = `↑${fmtTokens(turn.inputTokens)} ↓${fmtTokens(turn.outputTokens)} ${fmtElapsed(turn.elapsedMs)}`;
-    if (turn.model.length > 0) stats += ` · ${turn.model}`;
+    if (turn.models.length > 0) stats += ` · ${turn.models.join(", ")}`;
     parts.unshift(stats);
   }
   if (parts.length === 0) return;
@@ -758,7 +787,7 @@ export async function _runLineRepl(
           elapsedMs: Date.now() - turnStartMs,
           inputTokens: tokensAfter.inputTokens - tokensBefore.inputTokens,
           outputTokens: tokensAfter.outputTokens - tokensBefore.outputTokens,
-          model: tokensAfter.model,
+          models: modelsUsedThisTurn(tokensBefore, tokensAfter),
         });
         continue;
       } finally {
@@ -786,7 +815,7 @@ export async function _runLineRepl(
         elapsedMs: Date.now() - turnStartMs,
         inputTokens: tokensAfter.inputTokens - tokensBefore.inputTokens,
         outputTokens: tokensAfter.outputTokens - tokensBefore.outputTokens,
-        model: tokensAfter.model,
+        models: modelsUsedThisTurn(tokensBefore, tokensAfter),
       });
     }
   } finally {
@@ -1014,6 +1043,7 @@ export const _internal = {
   pasteJoin,
   classifyPasteKey,
   readMultiline,
+  modelsUsedThisTurn,
 };
 
 export function _clearScreen(): void {

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -14,6 +14,7 @@ import { color, colors, bgColors } from "../utils/termcolors.js";
 import { _promptsAutocomplete } from "./ui.js";
 import { isFailure } from "../runtime/result.js";
 import { isAbortError } from "../runtime/errors.js";
+import { normalizeModelUsage } from "../runtime/utils.js";
 // ---------------------------------------------------------------------------
 // TS bridge for `std::cli` — the line-mode REPL.
 //
@@ -506,17 +507,11 @@ function readTokenSnapshot(): TokenSnapshot {
     const stats = ctx?.globals?.getTokenStats?.();
     if (!stats || typeof stats !== "object") return empty;
     // Per-model breakdown (updateTokenStats). Snapshotted so the footer
-    // can diff before/after and list the models used *this turn*.
+    // can diff before/after and list the models used *this turn*. Shares
+    // the defensive field-narrowing in `normalizeModelUsage`.
     const models: ModelTotals = {};
-    const rawModels = (stats as { models?: Record<string, unknown> }).models;
-    if (rawModels && typeof rawModels === "object") {
-      for (const [name, v] of Object.entries(rawModels)) {
-        const e = v as { inputTokens?: unknown; outputTokens?: unknown; totalCost?: unknown };
-        const inTok = typeof e?.inputTokens === "number" ? e.inputTokens : 0;
-        const outTok = typeof e?.outputTokens === "number" ? e.outputTokens : 0;
-        const cost = typeof e?.totalCost === "number" ? e.totalCost : 0;
-        models[name] = { tokens: inTok + outTok, cost };
-      }
+    for (const m of normalizeModelUsage((stats as { models?: unknown }).models)) {
+      models[m.model] = { tokens: m.inputTokens + m.outputTokens, cost: m.cost };
     }
     const usage = (stats as { usage?: Record<string, unknown> }).usage;
     if (!usage || typeof usage !== "object") {
@@ -541,7 +536,12 @@ function modelsUsedThisTurn(before: TokenSnapshot, after: TokenSnapshot): string
   for (const [name, a] of Object.entries(after.models)) {
     const b = before.models[name];
     const tokenDelta = a.tokens - (b?.tokens ?? 0);
-    if (tokenDelta > 0) used.push({ name, cost: a.cost - (b?.cost ?? 0) });
+    const costDelta = a.cost - (b?.cost ?? 0);
+    // A model "did work this turn" if its tokens OR cost grew. With
+    // current providers every call adds tokens, so the cost check is a
+    // belt-and-suspenders guard against a (hypothetical) zero-token but
+    // non-zero-cost call being silently dropped from the footer.
+    if (tokenDelta > 0 || costDelta > 0) used.push({ name, cost: costDelta });
   }
   used.sort((x, y) => y.cost - x.cost || (x.name < y.name ? -1 : 1));
   return used.map((u) => u.name);
@@ -564,6 +564,18 @@ function fmtElapsed(ms: number): string {
   const mins = Math.floor(totalSec / 60);
   const secs = totalSec % 60;
   return `${mins}m ${secs}s`;
+}
+
+/** Render the per-turn model list for the footer. The list is already
+ *  ordered by spend descending; we show at most `FOOTER_MODEL_CAP` and
+ *  collapse the rest to `+N more` so a turn that touched many models
+ *  can't blow out the single-line footer. (Use `/cost` for the full
+ *  per-model breakdown.) */
+const FOOTER_MODEL_CAP = 3;
+function fmtModels(models: string[]): string {
+  if (models.length <= FOOTER_MODEL_CAP) return models.join(", ");
+  const shown = models.slice(0, FOOTER_MODEL_CAP).join(", ");
+  return `${shown} +${models.length - FOOTER_MODEL_CAP} more`;
 }
 
 async function printFooter(
@@ -591,7 +603,7 @@ async function printFooter(
   // model is appended only when known.
   if (turn) {
     let stats = `↑${fmtTokens(turn.inputTokens)} ↓${fmtTokens(turn.outputTokens)} ${fmtElapsed(turn.elapsedMs)}`;
-    if (turn.models.length > 0) stats += ` · ${turn.models.join(", ")}`;
+    if (turn.models.length > 0) stats += ` · ${fmtModels(turn.models)}`;
     parts.unshift(stats);
   }
   if (parts.length === 0) return;
@@ -1044,6 +1056,7 @@ export const _internal = {
   classifyPasteKey,
   readMultiline,
   modelsUsedThisTurn,
+  fmtModels,
 };
 
 export function _clearScreen(): void {

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -100,6 +100,40 @@ export async function _getTokens(): Promise<number> {
   return stack.localTokens;
 }
 
+export type ModelCost = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+};
+
+/**
+ * Per-model usage breakdown from the global `__tokenStats.models`
+ * accumulator (populated by `updateTokenStats` on every LLM call,
+ * including subagent/tool branches that pointer-share it). Returned
+ * sorted by cost descending so callers can show the priciest model
+ * first. Unlike `_getCost`/`_getTokens`, this reads the process-wide
+ * total (not the per-branch accumulator), which is the right scope for
+ * a `/cost` summary that attributes spend across every model used.
+ */
+export async function _getModelCosts(): Promise<ModelCost[]> {
+  const { ctx } = getRuntimeContext();
+  const stats = ctx?.globals?.getTokenStats?.();
+  const models = stats?.models;
+  if (!models || typeof models !== "object") return [];
+  const out: ModelCost[] = [];
+  for (const [model, v] of Object.entries(models as Record<string, any>)) {
+    out.push({
+      model,
+      inputTokens: typeof v?.inputTokens === "number" ? v.inputTokens : 0,
+      outputTokens: typeof v?.outputTokens === "number" ? v.outputTokens : 0,
+      cost: typeof v?.totalCost === "number" ? v.totalCost : 0,
+    });
+  }
+  out.sort((a, b) => b.cost - a.cost || (a.model < b.model ? -1 : 1));
+  return out;
+}
+
 /**
  * Open 0..2 guard scopes on the caller's stack, depending on which
  * limits were passed. Returns the count actually pushed so the

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -1,6 +1,7 @@
 import * as smoltalk from "smoltalk";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { CostGuard, TimeGuard } from "../runtime/guard.js";
+import { normalizeModelUsage, type ModelUsage } from "../runtime/utils.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
@@ -100,12 +101,7 @@ export async function _getTokens(): Promise<number> {
   return stack.localTokens;
 }
 
-export type ModelCost = {
-  model: string;
-  inputTokens: number;
-  outputTokens: number;
-  cost: number;
-};
+export type ModelCost = ModelUsage;
 
 /**
  * Per-model usage breakdown from the global `__tokenStats.models`
@@ -119,19 +115,7 @@ export type ModelCost = {
 export async function _getModelCosts(): Promise<ModelCost[]> {
   const { ctx } = getRuntimeContext();
   const stats = ctx?.globals?.getTokenStats?.();
-  const models = stats?.models;
-  if (!models || typeof models !== "object") return [];
-  const out: ModelCost[] = [];
-  for (const [model, v] of Object.entries(models as Record<string, any>)) {
-    out.push({
-      model,
-      inputTokens: typeof v?.inputTokens === "number" ? v.inputTokens : 0,
-      outputTokens: typeof v?.outputTokens === "number" ? v.outputTokens : 0,
-      cost: typeof v?.totalCost === "number" ? v.totalCost : 0,
-    });
-  }
-  out.sort((a, b) => b.cost - a.cost || (a.model < b.model ? -1 : 1));
-  return out;
+  return normalizeModelUsage(stats?.models);
 }
 
 /**

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -10,6 +10,7 @@ import {
   _assistantMessage,
   _getCost,
   _getTokens,
+  _getModelCosts,
   _pushGuard,
   _popGuard,
  } from "agency-lang/stdlib-lib/thread.js"
@@ -72,6 +73,29 @@ export safe def getTokens(): number {
   Same per-branch semantics as getCost().
   """
   return _getTokens()
+}
+
+export type ModelCost = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number
+}
+
+export safe def getModelCosts(): ModelCost[] {
+  """
+  Get a per-model breakdown of cumulative LLM usage, one entry per
+  model that has been called, sorted by cost descending.
+
+  Unlike getCost()/getTokens() (which read the per-branch accumulator),
+  this reads the process-wide totals across every branch — including
+  subagents and tool calls that run on a different model. Useful for a
+  cost summary that attributes spend per model.
+
+  Each entry has `model` (the model name), `inputTokens`,
+  `outputTokens`, and `cost` (USD).
+  """
+  return _getModelCosts()
 }
 
 export type GuardFailureData = {

--- a/packages/agency-lang/tests/agency/model-cost-breakdown.agency
+++ b/packages/agency-lang/tests/agency/model-cost-breakdown.agency
@@ -1,0 +1,44 @@
+import { getModelCosts, getTokens } from "std::thread"
+
+// getModelCosts() exposes the per-model usage breakdown from the global
+// __tokenStats accumulator. The deterministic test provider tags every
+// LLM call as model "deterministic" (1 input + 1 output token, so 2 per
+// call), so under tests every call lands in a single "deterministic"
+// entry. These tests verify the end-to-end wiring: updateTokenStats ->
+// globalStore.models -> _getModelCosts -> the agency-side wrapper, and
+// that subagent/tool-branch spend (which pointer-shares __tokenStats)
+// is aggregated into the breakdown too.
+
+def innerTool(): string {
+  """Calls the LLM from inside a tool."""
+  return llm("inner")
+}
+
+// One LLM call → exactly one model entry, named "deterministic".
+node modelBreakdownName(): string {
+  llm("hello")
+  return getModelCosts()[0].model
+}
+
+// One LLM call → one entry. (The breakdown groups by model, not by call.)
+node modelBreakdownCount(): number {
+  llm("hello")
+  return getModelCosts().length
+}
+
+// A tool call runs in its own branch but pointer-shares __tokenStats, so
+// its LLM spend must show up in the breakdown. outer + inner +
+// outer-continues = 3 calls × 2 tokens = 6, all under the one model.
+node modelBreakdownAggregatesToolBranch(): number {
+  llm("outer", { tools: [innerTool] })
+  const byModel = getModelCosts()
+  return byModel[0].inputTokens + byModel[0].outputTokens
+}
+
+// The per-model token total matches getTokens() (no double-counting, no
+// dropped calls) when only one model is in play.
+node modelBreakdownMatchesTotal(): boolean {
+  llm("outer", { tools: [innerTool] })
+  const byModel = getModelCosts()
+  return byModel[0].inputTokens + byModel[0].outputTokens == getTokens()
+}

--- a/packages/agency-lang/tests/agency/model-cost-breakdown.test.json
+++ b/packages/agency-lang/tests/agency/model-cost-breakdown.test.json
@@ -1,0 +1,48 @@
+{
+  "tests": [
+    {
+      "nodeName": "modelBreakdownName",
+      "description": "Breakdown entry is keyed by the model name reported by the provider",
+      "input": "",
+      "expectedOutput": "\"deterministic\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "hi" }]
+    },
+    {
+      "nodeName": "modelBreakdownCount",
+      "description": "Breakdown groups by model: one model used → one entry",
+      "input": "",
+      "expectedOutput": "1",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "hi" }]
+    },
+    {
+      "nodeName": "modelBreakdownAggregatesToolBranch",
+      "description": "Tool-branch LLM spend is aggregated into the per-model breakdown (3 calls × 2 tokens = 6)",
+      "input": "",
+      "expectedOutput": "6",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCall": { "name": "innerTool" } },
+        { "return": "inner result" },
+        { "return": "done" }
+      ]
+    },
+    {
+      "nodeName": "modelBreakdownMatchesTotal",
+      "description": "Per-model token total equals getTokens() (no double-count, no drop)",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCall": { "name": "innerTool" } },
+        { "return": "inner result" },
+        { "return": "done" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Surface **which models** a turn actually used, with per-model cost attribution.

The REPL footer showed the model name from a single `lastModel` scalar that `updateTokenStats` overwrote on *every* LLM call. Because the coordinator makes a final wrap-up call after a subagent returns, the last writer almost always won — so the footer showed the coordinator's model and quietly hid that a turn delegated to, say, the oracle on `opus-4.8`. The cost was already accumulated correctly (#323); only the *attribution* was lost.

## Changes

- **Data layer** — `__tokenStats.models[model]` now accumulates `inputTokens` / `outputTokens` / `cost` on every LLM call in `updateTokenStats`. Tool/subagent branches pointer-share `__tokenStats` (via `shareGlobals`), so their spend lands here automatically — no branch roll-up wiring needed. Plain JSON, so it survives checkpoint/restore.
- **Footer (Option A)** — lists the distinct models that did work *this turn*, ordered by spend descending (`… · opus-4.8, gpt-5-mini`). A single-model turn reads exactly as before. Computed by diffing a before/after per-model snapshot (`modelsUsedThisTurn`).
- **`/cost`** — gains a per-model breakdown:
  ```
  Cost:   $0.0410
  Tokens: 1340

  By model:
    opus-4.8     ↑800 ↓200  $0.0300
    gpt-5-mini   ↑400 ↓140  $0.0110
  ```
  backed by a new `getModelCosts()` builtin in `std::thread` (process-wide totals, sorted by cost descending).
- **Removed** the now-redundant `lastModel` scalar (it had two sources of truth and only the footer read it).

## DX decisions

- Footer shows **names only** by default; the full per-model breakdown is on demand via `/cost`.
- Multiple models in the footer are ordered **by spend descending** so the pricey one catches the eye.

## Tests

- `lib/stdlib/cli.test.ts` — `modelsUsedThisTurn`: empty turn, single model, multi-model sort by spend, delta-not-cumulative ordering, excludes a model used only in a prior turn, cost-tie tie-break by name.
- `lib/runtime/utils.test.ts` — `updateTokenStats` per-model: new model, repeated accumulation, multiple models tracked separately, no entry without a model name, backfill for token-stats restored from older checkpoints.
- `tests/agency/model-cost-breakdown.agency` — end-to-end: the breakdown is keyed by the provider's model name, groups by model, and **aggregates tool-branch spend** into the per-model totals (matches `getTokens()`).

All unit + new Agency tests pass; structural linter clean; existing `subagent-cost-propagation` Agency test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
