### PR TITLE
Fix type validation for value-parameterized stdlib aliases imported from std::types

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -69,6 +69,7 @@ import { HandleBlock } from "../types/handleBlock.js";
 import { WithModifier } from "../types/withModifier.js";
 import { IfElse } from "../types/ifElse.js";
 import {
+  getImportedNames,
   ImportNodeStatement,
   ImportStatement,
 } from "../types/importStatement.js";
@@ -200,6 +201,14 @@ export class TypeScriptBuilder {
   // Import tracking
   private importStatements: TsNode[] = [];
   private toolRegistrations: TsNode[] = [];
+  /** Local names the user explicitly imported, across all import statements.
+   *  Used to dedupe transitive validator imports so we never re-declare a
+   *  name the module already binds. */
+  private directlyImportedNames: Set<string> = new Set();
+  /** Validators that imported value-parameterized aliases reference, grouped
+   *  by the (Agency) module path to import them from. Emitted, deduped,
+   *  after all import statements are processed. See ValidatorImport. */
+  private transitiveValidatorImports: Record<string, Set<string>> = {};
 
   // Function tracking
   private functionsUsed: Set<string> = new Set();
@@ -438,6 +447,8 @@ export class TypeScriptBuilder {
       globalOrder: this.initPlan?.globalLocalOrder,
     });
     this.generatedStatements.push(...partition.topLevelStatements);
+
+    this.emitTransitiveValidatorImports();
 
     return assembleSections({
       moduleId: this.moduleId,
@@ -1262,6 +1273,30 @@ export class TypeScriptBuilder {
       if (!entry?.valueParams || entry.valueParams.length === 0) return false;
       return !entry.typeParams || entry.typeParams.length === 0;
     };
+    // Record every local name the user imports so transitive validator
+    // imports can avoid re-declaring an already-bound name.
+    for (const nameType of node.importedNames) {
+      for (const local of getImportedNames(nameType)) {
+        this.directlyImportedNames.add(local);
+      }
+    }
+    // An imported value-parameterized validated alias inlines its validator
+    // chain at every use site, naming validator functions that live in the
+    // alias's defining module. Replay those imports into this module. (Bare
+    // aliases don't need this — their descriptor const is emitted in the
+    // defining module with validators already in scope.)
+    for (const nameType of node.importedNames) {
+      if (nameType.type !== "namedImport") continue;
+      for (const name of nameType.importedNames) {
+        const entry = aliasesFull[name];
+        if (!entry?.validatorImports) continue;
+        for (const vi of entry.validatorImports) {
+          (this.transitiveValidatorImports[vi.modulePath] ??= new Set()).add(
+            vi.name,
+          );
+        }
+      }
+    }
     const imports = node.importedNames.map((nameType) => {
       switch (nameType.type) {
         case "namedImport": {
@@ -1314,6 +1349,32 @@ export class TypeScriptBuilder {
       }
     }
     return importNode;
+  }
+
+  /**
+   * Emit import declarations for validator functions that imported
+   * value-parameterized aliases reference in their inlined validation
+   * chains (see ValidatorImport). Deduped against names the user already
+   * imports and against each other, so we never re-declare a binding.
+   * Called once, after every import statement has been processed.
+   */
+  private emitTransitiveValidatorImports(): void {
+    const fromFile = this.outputFile ?? path.resolve(this.moduleId);
+    const alreadyBound = new Set<string>(this.directlyImportedNames);
+    for (const [modulePath, names] of Object.entries(
+      this.transitiveValidatorImports,
+    )) {
+      const toImport = [...names].filter((n) => !alreadyBound.has(n)).sort();
+      if (toImport.length === 0) continue;
+      for (const n of toImport) alreadyBound.add(n);
+      this.importStatements.push(
+        ts.importDecl({
+          importKind: "named",
+          names: toImport,
+          from: toCompiledImportPath(modulePath, fromFile),
+        }),
+      );
+    }
   }
 
   private processImportNodeStatement(_node: ImportNodeStatement): TsNode {

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -7,6 +7,7 @@ import type {
   Tag,
   TypeAliasEntry,
   TypeParam,
+  ValidatorImport,
   ValueParam,
   VariableType,
 } from "./types.js";
@@ -48,6 +49,7 @@ export class ScopedTypeAliases {
     tags?: Tag[],
     valueParams?: ValueParam[],
     isEffectSet?: boolean,
+    validatorImports?: ValidatorImport[],
   ): void {
     if (!this.byScope[scopeKey]) this.byScope[scopeKey] = {};
     const entry: TypeAliasEntry = { body };
@@ -55,6 +57,9 @@ export class ScopedTypeAliases {
     if (valueParams) entry.valueParams = valueParams;
     if (tags && tags.length > 0) entry.tags = tags;
     if (isEffectSet) entry.isEffectSet = true;
+    if (validatorImports && validatorImports.length > 0) {
+      entry.validatorImports = validatorImports;
+    }
     this.byScope[scopeKey][name] = entry;
   }
 
@@ -288,6 +293,7 @@ export function buildCompilationUnit(
             r.symbol.tags,
             r.symbol.valueParams,
             r.symbol.isEffectSet,
+            r.symbol.validatorImports,
           );
           // Imported type's body may reference other aliases from its
           // module — pull those transitively too.
@@ -370,6 +376,8 @@ function pullTransitiveAliases(
       found.typeParams,
       found.tags,
       found.valueParams,
+      undefined,
+      found.validatorImports,
     );
     // Nested aliases referenced by this type should resolve in the file
     // the type was actually found in (not the original preferFile) — the
@@ -391,7 +399,7 @@ function resolveTypeFromFile(
   symbolTable: SymbolTable,
   name: string,
   preferFile: string | undefined,
-): { aliasedType: VariableType; typeParams?: TypeParam[]; valueParams?: ValueParam[]; tags?: Tag[]; file: string } | undefined {
+): { aliasedType: VariableType; typeParams?: TypeParam[]; valueParams?: ValueParam[]; tags?: Tag[]; validatorImports?: ValidatorImport[]; file: string } | undefined {
   if (preferFile) {
     const fileSym = symbolTable.getFile(preferFile)?.[name];
     if (fileSym?.kind === "type") {
@@ -400,6 +408,7 @@ function resolveTypeFromFile(
         typeParams: fileSym.typeParams,
         valueParams: fileSym.valueParams,
         tags: fileSym.tags,
+        validatorImports: fileSym.validatorImports,
         file: preferFile,
       };
     }
@@ -412,6 +421,7 @@ function resolveTypeFromFile(
         typeParams: sym.typeParams,
         valueParams: sym.valueParams,
         tags: sym.tags,
+        validatorImports: sym.validatorImports,
         file,
       };
     }

--- a/packages/agency-lang/lib/symbolTable.test.ts
+++ b/packages/agency-lang/lib/symbolTable.test.ts
@@ -106,6 +106,61 @@ type NumberInRange(low: number, high: number) = number
     expect(p.kind).toBe("type");
     expect(p.valueParams).toBeUndefined();
   });
+
+  it("records validatorImports for a value-parameterized validated alias", () => {
+    const symbols = parseAndClassify(`
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+`);
+    const r = symbols.NumberInRange as any;
+    expect(r.kind).toBe("type");
+    expect(r.validatorImports).toEqual([
+      { name: "min", modulePath: "std::validators" },
+      { name: "max", modulePath: "std::validators" },
+    ]);
+  });
+
+  it("honors import aliasing when recording validatorImports", () => {
+    const symbols = parseAndClassify(`
+import { min as atLeast } from "std::validators"
+
+@validate(atLeast.partial(n: low))
+type AtLeast(low: number) = number
+`);
+    const r = symbols.AtLeast as any;
+    expect(r.validatorImports).toEqual([
+      { name: "atLeast", modulePath: "std::validators" },
+    ]);
+  });
+
+  it("omits validatorImports for a locally-defined validator", () => {
+    const symbols = parseAndClassify(`
+safe def positive(n: number, value: number): Result { return success(value) }
+
+@validate(positive.partial(n: low))
+type AtLeast(low: number) = number
+`);
+    const r = symbols.AtLeast as any;
+    // The validator lives in this same module (not imported), so there is
+    // nothing to replay into a consumer — no validatorImports recorded.
+    expect(r.validatorImports).toBeUndefined();
+  });
+
+  it("does not record validatorImports for a bare (non-value-param) alias", () => {
+    const symbols = parseAndClassify(`
+import { isEmail } from "std::validators"
+
+@validate(isEmail)
+type Email = string
+`);
+    const e = symbols.Email as any;
+    expect(e.kind).toBe("type");
+    // Bare aliases emit their descriptor const in the defining module where
+    // validators are already in scope, so no transitive import is needed.
+    expect(e.validatorImports).toBeUndefined();
+  });
 });
 
 describe("SymbolTable direct interrupt collection", () => {

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -5,9 +5,11 @@ import type { AgencyConfig } from "./config.js";
 import type {
   AgencyNode,
   AgencyProgram,
+  Expression,
   FunctionParameter,
   Tag,
   TypeParam,
+  ValidatorImport,
   ValueParam,
   VariableType,
 } from "./types.js";
@@ -80,6 +82,11 @@ export type TypeSymbol = {
   /** True when declared via `effectSet` (not `type`). Carried through imports
    *  so an imported effect set is recognized as one. */
   isEffectSet?: boolean;
+  /** For value-parameterized aliases: where each validator function referenced
+   *  by a `@validate(...)` tag was imported from in this module. Lets a
+   *  consuming module replay those imports so the inlined validator chain
+   *  resolves. See {@link ValidatorImport}. */
+  validatorImports?: ValidatorImport[];
   reExportedFrom?: ReExportedFrom;
 };
 
@@ -318,6 +325,70 @@ export function collectTypeAliasTags(program: AgencyProgram): Record<string, Tag
 }
 
 /**
+ * Head free identifier of a `@validate(...)` tag argument — the validator
+ * function that needs to be in scope at the use site:
+ *   - `isEmail`            → "isEmail"   (bare identifier)
+ *   - `min.partial(n: 0)`  → "min"       (PFA: identifier at the chain base)
+ *   - `makeValidator(...)` → "makeValidator" (direct call)
+ * Returns undefined for argument shapes that reference no free identifier
+ * (string/number/object literals, etc.).
+ */
+function validatorHeadIdentifier(expr: Expression): string | undefined {
+  switch (expr.type) {
+    case "variableName":
+      return (expr as { value: string }).value;
+    case "functionCall":
+      return (expr as { functionName: string }).functionName;
+    case "valueAccess":
+      return validatorHeadIdentifier((expr as { base: Expression }).base);
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * For a value-parameterized alias, resolve each validator referenced by its
+ * `@validate(...)` tags to the module it was imported from in `program`
+ * (the alias's defining module). Validators that are not imported by name
+ * (locally defined, or not found) are skipped — those don't need a replayed
+ * import. Returns undefined when there is nothing to record.
+ */
+function resolveValidatorImports(
+  tags: Tag[] | undefined,
+  program: AgencyProgram,
+): ValidatorImport[] | undefined {
+  if (!tags || tags.length === 0) return undefined;
+
+  // Build identifier → modulePath from this module's named imports.
+  const importedFrom: Record<string, string> = {};
+  for (const node of program.nodes) {
+    if (node.type !== "importStatement") continue;
+    for (const nameType of node.importedNames) {
+      if (nameType.type !== "namedImport") continue;
+      for (const originalName of nameType.importedNames) {
+        const localName = nameType.aliases[originalName] ?? originalName;
+        importedFrom[localName] = node.modulePath;
+      }
+    }
+  }
+
+  const out: ValidatorImport[] = [];
+  const seen = new Set<string>();
+  for (const tag of tags) {
+    if (tag.name !== "validate") continue;
+    for (const arg of tag.arguments) {
+      const head = validatorHeadIdentifier(arg);
+      if (!head || seen.has(head)) continue;
+      const modulePath = importedFrom[head];
+      if (!modulePath) continue; // locally defined or unresolved — leave as-is
+      seen.add(head);
+      out.push({ name: head, modulePath });
+    }
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
  * Classify symbols in a parsed Agency program.
  * Uses walkNodes to find symbols at all nesting levels (e.g. type aliases inside functions).
  */
@@ -369,6 +440,21 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
           ...(node.isEffectSet ? { isEffectSet: true } : {}),
           ...(typeAliasTags[node.aliasName]?.length
             ? { tags: typeAliasTags[node.aliasName] }
+            : {}),
+          // Value-parameterized aliases inline their validator chain at every
+          // use site (see ValidatorImport). Record where each referenced
+          // validator was imported so a consuming module can replay those
+          // imports. Bare (non-value-param) aliases don't need this: their
+          // descriptor const is emitted in this module where validators are
+          // already in scope.
+          ...(node.valueParams?.length
+            ? (() => {
+                const vi = resolveValidatorImports(
+                  typeAliasTags[node.aliasName],
+                  program,
+                );
+                return vi ? { validatorImports: vi } : {};
+              })()
             : {}),
         };
         break;

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -77,6 +77,27 @@ export type ValueParam = {
 };
 
 /**
+ * A validator function referenced by an alias's `@validate(...)` tag,
+ * together with the module path it was imported from in the alias's
+ * defining module.
+ *
+ * Value-parameterized aliases emit their validation descriptor *inline at
+ * every use site* (the schema differs per use, so no single descriptor
+ * const can live in the defining module). That inlined descriptor names
+ * the validator functions directly — e.g. `min.partial({ n: 1 })` — so the
+ * consuming module must import those functions too. We capture where each
+ * one came from at symbol-table build time (where the defining module's
+ * imports are visible) and replay those imports into the consumer's
+ * generated output. See `validatorImports` on TypeAliasEntry.
+ */
+export type ValidatorImport = {
+  /** Validator identifier as referenced in the `@validate(...)` tag. */
+  name: string;
+  /** Agency module path it was imported from (e.g. `"std::validators"`). */
+  modulePath: string;
+};
+
+/**
  * Entry in the type alias registry. For non-generic aliases `typeParams`
  * is absent; for generic aliases it carries the declared parameters.
  *
@@ -98,6 +119,14 @@ export type TypeAliasEntry = {
   /** True when the alias was declared with `effectSet` (not `type`).
    *  Lets the effect-set resolver tell an effect set from a plain alias. */
   isEffectSet?: boolean;
+  /**
+   * For value-parameterized aliases whose `@validate(...)` tags reference
+   * imported validator functions: where each validator was imported from in
+   * the defining module. Lets a consuming module that imports this alias
+   * replay those imports so the inlined validator chain resolves. See
+   * {@link ValidatorImport}.
+   */
+  validatorImports?: ValidatorImport[];
 };
 
 export type ResultType = {

--- a/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.agency
+++ b/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.agency
@@ -1,0 +1,33 @@
+// Regression test: importing a value-parameterized validated alias from
+// another module must transitively pull in the validator functions its
+// `@validate(...)` tag references. `NumberInRange` (std::types) references
+// `min`/`max` and `StringWithLength` references `minLength`/`maxLength`,
+// all defined in std::validators. Before the transitive-import fix this
+// crashed at runtime with `ReferenceError: min is not defined` because the
+// inlined validator chain emitted bare `min`/`max` identifiers that were
+// never imported into the consuming module.
+//
+// Uses BOTH aliases so the codegen has to resolve and dedupe several
+// validators across two value-parameterized aliases. Returns per-assertion
+// isSuccess() flags so a regression diff pinpoints which check failed.
+
+import { NumberInRange, StringWithLength } from "std::types"
+
+node main() {
+  const okNum: NumberInRange(1, 10)! = 5
+  const lowNum: NumberInRange(1, 10)! = 0
+  const highNum: NumberInRange(1, 10)! = 11
+
+  const okStr: StringWithLength(2, 5)! = "abc"
+  const shortStr: StringWithLength(2, 5)! = "a"
+  const longStr: StringWithLength(2, 5)! = "abcdef"
+
+  return {
+    okNum: isSuccess(okNum),
+    lowNum: isSuccess(lowNum),
+    highNum: isSuccess(highNum),
+    okStr: isSuccess(okStr),
+    shortStr: isSuccess(shortStr),
+    longStr: isSuccess(longStr)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.test.json
+++ b/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"okNum\":true,\"lowNum\":false,\"highNum\":false,\"okStr\":true,\"shortStr\":false,\"longStr\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Importing value-parameterized validated aliases (NumberInRange, StringWithLength) from std::types transitively imports the min/max/minLength/maxLength validators their @validate tags reference, so runtime validation runs instead of crashing with 'min is not defined'."
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Type validation is broken for the documented usage of value-parameterized stdlib aliases. Following the [type-validation guide](https://agency-lang.com/guide/type-validation.html):

```agency
import { NumberInRange } from "std::types"

node main(): string {
  const n: NumberInRange(1, 10)! = 5
  print(`The number is ${n}`)
}
```

…crashes at runtime:

```
ERROR Node main crashed: min is not defined
ReferenceError: min is not defined
```

### Root cause

`NumberInRange` (in `std::types`) is defined as:

```agency
@validate(min.partial(n: low), max.partial(n: high))
export type NumberInRange(low: number, high: number) = number
```

`min`/`max` come from `std::validators`. Because a value-parameterized alias emits **nothing** at its definition site (the schema differs per use site), its validation descriptor is inlined at every use site:

```js
"validators": [min.partial({ n: 1 }), max.partial({ n: 10 })]
```

…but the consuming module only imported `NumberInRange`, so `min`/`max` were never imported — hence the `ReferenceError`.

Bare (non-value-param) aliases like `Email`/`UUIDString` were unaffected: their descriptor const is emitted in the *defining* module where the validators are already in scope.

The existing `valueParam*` tests all missed this because they **redefine** `NumberInRange` locally and `import { min, max }` explicitly — i.e. they never exercised the documented "import the alias from std::types" path.

## Fix

1. At symbol-table build time (where the defining module's imports are visible), record for each value-parameterized validated alias which module each referenced validator was imported from (`validatorImports` on the type symbol / `TypeAliasEntry`).
2. Carry it through `buildCompilationUnit` (including transitive alias pulls).
3. When a consuming module imports such an alias, replay those imports into its generated output — deduped against names the module already binds, so a user who also imports `min` directly never gets a double declaration.

The validators flow in only as in-scope bindings for the validator chain; they are **not** registered as LLM tools.

### Scope / limitation
Resolution uses the validator's source module path as written in the defining module. This is consumer-independent for `std::`/`pkg::` imports (the realistic case — stdlib and npm-packaged validated aliases). Validators that are defined locally in the alias's module (rather than imported) are not replayed; that case was never wired up and is unaffected.

## Testing

- New agency execution regression test `tests/agency/validation/stdTypesValueParamImport.{agency,test.json}` — imports `NumberInRange` **and** `StringWithLength` from `std::types` and asserts per-bound `isSuccess()` results (covers multi-alias dedup of `min`/`max`/`minLength`/`maxLength`). Fails with `min is not defined` before the fix; passes after.
- New `symbolTable` unit tests covering the recorded `validatorImports` metadata (import aliasing, locally-defined validator omission, bare-alias non-recording).
- Full validation agency suite: **80/80 pass**.
- Full vitest unit suite: **6096 pass** (36 pre-existing skips).
- Structural linter clean; full `make` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
