### PR TITLE
Value-parameterized validator factory

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
@@ -371,4 +371,29 @@ node main() {
     // The \`!\` site validates against a CALL to the factory, not an inlined chain:
     expect(out).toContain("NumberInRange(1, 10)");
   });
+
+  it("evaluates the factory call once when use-site validators are stacked", () => {
+    const out = generateWithBuilder(`
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+type Holder = {
+  @validate(min.partial(n: 3)) val: NumberInRange(1, 10)
+}
+
+node main() {
+  const h: Holder! = { val: 5 }
+  return h
+}
+`);
+    // Use-site validators must be concatenated via an IIFE that binds the
+    // factory call to a local, so the factory (and its min.partial(...)
+    // allocations) is evaluated exactly once, not twice.
+    expect(out).toContain("(__d) =>");
+    // The factory call appears once (as the IIFE argument), not spread + read.
+    const calls = out.match(/NumberInRange\(1, 10\)/g) ?? [];
+    expect(calls.length).toBe(1);
+  });
 });

--- a/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
@@ -313,3 +313,62 @@ describe("mapTypeToValidationSchema", () => {
     expect(schema).toBe("z.number()");
   });
 });
+
+describe("value-parameterized validator factory", () => {
+  it("emits a descriptor factory for a validated value-param alias", () => {
+    const out = generateWithBuilder(`
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+
+node main() {
+  return 1
+}
+`);
+    // Factory function, parameterized by the alias's value params, lives here:
+    expect(out).toContain("function NumberInRange(low, high)");
+    // Validators reference low/high as the factory's parameters (not literals):
+    expect(out).toContain("min.partial({ n: low })");
+    expect(out).toContain("max.partial({ n: high })");
+    // Schema-path identifiers survive too: the `@jsonSchema(...)` tag goes
+    // through `appendMeta` (typeToZodSchema.ts:32) and must reference the
+    // factory params, NOT substituted literals. This mirrors how every
+    // stdlib value-param alias (NumberInRange/StringWithLength) is defined.
+    expect(out).toContain("minimum: low");
+    expect(out).toContain("maximum: high");
+  });
+
+  it("bakes value-param defaults into the factory signature", () => {
+    const out = generateWithBuilder(`
+import { min } from "std::validators"
+
+@validate(min.partial(n: low))
+type Age(low: number = 0) = number
+
+node main() {
+  return 1
+}
+`);
+    // An omitted use-site arg (Age() / bare Age) must fall back to the default,
+    // so the default has to live in the factory signature itself.
+    expect(out).toContain("function Age(low = 0)");
+  });
+
+  it("references the factory by call at a validated use site", () => {
+    const out = generateWithBuilder(`
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+node main() {
+  const n: NumberInRange(1, 10)! = 5
+  return n
+}
+`);
+    // The \`!\` site validates against a CALL to the factory, not an inlined chain:
+    expect(out).toContain("NumberInRange(1, 10)");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -91,7 +91,9 @@ import {
 import {
   buildValidationDescriptor,
   hasAnyValidateTag,
+  hasAliasValidate,
 } from "./typescriptGenerator/validationDescriptor.js";
+import { tagArgToTs } from "./typescriptGenerator/tagArgToTs.js";
 import { resolveTypeDeep } from "../typeChecker/assignability.js";
 import { isFunctionTyped } from "../typeChecker/utils.js";
 
@@ -677,12 +679,48 @@ export class TypeScriptBuilder {
       if (!node.exported) return ts.empty();
       return ts.raw(`export const ${node.aliasName} = undefined;`);
     }
-    // Value-parameterized aliases (e.g. `type NumberInRange(low, high) = ...`)
-    // have no single schema — every use-site inlines a fresh substituted
-    // schema. Emit nothing at the declaration site; importers should never
-    // reference the bare name (use-sites are resolved before codegen).
+    // Value-parameterized aliases have no single schema — every use-site
+    // depends on the value args. For a VALIDATED one we emit a descriptor
+    // FACTORY here, in the alias's own module, so the validators it
+    // references stay in scope (exactly like a bare alias's
+    // `__agency_descriptor`). Use sites call `AliasName(args)` (see
+    // validationDescriptor.ts). A NON-validated value-param alias has no
+    // validators to leak, so it keeps emitting nothing and its schema is
+    // inlined at the use site.
     if (node.valueParams && node.valueParams.length > 0) {
-      return ts.empty();
+      const vpAliasesFull = this.scopes.visibleTypeAliasesFull();
+      const vpAliasedWithTags: VariableType = node.tags
+        ? {
+            ...node.aliasedType,
+            tags: [...(node.aliasedType.tags ?? []), ...node.tags],
+          }
+        : node.aliasedType;
+      if (!hasAnyValidateTag(vpAliasedWithTags, vpAliasesFull)) {
+        return ts.empty();
+      }
+      const vpResolved = resolveTypeDeep(vpAliasedWithTags, vpAliasesFull);
+      const vpDescriptor = buildValidationDescriptor(
+        vpResolved,
+        this.scopes.visibleTypeAliases(),
+        vpAliasesFull,
+      );
+      // Bake value-param DEFAULTS into the factory signature so an omitted
+      // use-site arg (e.g. `Age()!` or bare `Age!`) resolves the same default
+      // the old inline path got via `applyValueArgs` (which fills
+      // `bindings[p.name] = p.default`). Without this, `function Age(low)`
+      // called as `Age()` leaves `low` undefined and
+      // `min.partial({ n: undefined })` silently mis-validates.
+      const vpParams = node.valueParams
+        .map((p) =>
+          p.default !== undefined
+            ? `${p.name} = ${tagArgToTs(p.default)}`
+            : p.name,
+        )
+        .join(", ");
+      const vpExportPrefix = node.exported ? "export " : "";
+      return ts.raw(
+        `${vpExportPrefix}function ${node.aliasName}(${vpParams}) { return ${printTs(vpDescriptor)}; }`,
+      );
     }
     const exportPrefix = node.exported ? "export " : "";
     // Thread alias-level @validate / @jsonSchema tags onto the body type so

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -721,16 +721,16 @@ export class TypeScriptBuilder {
       // `bindings[p.name] = p.default`). Without this, `function Age(low)`
       // called as `Age()` leaves `low` undefined and
       // `min.partial({ n: undefined })` silently mis-validates.
-      const vpParams = node.valueParams
-        .map((p) =>
-          p.default !== undefined
-            ? `${p.name} = ${tagArgToTs(p.default)}`
-            : p.name,
-        )
-        .join(", ");
-      const vpExportPrefix = node.exported ? "export " : "";
-      return ts.raw(
-        `${vpExportPrefix}function ${node.aliasName}(${vpParams}) { return ${printTs(vpDescriptor)}; }`,
+      const vpFnParams: TsParam[] = node.valueParams.map((p) =>
+        p.default !== undefined
+          ? { name: p.name, defaultValue: ts.raw(tagArgToTs(p.default)) }
+          : { name: p.name },
+      );
+      return ts.functionDecl(
+        node.aliasName,
+        vpFnParams,
+        ts.statements([ts.return(vpDescriptor)]),
+        { export: node.exported },
       );
     }
     const exportPrefix = node.exported ? "export " : "";

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1301,15 +1301,20 @@ export class TypeScriptBuilder {
   private processImportStatement(node: ImportStatement): TsNode {
     const from = toCompiledImportPath(node.modulePath, this.outputFile ?? path.resolve(this.moduleId));
     const aliasesFull = this.scopes.visibleTypeAliasesFull();
-    // Value-only-parameterized aliases (e.g. `type NumberInRange(low, high) = number`)
-    // emit nothing at their declaration site (see processTypeAlias) because
-    // every use-site inlines a fresh schema. Importing such a name from the
-    // compiled target module would fail with "does not provide an export"
-    // and registering it as a tool would reference an undefined local.
+    // Non-validated value-only-parameterized aliases (e.g. `type
+    // OneOf(choices) = string` with only `@jsonSchema`) emit nothing at their
+    // declaration site (see processTypeAlias) because every use-site inlines a
+    // fresh schema. Importing such a name from the compiled target module
+    // would fail with "does not provide an export" and registering it as a
+    // tool would reference an undefined local — so filter them out.
+    //
+    // A VALIDATED value-param alias now compiles to (and exports) a descriptor
+    // factory, so it IS importable; only the non-validated ones are filtered.
     const isInlinedAlias = (name: string): boolean => {
       const entry = aliasesFull[name];
       if (!entry?.valueParams || entry.valueParams.length === 0) return false;
-      return !entry.typeParams || entry.typeParams.length === 0;
+      if (entry.typeParams && entry.typeParams.length > 0) return false;
+      return !hasAliasValidate(entry, aliasesFull);
     };
     const imports = node.importedNames.map((nameType) => {
       switch (nameType.type) {
@@ -1348,6 +1353,12 @@ export class TypeScriptBuilder {
           case "namedImport":
             for (const name of nameType.importedNames) {
               if (isInlinedAlias(name)) continue;
+              const vpEntry = aliasesFull[name];
+              // A value-param alias imports as a descriptor factory, not an
+              // AgencyFunction — never register it as an LLM tool.
+              if (vpEntry?.valueParams && vpEntry.valueParams.length > 0) {
+                continue;
+              }
               const localName = nameType.aliases[name] ?? name;
               this.toolRegistrations.push(ts.raw(`__registerTool(${localName});`));
             }

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -698,9 +698,20 @@ export class TypeScriptBuilder {
       if (!hasAnyValidateTag(vpAliasedWithTags, vpAliasesFull)) {
         return ts.empty();
       }
-      const vpResolved = resolveTypeDeep(vpAliasedWithTags, vpAliasesFull);
+      // Build the descriptor from the UNRESOLVED body. Unlike the bare-alias
+      // path we must NOT `resolveTypeDeep` here: the body legitimately
+      // contains this alias's own value-param identifiers (and, for a
+      // forwarding alias, a reference to another value-param alias). Deep
+      // resolution eagerly substitutes those, which both (a) trips
+      // `applyValueArgs`'s unsubstituted-param guard when a forwarded name
+      // collides with the inner param name, and (b) inlines the inner
+      // alias's validators into THIS factory — re-introducing the
+      // cross-module leak this feature exists to remove. Leaving the body
+      // intact lets `buildValidationDescriptor` emit a nested factory CALL
+      // for any value-param reference (validators resolve in their own
+      // module); the schema strings still substitute identifiers locally.
       const vpDescriptor = buildValidationDescriptor(
-        vpResolved,
+        vpAliasedWithTags,
         this.scopes.visibleTypeAliases(),
         vpAliasesFull,
       );

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -155,6 +155,69 @@ function schemaNode(
   return ts.raw(mapTypeToValidationSchema(t, typeAliases, typeAliasesFull));
 }
 
+/**
+ * Concatenate use-site `@validate(...)` validators on top of a base
+ * descriptor expression: `{ ...base, validators: [...(base?.validators ??
+ * []), ...useSite] }`. Returns `base` unchanged when there are none.
+ * Shared by the `__agency_descriptor` and value-param factory-call paths.
+ */
+function withUseSiteValidators(
+  base: TsNode,
+  useSiteValidators: TsNode[],
+): TsNode {
+  if (useSiteValidators.length === 0) return base;
+  const existingValidators = ts.binOp(
+    ts.prop(base, "validators", { optional: true }),
+    "??",
+    ts.arr([]),
+    { parenLeft: true },
+  );
+  return ts.obj([
+    ts.setSpread(base),
+    ts.set(
+      '"validators"',
+      ts.arr([ts.spread(existingValidators), ...useSiteValidators]),
+    ),
+  ]);
+}
+
+/**
+ * Build the descriptor for a value-parameterized alias instantiation.
+ * A VALIDATED value-param alias compiles to a descriptor factory in its
+ * defining module (see `processTypeAlias`), so we reference it by CALL —
+ * its validators resolve in that module's scope, never injected into the
+ * consumer and impossible to shadow with a same-named local. A
+ * NON-validated one has no validators to leak, so we inline its
+ * substituted schema as before.
+ */
+function valueParamDescriptor(
+  variableType: Extract<VariableType, { type: "typeAliasVariable" }>,
+  entry: TypeAliasEntry | undefined,
+  useSiteValidators: TsNode[],
+  typeAliases: Record<string, VariableType>,
+  typeAliasesFull: Record<string, TypeAliasEntry>,
+  seen: Set<string>,
+): TsNode {
+  if (entry && hasAliasValidate(entry, typeAliasesFull)) {
+    const argList = (variableType.valueArgs ?? [])
+      .map((a) => tagArgToTs(a))
+      .join(", ");
+    const call = ts.raw(`${variableType.aliasName}(${argList})`);
+    return withUseSiteValidators(call, useSiteValidators);
+  }
+  const substituted = applyValueArgs(
+    entry!,
+    variableType.valueArgs,
+    variableType.aliasName,
+  );
+  const merged = mergeTagSets(substituted.tags, variableType.tags);
+  const bodyWithTags: VariableType = {
+    ...substituted.body,
+    tags: mergeTagSets(substituted.body.tags, merged),
+  };
+  return descriptor(bodyWithTags, typeAliases, typeAliasesFull, seen);
+}
+
 function descriptor(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
@@ -171,52 +234,18 @@ function descriptor(
   if (variableType.type === "typeAliasVariable") {
     const entry = typeAliasesFull[variableType.aliasName];
     const useSiteValidators = validatorNodes(variableType.tags);
-    // Value-parameterized alias instantiation: there is NO
-    // `__agency_descriptor` side-channel (those only exist for bare
-    // aliases). Inline the descriptor for the substituted body with
-    // substituted tags threaded through. See `isValueParamInstantiation`
+    // Value-parameterized alias instantiation. See `isValueParamInstantiation`
     // — the canonical predicate, also used in `typeToZodSchema` and
     // `hasAnyValidateTag`.
     if (isValueParamInstantiation(variableType, entry)) {
-      // A VALIDATED value-param alias compiles to a descriptor factory in
-      // its defining module (see processTypeAlias). Reference it by CALL so
-      // its validators resolve in that module's scope — never injected into
-      // the consumer, and impossible to shadow with a same-named local.
-      if (entry && hasAliasValidate(entry, typeAliasesFull)) {
-        const argList = (variableType.valueArgs ?? [])
-          .map((a) => tagArgToTs(a))
-          .join(", ");
-        const call = ts.raw(`${variableType.aliasName}(${argList})`);
-        if (useSiteValidators.length === 0) return call;
-        // Concatenate use-site validators on top of the factory's chain:
-        // `{ ...AliasName(args), validators: [...(AliasName(args)?.validators ?? []), ...useSite] }`
-        const existingValidators = ts.binOp(
-          ts.prop(call, "validators", { optional: true }),
-          "??",
-          ts.arr([]),
-          { parenLeft: true },
-        );
-        return ts.obj([
-          ts.setSpread(call),
-          ts.set(
-            '"validators"',
-            ts.arr([ts.spread(existingValidators), ...useSiteValidators]),
-          ),
-        ]);
-      }
-      // Non-validated value-param alias: inline the substituted schema. There
-      // are no validators to leak, so this stays as-is.
-      const substituted = applyValueArgs(
-        entry!,
-        variableType.valueArgs,
-        variableType.aliasName,
+      return valueParamDescriptor(
+        variableType,
+        entry,
+        useSiteValidators,
+        typeAliases,
+        typeAliasesFull,
+        seen,
       );
-      const merged = mergeTagSets(substituted.tags, variableType.tags);
-      const bodyWithTags: VariableType = {
-        ...substituted.body,
-        tags: mergeTagSets(substituted.body.tags, merged),
-      };
-      return descriptor(bodyWithTags, typeAliases, typeAliasesFull, seen);
     }
     if (entry && hasAliasValidate(entry, typeAliasesFull)) {
       // `(Alias as any).__agency_descriptor`
@@ -224,21 +253,7 @@ function descriptor(
         ts.raw(`(${variableType.aliasName} as any)`),
         "__agency_descriptor",
       );
-      if (useSiteValidators.length === 0) return aliasRef;
-      // `{ ...aliasRef, validators: [...(aliasRef?.validators ?? []), ...] }`
-      const existingValidators = ts.binOp(
-        ts.prop(aliasRef, "validators", { optional: true }),
-        "??",
-        ts.arr([]),
-        { parenLeft: true },
-      );
-      return ts.obj([
-        ts.setSpread(aliasRef),
-        ts.set(
-          '"validators"',
-          ts.arr([ts.spread(existingValidators), ...useSiteValidators]),
-        ),
-      ]);
+      return withUseSiteValidators(aliasRef, useSiteValidators);
     }
     // No alias-level validators — emit a leaf using only the alias schema and
     // any use-site validators.

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -99,7 +99,7 @@ function tagsHaveValidate(tags: Tag[] | undefined): boolean {
  * Used to decide whether a `typeAliasVariable` reference should emit a
  * `(Alias as any).__agency_descriptor` reference vs. a flat leaf schema.
  */
-function hasAliasValidate(
+export function hasAliasValidate(
   entry: TypeAliasEntry,
   typeAliasesFull: Record<string, TypeAliasEntry>,
 ): boolean {

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -8,6 +8,12 @@ import {
   applyValueArgs,
   isValueParamInstantiation,
 } from "@/typeChecker/valueParamSubstitution.js";
+import { resolveTypeDeep } from "@/typeChecker/assignability.js";
+
+/** A user-defined generic alias has type params we can't represent at runtime. */
+function isGenericAlias(entry: TypeAliasEntry | undefined): boolean {
+  return !!entry?.typeParams && entry.typeParams.length > 0;
+}
 
 /**
  * Build a TS IR node that evaluates to a runtime `TypeValidationDescriptor`.
@@ -63,10 +69,27 @@ export function hasAnyValidateTag(
       return t.types.some((m) => hasAnyValidateTag(m, aliasesFull, seen));
     case "resultType":
       return hasAnyValidateTag(t.successType, aliasesFull, seen);
-    case "genericType":
-      return (t.typeArgs ?? []).some((a) =>
-        hasAnyValidateTag(a, aliasesFull, seen),
-      );
+    case "genericType": {
+      // Type arguments may themselves carry @validate (e.g. `Array<Email>`).
+      if (
+        (t.typeArgs ?? []).some((a) => hasAnyValidateTag(a, aliasesFull, seen))
+      ) {
+        return true;
+      }
+      // A user-defined generic alias reference (`Ranked<string>(...)`) carries
+      // its own alias-level tags / body, exactly like a typeAliasVariable. The
+      // old code only inspected typeArgs, so a `@validate` on the generic alias
+      // itself was missed — making a forwarded reference fall to the plain
+      // schema path and crash on the unresolved generic.
+      if (!aliasesFull) return false;
+      const gEntry = aliasesFull[t.name];
+      if (!gEntry) return false;
+      if (tagsHaveValidate(gEntry.tags)) return true;
+      if (seen.has(t.name)) return false;
+      const gNextSeen = new Set(seen);
+      gNextSeen.add(t.name);
+      return hasAnyValidateTag(gEntry.body, aliasesFull, gNextSeen);
+    }
     case "typeAliasVariable": {
       if (!aliasesFull) return false;
       const entry = aliasesFull[t.aliasName];
@@ -157,28 +180,38 @@ function schemaNode(
 
 /**
  * Concatenate use-site `@validate(...)` validators on top of a base
- * descriptor expression: `{ ...base, validators: [...(base?.validators ??
- * []), ...useSite] }`. Returns `base` unchanged when there are none.
+ * descriptor expression. Returns `base` unchanged when there are none.
  * Shared by the `__agency_descriptor` and value-param factory-call paths.
+ *
+ * `base` is bound to a local via an IIFE so it is evaluated exactly once:
+ * `((__d) => ({ ...__d, validators: [...(__d?.validators ?? []), ...useSite] }))(base)`.
+ * For the factory-call path `base` is a function call (`NumberInRange(1, 10)`),
+ * so spreading it AND reading `.validators` off it directly would rebuild the
+ * whole descriptor — including the `min.partial(...)` allocations — twice.
  */
 function withUseSiteValidators(
   base: TsNode,
   useSiteValidators: TsNode[],
 ): TsNode {
   if (useSiteValidators.length === 0) return base;
+  const d = ts.id("__d");
   const existingValidators = ts.binOp(
-    ts.prop(base, "validators", { optional: true }),
+    ts.prop(d, "validators", { optional: true }),
     "??",
     ts.arr([]),
     { parenLeft: true },
   );
-  return ts.obj([
-    ts.setSpread(base),
+  const merged = ts.obj([
+    ts.setSpread(d),
     ts.set(
       '"validators"',
       ts.arr([ts.spread(existingValidators), ...useSiteValidators]),
     ),
   ]);
+  return ts.call(
+    ts.arrowFn([{ name: "__d" }], ts.statements([ts.return(merged)])),
+    [base],
+  );
 }
 
 /**
@@ -189,6 +222,11 @@ function withUseSiteValidators(
  * consumer and impossible to shadow with a same-named local. A
  * NON-validated one has no validators to leak, so we inline its
  * substituted schema as before.
+ *
+ * A COMBINED type-param + value-param alias (`type Foo<T>(n) = ...`) cannot
+ * be a runtime factory — its schema depends on the type argument, which only
+ * exists at codegen. We resolve it in place (substituting both type and value
+ * args) and inline, exactly as a direct `!` use site does via resolveTypeDeep.
  */
 function valueParamDescriptor(
   variableType: Extract<VariableType, { type: "typeAliasVariable" }>,
@@ -198,6 +236,14 @@ function valueParamDescriptor(
   typeAliasesFull: Record<string, TypeAliasEntry>,
   seen: Set<string>,
 ): TsNode {
+  if (isGenericAlias(entry)) {
+    return descriptor(
+      resolveTypeDeep(variableType, typeAliasesFull),
+      typeAliases,
+      typeAliasesFull,
+      seen,
+    );
+  }
   if (entry && hasAliasValidate(entry, typeAliasesFull)) {
     const argList = (variableType.valueArgs ?? [])
       .map((a) => tagArgToTs(a))
@@ -262,6 +308,24 @@ function descriptor(
       ["schema", schemaNode(variableType, typeAliases, typeAliasesFull)],
       ["validators", ts.arr(useSiteValidators)],
     ]);
+  }
+
+  // A user-defined generic alias reference (e.g. `Ranked<string>(1, high)`) is
+  // a `genericType` node, not a `typeAliasVariable`. It reaches here only when
+  // nested inside another value-param alias's factory body (use sites are
+  // resolved earlier). It can't be a runtime factory, so resolve it in place —
+  // substituting type AND value args — and inline, rather than letting the
+  // schema mapper choke on an unresolved generic.
+  if (
+    variableType.type === "genericType" &&
+    isGenericAlias(typeAliasesFull[variableType.name])
+  ) {
+    return descriptor(
+      resolveTypeDeep(variableType, typeAliasesFull),
+      typeAliases,
+      typeAliasesFull,
+      seen,
+    );
   }
 
   const schema = schemaNode(variableType, typeAliases, typeAliasesFull);

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -176,6 +176,34 @@ function descriptor(
     // — the canonical predicate, also used in `typeToZodSchema` and
     // `hasAnyValidateTag`.
     if (isValueParamInstantiation(variableType, entry)) {
+      // A VALIDATED value-param alias compiles to a descriptor factory in
+      // its defining module (see processTypeAlias). Reference it by CALL so
+      // its validators resolve in that module's scope — never injected into
+      // the consumer, and impossible to shadow with a same-named local.
+      if (entry && hasAliasValidate(entry, typeAliasesFull)) {
+        const argList = (variableType.valueArgs ?? [])
+          .map((a) => tagArgToTs(a))
+          .join(", ");
+        const call = ts.raw(`${variableType.aliasName}(${argList})`);
+        if (useSiteValidators.length === 0) return call;
+        // Concatenate use-site validators on top of the factory's chain:
+        // `{ ...AliasName(args), validators: [...(AliasName(args)?.validators ?? []), ...useSite] }`
+        const existingValidators = ts.binOp(
+          ts.prop(call, "validators", { optional: true }),
+          "??",
+          ts.arr([]),
+          { parenLeft: true },
+        );
+        return ts.obj([
+          ts.setSpread(call),
+          ts.set(
+            '"validators"',
+            ts.arr([ts.spread(existingValidators), ...useSiteValidators]),
+          ),
+        ]);
+      }
+      // Non-validated value-param alias: inline the substituted schema. There
+      // are no validators to leak, so this stays as-is.
       const substituted = applyValueArgs(
         entry!,
         variableType.valueArgs,

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -71,19 +71,21 @@ export function hasAnyValidateTag(
       if (!aliasesFull) return false;
       const entry = aliasesFull[t.aliasName];
       if (!entry) return false;
-      // For value-parameterized references, the alias's raw tags may
-      // reference value-param identifiers; substitute first so the
-      // post-substitution tag set is what we check for `@validate`.
-      // See `isValueParamInstantiation` — the canonical predicate.
-      const effectiveEntry = isValueParamInstantiation(t, entry)
-        ? applyValueArgs(entry, t.valueArgs, t.aliasName)
-        : entry;
-      if (tagsHaveValidate(effectiveEntry.tags)) return true;
+      // The PRESENCE of a `@validate(...)` tag is substitution-invariant:
+      // value-arg substitution only rewrites a tag's argument expressions,
+      // never adds or removes the tag itself. So we check the raw entry
+      // directly rather than calling `applyValueArgs`. This also matters
+      // for forwarding aliases (`type AdultAge(high) = NumberInRange(18,
+      // high)`): substituting here would pass the still-symbolic `high`
+      // into the inner alias and trip `applyValueArgs`'s
+      // unsubstituted-value-param guard when the forwarded name collides
+      // with the inner param name.
+      if (tagsHaveValidate(entry.tags)) return true;
       // Guard against recursive alias self-reference.
       if (seen.has(t.aliasName)) return false;
       const nextSeen = new Set(seen);
       nextSeen.add(t.aliasName);
-      return hasAnyValidateTag(effectiveEntry.body, aliasesFull, nextSeen);
+      return hasAnyValidateTag(entry.body, aliasesFull, nextSeen);
     }
     default:
       return false;

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -501,9 +501,25 @@ export function applyValueArgs(
   // names. If any do, substitution missed a spot — surface it loudly
   // here rather than letting an out-of-scope identifier leak into the
   // generated TypeScript.
-  const paramNames = new Set(params.map((p) => p.name));
-  if (paramNames.size > 0) {
-    assertNoUnsubstitutedValueParams(newTags, newBody, paramNames, aliasName);
+  //
+  // Exception: a value param can be bound to a *forwarded* identifier from
+  // an enclosing alias — `type AdultAge(high) = NumberInRange(18, high)`
+  // binds NumberInRange's `high` to the identifier `high`. That identifier
+  // is a legitimate in-scope reference at the call site even when it
+  // collides in name with one of THIS alias's own params, so exclude any
+  // such forwarded names from the check (otherwise the collision is a false
+  // positive). Names bound to literals are still checked normally.
+  const forwarded = new Set<string>();
+  for (const v of Object.values(bindings)) {
+    if (v && (v as Expression).type === "variableName") {
+      forwarded.add((v as Expression & { value: string }).value);
+    }
+  }
+  const checkNames = new Set(
+    params.map((p) => p.name).filter((n) => !forwarded.has(n)),
+  );
+  if (checkNames.size > 0) {
+    assertNoUnsubstitutedValueParams(newTags, newBody, checkNames, aliasName);
   }
 
   return {

--- a/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.agency
+++ b/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.agency
@@ -1,0 +1,19 @@
+// Regression: importing a value-parameterized validated alias from another
+// module must validate correctly. The factory that builds the validator
+// chain lives in std::types, so min/max/minLength/maxLength resolve there —
+// nothing is injected into this module. Uses two aliases to exercise
+// multiple factories.
+import { NumberInRange, StringWithLength } from "std::types"
+
+node main() {
+  const okNum: NumberInRange(1, 10)! = 5
+  const lowNum: NumberInRange(1, 10)! = 0
+  const okStr: StringWithLength(2, 5)! = "abc"
+  const longStr: StringWithLength(2, 5)! = "abcdef"
+  return {
+    okNum: isSuccess(okNum),
+    lowNum: isSuccess(lowNum),
+    okStr: isSuccess(okStr),
+    longStr: isSuccess(longStr)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.test.json
+++ b/packages/agency-lang/tests/agency/validation/stdTypesValueParamImport.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"okNum\":true,\"lowNum\":false,\"okStr\":true,\"longStr\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Importing value-parameterized validated aliases from std::types validates correctly via the defining module's descriptor factory."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamFactoryLocal.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamFactoryLocal.agency
@@ -1,0 +1,14 @@
+// A locally-defined value-param validated alias must validate end-to-end
+// via its emitted factory. min/max are imported in THIS module, so the
+// factory (also in this module) sees them in scope.
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+node main() {
+  const ok: NumberInRange(1, 10)! = 5
+  const lo: NumberInRange(1, 10)! = 0
+  const hi: NumberInRange(1, 10)! = 11
+  return { ok: isSuccess(ok), lo: isSuccess(lo), hi: isSuccess(hi) }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamFactoryLocal.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamFactoryLocal.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"ok\":true,\"lo\":false,\"hi\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Locally-defined value-param validated alias validates end-to-end through its emitted descriptor factory."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamForwardImported.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamForwardImported.agency
@@ -1,0 +1,17 @@
+// A forwarding alias wrapping an imported value-param validated alias.
+// AdultAge has no @validate of its own; it inherits NumberInRange's via its
+// body. AdultAge's factory should call NumberInRange's factory.
+import { NumberInRange } from "std::types"
+
+type AdultAge(high: number) = NumberInRange(18, high)
+
+node main() {
+  const ok: AdultAge(65)! = 30
+  const tooYoung: AdultAge(65)! = 17
+  const tooOld: AdultAge(65)! = 70
+  return {
+    ok: isSuccess(ok),
+    tooYoung: isSuccess(tooYoung),
+    tooOld: isSuccess(tooOld)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamForwardImported.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamForwardImported.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"ok\":true,\"tooYoung\":false,\"tooOld\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A forwarding alias whose body is an imported value-param validated alias validates via nested factory calls (AdultAge -> NumberInRange)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.agency
@@ -18,13 +18,18 @@ node main() {
   // Direct use site of the combined alias:
   const okDirect: Ranked<string>(1, 10)! = 5
   const hiDirect: Ranked<string>(1, 10)! = 11
-  // Forwarded through a value-param alias:
+  // Forwarded through a value-param alias. Wrapped(10) = Ranked<string>(1, 10),
+  // so cover BOTH bounds — including the forwarded `high` upper bound (hiFwd),
+  // which is the whole point of the collision case: if `high` silently failed
+  // to forward, hiFwd would wrongly pass.
   const okFwd: Wrapped(10)! = 5
   const loFwd: Wrapped(10)! = 0
+  const hiFwd: Wrapped(10)! = 11
   return {
     okDirect: isSuccess(okDirect),
     hiDirect: isSuccess(hiDirect),
     okFwd: isSuccess(okFwd),
-    loFwd: isSuccess(loFwd)
+    loFwd: isSuccess(loFwd),
+    hiFwd: isSuccess(hiFwd)
   }
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.agency
@@ -1,0 +1,30 @@
+// Regression: a validated alias that combines TYPE params and VALUE params
+// (`@validate(...) type R<T>(low, high) = ...`). Such an alias cannot become a
+// runtime descriptor factory (its schema depends on the type argument, known
+// only at codegen), so it must inline its validators at every use site —
+// including when forwarded through another value-param alias. Pre-fix, the
+// forwarding case routed to a non-existent/unresolved factory and crashed.
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type Ranked<T>(low: number, high: number) = number
+
+// Forwarding alias whose body references the generic value-param alias and
+// FORWARDS its own value param (`high`) into it — note the name collision
+// with Ranked's own `high` param, which must not trip substitution guards.
+type Wrapped(high: number) = Ranked<string>(1, high)
+
+node main() {
+  // Direct use site of the combined alias:
+  const okDirect: Ranked<string>(1, 10)! = 5
+  const hiDirect: Ranked<string>(1, 10)! = 11
+  // Forwarded through a value-param alias:
+  const okFwd: Wrapped(10)! = 5
+  const loFwd: Wrapped(10)! = 0
+  return {
+    okDirect: isSuccess(okDirect),
+    hiDirect: isSuccess(hiDirect),
+    okFwd: isSuccess(okFwd),
+    loFwd: isSuccess(loFwd)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"okDirect\":true,\"hiDirect\":false,\"okFwd\":true,\"loFwd\":false}",
+      "expectedOutput": "{\"okDirect\":true,\"hiDirect\":false,\"okFwd\":true,\"loFwd\":false,\"hiFwd\":false}",
       "evaluationCriteria": [{ "type": "exact" }],
       "description": "A validated alias combining type params and value params validates correctly both directly and when forwarded through another value-param alias (it inlines rather than routing to a non-existent runtime factory)."
     }

--- a/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamGenericValidate.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"okDirect\":true,\"hiDirect\":false,\"okFwd\":true,\"loFwd\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A validated alias combining type params and value params validates correctly both directly and when forwarded through another value-param alias (it inlines rather than routing to a non-existent runtime factory)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamImportLocalShadow.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamImportLocalShadow.agency
@@ -1,0 +1,21 @@
+// The factory model must be immune to a consumer defining its own `min`.
+// NumberInRange's validator chain is built in std::types, so its `min`
+// resolves there; a local `min` here cannot hijack validation.
+import { NumberInRange } from "std::types"
+
+// A local `min` that ALWAYS passes. If validation bound to THIS, an
+// out-of-range value would wrongly pass.
+def min(n: number, value: number): Result {
+  return success(value)
+}
+
+node main() {
+  const tooLow: NumberInRange(5, 10)! = 1   // 1 < 5 -> must FAIL
+  const ok: NumberInRange(5, 10)! = 7       // in range -> must PASS
+  const localMin = min(99, 0)               // user's own min still callable
+  return {
+    tooLow: isSuccess(tooLow),
+    ok: isSuccess(ok),
+    localMin: isSuccess(localMin)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamImportLocalShadow.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamImportLocalShadow.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"tooLow\":false,\"ok\":true,\"localMin\":true}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A consumer-defined `min` does not affect an imported value-param alias's validation (factory resolves validators in std::types); the local `min` remains usable."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamNullable.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamNullable.agency
@@ -1,0 +1,21 @@
+// Edge case: a NULLABLE value-param validated alias (`NumberInRange(1,10) | null!`).
+// The descriptor wraps the value-param factory CALL in a `nullable` descriptor,
+// so null must short-circuit (validation skipped) while a non-null value still
+// runs the factory's validator chain (min 1 / max 10).
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+node main() {
+  const nothing: NumberInRange(1, 10) | null! = null  // null -> short-circuits, PASS
+  const ok: NumberInRange(1, 10) | null! = 5          // in range -> PASS
+  const lo: NumberInRange(1, 10) | null! = 0          // 0 < 1 -> FAIL
+  const hi: NumberInRange(1, 10) | null! = 11         // 11 > 10 -> FAIL
+  return {
+    nothing: isSuccess(nothing),
+    ok: isSuccess(ok),
+    lo: isSuccess(lo),
+    hi: isSuccess(hi)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamNullable.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamNullable.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"nothing\":true,\"ok\":true,\"lo\":false,\"hi\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A nullable value-param validated alias short-circuits on null but still runs the factory's validator chain (both bounds) on a non-null value."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamUseSiteValidatorStack.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamUseSiteValidatorStack.agency
@@ -1,0 +1,25 @@
+// A use site that stacks its OWN @validate on top of a value-param alias
+// reference. The descriptor must concatenate the use-site validator onto the
+// factory's chain (see withUseSiteValidators), so BOTH run:
+//   - the factory's own bounds (min 1 / max 10 from NumberInRange), and
+//   - the use-site `min 3`.
+// This exercises the IIFE single-evaluation path at runtime, not just codegen.
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+type Holder = {
+  @validate(min.partial(n: 3)) val: NumberInRange(1, 10)
+}
+
+node main() {
+  const ok: Holder! = { val: 5 }            // in [1,10] and >= 3 -> PASS
+  const failFactoryMax: Holder! = { val: 11 }  // 11 > 10 (factory bound) -> FAIL
+  const failUseSiteMin: Holder! = { val: 2 }   // in [1,10] but < 3 (use-site) -> FAIL
+  return {
+    ok: isSuccess(ok),
+    failFactoryMax: isSuccess(failFactoryMax),
+    failUseSiteMin: isSuccess(failUseSiteMin)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamUseSiteValidatorStack.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamUseSiteValidatorStack.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"ok\":true,\"failFactoryMax\":false,\"failUseSiteMin\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A use-site @validate stacked on a value-param alias reference runs alongside the factory's own validator chain; both the factory bound and the use-site bound are enforced."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Makes `@validate` on a value-parameterized type alias (e.g. `NumberInRange(low, high)` in `std::types`) resolve its validator functions in the alias's **defining** module. Importing the alias from another module now validates correctly without injecting anything into the consumer's scope.

### The problem

Value-parameterized validated aliases previously emitted **nothing** at their definition site and inlined a fresh validator chain at every use site — leaking bare `min`/`max` identifiers into the consumer's scope. This caused:
- a crash (`ReferenceError`) if the consumer didn't import the validators, and
- a **silent wrong-answer** if the consumer defined its own same-named `min`/`max` (validation would bind to the wrong function).

### The fix

Emit a **descriptor factory function** in the alias's own module, where the validators are already in scope:

```js
export function NumberInRange(low, high) {
  return { kind: "leaf", schema: z.number().meta({ minimum: low, maximum: high }),
           validators: [min.partial({ n: low }), max.partial({ n: high })] };
}
```

Use sites just **call** it: `__validateChainRecursive(v, NumberInRange(1, 10))`. This mirrors how bare validated aliases already work (their `__agency_descriptor` const lives in the defining module).

## Changes

- **Task 1** — `processTypeAlias` emits an (exported) descriptor factory for validated value-param aliases, with value-param **defaults baked into the factory signature** (`function Age(low = 0)`) so omitted args still resolve.
- **Task 2** — use sites of validated value-param aliases reference the factory by **call** instead of inlining; use-site `@validate` validators concatenate on top.
- **Task 4** — validated value-param aliases are now **importable** (factory is exported); they are never registered as LLM tools.
- **Bug fix found during execution** — building a *forwarding* alias's factory body (`type AdultAge(high) = NumberInRange(18, high)`) must **not** deep-resolve/substitute the body. Doing so tripped `applyValueArgs`'s unsubstituted-param guard when a forwarded name collided with the inner param name (`high` → `high`), and would have re-introduced the cross-module leak. The body is now passed unresolved so nested value-param refs become nested factory **calls**. `hasAnyValidateTag` no longer calls `applyValueArgs` (presence of `@validate` is substitution-invariant). Surfaced by the `valueParamPartialForwarding` / `valueParamWrappingAlias` fixtures.

## Tests

New agency execution fixtures under `tests/agency/validation/`:
- `valueParamFactoryLocal` — local value-param validated alias validates end-to-end.
- `stdTypesValueParamImport` — importing `NumberInRange`/`StringWithLength` from `std::types` validates correctly; no `min`/`max` leak.
- `valueParamImportLocalShadow` — a consumer-defined `min` cannot hijack an imported alias's validation (the core motivation; `tooLow:false`).
- `valueParamForwardImported` — a forwarding alias over an imported value-param alias validates via nested factory calls.

New unit tests in `typescriptBuilder.integration.test.ts` cover factory emission, default-in-signature, schema-identifier survival (`@jsonSchema`), and use-site call.

## Verification

- `pnpm test:run` — **6104 passed**, 0 failed.
- Full `tests/agency/validation` agency suite — **83 passed**, 0 failed.
- `pnpm run lint:structure` — clean.
- `make` — builds clean (stdlib recompiled with the new factories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
