### PR TITLE
Finish & harden optimizers: expected-aware default judge, breakdown + validation parity

### DIFF
--- a/packages/agency-lang/docs/dev/writing-optimizers.md
+++ b/packages/agency-lang/docs/dev/writing-optimizers.md
@@ -140,13 +140,19 @@ This renders, per input, the args, the **output**, the **`expected`** answer (wh
 
 ## Validation
 
-`this.validationInputs` is the held-out set (empty if none). Search on `inputs`; if you support validation-based selection, score candidates on the validation set with `scoreFiles(source, files, this.validationInputs)` and pick the champion by that objective. Greedy does this; `gepa`/`example` select on training and emit a `reporter.note` when a validation set was provided but unused — do the same if your optimizer doesn't use it, so behavior isn't silently dropped.
+`this.validationInputs` is the held-out set (empty if none). Search on `inputs`, then pick the writeback champion by validation with the shared helper:
+
+```ts
+const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
+```
+
+`pickValidationChampion` (on `BaseOptimizer`) takes your candidate list (e.g. `[baseline, ...accepted]`) and the train champion; with a validation set it scores each candidate via `scoreFiles(source, files, this.validationInputs)` and returns the best, else returns the train champion. All three built-ins (`greedy`, `gepa`, `example`) use it. If your optimizer deliberately ignores validation it just won't set `result.validationObjective`, and the report notes that a validation set was provided but unused — so the behavior isn't silently dropped.
 
 Record both numbers on the result for the report:
 
 ```ts
 result.trainObjective = champion.scorecard.objective();
-result.validationObjective = /* best validation objective, if used */;
+if (validationObjective !== undefined) result.validationObjective = validationObjective;
 ```
 
 ## Reporting and the result

--- a/packages/agency-lang/docs/site/cli/optimize.md
+++ b/packages/agency-lang/docs/site/cli/optimize.md
@@ -140,7 +140,7 @@ Also returns a binary pass/fail like exact match, but this one checks to see if 
 Calculates the levenshtein distance and returns a score between 0 and 1 (0 = no match, 1 = perfect match).
 
 #### LLM Judge
-Asks an LLM to return a score between 0 and 1 (0 = no match, 1 = perfect match) for how well the response matches the expected output.
+Asks an LLM to return a score between 0 and 1 (0 = no match, 1 = perfect match) for how well the response matches the goal — and, when an input sets `expected`, grades against that gold answer too (so `expected` tightens the default judge even without a custom grader).
 
 This is the default grader.
 
@@ -235,7 +235,7 @@ Every grade counts: a number contributes its value (0..1), and a boolean / `Exac
 
 ## Validation sets
 
-Pass `--validation-inputs <file|dir>` to grade the champion against held-out inputs, or `--validation-split <ratio>` to hold out a seeded fraction of `--inputs`. Search and candidate acceptance run on the **training** inputs; with the default `greedy` optimizer the champion written back is the one with the best **validation** objective, and `report.md` shows train-vs-validation side by side so an overfit prompt (high train, flat validation) is visible.
+Pass `--validation-inputs <file|dir>` to grade the champion against held-out inputs, or `--validation-split <ratio>` to hold out a seeded fraction of `--inputs`. Search and candidate acceptance run on the **training** inputs; the champion written back is the one with the best **validation** objective, and `report.md` shows train-vs-validation side by side so an overfit prompt (high train, flat validation) is visible. All built-in optimizers (`greedy`, `gepa`, `example`) select by validation; a custom optimizer that doesn't will say so in the report.
 
 ## Configuration
 

--- a/packages/agency-lang/lib/agents/eval/goalJudge.agency
+++ b/packages/agency-lang/lib/agents/eval/goalJudge.agency
@@ -3,16 +3,19 @@ type GoalVerdict = {
   reasoning: string # brief explanation for the score
 }
 
-node main(goal: string, output: string): GoalVerdict {
+node main(goal: string, output: string, expected: string = ""): GoalVerdict {
   result: GoalVerdict = llm("You are a strict evaluation judge. Score how well the agent output satisfies the goal.
 
 Goal: ${goal}
+
+Expected answer (authoritative when non-empty; ignore this line if blank): ${expected}
 
 Agent output: ${output}
 
 Score from 0.0 to 1.0, where 1.0 means the output fully and directly satisfies the goal, and 0.0 means it does not satisfy it at all.
 
 Judge ONLY whether the output is a correct, direct answer to what the goal asks for. Apply these rules strictly:
+- If an expected answer is given above, the output must state that answer to score above 0.5; an output that omits it, contradicts it, or gives a different value scores near 0.0.
 - Grade what the output actually claims, on its own terms. If the output answers a different question than the goal asks (e.g. the goal asks for a capital but the output gives an area, population, or some other property), score it near 0.0 — even if the correct answer happens to appear somewhere in the text.
 - Do NOT give credit merely because the target word or phrase is present. A correct token buried in an otherwise wrong, off-topic, or contradictory answer does not satisfy the goal.
 - Penalize outputs that dump extra unrequested information, list multiple candidate answers, or hedge instead of committing to the single answer the goal asks for. The output must stand alone as the answer a user actually wanted.

--- a/packages/agency-lang/lib/cli/eval/optimize.ts
+++ b/packages/agency-lang/lib/cli/eval/optimize.ts
@@ -61,13 +61,16 @@ export async function evalOptimize(
   if (result.runDir) {
     fs.mkdirSync(result.runDir, { recursive: true });
     fs.writeFileSync(path.join(result.runDir, "summary.json"), JSON.stringify(result, null, 2));
-    const ignoresValidation = optimizer.name !== "greedy";   // only greedy selects by validation
+    // A validation set was provided but the optimizer didn't select on it (it
+    // produced no validation objective) — true for a custom optimizer that ignores it.
+    const validationConfiguredButUnused =
+      (target.validationInputs?.length ?? 0) > 0 && result.validationObjective === undefined;
     writeReport(result.runDir, result, {
       optimizer: optimizer.name,
       graders: config.graders.map((g) => g.name()),
       trainObjective: result.trainObjective,
       validationObjective: result.validationObjective,
-      validationConfiguredButUnused: ignoresValidation && (target.validationInputs?.length ?? 0) > 0,
+      validationConfiguredButUnused,
     });
   }
   return result;

--- a/packages/agency-lang/lib/optimize/baseOptimizer.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.ts
@@ -147,6 +147,27 @@ export abstract class BaseOptimizer {
     return this.evaluate(ws, source.entryFile, inputs);
   }
 
+  /** Choose the writeback champion among candidates: the one with the best
+   *  validation objective when a validation set exists, else the given train
+   *  champion. Scoring (the "how") is separated from the max selection (the
+   *  "what"); shared by the pointwise optimizers so validation selection lives
+   *  in one place. */
+  protected async pickValidationChampion<C extends { files: Record<string, string>; scorecard: Scorecard }>(
+    source: OptimizeTargetSet,
+    candidates: C[],
+    trainChampion: C,
+  ): Promise<{ champion: C; validationObjective?: number }> {
+    if (this.validationInputs.length === 0) return { champion: trainChampion };
+    const scored = await Promise.all(
+      candidates.map(async (candidate) => {
+        const sc = await this.scoreFiles(source, candidate.files, this.validationInputs);
+        return { candidate, objective: sc.gatesPassed() ? sc.objective() : 0 };
+      }),
+    );
+    const winner = scored.reduce((best, s) => (s.objective > best.objective ? s : best));
+    return { champion: winner.candidate, validationObjective: winner.objective };
+  }
+
   /** Run the agent once per input (cached by (workspace,input)), grade each, return a Scorecard. */
   protected async evaluate(ws: Workspace, entryFile: string, inputs: Input[]): Promise<Scorecard> {
     const perInput = await Promise.all(

--- a/packages/agency-lang/lib/optimize/baseOptimizer.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { evalRunLoadedInputs, optimizeEvalRecordExtractor, resolveEvalRunTarget } from "@/cli/eval/run.js";
 
 import { EvalCache } from "./evalCache.js";
+import { breakdown } from "./gradeBreakdown.js";
 import { AgencyRunner } from "./grading/agencyRunner.js";
 import type { BaseGrader } from "./grading/baseGrader.js";
 import { Scorecard, type GraderGrade, type InputGrades } from "./grading/scorecard.js";
@@ -158,14 +159,41 @@ export abstract class BaseOptimizer {
     trainChampion: C,
   ): Promise<{ champion: C; validationObjective?: number }> {
     if (this.validationInputs.length === 0) return { champion: trainChampion };
+    // Always consider the train champion, even if a caller forgot to include it.
+    const pool = candidates.includes(trainChampion) ? candidates : [trainChampion, ...candidates];
     const scored = await Promise.all(
-      candidates.map(async (candidate) => {
+      pool.map(async (candidate) => {
         const sc = await this.scoreFiles(source, candidate.files, this.validationInputs);
         return { candidate, objective: sc.gatesPassed() ? sc.objective() : 0 };
       }),
     );
+    // pool always has the train champion, so reduce has at least one element.
     const winner = scored.reduce((best, s) => (s.objective > best.objective ? s : best));
     return { champion: winner.candidate, validationObjective: winner.objective };
+  }
+
+  /** The shared tail every pointwise optimizer runs: pick the writeback champion
+   *  (by validation when configured), write it back, build the result with its
+   *  train/validation objectives + grade breakdown, and report completion. An
+   *  optimizer's job is just to produce the candidates and per-iteration attempts;
+   *  this turns them into the final OptimizeResult. */
+  protected async finishPointwise<C extends { iter: number | "baseline"; files: Record<string, string>; scorecard: Scorecard; targetSet: OptimizeTargetSet }>(
+    source: OptimizeTargetSet,
+    candidates: C[],
+    trainChampion: C,
+    attempts: { iter: number; decision: OptimizeDecision; detail?: string }[],
+    startedAt: number,
+  ): Promise<OptimizeResult> {
+    const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
+    if (this.config.writeback && champion.iter !== "baseline") this.workspace.writeBack(source, champion.files);
+    const result = this.buildPointwiseResult({ championIter: champion.iter, championFiles: champion.files, attempts });
+    result.trainObjective = champion.scorecard.objective();
+    if (validationObjective !== undefined) result.validationObjective = validationObjective;
+    result.championBreakdown = breakdown(champion.scorecard);
+    this.reporter.runFinished({
+      result, initialTargets: source.targets, finalTargets: champion.targetSet.targets, durationMs: Date.now() - startedAt,
+    });
+    return result;
   }
 
   /** Run the agent once per input (cached by (workspace,input)), grade each, return a Scorecard. */

--- a/packages/agency-lang/lib/optimize/grading/functionGrader.test.ts
+++ b/packages/agency-lang/lib/optimize/grading/functionGrader.test.ts
@@ -43,6 +43,30 @@ describe("FunctionGrader", () => {
     expect(runStructured).toHaveBeenCalledTimes(1);
   });
 
+  it("ctx.judge forwards input.expected as the third judge arg by default", async () => {
+    const runStructured = vi.fn(async () => ({ score: 1, reasoning: "" }));
+    const input: GraderInput = {
+      input: { id: "a", args: {}, expected: "New Delhi" },
+      run: { output: "New Delhi", recordPath: "" },
+      runAgency: { runStructured } as unknown as AgencyRunner,
+    };
+    const g = new FunctionGrader(async ({ judge }) => (await judge({ goal: "capital" })).score);
+    await g.run(input);
+    expect(runStructured.mock.calls[0][2]).toEqual(["capital", "New Delhi", "New Delhi"]);
+  });
+
+  it("ctx.judge lets the caller override expected explicitly", async () => {
+    const runStructured = vi.fn(async () => ({ score: 1, reasoning: "" }));
+    const input: GraderInput = {
+      input: { id: "a", args: {}, expected: "New Delhi" },
+      run: { output: "Mumbai", recordPath: "" },
+      runAgency: { runStructured } as unknown as AgencyRunner,
+    };
+    const g = new FunctionGrader(async ({ judge }) => (await judge({ goal: "capital", expected: "Delhi" })).score);
+    await g.run(input);
+    expect(runStructured.mock.calls[0][2]).toEqual(["capital", "Mumbai", "Delhi"]);
+  });
+
   it("grader() attaches policy options (mustPass/name) to the wrapped function", () => {
     const g = grader(() => 1, { mustPass: true, name: "exact" });
     expect(g.mustPass()).toBe(true);

--- a/packages/agency-lang/lib/optimize/grading/functionGrader.ts
+++ b/packages/agency-lang/lib/optimize/grading/functionGrader.ts
@@ -9,8 +9,11 @@ import type { Grade, GraderInput, GraderOptions, Input, JSON } from "./types.js"
 export type GraderContext = {
   output: JSON;
   input: Input;
-  /** Run the bundled LLM goal judge and get back its 0..1 score + reasoning. */
-  judge: (args: { goal: string; output?: JSON }) => Promise<{ score: number; reasoning: string }>;
+  /** Run the bundled LLM goal judge and get back its 0..1 score + reasoning.
+   *  Defaults: `output` falls back to `run.output`, `expected` falls back to
+   *  `input.expected` (so the bundled judge grades against the gold answer when
+   *  one is present, matching `LlmJudge`). */
+  judge: (args: { goal: string; output?: JSON; expected?: JSON }) => Promise<{ score: number; reasoning: string }>;
 };
 
 /** A metric: return a 0..1 number, a pass/fail boolean, or a full Grade. */
@@ -28,8 +31,17 @@ export class FunctionGrader extends BaseGrader {
   }
 
   protected async _run({ input, run, runAgency }: GraderInput): Promise<Grade> {
-    const judge = ({ goal, output }: { goal: string; output?: JSON }) =>
-      runAgency.runStructured(goalJudgeFile(), "main", [goal, asJudgeText(output ?? run.output)], ScalarVerdict);
+    // The bundled judge takes (goal, output, expected); default expected to the
+    // input's gold answer so a metric that calls ctx.judge({ goal }) grades the
+    // same way LlmJudge does when input.expected is present.
+    const inputExpected = (input as { expected?: JSON }).expected;
+    const judge = ({ goal, output, expected }: { goal: string; output?: JSON; expected?: JSON }) => {
+      const exp = expected ?? inputExpected;
+      const expectedText = exp === undefined || exp === null ? "" : asJudgeText(exp);
+      return runAgency.runStructured(
+        goalJudgeFile(), "main", [goal, asJudgeText(output ?? run.output), expectedText], ScalarVerdict,
+      );
+    };
     const result = await this.fn({ output: run.output, input, judge });
     return coerce(result);
   }

--- a/packages/agency-lang/lib/optimize/grading/graders/llmJudge.test.ts
+++ b/packages/agency-lang/lib/optimize/grading/graders/llmJudge.test.ts
@@ -42,7 +42,7 @@ describe("LlmJudge", () => {
     const grade = await judge.run({ input: { id: "a", args: {} }, run: { output: "Paris", recordPath: "" }, runAgency });
     expect(grade.score).toEqual({ kind: "scalar", value: 0.8 });
     expect(captured?.agencyFile.endsWith("eval/goalJudge.agency")).toBe(true);   // default file
-    expect(captured?.argsString).toBe('"Return the capital.", "Paris"');         // inline goal, not from input
+    expect(captured?.argsString).toBe('"Return the capital.", "Paris", ""');     // inline goal; no expected → ""
   });
 
   it("reads the goal from the input via goalPath when no inline goal is given", async () => {
@@ -53,6 +53,17 @@ describe("LlmJudge", () => {
     });
     const judge = new LlmJudge({});   // default goalPath ["goal"]
     await judge.run({ input: { id: "a", args: {}, goal: "from input" }, run: { output: "x", recordPath: "" }, runAgency });
-    expect(captured).toBe('"from input", "x"');
+    expect(captured).toBe('"from input", "x", ""');
+  });
+
+  it("passes the input's expected answer to the judge as the third arg", async () => {
+    let captured: string | undefined;
+    const runAgency = new AgencyRunner({}, async (a) => {
+      captured = a.argsString;
+      return { data: { score: 1, reasoning: "" } };
+    });
+    const judge = new LlmJudge({ goal: "Return the capital." });   // default expectedPath ["expected"]
+    await judge.run({ input: { id: "a", args: {}, expected: "New Delhi" }, run: { output: "New Delhi", recordPath: "" }, runAgency });
+    expect(captured).toBe('"Return the capital.", "New Delhi", "New Delhi"');
   });
 });

--- a/packages/agency-lang/lib/optimize/grading/graders/llmJudge.ts
+++ b/packages/agency-lang/lib/optimize/grading/graders/llmJudge.ts
@@ -6,11 +6,12 @@ import { getPath } from "../getPath.js";
 import type { Grade, GraderInput, GraderOptions, JSONPath } from "../types.js";
 
 type LlmJudgeOptions = GraderOptions & {
-  agencyFile?: string;  // judge .agency file (default: the bundled goal judge)
-  goal?: string;        // fixed goal for every input (overrides goalPath)
-  goalPath?: JSONPath;  // where to read the goal from the input (default ["goal"])
-  binary?: boolean;     // expect a pass/fail verdict instead of a 0..1 score
-  node?: string;        // judge node (default "main")
+  agencyFile?: string;     // judge .agency file (default: the bundled goal judge)
+  goal?: string;           // fixed goal for every input (overrides goalPath)
+  goalPath?: JSONPath;     // where to read the goal from the input (default ["goal"])
+  expectedPath?: JSONPath; // where to read the gold answer (default ["expected"]); passed to the judge
+  binary?: boolean;        // expect a pass/fail verdict instead of a 0..1 score
+  node?: string;           // judge node (default "main")
 };
 
 const BinaryVerdict = z.object({ pass: z.boolean(), reasoning: z.string() });
@@ -35,7 +36,11 @@ export class LlmJudge extends BaseGrader {
     // Judges take a string output; stringify structured outputs so they read as JSON
     // rather than "[object Object]".
     const output = asJudgeText(run.output);
-    const args = [String(goal), output];
+    // The gold answer, when the input carries one — the bundled judge grades against
+    // it. Empty string when absent; a custom judge node that ignores it is unaffected.
+    const expectedRaw = getPath(input, this.options.expectedPath ?? ["expected"]);
+    const expected = expectedRaw === undefined || expectedRaw === null ? "" : asJudgeText(expectedRaw);
+    const args = [String(goal), output, expected];
     const node = this.options.node ?? "main";
     if (this.options.binary) {
       const v = await runAgency.runStructured(agencyFile, node, args, BinaryVerdict);

--- a/packages/agency-lang/lib/optimize/optimizers/example.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/example.test.ts
@@ -64,6 +64,18 @@ describe("ExampleOptimizer", () => {
     const result = await run(opt);
     expect(result.championIter).toBe(1);
     expect(result.acceptedCount).toBe(1);
+    expect(result.championBreakdown?.length).toBeGreaterThan(0);   // breakdown now emitted
+  });
+
+  it("reports a validation objective and breakdown when a validation set is given", async () => {
+    const opt = new ExampleOptimizer(config([new QueueGrader([0.2, 0.9, 0.5, 0.6])], "val"), deps());
+    const result = await opt.optimize({
+      agent: path.join(src, "agent.agency"),
+      inputs: [{ id: "a", args: {} }],
+      validationInputs: [{ id: "v", args: {} }],
+    });
+    expect(typeof result.validationObjective).toBe("number");
+    expect(result.championBreakdown?.length).toBeGreaterThan(0);
   });
 
   it("keeps the baseline when the candidate does not beat it", async () => {

--- a/packages/agency-lang/lib/optimize/optimizers/example.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/example.ts
@@ -1,10 +1,20 @@
 import { BaseOptimizer, type BaseOptimizerDeps } from "../baseOptimizer.js";
+import { breakdown } from "../gradeBreakdown.js";
+import type { Scorecard } from "../grading/scorecard.js";
 import type { Input } from "../grading/types.js";
 import { proposeMutation, type ProposeMutationArgs } from "../mutator.js";
 import type { BaseOptimizerConfig } from "../optimizer.js";
 import { defaultPreview, type OptimizeMutationOperation, type OptimizeMutationPreview } from "../sourceMutator.js";
 import { fileMap, type OptimizeTargetSet } from "../targets.js";
 import type { MutationProposal, OptimizeResult } from "../types.js";
+
+/** A scored point in the search: its file set + the Scorecard it earned. */
+type Candidate = { iter: number | "baseline"; files: Record<string, string>; scorecard: Scorecard };
+
+/** Gate-aware objective: a failed must-pass gate scores 0. */
+function objectiveOf(scorecard: Scorecard): number {
+  return scorecard.gatesPassed() ? scorecard.objective() : 0;
+}
 
 /**
  * Optional injection points, so the optimizer can be unit-tested without an LLM
@@ -24,17 +34,18 @@ export type ExampleDeps = BaseOptimizerDeps & {
  * search for better target values and return the best candidate.
  *
  * This one runs a single round: score the agent as-is, ask the built-in mutator
- * for one new set of values, score those, and keep whichever scored higher. The
- * real optimizers (greedy, gepa) loop and search more cleverly, but they all
- * follow the same shape — fork → apply → evaluate → compare → report → return.
+ * for one new set of values, score those, and keep the candidate if it beats the
+ * baseline. The real optimizers (greedy, gepa) loop and search more cleverly, but
+ * they all follow the same shape — fork → apply → evaluate → compare → report → return.
  *
  * Protected helpers available from BaseOptimizer:
- *   - `this.fork(dir)` — copy the agent into an isolated workspace
- *   - `this.workspace.applyFiles(ws, files)` — write candidate files into it
- *   - `this.evaluate(ws, entryFile, inputs)` — run + grade, returns a Scorecard
+ *   - `this.scoreFiles(source, files, inputs)` — fork + apply + grade, returns a Scorecard
+ *   - `this.pickValidationChampion(source, candidates, trainChampion)` — choose the
+ *     writeback champion by validation objective when a validation set exists
  *   - `this.reporter` — progress output (silent unless the CLI sets verbosity)
  *   - `this.buildPointwiseResult(...)` — package the OptimizeResult
  *   - `this.config` — graders, runId, writeback, mutatorModel, …
+ * (and `breakdown(scorecard)` builds the per-input grade breakdown for the report.)
  *
  * Register it (see registry.ts):
  *   registerOptimizer("example", (config) => new ExampleOptimizer(config));
@@ -48,17 +59,14 @@ export class ExampleOptimizer extends BaseOptimizer {
 
   protected async optimizeTargets(source: OptimizeTargetSet, inputs: Input[]): Promise<OptimizeResult> {
     const startedAt = Date.now();
-    if (this.validationInputs.length > 0) {
-      this.reporter.note(`validation set provided, but ${this.name} selects the champion on the training objective`);
-    }
     this.reporter.runStarted({
       optimizer: this.name, runId: this.config.runId,
       targets: source.targets, inputCount: inputs.length, iterations: 1,
     });
 
     // 1. Score the unchanged agent.
-    const baseline = await this.score(source, fileMap(source), inputs);
-    this.reporter.baselineScored({ objective: baseline });
+    const baseline = await this.candidate("baseline", fileMap(source), source, inputs);
+    this.reporter.baselineScored({ objective: objectiveOf(baseline.scorecard) });
 
     // 2. Ask the built-in mutator for one new set of target values. proposeValidMutation
     //    (from BaseOptimizer) retries on validation errors and never throws on a bad response.
@@ -74,36 +82,37 @@ export class ExampleOptimizer extends BaseOptimizer {
       (operations) => (this.exampleDeps.preview ?? defaultPreview)(source, operations),
     );
 
-    // 3. If we got a valid proposal, score it and keep it only if it beats the baseline.
+    // 3. Keep the candidate only if it beats the baseline on the training objective.
+    const candidates: Candidate[] = [baseline];
+    let decision: "accepted" | "rejected" = "rejected";
     if (outcome.ok) {
-      const candidate = await this.score(source, outcome.preview.files, inputs);
-      if (candidate > baseline) {
-        if (this.config.writeback) this.workspace.writeBack(source, outcome.preview.files);
-        this.reporter.iterationDecided({ iter: 1, total: 1, decision: "accepted", objective: candidate, changes: outcome.preview.changes, rationale: outcome.rationale });
-        return this.result(source, 1, outcome.preview.files, "accepted", startedAt);
+      const candidate = await this.candidate(1, outcome.preview.files, source, inputs);
+      if (objectiveOf(candidate.scorecard) > objectiveOf(baseline.scorecard)) {
+        candidates.push(candidate);
+        decision = "accepted";
+        this.reporter.iterationDecided({ iter: 1, total: 1, decision: "accepted", objective: objectiveOf(candidate.scorecard), changes: outcome.preview.changes, rationale: outcome.rationale });
       }
     }
+    if (decision === "rejected") {
+      this.reporter.iterationDecided({ iter: 1, total: 1, decision: "rejected", objective: objectiveOf(baseline.scorecard) });
+    }
 
-    // 4. Otherwise keep the original.
-    this.reporter.iterationDecided({ iter: 1, total: 1, decision: "rejected", objective: baseline });
-    return this.result(source, "baseline", fileMap(source), "rejected", startedAt);
-  }
-
-  /** Apply a candidate file set into a fresh workspace, run + grade it; return its objective (0 if a gate fails). */
-  private async score(source: OptimizeTargetSet, files: Record<string, string>, inputs: Input[]): Promise<number> {
-    const scorecard = await this.scoreFiles(source, files, inputs);
-    return scorecard.gatesPassed() ? scorecard.objective() : 0;
-  }
-
-  private result(
-    source: OptimizeTargetSet,
-    championIter: number | "baseline",
-    championFiles: Record<string, string>,
-    decision: "accepted" | "rejected",
-    startedAt: number,
-  ): OptimizeResult {
-    const result = this.buildPointwiseResult({ championIter, championFiles, attempts: [{ iter: 1, decision }] });
+    // 4. Pick the writeback champion by validation objective when a validation set
+    //    exists (else the train winner), then package the result.
+    const trainChampion = candidates[candidates.length - 1];
+    const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
+    if (this.config.writeback && champion.iter !== "baseline") this.workspace.writeBack(source, champion.files);
+    const result = this.buildPointwiseResult({ championIter: champion.iter, championFiles: champion.files, attempts: [{ iter: 1, decision }] });
+    result.trainObjective = objectiveOf(champion.scorecard);
+    if (validationObjective !== undefined) result.validationObjective = validationObjective;
+    result.championBreakdown = breakdown(champion.scorecard);
     this.reporter.runFinished({ result, initialTargets: source.targets, finalTargets: source.targets, durationMs: Date.now() - startedAt });
     return result;
+  }
+
+  /** Apply a candidate file set into a fresh workspace, run + grade it. */
+  private async candidate(iter: number | "baseline", files: Record<string, string>, source: OptimizeTargetSet, inputs: Input[]): Promise<Candidate> {
+    const scorecard = await this.scoreFiles(source, files, inputs);
+    return { iter, files, scorecard };
   }
 }

--- a/packages/agency-lang/lib/optimize/optimizers/example.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/example.ts
@@ -1,5 +1,4 @@
 import { BaseOptimizer, type BaseOptimizerDeps } from "../baseOptimizer.js";
-import { breakdown } from "../gradeBreakdown.js";
 import type { Scorecard } from "../grading/scorecard.js";
 import type { Input } from "../grading/types.js";
 import { proposeMutation, type ProposeMutationArgs } from "../mutator.js";
@@ -9,11 +8,16 @@ import { fileMap, type OptimizeTargetSet } from "../targets.js";
 import type { MutationProposal, OptimizeResult } from "../types.js";
 
 /** A scored point in the search: its file set + the Scorecard it earned. */
-type Candidate = { iter: number | "baseline"; files: Record<string, string>; scorecard: Scorecard };
+type Candidate = {
+  iter: number | "baseline";
+  files: Record<string, string>;
+  scorecard: Scorecard;
+  targetSet: OptimizeTargetSet;
+};
 
-/** Gate-aware objective: a failed must-pass gate scores 0. */
-function objectiveOf(scorecard: Scorecard): number {
-  return scorecard.gatesPassed() ? scorecard.objective() : 0;
+/** Gate-aware objective used to compare candidates on the training set. */
+function trainScore(c: Candidate): number {
+  return c.scorecard.gatesPassed() ? c.scorecard.objective() : 0;
 }
 
 /**
@@ -40,12 +44,11 @@ export type ExampleDeps = BaseOptimizerDeps & {
  *
  * Protected helpers available from BaseOptimizer:
  *   - `this.scoreFiles(source, files, inputs)` — fork + apply + grade, returns a Scorecard
- *   - `this.pickValidationChampion(source, candidates, trainChampion)` — choose the
- *     writeback champion by validation objective when a validation set exists
+ *   - `this.finishPointwise(source, candidates, trainChampion, attempts, startedAt)` —
+ *     pick the writeback champion (by validation when configured), write it back,
+ *     and build the OptimizeResult with train/validation objectives + breakdown
  *   - `this.reporter` — progress output (silent unless the CLI sets verbosity)
- *   - `this.buildPointwiseResult(...)` — package the OptimizeResult
  *   - `this.config` — graders, runId, writeback, mutatorModel, …
- * (and `breakdown(scorecard)` builds the per-input grade breakdown for the report.)
  *
  * Register it (see registry.ts):
  *   registerOptimizer("example", (config) => new ExampleOptimizer(config));
@@ -65,8 +68,8 @@ export class ExampleOptimizer extends BaseOptimizer {
     });
 
     // 1. Score the unchanged agent.
-    const baseline = await this.candidate("baseline", fileMap(source), source, inputs);
-    this.reporter.baselineScored({ objective: objectiveOf(baseline.scorecard) });
+    const baseline = await this.makeCandidate("baseline", fileMap(source), source, inputs);
+    this.reporter.baselineScored({ objective: trainScore(baseline) });
 
     // 2. Ask the built-in mutator for one new set of target values. proposeValidMutation
     //    (from BaseOptimizer) retries on validation errors and never throws on a bad response.
@@ -82,37 +85,30 @@ export class ExampleOptimizer extends BaseOptimizer {
       (operations) => (this.exampleDeps.preview ?? defaultPreview)(source, operations),
     );
 
-    // 3. Keep the candidate only if it beats the baseline on the training objective.
-    const candidates: Candidate[] = [baseline];
-    let decision: "accepted" | "rejected" = "rejected";
-    if (outcome.ok) {
-      const candidate = await this.candidate(1, outcome.preview.files, source, inputs);
-      if (objectiveOf(candidate.scorecard) > objectiveOf(baseline.scorecard)) {
-        candidates.push(candidate);
-        decision = "accepted";
-        this.reporter.iterationDecided({ iter: 1, total: 1, decision: "accepted", objective: objectiveOf(candidate.scorecard), changes: outcome.preview.changes, rationale: outcome.rationale });
-      }
-    }
-    if (decision === "rejected") {
-      this.reporter.iterationDecided({ iter: 1, total: 1, decision: "rejected", objective: objectiveOf(baseline.scorecard) });
-    }
+    // 3. Score the proposal (if any) and decide acceptance on the training objective.
+    const candidate = outcome.ok
+      ? await this.makeCandidate(1, outcome.preview.files, source, inputs)
+      : undefined;
+    const beatsBaseline = candidate !== undefined && trainScore(candidate) > trainScore(baseline);
+    const trainChampion = beatsBaseline ? candidate : baseline;
+    const decision = beatsBaseline ? "accepted" : "rejected";
 
-    // 4. Pick the writeback champion by validation objective when a validation set
-    //    exists (else the train winner), then package the result.
-    const trainChampion = candidates[candidates.length - 1];
-    const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
-    if (this.config.writeback && champion.iter !== "baseline") this.workspace.writeBack(source, champion.files);
-    const result = this.buildPointwiseResult({ championIter: champion.iter, championFiles: champion.files, attempts: [{ iter: 1, decision }] });
-    result.trainObjective = objectiveOf(champion.scorecard);
-    if (validationObjective !== undefined) result.validationObjective = validationObjective;
-    result.championBreakdown = breakdown(champion.scorecard);
-    this.reporter.runFinished({ result, initialTargets: source.targets, finalTargets: source.targets, durationMs: Date.now() - startedAt });
-    return result;
+    this.reporter.iterationDecided({
+      iter: 1, total: 1, decision, objective: trainScore(trainChampion),
+      ...(beatsBaseline && outcome.ok
+        ? { changes: outcome.preview.changes, rationale: outcome.rationale }
+        : {}),
+    });
+
+    // 4. Pick the writeback champion (by validation when configured), write it back,
+    //    build the result with train/validation objectives + breakdown, and report.
+    const candidates = beatsBaseline ? [baseline, candidate] : [baseline];
+    return this.finishPointwise(source, candidates, trainChampion, [{ iter: 1, decision }], startedAt);
   }
 
   /** Apply a candidate file set into a fresh workspace, run + grade it. */
-  private async candidate(iter: number | "baseline", files: Record<string, string>, source: OptimizeTargetSet, inputs: Input[]): Promise<Candidate> {
+  private async makeCandidate(iter: number | "baseline", files: Record<string, string>, source: OptimizeTargetSet, inputs: Input[]): Promise<Candidate> {
     const scorecard = await this.scoreFiles(source, files, inputs);
-    return { iter, files, scorecard };
+    return { iter, files, scorecard, targetSet: source };
   }
 }

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
@@ -156,4 +156,16 @@ describe("Gepa (reflective Pareto optimizer)", () => {
     // A full eval would add the 3rd input per child (+1 each) → 12. Rejection path = 3 + 3*2 = 9.
     expect(runInput).toHaveBeenCalledTimes(9);
   });
+
+  it("emits a champion grade breakdown and reports a validation objective when a validation set is given", async () => {
+    const runInput = vi.fn(scoredRunner([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]));
+    const opt = new Gepa(config({ runId: "val", iterations: 1 }), deps(runInput));
+    const result = await opt.optimize({
+      agent: path.join(src, "agent.agency"),
+      inputs: threeInputs,
+      validationInputs: [{ id: "v", args: {} }],
+    });
+    expect(result.championBreakdown?.length).toBeGreaterThan(0);   // #2: breakdown now emitted
+    expect(typeof result.validationObjective).toBe("number");      // #3: champion picked by validation
+  });
 });

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.ts
@@ -1,5 +1,6 @@
 import { BaseOptimizer, type BaseOptimizerDeps } from "../baseOptimizer.js";
 import { CandidatePool, type PoolCandidate } from "../candidatePool.js";
+import { breakdown } from "../gradeBreakdown.js";
 import { renderReflectionFeedback } from "../reflectionFeedback.js";
 import { proposeReflective, type ReflectionSections } from "../gepaReflect.js";
 import type { AgencyRunner } from "../grading/agencyRunner.js";
@@ -65,9 +66,6 @@ export class Gepa extends BaseOptimizer {
   }
 
   protected async optimizeTargets(source: OptimizeTargetSet, inputs: Input[]): Promise<OptimizeResult> {
-    if (this.validationInputs.length > 0) {
-      this.reporter.note(`validation set provided, but ${this.name} selects the champion on the training objective`);
-    }
     const paretoInputs = this.gepaConfig.paretoSet ?? inputs;
     const rng = makeRng(this.config.seed ?? 0);
 
@@ -82,21 +80,27 @@ export class Gepa extends BaseOptimizer {
 
     if (this.isMaxObjective(baseline.scorecard)) {
       this.reporter.note("baseline already scores the maximum objective (1.000) — nothing to optimize");
-      return this.finish(source, baseline, [], startedAt);
+      return this.finish(source, baseline, [baseline], [], startedAt);
     }
 
     const pool = new CandidatePool<Candidate>([toPoolCandidate(baseline)]);
     const attempts = await this.evolve(pool, inputs, paretoInputs, rng);
-    return this.finish(source, pool.best().value, attempts, startedAt);
+    const accepted = attempts.filter((a) => a.decision === "accepted" && a.candidate).map((a) => a.candidate!);
+    return this.finish(source, pool.best().value, [baseline, ...accepted], attempts, startedAt);
   }
 
-  /** Write back the champion (if enabled), build the result, and report completion. */
-  private finish(source: OptimizeTargetSet, champion: Candidate, attempts: Attempt[], startedAt: number): OptimizeResult {
+  /** Pick the writeback champion (best validation objective when a validation set
+   *  exists, else the train champion = Pareto best), write it back, build + report. */
+  private async finish(source: OptimizeTargetSet, trainChampion: Candidate, candidates: Candidate[], attempts: Attempt[], startedAt: number): Promise<OptimizeResult> {
+    const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
     if (this.config.writeback && champion.iter !== "baseline") this.workspace.writeBack(source, champion.files);
     const result = this.buildPointwiseResult({
       championIter: champion.iter, championFiles: champion.files,
       attempts: attempts.map((a) => ({ iter: a.iter, decision: a.decision, detail: attemptDetail(a) })),
     });
+    result.trainObjective = champion.scorecard.objective();
+    if (validationObjective !== undefined) result.validationObjective = validationObjective;
+    result.championBreakdown = breakdown(champion.scorecard);
     this.reporter.runFinished({
       result, initialTargets: source.targets, finalTargets: champion.targetSet.targets, durationMs: Date.now() - startedAt,
     });

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.ts
@@ -80,31 +80,16 @@ export class Gepa extends BaseOptimizer {
 
     if (this.isMaxObjective(baseline.scorecard)) {
       this.reporter.note("baseline already scores the maximum objective (1.000) — nothing to optimize");
-      return this.finish(source, baseline, [baseline], [], startedAt);
+      return this.finishPointwise(source, [baseline], baseline, [], startedAt);
     }
 
     const pool = new CandidatePool<Candidate>([toPoolCandidate(baseline)]);
     const attempts = await this.evolve(pool, inputs, paretoInputs, rng);
     const accepted = attempts.filter((a) => a.decision === "accepted" && a.candidate).map((a) => a.candidate!);
-    return this.finish(source, pool.best().value, [baseline, ...accepted], attempts, startedAt);
-  }
-
-  /** Pick the writeback champion (best validation objective when a validation set
-   *  exists, else the train champion = Pareto best), write it back, build + report. */
-  private async finish(source: OptimizeTargetSet, trainChampion: Candidate, candidates: Candidate[], attempts: Attempt[], startedAt: number): Promise<OptimizeResult> {
-    const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
-    if (this.config.writeback && champion.iter !== "baseline") this.workspace.writeBack(source, champion.files);
-    const result = this.buildPointwiseResult({
-      championIter: champion.iter, championFiles: champion.files,
-      attempts: attempts.map((a) => ({ iter: a.iter, decision: a.decision, detail: attemptDetail(a) })),
-    });
-    result.trainObjective = champion.scorecard.objective();
-    if (validationObjective !== undefined) result.validationObjective = validationObjective;
-    result.championBreakdown = breakdown(champion.scorecard);
-    this.reporter.runFinished({
-      result, initialTargets: source.targets, finalTargets: champion.targetSet.targets, durationMs: Date.now() - startedAt,
-    });
-    return result;
+    return this.finishPointwise(
+      source, [baseline, ...accepted], pool.best().value,
+      attempts.map((a) => ({ iter: a.iter, decision: a.decision, detail: attemptDetail(a) })), startedAt,
+    );
   }
 
   /** Run the optimization loop, threading the pool. */

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.ts
@@ -1,5 +1,4 @@
 import { BaseOptimizer, type BaseOptimizerDeps } from "../baseOptimizer.js";
-import { breakdown } from "../gradeBreakdown.js";
 import { proposeMutation, type ProposeMutationArgs } from "../mutator.js";
 import { renderReflectionFeedback } from "../reflectionFeedback.js";
 import type { Scorecard } from "../grading/scorecard.js";
@@ -56,39 +55,16 @@ export class GreedyReflective extends BaseOptimizer {
 
     if (this.isMaxObjective(baseline.scorecard)) {
       this.reporter.note("baseline already scores the maximum objective (1.000) — nothing to optimize");
-      return this.finish(source, baseline, [baseline], [], startedAt);
+      return this.finishPointwise(source, [baseline], baseline, [], startedAt);
     }
 
     const attempts = await this.hillClimb(baseline, inputs);
     const accepted = attempts.filter((a) => a.decision === "accepted" && a.candidate).map((a) => a.candidate!);
     const trainChampion = accepted.length ? accepted[accepted.length - 1] : baseline;
-    return this.finish(source, trainChampion, [baseline, ...accepted], attempts, startedAt);
-  }
-
-  /** Choose the writeback champion (validation objective when a validation set
-   *  exists, else the train champion), write it back, build + report the result. */
-  private async finish(
-    source: OptimizeTargetSet,
-    trainChampion: Candidate,
-    candidates: Candidate[],
-    attempts: Attempt[],
-    startedAt: number,
-  ): Promise<OptimizeResult> {
-    const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
-    if (this.config.writeback && champion.iter !== "baseline") {
-      this.workspace.writeBack(source, champion.files);
-    }
-    const result = this.buildPointwiseResult({
-      championIter: champion.iter, championFiles: champion.files,
-      attempts: attempts.map((a) => ({ iter: a.iter, decision: a.decision, detail: attemptDetail(a) })),
-    });
-    result.trainObjective = champion.scorecard.objective();
-    if (validationObjective !== undefined) result.validationObjective = validationObjective;
-    result.championBreakdown = breakdown(champion.scorecard);   // the headline DX artifact
-    this.reporter.runFinished({
-      result, initialTargets: source.targets, finalTargets: champion.targetSet.targets, durationMs: Date.now() - startedAt,
-    });
-    return result;
+    return this.finishPointwise(
+      source, [baseline, ...accepted], trainChampion,
+      attempts.map((a) => ({ iter: a.iter, decision: a.decision, detail: attemptDetail(a) })), startedAt,
+    );
   }
 
   /** The one place the champion is threaded across iterations. */

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.ts
@@ -74,7 +74,7 @@ export class GreedyReflective extends BaseOptimizer {
     attempts: Attempt[],
     startedAt: number,
   ): Promise<OptimizeResult> {
-    const { champion, validationObjective } = await this.pickChampion(source, trainChampion, candidates);
+    const { champion, validationObjective } = await this.pickValidationChampion(source, candidates, trainChampion);
     if (this.config.writeback && champion.iter !== "baseline") {
       this.workspace.writeBack(source, champion.files);
     }
@@ -89,25 +89,6 @@ export class GreedyReflective extends BaseOptimizer {
       result, initialTargets: source.targets, finalTargets: champion.targetSet.targets, durationMs: Date.now() - startedAt,
     });
     return result;
-  }
-
-  /** Pick the writeback champion. With no validation set, that is the train
-   *  champion. With one, score every candidate on validation (the "how") and
-   *  take the max (the "what") — no order-dependent mutable accumulation. */
-  private async pickChampion(
-    source: OptimizeTargetSet,
-    trainChampion: Candidate,
-    candidates: Candidate[],
-  ): Promise<{ champion: Candidate; validationObjective?: number }> {
-    if (this.validationInputs.length === 0) return { champion: trainChampion };
-    const scored = await Promise.all(
-      candidates.map(async (candidate) => {
-        const sc = await this.scoreFiles(source, candidate.files, this.validationInputs);
-        return { candidate, objective: sc.gatesPassed() ? sc.objective() : 0 };
-      }),
-    );
-    const winner = scored.reduce((best, s) => (s.objective > best.objective ? s : best));
-    return { champion: winner.candidate, validationObjective: winner.objective };
   }
 
   /** The one place the champion is threaded across iterations. */


### PR DESCRIPTION
## Summary

A focused "finish & harden" pass that makes the three shipped optimizer features (custom graders, validation sets, the DX report) behave **consistently across all built-in optimizers**, and closes a surprising gap in the default judge.

## What changed

1. **Default judge grades against `expected`.** Previously, setting `input.expected` without a custom grader was silently ignored — the built-in `LlmJudge` only used `goal`. Now the bundled `goalJudge` agent takes an optional `expected` param and `LlmJudge` passes the input's `expected` (default `expectedPath: ["expected"]`), so providing a gold answer tightens grading even with no custom grader. (Empty when absent; a custom judge node that ignores it is unaffected.)
2. **Champion grade breakdown for `gepa` and `example`.** Only `greedy` set `result.championBreakdown`, so `report.md`/`champion/grades.json` (the reward-hacking lens) were empty for the others. Now all three populate it.
3. **`gepa`/`example` select the champion by validation.** They previously reported a validation objective but still selected on train. Champion selection is now hoisted into a shared `BaseOptimizer.pickValidationChampion` helper that `greedy`, `gepa`, and `example` all use, so validation-based selection is uniform.

Supporting cleanup: the report's "validation provided but unused" note is now derived from whether a validation objective was produced (robust for custom optimizers that ignore validation), replacing the name-based heuristic. Docs (`optimize.md`, `writing-optimizers.md`) updated.

## Test plan

- [x] Unit: `LlmJudge` passes `expected` as the third judge arg; `gepa`/`example` emit `championBreakdown` and a `validationObjective` when a validation set is given; greedy's existing validation-selection test still passes through the shared helper.
- [x] `pnpm run build` (tsc + make, incl. recompiled `goalJudge`) clean; `pnpm run lint:structure` clean; 310 tests pass across `lib/optimize` + `lib/cli/eval`.
- [ ] Full agency execution suite — deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
