### PR TITLE
fix(guards): carry structured AbortCause so time-guard trips don't crash CI

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-06-22-abort-taxonomy-increment1.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-22-abort-taxonomy-increment1.md
@@ -1,0 +1,176 @@
+# Abort Taxonomy — Increment 1 (Core) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn CI green by fixing the three time-guard fixtures that crash, by carrying a structured `AbortCause` on every abort so guard trips are recognized at boundaries instead of escaping as unhandled rejections — and lay the carrier foundation that Increment 2 (full unification) builds on.
+
+**Architecture:** Every abort carries a tagged `AbortCause` (`signal.reason` stays an `AgencyCancelledError`, with the cause on its `agencyCause` field; `readCause()` reads it back from either a signal or an error). A time-guard trip that surfaces as an aborted leaf op (an in-flight `sleep`) now carries `kind: "guardTrip"`, so the stdlib `guard`'s `try` (`__tryCall`) converts it to a `Failure` — checked **before** the blanket `isAbortError → throw`. A shared mutable `delivered` flag on the cause de-dups the two trip-delivery paths (leaf-op vs runner `shouldSkip`) so the guard's own `_popGuard` step never re-throws.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/*`), stdlib JS (`lib/stdlib/*`). No codegen template changes, no fixture regeneration.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md` (Increment 1, §4).
+- **No codegen template change; no `make fixtures` regeneration.** The generated catch ladders still only *propagate* aborts — they need no change in Increment 1.
+- **`AgencyCancelledError` and `GuardExceededError` stay distinct types.** Unification is Increment 2.
+- **Preserve the propagate-never-swallow contract** (CLAUDE.md: handlers are safety infrastructure). A user cancel / race-loser abort must still propagate; only a `guardTrip` cause converts to a `Failure`.
+- **`signal.reason` must stay an `Error`** — `runBatch.ts:513` does `throw signal.reason`; aborting with a bare cause object would throw a non-Error. Producers abort with an `AgencyCancelledError` *carrying* the cause.
+- **Build:** `make` (not `pnpm run build`) before running fixtures — only `make` copies `lib/agents` into `dist`, which the interrupt-harness fixtures (race-multi-cycle, etc.) need.
+- **Test runner:** agency fixtures run via `pnpm run a test <file.agency>`; unit tests via `pnpm test:run <file>`.
+
+---
+
+## Task 1: `AbortCause` carrier + `readCause`
+
+**Files:**
+- Modify: `lib/runtime/errors.ts`
+- Test: `lib/runtime/errors.test.ts`
+
+**Interfaces:**
+- Produces: `type AbortCause` (tagged union); `makeAbortCause(c): AbortCause` (brands the object); `readCause(source: unknown): AbortCause | undefined` (reads from an `AbortSignal`, an `AgencyCancelledError`, or a bare branded cause); `AgencyCancelledError` gains an optional 2nd ctor arg `cause?: AbortCause` exposed as `readonly agencyCause?`.
+
+- [ ] **Step 1: Write failing tests** in `errors.test.ts`: round-trip each `AbortCause` variant through (a) `AbortController.abort(makeAbortCause(c))` → `readCause(signal)` and (b) `new AgencyCancelledError("x", makeAbortCause(c))` → `readCause(err)`; assert `readCause` returns `undefined` for a bare string reason / plain Error / null; assert a `guardTrip`-carrying `AgencyCancelledError` still satisfies `isAbortError`.
+
+- [ ] **Step 2: Run, verify fail** (`pnpm test:run lib/runtime/errors.test.ts`) — `makeAbortCause`/`readCause` undefined.
+
+- [ ] **Step 3: Implement** in `errors.ts`: the `AbortCause` union (`userInterrupt | userKill | guardTrip{dimension,limit,spent,guardId,delivered?} | raceLoser | cleanup`), a `__agencyAbortCause` brand, `makeAbortCause`, `isAbortCause`, `readCause` (signal → recurse on `.reason`; `AgencyCancelledError` → `.agencyCause`; bare branded → itself), and the `agencyCause` ctor arg/field on `AgencyCancelledError`.
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit.**
+
+---
+
+## Task 2: `TimeGuard` emits a `guardTrip` cause
+
+**Files:**
+- Modify: `lib/runtime/guard.ts`
+- Test: `lib/runtime/guard.test.ts`
+
+**Interfaces:**
+- Consumes: `makeAbortCause`, `AgencyCancelledError` (Task 1).
+- Produces: `nextGuardId(): string`; `TimeGuard.guardId: string`. On timer fire, `TimeGuard` aborts its controller with `new AgencyCancelledError(msg, makeAbortCause({ kind:"guardTrip", dimension:"time", limit, spent, guardId }))`.
+
+- [ ] **Step 1: Write failing test** (`guard.test.ts`, fake timers): install a `TimeGuard(500)`, `vi.advanceTimersByTime(500)`, assert `readCause(stack.abortSignal)` matches `{ kind:"guardTrip", dimension:"time", limit:500, guardId: g.guardId }`.
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement:** add module-level `nextGuardId`, a `guardId` field on `TimeGuard`, and rewrite `startWindow`'s `setTimeout` callback to compute `spent = elapsedMs + (now - windowStart)` and `controller.abort(new AgencyCancelledError(..., makeAbortCause({...})))`.
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit.**
+
+---
+
+## Task 3: Leaf ops propagate the cause
+
+**Files:**
+- Modify: `lib/stdlib/abortable.ts`
+
+**Interfaces:**
+- Consumes: `readCause`, `AgencyCancelledError` (Task 1).
+- Produces: `leafCancel(message, signal)` → `new AgencyCancelledError(message, readCause(signal))`. Every reject-on-abort site in `abortableSleep`/`abortableSpawn`/`abortableExec` uses it.
+
+- [ ] **Step 1: Implement** `leafCancel` and replace each `reject(new AgencyCancelledError(\`${command} cancelled\`))` / `reject(new AgencyCancelledError("sleep cancelled"))` with `reject(leafCancel(msg, <signal-in-scope>))`. (Spawn/close/error sites use `options.signal`; exec/sleep use `signal`.)
+
+- [ ] **Step 2:** `grep -n "new AgencyCancelledError" lib/stdlib/abortable.ts` — only the one inside `leafCancel` remains.
+
+- [ ] **Step 3:** `pnpm run build` clean; `pnpm test:run lib/stdlib/abortable.test.ts` green (no behavior change when no cause present).
+
+- [ ] **Step 4: Commit.**
+
+---
+
+## Task 4: `__tryCall` converts a `guardTrip` cause — BEFORE `isAbortError`
+
+**Files:**
+- Modify: `lib/runtime/result.ts`
+
+**Interfaces:**
+- Consumes: `readCause` (Task 1).
+- Produces: a `guardFailureData(dimension, limit, spent)` helper (shared by the cause path and the existing `GuardExceededError` path).
+
+- [ ] **Step 1: Implement** in `__tryCall`'s catch, **above** `if (isAbortError(error)) throw error`:
+  ```ts
+  const guardCause = readCause(error);
+  if (guardCause?.kind === "guardTrip") {
+    guardCause.delivered = true; // de-dup with the runner path (Task 5)
+    return failure(guardFailureData(guardCause.dimension, guardCause.limit, guardCause.spent), opts);
+  }
+  ```
+  Refactor the existing `GuardExceededError` branch to reuse `guardFailureData`.
+
+  **Why the order matters:** `isAbortError` returns `true` for the cause-carrying `AgencyCancelledError` too. If this check ran after the `isAbortError → throw`, the conversion would be dead code and the crash would remain. This ordering IS the fix (spec Concern 1).
+
+- [ ] **Step 2:** `make`; run all three guard-time fixtures — the bare-cancel crash is gone (they may still fail on the runner path until Task 5).
+
+- [ ] **Step 3: Commit.**
+
+---
+
+## Task 5: `shouldSkip` honors the `delivered` flag
+
+**Files:**
+- Modify: `lib/runtime/runner.ts`
+
+**Interfaces:**
+- Consumes: `readCause` (Task 1).
+
+**Background (the second trip path):** A time-guard trip can be delivered by EITHER the leaf-op path (Task 4) OR the runner's `shouldSkip` → `check()` → `throw GuardExceededError`. In the no-leaf case, the block's own `shouldSkip` calls `check()` (which sets the guard's `consumed` flag), so the later `_popGuard` step falls through. The leaf path bypasses `check()`, leaving `consumed=false` — so the guard's own `_popGuard` step's `shouldSkip` re-throws an **unhandled** `GuardExceededError`. The shared `delivered` flag on the cause (set by Task 4) closes this.
+
+- [ ] **Step 1: Implement** at the top of `shouldSkip`'s `aborted` branch:
+  ```ts
+  const cause = readCause(this.stack.abortSignal);
+  if (cause?.kind === "guardTrip" && cause.delivered) {
+    return this.halted || this._break || this._continue; // fall through; let _popGuard run
+  }
+  ```
+  Leave the existing innermost-first `check()` loop and `guardOwnsAbort` logic below it (the no-leaf path still relies on `check()`/`consumed`).
+
+- [ ] **Step 2: Run all three guard-time fixtures** — now pass (no unhandled rejection):
+  ```bash
+  for f in guard-time-trip guard-time-nested guard-time-and-cost; do pnpm run a test tests/agency/guards/$f.agency; done
+  ```
+
+- [ ] **Step 3:** Regression — full guards dir + race fixtures:
+  ```bash
+  pnpm run a test tests/agency/guards   # 20 passed
+  for f in tests/agency/fork/race/*.agency; do pnpm run a test "$f"; done
+  ```
+
+- [ ] **Step 4: Commit.**
+
+---
+
+## Task 6: `context.cancel` / REPL Esc carry user causes
+
+**Files:**
+- Modify: `lib/runtime/state/context.ts`, `lib/stdlib/cli.ts`
+
+**Interfaces:**
+- `RuntimeContext.cancel(reason?: string, cause?: AbortCause)` — defaults the cause to `userKill` (TS `cancel()` / external abort). `ctx.cleanup()` aborts with a `cleanup` cause. The REPL's Esc handler passes `makeAbortCause({ kind: "userInterrupt" })`.
+
+- [ ] **Step 1: Implement** the optional `cause` arg on `cancel` (default `userKill`), the `cleanup` cause in `cleanup()`, and `userInterrupt` at the `cli.ts` Esc handler. Widen `activeCtxOrNull`'s local `cancel` type to `(r?: string, cause?: AbortCause) => void`.
+
+- [ ] **Step 2:** `make` clean; `pnpm test:run` (full unit suite) green.
+
+- [ ] **Step 3: Commit.**
+
+---
+
+## Task 7: Full verification
+
+- [ ] **Step 1:** `make` clean.
+- [ ] **Step 2:** Full unit suite: `pnpm test:run` → all green (the 3 new error tests + 1 new guard test included).
+- [ ] **Step 3:** The 3 originally-failing fixtures pass; guards dir (20) + race fixtures green.
+- [ ] **Step 4:** `pnpm run lint:structure` clean.
+- [ ] **Step 5: Commit; open PR to `main`.**
+
+---
+
+## Deferred to follow-ups (NOT in this increment)
+
+- **`prompt.ts` cause-driven thread repair** (gate `markThreadCancelled` to `user*` causes) and the **`prompt.ts` normalization** preferring `readCause` over the `isCancelled` heuristic. These change the agent-cancel cleanup path and want PTY/agent-level test coverage; not needed to turn CI green. Spec §4.1 steps 5–6.
+- **Explicit `raceLoser` tagging** in `runBatch`. Today branch aborts carry no structured cause → `readCause` returns `undefined` → existing silent-halt behavior is preserved, so this is safe to defer.
+- **Increment 2 (full unification):** one `AgencyAbort` type, collapsed codegen ladder, ~95 regenerated fixtures, stdlib leaf migration. Separate spec→plan→PR.

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
@@ -32,10 +32,12 @@ AgencyCancelledError: sleep cancelled
 The chain:
 
 1. A `TimeGuard` timer fires and calls `this.controller?.abort()` **with no reason** (`lib/runtime/guard.ts:364`, inside `startWindow`).
-2. That abort is composed into `stack.abortSignal`, which an in-flight `sleep()` is listening on. Sleep's abort handler rejects with a **bare** `AgencyCancelledError("sleep cancelled")` (`lib/stdlib/abortable.ts:170`) — an error that carries *no information about why it aborted*.
+2. That abort is composed into `stack.abortSignal`, which an in-flight `sleep()` is listening on. Sleep's abort handler rejects with a **bare** `AgencyCancelledError("sleep cancelled")` (`lib/stdlib/abortable.ts:211`) — an error that carries *no information about why it aborted*.
 3. **Before** Esc-cancel: the generated per-function/per-node catch ladders converted `AgencyCancelledError` into a `Failure`, so the guard's `try` still observed a budget failure and the time guard surfaced a `timeoutFailure`.
-4. **After** Esc-cancel: those ladders now *re-throw* `isAbortError` so user cancellations propagate cleanly (`lib/templates/backends/typescriptGenerator/functionCatchFailure.ts:23`, `lib/backends/typescriptBuilder.ts:2554`). The bare cancel from `sleep` now escapes the guard boundary as an **unhandled async rejection** and crashes the process.
-5. The runner's `shouldSkip` guard-sniff added to mitigate this (`lib/runtime/runner.ts:241`, commit `99e92199`) only catches the *synchronous step-boundary* case. The `sleep` rejection fires from the timer's microtask and never passes through a step boundary, so the sniff misses it.
+4. **After** Esc-cancel: those ladders now *re-throw* `isAbortError` so user cancellations propagate cleanly (`lib/templates/backends/typescriptGenerator/functionCatchFailure.ts:23`, `lib/backends/typescriptBuilder.ts:2554`). The `sleep` rejection still propagates through the await chain and reaches the enclosing `guard`'s `try` — but that `try` today only recognizes `GuardExceededError`, so it re-throws the bare cancel. By then the awaiting runner step has already halted, so the re-thrown cancel lands at top level as an **unhandled async rejection** and crashes the process.
+5. The runner's `shouldSkip` guard-sniff added to mitigate this (`lib/runtime/runner.ts:269`, commit `99e92199`) only catches the *synchronous step-boundary* case — it converts an aborted signal into a `GuardExceededError` when the runner steps next. But the `sleep` rejection fires from the timer's microtask and propagates straight through the await chain to the guard `try` without the runner stepping, so the sniff never runs for it.
+
+> **Why the fix is reachable:** the bare cancel *does* reach the guard's `try` (point 4) — the boundary exists; it just doesn't recognize the error. So attaching a `guardTrip` cause to the rejection and teaching the guard `try` to convert cause-carrying aborts is sufficient. (An implementer should confirm this await-chain reachability first; if a future refactor ever halts the step before the rejection reaches the `try`, the boundary-conversion approach would need rethinking.)
 
 The deeper issue: **the leaf abort cannot tell the guard boundary "I am a guard trip — convert me to a Failure" because intent is not carried.** Every abort is the same `AgencyCancelledError`, discriminated only by re-derivation at catch time. The Esc-cancel change made the default disposition "propagate," and there's no carried signal to override it back to "convert" for guard-owned aborts.
 
@@ -65,7 +67,7 @@ Every generated function catch (`functionCatchFailure.ts`), every generated node
 
 ### 2.3 The re-derivation smells (intent reconstructed at catch time)
 
-- `runner.shouldSkip` (`runner.ts:241`) walks `stack.guards` innermost-first to decide a three-way: **guard trip** (throw `GuardExceededError`) vs **guard-already-consumed** (fall through for cleanup) vs **external/race-loser** (halt silently). This is the exact debt; it's what broke under Esc-cancel.
+- `runner.shouldSkip` (`runner.ts:269`) walks `stack.guards` innermost-first to decide a three-way: **guard trip** (throw `GuardExceededError`) vs **guard-already-consumed** (fall through for cleanup) vs **external/race-loser** (halt silently). This is the exact debt; it's what broke under Esc-cancel.
 - `prompt.ts:242` uses `ctx.isCancelled` *state* as the authority to reclassify an unrecognizable provider error as a cancel.
 - `__tryCall` (`result.ts:84`) reclassifies `GuardExceededError` into `{guardFailure}` / `{timeoutFailure}` Result shapes by sniffing `.type`.
 
@@ -122,6 +124,10 @@ This is ordinary typed-exception handling, except the discrimination data rides 
 
 Thread repair (`markThreadCancelled`) runs only for `user*` causes — not for `guardTrip` or `raceLoser`, which don't leave dangling tool calls the way a mid-LLM user cancel does. This removes the `prompt.ts:1106` "repair on any abort" coupling.
 
+### 3.4 Dependency: `AbortSignal.any` reason propagation
+
+The carrier design assumes that when a composed signal (`AbortSignal.any([...])`, used by both `TimeGuard.installAbortPlumbing` at `guard.ts:349` and `ctx.getAbortSignal` at `context.ts:512`) fires, `signal.reason` is the reason of whichever *source* signal aborted first. This is standard `AbortSignal.any` behavior — the composite adopts the first-aborting source's reason — and it is what lets a leaf op read the originating `AbortCause` off `stack.abortSignal` even though it's a composite. The design rests on this; if it ever proves unreliable across the supported Node versions, the producer would need to also stash the cause somewhere the leaf can read directly.
+
 ---
 
 ## 4. Increment 1 — Core (this plan): green CI + carrier foundation
@@ -141,14 +147,17 @@ Thread repair (`markThreadCancelled`) runs only for `user*` causes — not for `
    - Race/fork abort site: abort with `{ kind: "raceLoser" }`.
    - `ctx.cleanup()` (`context.ts:542`): `{ kind: "cleanup" }`.
 
-3. **Leaf ops propagate the cause** instead of minting a bare cancel. The crashing site `abortable.ts:170` (and its siblings, plus `http.ts:87`, `builtins.ts`, `ui.ts:864`, `oauth.ts`, `speech.ts`) read `signal.reason` and reject with an `AgencyCancelledError` **that carries `cause`** (add a `cause?: AbortCause` field to `AgencyCancelledError` for Increment 1 — small, additive, no type unification yet). If `signal.reason` is a `guardTrip`, the rejection carries it; the guard boundary converts it.
+3. **Leaf ops propagate the cause** instead of minting a bare cancel. The crashing site `abortable.ts:211` (and its siblings, plus `http.ts:87`, `builtins.ts`, `ui.ts:864`, `oauth.ts`, `speech.ts`) read `signal.reason` and reject with an `AgencyCancelledError` **that carries `cause`** (add a `cause?: AbortCause` field to `AgencyCancelledError` for Increment 1 — small, additive, no type unification yet). If `signal.reason` is a `guardTrip`, the rejection carries it; the guard boundary converts it. *(This relies on `AbortSignal.any` adopting the reason of whichever composed source aborts first — see §3.4.)*
 
-4. **Boundaries read the cause:**
-   - `runner.shouldSkip` (`runner.ts:241`): replace the innermost-first `guards` walk with `switch (readCause(stack.abortSignal)?.kind)`. `guardTrip` → return the matching guard's `check()` error (or build the `GuardExceededError` from the cause). `raceLoser`/`cleanup` → silent halt. `userInterrupt`/`userKill` → propagate (no silent halt). This is the direct regression fix.
-   - The **guard `try` boundary** (`result.ts` `__tryCall` / stdlib `guard`): when catching an abort error whose `cause.kind === "guardTrip"` and whose `guardId` matches this guard, convert to the structured `Failure`; otherwise re-throw so it keeps unwinding to its real owner. **This is the fix for the async-leaf-rejection crash**: the `sleep` rejection now carries `guardTrip`, so the enclosing guard converts it instead of letting it escape.
+4. **Introduce a stable `guardId`** on every `Guard` instance, threaded into both (a) the `guardTrip` cause it emits and (b) the converting `try` boundary so the two can be matched. This is a **new invariant**, not an existing field — call it out as an explicit work item. For nested guards, stack unwinding already makes the innermost `try` catch first, so id-matching is primarily a correctness backstop (it prevents an inner trip from being converted by the wrong outer guard if the unwinding order ever surprises us); it must still be implemented, not assumed.
+
+5. **Boundaries read the cause:**
+   - `runner.shouldSkip` (`runner.ts:269`): replace the innermost-first `guards` walk with `switch (readCause(stack.abortSignal)?.kind)`. `guardTrip` → return the matching guard's `check()` error (or build the `GuardExceededError` from the cause). `raceLoser`/`cleanup` → silent halt. `userInterrupt`/`userKill` → propagate (no silent halt). This is the direct regression fix.
+   - The **guard `try` boundary** (`result.ts` `__tryCall:62` / stdlib `guard`): when catching an abort error whose `cause.kind === "guardTrip"` and whose `guardId` matches this guard, convert to the structured `Failure`; otherwise re-throw so it keeps unwinding to its real owner. **This is the fix for the async-leaf-rejection crash**: the `sleep` rejection now carries `guardTrip`, so the enclosing guard converts it instead of letting it escape.
+     - **CRITICAL ORDERING (the actual fix):** the `guardTrip`-cause check must run **before** the blanket `if (isAbortError(error)) throw error` at `result.ts:76`. `isAbortError` returns `true` for *any* `AgencyCancelledError` — including the cause-carrying one — so if the cause check is added *after* the existing ladder, line 76 re-throws first and the conversion is dead code, leaving the crash in place. Reorder so `__tryCall` reads: *is this a `guardTrip` cause (matching `guardId`)? → convert. Else is it an abort? → throw. Else → Failure.*
    - `prompt.ts:242` normalization: prefer `readCause(...)` over the `isCancelled`-state heuristic where a cause is present; keep the existing heuristic as a fallback for provider errors that arrive with no cause.
 
-5. **Cause-driven thread repair:** `prompt.ts:1106` runs `markThreadCancelled` only when `readCause(error)?.kind` is `userInterrupt`/`userKill` (or cause is absent — conservative default), not for `guardTrip`/`raceLoser`.
+6. **Cause-driven thread repair:** `prompt.ts:1106` runs `markThreadCancelled` only when `readCause(error)?.kind` is `userInterrupt`/`userKill` (or cause is absent — conservative default), not for `guardTrip`/`raceLoser`. The REPL-only `resetCancel` (`cli.ts:812`) is **untouched in Increment 1** — the §3.2 table lists it as part of the `userInterrupt` boundary's cleanup, but it already runs correctly in the REPL turn boundary and needs no change here.
 
 ### 4.2 What does NOT change in Increment 1
 
@@ -232,3 +241,4 @@ Therefore abort handling lives in the **backend boundary/disposition layer** (§
 - **`spent` accuracy in the `guardTrip` cause.** The cause carries an approximate `spent` at abort time; `TimeGuard.check()` remains the authority for the number surfaced in `GuardFailureData`. Keep `check()` as the source of truth; the cause is for discrimination.
 - **Provider errors with no cause.** Some provider SDK abort errors arrive without our `AbortCause`. Keep `prompt.ts`'s `isCancelled`-state fallback so these are still classified as cancellations when a cause is absent.
 - **Cross-module identity.** `readCause`/`isAbortError` must keep the name-based fallback for errors that cross module instances (e.g. the subprocess resolver shim), per `errors.ts:80`.
+- **Cause payload across the subprocess boundary (out of scope for now).** The name-based fallback preserves abort *identity* across a process boundary, but the `cause` *payload* on a reconstructed error may not survive serialization through the subprocess resolver shim. The failing CI tests are all in-process, so this is not an Increment-1 blocker — but a `guardTrip` (or any cause) originating *inside* a subprocess could lose its discrimination data at the parent. Explicitly deferred; revisit when guard/abort semantics need to span subprocesses.

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
@@ -1,0 +1,234 @@
+# Abort Taxonomy & Disposition Architecture
+
+**Status:** Design approved; ready for implementation planning.
+**Scope of this spec:** Describes the full target architecture, but splits delivery into two increments. **Increment 1 (Core)** is the implementable-now plan that turns CI green and lays the carrier foundation. **Increment 2 (Full unification)** is described in detail here but is explicitly deferred to a *separate* implementation plan.
+
+---
+
+## 1. The concrete problem
+
+Three Agency fixture tests fail on CI ([run 27907963302](https://github.com/egonSchiele/agency-lang/actions/runs/27907963302/job/82579909174)), all time-guard tests:
+
+- `tests/agency/guards/guard-time-trip.test.json`
+- `tests/agency/guards/guard-time-nested.test.json`
+- `tests/agency/guards/guard-time-and-cost.test.json`
+
+Cost-guard fixtures and the 27-case `lib/runtime/guard.test.ts` unit suite all pass. The regression appeared when we added **"press Esc to cancel the in-flight request"** to the agency agent (`docs/superpowers/plans/2026-06-02-tui-pr6-ws3a-esc-cancel.md`, and the REPL-side `installCancelKey` in `lib/stdlib/cli.ts`).
+
+### Root cause
+
+The failure is a process crash, not an assertion miss:
+
+```
+file:///.../dist/lib/stdlib/abortable.js:170
+            reject(new AgencyCancelledError("sleep cancelled"));
+                   ^
+AgencyCancelledError: sleep cancelled
+    at AbortSignal.onAbort (.../abortable.js:170:20)
+    ...
+    at Timeout._onTimeout (.../runtime/guard.js:259:62)   // TimeGuard timer → controller.abort()
+```
+
+The chain:
+
+1. A `TimeGuard` timer fires and calls `this.controller?.abort()` **with no reason** (`lib/runtime/guard.ts:364`, inside `startWindow`).
+2. That abort is composed into `stack.abortSignal`, which an in-flight `sleep()` is listening on. Sleep's abort handler rejects with a **bare** `AgencyCancelledError("sleep cancelled")` (`lib/stdlib/abortable.ts:170`) — an error that carries *no information about why it aborted*.
+3. **Before** Esc-cancel: the generated per-function/per-node catch ladders converted `AgencyCancelledError` into a `Failure`, so the guard's `try` still observed a budget failure and the time guard surfaced a `timeoutFailure`.
+4. **After** Esc-cancel: those ladders now *re-throw* `isAbortError` so user cancellations propagate cleanly (`lib/templates/backends/typescriptGenerator/functionCatchFailure.ts:23`, `lib/backends/typescriptBuilder.ts:2554`). The bare cancel from `sleep` now escapes the guard boundary as an **unhandled async rejection** and crashes the process.
+5. The runner's `shouldSkip` guard-sniff added to mitigate this (`lib/runtime/runner.ts:241`, commit `99e92199`) only catches the *synchronous step-boundary* case. The `sleep` rejection fires from the timer's microtask and never passes through a step boundary, so the sniff misses it.
+
+The deeper issue: **the leaf abort cannot tell the guard boundary "I am a guard trip — convert me to a Failure" because intent is not carried.** Every abort is the same `AgencyCancelledError`, discriminated only by re-derivation at catch time. The Esc-cancel change made the default disposition "propagate," and there's no carried signal to override it back to "convert" for guard-owned aborts.
+
+---
+
+## 2. Background: the current architecture and its surface area
+
+A full survey of every abort throw/catch/derive site (file:line references below) reveals **one transport carrying many intents**.
+
+### 2.1 The "must-propagate, never-convert-to-Failure" family
+
+Every generated function catch (`functionCatchFailure.ts`), every generated node catch (`typescriptBuilder.ts:2543`), and `__tryCall` (`result.ts:62`) check these *in priority order* and re-throw them so they are not swallowed into a `Failure`:
+
+1. `RestoreSignal` — checkpoint restore (not an abort; a separate control signal).
+2. `GuardExceededError` — so the stdlib `guard`'s own `try` can catch and structure it.
+3. `AgencyCancelledError` / `AbortError` — cancellation.
+4. `PromptBailout` — interrupt batching (handled in `prompt.ts`).
+
+### 2.2 Where aborts originate (5 transports, all funneling to one error)
+
+- `ctx.cancel(reason)` → global `abortController` (`context.ts:517`). Fired by: **TS-interop `cancel()`** callback (`node.ts:228`), **external `abortSignal`** passed to `runNode` (`node.ts:229`), **Esc in the REPL** (`cli.ts:778`), and **`ctx.cleanup()`** GC (`context.ts:542`).
+- **Time guard** → composes an abort into branch-local `stack.abortSignal` (`guard.ts:349` `installAbortPlumbing`, `:364` the `abort()` call).
+- **Race-loser / fork** → fires branch-local `stack.abortSignal`.
+- **Cost guard** → throws `GuardExceededError` *directly*, no signal (`guard.ts:151`).
+- **stdlib leaf ops** → translate their own abort to `AgencyCancelledError`: `http.ts:87`, `abortable.ts` (spawn/exec/sleep — `:55/:105/:115/:141/:168/:182/:202/:211`), `builtins.ts:55/:64` (input), `ui.ts:864`, `oauth.ts:177`, `speech.ts:169`.
+- **prompt.ts** normalizes provider abort errors → `AgencyCancelledError` when `ctx.isCancelled` (`prompt.ts:242`).
+
+### 2.3 The re-derivation smells (intent reconstructed at catch time)
+
+- `runner.shouldSkip` (`runner.ts:241`) walks `stack.guards` innermost-first to decide a three-way: **guard trip** (throw `GuardExceededError`) vs **guard-already-consumed** (fall through for cleanup) vs **external/race-loser** (halt silently). This is the exact debt; it's what broke under Esc-cancel.
+- `prompt.ts:242` uses `ctx.isCancelled` *state* as the authority to reclassify an unrecognizable provider error as a cancel.
+- `__tryCall` (`result.ts:84`) reclassifies `GuardExceededError` into `{guardFailure}` / `{timeoutFailure}` Result shapes by sniffing `.type`.
+
+### 2.4 Cleanup is scattered and origin-coupled, not cause-driven
+
+- `markThreadCancelled` (thread repair for dangling tool calls) fires in `prompt.ts:1106` on **any** abort — including guard trips and race-losers, which don't need thread repair.
+- `resetCancel` — REPL only (`cli.ts:812`).
+- `deleteBranch` — tool-branch cleanup (`prompt.ts:699`).
+- `popGuard` timer teardown — guard `finally`.
+
+### 2.5 Disposition is decided by *where* an abort is caught, not *what* it is
+
+A guard trip becomes a `Result` only because the stdlib `guard`'s `try` happens to wrap it; everything else propagates to the top. There is **no representation at all** for environmental/recoverable aborts (network drop, laptop closed) or per-call timeouts — exactly the cases we lack UX for.
+
+---
+
+## 3. Design: carry intent, convert at boundaries
+
+The architecture rests on three ideas.
+
+### 3.1 `AbortCause` — a tagged value carried on every abort
+
+`signal.reason` is **always** an `AbortCause` (never a bare string); directly-thrown aborts carry the same value. The taxonomy:
+
+```ts
+type AbortCause =
+  | { kind: "userInterrupt" }                     // Esc — stop work, hand control back, session lives
+  | { kind: "userKill"; reason?: string }         // TS cancel() — terminal, propagate to caller
+  | { kind: "guardTrip"; dimension: "cost" | "time"; limit: number; spent: number; guardId: string }
+  | { kind: "raceLoser" }                          // internal — a fork/race sibling won
+  | { kind: "cleanup" }                            // internal — ctx.cleanup() GC
+  // ---- future (Increment 2+ / separate plans) ----
+  | { kind: "callTimeout"; limitMs: number }       // one LLM call exceeded its own timeout; retryable
+  | { kind: "connectionLost"; detail: string }     // environmental; recoverable
+```
+
+The cause is **read, never re-derived**. Every catch site that currently sniffs switches on `cause.kind`.
+
+### 3.2 Boundaries convert; everything else propagates
+
+Disposition is currently an accident of which catch fires. Make it explicit: each cause has an **owning boundary** that recognizes it (by `kind`, plus identity such as `guardId`) and converts it. Any abort that reaches a frame which is *not* its owning boundary simply keeps unwinding.
+
+| cause | owning boundary | becomes at the boundary | cleanup at boundary |
+| --- | --- | --- | --- |
+| `guardTrip` | the matching `guard` block (by `guardId`) | `Result` (`GuardFailureData`) | `popGuard` timers |
+| `userInterrupt` | the REPL turn | propagates; REPL prints "cancelled", reprompts | `markThreadCancelled` + `resetCancel` |
+| `userKill` | the TS run boundary (`runNode`) | propagates to the caller | `markThreadCancelled` |
+| `raceLoser` / `cleanup` | branch / run | halt silently | `popBranches` |
+| `connectionLost` / `callTimeout` | (future) the call or an enclosing recover-scope | recoverable `Failure` / retry | thread repair if needed |
+
+This is ordinary typed-exception handling, except the discrimination data rides on the cause instead of being reconstructed.
+
+### 3.3 Cleanup becomes cause-driven
+
+Thread repair (`markThreadCancelled`) runs only for `user*` causes — not for `guardTrip` or `raceLoser`, which don't leave dangling tool calls the way a mid-LLM user cancel does. This removes the `prompt.ts:1106` "repair on any abort" coupling.
+
+---
+
+## 4. Increment 1 — Core (this plan): green CI + carrier foundation
+
+**Goal:** Turn CI green by fixing the three time-guard fixtures, and lay the `AbortCause` carrier so Increment 2 is purely a type-unification refactor. **No codegen template change. No fixture regeneration.** `AgencyCancelledError` and `GuardExceededError` remain as distinct types.
+
+### 4.1 What changes
+
+1. **Define `AbortCause`** (in `lib/runtime/errors.ts` or a new `lib/runtime/abortCause.ts`) plus helpers:
+   - `abortWith(controller, cause)` — `controller.abort(cause)`.
+   - `readCause(signal | error): AbortCause | undefined` — reads `signal.reason` if it's an `AbortCause`, else `undefined`; also reads a `cause` field off an abort error (see step 3).
+   - `isGuardTrip(cause)`, etc., as needed.
+
+2. **Producers attach a structured cause** instead of `undefined`/string:
+   - `TimeGuard.startWindow` (`guard.ts:364`): `this.controller.abort(guardTripCause(...))` carrying `{ kind: "guardTrip", dimension: "time", limit, spent, guardId }`. *(`spent` may be approximate at abort time; `check()` still computes the exact value — the cause's role is discrimination, not the authoritative number.)*
+   - `context.cancel(reason)` (`context.ts:517`): abort with `{ kind: "userKill", reason }` for the TS/external path and `{ kind: "userInterrupt" }` for the Esc path. Distinguish via an argument to `cancel` (the REPL's `installCancelKey` passes the interrupt variant; `node.ts`/TS-interop passes kill).
+   - Race/fork abort site: abort with `{ kind: "raceLoser" }`.
+   - `ctx.cleanup()` (`context.ts:542`): `{ kind: "cleanup" }`.
+
+3. **Leaf ops propagate the cause** instead of minting a bare cancel. The crashing site `abortable.ts:170` (and its siblings, plus `http.ts:87`, `builtins.ts`, `ui.ts:864`, `oauth.ts`, `speech.ts`) read `signal.reason` and reject with an `AgencyCancelledError` **that carries `cause`** (add a `cause?: AbortCause` field to `AgencyCancelledError` for Increment 1 — small, additive, no type unification yet). If `signal.reason` is a `guardTrip`, the rejection carries it; the guard boundary converts it.
+
+4. **Boundaries read the cause:**
+   - `runner.shouldSkip` (`runner.ts:241`): replace the innermost-first `guards` walk with `switch (readCause(stack.abortSignal)?.kind)`. `guardTrip` → return the matching guard's `check()` error (or build the `GuardExceededError` from the cause). `raceLoser`/`cleanup` → silent halt. `userInterrupt`/`userKill` → propagate (no silent halt). This is the direct regression fix.
+   - The **guard `try` boundary** (`result.ts` `__tryCall` / stdlib `guard`): when catching an abort error whose `cause.kind === "guardTrip"` and whose `guardId` matches this guard, convert to the structured `Failure`; otherwise re-throw so it keeps unwinding to its real owner. **This is the fix for the async-leaf-rejection crash**: the `sleep` rejection now carries `guardTrip`, so the enclosing guard converts it instead of letting it escape.
+   - `prompt.ts:242` normalization: prefer `readCause(...)` over the `isCancelled`-state heuristic where a cause is present; keep the existing heuristic as a fallback for provider errors that arrive with no cause.
+
+5. **Cause-driven thread repair:** `prompt.ts:1106` runs `markThreadCancelled` only when `readCause(error)?.kind` is `userInterrupt`/`userKill` (or cause is absent — conservative default), not for `guardTrip`/`raceLoser`.
+
+### 4.2 What does NOT change in Increment 1
+
+- The generated catch ladders (`functionCatchFailure.ts`, `typescriptBuilder.ts:2543`) stay as-is — they still `instanceof GuardExceededError` / `isAbortError` and re-throw. Because they only *propagate* (never inspect cause), they need no change. **→ zero fixture regeneration.**
+- `GuardExceededError` and `AgencyCancelledError` remain separate classes.
+- `isAbortError` / `isGuardExceededError` keep their current name-based cross-module checks.
+
+### 4.3 Acceptance for Increment 1
+
+- The 3 time-guard fixtures pass; CI is green.
+- `lib/runtime/guard.test.ts` (27) and all cost-guard fixtures stay green.
+- Esc-cancel still aborts the in-flight LLM call and reprompts (manual + `lib/stdlib/ui.test.ts` / `ui-smoke.test.ts`).
+- Race/fork tests (`tests/agency/fork/race/*`) stay green.
+- New unit test: a time guard wrapping an in-flight `sleep` trips and produces a `timeoutFailure` Result, with **no unhandled rejection** (the exact CI crash, locked down).
+- New unit test: `readCause` round-trips each `AbortCause` variant through both `signal.reason` and an `AgencyCancelledError.cause`.
+
+---
+
+## 5. Increment 2 — Full unification (SEPARATE implementation plan)
+
+> This section documents the target end-state in detail. **It is not part of the Increment 1 plan.** It should become its own spec→plan→implementation cycle once Increment 1 has landed and CI is green.
+
+### 5.1 Goal
+
+Collapse the two abort error types and the multi-rung catch ladder into a single carrier, so the taxonomy is the *only* representation of an abort anywhere in the system.
+
+### 5.2 Changes
+
+1. **One error type:** `AgencyAbort extends Error { readonly cause: AbortCause }`. `GuardExceededError` becomes `AgencyAbort` with `cause.kind === "guardTrip"`; `AgencyCancelledError` becomes `AgencyAbort` with a `user*`/`raceLoser`/`cleanup` cause. Keep thin compatibility shims (or codemod call sites) across the ~27 non-test `lib/` files that currently reference the old classes.
+2. **Collapse the codegen ladder:** the per-function and per-node catches reduce to:
+   ```
+   if (__error instanceof RestoreSignal) throw __error;   // still a separate control signal
+   if (__error instanceof AgencyAbort)   throw __error;   // all aborts: one check
+   // ...else log + convert to Failure
+   ```
+   Update `functionCatchFailure.mustache` + `imports.ts` + `typescriptBuilder.ts:2543`, run `pnpm run templates`, then `make fixtures`.
+3. **Regenerate ~95 fixtures** (`grep -rl __isAbortError tests | wc -l` ≈ 95). Large but mechanical diff; spot-check a couple of regenerated catches, trust the rest. Land this in its own commit so the churn is reviewable in isolation.
+4. **Migrate stdlib leaves** (`http`, `abortable`, `builtins`, `ui`, `oauth`, `speech`) to throw `AgencyAbort` carrying the read cause.
+5. **Unify the predicates:** `isAbortError` becomes `instanceof AgencyAbort` (plus the existing `DOMException("AbortError")` / name-based cross-module fallback). `isGuardExceededError` becomes `cause.kind === "guardTrip"`. `__tryCall` converts by reading `cause` directly.
+
+### 5.3 Why staged this way
+
+Increment 1's semantic core (the regression fix) is reviewable on its own with no fixture churn. Increment 2's ~95-fixture diff lands in isolation where it's obviously mechanical, and the "handlers are safety infrastructure" propagate-never-swallow contract can be re-verified site-by-site without being tangled in behavior changes. Same end-state; lower risk per PR.
+
+---
+
+## 6. Future extensions (beyond both increments)
+
+The taxonomy is designed so these are *additions*, not redesigns:
+
+- **`callTimeout`** — a per-LLM-call timeout (sibling of a time guard but scoped to one call, with a retry disposition). New cause variant + a boundary that retries N times before surfacing a `Failure`. See `docs/superpowers/plans/2026-05-24-timeout-guards.md` for prior thinking.
+- **`connectionLost`** — environmental aborts (network drop, laptop closed). Today these surface either as a non-abort fetch error converted to a useless string `Failure`, or as a misclassified cancel. A new cause + a recoverable-failure disposition gives the agency agent a real "lost connection — retry?" UX.
+- **Notification callbacks** (cheapest near-term UX, layerable on Increment 1): add side-effect-only hooks such as `onAbort(cause)` / `onConnectionLost(detail)` to the callbacks system (`docs/site/appendix/callbacks.md`). These can *notify* (print a message) but, per the decision record in §7, **cannot** decide disposition.
+- **A language surface** for authors to declare custom abort handling. Deferred deliberately (see §7). Whatever shape it takes, the backend already speaks `cause → boundary → disposition`, so the surface is sugar over registering a boundary/policy — not a new mechanism.
+
+---
+
+## 7. Decision record: why not handlers or callbacks (for the *handling* mechanism)
+
+This came up before and was rejected; the rationale, recovered from `docs/superpowers/plans/2026-05-23-remove-callback-interrupts.md` and `docs/site/appendix/callbacks.md:39`:
+
+- **Handlers (`handle` blocks)** intercept *interrupts* — cooperative, checkpointed, **resumable** pauses. An aborted LLM call is the opposite: the socket is dead, there is nothing to resume. Routing aborts through handlers would force aborts to become interrupt-shaped (resumable), which they are not.
+- **Callbacks** were *deliberately stripped of control-flow power*: the typechecker rejects `interrupt(...)` inside any callback body. They run as side effects, may throw a logged-and-dropped JS error, and that is it. They can *notify* about an abort but cannot *decide* its disposition (convert to `Result`, retry, hand control back).
+
+Therefore abort handling lives in the **backend boundary/disposition layer** (§3.2). Callbacks remain available as a complementary *notification* layer only (§6). A first-class author-facing language surface is intentionally **out of scope** for both increments and will be designed separately if/when needed.
+
+---
+
+## 8. Testing strategy
+
+- **Increment 1 regression lock:** a deterministic unit test reproducing the CI crash — a `guard(time: …)` around an in-flight `sleep`, asserting a `timeoutFailure` Result and asserting **no unhandled rejection** is emitted.
+- **Carrier round-trip:** `readCause` over every variant via both `signal.reason` and `AgencyCancelledError.cause`.
+- **Boundary matrix:** for each `{ guardTrip, userInterrupt, userKill, raceLoser }`, assert the correct boundary converts/propagates and the correct cleanup runs (e.g. `markThreadCancelled` runs for `userInterrupt` but not `guardTrip`).
+- **Existing suites that must stay green:** `lib/runtime/guard.test.ts`, all `tests/agency/guards/*`, `tests/agency/fork/race/*`, `lib/stdlib/ui*.test.ts`. Per CLAUDE.md, do not run the full agency suite locally — let CI run it; run the specific guard/race fixtures locally while iterating, saving output to a file.
+
+---
+
+## 9. Risks
+
+- **Handlers-are-safety-infrastructure (CLAUDE.md).** Every migrated catch must preserve the propagate-never-swallow contract. Increment 1 keeps the codegen ladder untouched specifically to avoid touching this in the regression fix; Increment 2 re-verifies it site-by-site.
+- **`spent` accuracy in the `guardTrip` cause.** The cause carries an approximate `spent` at abort time; `TimeGuard.check()` remains the authority for the number surfaced in `GuardFailureData`. Keep `check()` as the source of truth; the cause is for discrimination.
+- **Provider errors with no cause.** Some provider SDK abort errors arrive without our `AbortCause`. Keep `prompt.ts`'s `isCancelled`-state fallback so these are still classified as cancellations when a cause is absent.
+- **Cross-module identity.** `readCause`/`isAbortError` must keep the name-based fallback for errors that cross module instances (e.g. the subprocess resolver shim), per `errors.ts:80`.

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
@@ -159,6 +159,17 @@ The carrier design assumes that when a composed signal (`AbortSignal.any([...])`
 
 6. **Cause-driven thread repair:** `prompt.ts:1106` runs `markThreadCancelled` only when `readCause(error)?.kind` is `userInterrupt`/`userKill` (or cause is absent — conservative default), not for `guardTrip`/`raceLoser`. The REPL-only `resetCancel` (`cli.ts:812`) is **untouched in Increment 1** — the §3.2 table lists it as part of the `userInterrupt` boundary's cleanup, but it already runs correctly in the REPL turn boundary and needs no change here.
 
+### 4.1.1 Implementation discovery: TWO trip-delivery paths, de-duped by a `delivered` flag
+
+The §1 root-cause analysis anticipated *one* boundary fix (teach the guard `try` to convert a cause-carrying abort). Implementation surfaced a **second** delivery path the original analysis missed, and the fix needs both to cooperate:
+
+- **Path A (leaf-op):** an in-flight `sleep`/`fetch` aborts and rejects carrying the `guardTrip` cause → `__tryCall` converts to a `Failure` (§4.1 step 5).
+- **Path B (runner):** `Runner.shouldSkip` sees the aborted signal at a step boundary, calls `guard.check()` (which sets the guard's `consumed` flag), and throws a `GuardExceededError` — the path the guards-design doc already documents. This path is still needed for a guard wrapping pure compute with **no** abortable leaf op to interrupt.
+
+Both can fire for the same trip. In the no-leaf case the block's own `shouldSkip` runs first and `consumed` de-dups the later `_popGuard`-step check. But the leaf path bypasses `check()`, so `consumed` stays `false` and the guard's **own `_popGuard` step** then trips `shouldSkip` → throws an **unhandled** `GuardExceededError` (a *second* crash, revealed only after Path A was fixed).
+
+The fix: a mutable `delivered?: boolean` on the `guardTrip` cause. Path A sets it when it converts; `shouldSkip` early-returns (does not re-throw) when it sees an already-`delivered` trip, letting `_popGuard` run. This works because the cause object has **stable identity** across the composed signal and the leaf rejection (the `AbortSignal.any` reason-propagation dependency, §3.4) — the same object is visible to both paths. Net: each trip is delivered exactly once regardless of which path wins.
+
 ### 4.2 What does NOT change in Increment 1
 
 - The generated catch ladders (`functionCatchFailure.ts`, `typescriptBuilder.ts:2543`) stay as-is — they still `instanceof GuardExceededError` / `isAbortError` and re-throw. Because they only *propagate* (never inspect cause), they need no change. **→ zero fixture regeneration.**

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md
@@ -134,6 +134,11 @@ The carrier design assumes that when a composed signal (`AbortSignal.any([...])`
 
 **Goal:** Turn CI green by fixing the three time-guard fixtures, and lay the `AbortCause` carrier so Increment 2 is purely a type-unification refactor. **No codegen template change. No fixture regeneration.** `AgencyCancelledError` and `GuardExceededError` remain as distinct types.
 
+> **What actually shipped vs. what §4 below describes.** §4 describes the full Increment-1 *design*. The delivered PR is **narrower by design** — it does exactly what's needed to turn CI green plus the safe, additive carrier — and the plan (`docs/superpowers/plans/2026-06-22-abort-taxonomy-increment1.md`) "Deferred" section is authoritative on scope. Specifically, these §4 items are **deferred**, not shipped:
+> - **Full `shouldSkip` cause-switch (step 5).** The shipped `shouldSkip` only adds the `delivered`-guardTrip early-return (§4.1.1). `userInterrupt`/`userKill` causes still fall through to the existing silent `halt(undefined)` — Esc propagates via the leaf/catch-ladder path, not via `shouldSkip`, so the runner's user-cancel behavior is intentionally unchanged.
+> - **`guardId` matching at the boundary.** A `guardId` is emitted on the cause, but no boundary matches on it — `__tryCall` converts *any* `guardTrip` cause it catches, relying on structural call-stack nesting (exactly as cost guards do today). Real id-matching needs threading the id into `__tryCall`, a **codegen change** Increment 1 avoids; it is deferred to Increment 2. Consequence (pinned by `tests/agency/guards/guard-time-nested-outer-tighter`): when an **outer** guard is tighter than an inner one, the inner's `try` mis-attributes the outer's trip to the inner guard's Failure. Not a crash (pre-fix it crashed); just mis-attributed until Increment 2.
+> - **`prompt.ts` thread-repair gating + normalization (steps 5–6)** and **`raceLoser` tagging (step 2)** — deferred and safe (untagged → `readCause` undefined → existing behavior).
+
 ### 4.1 What changes
 
 1. **Define `AbortCause`** (in `lib/runtime/errors.ts` or a new `lib/runtime/abortCause.ts`) plus helpers:

--- a/packages/agency-lang/lib/runtime/errors.test.ts
+++ b/packages/agency-lang/lib/runtime/errors.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { CheckpointError, RestoreSignal, AgencyCancelledError, isAbortError } from "./errors.js";
+import {
+  CheckpointError,
+  RestoreSignal,
+  AgencyCancelledError,
+  isAbortError,
+  makeAbortCause,
+  readCause,
+  type AbortCause,
+} from "./errors.js";
 
 describe("CheckpointError", () => {
   it("should have correct name and message", () => {
@@ -39,6 +47,87 @@ describe("AgencyCancelledError", () => {
   it("should accept a custom reason", () => {
     const err = new AgencyCancelledError("user clicked stop");
     expect(err.message).toBe("user clicked stop");
+  });
+
+  it("should carry a structured AbortCause when given one", () => {
+    const cause = makeAbortCause({ kind: "userInterrupt" });
+    const err = new AgencyCancelledError("esc", cause);
+    expect(err.agencyCause).toBe(cause);
+  });
+});
+
+describe("AbortCause / readCause", () => {
+  const cases: AbortCause[] = [
+    { kind: "userInterrupt" },
+    { kind: "userKill", reason: "ts cancel" },
+    { kind: "guardTrip", dimension: "time", limit: 20, spent: 21, guardId: "g1" },
+    { kind: "guardTrip", dimension: "cost", limit: 2, spent: 3, guardId: "g2" },
+    { kind: "raceLoser" },
+    { kind: "cleanup" },
+  ];
+
+  it("round-trips every variant through an AbortSignal's reason", () => {
+    for (const c of cases) {
+      const controller = new AbortController();
+      controller.abort(makeAbortCause(c));
+      const read = readCause(controller.signal);
+      expect(read?.kind).toBe(c.kind);
+    }
+  });
+
+  it("round-trips every variant through AgencyCancelledError.agencyCause", () => {
+    for (const c of cases) {
+      const err = new AgencyCancelledError("x", makeAbortCause(c));
+      const read = readCause(err);
+      expect(read?.kind).toBe(c.kind);
+    }
+  });
+
+  it("preserves guardTrip payload fields", () => {
+    const controller = new AbortController();
+    controller.abort(
+      makeAbortCause({
+        kind: "guardTrip",
+        dimension: "time",
+        limit: 20,
+        spent: 21,
+        guardId: "g7",
+      }),
+    );
+    const read = readCause(controller.signal);
+    expect(read).toMatchObject({
+      kind: "guardTrip",
+      dimension: "time",
+      limit: 20,
+      guardId: "g7",
+    });
+  });
+
+  it("returns undefined when no structured cause is present", () => {
+    // Bare string reason (the legacy shape) is not a structured cause.
+    const controller = new AbortController();
+    controller.abort("just a string");
+    expect(readCause(controller.signal)).toBeUndefined();
+    expect(readCause(new AgencyCancelledError("no cause"))).toBeUndefined();
+    expect(readCause(new Error("plain"))).toBeUndefined();
+    expect(readCause(null)).toBeUndefined();
+  });
+
+  it("a structured guardTrip cause is also recognized as an abort error when on AgencyCancelledError", () => {
+    // The cause-carrying cancel must still pass isAbortError — this is
+    // exactly why __tryCall checks the guardTrip cause BEFORE isAbortError.
+    const err = new AgencyCancelledError(
+      "sleep cancelled",
+      makeAbortCause({
+        kind: "guardTrip",
+        dimension: "time",
+        limit: 20,
+        spent: 21,
+        guardId: "g1",
+      }),
+    );
+    expect(isAbortError(err)).toBe(true);
+    expect(readCause(err)?.kind).toBe("guardTrip");
   });
 });
 

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -41,10 +41,87 @@ export class ConcurrentInterruptError extends Error {
   }
 }
 
+/**
+ * Structured reason carried by every abort — on `AbortController.abort(cause)`
+ * (so it surfaces as `signal.reason`) and on the `agencyCause` field of a
+ * thrown `AgencyCancelledError`. The `kind` discriminant lets every
+ * catch/boundary READ the intent instead of re-deriving it (which is what the
+ * runner's guard-sniff and the leaf bare-throws used to do). See
+ * docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md.
+ */
+export type AbortCause =
+  | { kind: "userInterrupt" }
+  | { kind: "userKill"; reason?: string }
+  | {
+      kind: "guardTrip";
+      dimension: "cost" | "time";
+      limit: number;
+      spent: number;
+      guardId: string;
+      /**
+       * Mutable de-dup flag. A time-guard trip can be delivered by EITHER
+       * an aborted leaf op (→ `__tryCall` converts to a Failure) OR the
+       * runner's `shouldSkip` (→ throws `GuardExceededError`). Whichever
+       * fires first sets this; the other then knows the trip is already
+       * handled and must not re-deliver. The cause object has stable
+       * identity across the composed signal (`AbortSignal.any` adopts the
+       * source's reason object), so this single flag is visible to both
+       * paths. See docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md §3.4.
+       */
+      delivered?: boolean;
+    }
+  | { kind: "raceLoser" }
+  | { kind: "cleanup" };
+
+/** Brand so a plain object on `signal.reason` is recognizable as ours. */
+const ABORT_CAUSE_BRAND = "__agencyAbortCause";
+
+export function makeAbortCause(
+  cause: AbortCause,
+): AbortCause & { [ABORT_CAUSE_BRAND]: true } {
+  return { ...cause, [ABORT_CAUSE_BRAND]: true } as AbortCause & {
+    [ABORT_CAUSE_BRAND]: true;
+  };
+}
+
+function isAbortCause(value: unknown): value is AbortCause {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    (value as Record<string, unknown>)[ABORT_CAUSE_BRAND] === true &&
+    typeof (value as Record<string, unknown>).kind === "string"
+  );
+}
+
+/**
+ * Read the structured `AbortCause` off an `AbortSignal` (its `reason`), a
+ * thrown `AgencyCancelledError` (its `agencyCause`), or a bare cause value.
+ * Returns `undefined` when no structured cause is present — callers keep
+ * their existing heuristics as a fallback for that case.
+ */
+export function readCause(source: unknown): AbortCause | undefined {
+  if (source == null) return undefined;
+  if (typeof AbortSignal !== "undefined" && source instanceof AbortSignal) {
+    // `signal.reason` is kept as an Error (so `throw signal.reason` in
+    // runBatch stays an Error), with the structured cause carried on it —
+    // but a bare branded cause is also accepted for forward-compat.
+    return readCause(source.reason);
+  }
+  if (source instanceof AgencyCancelledError && source.agencyCause) {
+    return source.agencyCause;
+  }
+  if (isAbortCause(source)) return source;
+  return undefined;
+}
+
 export class AgencyCancelledError extends Error {
-  constructor(reason?: string) {
+  /** Structured intent for this abort, when known. */
+  readonly agencyCause?: AbortCause;
+
+  constructor(reason?: string, cause?: AbortCause) {
     super(reason ?? "Agent execution was cancelled");
     this.name = "AgencyCancelledError";
+    this.agencyCause = cause;
   }
 }
 

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -98,6 +98,15 @@ function isAbortCause(value: unknown): value is AbortCause {
  * thrown `AgencyCancelledError` (its `agencyCause`), or a bare cause value.
  * Returns `undefined` when no structured cause is present — callers keep
  * their existing heuristics as a fallback for that case.
+ *
+ * Note: this uses `instanceof AgencyCancelledError`, NOT the name-based
+ * fallback that `isAbortError` adds for errors that cross module instances
+ * (the resolver shim — see below). In Increment 1 every guard-trip
+ * producer and consumer lives in one runtime module instance, so
+ * `instanceof` holds. If a cause ever needs reading across that boundary,
+ * `readCause` returns `undefined` where `isAbortError` would still
+ * recognize the error — the in-process sibling of the subprocess
+ * cause-payload risk noted in the abort-taxonomy spec.
  */
 export function readCause(source: unknown): AbortCause | undefined {
   if (source == null) return undefined;

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -7,6 +7,7 @@ import {
   isGuardExceededError,
 } from "./guard.js";
 import { StateStack } from "./state/stateStack.js";
+import { readCause } from "./errors.js";
 
 describe("GuardExceededError", () => {
   it("is an Error subclass with name, type, limit, spent fields", () => {
@@ -161,6 +162,24 @@ describe("TimeGuard", () => {
     expect(err).toBeInstanceOf(GuardExceededError);
     expect(err.type).toBe("time");
     expect(err.limit).toBe(500);
+  });
+
+  it("aborts with a structured guardTrip cause on its signal reason", () => {
+    const stack = new StateStack();
+    const g = new TimeGuard(500);
+    g.install(stack);
+    vi.advanceTimersByTime(500);
+    const cause = readCause(stack.abortSignal);
+    expect(cause).toMatchObject({
+      kind: "guardTrip",
+      dimension: "time",
+      limit: 500,
+      guardId: g.guardId,
+    });
+    // A leaf op that reads this cause and rejects with it must surface as
+    // a guardTrip — this is what lets __tryCall convert it to a Failure
+    // instead of letting a bare cancel escape the guarded block.
+    expect((cause as { spent: number }).spent).toBeGreaterThanOrEqual(0);
   });
 
   it("pause is idempotent — multiple calls charge elapsedMs once", () => {

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -3,9 +3,14 @@ import { AgencyCancelledError, makeAbortCause } from "./errors.js";
 
 /** Monotonic source of stable per-guard ids. Threaded into the
  *  `guardTrip` AbortCause a TimeGuard emits so boundaries can identify
- *  which guard tripped (diagnostics + future cross-checks; structural
- *  call-stack nesting is what actually routes a trip to its owning
- *  `try`, exactly as it does for cost guards today). */
+ *  which guard tripped. NOTE: in Increment 1 no boundary actually
+ *  MATCHES on this id — `__tryCall` converts any guardTrip cause it
+ *  catches, relying on structural call-stack nesting to route a trip to
+ *  its owning `try` (exactly as cost guards do today). Real id-matching
+ *  (which would fix outer-tighter-than-inner mis-attribution; see
+ *  tests/agency/guards/guard-time-nested-outer-tighter) needs threading
+ *  the id into `__tryCall` — a codegen change deferred to Increment 2.
+ *  The id is emitted now so the cause shape is stable for that work. */
 let __guardIdCounter = 0;
 export function nextGuardId(): string {
   __guardIdCounter += 1;

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -1,4 +1,16 @@
 import type { StateStack } from "./state/stateStack.js";
+import { AgencyCancelledError, makeAbortCause } from "./errors.js";
+
+/** Monotonic source of stable per-guard ids. Threaded into the
+ *  `guardTrip` AbortCause a TimeGuard emits so boundaries can identify
+ *  which guard tripped (diagnostics + future cross-checks; structural
+ *  call-stack nesting is what actually routes a trip to its owning
+ *  `try`, exactly as it does for cost guards today). */
+let __guardIdCounter = 0;
+export function nextGuardId(): string {
+  __guardIdCounter += 1;
+  return `g${__guardIdCounter}`;
+}
 
 /**
  * Per-guard scope state for cost / time limits. Held on
@@ -250,6 +262,9 @@ export class TimeGuard implements Guard {
    *  steps (popGuard) on its way out. */
   private consumed: boolean = false;
 
+  /** Stable id threaded into the emitted `guardTrip` cause. */
+  readonly guardId: string = nextGuardId();
+
   constructor(public readonly timeLimit: number) {}
 
   install(stack: StateStack): void {
@@ -360,10 +375,32 @@ export class TimeGuard implements Guard {
   private startWindow(): void {
     const remaining = this.timeLimit - this.elapsedMs;
     const delay = remaining > 0 ? remaining : 0;
-    this.timerHandle = setTimeout(
-      () => this.controller?.abort(),
-      delay,
-    );
+    this.timerHandle = setTimeout(() => {
+      // Abort WITH a structured cause so any in-flight leaf op (sleep,
+      // fetch, …) listening on the composed signal rejects carrying the
+      // guard trip — not a bare cancel that the guard's `try` boundary
+      // can't recognize and would let escape as an unhandled rejection.
+      const spent = this.elapsedMs +
+        (this.windowStart !== undefined
+          ? performance.now() - this.windowStart
+          : 0);
+      // Abort with an AgencyCancelledError that CARRIES the structured
+      // cause. Keeping `signal.reason` an Error (not a bare object) means
+      // a `throw signal.reason` site — e.g. runBatch's race-loser path —
+      // still throws an Error; `readCause` digs the cause back out.
+      this.controller?.abort(
+        new AgencyCancelledError(
+          `guard exceeded: time limit ${this.timeLimit}`,
+          makeAbortCause({
+            kind: "guardTrip",
+            dimension: "time",
+            limit: this.timeLimit,
+            spent,
+            guardId: this.guardId,
+          }),
+        ),
+      );
+    }, delay);
     this.windowStart = performance.now();
     this.state = "running";
   }

--- a/packages/agency-lang/lib/runtime/result.test.ts
+++ b/packages/agency-lang/lib/runtime/result.test.ts
@@ -1,5 +1,78 @@
 import { describe, it, expect } from "vitest";
-import { success, failure, isSuccess, isFailure, __pipeBind } from "./result.js";
+import { success, failure, isSuccess, isFailure, __pipeBind, __tryCall } from "./result.js";
+import { AgencyCancelledError, makeAbortCause } from "./errors.js";
+
+describe("__tryCall — guardTrip cause conversion (the CI-crash fix)", () => {
+  it("converts a guardTrip-cause-carrying abort to a timeoutFailure (NOT a throw)", async () => {
+    // This is the exact shape an aborted in-flight `sleep` rejects with
+    // when a time guard trips. It MUST convert to a Failure here — even
+    // though it is also an abort error — because the guardTrip check runs
+    // BEFORE the blanket `isAbortError -> throw`.
+    const cause = makeAbortCause({
+      kind: "guardTrip",
+      dimension: "time",
+      limit: 20,
+      spent: 21,
+      guardId: "g1",
+    });
+    const result = await __tryCall(() => {
+      throw new AgencyCancelledError("sleep cancelled", cause);
+    });
+    expect(isFailure(result)).toBe(true);
+    expect((result as { error: { type: string; maxTime: number } }).error).toMatchObject({
+      type: "timeoutFailure",
+      maxTime: 20,
+    });
+  });
+
+  it("converts a cost guardTrip cause to a guardFailure", async () => {
+    const cause = makeAbortCause({
+      kind: "guardTrip",
+      dimension: "cost",
+      limit: 2,
+      spent: 3,
+      guardId: "g2",
+    });
+    const result = await __tryCall(() => {
+      throw new AgencyCancelledError("cancelled", cause);
+    });
+    expect((result as { error: { type: string; maxCost: number } }).error).toMatchObject({
+      type: "guardFailure",
+      maxCost: 2,
+    });
+  });
+
+  it("marks the cause `delivered` so the runner path won't re-deliver the same trip", async () => {
+    const cause = makeAbortCause({
+      kind: "guardTrip",
+      dimension: "time",
+      limit: 20,
+      spent: 21,
+      guardId: "g1",
+    });
+    await __tryCall(() => {
+      throw new AgencyCancelledError("sleep cancelled", cause);
+    });
+    expect((cause as { delivered?: boolean }).delivered).toBe(true);
+  });
+
+  it("still RE-THROWS a non-guard abort (userInterrupt) — cancellation must propagate", async () => {
+    const cause = makeAbortCause({ kind: "userInterrupt" });
+    await expect(
+      __tryCall(() => {
+        throw new AgencyCancelledError("cancelled by user", cause);
+      }),
+    ).rejects.toBeInstanceOf(AgencyCancelledError);
+  });
+
+  it("still re-throws a bare abort with no cause", async () => {
+    await expect(
+      __tryCall(() => {
+        throw new AgencyCancelledError("cancelled");
+      }),
+    ).rejects.toBeInstanceOf(AgencyCancelledError);
+  });
+});
 
 describe("success", () => {
   it("creates a success result", () => {

--- a/packages/agency-lang/lib/runtime/result.ts
+++ b/packages/agency-lang/lib/runtime/result.ts
@@ -1,7 +1,41 @@
 import { z } from "zod";
-import { isAbortError } from "./errors.js";
+import { isAbortError, readCause } from "./errors.js";
 import { isGuardExceededError } from "./guard.js";
 import { hasInterrupts } from "./interrupts.js";
+
+/** Structured `GuardFailureData` for a tripped guard. Shared by the
+ *  `guardTrip`-cause path (a trip that surfaced as an aborted leaf op)
+ *  and the `GuardExceededError` path (a trip thrown at a sync point).
+ *  Both must produce the identical Failure shape the stdlib `guard`
+ *  documents. */
+function guardFailureData(
+  dimension: "cost" | "time",
+  limit: number,
+  spent: number,
+): {
+  type: string;
+  maxCost: number | null;
+  actualCost: number | null;
+  maxTime: number | null;
+  actualTime: number | null;
+} {
+  if (dimension === "time") {
+    return {
+      type: "timeoutFailure",
+      maxCost: null,
+      actualCost: null,
+      maxTime: limit,
+      actualTime: spent,
+    };
+  }
+  return {
+    type: "guardFailure",
+    maxCost: limit,
+    actualCost: spent,
+    maxTime: null,
+    actualTime: null,
+  };
+}
 
 export type ResultValue = ResultSuccess | ResultFailure;
 
@@ -73,6 +107,27 @@ export async function __tryCall(fn: () => any, opts?: FailureOpts): Promise<Resu
     // swallow with `catch fallback`. See lib/stdlib/http.ts's
     // `runHttp` helper that translates DOMException("AbortError")
     // into AgencyCancelledError specifically so this re-throw fires.
+    // A guard trip can surface here in TWO shapes: as a thrown
+    // `GuardExceededError` (the trip caught at a sync point) OR as an
+    // aborted leaf op (e.g. an in-flight `sleep`) whose cancellation
+    // CARRIES a `guardTrip` cause. The cause-carrying shape is ALSO an
+    // abort error, so this guardTrip check MUST run BEFORE the blanket
+    // `isAbortError -> throw` below — otherwise `isAbortError` re-throws
+    // the cancel first, the conversion never runs, and the bare cancel
+    // escapes the guarded block as an unhandled rejection (the bug this
+    // fixes). See docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md.
+    const guardCause = readCause(error);
+    if (guardCause?.kind === "guardTrip") {
+      // Mark the trip delivered so the runner's `shouldSkip` (which may
+      // step the guard's own `_popGuard` next, while the signal is still
+      // aborted) does NOT re-throw a GuardExceededError for the same
+      // trip. The cause object is shared by identity with `signal.reason`.
+      guardCause.delivered = true;
+      return failure(
+        guardFailureData(guardCause.dimension, guardCause.limit, guardCause.spent),
+        opts,
+      );
+    }
     if (isAbortError(error)) {
       throw error;
     }
@@ -82,26 +137,8 @@ export async function __tryCall(fn: () => any, opts?: FailureOpts): Promise<Resu
     // this branch the user would see only the stringified error
     // message and lose the numeric limits. See lib/runtime/guard.ts.
     if (isGuardExceededError(error)) {
-      if (error.type === "time") {
-        return failure(
-          {
-            type: "timeoutFailure",
-            maxCost: null,
-            actualCost: null,
-            maxTime: error.limit,
-            actualTime: error.spent,
-          },
-          opts,
-        );
-      }
       return failure(
-        {
-          type: "guardFailure",
-          maxCost: error.limit,
-          actualCost: error.spent,
-          maxTime: null,
-          actualTime: null,
-        },
+        guardFailureData(error.type, error.limit, error.spent),
         opts,
       );
     }

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -1,13 +1,64 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { Runner, stripSlug, safeStatelogValue } from "./runner.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { getRuntimeContext } from "./asyncContext.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
+import { GuardExceededError, TimeGuard } from "./guard.js";
+import { readCause } from "./errors.js";
 
 function makeFrame(): State {
   return new State({ args: {}, locals: {}, step: 0 });
 }
+
+describe("Runner.shouldSkip — guard-trip delivery de-dup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // A tripped time guard whose abort signal is still aborted at the next
+  // step boundary. Mirrors the state when the guard's OWN _popGuard step
+  // runs after the block already unwound.
+  function trippedGuardStack(): StateStack {
+    const stack = new StateStack();
+    const g = new TimeGuard(20);
+    stack.pushGuard(g); // install: composes abortSignal + arms timer
+    vi.advanceTimersByTime(20); // fire: signal aborted, cause on reason, g.tripped
+    return stack;
+  }
+
+  it("throws GuardExceededError for an UNdelivered trip (the no-leaf runner path)", async () => {
+    const stack = trippedGuardStack();
+    const runner = new Runner(makeMockCtx(), makeFrame(), { stack });
+    await expect(
+      runner.step(0, async () => {}),
+    ).rejects.toBeInstanceOf(GuardExceededError);
+  });
+
+  it("does NOT re-throw a trip already DELIVERED via the leaf path — lets cleanup run", async () => {
+    const stack = trippedGuardStack();
+    // Simulate __tryCall having already converted the leaf-op rejection
+    // to a Failure and flagged the shared cause object as delivered.
+    const cause = readCause(stack.abortSignal);
+    expect(cause?.kind).toBe("guardTrip");
+    (cause as { delivered?: boolean }).delivered = true;
+
+    const runner = new Runner(makeMockCtx(), makeFrame(), { stack });
+    let ran = false;
+    // This stands in for the guard's own `_popGuard` step: it must run
+    // rather than throw an unhandled GuardExceededError for an
+    // already-handled trip (the second crash this PR fixes).
+    await expect(
+      runner.step(0, async () => {
+        ran = true;
+      }),
+    ).resolves.toBeUndefined();
+    expect(ran).toBe(true);
+  });
+});
 
 describe("safeStatelogValue", () => {
   it("deep-clones small JSON values", () => {

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 import { agencyStore } from "./asyncContext.js";
 import { debugStep } from "./debugger.js";
-import { RestoreSignal } from "./errors.js";
+import { RestoreSignal, readCause } from "./errors.js";
 import { HaltSignal } from "./haltSignal.js";
 import { invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
@@ -268,6 +268,17 @@ export class Runner {
    *      abort (race-loser branch cancel). Halt silently as before. */
   private shouldSkip(): boolean {
     if (this.stack?.abortSignal?.aborted && !this.halted) {
+      // If the abort carries a guard trip that was ALREADY delivered via
+      // the leaf-op path (an in-flight sleep/fetch aborted, then __tryCall
+      // converted it to a Failure), the trip is handled. Do NOT re-throw
+      // it here — this `shouldSkip` may be gating the guard's own
+      // `_popGuard` cleanup step, and throwing would surface an unhandled
+      // GuardExceededError for a trip the user already saw as a Failure.
+      // Fall through so cleanup runs. See the abort-taxonomy spec.
+      const cause = readCause(this.stack.abortSignal);
+      if (cause?.kind === "guardTrip" && cause.delivered) {
+        return this.halted || this._break || this._continue;
+      }
       // Walk innermost-first so the deepest guard reports its trip
       // first. Mirrors the order in prompt.ts's cost-check loop.
       for (let i = this.stack.guards.length - 1; i >= 0; i--) {

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -6,7 +6,8 @@ import { SimpleMachine } from "../../simplemachine/index.js";
 import { StatelogClient, StatelogConfig } from "../../statelogClient.js";
 import { nativeTypeReplacer, nativeTypeReviver } from "../revivers/index.js";
 import { CoverageCollector } from "../coverageCollector.js";
-import { AgencyCancelledError } from "../errors.js";
+import { AgencyCancelledError, makeAbortCause } from "../errors.js";
+import type { AbortCause } from "../errors.js";
 import { agencyStore } from "../asyncContext.js";
 import type { AgencyCallbacks } from "../hooks.js";
 import type { InterruptResponse } from "../interrupts.js";
@@ -514,9 +515,21 @@ export class RuntimeContext<T> {
     return AbortSignal.any([this.abortController.signal, stack.abortSignal]);
   }
 
-  cancel(reason?: string): void {
+  /**
+   * Cancel the whole execution. `cause` records WHY: a terminal
+   * `userKill` (TS `cancel()` / an external abort — the default) vs a
+   * recoverable `userInterrupt` (the REPL's Esc, which hands control back
+   * but keeps the session). The cause rides on the AgencyCancelledError
+   * so downstream boundaries can read it via `readCause`. Leaving the
+   * error itself as the abort reason keeps `signal.reason` an Error.
+   */
+  cancel(reason?: string, cause?: AbortCause): void {
     if (!this.abortController.signal.aborted) {
-      this.abortController.abort(new AgencyCancelledError(reason));
+      const resolvedCause =
+        cause ?? makeAbortCause({ kind: "userKill", reason });
+      this.abortController.abort(
+        new AgencyCancelledError(reason, resolvedCause),
+      );
     }
   }
 
@@ -539,7 +552,12 @@ export class RuntimeContext<T> {
   /** Sever references held by an execution context so GC can reclaim them. */
   cleanup(): void {
     if (!this.abortController.signal.aborted) {
-      this.abortController.abort(new AgencyCancelledError("cleanup"));
+      this.abortController.abort(
+        new AgencyCancelledError(
+          "cleanup",
+          makeAbortCause({ kind: "cleanup" }),
+        ),
+      );
     }
     this.pendingPromises.clear();
     this.stateStack = null as any;

--- a/packages/agency-lang/lib/stdlib/abortable.ts
+++ b/packages/agency-lang/lib/stdlib/abortable.ts
@@ -1,5 +1,24 @@
 import { spawn, SpawnOptions, ChildProcess } from "child_process";
-import { AgencyCancelledError, isAbortError } from "../runtime/errors.js";
+import {
+  AgencyCancelledError,
+  isAbortError,
+  readCause,
+} from "../runtime/errors.js";
+
+/**
+ * Build the cancellation a leaf op rejects with when its abort signal
+ * fires. Reads the structured `AbortCause` off the signal (a guard trip,
+ * a user interrupt, …) and carries it on the error so the boundary that
+ * catches it — e.g. the stdlib `guard`'s `try` via `__tryCall` — can
+ * convert it instead of letting a bare cancel escape. Falls back to a
+ * plain cancel when no structured cause is present.
+ */
+function leafCancel(
+  message: string,
+  signal: AbortSignal | undefined,
+): AgencyCancelledError {
+  return new AgencyCancelledError(message, readCause(signal));
+}
 
 /**
  * Shared abortability helpers for stdlib JS implementations whose
@@ -52,7 +71,7 @@ export function abortableSpawn(
     // don't want Node's built-in handler racing with ours.
     const { signal: _sig, input: _in, timeout: _to, ...spawnOptions } = options;
     if (options.signal?.aborted) {
-      reject(new AgencyCancelledError(`${command} cancelled`));
+      reject(leafCancel(`${command} cancelled`, options.signal));
       return;
     }
     const child = spawn(command, args, {
@@ -102,7 +121,7 @@ export function abortableSpawn(
     child.on("close", (code) => {
       cleanup();
       if (aborted) {
-        reject(new AgencyCancelledError(`${command} cancelled`));
+        reject(leafCancel(`${command} cancelled`, options.signal));
       } else if (timedOut) {
         resolve({ stdout, stderr: stderr + "\nProcess timed out", exitCode: 1 });
       } else {
@@ -112,7 +131,7 @@ export function abortableSpawn(
     child.on("error", (err) => {
       cleanup();
       if (aborted || isAbortError(err)) {
-        reject(new AgencyCancelledError(`${command} cancelled`));
+        reject(leafCancel(`${command} cancelled`, options.signal));
         return;
       }
       reject(err);
@@ -138,7 +157,7 @@ export function abortableExec(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
-      reject(new AgencyCancelledError(`${command} cancelled`));
+      reject(leafCancel(`${command} cancelled`, signal));
       return;
     }
     const child: ChildProcess = spawn(command, args, {
@@ -165,7 +184,7 @@ export function abortableExec(
     child.on("close", (code, sig) => {
       cleanup();
       if (aborted) {
-        reject(new AgencyCancelledError(`${command} cancelled`));
+        reject(leafCancel(`${command} cancelled`, signal));
       } else if (code === 0) {
         resolve();
       } else if (code === null) {
@@ -179,7 +198,7 @@ export function abortableExec(
     child.on("error", (err) => {
       cleanup();
       if (aborted || isAbortError(err)) {
-        reject(new AgencyCancelledError(`${command} cancelled`));
+        reject(leafCancel(`${command} cancelled`, signal));
         return;
       }
       reject(err);
@@ -199,7 +218,7 @@ export function abortableSleep(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
-      reject(new AgencyCancelledError("sleep cancelled"));
+      reject(leafCancel("sleep cancelled", signal));
       return;
     }
     const timer = setTimeout(() => {
@@ -208,7 +227,7 @@ export function abortableSleep(
     }, ms);
     const onAbort = () => {
       clearTimeout(timer);
-      reject(new AgencyCancelledError("sleep cancelled"));
+      reject(leafCancel("sleep cancelled", signal));
     };
     if (signal) signal.addEventListener("abort", onAbort, { once: true });
   });

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -13,7 +13,8 @@ import { modifiers, RESET, styles } from "@/utils/termcolors.js"
 import { color, colors, bgColors } from "../utils/termcolors.js";
 import { _promptsAutocomplete } from "./ui.js";
 import { isFailure } from "../runtime/result.js";
-import { isAbortError } from "../runtime/errors.js";
+import { isAbortError, makeAbortCause } from "../runtime/errors.js";
+import type { AbortCause } from "../runtime/errors.js";
 import { normalizeModelUsage } from "../runtime/utils.js";
 // ---------------------------------------------------------------------------
 // TS bridge for `std::cli` — the line-mode REPL.
@@ -448,7 +449,7 @@ function installCancelKey(
 /** Safely fetch the active RuntimeContext, or null when none is bound
  *  (e.g. tests drive `_runLineRepl` without a runtime). */
 function activeCtxOrNull(): {
-  cancel: (r?: string) => void;
+  cancel: (r?: string, cause?: AbortCause) => void;
   resetCancel: () => void;
   readonly aborted: boolean;
 } | null {
@@ -775,7 +776,13 @@ export async function _runLineRepl(
         // AgencyCancelledError propagates out and the catch below prints
         // "cancelled".
         stopActiveSpinner();
-        turnCtx?.cancel("cancelled by user");
+        // Esc is a recoverable interrupt: stop this turn's work and hand
+        // control back, but keep the REPL session alive (vs a terminal
+        // userKill from TS `cancel()`).
+        turnCtx?.cancel(
+          "cancelled by user",
+          makeAbortCause({ kind: "userInterrupt" }),
+        );
       });
 
       try {

--- a/packages/agency-lang/tests/agency/guards/guard-time-nested-outer-tighter.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-nested-outer-tighter.agency
@@ -1,0 +1,33 @@
+import { guard } from "std::thread"
+
+// Outer time budget (20ms) is TIGHTER than the inner (5s). The OUTER's
+// timer fires while the inner block's `sleep` is in flight, so the
+// in-flight sleep is aborted carrying the OUTER's guardTrip cause.
+//
+// KNOWN INCREMENT-1 LIMITATION (documented in
+// docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md §4.1.1):
+// the inner guard's `try` (__tryCall) converts ANY guardTrip cause it
+// catches — it does NOT match on guardId — so the OUTER's trip is
+// mis-attributed to the INNER guard's Failure (carrying the outer's
+// 20ms limit), and the OUTER block sees a normal return instead of
+// tripping. This is NOT a crash (the pre-fix code crashed the process
+// with an unhandled rejection); the guarded work still aborts and
+// surfaces a timeoutFailure. Increment 2's guardId matching will
+// re-route the trip to the OUTER guard, at which point this fixture's
+// expected output changes to "outer:timeoutFailure".
+node main() {
+  const outer = guard(time: 20ms) as {
+    const inner = guard(time: 5s) as {
+      sleep(150ms)
+      return "inner did not trip"
+    }
+    if (isFailure(inner)) {
+      return "inner:${inner.error.type}:${inner.error.maxTime}"
+    }
+    return "no trip"
+  }
+  if (isFailure(outer)) {
+    return "outer:${outer.error.type}"
+  }
+  return outer.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-nested-outer-tighter.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-time-nested-outer-tighter.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"inner:timeoutFailure:20\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Outer time guard (20ms) TIGHTER than inner (5s). The outer trips while the inner block's sleep is in flight. KNOWN Increment-1 limitation: __tryCall converts any guardTrip cause without matching guardId, so the outer's trip is mis-attributed to the inner guard's Failure (type timeoutFailure, maxTime=20 = the OUTER's limit) and the outer block returns normally instead of tripping. NOT a crash (pre-fix this crashed with an unhandled rejection). Increment 2's guardId matching will re-route to the outer and flip the expected output. Pins the documented behavior so that change is visible."
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

Three time-guard fixtures have been **crashing on CI** ever since Esc-cancel landed:
`guard-time-trip`, `guard-time-nested`, `guard-time-and-cost` ([failing run](https://github.com/egonSchiele/agency-lang/actions/runs/27907963302/job/82579909174)).

**Root cause:** a `TimeGuard` timer aborts an in-flight `sleep`, which rejected with a **bare** `AgencyCancelledError` carrying no intent. Before Esc-cancel the generated catch ladders swallowed that into a `Failure`; after Esc-cancel they *re-throw* aborts (so user cancels propagate cleanly), so the bare cancel escaped the guarded block as an **unhandled rejection and killed the process**.

This is Increment 1 of a larger design ([spec](packages/agency-lang/docs/superpowers/specs/2026-06-21-abort-taxonomy-design.md), [plan](packages/agency-lang/docs/superpowers/plans/2026-06-22-abort-taxonomy-increment1.md)): **carry intent on the abort instead of re-deriving it at every catch site.**

## The fix

- **`AbortCause` carrier** (`errors.ts`): a tagged union (`userInterrupt | userKill | guardTrip | raceLoser | cleanup`) carried on the `AgencyCancelledError`'s new `agencyCause` field; `readCause()` reads it back from a signal or an error. `signal.reason` stays an `Error` (so `runBatch`'s `throw signal.reason` is unaffected).
- **Time-guard trips are recognizable:** `TimeGuard` aborts with a `guardTrip` cause; the leaf `sleep` propagates it; **`__tryCall` converts a `guardTrip` cause to a `Failure` — checked BEFORE the blanket `isAbortError → throw`** (the actual fix: `isAbortError` is `true` for the cause-carrying cancel too, so order matters).
- **Two-path de-dup:** implementation surfaced a *second* delivery path — the runner's `shouldSkip` throws `GuardExceededError` at the guard's own `_popGuard` step. A shared mutable `delivered` flag on the cause makes the leaf-op and runner paths cooperate so each trip is delivered exactly once. (Documented in spec §4.1.1.)
- **Foundation (additive):** leaf ops propagate the cause; `ctx.cancel()`/`cleanup()` and the REPL Esc handler carry `userKill`/`userInterrupt`/`cleanup` causes.

## Scope

- **No codegen/template change, no fixture regeneration.** `AgencyCancelledError` and `GuardExceededError` stay distinct — collapsing them into one `AgencyAbort` is **Increment 2** (separate PR).
- **Deferred (documented):** `prompt.ts` cause-driven thread-repair gating + normalization (changes the agent-cancel cleanup path; wants PTY coverage), and explicit `raceLoser` tagging (current untagged behavior is preserved).

## Testing

- +7 unit tests (`errors.test.ts` cause round-trips; `guard.test.ts` time-guard emits a `guardTrip` cause).
- Full vitest suite **6086 passed**; the 3 previously-failing fixtures + full guards dir (20) + race fixtures green; `lint:structure` clean.
- Verified the original crash is gone (no unhandled rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
