### PR TITLE
Fix optimizer creating an empty per-input workdir

### DIFF
--- a/packages/agency-lang/lib/optimize/baseOptimizer.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.ts
@@ -250,8 +250,13 @@ export abstract class BaseOptimizer {
   /** Default runInput: run the agent for one input via the eval-run subprocess path (named args). */
   private async runInputViaEval(ws: Workspace, entryFile: string, input: Input, id: string): Promise<AgentRun> {
     // Now that eval and optimize share the Input type, the input flows straight
-    // through — we only pin the id so artifacts land in a predictable directory.
-    const spec: Input = { ...input, id };
+    // through — we pin the id so artifacts land in a predictable directory, and
+    // default working_dir to the forked workspace. The workspace is a full copy
+    // of the source tree, so seeding each per-input workdir from it gives the
+    // agent an isolated copy of the project as its cwd; without this the workdir
+    // is created empty and relative file references (e.g. exec on a repo path)
+    // resolve against nothing. An input that names its own working_dir wins.
+    const spec: Input = { ...input, id, working_dir: input.working_dir ?? ws.dir };
     this.runCounter += 1;
     const result = await evalRunLoadedInputs({
       agent: path.join(ws.dir, entryFile),

--- a/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
@@ -1,0 +1,91 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BaseGrader } from "./grading/baseGrader.js";
+import type { Grade, GraderInput, GraderOptions, Input } from "./grading/types.js";
+import type { Scorecard } from "./grading/scorecard.js";
+import { BaseOptimizer } from "./baseOptimizer.js";
+import type { OptimizeResult } from "./types.js";
+
+// Capture the spec the default eval-run path hands to the eval runner so we can
+// assert it carries a working_dir (without spawning a real agent subprocess).
+const { mockEval } = vi.hoisted(() => ({ mockEval: vi.fn() }));
+vi.mock("@/cli/eval/run.js", () => ({
+  evalRunLoadedInputs: mockEval,
+  optimizeEvalRecordExtractor: {},
+  resolveEvalRunTarget: vi.fn(),
+}));
+
+class FixedGrader extends BaseGrader {
+  protected readonly defaultName = "fixed";
+  constructor(private readonly grade: Grade, options: GraderOptions = {}) { super(options); }
+  protected _run(_input: GraderInput): Promise<Grade> { return Promise.resolve(this.grade); }
+}
+
+/** Concrete subclass exposing `evaluate` so we can drive the default runInput path. */
+class Probe extends BaseOptimizer {
+  readonly name = "probe";
+  protected async optimizeTargets(): Promise<OptimizeResult> { return {} as OptimizeResult; }
+  evaluateAt(ws: ReturnType<Probe["fork"]>, entry: string, inputs: Input[]): Promise<Scorecard> {
+    return this.evaluate(ws, entry, inputs);
+  }
+  forkAt(dir: string) { return this.fork(dir); }
+}
+
+describe("BaseOptimizer.runInputViaEval working_dir", () => {
+  let root: string;
+  let src: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "bo-wd-"));
+    src = path.join(root, "src");
+    fs.mkdirSync(src);
+    fs.writeFileSync(path.join(src, "agent.agency"), "node main() {}\n");
+    // A sibling file the agent would reference relative to its cwd (the workdir).
+    fs.writeFileSync(path.join(src, "data.txt"), "hello\n");
+
+    mockEval.mockImplementation(async (args: { runsDir: string; runId: string; inputs: Input[] }) => {
+      const input = args.inputs[0];
+      const recordPath = path.join(root, `${args.runId}-record.json`);
+      fs.writeFileSync(recordPath, JSON.stringify({ evalOutputs: [{ value: "out" }] }));
+      return { inputs: [{ status: "success", evalRecordPath: recordPath, input }] };
+    });
+  });
+  afterEach(() => {
+    mockEval.mockReset();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  function probe(): Probe {
+    return new Probe(
+      { graders: [new FixedGrader({ score: { kind: "scalar", value: 1 } })], iterations: 1, config: {}, runsDir: root, runId: "r" },
+      { workspaceRoot: path.join(root, "ws") },
+    );
+  }
+
+  it("points the per-input working_dir at the forked workspace so its files land in the workdir", async () => {
+    const p = probe();
+    const ws = p.forkAt(src);
+    await p.evaluateAt(ws, "agent.agency", [{ id: "a", args: {} }]);
+
+    expect(mockEval).toHaveBeenCalledTimes(1);
+    const spec = mockEval.mock.calls[0][0].inputs[0] as Input;
+    // The workspace is a full copy of the source tree; the per-input workdir must
+    // be seeded from it, or relative file references resolve against an empty dir.
+    expect(spec.working_dir).toBe(ws.dir);
+    expect(fs.existsSync(path.join(ws.dir, "data.txt"))).toBe(true);
+  });
+
+  it("preserves an input-provided working_dir instead of overriding it", async () => {
+    const p = probe();
+    const ws = p.forkAt(src);
+    const custom = path.join(root, "custom");
+    fs.mkdirSync(custom);
+    await p.evaluateAt(ws, "agent.agency", [{ id: "a", args: {}, working_dir: custom }]);
+
+    const spec = mockEval.mock.calls[0][0].inputs[0] as Input;
+    expect(spec.working_dir).toBe(custom);
+  });
+});


### PR DESCRIPTION
## Problem

Running `agency optimize <file> --goal "..."` on an agent that references project files fails because the file isn't found. The optimizer is supposed to give each agent run an isolated copy of the project as its working directory ("workdir"), but the workdir was created **empty**.

Observed in a real run's `eval-record.json`:

```
python: can't open file '.../inputs/input-1/workdir/examples/demo/test_median.py': [Errno 2] No such file or directory
```

…and the `workdir/` directory was blank.

## Root cause

The optimizer runs each input through the shared eval-run path. In `runInputViaEval` (`lib/optimize/baseOptimizer.ts`) the spec was built as:

```ts
const spec: Input = { ...input, id };   // working_dir never set
```

The eval layer's `prepareInput` only seeds the per-input `workdir/` when `input.working_dir` is set; otherwise it just creates an empty dir. The agent then runs with `cwd = workdirPath`, so relative file references resolve against an empty directory.

The optimizer already forks a complete copy of the source tree per candidate into the **workspace** (`ws.dir`). That's the natural source to seed each per-input workdir from.

## Fix

```ts
const spec: Input = { ...input, id, working_dir: input.working_dir ?? ws.dir };
```

Defaults `working_dir` to the forked workspace so each per-input workdir is seeded with a fresh, isolated copy of the project tree. An explicit per-input `working_dir` still wins.

## Tests

New isolated test file `lib/optimize/baseOptimizer.workdir.test.ts` (mocks `@/cli/eval/run.js` to capture the spec without spawning a real agent subprocess):

- Default path sets `spec.working_dir === ws.dir`, and the forked workspace contains the sibling project file — **failed before the fix** (`working_dir` was `undefined`), passes after.
- An input-provided `working_dir` is preserved, not overridden.

## Notes / follow-up

This is the minimal, targeted fix for the empty-workdir bug. A larger follow-up (discussed separately) will unify eval and optimize onto a single per-input working-directory mechanism — compiling and running the agent *inside* the workdir so `module-dir == cwd == workdir` and reads/writes/execs can't diverge across copies. That is intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
