### PR TITLE
Fix time guard trip crashing instead of producing a Failure

### DIFF
--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,7 +1,8 @@
 import { nanoid } from "nanoid";
 import { agencyStore } from "./asyncContext.js";
 import { debugStep } from "./debugger.js";
-import { RestoreSignal } from "./errors.js";
+import { RestoreSignal, isAbortError } from "./errors.js";
+import type { Guard } from "./guard.js";
 import { HaltSignal } from "./haltSignal.js";
 import { invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
@@ -240,18 +241,31 @@ export class Runner {
    *      abort (race-loser branch cancel). Halt silently as before. */
   private shouldSkip(): boolean {
     if (this.stack?.abortSignal?.aborted && !this.halted) {
-      // Walk innermost-first so the deepest guard reports its trip
-      // first. Mirrors the order in prompt.ts's cost-check loop.
-      for (let i = this.stack.guards.length - 1; i >= 0; i--) {
-        const err = this.stack.guards[i].check(this.stack);
-        if (err) throw err;
-      }
+      const guardError = this.firstTrippedGuardError();
+      if (guardError) throw guardError;
       const guardOwnsAbort = this.stack.guards.some((g) => g.isTripped());
       if (!guardOwnsAbort) {
         this.halt(undefined);
       }
     }
     return this.halted || this._break || this._continue;
+  }
+
+  /** Walk this stack's guards innermost-first and return the first one
+   *  reporting a trip (or null if none is tripped / all already
+   *  consumed). Innermost-first mirrors prompt.ts's cost-check loop, so
+   *  the deepest guard's limit wins. `check()` consumes the trip (so it
+   *  fires exactly once); `isTripped()` keeps returning true afterward
+   *  for the popGuard-cleanup path. Shared by `shouldSkip` (abort
+   *  noticed at a step boundary) and `step`'s catch (abort surfaced
+   *  mid-step as a bare cancellation from an aborted in-flight call). */
+  private firstTrippedGuardError(): ReturnType<Guard["check"]> {
+    if (!this.stack) return null;
+    for (let i = this.stack.guards.length - 1; i >= 0; i--) {
+      const err = this.stack.guards[i].check(this.stack);
+      if (err) return err;
+    }
+    return null;
   }
 
   // ── Debug hook ──
@@ -390,9 +404,27 @@ export class Runner {
       // codegen "halt + return" pattern) signals a halt by throwing
       // `HaltSignal` so the surrounding step body unwinds without
       // executing post-interrupt code. Absorb the signal here once the
-      // runner is in the halted state; everything else (real errors,
-      // RestoreSignal, etc.) propagates as usual.
-      if (!(e instanceof HaltSignal && this.halted)) throw e;
+      // runner is in the halted state.
+      if (e instanceof HaltSignal && this.halted) {
+        // absorbed — fall through to the post-callback halt handling
+      } else {
+        // A guard trip (e.g. `guard(time:)`) fires the stack's abort
+        // signal, so an abortable in-flight call (sleep, llm, fetch, …)
+        // wakes early and rejects with a bare AgencyCancelledError. Left
+        // as-is that cancellation would escape the guarded scope — past
+        // the stdlib `guard`'s `try`, which re-throws abort errors — and
+        // crash a standalone program instead of becoming a timeout/cost
+        // Failure. Re-route a *guard-owned* abort through the same check
+        // `shouldSkip` uses so it surfaces as the structured
+        // GuardExceededError, exactly as if the trip had been noticed at
+        // the next step boundary. A genuine cancellation (Esc, race
+        // loser) has no tripped guard and propagates untouched.
+        if (isAbortError(e) && this.stack?.abortSignal?.aborted) {
+          const guardError = this.firstTrippedGuardError();
+          if (guardError) throw guardError;
+        }
+        throw e;
+      }
     } finally {
       this.path.pop();
     }

--- a/packages/agency-lang/tests/agency/guards/guard-time-trip-last-stmt.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-trip-last-stmt.agency
@@ -1,0 +1,21 @@
+import { guard } from "std::thread"
+
+// Regression guard for the abort-vs-cancellation fix: the guarded block
+// trips while its LAST statement (the sleep) is in flight, with NO
+// trailing statement to fall through to. The time guard fires its abort
+// signal, the abortable sleep wakes early and rejects with a bare
+// cancellation, and the runner step that owns the sleep re-routes that
+// guard-owned abort into the structured GuardExceededError on the spot —
+// rather than letting the cancellation escape the guard (which would
+// crash a standalone program) or relying on a non-existent next step
+// boundary to deliver the trip. The stdlib `guard`'s `try` then surfaces
+// it as a "timeoutFailure".
+node main() {
+  const result = guard(time: 20ms) as {
+    sleep(150ms)
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}:${result.error.maxTime}"
+  }
+  return "did not trip"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-trip-last-stmt.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-time-trip-last-stmt.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped:timeoutFailure:20\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A time guard trips while its block's LAST statement (a sleep) is in flight, with no trailing step. The guard-owned abort is converted to a GuardExceededError at the aborting step and surfaced as a timeoutFailure, instead of escaping as a bare cancellation (which crashed the program) or being dropped for lack of a next step boundary."
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Three guard tests crash on `main` (CI red across several commits):
`guard-time-trip`, `guard-time-nested`, `guard-time-and-cost`. Each fails
with an uncaught `AgencyCancelledError: sleep cancelled` → the generated
top-level wrapper prints `Agent crashed` and exits non-zero.

## Root cause

A `guard(time:)` trip enforces itself by firing the stack's abort signal.
Once `sleep` (and `llm`/`fetch`/…) became abortable, an in-flight call now
wakes early on that abort and rejects with a bare `AgencyCancelledError`.

The trip was *designed* to be delivered by `Runner.shouldSkip()` at the
next step boundary as a structured `GuardExceededError`, which the stdlib
`guard`'s `try` converts to a `timeoutFailure`. But the recent Esc-cancel
work (`functionCatchFailure` + `__tryCall` now re-throw `isAbortError`) so
a genuine cancellation unwinds cleanly to the REPL — also made a
*guard-owned* abort escape the guarded scope before `shouldSkip()` ran. In
a standalone program nothing absorbs it, so it crashes.

Semantically: an abort can mean *cancellation* (unwind to the initiator),
*limit exceeded* (a guard, → a `Failure`), or *branch prune* (race loser,
silent halt). They share one mechanism (abort the in-flight call) but need
different dispositions. The regression collapsed "limit exceeded" into
"cancellation."

## Fix (narrow)

In `Runner.step()`, when a step body throws a **guard-owned** abort
(`isAbortError(e)` and a stack guard `isTripped()`), re-route it through
the same innermost-first guard check `shouldSkip()` already uses, so it
becomes the `GuardExceededError` right where the abort landed.

Why `step()` and not the catch templates:
- It sits **above** any user `try`, so an inner `try sleep()` can't swallow
  the trip and let execution limp forward.
- It delivers the trip even when the aborting call is the block's **last
  statement** (no next step boundary to fall through to).
- A genuine cancellation (Esc, race-loser) has no tripped guard, so it
  still propagates untouched.

Refactor: extracted the guard-walk into `firstTrippedGuardError()`, shared
by `shouldSkip()` and the new `step()` catch path.

## Tests

- The three previously-crashing tests now pass.
- All 20 existing guard tests pass; runtime unit suites (guard, runner,
  result, abortable, promptRunner) and fork/race/interrupt/handler agency
  tests pass.
- Added `guard-time-trip-last-stmt` locking in the no-trailing-step case.

## Follow-up (not in this PR)

The deeper gap: a *legitimate* cancellation reaching the top of a
standalone program is still treated as `Agent crashed` + non-zero exit,
rather than a clean termination like the REPL does (cli.ts ~L745). Worth a
separate change to make the top-level wrapper cancellation-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
