### PR TITLE
Grouped, flattened LLM-call view in the logs viewer

### DIFF
--- a/packages/agency-lang/docs/superpowers/specs/2026-06-21-llm-call-grouped-view-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-21-llm-call-grouped-view-design.md
@@ -1,0 +1,187 @@
+# Grouped, flattened LLM-call view
+
+**Date:** 2026-06-21
+**Status:** Design — approved, pending spec review
+**Branch:** `llm-call-grouped-view`
+
+## Problem
+
+In the logs viewer, a single `llm(prompt, { tools })` call that triggers a
+tool renders confusingly. Two issues, reported from `foo.agency` (an LLM
+call whose `getArea` tool makes its own LLM call):
+
+1. **`llmCall` vs `promptCompletion` look redundant.** Each `llmCall`
+   span wraps exactly one `promptCompletion` event, so the two nodes
+   nest 1:1 with no added meaning.
+2. **One `llm()` call shows as multiple top-level `llmCall` nodes.** A
+   call with tools runs a multi-round tool loop, and today **each round
+   opens its own `llmCall` span** (`lib/runtime/prompt.ts:594, 632,
+   1080`). So an N-round call produces N sibling `llmCall` nodes under
+   `nodeExecution`, none of which represents "the whole call."
+
+### Current span shape (from `log.jsonl` for `foo.agency`)
+
+```
+agentRun
+└─ nodeExecution
+   ├─ llmCall #1            ← round 1
+   │  ├─ promptCompletion   [user] + [assistant: tool call getArea]
+   │  └─ toolExecution getArea
+   │     ├─ toolCallStart
+   │     ├─ threadCreated
+   │     ├─ llmCall         getArea's nested call
+   │     │  └─ promptCompletion  [user] + [assistant: "area is…"]
+   │     └─ toolCall
+   └─ llmCall #2            ← round 2
+      └─ promptCompletion   [user, tool call, tool result, assistant final]
+```
+
+## Goal
+
+One `llm()` call renders as **one** node showing a single, continuous
+conversation, with tool executions spliced inline and nested `llm()`
+calls shown as their own nodes:
+
+```
+nodeExecution
+└─ ▼ llm · gpt-4o-mini  (286 tok, $0.000)
+      [user] "Get the area of France…"
+      [assistant] tool call: getArea({"country":"France"})
+      └─ ▼ toolExecution getArea
+         ├─ ▼ getArea's llm · gpt-4o-mini
+         │     [user] "What is the area of France?"
+         │     [assistant] "≈551,695 km²…"
+         └─ toolCall "getArea"
+      [tool: getArea] "≈551,695 km²…"
+      [assistant] "The area of France is ≈551,695 km²…"
+```
+
+## Non-goals / out of scope
+
+- **Backward compatibility.** Old logs (per-round `llmCall` spans) are
+  not supported by the new rendering and will degrade to roughly the
+  current multi-node look. No `STATELOG_FORMAT_VERSION` bump, no
+  dual-mode rendering. Logs are regenerated.
+- No change to what events are emitted (`promptCompletion`,
+  `toolCall`, etc.) — only the **granularity of the `llmCall` span**.
+
+## Design
+
+Two changes: one runtime, one viewer.
+
+### 1. Runtime — `llmCall` is one span per `llm()` call
+
+**File:** `lib/runtime/prompt.ts` (`runPrompt`).
+
+Today the span is opened and closed **per round**:
+- `initialLlmCall` step opens it (line 594),
+- the resume path reopens it (lines 631–633),
+- each `round.N.nextLlmCall` step closes the previous and opens a new
+  one (lines 1078–1080),
+- `finally` closes the last (line 1123).
+
+Change to **one span for the whole tool loop**:
+- Open a single `llmCall` span once, before the `initialLlmCall` step.
+- Remove the per-round close+reopen at `nextLlmCall` (the span stays
+  open across rounds).
+- Close it once in the existing `finally`.
+- Preserve resume semantics: the span is opened at `runPrompt` entry
+  (outside `pr.step`, as today), so a resumed execution opens its own
+  span — consistent with the current per-round behavior. Spans are
+  runtime-only and not serialized.
+
+Result: all rounds' `promptCompletion` events and all `toolExecution`
+spans nest under one `llmCall` span. No new `SpanType`. `llmCall` now
+means exactly "one `llm()` call." Per-call duration/tokens/cost roll up
+to the single span via the existing aggregation in
+`lib/logsViewer/tree.ts` (`measuredDuration` sums every
+`promptCompletion.timeTaken` under the span — now the call total).
+
+### 2. Viewer — render an `llmCall` span as a flattened conversation
+
+**Files:** `lib/logsViewer/render.ts` (primary), `summary.ts` (label).
+
+The tree builder (`tree.ts`) is unchanged: an `llmCall` span still has
+its `promptCompletion` leaves and `toolExecution` child spans. The
+**flatten happens at display time** in `flattenVisibleRows`.
+
+When an `llmCall` span is expanded, instead of listing its raw children,
+produce synthetic expansion rows:
+
+1. **Pick the transcript source.** Take the **last** `promptCompletion`
+   leaf under the span (latest by timestamp). Its `messages` array is
+   the complete request transcript of the final round; its
+   `completion` is the final assistant turn. Assemble
+   `[...messages, assistantMessage(completion)]` — reusing the existing
+   message-assembly in `promptCompletionChildren` (the same logic that
+   already renders a single `promptCompletion`, including the
+   tool-call-aware completion turn from the earlier render.ts fix).
+2. **Build conversation rows.** Run the assembled messages through
+   `formatConversation` → one `convoLine` per line (with the existing
+   width-wrapping).
+3. **Splice tool executions inline.** Collect the span's
+   `toolExecution` child spans in timestamp order. Walk the assembled
+   messages; when a message is an assistant turn carrying `toolCalls`,
+   emit its `convoLine`(s) and then emit the **next N** `toolExecution`
+   span nodes (N = that message's tool-call count), in order. These are
+   the real tree nodes, so they keep their normal expansion (and the
+   nested `llmCall` inside each tool execution flattens recursively).
+4. **Absorb the rest.** The intermediate `promptCompletion` leaves
+   (earlier rounds) are not rendered as their own rows — their content
+   is a prefix of the final transcript. A "raw data" affordance on the
+   node still exposes the underlying envelope(s) for debugging.
+
+Matching tool executions by greedy count + time order needs no
+tool-call ids: across the whole call, the assistant tool-call messages
+appear in order and the `toolExecution` spans were created in that same
+order. Parallel tool calls in one round (one assistant message with
+N>1 `toolCalls`) splice all N.
+
+**Label.** Display the `llmCall` span as `llm` in the viewer (matches
+how users think of the call). The internal `SpanType` stays `"llmCall"`
+to avoid churn in `inferSpanLabel` / `colorFor` / tests; only the
+rendered label changes.
+
+## Edge cases
+
+- **No-tool call.** One round, one `promptCompletion`, no
+  `toolExecution`s → just the `[user]/[assistant]` conversation rows.
+- **Parallel tool calls in a round.** Assistant message with N tool
+  calls → splice the next N tool-execution spans.
+- **Multi-round with tools in several rounds.** Greedy count consumes
+  tool-execution spans in order across rounds; each round's assistant
+  tool-call message gets its round's executions.
+- **Error / cancelled round (no clean final `promptCompletion`).** Fall
+  back to the last available `promptCompletion`; if none exists under
+  the span, fall back to listing the raw children (current behavior).
+- **Nested `llm()` (the `getArea` case).** Its own `llmCall` span,
+  flattened by the same code path, rendered inside the spliced
+  `toolExecution`.
+
+## Testing
+
+- **Runtime** (`tests/agency-js/`): a multi-round tool call emits
+  exactly **one** `llmCall` span wrapping both rounds' `promptCompletion`
+  events and the `toolExecution`. Assert span counts/parentage by
+  reading `statelog.log` (same harness as
+  `tool-call-no-phantom-thread`).
+- **Viewer** (`lib/logsViewer/render.test.ts`, `tree.test.ts`):
+  - single-round `llmCall` → conversation rows, no tool splice;
+  - multi-round `llmCall` with one tool → flattened transcript with the
+    `toolExecution` spliced after the assistant tool-call line;
+  - parallel tool calls → two executions spliced after one assistant
+    message;
+  - recursive nested `llmCall` inside a tool execution renders flattened;
+  - greedy splice order is correct across rounds.
+
+## Risks
+
+- **Per-round timing is no longer a separate span.** Only the per-call
+  total shows on the node; individual round `timeTaken` remains in each
+  `promptCompletion`'s raw data. Accepted.
+- **Resume span semantics.** Opening one span at `runPrompt` entry must
+  not break checkpoint/resume; verified against the existing per-entry
+  span behavior (spans are not serialized). Covered by runtime tests.
+- **Flatten correctness depends on the last `promptCompletion` holding
+  the full transcript.** True for the tool loop (each round resends the
+  growing thread). The error-path fallback covers the exception.

--- a/packages/agency-lang/lib/logsViewer/conversation.test.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.test.ts
@@ -63,6 +63,26 @@ describe("formatConversation", () => {
     expect(lines).toEqual([`${color.green("[user]")} "first second"`]);
   });
 
+  it("renders a non-content-part array (e.g. a tool result) as JSON", () => {
+    // A tool message's content can be the raw return value — here a
+    // number array. It must not be mistaken for a multimodal
+    // content-parts array (which would extract zero text and render
+    // nothing).
+    const lines = formatConversation([
+      { role: "tool", name: "fibonacciNumbers", content: [0, 1, 1, 2, 3], tool_call_id: "x" },
+    ]);
+    expect(lines).toEqual([
+      `${color.green("[tool: fibonacciNumbers]")} [0,1,1,2,3]`,
+    ]);
+  });
+
+  it("renders an object tool result as JSON", () => {
+    const lines = formatConversation([
+      { role: "tool", name: "t", content: { response: [1, 2] }, tool_call_id: "x" },
+    ]);
+    expect(lines).toEqual([`${color.green("[tool: t]")} {"response":[1,2]}`]);
+  });
+
   it("emits a placeholder row for empty turns", () => {
     const lines = formatConversation([{ role: "assistant", content: null }]);
     expect(lines).toEqual([color.green("[assistant]")]);

--- a/packages/agency-lang/lib/logsViewer/conversation.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.ts
@@ -73,7 +73,10 @@ function stringifyContent(content: unknown): string | undefined {
     const parts = content
       .map((p) => contentPartText(p))
       .filter((s): s is string => s !== undefined);
-    if (parts.length === 0) return undefined;
+    // A multimodal content-parts array yields text parts. A plain data
+    // array (e.g. a tool result like [0,1,1,2,3]) yields none — render
+    // the whole value as JSON rather than showing nothing.
+    if (parts.length === 0) return JSON.stringify(content);
     return JSON.stringify(parts.join(" "));
   }
   return JSON.stringify(content);

--- a/packages/agency-lang/lib/logsViewer/render.e2e.test.ts
+++ b/packages/agency-lang/lib/logsViewer/render.e2e.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { buildForest } from "./tree.js";
+import { flattenVisibleRows, renderRowText } from "./render.js";
+import { EventEnvelope, TreeNode, ViewerState } from "./types.js";
+
+// End-to-end: feed a realistic statelog through the WHOLE viewer
+// pipeline (buildForest → flattenVisibleRows → renderRowText) and assert
+// the composed behavior of every recent change at once:
+//   - the grouped/flattened llmCall view with the tool execution
+//     spliced inline,
+//   - a non-string (array) tool result rendered as JSON,
+//   - identifying detail in span summaries (node/tool names, branch
+//     count, model + prompt + outcome),
+//   - forkBranchEnd values,
+//   - wall-clock envelope durations with parent ⊇ child.
+//
+// Scenario (mirrors bar.agency, shrunk to 2 fork branches):
+//   agent → llm("use fibonacciNumbers") → tool forks 2 parallel llms.
+
+const E = (
+  spanId: string | null,
+  parentSpanId: string | null,
+  data: any,
+): EventEnvelope => ({
+  format_version: 1,
+  trace_id: "t1",
+  project_id: "p",
+  span_id: spanId,
+  parent_span_id: parentSpanId,
+  data,
+});
+
+const TS = (sec: string) => `2026-06-21T00:00:0${sec}Z`;
+const TOOLCALL = { id: "c1", name: "fibonacciNumbers", arguments: { num: 2 } };
+
+const events: EventEnvelope[] = [
+  E("A", null, { type: "agentStart", timestamp: TS("0.000"), entryNode: "main" }),
+  E("N", "A", { type: "enterNode", timestamp: TS("0.100"), nodeId: "agent" }),
+  // Round 1: the model asks for the tool.
+  E("L", "N", {
+    type: "promptCompletion",
+    timestamp: TS("1.000"),
+    timeTaken: 1000,
+    model: '"gpt-4o-mini"',
+    messages: [{ role: "user", content: "Use the fibonacciNumbers tool" }],
+    completion: { output: null, toolCalls: [TOOLCALL] },
+  }),
+  // The tool execution: forks two parallel llm() calls.
+  E("T", "L", { type: "toolCallStart", timestamp: TS("1.000"), toolName: "fibonacciNumbers" }),
+  E("F", "T", { type: "forkStart", timestamp: TS("1.100"), mode: "all", branchCount: 2 }),
+  E("B1", "F", {
+    type: "promptCompletion",
+    timestamp: TS("4.000"),
+    timeTaken: 2800,
+    model: '"gpt-4o-mini"',
+    messages: [{ role: "user", content: "Calculate the 0th Fibonacci number" }],
+    completion: { output: '{"response":0}' },
+  }),
+  E("B2", "F", {
+    type: "promptCompletion",
+    timestamp: TS("4.000"),
+    timeTaken: 2900,
+    model: '"gpt-4o-mini"',
+    messages: [{ role: "user", content: "Calculate the 1th Fibonacci number" }],
+    completion: { output: '{"response":1}' },
+  }),
+  E("F", "T", { type: "forkBranchEnd", timestamp: TS("4.000"), branchIndex: 0, outcome: "success", timeTaken: 2800, value: 0 }),
+  E("F", "T", { type: "forkBranchEnd", timestamp: TS("4.000"), branchIndex: 1, outcome: "success", timeTaken: 2900, value: 1 }),
+  E("F", "T", { type: "forkEnd", timestamp: TS("4.100"), mode: "all", timeTaken: 3000 }),
+  E("T", "L", { type: "toolCall", timestamp: TS("4.100"), toolName: "fibonacciNumbers", output: [0, 1], timeTaken: 3000 }),
+  // Round 2: the final answer. The tool message content is the RAW array.
+  E("L", "N", {
+    type: "promptCompletion",
+    timestamp: TS("5.000"),
+    timeTaken: 1000,
+    model: '"gpt-4o-mini"',
+    messages: [
+      { role: "user", content: "Use the fibonacciNumbers tool" },
+      { role: "assistant", content: null, toolCalls: [TOOLCALL] },
+      { role: "tool", name: "fibonacciNumbers", content: [0, 1], tool_call_id: "c1" },
+    ],
+    completion: { output: '{"response":[0,1]}' },
+  }),
+  E("N", "A", { type: "exitNode", timestamp: TS("5.100"), nodeId: "agent" }),
+  E("A", null, { type: "agentEnd", timestamp: TS("5.500"), timeTaken: 5500 }),
+];
+
+function buildState(): { roots: TreeNode[]; state: ViewerState } {
+  const roots = buildForest(events);
+  const expanded = new Set<string>();
+  const walk = (n: TreeNode): void => {
+    expanded.add(n.id);
+    for (const c of n.children) walk(c);
+  };
+  roots.forEach(walk);
+  return {
+    roots,
+    state: { roots, expanded, cursorId: roots[0].id, scrollTop: 0, quit: false, viewportCols: 200 },
+  };
+}
+
+function findNode(roots: TreeNode[], id: string): TreeNode {
+  const stack = [...roots];
+  while (stack.length) {
+    const n = stack.pop()!;
+    if (n.id === id) return n;
+    stack.push(...n.children);
+  }
+  throw new Error(`node ${id} not found`);
+}
+
+// Strip ANSI color escapes and {…-fg} style tags so substring asserts
+// match the visible text.
+function clean(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b?\[[0-9;]*m/g, "").replace(/\{\/?[a-z-]+\}/g, "");
+}
+
+describe("logs viewer — end-to-end render", () => {
+  const { roots, state } = buildState();
+  const text = clean(
+    flattenVisibleRows(state)
+      .map((r) => renderRowText(r, false, state.expanded.has(r.node.id), {}))
+      .join("\n"),
+  );
+
+  it("groups the outer llm() into one flattened conversation with the tool spliced inline", () => {
+    // Conversation appears once, in order, with the tool execution between
+    // the assistant tool-call line and the tool-result line.
+    const lines = text.split("\n").map((l) => l.trim());
+    const idxAsstCall = lines.findIndex((l) => l.includes("tool call: fibonacciNumbers"));
+    const idxToolExec = lines.findIndex((l) => l.startsWith("▼ toolExecution") || l.startsWith("▶ toolExecution"));
+    const idxToolResult = lines.findIndex((l) => l.includes("[tool: fibonacciNumbers]"));
+    expect(idxAsstCall).toBeGreaterThanOrEqual(0);
+    expect(idxToolExec).toBeGreaterThan(idxAsstCall);
+    expect(idxToolResult).toBeGreaterThan(idxToolExec);
+  });
+
+  it("renders the array tool result as JSON (not blank)", () => {
+    expect(text).toContain("[tool: fibonacciNumbers] [0,1]");
+  });
+
+  it("shows identifying detail in span summaries", () => {
+    expect(text).toContain('nodeExecution "agent"');
+    expect(text).toContain("toolExecution fibonacciNumbers");
+    expect(text).toContain("forkAll 2 branches");
+    expect(text).toContain("agentRun \"main\"");
+  });
+
+  it("makes the parallel branch llmCalls distinguishable by prompt and outcome", () => {
+    expect(text).toContain('· "Calculate the 0th Fibonacci');
+    expect(text).toContain('· "Calculate the 1th Fibonacci');
+    expect(text).toContain("gpt-4o-mini");
+  });
+
+  it("shows forkBranchEnd return values", () => {
+    expect(text).toMatch(/forkBranchEnd #0 \(success.*\) → 0/);
+    expect(text).toMatch(/forkBranchEnd #1 \(success.*\) → 1/);
+  });
+
+  it("computes wall-clock durations with parent ⊇ child (no parallel summing)", () => {
+    const node = findNode(roots, "N"); // nodeExecution
+    const outer = findNode(roots, "L"); // outer llmCall
+    const tool = findNode(roots, "T"); // toolExecution
+    const fork = findNode(roots, "F"); // forkAll
+    const branch = findNode(roots, "B1"); // a branch llmCall
+    // The outer call ran ~5s wall-clock, NOT the ~8.7s sum of its rounds
+    // plus the two parallel branches.
+    expect(outer.duration).toBe(5000);
+    expect(outer.duration!).toBeLessThanOrEqual(node.duration!);
+    expect(tool.duration!).toBeLessThanOrEqual(outer.duration!);
+    expect(fork.duration!).toBeLessThanOrEqual(tool.duration!);
+    expect(branch.duration!).toBeLessThanOrEqual(fork.duration!);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/render.flatten.test.ts
+++ b/packages/agency-lang/lib/logsViewer/render.flatten.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect } from "vitest";
+import { buildForest } from "./tree.js";
+import { flattenVisibleRows } from "./render.js";
+import { EventEnvelope, TreeNode, ViewerState } from "./types.js";
+
+// Build an envelope with sane defaults.
+const evt = (over: Partial<EventEnvelope>): EventEnvelope => ({
+  format_version: 1,
+  trace_id: "t1",
+  project_id: "p",
+  span_id: null,
+  parent_span_id: null,
+  data: { type: "debug", timestamp: "2026-06-21T00:00:00Z" },
+  ...over,
+});
+
+// Expand every span/trace node so the flattened conversation rows are
+// produced. Leaves/synthetic rows don't need expanding for the span
+// flatten, but expanding spans (incl. toolExecution + nested llmCall)
+// exercises recursion.
+function expandAll(roots: TreeNode[]): Set<string> {
+  const ids = new Set<string>();
+  const walk = (n: TreeNode): void => {
+    if (n.nodeKind !== "event") ids.add(n.id);
+    // Also expand event leaves so any non-flattened paths still open.
+    if (n.nodeKind === "event") ids.add(n.id);
+    for (const c of n.children) walk(c);
+  };
+  for (const r of roots) walk(r);
+  return ids;
+}
+
+function stateFor(events: EventEnvelope[]): ViewerState {
+  const roots = buildForest(events);
+  return {
+    roots,
+    expanded: expandAll(roots),
+    cursorId: roots[0].id,
+    scrollTop: 0,
+    quit: false,
+  };
+}
+
+// Summaries of the convoLine rows, in order, with ANSI color stripped
+// so assertions are readable.
+function convoSummaries(rows: { node: TreeNode }[]): string[] {
+  return rows
+    .filter((r) => r.node.nodeKind === "convoLine")
+    .map((r) => stripAnsi(r.node.summary));
+}
+
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\[[0-9;]*m/g, "");
+}
+
+describe("llmCall span flatten", () => {
+  it("single-round call → flattened user/assistant, no tool splice", () => {
+    const rows = flattenVisibleRows(
+      stateFor([
+        evt({ span_id: "a", data: { type: "agentStart", timestamp: "2026-06-21T00:00:00Z" } }),
+        evt({
+          span_id: "L",
+          parent_span_id: "a",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:01Z",
+            messages: [{ role: "user", content: "hello" }],
+            completion: { output: "hi there", toolCalls: [] },
+          },
+        }),
+      ]),
+    );
+    const convos = convoSummaries(rows);
+    expect(convos).toEqual(['[user] "hello"', '[assistant] "hi there"']);
+    // No toolExecution row, but a raw-data toggle should be present.
+    expect(rows.some((r) => r.node.nodeKind === "rawDataToggle")).toBe(true);
+    // The intermediate promptCompletion leaf is absorbed (not shown).
+    expect(rows.some((r) => r.node.label === "promptCompletion")).toBe(false);
+  });
+
+  it("multi-round tool call → one llmCall node with the tool execution spliced inline", () => {
+    const rows = flattenVisibleRows(
+      stateFor([
+        evt({ span_id: "a", data: { type: "agentStart", timestamp: "2026-06-21T00:00:00Z" } }),
+        // Round 1: assistant asks for getArea.
+        evt({
+          span_id: "L",
+          parent_span_id: "a",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:01Z",
+            messages: [{ role: "user", content: "Get the area of France" }],
+            completion: {
+              output: null,
+              toolCalls: [{ id: "c1", name: "getArea", arguments: { country: "France" } }],
+            },
+          },
+        }),
+        // The tool execution (nested under the same llmCall span).
+        evt({
+          span_id: "T",
+          parent_span_id: "L",
+          data: { type: "toolCallStart", timestamp: "2026-06-21T00:00:02Z", toolName: "getArea" },
+        }),
+        evt({
+          span_id: "T",
+          parent_span_id: "L",
+          data: { type: "toolCall", timestamp: "2026-06-21T00:00:03Z", toolName: "getArea", output: "551695" },
+        }),
+        // Round 2: final answer (holds the full transcript).
+        evt({
+          span_id: "L",
+          parent_span_id: "a",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:04Z",
+            messages: [
+              { role: "user", content: "Get the area of France" },
+              { role: "assistant", content: null, toolCalls: [{ id: "c1", name: "getArea", arguments: { country: "France" } }] },
+              { role: "tool", name: "getArea", content: "551695", tool_call_id: "c1" },
+            ],
+            completion: { output: "The area of France is 551,695 km²", toolCalls: [] },
+          },
+        }),
+      ]),
+    );
+
+    // Conversation appears once, in order, with no duplication.
+    const convos = convoSummaries(rows);
+    expect(convos).toEqual([
+      '[user] "Get the area of France"',
+      '[assistant] tool call: getArea({"country":"France"})',
+      '[tool: getArea] "551695"',
+      '[assistant] "The area of France is 551,695 km²"',
+    ]);
+
+    // The toolExecution span is spliced between the assistant tool-call
+    // line and the tool-result line.
+    const kinds = rows
+      .filter(
+        (r) =>
+          r.node.nodeKind === "convoLine" ||
+          (r.node.nodeKind === "span" && r.node.label === "toolExecution"),
+      )
+      .map((r) =>
+        r.node.nodeKind === "span" ? "toolExecution" : stripAnsi(r.node.summary),
+      );
+    expect(kinds).toEqual([
+      '[user] "Get the area of France"',
+      '[assistant] tool call: getArea({"country":"France"})',
+      "toolExecution",
+      '[tool: getArea] "551695"',
+      '[assistant] "The area of France is 551,695 km²"',
+    ]);
+
+    // Exactly one llmCall span node at the top level (no sibling rounds).
+    const llmNodes = rows.filter(
+      (r) => r.node.nodeKind === "span" && r.node.label === "llmCall",
+    );
+    expect(llmNodes).toHaveLength(1);
+  });
+
+  it("parallel tool calls in one round → both executions spliced after the assistant message", () => {
+    const rows = flattenVisibleRows(
+      stateFor([
+        evt({ span_id: "a", data: { type: "agentStart", timestamp: "2026-06-21T00:00:00Z" } }),
+        evt({
+          span_id: "L",
+          parent_span_id: "a",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:01Z",
+            messages: [{ role: "user", content: "do both" }],
+            completion: {
+              output: null,
+              toolCalls: [
+                { id: "c1", name: "toolA", arguments: {} },
+                { id: "c2", name: "toolB", arguments: {} },
+              ],
+            },
+          },
+        }),
+        evt({ span_id: "TA", parent_span_id: "L", data: { type: "toolCall", timestamp: "2026-06-21T00:00:02Z", toolName: "toolA", output: "a" } }),
+        evt({ span_id: "TB", parent_span_id: "L", data: { type: "toolCall", timestamp: "2026-06-21T00:00:03Z", toolName: "toolB", output: "b" } }),
+        evt({
+          span_id: "L",
+          parent_span_id: "a",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:04Z",
+            messages: [
+              { role: "user", content: "do both" },
+              { role: "assistant", content: null, toolCalls: [
+                { id: "c1", name: "toolA", arguments: {} },
+                { id: "c2", name: "toolB", arguments: {} },
+              ] },
+              { role: "tool", name: "toolA", content: "a", tool_call_id: "c1" },
+              { role: "tool", name: "toolB", content: "b", tool_call_id: "c2" },
+            ],
+            completion: { output: "done", toolCalls: [] },
+          },
+        }),
+      ]),
+    );
+    // The assistant turn produces one "tool call" line per call (2),
+    // then both tool executions are spliced after, in order.
+    const seq = rows
+      .filter(
+        (r) =>
+          (r.node.nodeKind === "span" && r.node.label === "toolExecution") ||
+          (r.node.nodeKind === "convoLine" && r.node.summary.includes("tool call")),
+      )
+      .map((r) => (r.node.nodeKind === "span" ? "exec" : "tool-call-line"));
+    expect(seq).toEqual(["tool-call-line", "tool-call-line", "exec", "exec"]);
+  });
+
+  it("nested llm() inside a tool flattens recursively", () => {
+    const rows = flattenVisibleRows(
+      stateFor([
+        evt({ span_id: "a", data: { type: "agentStart", timestamp: "2026-06-21T00:00:00Z" } }),
+        evt({
+          span_id: "L",
+          parent_span_id: "a",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:01Z",
+            messages: [{ role: "user", content: "outer" }],
+            completion: { output: null, toolCalls: [{ id: "c1", name: "getArea", arguments: {} }] },
+          },
+        }),
+        evt({ span_id: "T", parent_span_id: "L", data: { type: "toolCall", timestamp: "2026-06-21T00:00:05Z", toolName: "getArea", output: "x" } }),
+        // getArea's own llm() — a nested llmCall span under the tool.
+        evt({
+          span_id: "L2",
+          parent_span_id: "T",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:03Z",
+            messages: [{ role: "user", content: "What is the area?" }],
+            completion: { output: "about 551,695", toolCalls: [] },
+          },
+        }),
+        evt({
+          span_id: "L",
+          parent_span_id: "a",
+          data: {
+            type: "promptCompletion",
+            timestamp: "2026-06-21T00:00:06Z",
+            messages: [
+              { role: "user", content: "outer" },
+              { role: "assistant", content: null, toolCalls: [{ id: "c1", name: "getArea", arguments: {} }] },
+              { role: "tool", name: "getArea", content: "about 551,695", tool_call_id: "c1" },
+            ],
+            completion: { output: "final", toolCalls: [] },
+          },
+        }),
+      ]),
+    );
+    const convos = convoSummaries(rows);
+    // Outer conversation + the nested call's own conversation both show.
+    expect(convos).toContain('[user] "outer"');
+    expect(convos).toContain('[user] "What is the area?"');
+    expect(convos).toContain('[assistant] "about 551,695"');
+    expect(convos).toContain('[assistant] "final"');
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/render.ts
+++ b/packages/agency-lang/lib/logsViewer/render.ts
@@ -31,6 +31,16 @@ export function flattenVisibleRows(state: ViewerState): VisibleRow[] {
       }
       return;
     }
+    // An `llmCall` span renders its one-or-more rounds as a single
+    // flattened conversation with tool executions spliced inline,
+    // instead of listing its raw promptCompletion/toolExecution
+    // children. See llmCallSpanChildren.
+    if (node.nodeKind === "span" && node.label === "llmCall") {
+      for (const child of llmCallSpanChildren(node, depth + 1, cols)) {
+        walk(child, depth + 1);
+      }
+      return;
+    }
     for (const c of node.children) walk(c, depth + 1);
   };
   for (const r of state.roots) walk(r, 0);
@@ -70,22 +80,20 @@ export function rawDataChildren(toggle: TreeNode): TreeNode[] {
   return jsonLineChildren(toggle, toggle.event);
 }
 
-function promptCompletionChildren(
-  leaf: TreeNode,
-  childDepth = 0,
-  cols?: number,
-): TreeNode[] {
-  const messages = Array.isArray(leaf.event!.data.messages)
-    ? leaf.event!.data.messages
+// Assemble the displayable transcript for a promptCompletion event:
+// the request `messages` plus the assistant turn from `completion`.
+// Render the assistant turn whenever it has text OR tool calls — the
+// common tool-calling completion has `output: null` and a non-empty
+// `toolCalls` array, and `formatConversation` already renders an
+// assistant message's `toolCalls`, so we just pass them through.
+function assembleTranscript(
+  event: NonNullable<TreeNode["event"]>,
+): any[] {
+  const messages = Array.isArray(event.data.messages)
+    ? event.data.messages
     : [];
-  const completion = leaf.event!.data.completion;
-  const completionMessage = [];
-  // Render the assistant turn whenever it has text OR tool calls. The
-  // common tool-calling completion has `output: null` and a non-empty
-  // `toolCalls` array — keying only on `output` dropped the tool call
-  // from the conversation view (it was visible only under "raw data").
-  // `formatConversation` already renders an assistant message's
-  // `toolCalls`, so just pass them through.
+  const completion = event.data.completion;
+  const completionMessage: any[] = [];
   if (completion?.output || completion?.toolCalls?.length) {
     completionMessage.push({
       role: "assistant",
@@ -93,39 +101,123 @@ function promptCompletionChildren(
       toolCalls: completion.toolCalls,
     });
   }
-  const convoLines = formatConversation([...messages, ...completionMessage]);
-  // renderRowText prefixes each row with `marker` (2 chars) + indent
-  // (`depth * 2` chars) before the convoLine summary. Subtract both
-  // so wrapped chunks fit without triggering the TUI clipper.
-  const available = cols !== undefined
-    ? Math.max(20, cols - childDepth * 2 - 2)
-    : undefined;
-  const convoNodes: TreeNode[] = [];
-  convoLines.forEach((line, i) => {
-    const chunks = available !== undefined ? wrapLine(line, available) : [line];
-    chunks.forEach((chunk, j) => {
-      convoNodes.push({
-        id: `${leaf.id}:convo:${i}:${j}`,
-        traceId: leaf.traceId,
-        parentId: leaf.id,
-        children: [],
-        nodeKind: "convoLine" as const,
-        label: "",
-        summary: chunk,
-      });
-    });
-  });
-  const toggle: TreeNode = {
-    id: `${leaf.id}:raw`,
-    traceId: leaf.traceId,
-    parentId: leaf.id,
+  return [...messages, ...completionMessage];
+}
+
+// Available text width for a synthetic child row at `childDepth`.
+// renderRowText prefixes each row with `marker` (2 chars) + indent
+// (`depth * 2` chars); subtract both so wrapped chunks fit without
+// triggering the TUI clipper. Undefined cols (tests) disables wrapping.
+function availableWidth(childDepth: number, cols?: number): number | undefined {
+  return cols !== undefined ? Math.max(20, cols - childDepth * 2 - 2) : undefined;
+}
+
+// Turn one conversation line into one-or-more wrapped `convoLine` nodes.
+function convoLineNodes(
+  idPrefix: string,
+  parent: TreeNode,
+  line: string,
+  lineIdx: number,
+  available?: number,
+): TreeNode[] {
+  const chunks = available !== undefined ? wrapLine(line, available) : [line];
+  return chunks.map((chunk, j) => ({
+    id: `${idPrefix}:${lineIdx}:${j}`,
+    traceId: parent.traceId,
+    parentId: parent.id,
+    children: [],
+    nodeKind: "convoLine" as const,
+    label: "",
+    summary: chunk,
+  }));
+}
+
+function rawDataToggleNode(
+  id: string,
+  parent: TreeNode,
+  event: TreeNode["event"],
+): TreeNode {
+  return {
+    id,
+    traceId: parent.traceId,
+    parentId: parent.id,
     children: [],
     nodeKind: "rawDataToggle" as const,
     label: "raw data",
     summary: "raw data",
-    event: leaf.event,
+    event,
   };
-  return [...convoNodes, toggle];
+}
+
+function promptCompletionChildren(
+  leaf: TreeNode,
+  childDepth = 0,
+  cols?: number,
+): TreeNode[] {
+  const convoLines = formatConversation(assembleTranscript(leaf.event!));
+  const available = availableWidth(childDepth, cols);
+  const convoNodes: TreeNode[] = [];
+  convoLines.forEach((line, i) => {
+    convoNodes.push(...convoLineNodes(`${leaf.id}:convo`, leaf, line, i, available));
+  });
+  return [...convoNodes, rawDataToggleNode(`${leaf.id}:raw`, leaf, leaf.event)];
+}
+
+// Synthetic children shown when an `llmCall` span is expanded — the
+// flattened, deduplicated conversation for one `llm()` call. Because a
+// tool-loop's final round resends the whole growing thread, the LAST
+// promptCompletion under the span holds the complete transcript; we
+// render that and splice each `toolExecution` child span inline right
+// after the assistant message whose tool calls triggered it (greedy by
+// tool-call count, in time order — the tree already sorts children by
+// time). The intermediate promptCompletion leaves are absorbed (their
+// content is a prefix of the final transcript). A nested `llm()` inside
+// a tool execution is itself an `llmCall` span, so it flattens
+// recursively when its tool execution is expanded.
+//
+// Exported so search.ts walks the same rows the renderer shows.
+export function llmCallSpanChildren(
+  span: TreeNode,
+  childDepth = 0,
+  cols?: number,
+): TreeNode[] {
+  const pcLeaves = span.children.filter(
+    (c) => c.event?.data.type === "promptCompletion",
+  );
+  // No promptCompletion under this span (e.g. the call errored before a
+  // response). Fall back to the raw children so nothing is hidden.
+  if (pcLeaves.length === 0) return span.children;
+
+  // Under an llmCall span the only child SPANS are tool executions, so
+  // match on nodeKind (robust to how the span happened to be labeled).
+  const toolExecs = span.children.filter((c) => c.nodeKind === "span");
+  const others = span.children.filter(
+    (c) => !pcLeaves.includes(c) && !toolExecs.includes(c),
+  );
+
+  const last = pcLeaves[pcLeaves.length - 1];
+  const transcript = assembleTranscript(last.event!);
+  const available = availableWidth(childDepth, cols);
+
+  const out: TreeNode[] = [];
+  const queue = [...toolExecs];
+  let lineIdx = 0;
+  for (const msg of transcript) {
+    for (const line of formatConversation([msg])) {
+      out.push(...convoLineNodes(`${span.id}:llm:convo`, span, line, lineIdx++, available));
+    }
+    const toolCallCount = (msg?.toolCalls ?? msg?.tool_calls ?? []).length;
+    for (let i = 0; i < toolCallCount && queue.length > 0; i++) {
+      out.push(queue.shift()!);
+    }
+  }
+  // Any tool executions or other children we couldn't place inline
+  // (defensive — e.g. a count mismatch or an error event) go at the end
+  // so nothing is silently dropped.
+  out.push(...queue, ...others);
+  // Raw-data toggle exposing the final promptCompletion envelope.
+  out.push(rawDataToggleNode(`${span.id}:llm:raw`, span, last.event));
+  return out;
 }
 
 // Word-aware hard wrap. Splits `text` into chunks of at most `width`

--- a/packages/agency-lang/lib/logsViewer/search.test.ts
+++ b/packages/agency-lang/lib/logsViewer/search.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { findMatches, expandAncestorsOf, highlightMatches } from "./search.js";
-import { TreeNode, ViewerState } from "./types.js";
+import { buildForest } from "./tree.js";
+import { EventEnvelope, TreeNode, ViewerState } from "./types.js";
 
 function span(id: string, summary: string, children: TreeNode[] = [], parentId: string | null = null): TreeNode {
   return {
@@ -157,6 +158,94 @@ describe("findMatches — synthetic rows", () => {
     const next = expandAncestorsOf(state, ["evt-0:raw:json:5"]);
     expect(next.expanded.has("evt-0")).toBe(true);
     expect(next.expanded.has("evt-0:raw")).toBe(true);
+  });
+});
+
+describe("findMatches — llmCall span flatten", () => {
+  // A two-round tool call. The tool result + final answer ("551695")
+  // appear only in the flattened conversation under the llmCall span,
+  // not in any persistent forest node — search must still find them.
+  const evt = (over: Partial<EventEnvelope>): EventEnvelope => ({
+    format_version: 1,
+    trace_id: "T",
+    project_id: "p",
+    span_id: null,
+    parent_span_id: null,
+    data: { type: "debug", timestamp: "2026-06-21T00:00:00Z" },
+    ...over,
+  });
+
+  const events: EventEnvelope[] = [
+    evt({ span_id: "a", data: { type: "agentStart", timestamp: "2026-06-21T00:00:00Z" } }),
+    evt({
+      span_id: "L",
+      parent_span_id: "a",
+      data: {
+        type: "promptCompletion",
+        timestamp: "2026-06-21T00:00:01Z",
+        messages: [{ role: "user", content: "area of France" }],
+        completion: { output: null, toolCalls: [{ id: "c1", name: "getArea", arguments: {} }] },
+      },
+    }),
+    evt({ span_id: "T", parent_span_id: "L", data: { type: "toolCall", timestamp: "2026-06-21T00:00:02Z", toolName: "getArea", output: "551695" } }),
+    evt({
+      span_id: "L",
+      parent_span_id: "a",
+      data: {
+        type: "promptCompletion",
+        timestamp: "2026-06-21T00:00:03Z",
+        messages: [
+          { role: "user", content: "area of France" },
+          { role: "assistant", content: null, toolCalls: [{ id: "c1", name: "getArea", arguments: {} }] },
+          { role: "tool", name: "getArea", content: "551695", tool_call_id: "c1" },
+        ],
+        completion: { output: "The area is 551695", toolCalls: [] },
+      },
+    }),
+  ];
+
+  it("finds text that only exists in the flattened conversation", () => {
+    const roots = buildForest(events);
+    const matches = findMatches(roots, "551695");
+    // At least one match is a convoLine synthetic id under the L span.
+    expect(matches.some((id) => id.startsWith("L:llm:convo:"))).toBe(true);
+  });
+
+  it("expandAncestorsOf reveals a flattened-convo match by expanding the llmCall span", () => {
+    const roots = buildForest(events);
+    const state: ViewerState = {
+      roots,
+      expanded: new Set(),
+      cursorId: roots[0].id,
+      scrollTop: 0,
+      quit: false,
+    };
+    const next = expandAncestorsOf(state, ["L:llm:convo:3:0"]);
+    // The llmCall span itself and its ancestors (nodeExecution/agent
+    // span + trace) are expanded so the convo row becomes visible.
+    expect(next.expanded.has("L")).toBe(true);
+    expect(next.expanded.has("a")).toBe(true);
+    expect(next.expanded.has(roots[0].id)).toBe(true);
+  });
+
+  it("finds and reveals text inside a nested tool's llm() call", () => {
+    const nested: EventEnvelope[] = [
+      ...events.slice(0, 3),
+      evt({
+        span_id: "L2",
+        parent_span_id: "T",
+        data: {
+          type: "promptCompletion",
+          timestamp: "2026-06-21T00:00:025Z",
+          messages: [{ role: "user", content: "compute area" }],
+          completion: { output: "nested-answer-xyz", toolCalls: [] },
+        },
+      }),
+      events[3],
+    ];
+    const roots = buildForest(nested);
+    const matches = findMatches(roots, "nested-answer-xyz");
+    expect(matches.some((id) => id.startsWith("L2:llm:convo:"))).toBe(true);
   });
 });
 

--- a/packages/agency-lang/lib/logsViewer/search.ts
+++ b/packages/agency-lang/lib/logsViewer/search.ts
@@ -1,5 +1,9 @@
 import { TreeNode, ViewerState } from "./types.js";
-import { eventExpansionChildren, rawDataChildren } from "./render.js";
+import {
+  eventExpansionChildren,
+  rawDataChildren,
+  llmCallSpanChildren,
+} from "./render.js";
 
 // Walk every node in the forest (regardless of current expansion
 // state) AND every synthetic expansion row (conversation lines, JSON
@@ -30,6 +34,24 @@ export function findMatches(
   };
   const walk = (node: TreeNode, depth: number): void => {
     pushIfMatches(node);
+    // An `llmCall` span shows a flattened conversation (convoLines +
+    // spliced toolExecution spans + a raw-data toggle) instead of its
+    // raw children — walk exactly those rows so search matches what the
+    // renderer shows. Synthetic rows (convoLine / rawDataToggle) are
+    // leaves here; real nodes (the spliced toolExecution spans) recurse.
+    if (node.nodeKind === "span" && node.label === "llmCall") {
+      for (const child of llmCallSpanChildren(node, depth + 1, cols)) {
+        if (child.nodeKind === "convoLine") {
+          pushIfMatches(child);
+        } else if (child.nodeKind === "rawDataToggle") {
+          pushIfMatches(child);
+          for (const json of rawDataChildren(child)) pushIfMatches(json);
+        } else {
+          walk(child, depth + 1);
+        }
+      }
+      return;
+    }
     if (node.nodeKind === "event" && node.event) {
       for (const synth of eventExpansionChildren(node, depth + 1, cols)) {
         pushIfMatches(synth);
@@ -75,25 +97,32 @@ export function expandAncestorsOf(
   return next.size === state.expanded.size ? state : { ...state, expanded: next };
 }
 
-// Walk a synthetic id back to its real-forest leaf id, expanding each
-// synthetic parent so the match is visible. Synthetic id forms:
-//   <leaf>:convo:<n>          — conversation line under a leaf event
+// Walk a synthetic id back to its real-forest node id, expanding each
+// synthetic parent so the match is visible. The real node id is always
+// the first colon-delimited segment (nanoid span ids, `evt-N`,
+// `trace-…` contain no colons). Synthetic id forms:
+//   <leaf>:convo:<n>:<j>      — conversation line under a leaf event
 //   <leaf>:json:<n>           — raw JSON line under a non-pc leaf
 //   <leaf>:raw                — "raw data" toggle under a leaf
 //   <leaf>:raw:json:<n>       — JSON line under an opened raw toggle
-// Leaves themselves are returned unchanged.
+//   <span>:llm:convo:<n>:<j>  — conversation line under an llmCall span
+//   <span>:llm:raw            — "raw data" toggle under an llmCall span
+//   <span>:llm:raw:json:<n>   — JSON line under that opened raw toggle
+// Real node ids themselves are returned unchanged.
 function expandSyntheticAncestors(id: string, expanded: Set<string>): string {
   const colon = id.indexOf(":");
   if (colon < 0) return id;
-  const leafId = id.slice(0, colon);
+  const realId = id.slice(0, colon);
   const rest = id.slice(colon + 1);
-  // Always expand the leaf so its synthetic children become visible.
-  expanded.add(leafId);
-  // If the match lives under the "raw data" toggle, also expand it.
-  if (rest.startsWith("raw:") || rest === "raw") {
-    expanded.add(`${leafId}:raw`);
+  // Always expand the real node so its synthetic children become visible.
+  expanded.add(realId);
+  // If the match lives under a "raw data" toggle, also expand that toggle.
+  if (rest === "raw" || rest.startsWith("raw:")) {
+    expanded.add(`${realId}:raw`);
+  } else if (rest === "llm:raw" || rest.startsWith("llm:raw:")) {
+    expanded.add(`${realId}:llm:raw`);
   }
-  return leafId;
+  return realId;
 }
 
 function indexById(roots: TreeNode[]): Record<string, TreeNode> {

--- a/packages/agency-lang/lib/logsViewer/summary.test.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.test.ts
@@ -44,6 +44,46 @@ describe("summarize (leaf events)", () => {
     expect(s).toContain("tool blew up");
   });
 
+  it("forkBranchEnd shows the returned value on success", () => {
+    const s = summarize({
+      format_version: 1,
+      trace_id: "",
+      project_id: "",
+      span_id: null,
+      parent_span_id: null,
+      data: {
+        type: "forkBranchEnd",
+        timestamp: "",
+        branchIndex: 0,
+        outcome: "success",
+        timeTaken: 653,
+        value: 3,
+      },
+    });
+    expect(s).toContain("forkBranchEnd #0");
+    expect(s).toContain("success");
+    expect(s).toContain("→ 3");
+  });
+
+  it("forkBranchEnd omits the value arrow when there is none (non-success)", () => {
+    const s = summarize({
+      format_version: 1,
+      trace_id: "",
+      project_id: "",
+      span_id: null,
+      parent_span_id: null,
+      data: {
+        type: "forkBranchEnd",
+        timestamp: "",
+        branchIndex: 1,
+        outcome: "aborted",
+        timeTaken: 10,
+      },
+    });
+    expect(s).toContain("forkBranchEnd #1");
+    expect(s).not.toContain("→");
+  });
+
   it("toolCall shows the tool name", () => {
     const s = summarize({
       format_version: 1,

--- a/packages/agency-lang/lib/logsViewer/summary.test.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.test.ts
@@ -147,6 +147,123 @@ describe("summarizeSpan", () => {
   });
 });
 
+describe("summarizeSpan — identifying detail", () => {
+  const leaf = (data: any): TreeNode => ({
+    id: `e-${data.type}`,
+    traceId: "",
+    parentId: null,
+    children: [],
+    nodeKind: "event",
+    label: data.type,
+    summary: data.type,
+    event: {
+      format_version: 1,
+      trace_id: "",
+      project_id: "",
+      span_id: null,
+      parent_span_id: null,
+      data: { timestamp: "", ...data },
+    },
+  });
+
+  const spanNode = (
+    label: string,
+    children: TreeNode[],
+    extra: Partial<TreeNode> = {},
+  ): TreeNode => ({
+    id: "s",
+    traceId: "",
+    parentId: null,
+    children,
+    nodeKind: "span",
+    label,
+    summary: "",
+    ...extra,
+  });
+
+  it("nodeExecution shows the node name", () => {
+    const node = spanNode("nodeExecution", [leaf({ type: "enterNode", nodeId: "agent" })], { duration: 5600 });
+    expect(summarizeSpan(node)).toBe('nodeExecution "agent" (5.6s)');
+  });
+
+  it("agentRun shows the entry node", () => {
+    const node = spanNode("agentRun", [leaf({ type: "agentStart", entryNode: "main" })]);
+    expect(summarizeSpan(node)).toBe('agentRun "main"');
+  });
+
+  it("toolExecution shows the tool name", () => {
+    const node = spanNode("toolExecution", [leaf({ type: "toolCallStart", toolName: "fib" }), leaf({ type: "toolCall", toolName: "fib" })], { duration: 3000 });
+    expect(summarizeSpan(node)).toBe("toolExecution fib (3.0s)");
+  });
+
+  it("forkAll shows the branch count", () => {
+    const node = spanNode("forkAll", [leaf({ type: "forkStart", mode: "all", branchCount: 5 })], { duration: 3000 });
+    expect(summarizeSpan(node)).toBe("forkAll 5 branches (3.0s)");
+  });
+
+  it("llmCall shows model, prompt preview, and outcome", () => {
+    const node = spanNode(
+      "llmCall",
+      [
+        leaf({
+          type: "promptCompletion",
+          model: '"gpt-4o-mini"',
+          messages: [{ role: "user", content: "Calculate the 2th Fibonacci number." }],
+          completion: { output: '{"response":1}' },
+        }),
+      ],
+      { duration: 2900, tokens: 62 },
+    );
+    const s = summarizeSpan(node);
+    expect(s).toContain("llmCall gpt-4o-mini");
+    expect(s).toContain('· "Calculate the 2th Fibonacci');
+    expect(s).toContain('→ {"response":1}');
+    expect(s).toContain("(2.9s, 62 tok)");
+  });
+
+  it("llmCall outcome names the tool when the completion is a tool call", () => {
+    const node = spanNode("llmCall", [
+      leaf({
+        type: "promptCompletion",
+        model: '"gpt-4o-mini"',
+        messages: [{ role: "user", content: "Use the getArea tool" }],
+        completion: { output: null, toolCalls: [{ id: "c", name: "getArea", arguments: {} }] },
+      }),
+    ]);
+    expect(summarizeSpan(node)).toContain("→ tool: getArea");
+  });
+
+  it("llmCall uses the first round's prompt and the last round's outcome", () => {
+    const node = spanNode("llmCall", [
+      leaf({
+        type: "promptCompletion",
+        model: '"gpt-4o-mini"',
+        messages: [{ role: "user", content: "outer request" }],
+        completion: { output: null, toolCalls: [{ id: "c", name: "tool", arguments: {} }] },
+      }),
+      leaf({
+        type: "promptCompletion",
+        model: '"gpt-4o-mini"',
+        messages: [{ role: "user", content: "outer request" }, { role: "tool", content: "x" }],
+        completion: { output: "final answer" },
+      }),
+    ]);
+    const s = summarizeSpan(node);
+    expect(s).toContain('· "outer request"');
+    expect(s).toContain("→ final answer");
+  });
+
+  it("falls back to the bare label when no detail event is present", () => {
+    const node = spanNode("nodeExecution", [], { duration: 100 });
+    expect(summarizeSpan(node)).toBe("nodeExecution (100ms)");
+  });
+
+  it("styled variant includes the detail too", () => {
+    const node = spanNode("toolExecution", [leaf({ type: "toolCall", toolName: "fib" })], { duration: 3000 });
+    expect(summarizeSpanStyled(node)).toContain("toolExecution fib");
+  });
+});
+
 describe("summarizeTrace", () => {
   it("leads with local timestamp when firstTs is set, ends with short id", () => {
     const node: TreeNode = {

--- a/packages/agency-lang/lib/logsViewer/summary.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.ts
@@ -78,8 +78,125 @@ export function summarize(evt: EventEnvelope): string {
 }
 
 export function summarizeSpan(node: TreeNode): string {
+  const head = spanHead(node);
   const metrics = formatMetrics(node);
-  return metrics ? `${node.label} (${metrics})` : node.label;
+  return metrics ? `${head} (${metrics})` : head;
+}
+
+// `<label> <identifying detail>` for a span — e.g. `nodeExecution "agent"`,
+// `toolExecution getArea`, `llmCall gpt-4o-mini · "..." → "..."`. The
+// detail is pulled from the span's characteristic child event so a
+// collapsed row tells you *which* node/tool/call it is, not just timing.
+// Returns just the label when no detail applies.
+function spanHead(node: TreeNode): string {
+  const detail = spanDetail(node);
+  return detail ? `${node.label} ${detail}` : node.label;
+}
+
+// Find the first direct child leaf event of the given type under a span.
+function childEvent(node: TreeNode, type: string): EventEnvelope | undefined {
+  for (const c of node.children) {
+    if (c.event?.data.type === type) return c.event;
+  }
+  return undefined;
+}
+
+function childEvents(node: TreeNode, type: string): EventEnvelope[] {
+  const out: EventEnvelope[] = [];
+  for (const c of node.children) {
+    if (c.event?.data.type === type) out.push(c.event);
+  }
+  return out;
+}
+
+function spanDetail(node: TreeNode): string | undefined {
+  switch (node.label) {
+    case "nodeExecution": {
+      const e = childEvent(node, "enterNode");
+      return e?.data.nodeId ? `"${e.data.nodeId}"` : undefined;
+    }
+    case "agentRun": {
+      const e = childEvent(node, "agentStart");
+      return e?.data.entryNode ? `"${e.data.entryNode}"` : undefined;
+    }
+    case "toolExecution": {
+      const e = childEvent(node, "toolCall") ?? childEvent(node, "toolCallStart");
+      return e?.data.toolName ? String(e.data.toolName) : undefined;
+    }
+    case "forkAll":
+    case "race": {
+      const e = childEvent(node, "forkStart");
+      const n = e?.data.branchCount;
+      return typeof n === "number" ? `${n} ${n === 1 ? "branch" : "branches"}` : undefined;
+    }
+    case "embedding": {
+      const e = childEvent(node, "embedCompletion");
+      if (!e) return undefined;
+      const phase = e.data.phase ? String(e.data.phase) : null;
+      const dims = typeof e.data.dimensions === "number" ? `${e.data.dimensions}d` : null;
+      const parts = [phase, dims].filter((p): p is string => !!p);
+      return parts.length > 0 ? parts.join(" · ") : undefined;
+    }
+    case "llmCall":
+      return llmCallDetail(node);
+    default:
+      return undefined;
+  }
+}
+
+// `<model> · "<prompt preview>" → <outcome>` for an llmCall span. The
+// prompt comes from the first round's user message (the original
+// request); the outcome from the last round's completion (the final
+// answer, or the tool call(s) it made). Each free-text piece is
+// truncated so the row stays scannable.
+function llmCallDetail(node: TreeNode): string | undefined {
+  const pcs = childEvents(node, "promptCompletion");
+  if (pcs.length === 0) return undefined;
+  const first = pcs[0];
+  const last = pcs[pcs.length - 1];
+
+  const model = stripQuotes(typeof first.data.model === "string" ? first.data.model : undefined);
+  const prompt = lastUserMessage(first);
+  const outcome = completionOutcome(last);
+
+  let s = model && model !== "?" ? model : "";
+  if (prompt) s += `${s ? " " : ""}· "${truncate(prompt, 32)}"`;
+  if (outcome) s += ` → ${truncate(outcome, 32)}`;
+  return s.length > 0 ? s : undefined;
+}
+
+// The last user-role message's text in a promptCompletion's messages —
+// the prompt that was just sent.
+function lastUserMessage(pc: EventEnvelope): string | undefined {
+  const msgs = pc.data.messages;
+  if (!Array.isArray(msgs)) return undefined;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const m = msgs[i];
+    if (m?.role !== "user") continue;
+    if (typeof m.content === "string") return m.content;
+    if (Array.isArray(m.content)) {
+      const text = m.content
+        .map((p: any) => (typeof p?.text === "string" ? p.text : ""))
+        .join("");
+      return text || undefined;
+    }
+  }
+  return undefined;
+}
+
+// What an llmCall produced: the assistant text if present, else the
+// name(s) of the tool call(s) it made.
+function completionOutcome(pc: EventEnvelope): string | undefined {
+  const c = pc.data.completion;
+  if (typeof c === "string" && c.length > 0) return c;
+  if (c && typeof c === "object") {
+    if (typeof c.output === "string" && c.output.length > 0) return c.output;
+    if (Array.isArray(c.toolCalls) && c.toolCalls.length > 0) {
+      const names = c.toolCalls.map((t: any) => t?.name).filter(Boolean);
+      if (names.length > 0) return `tool: ${names.join(", ")}`;
+    }
+  }
+  return undefined;
 }
 
 export function summarizeTrace(node: TreeNode): string {
@@ -189,8 +306,9 @@ export function summarizeSpanStyled(
   node: TreeNode,
   thresholds: ViewerThresholds = DEFAULT_THRESHOLDS,
 ): string {
+  const head = spanHead(node);
   const metrics = formatMetricsStyled(node, thresholds);
-  return metrics ? `${node.label} (${metrics})` : node.label;
+  return metrics ? `${head} (${metrics})` : head;
 }
 
 export function summarizeTraceStyled(

--- a/packages/agency-lang/lib/logsViewer/summary.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.ts
@@ -36,8 +36,14 @@ export function summarize(evt: EventEnvelope): string {
       return `checkpointRestored #${shortId(d.checkpointId)} (attempt ${d.restoreCount ?? "?"})`;
     case "forkStart":
       return `forkStart ${d.mode} (${d.branchCount} branches)`;
-    case "forkBranchEnd":
-      return `forkBranchEnd #${d.branchIndex} (${d.outcome}, ${fmtDuration(d.timeTaken)})`;
+    case "forkBranchEnd": {
+      const head = `forkBranchEnd #${d.branchIndex} (${d.outcome}, ${fmtDuration(d.timeTaken)})`;
+      // Show the branch's return value (success only) so you can see what
+      // each branch produced without opening raw data.
+      return d.value !== undefined
+        ? `${head} → ${truncate(stringifyValue(d.value), 40)}`
+        : head;
+    }
     case "forkEnd":
       return `forkEnd ${d.mode} (${fmtDuration(d.timeTaken)})`;
     case "threadCreated": {

--- a/packages/agency-lang/lib/logsViewer/tree.test.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildForest } from "./tree.js";
-import { EventEnvelope } from "./types.js";
+import { EventEnvelope, TreeNode } from "./types.js";
 
 const evt = (over: Partial<EventEnvelope>): EventEnvelope => ({
   format_version: 1,
@@ -97,11 +97,10 @@ describe("buildForest", () => {
     expect(s1.cost).toBeCloseTo(0.0052, 5);
   });
 
-  it("prefers promptCompletion.timeTaken for llmCall span duration", () => {
-    // Both events fire at nearly the same moment (the timestamps
-    // are *emission* times), but the LLM call actually took 3.5s
-    // as recorded in promptCompletion.timeTaken. Without the fix the
-    // viewer would show 1ms.
+  it("uses promptCompletion.timeTaken for a single-round llmCall duration", () => {
+    // The emission timestamp is the END of the call, so the timestamp
+    // range alone would be ~0ms. The envelope (start = timestamp -
+    // timeTaken) recovers the real 3.5s latency.
     const forest = buildForest([
       evt({
         span_id: "s1",
@@ -112,32 +111,25 @@ describe("buildForest", () => {
           timeTaken: 3500,
         },
       }),
-      evt({
-        span_id: "s1",
-        parent_span_id: null,
-        data: {
-          type: "debug",
-          timestamp: "2026-05-16T00:00:03.501Z",
-          message: "ack",
-        },
-      }),
     ]);
     const s1 = forest[0].children[0];
     expect(s1.label).toBe("llmCall");
     expect(s1.duration).toBe(3500);
   });
 
-  it("sums timeTaken across multiple toolCall leaves for toolExecution spans", () => {
+  it("computes wall-clock across back-to-back toolCall leaves (not a blind sum)", () => {
+    // Two sequential toolCalls (e.g. a retry): 120ms then 80ms,
+    // back-to-back, so the wall-clock envelope is 200ms.
     const forest = buildForest([
       evt({
         span_id: "s1",
         parent_span_id: null,
-        data: { type: "toolCall", timestamp: "", timeTaken: 120 },
+        data: { type: "toolCall", timestamp: "2026-05-16T00:00:00.120Z", timeTaken: 120 },
       }),
       evt({
         span_id: "s1",
         parent_span_id: null,
-        data: { type: "toolCall", timestamp: "", timeTaken: 80 },
+        data: { type: "toolCall", timestamp: "2026-05-16T00:00:00.200Z", timeTaken: 80 },
       }),
     ]);
     const s1 = forest[0].children[0];
@@ -183,6 +175,44 @@ describe("buildForest", () => {
     ]);
     const s1 = forest[0].children[0];
     expect(s1.duration).toBeCloseTo(4200, 0);
+  });
+
+  it("uses wall-clock, NOT the sum of nested parallel llmCall durations", () => {
+    // An outer llmCall (L) runs a tool (T) whose body forks two parallel
+    // llmCalls (N1, N2), each ~3s, overlapping. The OLD logic summed
+    // every promptCompletion.timeTaken in the subtree
+    // (1 + 3 + 3 + 1 = 8s), making the parent appear longer than it ran
+    // and longer than its own node. The wall-clock envelope is 5s, and
+    // parent ⊇ child holds.
+    const B = "2026-06-21T00:00:0";
+    const forest = buildForest([
+      evt({ span_id: "A", parent_span_id: null, data: { type: "agentStart", timestamp: `${B}0.000Z` } }),
+      evt({ span_id: "L", parent_span_id: "A", data: { type: "promptCompletion", timestamp: `${B}1.000Z`, timeTaken: 1000 } }),
+      evt({ span_id: "T", parent_span_id: "L", data: { type: "toolCall", timestamp: `${B}4.000Z`, timeTaken: 3000, toolName: "fib" } }),
+      evt({ span_id: "N1", parent_span_id: "T", data: { type: "promptCompletion", timestamp: `${B}4.000Z`, timeTaken: 3000 } }),
+      evt({ span_id: "N2", parent_span_id: "T", data: { type: "promptCompletion", timestamp: `${B}4.000Z`, timeTaken: 3000 } }),
+      evt({ span_id: "L", parent_span_id: "A", data: { type: "promptCompletion", timestamp: `${B}5.000Z`, timeTaken: 1000 } }),
+      evt({ span_id: "A", parent_span_id: null, data: { type: "agentEnd", timestamp: `${B}5.500Z`, timeTaken: 5500 } }),
+    ]);
+    const find = (id: string): TreeNode => {
+      const stack = [...forest];
+      while (stack.length) {
+        const n = stack.pop()!;
+        if (n.id === id) return n;
+        stack.push(...n.children);
+      }
+      throw new Error(`span ${id} not found`);
+    };
+    const L = find("L");
+    const T = find("T");
+    const N1 = find("N1");
+    expect(L.label).toBe("llmCall");
+    expect(L.duration).toBe(5000); // wall-clock, not 8000 (the old sum)
+    expect(T.duration).toBe(3000);
+    expect(N1.duration).toBe(3000);
+    // Parent contains child: no child is longer than its parent.
+    expect(T.duration!).toBeLessThanOrEqual(L.duration!);
+    expect(N1.duration!).toBeLessThanOrEqual(T.duration!);
   });
 
   it("preserves event arrival order within a span", () => {

--- a/packages/agency-lang/lib/logsViewer/tree.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.ts
@@ -177,7 +177,11 @@ function inferSpanLabel(evt: EventEnvelope): string {
       // own label so the viewer can color/filter them separately and
       // cost roll-ups don't conflate the two.
       return "embedding";
+    case "toolCallStart":
     case "toolCall":
+      // A tool execution emits `toolCallStart` first, so the span is
+      // usually introduced by it — label both as `toolExecution` so the
+      // span reads consistently regardless of which event created it.
       return "toolExecution";
     case "forkStart":
     case "forkEnd":

--- a/packages/agency-lang/lib/logsViewer/tree.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.ts
@@ -230,43 +230,36 @@ function aggregateMetrics(node: TreeNode): void {
     node.firstTs = Math.min(...timestamps);
   }
 
-  // Prefer the authoritative `timeTaken` field on the span's
-  // characteristic leaf events. Event timestamps record *emission*
-  // time, so a span with a single completion event (like an llmCall
-  // with one promptCompletion) would otherwise compute a duration
-  // of 0/1ms even when the LLM call took seconds.
-  const measured = measuredDuration(node, leaves);
-  if (measured !== undefined) {
-    node.duration = measured;
-  } else if (timestamps.length >= 2) {
-    node.duration = Math.max(...timestamps) - Math.min(...timestamps);
+  // Duration is the span's wall-clock ENVELOPE: earliest start to latest
+  // end across all of its events. Events record their *emission* time
+  // (`timestamp`) and, where known, their own length (`timeTaken`), so an
+  // event's start is `timestamp - timeTaken`. Taking max(end) - min(start):
+  //  - a single completion event (e.g. a one-round llmCall) yields its
+  //    real latency via timeTaken — emission timestamps alone would give
+  //    ~0ms since they cluster at the end;
+  //  - a multi-event span yields its true wall-clock;
+  //  - parallel/nested work is never SUMMED (it's an envelope, not a
+  //    sum) — previously an llmCall's duration summed every nested
+  //    promptCompletion, so a tool that forked N parallel LLM calls made
+  //    the parent look N× longer than it ran;
+  //  - parent ⊇ child holds, because a parent's leaves are a superset of
+  //    each child's.
+  let minStart = Number.POSITIVE_INFINITY;
+  let maxEnd = Number.NEGATIVE_INFINITY;
+  for (const l of leaves) {
+    const ts = Date.parse(l.event!.data.timestamp);
+    if (!Number.isFinite(ts)) continue;
+    const tt =
+      typeof l.event!.data.timeTaken === "number" ? l.event!.data.timeTaken : 0;
+    if (ts - tt < minStart) minStart = ts - tt;
+    if (ts > maxEnd) maxEnd = ts;
+  }
+  if (Number.isFinite(minStart) && maxEnd > minStart) {
+    node.duration = maxEnd - minStart;
   }
 
   if (node.nodeKind === "span") {
     node.summary = summarizeSpan(node);
-  }
-}
-
-function measuredDuration(node: TreeNode, leaves: TreeNode[]): number | undefined {
-  if (node.nodeKind !== "span") return undefined;
-  const matchingLeaves = leaves.filter(
-    (l) => l.event!.data.type === durationEventType(node.label),
-  );
-  const times = matchingLeaves
-    .map((l) => l.event!.data.timeTaken)
-    .filter((t): t is number => typeof t === "number");
-  if (times.length === 0) return undefined;
-  return times.reduce((a, b) => a + b, 0);
-}
-
-function durationEventType(spanLabel: string): string | undefined {
-  switch (spanLabel) {
-    case "llmCall": return "promptCompletion";
-    case "toolExecution": return "toolCall";
-    case "agentRun": return "agentEnd";
-    case "forkAll":
-    case "race": return "forkEnd";
-    default: return undefined;
   }
 }
 

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -550,11 +550,14 @@ export async function runPrompt(args: {
     snapshotMessages: () => messages.toJSON().messages,
   });
 
-  // Manage llmCall spans across the prompt round-trip loop. Each
-  // llmCall span covers one `_runPrompt` call PLUS the tool executions
-  // triggered by its returned tool_calls, so toolExecution spans nest
-  // under their parent llmCall — matching the
-  // agentRun > nodeExecution > llmCall > toolExecution hierarchy.
+  // One llmCall span covers the WHOLE `llm()` call — every tool-loop
+  // round plus the tool executions they trigger. So all rounds'
+  // promptCompletion events and all toolExecution spans nest under a
+  // single llmCall span, matching the
+  // agentRun > nodeExecution > llmCall > toolExecution hierarchy and
+  // the "one llmCall span == one llm() call" model the viewer renders.
+  // Opened once below (outside `pr.step` so resume re-opens it on
+  // re-entry) and closed once in `finally`.
   let currentLlmSpanId: string | undefined;
   const closeLlmSpan = () => {
     if (currentLlmSpanId) {
@@ -568,6 +571,11 @@ export async function runPrompt(args: {
   let toolCalls: smoltalk.ToolCallJSON[] = self.pendingToolCalls ?? [];
 
   let shouldPop = true;
+  // Open the single llmCall span before the round-trip loop. Done here
+  // (not inside the idempotent `initialLlmCall` step) so a resumed run —
+  // which skips completed steps — still re-opens the span that the tool
+  // loop expects to be active.
+  currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
   try {
     // Initial LLM call wrapped in pr.step so it's idempotent on resume
     // (re-entries after a later tool-batch bailout skip this step).
@@ -591,22 +599,17 @@ export async function runPrompt(args: {
         }
       }
       messages.push(smoltalk.userMessage(prompt));
-      currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
-      let result: RunPromptResult;
-      try {
-        result = await _runPrompt({
-          ctx,
-          messages,
-          tools: tools || [],
-          prompt,
-          responseFormat,
-          clientConfig,
-          stateStack,
-        });
-      } catch (e) {
-        closeLlmSpan();
-        throw e;
-      }
+      // The llmCall span is already open (before the loop). On error,
+      // the outer `finally` closes it.
+      const result = await _runPrompt({
+        ctx,
+        messages,
+        tools: tools || [],
+        prompt,
+        responseFormat,
+        clientConfig,
+        stateStack,
+      });
       messages = result.messages;
       toolCalls = result.toolCalls;
       if (injectedFactsContent !== null) {
@@ -624,13 +627,6 @@ export async function runPrompt(args: {
       self.messagesJSON = messages.toJSON().messages;
       self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
     });
-
-    // After resume (initialLlmCall skipped), make sure there's an open
-    // llmCall span if we have pending tool calls — the tool loop expects
-    // one to be open so toolExecution spans nest correctly.
-    if (toolCalls.length > 0 && currentLlmSpanId === undefined) {
-      currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
-    }
 
     // Inner helper for the per-branch tool invocation. Extracted from
     // the pr.parallel branchFn so that arrow stays within the
@@ -1074,25 +1070,20 @@ export async function runPrompt(args: {
       );
 
       // Next LLM call wrapped in pr.step for resume idempotency. Once
-      // marked done, resume re-entries skip the LLM call.
+      // marked done, resume re-entries skip the LLM call. The llmCall
+      // span stays open across rounds (one span per llm() call), so we
+      // do NOT close/reopen it here — this round's promptCompletion
+      // nests under the same span as the first round's.
       await pr.step(`round.${round}.nextLlmCall`, async () => {
-        closeLlmSpan();
-        currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
-        let nextResult: RunPromptResult;
-        try {
-          nextResult = await _runPrompt({
-            ctx,
-            messages,
-            tools: tools || [],
-            prompt,
-            responseFormat,
-            clientConfig,
-            stateStack,
-          });
-        } catch (e) {
-          closeLlmSpan();
-          throw e;
-        }
+        const nextResult = await _runPrompt({
+          ctx,
+          messages,
+          tools: tools || [],
+          prompt,
+          responseFormat,
+          clientConfig,
+          stateStack,
+        });
         messages = nextResult.messages;
         toolCalls = nextResult.toolCalls;
         // Increment the round counter only after a successful LLM round,

--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -177,6 +177,50 @@ describe("runBatch — mode 'all'", () => {
     expect(result).toEqual({ kind: "values", values: [42] });
   });
 
+  it("onBranchEnd receives each branch's return value on success", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const ends: Array<{ index: number; outcome: string; value: unknown }> = [];
+    await runBatch<unknown>({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [
+        { key: "c0", invoke: async () => 42 },
+        { key: "c1", invoke: async () => ({ a: 1 }) },
+      ],
+      hooks: {
+        onBranchEnd: (_key, index, outcome, _t, value) =>
+          ends.push({ index, outcome, value }),
+      },
+    });
+    expect(ends).toEqual([
+      { index: 0, outcome: "success", value: 42 },
+      { index: 1, outcome: "success", value: { a: 1 } },
+    ]);
+  });
+
+  it("onBranchEnd reports no value for a non-success (interrupted) outcome", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const ends: Array<{ outcome: string; value: unknown }> = [];
+    await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [{ key: "c0", invoke: async () => [fakeInterrupt("z", 5)] }],
+      hooks: {
+        onBranchEnd: (_key, _index, outcome, _t, value) =>
+          ends.push({ outcome, value }),
+      },
+    });
+    expect(ends).toEqual([{ outcome: "interrupted", value: undefined }]);
+  });
+
   it("parent abort signal propagates into child stack", async () => {
     const { ctx } = makeCtx();
     const { parentStack, parentFrame } = makeParent();

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -104,12 +104,15 @@ export type BatchHooks = {
   ) => void;
   /** Called once per branch start (statelog). */
   onBranchStart?: (key: string, index: number) => void;
-  /** Called once per branch end with its outcome and elapsed time in ms. */
+  /** Called once per branch end with its outcome and elapsed time in ms.
+   *  On a `success` outcome `value` is the branch's return value; for
+   *  every other outcome it is `undefined` (there is no value to report). */
   onBranchEnd?: (
     key: string,
     index: number,
     outcome: "success" | "interrupted" | "failure" | "aborted",
     timeMs: number,
+    value?: unknown,
   ) => void;
   /** Called once immediately before `ctx.checkpoints.create` deep-clones
    * the parent frame. Use this to flush state that was mutated by
@@ -524,7 +527,7 @@ export async function runBatch<T>(
         );
       }
     } else {
-      if (!cached) hooks?.onBranchEnd?.(child.key, i, "success", timeMs);
+      if (!cached) hooks?.onBranchEnd?.(child.key, i, "success", timeMs, value);
       if (recordOutcomes) {
         parentFrame.setResultOnBranch(child.key, value as any);
       }
@@ -617,6 +620,7 @@ async function runRaceFirstTime<T>(
       winnerIndex,
       hasInterrupts(winnerValue) ? "interrupted" : "success",
       winnerTime,
+      hasInterrupts(winnerValue) ? undefined : winnerValue,
     );
   }
 
@@ -762,6 +766,7 @@ async function runRaceResume<T>(
     winnerIndex,
     "success",
     performance.now() - startedAt,
+    value,
   );
   parentFrame.setResultOnBranch(child.key, value as any);
   hooks?.propagateWinnerCost?.(branch, parentStack);

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Runner, stripSlug } from "./runner.js";
+import { Runner, stripSlug, safeStatelogValue } from "./runner.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { getRuntimeContext } from "./asyncContext.js";
@@ -8,6 +8,35 @@ import { makeMockCtx } from "./__tests__/testHelpers.js";
 function makeFrame(): State {
   return new State({ args: {}, locals: {}, step: 0 });
 }
+
+describe("safeStatelogValue", () => {
+  it("deep-clones small JSON values", () => {
+    expect(safeStatelogValue(42)).toBe(42);
+    expect(safeStatelogValue([0, 1, 1, 2, 3])).toEqual([0, 1, 1, 2, 3]);
+    const obj = { a: [1, 2] };
+    const out = safeStatelogValue(obj);
+    expect(out).toEqual(obj);
+    expect(out).not.toBe(obj); // cloned, not the same reference
+  });
+
+  it("returns undefined for undefined and values JSON can't represent", () => {
+    expect(safeStatelogValue(undefined)).toBeUndefined();
+    expect(safeStatelogValue(() => 1)).toBeUndefined();
+  });
+
+  it("truncates an oversized value to a marked string", () => {
+    const out = safeStatelogValue("x".repeat(5000));
+    expect(typeof out).toBe("string");
+    expect((out as string).length).toBeLessThan(5000);
+    expect(out as string).toMatch(/…\[truncated\]$/);
+  });
+
+  it("returns a placeholder for an unserializable (circular) value", () => {
+    const a: any = {};
+    a.self = a;
+    expect(safeStatelogValue(a)).toBe("[unserializable]");
+  });
+});
 
 describe("Runner", () => {
   describe("step()", () => {

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -41,6 +41,34 @@ export function stripSlug(slug: string): string {
   return /^t\d+$/.test(slug) ? slug.slice(1) : slug;
 }
 
+/** Cap on the serialized size of a fork-branch value attached to a
+ *  `forkBranchEnd` statelog event. Branch results are usually tiny (a
+ *  number, a short object) but could be large; bound it so telemetry
+ *  can't balloon. */
+const FORK_VALUE_CHAR_CAP = 4000;
+
+/** Serialize a fork branch's return value for the `forkBranchEnd` event
+ *  WITHOUT ever throwing — telemetry must not break execution. Returns:
+ *  - `undefined` when there is no value (non-success outcome, or a value
+ *    JSON can't represent, e.g. a function);
+ *  - a deep JSON clone for normal small values (so it renders cleanly);
+ *  - a truncated string for oversized values;
+ *  - `"[unserializable]"` when stringification throws (e.g. a cycle). */
+function safeStatelogValue(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(value);
+  } catch {
+    return "[unserializable]";
+  }
+  if (json === undefined) return undefined;
+  if (json.length > FORK_VALUE_CHAR_CAP) {
+    return json.slice(0, FORK_VALUE_CHAR_CAP) + "…[truncated]";
+  }
+  return JSON.parse(json);
+}
+
 /**
  * Runner centralizes step execution logic for generated Agency code.
  *
@@ -1057,12 +1085,13 @@ export class Runner {
           this.seedBranchCost(childStack, parentStack),
         propagateBranchCost: (branches, parentStack) =>
           this.propagateBranchCost(branches, parentStack),
-        onBranchEnd: (_key, branchIndex, outcome, timeTaken) => {
+        onBranchEnd: (_key, branchIndex, outcome, timeTaken, value) => {
           this.ctx.statelogClient.forkBranchEnd({
             forkId,
             branchIndex,
             outcome,
             timeTaken,
+            value: safeStatelogValue(value),
           });
         },
         onCheckpoint: (cpId) => {
@@ -1140,12 +1169,13 @@ export class Runner {
           this.propagateBranchCost(losers, parentStack),
         propagateWinnerCost: (winner, parentStack) =>
           this.propagateBranchCost([winner], parentStack),
-        onBranchEnd: (_key, branchIndex, outcome, timeTaken) => {
+        onBranchEnd: (_key, branchIndex, outcome, timeTaken, value) => {
           this.ctx.statelogClient.forkBranchEnd({
             forkId,
             branchIndex,
             outcome,
             timeTaken,
+            value: safeStatelogValue(value),
           });
         },
         onCheckpoint: (cpId) => {

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -54,7 +54,7 @@ const FORK_VALUE_CHAR_CAP = 4000;
  *  - a deep JSON clone for normal small values (so it renders cleanly);
  *  - a truncated string for oversized values;
  *  - `"[unserializable]"` when stringification throws (e.g. a cycle). */
-function safeStatelogValue(value: unknown): unknown {
+export function safeStatelogValue(value: unknown): unknown {
   if (value === undefined) return undefined;
   let json: string | undefined;
   try {

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -886,11 +886,16 @@ export class StatelogClient {
     branchIndex,
     outcome,
     timeTaken,
+    value,
   }: {
     forkId: string;
     branchIndex: number;
     outcome: "success" | "failure" | "interrupted" | "aborted";
     timeTaken: number;
+    /** The branch's return value, present only on a `success` outcome.
+     *  The caller serializes it defensively (see Runner's fork hooks) so
+     *  a large or non-JSON value can't bloat or break the telemetry post. */
+    value?: unknown;
   }): Promise<void> {
     await this.post({
       type: "forkBranchEnd",
@@ -898,6 +903,7 @@ export class StatelogClient {
       branchIndex,
       outcome,
       timeTaken,
+      value,
     });
   }
 

--- a/packages/agency-lang/tests/agency-js/fork-branch-value/agency.json
+++ b/packages/agency-lang/tests/agency-js/fork-branch-value/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/fork-branch-value/agent.agency
+++ b/packages/agency-lang/tests/agency-js/fork-branch-value/agent.agency
@@ -1,0 +1,8 @@
+// A pure fork (no LLM): each branch returns a value. The forkBranchEnd
+// statelog event for each branch should now carry that return value.
+node main() {
+  const results: number[] = fork([1, 2, 3]) as i {
+    return i * 10
+  }
+  return results
+}

--- a/packages/agency-lang/tests/agency-js/fork-branch-value/fixture.json
+++ b/packages/agency-lang/tests/agency-js/fork-branch-value/fixture.json
@@ -1,0 +1,6 @@
+{
+  "result": [10, 20, 30],
+  "branchValues": [10, 20, 30],
+  "count": 3,
+  "allSuccess": true
+}

--- a/packages/agency-lang/tests/agency-js/fork-branch-value/test.js
+++ b/packages/agency-lang/tests/agency-js/fork-branch-value/test.js
@@ -1,0 +1,37 @@
+import { main } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+// No LLM: the fork branches return plain values. Verify each
+// forkBranchEnd event carries the branch's return value.
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const result = await main();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((l) => l.trim() !== "")
+  .map((l) => JSON.parse(l));
+
+const forkBranchEnds = events.filter((e) => e.data?.type === "forkBranchEnd");
+// Branches complete in nondeterministic order — sort the values.
+const branchValues = forkBranchEnds.map((e) => e.data.value).sort((a, b) => a - b);
+const allSuccess = forkBranchEnds.every((e) => e.data.outcome === "success");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      result: result.data,
+      branchValues,
+      count: forkBranchEnds.length,
+      allSuccess,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/llm-call-single-span/agency.json
+++ b/packages/agency-lang/tests/agency-js/llm-call-single-span/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/llm-call-single-span/agent.agency
+++ b/packages/agency-lang/tests/agency-js/llm-call-single-span/agent.agency
@@ -1,0 +1,11 @@
+// getArea is a leaf tool (no nested llm()). The main() llm() call runs
+// a two-round tool loop: round 1 the model asks for getArea, round 2 it
+// answers after seeing the result. Both rounds belong to ONE llm() call,
+// so they should share ONE llmCall span. See test.js.
+def getArea(country: string): number {
+  return 100
+}
+
+node main() {
+  return llm("Get the area of France using your getArea tool.", { tools: [getArea] })
+}

--- a/packages/agency-lang/tests/agency-js/llm-call-single-span/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-call-single-span/fixture.json
@@ -1,0 +1,4 @@
+{
+  "finalData": "ok",
+  "llmCallSpanCount": 1
+}

--- a/packages/agency-lang/tests/agency-js/llm-call-single-span/test.js
+++ b/packages/agency-lang/tests/agency-js/llm-call-single-span/test.js
@@ -1,0 +1,78 @@
+import { main, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+// Two-round tool loop driven by a deterministic client: round 1 returns
+// a getArea tool call, round 2 returns the final answer. Both rounds are
+// one logical llm() call and must share ONE llmCall span.
+//
+// Spans aren't labeled in the wire format; the viewer infers an
+// `llmCall` span from a promptCompletion event's span_id. So the number
+// of distinct span_ids carrying a promptCompletion event == the number
+// of llmCall spans. getArea is a leaf tool (no nested llm()), so the
+// only promptCompletions come from main()'s two rounds: pre-fix that's
+// two distinct span_ids, post-fix one.
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+const client = {
+  async text() {
+    const idx = callIndex++;
+    if (idx === 0) {
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [new ToolCall("call-1", "getArea", { country: "France" })],
+          model: "test",
+          usage: USAGE,
+          cost: COST,
+        },
+      };
+    }
+    return {
+      success: true,
+      value: { output: "ok", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const result = await main();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((l) => l.trim() !== "")
+  .map((l) => JSON.parse(l));
+
+const llmSpanIds = new Set(
+  events
+    .filter((e) => e.data?.type === "promptCompletion")
+    .map((e) => e.span_id),
+);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    { finalData: result.data, llmCallSpanCount: llmSpanIds.size },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## Summary

A set of logs-viewer improvements that make `agency logs view` read the way you'd expect, plus the runtime changes that feed it. Built iteratively while reviewing real `foo.agency` / `bar.agency` traces.

Design spec: `packages/agency-lang/docs/superpowers/specs/2026-06-21-llm-call-grouped-view-design.md`.

## What's in it

**1. Grouped, flattened LLM-call view** (`04f51dba`)
One `llm()` call now renders as **one** node showing a single continuous conversation, with tool executions spliced inline and nested `llm()` calls flattened recursively. Runtime: the per-tool-loop-round `llmCall` spans collapse into one span per `llm()` call. Viewer: an `llmCall` span renders the flattened transcript (from the final round, which holds the full thread) with each `toolExecution` spliced after the assistant message that triggered it. Also relabels tool-execution spans `toolExecution` (they were mislabeled `toolCallStart`).

**2. Array tool results render as JSON** (`b12903e1`)
A tool message whose content is the tool's raw return value (e.g. `[0,1,1,2,3]`) was shown as an empty `[tool: …]` because `stringifyContent` treated every array as multimodal content-parts. Now falls back to JSON for non-content-part arrays. (Pre-existing bug, surfaced by the flatten.)

**3. `forkBranchEnd` carries the branch return value** (`0082234f`)
The event recorded only timing/outcome; now it also carries the branch's `value` on success, serialized defensively (caps, drops unserializable/undefined, never throws). The viewer shows `forkBranchEnd #0 (success, 653ms) → 0`.

**4. Identifying detail in collapsed span summaries** (`e80313de`)
Collapsed spans showed only metrics, so parallel calls were indistinguishable. Now each pulls its identity from its characteristic child event: `nodeExecution "agent"`, `agentRun "main"`, `toolExecution fibonacciNumbers`, `forkAll 5 branches`, `embedding recall-query · 1536d`, and `llmCall gpt-4o-mini · "prompt…" → outcome`.

**5. Wall-clock envelope durations** (`d337bb4d`)
Span duration summed `timeTaken` across the whole subtree, so an `llmCall` that forked N parallel LLM calls reported ~N× its real time (17.2s vs 5.6s) — longer than its own node. Replaced with a wall-clock envelope (earliest start to latest end, start = `timestamp − timeTaken`): correct single-round latency, true multi-event wall-clock, no parallel summing, and parent ⊇ child holds.

**6. Test coverage** (`c253298b`)
Unit tests for `safeStatelogValue` (the defensive serializer's edge cases) and a new `render.e2e.test.ts` that drives a realistic `llm → forking tool` log through the whole pipeline (`buildForest → flattenVisibleRows → renderRowText`), asserting all of the above together.

## Before / After (bar.agency)

Before: two/many sibling `llmCall` nodes per call, blank tool results, indistinguishable parallel calls, a 17.2s `llmCall` inside a 5.6s node.

After:
```
nodeExecution "agent" (5.6s, 565 tok)
  llmCall gpt-4o-mini · "Use the fibonacciNumbers tool…" → {"response":[0,1,1,2,3]} (5.6s, 565 tok)
    toolExecution fibonacciNumbers (3.0s, 310 tok)
      forkAll 5 branches (3.0s, 310 tok)
        llmCall gpt-4o-mini · "Calculate the 0th Fibonacci…" → {"response":0} (2.8s, 62 tok)
        … (each parallel call distinct)
        forkBranchEnd #0 (success, 3.0s) → 0
    [tool: fibonacciNumbers] [0,1,1,2,3]
    [assistant] {"response":[0,1,1,2,3]}
```

## Compatibility

No backward compatibility for old logs (per the spec) — they degrade to roughly the prior multi-node look; no `STATELOG_FORMAT_VERSION` bump. Regenerate logs to get the grouped view.

## Testing

~1040 runtime + logsViewer + statelog unit tests pass, plus end-to-end agency-js tests (`llm-call-single-span`, `fork-branch-value`) and the new `render.e2e.test.ts`. Verified end-to-end against real `foo.agency` / `bar.agency` traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
