### PR TITLE
Run served functions inside an Agency execution frame

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,7 @@ jobs:
         node tests/integration/bundlers/test-esbuild.mjs ./agency-lang-*.tgz
         node tests/integration/bundlers/test-vite.mjs ./agency-lang-*.tgz
         node tests/integration/cli/test.mjs ./agency-lang-*.tgz
+        node tests/integration/serve/test.mjs ./agency-lang-*.tgz
         rm -f agency-lang-*.tgz
     - name: Main-only CLI command integration tests
       if: matrix.node-version == '22.x' && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -120,7 +120,7 @@ export {
 } from "./state/checkpointStore.js";
 export type { Checkpoint } from "./state/checkpointStore.js";
 
-export { setupNode, setupFunction, runNode } from "./node.js";
+export { setupNode, setupFunction, runNode, runExportedFunction } from "./node.js";
 export { Runner } from "./runner.js";
 
 export { rewindFrom, applyOverrides } from "./rewind.js";

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -89,6 +89,105 @@ export function setupFunction(): {
 }
 
 /**
+ * Run the fresh-run bootstrap on a freshly created execution context:
+ * cross-module statics/globals, then this module's globals, then top-level
+ * callback registration — each inside a bootstrap ALS frame.
+ *
+ * Shared by the two fresh-run entry points (`runNode`, `runExportedFunction`).
+ * The resume family (`respondToInterrupts`, `rewindFrom`) does NOT use this:
+ * it restores statics/globals from a checkpoint and only re-registers
+ * top-level callbacks.
+ */
+async function initFreshExecCtx(
+  execCtx: RuntimeContext<GraphState>,
+  opts: {
+    initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+    registerTopLevelCallbacks?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+    moduleDir?: string;
+  },
+): Promise<void> {
+  const { initializeGlobals, registerTopLevelCallbacks, moduleDir } = opts;
+
+  // initializeGlobals + registerTopLevelCallbacks both invoke Agency
+  // code that goes through `__call` — and `__call` reads `ctx` /
+  // `threads` / `stateStack` from the ALS frame after the
+  // drop-per-call-context-plumbing migration. Without an ALS frame
+  // installed here, calls to user-defined stdlib helpers (e.g. the
+  // `callback(...)` wrapper that the codegen emits inside
+  // `__registerTopLevelCallbacks`) would invoke `_callbackImpl(name,
+  // fn, undefined)` and crash on `__state.ctx`.
+  //
+  // Consequences worth knowing:
+  //  - `stack` in the bootstrap frame is `execCtx.stateStack` — the
+  //    bare global stack with no node/function frames pushed. Globals
+  //    must not push node frames, so this is correct.
+  //  - `threads` is a `BootstrapThreadStore` sentinel. Any agency code
+  //    in global-init scope that reaches for a thread/message builtin
+  //    (e.g. `systemMessage("…")` at module top-level) now throws with
+  //    a clear error instead of silently writing into a placeholder
+  //    that this function discards on return.
+  //  - The `insideGlobalInit` codegen branch still emits an explicit
+  //    `{ ctx }` bag on `__call`, and `__call`'s merge prefers extras
+  //    over the ALS-read fields — so `ctx` resolution inside generated
+  //    global-init code does not depend on this frame's `ctx` either.
+  //    The frame is mostly here to satisfy the "every helper must see
+  //    *some* frame" contract.
+  //
+  // Closure-wide bootstrap (`__initAllRegistered`) MUST run BEFORE the
+  // entry's own `initializeGlobals`:
+  //   • A global-init expression in the entry can call a function /
+  //     node whose body reads an imported `static const`. Those
+  //     function-body reads don't show up in the compile-time
+  //     per-variable dep graph (which only walks initializer
+  //     expressions), so the foreign module's `__initializeGlobals`
+  //     would not have been pulled in by the dep-driven prelude. If
+  //     we ran the entry's globals init first, the read could hit
+  //     `__UNINIT_STATIC` and throw — the exact failure mode this
+  //     ordering exists to prevent.
+  //   • Running `__initAllRegistered` first guarantees every JS-loaded
+  //     module's statics and globals have been initialized before any
+  //     user code (including global-init expressions) runs. The
+  //     subsequent `initializeGlobals(execCtx)` call is then a no-op
+  //     for current codegen (per-execCtx early-return guard) and
+  //     double-call protected by the registry-level
+  //     `globals.isInitialized` check baked into `__initAllRegistered`.
+  await runInBootstrapFrame(execCtx, () => __initAllRegistered(execCtx), { moduleDir });
+  if (initializeGlobals) {
+    await runInBootstrapFrame(execCtx, () => initializeGlobals(execCtx), { moduleDir });
+  }
+  // Top-level callbacks are re-registered every fresh run AFTER global
+  // init so any module-level vars they reference (via `__ctx.globals`)
+  // are already set up. The registration sequence mirrors what
+  // `respondToInterrupts` does on resume — keep them in sync if you
+  // touch either site.
+  if (registerTopLevelCallbacks) {
+    await runInBootstrapFrame(execCtx, () => registerTopLevelCallbacks(execCtx), { moduleDir });
+  }
+}
+
+/**
+ * Tear down an execution context after a fresh run: persist any cached
+ * MemoryManager state, drain fire-and-forget statelog POSTs, then release
+ * resources. Memory writes are best-effort — a save failure is logged,
+ * never thrown — and every cached manager is iterated so a fork branch's
+ * side store isn't lost. Shared by `runNode` and `runExportedFunction`;
+ * callers run their own span/trace teardown around this.
+ */
+async function finalizeExecCtx(execCtx: RuntimeContext<GraphState>): Promise<void> {
+  for (const manager of execCtx.getAllCachedMemoryManagers()) {
+    try {
+      await manager.save();
+    } catch (err) {
+      console.warn(`[memory] save failed: ${(err as Error).message}`);
+    }
+  }
+  // Remote statelog POSTs are fire-and-forget; drain any still in flight
+  // so telemetry is delivered before the context is released.
+  await execCtx.statelogClient.flush();
+  execCtx.cleanup();
+}
+
+/**
  * Invoke an exported Agency function from *outside* any Agency execution
  * frame — the `agency serve` path, where an HTTP/MCP request maps a
  * function name + named args to a single stateless call.
@@ -138,17 +237,7 @@ export async function runExportedFunction({
   moduleDir?: string;
 }): Promise<unknown> {
   const execCtx = await ctx.createExecutionContext(nanoid());
-
-  // Same ordering as runNode: cross-module statics/globals first, then
-  // this module's globals (a no-op for current codegen but kept for
-  // parity), then top-level callbacks once globals exist.
-  await runInBootstrapFrame(execCtx, () => __initAllRegistered(execCtx), { moduleDir });
-  if (initializeGlobals) {
-    await runInBootstrapFrame(execCtx, () => initializeGlobals(execCtx), { moduleDir });
-  }
-  if (registerTopLevelCallbacks) {
-    await runInBootstrapFrame(execCtx, () => registerTopLevelCallbacks(execCtx), { moduleDir });
-  }
+  await initFreshExecCtx(execCtx, { initializeGlobals, registerTopLevelCallbacks, moduleDir });
 
   const threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
   try {
@@ -173,22 +262,7 @@ export async function runExportedFunction({
       },
     );
   } finally {
-    // Mirror runNode's teardown. Persist any MemoryManager state first:
-    // remember/forget/extraction already persist() eagerly, so this only
-    // matters for manager state that relies solely on end-of-run save, but
-    // keeping the loop makes the contract identical for both entry points.
-    // Writes are best-effort — a save failure is logged, never thrown, so a
-    // disk problem can't fail the request.
-    for (const manager of execCtx.getAllCachedMemoryManagers()) {
-      try {
-        await manager.save();
-      } catch (err) {
-        console.warn(`[memory] save failed: ${(err as Error).message}`);
-      }
-    }
-    // Drain fire-and-forget statelog POSTs, then release resources.
-    await execCtx.statelogClient.flush();
-    execCtx.cleanup();
+    await finalizeExecCtx(execCtx);
   }
 }
 
@@ -259,70 +333,11 @@ export async function runNode({
   }
 
   const execCtx = await ctx.createExecutionContext(runId);
-  // initializeGlobals + registerTopLevelCallbacks both invoke Agency
-  // code that goes through `__call` — and `__call` reads `ctx` /
-  // `threads` / `stateStack` from the ALS frame after the
-  // drop-per-call-context-plumbing migration. Without an ALS frame
-  // installed here, calls to user-defined stdlib helpers (e.g. the
-  // `callback(...)` wrapper that the codegen emits inside
-  // `__registerTopLevelCallbacks`) would invoke `_callbackImpl(name,
-  // fn, undefined)` and crash on `__state.ctx`.
-  //
-  // Consequences worth knowing:
-  //  - `stack` here is `execCtx.stateStack` — the bare global stack
-  //    with no node/function frames pushed. Globals must not push node
-  //    frames, so this is correct.
-  //  - `threads` is a `BootstrapThreadStore` sentinel. Any agency code
-  //    in global-init scope that reaches for a thread/message builtin
-  //    (e.g. `systemMessage("…")` at module top-level) now throws with
-  //    a clear error instead of silently writing into a placeholder
-  //    that this function discards on return.
-  //  - The `insideGlobalInit` codegen branch still emits an explicit
-  //    `{ ctx }` bag on `__call`, and `__call`'s merge prefers extras
-  //    over the ALS-read fields — so `ctx` resolution inside generated
-  //    global-init code does not depend on this frame's `ctx` either.
-  //    The frame is mostly here to satisfy the "every helper must see
-  //    *some* frame" contract.
-  // Closure-wide bootstrap MUST run BEFORE the entry's own
-  // `initializeGlobals`. Reasoning:
-  //
-  //   • A global-init expression in the entry can call a function /
-  //     node whose body reads an imported `static const`. Those
-  //     function-body reads don't show up in the compile-time
-  //     per-variable dep graph (which only walks initializer
-  //     expressions), so the foreign module's `__initializeGlobals`
-  //     would not have been pulled in by the dep-driven prelude. If
-  //     we ran the entry's globals init first, the read could hit
-  //     `__UNINIT_STATIC` and throw — the exact failure mode this
-  //     change exists to prevent.
-  //
-  //   • Running `__initAllRegistered` first guarantees every
-  //     JS-loaded module's statics and globals have been initialized
-  //     before any user code (including global-init expressions)
-  //     runs. The subsequent `initializeGlobals(execCtx)` call is
-  //     then a no-op for current codegen (per-execCtx early-return
-  //     guard in `__initializeGlobals`) and double-call protected
-  //     for any non-conforming compiled output by the registry-level
-  //     `globals.isInitialized` check baked into
-  //     `__initAllRegistered` itself.
-  //
-  //   • Same closure-bootstrap rationale: a
-  //     `node main() { route({ systemPrompt: foreignStatic }) }`
-  //     pattern that reads an imported static only from a function
-  //     body needs the foreign module's init to have run, and the
-  //     compile-time dep graph won't see that reference.
-  await runInBootstrapFrame(execCtx, () => __initAllRegistered(execCtx), { moduleDir });
-  if (initializeGlobals) {
-    await runInBootstrapFrame(execCtx, () => initializeGlobals(execCtx), { moduleDir });
-  }
-  // Top-level callbacks are re-registered every fresh run AFTER global
-  // init so any module-level vars they reference (via `__ctx.globals`)
-  // are already set up. The registration sequence mirrors what
-  // `respondToInterrupts` does on resume — keep them in sync if you
-  // touch either site.
-  if (registerTopLevelCallbacks) {
-    await runInBootstrapFrame(execCtx, () => registerTopLevelCallbacks(execCtx), { moduleDir });
-  }
+  // Cross-module init, this module's globals, then top-level callbacks —
+  // see `initFreshExecCtx` for the full ordering rationale (and the
+  // `node main() { route({ systemPrompt: foreignStatic }) }` case where a
+  // foreign static is read only from a function body).
+  await initFreshExecCtx(execCtx, { initializeGlobals, registerTopLevelCallbacks, moduleDir });
   // Externally-passed callbacks are stored on ctx; hook execution merges them
   // with scoped/top-level callbacks at call time.
   if (callbacks) {
@@ -497,22 +512,6 @@ export async function runNode({
     throw error;
   } finally {
     execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
-    // Persist any in-memory MemoryManager state. Writes are best-effort —
-    // we never fail the run because of a save error, but we do log it so
-    // disk problems are visible. Iterate every cached manager so a fork
-    // branch that opened a side store doesn't lose its writes.
-    for (const manager of execCtx.getAllCachedMemoryManagers()) {
-      try {
-        await manager.save();
-      } catch (err) {
-        console.warn(
-          `[memory] save failed: ${(err as Error).message}`,
-        );
-      }
-    }
-    // Remote statelog POSTs are fire-and-forget; drain any still in
-    // flight now so telemetry is delivered before the process exits.
-    await execCtx.statelogClient.flush();
-    execCtx.cleanup();
+    await finalizeExecCtx(execCtx);
   }
 }

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -107,8 +107,20 @@ export function setupFunction(): {
  * context so the function sees fully-initialized statics/globals and any
  * module-level `callback(...)` blocks, then runs the call inside a
  * node-grade ALS frame with a real `ThreadStore` (so functions that use
- * `llm()` / message threads work). No `agentStart`/`agentEnd` is emitted —
- * a bare function call is a stateless RPC, not a full agent run.
+ * `llm()` / message threads work), and tears it down like `runNode` does
+ * (persist memory, flush statelog).
+ *
+ * Two deliberate divergences from `runNode`, both consequences of the
+ * stateless-RPC model:
+ *   - No `agentStart`/`agentEnd` span and no run-level token roll-up. The
+ *     generated function body still reports its own failures to statelog
+ *     and converts exceptions to a `Failure` result, so per-call errors
+ *     are traced and surface to the caller; what is absent is only the
+ *     run-level envelope. A practical consequence: `llm()` spend inside a
+ *     served function is not attributed to `getCost` / cost dashboards.
+ *   - No checkpoint/restore loop — a function call is one shot, so there
+ *     is no `RestoreSignal` handling here (a `catch` would risk swallowing
+ *     that and other control-flow signals).
  */
 export async function runExportedFunction({
   ctx,
@@ -161,8 +173,20 @@ export async function runExportedFunction({
       },
     );
   } finally {
-    // Best-effort telemetry flush; never fail the call on a telemetry
-    // problem.
+    // Mirror runNode's teardown. Persist any MemoryManager state first:
+    // remember/forget/extraction already persist() eagerly, so this only
+    // matters for manager state that relies solely on end-of-run save, but
+    // keeping the loop makes the contract identical for both entry points.
+    // Writes are best-effort — a save failure is logged, never thrown, so a
+    // disk problem can't fail the request.
+    for (const manager of execCtx.getAllCachedMemoryManagers()) {
+      try {
+        await manager.save();
+      } catch (err) {
+        console.warn(`[memory] save failed: ${(err as Error).message}`);
+      }
+    }
+    // Drain fire-and-forget statelog POSTs, then release resources.
     await execCtx.statelogClient.flush();
     execCtx.cleanup();
   }

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -5,6 +5,7 @@ import { agencyStore, getRuntimeContext, runInBootstrapFrame } from "./asyncCont
 import { callHook } from "./hooks.js";
 import type { AgencyCallbacks } from "./hooks.js";
 import type { RuntimeContext } from "./state/context.js";
+import type { AgencyFunction } from "./agencyFunction.js";
 import {
   AgencyCancelledError,
   CheckpointError,
@@ -85,6 +86,86 @@ export function setupFunction(): {
   const { stack: stateStack, threads } = getRuntimeContext();
   const stack = stateStack.getNewState();
   return { stateStack, stack, step: stack.step, self: stack.locals, threads };
+}
+
+/**
+ * Invoke an exported Agency function from *outside* any Agency execution
+ * frame — the `agency serve` path, where an HTTP/MCP request maps a
+ * function name + named args to a single stateless call.
+ *
+ * Generated function bodies assume an ambient `agencyStore` frame: they
+ * read `getRuntimeContext().ctx`, the base `StateStack`/`ThreadStore` via
+ * `setupFunction()`, and globals via `__globals()`. In normal execution a
+ * function only ever runs inside a node body (or an LLM tool-call that is
+ * itself inside a node), so that frame is already installed. `runNode`
+ * installs it for nodes; this is the equivalent entry point for a bare
+ * function call. Without it the first line of every generated function
+ * throws "getRuntimeContext() called outside an Agency execution frame".
+ *
+ * Mirrors `runNode`'s bootstrap (cross-module init, this module's globals
+ * init, top-level callback registration) against a fresh execution
+ * context so the function sees fully-initialized statics/globals and any
+ * module-level `callback(...)` blocks, then runs the call inside a
+ * node-grade ALS frame with a real `ThreadStore` (so functions that use
+ * `llm()` / message threads work). No `agentStart`/`agentEnd` is emitted —
+ * a bare function call is a stateless RPC, not a full agent run.
+ */
+export async function runExportedFunction({
+  ctx,
+  fn,
+  namedArgs,
+  initializeGlobals,
+  registerTopLevelCallbacks,
+  moduleDir,
+}: {
+  ctx: RuntimeContext<GraphState>;
+  fn: AgencyFunction;
+  namedArgs: Record<string, unknown>;
+  initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+  registerTopLevelCallbacks?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+  moduleDir?: string;
+}): Promise<unknown> {
+  const execCtx = await ctx.createExecutionContext(nanoid());
+
+  // Same ordering as runNode: cross-module statics/globals first, then
+  // this module's globals (a no-op for current codegen but kept for
+  // parity), then top-level callbacks once globals exist.
+  await runInBootstrapFrame(execCtx, () => __initAllRegistered(execCtx), { moduleDir });
+  if (initializeGlobals) {
+    await runInBootstrapFrame(execCtx, () => initializeGlobals(execCtx), { moduleDir });
+  }
+  if (registerTopLevelCallbacks) {
+    await runInBootstrapFrame(execCtx, () => registerTopLevelCallbacks(execCtx), { moduleDir });
+  }
+
+  const threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
+  try {
+    return await agencyStore.run(
+      {
+        ctx: execCtx,
+        stack: execCtx.stateStack,
+        threads: threadStore,
+        globals: execCtx.globals,
+        moduleDir,
+      },
+      async () => {
+        const result = await fn.invoke({
+          type: "named",
+          positionalArgs: [],
+          namedArgs,
+        });
+        // Drain any async work the function spawned (async calls, pending
+        // promises) before returning, mirroring runNode's awaitAll.
+        await execCtx.pendingPromises.awaitAll();
+        return result;
+      },
+    );
+  } finally {
+    // Best-effort telemetry flush; never fail the call on a telemetry
+    // problem.
+    await execCtx.statelogClient.flush();
+    execCtx.cleanup();
+  }
 }
 
 // eslint-disable-next-line max-lines-per-function -- core node-execution loop; refactor tracked separately

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -30,8 +30,14 @@ function isExportedFromModule(fn: AgencyFunction, moduleId: string): boolean {
  * module's `__invokeFunction`, which runs the body inside a node-grade
  * execution frame (generated function bodies throw without an ambient
  * Agency frame). Falls back to a bare `agencyFunction.invoke` when the
- * module predates `__invokeFunction` — preserving behavior for
- * already-compiled bundles.
+ * module predates `__invokeFunction`.
+ *
+ * The fallback preserves the prior (broken) behavior for such stale
+ * bundles rather than masking it: a pre-`__invokeFunction` module will
+ * keep throwing "getRuntimeContext() called outside an Agency execution
+ * frame" on function calls until it is recompiled. Recompiling is the
+ * fix; the fallback only avoids a hard crash here (and keeps the path
+ * working for the plain-JS function bodies used in adapter unit tests).
  */
 function makeInvoker(
   fn: AgencyFunction,

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -11,17 +11,50 @@ export type DiscoverOptions = {
   interruptEffectsByName?: Record<string, InterruptEffect[]>;
 };
 
+/**
+ * The compiled module's generated `__invokeFunction`: runs an exported
+ * function inside a node-grade execution frame. Optional because modules
+ * compiled before it existed won't export it.
+ */
+type ModuleInvokeFunction = (
+  fn: AgencyFunction,
+  namedArgs: Record<string, unknown>,
+) => Promise<unknown>;
+
 function isExportedFromModule(fn: AgencyFunction, moduleId: string): boolean {
   return !!fn.exported && !!fn.toolDefinition && fn.module === moduleId;
 }
 
-function toExportedFunction(fn: AgencyFunction, interruptEffects: InterruptEffect[]): ExportedFunction {
+/**
+ * Build the per-request invoker for a function. Prefers the compiled
+ * module's `__invokeFunction`, which runs the body inside a node-grade
+ * execution frame (generated function bodies throw without an ambient
+ * Agency frame). Falls back to a bare `agencyFunction.invoke` when the
+ * module predates `__invokeFunction` — preserving behavior for
+ * already-compiled bundles.
+ */
+function makeInvoker(
+  fn: AgencyFunction,
+  moduleInvoke: ModuleInvokeFunction | undefined,
+): (namedArgs: Record<string, unknown>) => Promise<unknown> {
+  if (moduleInvoke) {
+    return (namedArgs) => moduleInvoke(fn, namedArgs);
+  }
+  return (namedArgs) => fn.invoke({ type: "named", positionalArgs: [], namedArgs });
+}
+
+function toExportedFunction(
+  fn: AgencyFunction,
+  interruptEffects: InterruptEffect[],
+  moduleInvoke: ModuleInvokeFunction | undefined,
+): ExportedFunction {
   return {
     kind: "function",
     name: fn.name,
     description: fn.toolDefinition!.description,
     agencyFunction: fn,
     interruptEffects,
+    invoke: makeInvoker(fn, moduleInvoke),
   };
 }
 
@@ -46,9 +79,11 @@ function toExportedNode(
 export function discoverExports(options: DiscoverOptions): ExportedItem[] {
   const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [], interruptEffectsByName = {} } = options;
 
+  const moduleInvoke = moduleExports.__invokeFunction as ModuleInvokeFunction | undefined;
+
   const functions = Object.values(toolRegistry)
     .filter((fn) => isExportedFromModule(fn, moduleId))
-    .map((fn) => toExportedFunction(fn, interruptEffectsByName[fn.name] ?? []));
+    .map((fn) => toExportedFunction(fn, interruptEffectsByName[fn.name] ?? [], moduleInvoke));
 
   const nodes = exportedNodeNames
     .map((name) => toExportedNode(name, moduleExports, interruptEffectsByName[name] ?? []))

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -38,6 +38,7 @@ function makeExports(): {
       description: "Add two numbers",
       agencyFunction: addFn,
       interruptEffects: [],
+      invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
     },
     {
       kind: "node",
@@ -193,6 +194,7 @@ describe("HTTP adapter", () => {
           description: "Deploy",
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }],
+          invoke: (namedArgs) => deployFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
         },
       ],
       port: 3545,
@@ -313,6 +315,7 @@ describe("startHttpServer auth and host validation", () => {
         description: "",
         agencyFunction: failFn,
         interruptEffects: [],
+        invoke: (namedArgs) => failFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
       },
     ];
     await withServer(baseConfig({ exports: exportsWithFail }), async (port) => {

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -63,11 +63,7 @@ async function callFunction(
   logger: Logger,
 ): Promise<RouteResult> {
   try {
-    const result = await fn.agencyFunction.invoke({
-      type: "named",
-      positionalArgs: [],
-      namedArgs: toArgs(body),
-    });
+    const result = await fn.invoke(toArgs(body));
     return ok(result);
   } catch (err) {
     logger.error(`function ${fn.name} threw: ${errorMessage(err)}`);

--- a/packages/agency-lang/lib/serve/http/functionFrame.integration.test.ts
+++ b/packages/agency-lang/lib/serve/http/functionFrame.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { pathToFileURL } from "url";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { compile, resetCompilationCache } from "../../cli/commands.js";
+import { discoverExports } from "../discovery.js";
+import { createHttpHandler } from "./adapter.js";
+import { createLogger } from "../../logger.js";
+import type { AgencyFunction } from "../../runtime/agencyFunction.js";
+
+/**
+ * Regression test for `agency serve` invoking exported FUNCTIONS.
+ *
+ * Generated function bodies assume an ambient Agency execution frame
+ * (their first lines read `getRuntimeContext().ctx`, the base stack /
+ * thread store via `setupFunction()`, and globals via `__globals()`).
+ * Nodes get that frame from `runNode`; functions used to be invoked cold
+ * by the serve adapters, so every `POST /function/:name` threw
+ * "getRuntimeContext() called outside an Agency execution frame".
+ *
+ * The fix routes function calls through the module's generated
+ * `__invokeFunction`, which installs a node-grade frame via
+ * `runExportedFunction`. This test compiles a real module and drives it
+ * through the actual HTTP handler — the adapter unit tests use plain-JS
+ * fake function bodies that never touch the runtime context, so only an
+ * end-to-end compile + invoke exercises the regression.
+ */
+describe("serve http invokes exported functions inside a runtime frame", () => {
+  const fixturesRoot = path.resolve(
+    __dirname,
+    "../../../.agency-tmp/serve-function-frame",
+  );
+  const mainAgency = path.join(fixturesRoot, "main.agency");
+  const mainJs = mainAgency.replace(/\.agency$/, ".js");
+
+  // Use a static const so the body depends on bootstrap init having run
+  // inside the frame (an uninitialized static read would throw), and an
+  // explicit return so we can assert the exact value.
+  const source = [
+    'static const GREETING = "Hello"',
+    "",
+    "export def greet(name: string): string {",
+    '  return "${GREETING}, ${name}!"',
+    "}",
+    "",
+    "node main() {",
+    '  print(greet("world"))',
+    "}",
+    "",
+  ].join("\n");
+
+  let handler: ReturnType<typeof createHttpHandler>;
+
+  beforeAll(async () => {
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    fs.writeFileSync(mainAgency, source);
+    resetCompilationCache();
+    compile({}, mainAgency);
+
+    const mod = (await import(pathToFileURL(mainJs).href)) as Record<string, unknown>;
+    const toolRegistry = (mod.__toolRegistry ?? {}) as Record<string, AgencyFunction>;
+    // Derive the moduleId the compiler baked into each AgencyFunction so
+    // discovery's `fn.module === moduleId` filter matches.
+    const greetFn = Object.values(toolRegistry).find((f) => f.name === "greet");
+    const moduleId = greetFn?.module ?? "";
+
+    const exports = discoverExports({
+      toolRegistry,
+      moduleExports: mod,
+      moduleId,
+    });
+
+    handler = createHttpHandler({
+      exports,
+      port: 0,
+      logger: createLogger("error"),
+      hasInterrupts: mod.hasInterrupts as (data: unknown) => boolean,
+      respondToInterrupts: mod.respondToInterrupts as (
+        i: unknown[],
+        r: unknown[],
+      ) => Promise<unknown>,
+    });
+  });
+
+  afterAll(() => {
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
+  it("POST /function/greet returns the computed value (no frame error)", async () => {
+    const result = await handler("POST", "/function/greet", { name: "foo" });
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ success: true, value: "Hello, foo!" });
+  });
+
+  it("lists greet as an exported function", async () => {
+    const result = await handler("GET", "/list", undefined);
+    const body = result.body as { functions: Array<{ name: string }> };
+    expect(body.functions.map((f) => f.name)).toContain("greet");
+  });
+});

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -37,6 +37,7 @@ function makeTestExports(): ExportedItem[] {
       description: "Add two numbers",
       agencyFunction: addFn,
       interruptEffects: [],
+      invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
     },
     {
       kind: "node",
@@ -175,6 +176,7 @@ describe("MCP adapter", () => {
           description: "Deploy app",
           agencyFunction: deployFn,
           interruptEffects: [{ effect: "myapp::deploy" }, { effect: "myapp::approve" }],
+          invoke: (namedArgs) => deployFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
         },
       ],
     });
@@ -357,7 +359,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }] },
+        { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptEffects: [{ effect: "test::greet" }], invoke: (namedArgs) => greetFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
       ],
       policyConfig: {
         policyStore: new PolicyStore("test", tmpDir),
@@ -408,7 +410,7 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test",
       serverVersion: "1.0.0",
       exports: [
-        { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }] },
+        { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptEffects: [{ effect: "email::send" }], invoke: (namedArgs) => sendFn.invoke({ type: "named", positionalArgs: [], namedArgs }) },
       ],
       policyConfig: {
         policyStore: store,

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -181,7 +181,7 @@ async function handleToolCall(
   if (fn) {
     return runToolInvocation(
       id,
-      () => fn.agencyFunction.invoke({ type: "named", positionalArgs: [], namedArgs: args }),
+      () => fn.invoke(args as Record<string, unknown>),
       policyConfig,
     );
   }

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -31,6 +31,7 @@ function makeHandler() {
       description: "Add two numbers",
       agencyFunction: addFn,
       interruptEffects: [],
+      invoke: (namedArgs) => addFn.invoke({ type: "named", positionalArgs: [], namedArgs }),
     },
   ];
   return createMcpHandler({

--- a/packages/agency-lang/lib/serve/types.ts
+++ b/packages/agency-lang/lib/serve/types.ts
@@ -7,6 +7,16 @@ export type ExportedFunction = {
   description: string;
   agencyFunction: AgencyFunction;
   interruptEffects: InterruptEffect[];
+  /**
+   * Invoke the function for a single request, given its named arguments.
+   * Populated by `discoverExports` from the compiled module's generated
+   * `__invokeFunction`, which runs the body inside a node-grade execution
+   * frame — generated function bodies require an ambient Agency frame and
+   * throw without one. Falls back to a bare `agencyFunction.invoke` for
+   * modules compiled before `__invokeFunction` existed (and for tests that
+   * build `ExportedFunction` from plain JS bodies that need no frame).
+   */
+  invoke: (namedArgs: Record<string, unknown>) => Promise<unknown>;
 };
 
 export type ExportedNode = {

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -48,6 +49,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -19,6 +19,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -53,6 +54,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// \`agency serve\` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -16,6 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -77,6 +78,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -16,6 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -77,6 +78,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -16,6 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -77,6 +78,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -16,6 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -77,6 +78,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -16,6 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -77,6 +78,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -16,6 +16,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -77,6 +78,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/integration/serve/test.mjs
+++ b/packages/agency-lang/tests/integration/serve/test.mjs
@@ -1,0 +1,155 @@
+// End-to-end test for `agency serve http`: spawn the real CLI server
+// against a compiled module and make real HTTP requests over a socket.
+//
+// This is the regression guard for served *functions*. Generated function
+// bodies require an ambient Agency execution frame; the serve adapters used
+// to invoke functions cold, so every `POST /function/:name` threw
+// "getRuntimeContext() called outside an Agency execution frame". Nodes were
+// unaffected. The adapter unit tests use fake JS function bodies that never
+// touch the runtime context, so only an end-to-end serve + request reproduces
+// it. No LLM calls.
+
+import { resolve, join } from "node:path";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import {
+  createTempProject, initProject, installTarball,
+  writeFile, assert, assertIncludes, cleanup, getTarballPath,
+} from "../helpers.mjs";
+
+// Ask the OS for a free TCP port, then hand it to the server. A tiny race
+// (port could be taken between close and the server binding) is acceptable
+// for a CI integration test and far simpler than parsing the port back out
+// of the server's stdout.
+function getFreePort() {
+  return new Promise((res, rej) => {
+    const srv = createServer();
+    srv.on("error", rej);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => res(port));
+    });
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Poll until the server answers GET /list, or fail (printing captured server
+// output) if it exits early or never comes up.
+async function waitForReady(baseUrl, child, getOutput, deadlineMs = 30_000) {
+  const start = Date.now();
+  while (Date.now() - start < deadlineMs) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `Server exited early (code ${child.exitCode}) before becoming ready.\n` +
+          `--- server output ---\n${getOutput()}`,
+      );
+    }
+    try {
+      const res = await fetch(`${baseUrl}/list`);
+      if (res.ok) return;
+    } catch {
+      // not listening yet
+    }
+    await sleep(250);
+  }
+  throw new Error(
+    `Server did not become ready within ${deadlineMs}ms.\n` +
+      `--- server output ---\n${getOutput()}`,
+  );
+}
+
+// SIGTERM, then SIGKILL as a fallback, and wait for the process to actually
+// exit so the temp dir can be removed cleanly.
+async function stopServer(child) {
+  if (child.exitCode !== null) return;
+  const exited = new Promise((res) => child.once("exit", res));
+  child.kill("SIGTERM");
+  const killed = await Promise.race([exited.then(() => true), sleep(3_000).then(() => false)]);
+  if (!killed) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+const tarball = resolve(getTarballPath());
+const dir = createTempProject("serve");
+let child;
+
+try {
+  initProject(dir);
+  installTarball(dir, tarball);
+
+  // A `static const` read makes the function body depend on bootstrap init
+  // having run inside the execution frame — an uninitialized static read
+  // would throw, so this also guards that the frame's globals/statics are set
+  // up, not merely that a frame exists.
+  writeFile(dir, "greet.agency", `static const GREETING = "Hello"
+
+export def greet(name: string): string {
+  return "\${GREETING}, \${name}!"
+}
+
+node main() {
+  print(greet("world"))
+}
+`);
+
+  const port = await getFreePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const agencyJs = join(dir, "node_modules", "agency-lang", "dist", "scripts", "agency.js");
+
+  // Spawn the real CLI (the node script directly, so there is a single process
+  // to terminate — no npx/shell wrapper subtree to leak).
+  let output = "";
+  child = spawn(process.execPath, [agencyJs, "serve", "http", "greet.agency", "--port", String(port)], {
+    cwd: dir,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout.on("data", (c) => { output += c; });
+  child.stderr.on("data", (c) => { output += c; });
+
+  await waitForReady(baseUrl, child, () => output);
+
+  // --- Test 1: POST /function/greet returns the computed value ---
+  console.log("--- Test 1: POST /function/greet ---");
+  const fnRes = await fetch(`${baseUrl}/function/greet`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: "foo" }),
+  });
+  assert(fnRes.status === 200, `expected 200, got ${fnRes.status}`);
+  const fnBody = await fnRes.json();
+  assert(
+    fnBody.success === true && fnBody.value === "Hello, foo!",
+    `unexpected function response: ${JSON.stringify(fnBody)}\n--- server output ---\n${output}`,
+  );
+  console.log("Test 1 passed");
+
+  // --- Test 2: GET /list advertises greet as a function ---
+  console.log("--- Test 2: GET /list ---");
+  const listRes = await fetch(`${baseUrl}/list`);
+  const listBody = await listRes.json();
+  const fnNames = (listBody.functions ?? []).map((f) => f.name);
+  assert(fnNames.includes("greet"), `greet not listed; got ${JSON.stringify(fnNames)}`);
+  console.log("Test 2 passed");
+
+  // --- Test 3: unknown function is a clean 404, not a crash ---
+  console.log("--- Test 3: unknown function 404 ---");
+  const missRes = await fetch(`${baseUrl}/function/nope`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  });
+  assert(missRes.status === 404, `expected 404, got ${missRes.status}`);
+  console.log("Test 3 passed");
+
+  console.log("=== All serve HTTP tests passed ===");
+  await stopServer(child);
+  cleanup(dir);
+} catch (err) {
+  console.error("serve HTTP test failed:", err);
+  console.error("Temp directory preserved at:", dir);
+  await stopServer(child);
+  process.exit(1);
+}

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -76,6 +77,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -76,6 +77,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -29,6 +29,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -90,6 +91,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -76,6 +77,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -15,6 +15,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -76,6 +77,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -14,6 +14,7 @@ import {
   interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
   RestoreSignal,
   GuardExceededError,
   isAbortError as __isAbortError,
@@ -75,6 +76,11 @@ function propagate() { return { type: "propagate" as const }; }
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };
 export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 // Reconfigure the trace file path at runtime. Mutates the module-level


### PR DESCRIPTION
## Problem

`agency serve http foo.agency`, then `POST /function/greet` (or the MCP equivalent), failed for **every** exported function:

```
ERROR function greet threw: getRuntimeContext() called outside an Agency execution frame.
```

Generated function bodies assume an ambient Agency execution frame — their first lines read `getRuntimeContext().ctx`, the base `StateStack`/`ThreadStore` via `setupFunction()`, and globals via `__globals()`. In normal execution a function only runs inside a node body (or an LLM tool-call that is itself inside a node), so the frame is already installed. **Nodes** work over `serve` because each generated node export installs the frame via `runNode`; the serve adapters invoked **functions** cold with `AgencyFunction.invoke()`, so no frame existed.

This affected both the HTTP and MCP adapters. The existing adapter unit tests didn't catch it because they construct fake `AgencyFunction.create({ fn: (a,b) => a+b })` JS bodies that never touch the runtime context.

## Fix

Route function calls through a node-grade frame:

- **runtime** (`node.ts`): new `runExportedFunction` mirrors `runNode`'s bootstrap (cross-module init → globals → top-level callbacks) against a fresh execution context, then runs the call inside `agencyStore.run({ctx, stack, threads, globals}, …)` with a real `ThreadStore` (so functions using `llm()` / message threads work). No `agentStart`/`agentEnd` — a bare function call is a stateless RPC.
- **codegen** (`imports.mustache`): emit a per-module `__invokeFunction` bound to that helper — the same pattern as the existing `respondToInterrupts` / `rewindFrom` exports.
- **serve** (`discovery.ts`, adapters): discovery attaches a frame-aware `invoke` to each exported function, falling back to the bare call for modules compiled before `__invokeFunction` existed; both adapters now call `fn.invoke(args)`.

## Testing

- New `lib/serve/http/functionFrame.integration.test.ts` compiles a real module (with a `static const` read, so the body depends on bootstrap init having run) and drives it through the actual HTTP handler — the only way to exercise the regression, since the adapter unit tests use fakes.
- Verified end-to-end by hand: `POST /function/greet {"name":"foo"}` → `{"success":true,"value":"Hello, foo!"}`.
- Full vitest suite green (6098 passed); structural lint clean. Generator/builder/debugger fixtures regenerated for the one-line preamble addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
