### PR TITLE
Unify eval + optimize on a single per-input working directory

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -12,6 +12,12 @@
 - Default judge now grades against `input.expected` even with no custom grader.
 - `gepa` and `example` optimizers now populate the champion grade breakdown and select the champion by validation, matching `greedy`.
 - Optimizer per-input working dir is seeded from the forked workspace, so agents that reference project files (e.g. `exec` on a repo path) find them instead of running in an empty dir.
+- Unified eval + optimize on a single per-input working directory: each input's workdir is seeded from the agent's project tree, candidate files (from the optimizer) are overlaid, and the entry agent is compiled in place — so module-dir, cwd, and workdir are the same directory for every run.
+
+#### Breaking
+- `agency eval run`: `working_dir`, when set, must now contain the agent file (was: any directory was copied as a separate fixture).
+- The agent is now compiled once per input (was: once up front). Workdirs are now isolated per input.
+- The optimizer no longer copies the project tree per candidate; per-candidate state lives as an overlay file map. `BaseOptimizerDeps.workspaceRoot` was removed and `Workspace` shrank to `{ key }` (cache-partition token only).
 
 ### Agency Agent
 - Can set the LLM provider used by the agency agent.

--- a/packages/agency-lang/lib/cli/eval/run.ts
+++ b/packages/agency-lang/lib/cli/eval/run.ts
@@ -5,9 +5,7 @@ import { fork } from "child_process";
 import { nanoid } from "nanoid";
 
 import type { AgencyConfig } from "@/config.js";
-import { compile } from "@/cli/commands.js";
 import { parseTarget } from "@/cli/util.js";
-import { RunStrategy } from "@/importStrategy.js";
 import { StatelogParser } from "@/eval/statelogParser.js";
 import { loadInputs, inputFromGoal } from "@/eval/loadInputs.js";
 import {
@@ -20,11 +18,11 @@ import {
   type EvalInputRunner,
 } from "@/eval/runEvalInput.js";
 import type {
-  EvalRunCompiledAgent,
   EvalRunResult,
   Input,
   EvalRunInputResult,
 } from "@/eval/runTypes.js";
+import { agentClosureBaseDir } from "@/optimize/targets.js";
 import {
   buildForkOptions,
   buildRunInstruction,
@@ -52,10 +50,24 @@ export type EvalRunLoadedInputsOptions = {
   continueOnError?: boolean;
   verbose?: boolean;
   config?: AgencyConfig;
-  /** Suppress compile progress lines for the agent compile. */
+  /** Suppress compile progress lines for the agent compile.
+   *  (Currently unused — kept for API compatibility.) */
   quietCompile?: boolean;
   /** Pipe agent subprocess stdout/stderr through to the console. Defaults to true. */
   pipeAgentOutput?: boolean;
+  /**
+   * Workdir seed override. When set, used verbatim for every input — no
+   * closure-base derivation, no relpath computation. The optimizer always
+   * sets this from `source.baseDir` + `source.entryFile`, so the seed
+   * cannot silently diverge from the closure walk.
+   *
+   * Mutually exclusive with per-input `working_dir`: setting both is an
+   * error.
+   */
+  seed?: { dir: string; agentRelPath: string };
+  /** Candidate-file overlay applied to every input in this call (over the
+   *  seeded copy, before compile). Plain eval never sets this. */
+  overlayFiles?: Record<string, string>;
 };
 
 /**
@@ -141,18 +153,17 @@ export async function evalRunLoadedInputs(
   } = {},
 ): Promise<EvalRunResult> {
   const target = resolveEvalRunTarget(opts.agent);
+  const absoluteAgent = fs.realpathSync(target.agentFile);
 
   const runsDir = path.resolve(
     opts.runsDir ?? opts.config?.eval?.runsDir ?? "runs",
   );
   const runId = opts.runId ?? nanoid();
   const continueOnError = opts.continueOnError ?? true;
+  const config = opts.config ?? {};
 
-  const compiled = await compileAgentForEvalRun({
-    config: opts.config ?? {},
-    agentFile: target.agentFile,
-    quiet: opts.quietCompile ?? false,
-  });
+  // One closure walk per call when no caller-supplied seed; never per input.
+  const defaultSeed = opts.seed ?? deriveSeedFromAgent(target.agentFile, absoluteAgent);
 
   const state = initializeEvalRun({
     runId,
@@ -169,10 +180,31 @@ export async function evalRunLoadedInputs(
 
   const results: EvalRunInputResult[] = [];
   for (const input of opts.inputs) {
+    let seed: { dir: string; agentRelPath: string };
+    try {
+      seed = resolveInputSeed(input, defaultSeed, absoluteAgent, opts.seed !== undefined);
+    } catch (err) {
+      // Seed-resolution errors (working_dir misuse, seed/working_dir conflict)
+      // are per-input prepare failures — never escape `evalRunLoadedInputs`.
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[evalRun] seed resolution failed for input ${input.id ?? "(no id)"}: ${message}`);
+      results.push({
+        inputId: input.id ?? "",
+        status: "error",
+        evalRecordPath: "",
+        statelogPath: "",
+        workdirPath: "",
+        errorMessage: message,
+      });
+      if (!continueOnError) break;
+      continue;
+    }
     const result = await runEvalInput({
       state,
       input,
-      compiled,
+      seed,
+      overlayFiles: opts.overlayFiles,
+      config,
       defaultNode: target.node,
       runner,
       extractor,
@@ -184,22 +216,36 @@ export async function evalRunLoadedInputs(
   return writeEvalRunSummary(state, results);
 }
 
-async function compileAgentForEvalRun(args: {
-  config: AgencyConfig;
-  agentFile: string;
-  quiet?: boolean;
-}): Promise<EvalRunCompiledAgent> {
-  const compiledPath = compile(args.config, args.agentFile, undefined, {
-    importStrategy: new RunStrategy(),
-    quiet: args.quiet,
-  });
-  if (compiledPath === null) {
-    throw new Error(`Failed to compile ${args.agentFile}`);
+/** Derive seed from agent file via closure walk. Called at most once per
+ *  `evalRunLoadedInputs` invocation, never per input. */
+function deriveSeedFromAgent(agentFile: string, absoluteAgent: string): { dir: string; agentRelPath: string } {
+  const dir = agentClosureBaseDir(agentFile);
+  return { dir, agentRelPath: path.relative(dir, absoluteAgent) };
+}
+
+/** Apply the per-input seed rule:
+ *  - `opts.seed` (callerSetSeed=true) + `input.working_dir` → conflict, throw.
+ *  - `input.working_dir` only → validate (must be a directory; must contain the agent).
+ *  - neither → use the default seed. */
+function resolveInputSeed(
+  input: Input,
+  defaultSeed: { dir: string; agentRelPath: string },
+  absoluteAgent: string,
+  callerSetSeed: boolean,
+): { dir: string; agentRelPath: string } {
+  if (!input.working_dir) return defaultSeed;
+  if (callerSetSeed) {
+    throw new Error(`input.working_dir cannot be combined with a caller-supplied seed (input id=${input.id ?? "(no id)"})`);
   }
-  return {
-    moduleId: path.basename(compiledPath, ".js"),
-    path: compiledPath,
-  };
+  const resolved = fs.realpathSync(path.resolve(input.working_dir));
+  if (!fs.statSync(resolved).isDirectory()) {
+    throw new Error(`Eval input working_dir is not a directory: ${input.working_dir}`);
+  }
+  const rel = path.relative(resolved, absoluteAgent);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(`working_dir must contain the agent file (working_dir=${resolved}, agent=${absoluteAgent})`);
+  }
+  return { dir: resolved, agentRelPath: rel };
 }
 
 const defaultEvalRecordExtractor: EvalRecordExtractor = async ({
@@ -228,12 +274,9 @@ export const optimizeEvalRecordExtractor: EvalRecordExtractor = async ({
 };
 
 function makeSubprocessEvalInputRunner(pipeAgentOutput: boolean): EvalInputRunner {
-  return async ({ compiled, node, args, cwd, statelogPath }) => {
-    if (!compiled.path) {
-      return { ok: false, errorMessage: "Compiled agent has no path" };
-    }
+  return async ({ compiledEntryPath, node, args, cwd, statelogPath }) => {
     return runCompiledAgentInSubprocess({
-      compiledPath: compiled.path,
+      compiledPath: compiledEntryPath,
       node,
       args,
       cwd,

--- a/packages/agency-lang/lib/cli/eval/run.workdir.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.workdir.test.ts
@@ -86,6 +86,34 @@ describe("evalRunLoadedInputs compiles + runs inside each input workdir", () => 
     expect(result.inputs[0].errorMessage).toMatch(/working_dir is not a directory/);
   });
 
+  it("overlayFiles overwrite the seed copy inside each input's workdir", async () => {
+    fs.writeFileSync(path.join(proj, "config.txt"), "original\n");
+    const observedCwd: string[] = [];
+    const runner = vi.fn(async (args: { cwd: string }) => {
+      observedCwd.push(fs.readFileSync(path.join(args.cwd, "config.txt"), "utf8"));
+      return { ok: true as const };
+    });
+
+    await evalRunLoadedInputs(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [{ id: "input-1", goal: "g", args: {} }],
+        inputsSource: "test",
+        runsDir: path.join(proj, "runs"),
+        runId: "r-overlay",
+        config: {},
+        pipeAgentOutput: false,
+        seed: { dir: proj, agentRelPath: "agent.agency" },
+        overlayFiles: { "config.txt": "patched\n" },
+      },
+      { runner },
+    );
+
+    // The overlay wins inside the workdir; the source tree is untouched.
+    expect(observedCwd).toEqual(["patched\n"]);
+    expect(fs.readFileSync(path.join(proj, "config.txt"), "utf8")).toBe("original\n");
+  });
+
   it("rejects combining a caller-supplied seed with input.working_dir", async () => {
     const runner = vi.fn(async () => ({ ok: true as const }));
     const result = await evalRunLoadedInputs(

--- a/packages/agency-lang/lib/cli/eval/run.workdir.test.ts
+++ b/packages/agency-lang/lib/cli/eval/run.workdir.test.ts
@@ -1,0 +1,107 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { evalRunLoadedInputs } from "./run.js";
+
+describe("evalRunLoadedInputs compiles + runs inside each input workdir", () => {
+  let proj: string;
+  beforeEach(() => {
+    proj = fs.mkdtempSync(path.join(os.tmpdir(), "evalwd-"));
+    fs.writeFileSync(path.join(proj, "agent.agency"), "node main() { return 1 }\n");
+  });
+  afterEach(() => {
+    fs.rmSync(proj, { recursive: true, force: true });
+  });
+
+  it("module-dir == cwd: compiled entry lives inside each input's workdir", async () => {
+    const runsDir = path.join(proj, "runs");
+    const seen: { compiledEntryPath: string; cwd: string }[] = [];
+    const runner = vi.fn(async (args: { compiledEntryPath: string; cwd: string }) => {
+      seen.push({ compiledEntryPath: args.compiledEntryPath, cwd: args.cwd });
+      return { ok: true as const };
+    });
+
+    const result = await evalRunLoadedInputs(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [{ id: "input-1", goal: "g", args: {} }],
+        inputsSource: "test",
+        runsDir,
+        runId: "r1",
+        config: {},
+        pipeAgentOutput: false,
+      },
+      { runner },
+    );
+
+    const workdir = result.inputs[0].workdirPath;
+    expect(seen).toHaveLength(1);
+    expect(seen[0].cwd).toBe(workdir);
+    expect(seen[0].compiledEntryPath.startsWith(workdir + path.sep)).toBe(true);
+    expect(fs.existsSync(seen[0].compiledEntryPath)).toBe(true);
+  });
+
+  it("rejects working_dir that does not contain the agent file", async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "outside-"));
+    const runner = vi.fn(async () => ({ ok: true as const }));
+    try {
+      const result = await evalRunLoadedInputs(
+        {
+          agent: path.join(proj, "agent.agency"),
+          inputs: [{ id: "input-1", goal: "g", args: {}, working_dir: outside }],
+          inputsSource: "test",
+          runsDir: path.join(proj, "runs"),
+          runId: "r-outside",
+          config: {},
+          pipeAgentOutput: false,
+        },
+        { runner },
+      );
+      expect(result.inputs[0].status).toBe("error");
+      expect(result.inputs[0].errorMessage).toMatch(/working_dir must contain the agent file/);
+      expect(runner).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects working_dir values that point to files", async () => {
+    const file = path.join(proj, "not-a-dir.txt");
+    fs.writeFileSync(file, "x");
+    const runner = vi.fn(async () => ({ ok: true as const }));
+    const result = await evalRunLoadedInputs(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [{ id: "input-1", goal: "g", args: {}, working_dir: file }],
+        inputsSource: "test",
+        runsDir: path.join(proj, "runs"),
+        runId: "r-file",
+        config: {},
+        pipeAgentOutput: false,
+      },
+      { runner },
+    );
+    expect(result.inputs[0].status).toBe("error");
+    expect(result.inputs[0].errorMessage).toMatch(/working_dir is not a directory/);
+  });
+
+  it("rejects combining a caller-supplied seed with input.working_dir", async () => {
+    const runner = vi.fn(async () => ({ ok: true as const }));
+    const result = await evalRunLoadedInputs(
+      {
+        agent: path.join(proj, "agent.agency"),
+        inputs: [{ id: "input-1", goal: "g", args: {}, working_dir: proj }],
+        inputsSource: "test",
+        runsDir: path.join(proj, "runs"),
+        runId: "r-seed-conflict",
+        config: {},
+        pipeAgentOutput: false,
+        seed: { dir: proj, agentRelPath: "agent.agency" },
+      },
+      { runner },
+    );
+    expect(result.inputs[0].status).toBe("error");
+    expect(result.inputs[0].errorMessage).toMatch(/cannot be combined with a caller-supplied seed/);
+  });
+});

--- a/packages/agency-lang/lib/eval/runArtifacts.test.ts
+++ b/packages/agency-lang/lib/eval/runArtifacts.test.ts
@@ -66,13 +66,15 @@ Choose a different --run-id or delete the existing directory.`,
     expect(fs.existsSync(path.join(tmpDir, "existing", "config.json"))).toBe(false);
   });
 
-  it("prepares per-input artifact paths and an empty workdir", () => {
+  it("prepares per-input artifact paths but leaves workdir to prepareRunDir", () => {
     const state = initializeState();
 
     const prepared = prepareInput(state, { id: "t1", goal: "goal", args: {} });
 
     expect(JSON.parse(fs.readFileSync(path.join(state.runDir, "inputs", "t1", "input.json"), "utf-8"))).toMatchObject({ id: "t1", goal: "goal" });
-    expect(fs.existsSync(prepared.workdirPath)).toBe(true);
+    // prepareInput allocates the path but no longer creates the workdir — that's
+    // prepareRunDir's job (seed + overlay + compile inside the workdir).
+    expect(fs.existsSync(prepared.workdirPath)).toBe(false);
     expect(prepared.statelogPath).toBe(path.join(state.runDir, "inputs", "t1", "statelog.jsonl"));
     expect(prepared.evalRecordPath).toBe(path.join(state.runDir, "inputs", "t1", "eval-record.json"));
   });
@@ -95,30 +97,12 @@ Choose a different --run-id or delete the existing directory.`,
     expect(() => prepareInput(state, { id: "../escape", goal: "goal", args: {} })).toThrow("Invalid id");
   });
 
-  it("copies a fixture working_dir into the input workdir", () => {
-    const state = initializeState();
-    const fixture = path.join(tmpDir, "fixture");
-    fs.mkdirSync(fixture);
-    fs.writeFileSync(path.join(fixture, "input.txt"), "fixture-data");
-
-    const prepared = prepareInput(state, { id: "t1", goal: "goal", args: {}, working_dir: fixture });
-
-    expect(fs.readFileSync(path.join(prepared.workdirPath, "input.txt"), "utf-8")).toBe("fixture-data");
-    expect(fs.readFileSync(path.join(fixture, "input.txt"), "utf-8")).toBe("fixture-data");
-  });
-
-  it("rejects working_dir values that point to files", () => {
-    const state = initializeState();
-    const fixtureFile = path.join(tmpDir, "fixture.txt");
-    fs.writeFileSync(fixtureFile, "fixture-data");
-
-    expect(() => prepareInput(state, {
-      id: "t1",
-      goal: "goal",
-      args: {},
-      working_dir: fixtureFile,
-    })).toThrow("working_dir must be a directory");
-  });
+  // Notes on `working_dir` handling: prepareInput is no longer responsible
+  // for materializing the workdir from a `working_dir` fixture or for
+  // validating that the value points to a directory. Both responsibilities
+  // moved to `evalRunLoadedInputs.resolveInputSeed`/`prepareRunDir`, where
+  // the agent file is in scope (enabling the "working_dir must contain the
+  // agent file" check). See `lib/cli/eval/run.workdir.test.ts`.
 
   it("records prepare failures without touching artifact paths", () => {
     const result = recordInputPrepareFailure("t1", "invalid id");

--- a/packages/agency-lang/lib/eval/runArtifacts.ts
+++ b/packages/agency-lang/lib/eval/runArtifacts.ts
@@ -77,16 +77,10 @@ export function prepareInput(
   const inputDir = path.join(state.inputsDir, id);
   const workdirPath = path.join(inputDir, "workdir");
   fs.mkdirSync(inputDir, { recursive: true });
-
-  if (input.working_dir) {
-    const workingDirStat = fs.statSync(input.working_dir);
-    if (!workingDirStat.isDirectory()) {
-      throw new Error("Eval input working_dir must be a directory");
-    }
-    fs.cpSync(input.working_dir, workdirPath, { recursive: true });
-  } else {
-    fs.mkdirSync(workdirPath, { recursive: true });
-  }
+  // workdir is materialized by prepareRunDir (seed + overlay + compile); we
+  // only allocate the path here. working_dir validation moves to
+  // evalRunLoadedInputs, where both working_dir and the agent file are in
+  // scope (it must enforce "working_dir contains the agent file").
 
   const prepared: PreparedInput = {
     input,

--- a/packages/agency-lang/lib/eval/runEvalInput.ts
+++ b/packages/agency-lang/lib/eval/runEvalInput.ts
@@ -1,6 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 
+import type { AgencyConfig } from "@/config.js";
+
+import { prepareRunDir, type RunWorkdirSpec } from "./runWorkdir.js";
 import {
   prepareInput,
   recordInputPrepareFailure,
@@ -11,7 +14,6 @@ import {
   type PreparedInput,
 } from "./runArtifacts.js";
 import type {
-  EvalRunCompiledAgent,
   Input,
   EvalRunInputResult,
 } from "./runTypes.js";
@@ -27,7 +29,7 @@ import type {
  * to the runner.
  */
 export type EvalInputRunner = (args: {
-  compiled: EvalRunCompiledAgent;
+  compiledEntryPath: string;
   node: string;
   args: Record<string, any>;
   cwd: string;
@@ -60,7 +62,11 @@ export type EvalRecordExtractor = (args: {
 export async function runEvalInput(args: {
   state: EvalRunState;
   input: Input;
-  compiled: EvalRunCompiledAgent;
+  /** The workdir spec for this input: seed dir + agent path within it. */
+  seed: { dir: string; agentRelPath: string };
+  /** Optional candidate-file overlay applied on top of the seed before compile. */
+  overlayFiles?: Record<string, string>;
+  config: AgencyConfig;
   defaultNode: string;
   runner: EvalInputRunner;
   extractor: EvalRecordExtractor;
@@ -75,8 +81,22 @@ export async function runEvalInput(args: {
     return recordInputPrepareFailure(inputId, message);
   }
 
+  let dir: ReturnType<typeof prepareRunDir>;
+  try {
+    const spec: RunWorkdirSpec = {
+      seedDir: args.seed.dir,
+      agentRelPath: args.seed.agentRelPath,
+      overlayFiles: args.overlayFiles,
+    };
+    dir = prepareRunDir(spec, prepared.workdirPath, args.config);
+  } catch (err) {
+    const message = errMessage(err);
+    console.error(`[evalRun] prepareRunDir failed for input ${inputId}: ${message}`);
+    return recordInputRunFailure(prepared, message);
+  }
+
   const runResult = await args.runner({
-    compiled: args.compiled,
+    compiledEntryPath: dir.compiledEntryPath,
     node: args.input.node ?? args.defaultNode,
     args: args.input.args,
     cwd: prepared.workdirPath,

--- a/packages/agency-lang/lib/eval/runTypes.ts
+++ b/packages/agency-lang/lib/eval/runTypes.ts
@@ -47,8 +47,3 @@ export type EvalRunConfig = {
   continueOnError: boolean;
   verbose?: boolean;
 };
-
-export type EvalRunCompiledAgent = {
-  moduleId: string;
-  path?: string;
-};

--- a/packages/agency-lang/lib/eval/runWorkdir.test.ts
+++ b/packages/agency-lang/lib/eval/runWorkdir.test.ts
@@ -1,0 +1,48 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { prepareRunDir } from "./runWorkdir.js";
+
+describe("prepareRunDir", () => {
+  let root: string;
+  let seed: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "prd-"));
+    seed = path.join(root, "proj");
+    fs.mkdirSync(path.join(seed, "demo"), { recursive: true });
+    fs.writeFileSync(path.join(seed, "agent.agency"), "node main() { return 1 }\n");
+    fs.writeFileSync(path.join(seed, "demo", "data.txt"), "original\n");
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("seeds the workdir, applies overlay, and compiles the entry in place", () => {
+    const workdir = path.join(root, "wd");
+    const prepared = prepareRunDir(
+      { seedDir: seed, agentRelPath: "agent.agency", overlayFiles: { "demo/data.txt": "patched\n" } },
+      workdir,
+      {},
+    );
+
+    // overlay applied on top of the seeded copy
+    expect(fs.readFileSync(path.join(workdir, "demo", "data.txt"), "utf8")).toBe("patched\n");
+    // compiled entry lives inside the workdir, next to its source
+    expect(prepared.compiledEntryPath).toBe(path.join(workdir, "agent.js"));
+    expect(fs.existsSync(prepared.compiledEntryPath)).toBe(true);
+    expect(prepared.workdirPath).toBe(workdir);
+  });
+
+  it("works without an overlay", () => {
+    const workdir = path.join(root, "wd2");
+    const prepared = prepareRunDir(
+      { seedDir: seed, agentRelPath: "agent.agency" },
+      workdir,
+      {},
+    );
+
+    expect(fs.readFileSync(path.join(workdir, "demo", "data.txt"), "utf8")).toBe("original\n");
+    expect(fs.existsSync(prepared.compiledEntryPath)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/eval/runWorkdir.test.ts
+++ b/packages/agency-lang/lib/eval/runWorkdir.test.ts
@@ -34,6 +34,26 @@ describe("prepareRunDir", () => {
     expect(prepared.workdirPath).toBe(workdir);
   });
 
+  it("refuses overlay keys that escape the workdir (traversal / absolute)", () => {
+    const workdir = path.join(root, "wd-escape");
+    const outside = path.join(root, "outside.txt");
+    expect(() =>
+      prepareRunDir(
+        { seedDir: seed, agentRelPath: "agent.agency", overlayFiles: { "../outside.txt": "x" } },
+        workdir,
+        {},
+      ),
+    ).toThrow(/escapes the workdir/);
+    expect(() =>
+      prepareRunDir(
+        { seedDir: seed, agentRelPath: "agent.agency", overlayFiles: { [outside]: "x" } },
+        path.join(root, "wd-escape-abs"),
+        {},
+      ),
+    ).toThrow(/escapes the workdir/);
+    expect(fs.existsSync(outside)).toBe(false);
+  });
+
   it("works without an overlay", () => {
     const workdir = path.join(root, "wd2");
     const prepared = prepareRunDir(

--- a/packages/agency-lang/lib/eval/runWorkdir.ts
+++ b/packages/agency-lang/lib/eval/runWorkdir.ts
@@ -26,10 +26,23 @@ export type PreparedRunDir = {
   compiledEntryPath: string;
 };
 
+/** Resolve `rel` against `workdirPath` and refuse paths that escape it (`..`,
+ *  absolute). Overlay keys come from optimizer candidates today but may flow in
+ *  from less-trusted callers later; this is the same guard the prior
+ *  `WorkspaceManager.resolveWithin` provided. */
+function resolveWithin(workdirPath: string, rel: string): string {
+  const root = path.resolve(workdirPath);
+  const abs = path.resolve(root, rel);
+  if (abs !== root && !abs.startsWith(root + path.sep)) {
+    throw new Error(`Path ${JSON.stringify(rel)} escapes the workdir ${root}`);
+  }
+  return abs;
+}
+
 /** Write each overlay file (path relative to the workdir root) over the seeded copy. */
 function applyOverlay(workdirPath: string, overlayFiles: Record<string, string>): void {
   for (const [rel, source] of Object.entries(overlayFiles)) {
-    const abs = path.join(workdirPath, rel);
+    const abs = resolveWithin(workdirPath, rel);
     fs.mkdirSync(path.dirname(abs), { recursive: true });
     fs.writeFileSync(abs, source);
   }
@@ -51,7 +64,7 @@ export function prepareRunDir(
     applyOverlay(workdirPath, spec.overlayFiles);
   }
 
-  const entryAgency = path.join(workdirPath, spec.agentRelPath);
+  const entryAgency = resolveWithin(workdirPath, spec.agentRelPath);
   const compiledEntryPath = compile(config, entryAgency, undefined, {
     importStrategy: new RunStrategy(),
     quiet: true,

--- a/packages/agency-lang/lib/eval/runWorkdir.ts
+++ b/packages/agency-lang/lib/eval/runWorkdir.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import type { AgencyConfig } from "@/config.js";
+import { compile } from "@/cli/commands.js";
+import { RunStrategy } from "@/importStrategy.js";
+
+import { copyProjectTree } from "@/utils/projectTree.js";
+
+/** Declarative description of a per-input run directory: where the project
+ *  tree is seeded from, where the entry agent lives within it, and any
+ *  candidate-file overlay applied before compile. */
+export type RunWorkdirSpec = {
+  /** Absolute dir whose contents seed the workdir (the agent's project tree). */
+  seedDir: string;
+  /** Entry agent path relative to seedDir, e.g. "examples/08-optimize.agency". */
+  agentRelPath: string;
+  /** Optional overlay applied after seeding — the optimizer's mutated candidate
+   *  files, keyed by path relative to seedDir. Absent for plain eval. */
+  overlayFiles?: Record<string, string>;
+};
+
+export type PreparedRunDir = {
+  workdirPath: string;
+  /** Absolute path of the compiled entry JS inside the workdir. */
+  compiledEntryPath: string;
+};
+
+/** Write each overlay file (path relative to the workdir root) over the seeded copy. */
+function applyOverlay(workdirPath: string, overlayFiles: Record<string, string>): void {
+  for (const [rel, source] of Object.entries(overlayFiles)) {
+    const abs = path.join(workdirPath, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, source);
+  }
+}
+
+/**
+ * Materialize an isolated run directory: copy the seed project tree into
+ * `workdirPath`, overlay the candidate's mutated files (if any), then compile
+ * the entry agent in place. The result has module-dir == cwd == workdir, so the
+ * agent's reads, writes, and execs all resolve to this one isolated copy.
+ */
+export function prepareRunDir(
+  spec: RunWorkdirSpec,
+  workdirPath: string,
+  config: AgencyConfig,
+): PreparedRunDir {
+  copyProjectTree(spec.seedDir, workdirPath);
+  if (spec.overlayFiles) {
+    applyOverlay(workdirPath, spec.overlayFiles);
+  }
+
+  const entryAgency = path.join(workdirPath, spec.agentRelPath);
+  const compiledEntryPath = compile(config, entryAgency, undefined, {
+    importStrategy: new RunStrategy(),
+    quiet: true,
+  });
+  if (compiledEntryPath === null) {
+    throw new Error(`Failed to compile ${entryAgency}`);
+  }
+  return { workdirPath, compiledEntryPath };
+}

--- a/packages/agency-lang/lib/optimize/artifacts.test.ts
+++ b/packages/agency-lang/lib/optimize/artifacts.test.ts
@@ -90,21 +90,25 @@ describe("createOptimizeArtifacts", () => {
     expect(fs.existsSync(path.join(workspace.workspaceDir, "runs", "run-1", "should-not-copy", "x.txt"))).toBe(false);
   });
 
-  it("excludes heavy directories while preserving runtime build output in workspaces", () => {
+  it("excludes heavy/irrelevant entries from iteration workspaces", () => {
     fs.writeFileSync(path.join(tmpDir, "helper.agency"), "def helper() {}\n");
-    for (const dir of [".git", ".worktrees", "node_modules", "runs", ".agency-tmp"]) {
+    for (const dir of [".git", ".worktrees", "node_modules", "runs", ".agency-tmp", ".js-tmp", ".agency-memory"]) {
       fs.mkdirSync(path.join(tmpDir, dir), { recursive: true });
       fs.writeFileSync(path.join(tmpDir, dir, "large.txt"), "x");
     }
     fs.mkdirSync(path.join(tmpDir, "dist", "lib"), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, "dist", "lib", "index.js"), "export {}\n");
+    // package.json must be excluded so the agent's bare `agency-lang` self-import
+    // climbs to the real package root instead of binding to the workspace's absent dist/.
+    fs.writeFileSync(path.join(tmpDir, "package.json"), '{"name":"agency-lang"}');
     const artifacts = makeArtifacts({ runsDir: path.join(tmpDir, "optimize-runs") });
 
     const workspace = artifacts.writeIterationWorkspace(0, {});
 
     expect(fs.existsSync(path.join(workspace.workspaceDir, "helper.agency"))).toBe(true);
-    expect(fs.existsSync(path.join(workspace.workspaceDir, "dist", "lib", "index.js"))).toBe(true);
-    for (const dir of [".git", ".worktrees", "node_modules", "runs", ".agency-tmp"]) {
+    expect(fs.existsSync(path.join(workspace.workspaceDir, "dist"))).toBe(false);
+    expect(fs.existsSync(path.join(workspace.workspaceDir, "package.json"))).toBe(false);
+    for (const dir of [".git", ".worktrees", "node_modules", "runs", ".agency-tmp", ".js-tmp", ".agency-memory"]) {
       expect(fs.existsSync(path.join(workspace.workspaceDir, dir, "large.txt"))).toBe(false);
     }
   });

--- a/packages/agency-lang/lib/optimize/artifacts.ts
+++ b/packages/agency-lang/lib/optimize/artifacts.ts
@@ -2,22 +2,13 @@ import * as fs from "fs";
 import * as path from "path";
 
 import type { JudgeAggregationPolicy, SuiteVerdict } from "@/eval/judge/types.js";
+import { copyProjectTree } from "@/utils/projectTree.js";
 
 import type { OptimizeMutationDiagnostic, OptimizeMutationPreview } from "./sourceMutator.js";
 import { sha256Text, type OptimizeTargetSet } from "./targets.js";
 import type { OptimizeResult } from "./types.js";
 
 export { sha256Text };
-
-const WORKSPACE_COPY_EXCLUDED_DIRS = [
-  ".git",
-  ".worktrees",
-  "node_modules",
-  "runs",
-  ".agency-tmp",
-  ".js-tmp",
-  ".agency-memory",
-];
 
 export type IterationAgentArtifact = {
   iter: number;
@@ -94,7 +85,7 @@ export function createOptimizeArtifacts(args: {
     },
     writeIterationWorkspace(iter, files) {
       const workspaceDir = path.join(iterationDir(runDir, iter), "workspace");
-      prepareWorkspace(args.workingDir, workspaceDir, runDir);
+      prepareWorkspace(args.workingDir, workspaceDir);
       for (const [file, source] of Object.entries(files)) {
         writeFile(path.join(workspaceDir, file), source);
       }
@@ -148,32 +139,14 @@ function iterationDir(runDir: string, iter: number): string {
   return path.join(runDir, `iter-${iter}`);
 }
 
-function prepareWorkspace(workingDir: string, workspaceDir: string, runDir: string): void {
+function prepareWorkspace(workingDir: string, workspaceDir: string): void {
   fs.rmSync(workspaceDir, { recursive: true, force: true });
-  fs.mkdirSync(workspaceDir, { recursive: true });
-  if (fs.existsSync(workingDir) && fs.statSync(workingDir).isDirectory()) {
-    copyDirectory(workingDir, workspaceDir, path.resolve(runDir));
+  if (!fs.existsSync(workingDir) || !fs.statSync(workingDir).isDirectory()) {
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    return;
   }
-}
-
-function copyDirectory(sourceDir: string, destDir: string, excludedDir: string): void {
-  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
-    const sourcePath = path.join(sourceDir, entry.name);
-    if (isInsideOrSame(sourcePath, excludedDir)) continue;
-    if (entry.isDirectory() && WORKSPACE_COPY_EXCLUDED_DIRS.includes(entry.name)) continue;
-    const destPath = path.join(destDir, entry.name);
-    if (entry.isDirectory()) {
-      fs.mkdirSync(destPath, { recursive: true });
-      copyDirectory(sourcePath, destPath, excludedDir);
-    } else if (entry.isFile()) {
-      fs.copyFileSync(sourcePath, destPath);
-    }
-  }
-}
-
-function isInsideOrSame(candidate: string, parent: string): boolean {
-  const relative = path.relative(parent, path.resolve(candidate));
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  // copyProjectTree handles excludes + self-skip when workspaceDir lives under workingDir.
+  copyProjectTree(workingDir, workspaceDir);
 }
 
 function mutationPreviewMarkdown(preview: OptimizeMutationPreview, rationale?: string): string {

--- a/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
@@ -23,10 +23,15 @@ class FixedGrader extends BaseGrader {
 class Probe extends BaseOptimizer {
   readonly name = "probe";
   protected async optimizeTargets(): Promise<OptimizeResult> { return {} as OptimizeResult; }
-  evaluateAt(ws: ReturnType<Probe["fork"]>, entry: string, inputs: Input[]): Promise<Scorecard> {
-    return this.evaluate(ws, entry, inputs);
+  evaluateAt(
+    ws: ReturnType<Probe["fork"]>,
+    source: OptimizeTargetSet,
+    files: Record<string, string>,
+    inputs: Input[],
+  ): Promise<Scorecard> {
+    return this.evaluate(ws, source, files, inputs);
   }
-  forkAt(dir: string) { return this.fork(dir); }
+  forkAt() { return this.fork(); }
   requireBaselineGatesPassAt(sc: Scorecard): void { this.requireBaselineGatesPass(sc); }
   proposeValidMutationAt(
     propose: (d: OptimizeMutationDiagnostic[]) => Promise<MutationProposal>,
@@ -53,31 +58,40 @@ describe("BaseOptimizer.evaluate", () => {
   function probe(graders: BaseGrader[], runInput: RunInput): Probe {
     return new Probe(
       { graders, iterations: 1, config: {}, runsDir: root, runId: "r" },
-      { workspaceRoot: path.join(root, "ws"), runInput },
+      { runInput },
     );
   }
 
   const inputs: Input[] = [{ id: "a", args: {} }, { id: "b", args: {} }];
   const fixedRun: RunInput = async () => ({ output: "out", recordPath: "" });
 
+  const source: OptimizeTargetSet = {
+    baseDir: "",
+    entryFile: "agent.agency",
+    files: {},
+    targets: [],
+  };
+  const sourceFor = (dir: string): OptimizeTargetSet => ({ ...source, baseDir: dir });
+  const noFiles: Record<string, string> = {};
+
   it("runs the agent once per input (cached) and builds a gate-aware Scorecard", async () => {
     const runInput = vi.fn(fixedRun);
     const p = probe([new FixedGrader({ score: { kind: "scalar", value: 0.5 } })], runInput);
-    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", inputs);
+    const sc = await p.evaluateAt(p.forkAt(), sourceFor(src), noFiles, inputs);
     expect(runInput).toHaveBeenCalledTimes(2);
     expect(sc.objective()).toBeCloseTo(0.5, 10);
     expect(sc.gatesPassed()).toBe(true);
   });
 
-  it("scoreFiles forks, applies files, and grades the given inputs", async () => {
+  it("scoreFiles forks and grades the given inputs against the candidate file map", async () => {
     const p = probe([new FixedGrader({ score: { kind: "scalar", value: 0.4 } })], fixedRun);
-    const source: OptimizeTargetSet = {
+    const scoreSource: OptimizeTargetSet = {
       baseDir: src,
       entryFile: "agent.agency",
       files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "node main() {}\n", sha256: "x" } },
       targets: [],
     };
-    const sc = await p.scoreFilesAt(source, { "agent.agency": "node main() {}\n" }, [{ id: "a", args: {} }]);
+    const sc = await p.scoreFilesAt(scoreSource, { "agent.agency": "node main() {}\n" }, [{ id: "a", args: {} }]);
     expect(sc.objective()).toBeCloseTo(0.4, 10);
   });
 
@@ -96,7 +110,6 @@ describe("BaseOptimizer.evaluate", () => {
     })(
       { graders: [new NeedsExpected()], iterations: 1, config: {}, runsDir: root, runId: "ff" },
       {
-        workspaceRoot: path.join(root, "ws"),
         runInput,
         discover: () => ({
           baseDir: src,
@@ -116,7 +129,7 @@ describe("BaseOptimizer.evaluate", () => {
     const advisory = new FixedGrader({ score: { kind: "scalar", value: 1 } });
     const advisorySpy = vi.spyOn(advisory as unknown as { _run: () => Promise<Grade> }, "_run");
     const p = probe([gate, advisory], fixedRun);
-    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", [{ id: "a", args: {} }]);
+    const sc = await p.evaluateAt(p.forkAt(), sourceFor(src), noFiles, [{ id: "a", args: {} }]);
     expect(sc.gatesPassed()).toBe(false);
     expect(advisorySpy).not.toHaveBeenCalled();
   });
@@ -124,7 +137,7 @@ describe("BaseOptimizer.evaluate", () => {
   it("only runs graders whose inputScope matches the input", async () => {
     const scoped = new FixedGrader({ score: { kind: "scalar", value: 1 } }, { inputScope: { ids: ["a"] } });
     const p = probe([scoped], fixedRun);
-    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", inputs);
+    const sc = await p.evaluateAt(p.forkAt(), sourceFor(src), noFiles, inputs);
     // input "a" scores 1; input "b" has no contributing grader → 0; mean = 0.5
     expect(sc.objective()).toBeCloseTo(0.5, 10);
   });
@@ -132,21 +145,21 @@ describe("BaseOptimizer.evaluate", () => {
   it("gives id-less inputs distinct cache keys so they do not collide", async () => {
     const runInput = vi.fn(fixedRun);
     const p = probe([new FixedGrader({ score: { kind: "scalar", value: 1 } })], runInput);
-    await p.evaluateAt(p.forkAt(src), "agent.agency", [{ args: {} }, { args: {} }]); // both omit id
+    await p.evaluateAt(p.forkAt(), sourceFor(src), noFiles, [{ args: {} }, { args: {} }]); // both omit id
     expect(runInput).toHaveBeenCalledTimes(2);
   });
 
   it("requireBaselineGatesPass throws naming the failing must-pass grader", async () => {
     const gate = new FixedGrader({ score: { kind: "binary", pass: false } }, { mustPass: true, name: "must-be-json" });
     const p = probe([gate], fixedRun);
-    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", [{ id: "a", args: {} }]);
+    const sc = await p.evaluateAt(p.forkAt(), sourceFor(src), noFiles, [{ id: "a", args: {} }]);
     expect(() => p.requireBaselineGatesPassAt(sc)).toThrow(/must-be-json/);
   });
 
   it("requireBaselineGatesPass does not throw when gates pass", async () => {
     const gate = new FixedGrader({ score: { kind: "binary", pass: true } }, { mustPass: true });
     const p = probe([gate], fixedRun);
-    const sc = await p.evaluateAt(p.forkAt(src), "agent.agency", [{ id: "a", args: {} }]);
+    const sc = await p.evaluateAt(p.forkAt(), sourceFor(src), noFiles, [{ id: "a", args: {} }]);
     expect(() => p.requireBaselineGatesPassAt(sc)).not.toThrow();
   });
 

--- a/packages/agency-lang/lib/optimize/baseOptimizer.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.ts
@@ -23,11 +23,18 @@ export type MutationOutcome =
 
 const MAX_PROPOSE_ATTEMPTS = 3;
 
-/** A function that runs the agent for one input in a workspace and returns its run. */
-export type RunInput = (ws: Workspace, entryFile: string, input: Input, id: string) => Promise<AgentRun>;
+/** A function that runs the agent for one input in a workspace and returns its run.
+ *  Receives the candidate's `source` (`baseDir`/`entryFile` live here) and `files`
+ *  (the candidate's complete file map, used as the workdir overlay). */
+export type RunInput = (
+  ws: Workspace,
+  source: OptimizeTargetSet,
+  files: Record<string, string>,
+  input: Input,
+  id: string,
+) => Promise<AgentRun>;
 
 export type BaseOptimizerDeps = {
-  workspaceRoot?: string;
   agencyRunner?: AgencyRunner;
   cache?: EvalCache;
   /** Override how the agent under test runs (tests inject a fake; default uses the eval-run path). */
@@ -50,11 +57,11 @@ export abstract class BaseOptimizer {
   protected validationInputs: Input[] = [];
 
   constructor(protected readonly config: BaseOptimizerConfig, deps: BaseOptimizerDeps = {}) {
-    this.workspace = new WorkspaceManager(deps.workspaceRoot ?? path.join(config.runsDir, config.runId, "ws"));
+    this.workspace = new WorkspaceManager();
     this.agencyRunner = deps.agencyRunner ?? new AgencyRunner(config.config);
     this.cache = deps.cache ?? new EvalCache();
     this.reporter = deps.reporter ?? createPointwiseReporter(config.verbosity ?? "silent");
-    this.runInput = deps.runInput ?? ((ws, entryFile, input, id) => this.runInputViaEval(ws, entryFile, input, id));
+    this.runInput = deps.runInput ?? ((ws, source, files, input, id) => this.runInputViaEval(ws, source, files, input, id));
     this.discover = deps.discover ?? discoverOptimizeTargets;
   }
 
@@ -136,16 +143,15 @@ export abstract class BaseOptimizer {
     return { ok: false, rationale, diagnostics };
   }
 
-  protected fork(sourceDir: string): Workspace {
-    return this.workspace.fork(sourceDir);
+  protected fork(): Workspace {
+    return this.workspace.fork();
   }
 
-  /** Fork the agent from source, apply a candidate's files, and grade it on the
-   *  given inputs. The canonical fresh-scoring primitive (used for validation). */
+  /** Allocate a fresh cache-partition workspace and grade `files` on `inputs`.
+   *  The canonical fresh-scoring primitive (used for validation). */
   protected async scoreFiles(source: OptimizeTargetSet, files: Record<string, string>, inputs: Input[]): Promise<Scorecard> {
-    const ws = this.fork(source.baseDir);
-    this.workspace.applyFiles(ws, files);
-    return this.evaluate(ws, source.entryFile, inputs);
+    const ws = this.fork();
+    return this.evaluate(ws, source, files, inputs);
   }
 
   /** Choose the writeback champion among candidates: the one with the best
@@ -213,16 +219,28 @@ export abstract class BaseOptimizer {
     return result;
   }
 
-  /** Run the agent once per input (cached by (workspace,input)), grade each, return a Scorecard. */
-  protected async evaluate(ws: Workspace, entryFile: string, inputs: Input[]): Promise<Scorecard> {
+  /** Run the agent once per input (cached by (workspace, input)), grade each, return a Scorecard.
+   *  The candidate's `files` map is the overlay applied inside each per-input workdir. */
+  protected async evaluate(
+    ws: Workspace,
+    source: OptimizeTargetSet,
+    files: Record<string, string>,
+    inputs: Input[],
+  ): Promise<Scorecard> {
     const perInput = await Promise.all(
-      inputs.map((input, index) => this.gradeInput(ws, entryFile, input, inputId(input, index))),
+      inputs.map((input, index) => this.gradeInput(ws, source, files, input, inputId(input, index))),
     );
     return new Scorecard(perInput);
   }
 
-  private async gradeInput(ws: Workspace, entryFile: string, input: Input, id: string): Promise<InputGrades> {
-    const run = await this.cache.get(ws.key, id, () => this.runInput(ws, entryFile, input, id));
+  private async gradeInput(
+    ws: Workspace,
+    source: OptimizeTargetSet,
+    files: Record<string, string>,
+    input: Input,
+    id: string,
+  ): Promise<InputGrades> {
+    const run = await this.cache.get(ws.key, id, () => this.runInput(ws, source, files, input, id));
     const gates = this.config.graders.filter((g) => g.mustPass() && g.gradesInput(input));
     const advisory = this.config.graders.filter((g) => !g.mustPass() && g.gradesInput(input));
 
@@ -247,20 +265,22 @@ export abstract class BaseOptimizer {
     };
   }
 
-  /** Default runInput: run the agent for one input via the eval-run subprocess path (named args). */
-  private async runInputViaEval(ws: Workspace, entryFile: string, input: Input, id: string): Promise<AgentRun> {
-    // Now that eval and optimize share the Input type, the input flows straight
-    // through — we pin the id so artifacts land in a predictable directory, and
-    // default working_dir to the forked workspace. The workspace is a full copy
-    // of the source tree, so seeding each per-input workdir from it gives the
-    // agent an isolated copy of the project as its cwd; without this the workdir
-    // is created empty and relative file references (e.g. exec on a repo path)
-    // resolve against nothing. An input that names its own working_dir wins.
-    const spec: Input = { ...input, id, working_dir: input.working_dir ?? ws.dir };
+  /** Default runInput: run the agent for one input via the eval-run subprocess path.
+   *  Passes `seed` (used verbatim — no closure recomputation, no silent divergence
+   *  from `source.baseDir`) and `overlayFiles` (the candidate's complete file map)
+   *  to `evalRunLoadedInputs`. The per-input `working_dir` field is forbidden
+   *  here (the caller-supplied seed would conflict with it). */
+  private async runInputViaEval(
+    ws: Workspace,
+    source: OptimizeTargetSet,
+    files: Record<string, string>,
+    input: Input,
+    id: string,
+  ): Promise<AgentRun> {
     this.runCounter += 1;
     const result = await evalRunLoadedInputs({
-      agent: path.join(ws.dir, entryFile),
-      inputs: [spec],
+      agent: path.join(source.baseDir, source.entryFile),  // used for label/node parsing only
+      inputs: [{ ...input, id, working_dir: undefined }],  // working_dir conflicts with seed
       inputsSource: "optimize",
       runsDir: path.join(this.config.runsDir, this.config.runId, "agent-runs", ws.key),
       runId: `run-${this.runCounter}`,
@@ -268,6 +288,8 @@ export abstract class BaseOptimizer {
       continueOnError: true,
       quietCompile: true,
       pipeAgentOutput: false,
+      seed: { dir: source.baseDir, agentRelPath: source.entryFile },
+      overlayFiles: files,
     }, {
       // Grade the node's return value (not its last LLM reply) and skip the
       // evalValue/evalOutput "did you forget to call…" warnings — neither

--- a/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
@@ -8,10 +8,12 @@ import { BaseGrader } from "./grading/baseGrader.js";
 import type { Grade, GraderInput, GraderOptions, Input } from "./grading/types.js";
 import type { Scorecard } from "./grading/scorecard.js";
 import { BaseOptimizer } from "./baseOptimizer.js";
+import type { OptimizeTargetSet } from "./targets.js";
 import type { OptimizeResult } from "./types.js";
 
-// Capture the spec the default eval-run path hands to the eval runner so we can
-// assert it carries a working_dir (without spawning a real agent subprocess).
+// Capture the call the optimizer makes into evalRunLoadedInputs so we can
+// assert the new spec: seed + overlayFiles travel out-of-band, no
+// working_dir on the per-input spec, agent path points at source.baseDir.
 const { mockEval } = vi.hoisted(() => ({ mockEval: vi.fn() }));
 vi.mock("@/cli/eval/run.js", () => ({
   evalRunLoadedInputs: mockEval,
@@ -25,17 +27,22 @@ class FixedGrader extends BaseGrader {
   protected _run(_input: GraderInput): Promise<Grade> { return Promise.resolve(this.grade); }
 }
 
-/** Concrete subclass exposing `evaluate` so we can drive the default runInput path. */
+/** Concrete subclass exposing `evaluate`/`fork` so we can drive the default runInput path. */
 class Probe extends BaseOptimizer {
   readonly name = "probe";
   protected async optimizeTargets(): Promise<OptimizeResult> { return {} as OptimizeResult; }
-  evaluateAt(ws: ReturnType<Probe["fork"]>, entry: string, inputs: Input[]): Promise<Scorecard> {
-    return this.evaluate(ws, entry, inputs);
+  evaluateAt(
+    ws: ReturnType<Probe["fork"]>,
+    source: OptimizeTargetSet,
+    files: Record<string, string>,
+    inputs: Input[],
+  ): Promise<Scorecard> {
+    return this.evaluate(ws, source, files, inputs);
   }
-  forkAt(dir: string) { return this.fork(dir); }
+  forkAt() { return this.fork(); }
 }
 
-describe("BaseOptimizer.runInputViaEval working_dir", () => {
+describe("BaseOptimizer.runInputViaEval threads seed + overlayFiles", () => {
   let root: string;
   let src: string;
   beforeEach(() => {
@@ -43,7 +50,6 @@ describe("BaseOptimizer.runInputViaEval working_dir", () => {
     src = path.join(root, "src");
     fs.mkdirSync(src);
     fs.writeFileSync(path.join(src, "agent.agency"), "node main() {}\n");
-    // A sibling file the agent would reference relative to its cwd (the workdir).
     fs.writeFileSync(path.join(src, "data.txt"), "hello\n");
 
     mockEval.mockImplementation(async (args: { runsDir: string; runId: string; inputs: Input[] }) => {
@@ -61,31 +67,36 @@ describe("BaseOptimizer.runInputViaEval working_dir", () => {
   function probe(): Probe {
     return new Probe(
       { graders: [new FixedGrader({ score: { kind: "scalar", value: 1 } })], iterations: 1, config: {}, runsDir: root, runId: "r" },
-      { workspaceRoot: path.join(root, "ws") },
     );
   }
 
-  it("points the per-input working_dir at the forked workspace so its files land in the workdir", async () => {
+  function source(): OptimizeTargetSet {
+    return { baseDir: src, entryFile: "agent.agency", files: {}, targets: [] };
+  }
+
+  it("passes seed + overlayFiles to evalRunLoadedInputs; no working_dir on input", async () => {
     const p = probe();
-    const ws = p.forkAt(src);
-    await p.evaluateAt(ws, "agent.agency", [{ id: "a", args: {} }]);
+    const ws = p.forkAt();
+    const files = { "agent.agency": "node main() { return 1 }\n" };
+    await p.evaluateAt(ws, source(), files, [{ id: "a", args: {} }]);
 
     expect(mockEval).toHaveBeenCalledTimes(1);
-    const spec = mockEval.mock.calls[0][0].inputs[0] as Input;
-    // The workspace is a full copy of the source tree; the per-input workdir must
-    // be seeded from it, or relative file references resolve against an empty dir.
-    expect(spec.working_dir).toBe(ws.dir);
-    expect(fs.existsSync(path.join(ws.dir, "data.txt"))).toBe(true);
+    const call = mockEval.mock.calls[0][0];
+    expect(call.seed).toEqual({ dir: src, agentRelPath: "agent.agency" });
+    expect(call.overlayFiles).toEqual(files);
+    expect(call.agent).toBe(path.join(src, "agent.agency"));
+    expect((call.inputs[0] as Input).working_dir).toBeUndefined();
   });
 
-  it("preserves an input-provided working_dir instead of overriding it", async () => {
+  it("partitions agent-runs by ws.key so caching is per-candidate", async () => {
     const p = probe();
-    const ws = p.forkAt(src);
-    const custom = path.join(root, "custom");
-    fs.mkdirSync(custom);
-    await p.evaluateAt(ws, "agent.agency", [{ id: "a", args: {}, working_dir: custom }]);
+    const ws1 = p.forkAt();
+    const ws2 = p.forkAt();
+    await p.evaluateAt(ws1, source(), {}, [{ id: "a", args: {} }]);
+    await p.evaluateAt(ws2, source(), {}, [{ id: "a", args: {} }]);
 
-    const spec = mockEval.mock.calls[0][0].inputs[0] as Input;
-    expect(spec.working_dir).toBe(custom);
+    expect(ws1.key).not.toBe(ws2.key);
+    expect(mockEval.mock.calls[0][0].runsDir).toContain(ws1.key);
+    expect(mockEval.mock.calls[1][0].runsDir).toContain(ws2.key);
   });
 });

--- a/packages/agency-lang/lib/optimize/optimizers/example.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/example.test.ts
@@ -44,7 +44,6 @@ describe("ExampleOptimizer", () => {
 
   function deps(over: Partial<ExampleDeps> = {}): ExampleDeps {
     return {
-      workspaceRoot: path.join(root, "ws"),
       runInput,
       discover: () => fakeSource(),
       propose: async () => ({ rationale: "tighten", operations: [] }),

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
@@ -49,14 +49,13 @@ describe("Gepa (reflective Pareto optimizer)", () => {
   function scoredRunner(scores: number[]): RunInput {
     const seen = new Map<string, number>();
     return async (ws) => {
-      if (!seen.has(ws.dir)) seen.set(ws.dir, scores[seen.size] ?? 0);
-      return { output: String(seen.get(ws.dir)), recordPath: recordFile };
+      if (!seen.has(ws.key)) seen.set(ws.key, scores[seen.size] ?? 0);
+      return { output: String(seen.get(ws.key)), recordPath: recordFile };
     };
   }
 
   function deps(runInput: RunInput, propose?: GepaDeps["propose"]): GepaDeps {
     return {
-      workspaceRoot: path.join(root, "ws"),
       runInput,
       discover: () => fakeSource(),
       propose: propose ?? (async () => ({ rationale: "r", operations: [{ target: "t-alpha", kind: "variable", op: "replaceInitializer", value: '"x"', rationale: "c" }] })),

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.ts
@@ -74,7 +74,7 @@ export class Gepa extends BaseOptimizer {
       optimizer: this.name, runId: this.config.runId,
       targets: source.targets, inputCount: inputs.length, iterations: this.config.iterations,
     });
-    const baseline = await this.makeCandidate("baseline", this.fork(source.baseDir), source, paretoInputs, fileMap(source));
+    const baseline = await this.makeCandidate("baseline", this.fork(), source, paretoInputs, fileMap(source));
     this.requireBaselineGatesPass(baseline.scorecard);
     this.reporter.baselineScored({ objective: baseline.scorecard.objective() });
 
@@ -133,15 +133,13 @@ export class Gepa extends BaseOptimizer {
     if (!outcome.ok) return { iter, decision: "validation-failed", rationale: outcome.rationale, diagnostics: outcome.diagnostics };
     const preview = outcome.preview;
 
-    const childWs = this.fork(parent.ws.dir);
-    this.workspace.applyFiles(childWs, preview.files);
-    const entry = preview.targetSet.entryFile;
-    const childMini = await this.evaluate(childWs, entry, minibatch);
-    const parentMini = await this.evaluate(parent.ws, parent.targetSet.entryFile, minibatch);   // cache hits
+    const childWs = this.fork();
+    const childMini = await this.evaluate(childWs, preview.targetSet, preview.files, minibatch);
+    const parentMini = await this.evaluate(parent.ws, parent.targetSet, parent.files, minibatch);   // cache hits
     if (!(childMini.gatesPassed() && childMini.objective() > parentMini.objective())) {
       return { iter, decision: "rejected", rationale: outcome.rationale, objective: childMini.objective(), changes: preview.changes };
     }
-    const full = await this.evaluate(childWs, entry, paretoInputs);
+    const full = await this.evaluate(childWs, preview.targetSet, preview.files, paretoInputs);
     const candidate: Candidate = { iter, ws: childWs, scorecard: full, targetSet: preview.targetSet, files: preview.files };
     return { iter, decision: "accepted", rationale: outcome.rationale, objective: full.objective(), changes: preview.changes, candidate };
   }
@@ -162,12 +160,11 @@ export class Gepa extends BaseOptimizer {
       .slice(0, this.gepaConfig.minibatch);
   }
 
-  /** Apply files into a workspace and grade on `inputs`. */
+  /** Grade a candidate `files` map (the overlay) on `inputs`. */
   private async makeCandidate(
     iter: number | "baseline", ws: Workspace, targetSet: OptimizeTargetSet, inputs: Input[], files: Record<string, string>,
   ): Promise<Candidate> {
-    this.workspace.applyFiles(ws, files);
-    const scorecard = await this.evaluate(ws, targetSet.entryFile, inputs);
+    const scorecard = await this.evaluate(ws, targetSet, files, inputs);
     return { iter, ws, scorecard, targetSet, files };
   }
 }

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
@@ -35,7 +35,6 @@ describe("GreedyReflective (pointwise)", () => {
   });
 
   const deps = (): GreedyDeps => ({
-    workspaceRoot: path.join(root, "ws"),
     runInput: async () => ({ output: "out", recordPath: "" }),
     discover: () => fakeSource(),
     propose: async () => ({ rationale: "tighten", operations: [] }),

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.ts
@@ -49,7 +49,7 @@ export class GreedyReflective extends BaseOptimizer {
       optimizer: this.name, runId: this.config.runId,
       targets: source.targets, inputCount: inputs.length, iterations: this.config.iterations,
     });
-    const baseline = await this.makeCandidate("baseline", this.fork(source.baseDir), source, inputs);
+    const baseline = await this.makeCandidate("baseline", this.fork(), source, inputs, fileMap(source));
     this.requireBaselineGatesPass(baseline.scorecard);
     this.reporter.baselineScored({ objective: baseline.scorecard.objective() });
 
@@ -107,22 +107,21 @@ export class GreedyReflective extends BaseOptimizer {
       return { iter, decision: "validation-failed", rationale: outcome.rationale, diagnostics: outcome.diagnostics };
     }
     const preview = outcome.preview;
-    const candidate = await this.makeCandidate(iter, this.fork(champion.ws.dir), preview.targetSet, inputs, preview.files);
+    const candidate = await this.makeCandidate(iter, this.fork(), preview.targetSet, inputs, preview.files);
     const decision: Decision = this.beats(candidate, champion) ? "accepted" : "rejected";
     return { iter, decision, rationale: outcome.rationale, objective: candidate.scorecard.objective(), changes: preview.changes, candidate };
   }
 
-  /** Apply the candidate's file set (if any) into its forked workspace and grade it. */
+  /** Grade a candidate `files` map (the overlay) on `inputs`. */
   private async makeCandidate(
     iter: number | "baseline",
     ws: Workspace,
     targetSet: OptimizeTargetSet,
     inputs: Input[],
-    files?: Record<string, string>,
+    files: Record<string, string>,
   ): Promise<Candidate> {
-    if (files) this.workspace.applyFiles(ws, files);
-    const scorecard = await this.evaluate(ws, targetSet.entryFile, inputs);
-    return { iter, ws, scorecard, targetSet, files: files ?? fileMap(targetSet) };
+    const scorecard = await this.evaluate(ws, targetSet, files, inputs);
+    return { iter, ws, scorecard, targetSet, files };
   }
 
   /** Greedy's acceptance policy: pass every gate AND beat the champion's objective. */

--- a/packages/agency-lang/lib/optimize/targets.ts
+++ b/packages/agency-lang/lib/optimize/targets.ts
@@ -65,6 +65,25 @@ export function discoverOptimizeTargets(
   const baseDir = options.baseDir
     ? fs.realpathSync(path.resolve(options.baseDir))
     : defaultBaseDir(parsedFiles.map((parsed) => parsed.absoluteFile));
+  return buildTargetSet(absoluteEntryFile, baseDir, parsedFiles);
+}
+
+/** Absolute base directory of `entryFile`'s local import closure — the seed
+ *  directory for a run. Shared by the optimizer (as `source.baseDir`) and by
+ *  plain eval, so both compute the same default seed when no explicit one is
+ *  given. */
+export function agentClosureBaseDir(entryFile: string): string {
+  const absoluteEntryFile = fs.realpathSync(path.resolve(entryFile));
+  const parsedFiles: ParsedSourceFile[] = [];
+  visitFile(absoluteEntryFile, {}, parsedFiles);
+  return defaultBaseDir(parsedFiles.map((parsed) => parsed.absoluteFile));
+}
+
+function buildTargetSet(
+  absoluteEntryFile: string,
+  baseDir: string,
+  parsedFiles: ParsedSourceFile[],
+): OptimizeTargetSet {
 
   const files: Record<string, OptimizeSourceFile> = {};
   const targets: OptimizeTarget[] = [];

--- a/packages/agency-lang/lib/optimize/workspace.test.ts
+++ b/packages/agency-lang/lib/optimize/workspace.test.ts
@@ -19,91 +19,21 @@ describe("WorkspaceManager", () => {
     files: { "a.agency": { file: "a.agency", absoluteFile: file, source, sha256: sha } },
   });
 
-  it("forks a source dir into an isolated copy; edits do not touch the source", () => {
-    const src = path.join(root, "src");
-    fs.mkdirSync(src);
-    fs.writeFileSync(path.join(src, "agent.agency"), "node main() {}\n");
-    const wsm = new WorkspaceManager(path.join(root, "ws"));
-    const ws = wsm.fork(src);
-    expect(wsm.read(ws, "agent.agency")).toContain("node main()");
-    wsm.write(ws, "agent.agency", "node main() { 1 }\n");
-    expect(fs.readFileSync(path.join(src, "agent.agency"), "utf8")).not.toContain("{ 1 }");
+  it("gives each fork a distinct key (used as the EvalCache partition)", () => {
+    const wsm = new WorkspaceManager();
+    expect(wsm.fork().key).not.toBe(wsm.fork().key);
   });
 
-  it("applyFiles writes a file map into the workspace", () => {
-    const src = path.join(root, "src");
-    fs.mkdirSync(src);
-    const wsm = new WorkspaceManager(path.join(root, "ws"));
-    const ws = wsm.fork(src);
-    wsm.applyFiles(ws, { "a/b.agency": "node main() {}\n" });
-    expect(wsm.read(ws, "a/b.agency")).toContain("node main()");
-  });
-
-  it("gives each fork a distinct key", () => {
-    const src = path.join(root, "src");
-    fs.mkdirSync(src);
-    const wsm = new WorkspaceManager(path.join(root, "ws"));
-    expect(wsm.fork(src).key).not.toBe(wsm.fork(src).key);
-  });
-
-  it("fork skips heavy directories like node_modules", () => {
-    const src = path.join(root, "src");
-    fs.mkdirSync(src);
-    fs.writeFileSync(path.join(src, "agent.agency"), "node main() {}\n");
-    fs.mkdirSync(path.join(src, "node_modules"));
-    fs.writeFileSync(path.join(src, "node_modules", "big.js"), "x");
-    const ws = new WorkspaceManager(path.join(root, "ws")).fork(src);
-    expect(fs.existsSync(path.join(ws.dir, "agent.agency"))).toBe(true);
-    expect(fs.existsSync(path.join(ws.dir, "node_modules"))).toBe(false);
-  });
-
-  it("forks when the workspace root lives inside the source dir (runs/ under the package)", () => {
-    // Mirrors the real layout: agent at the package root, runsDir = <root>/runs/optimize.
-    fs.writeFileSync(path.join(root, "agent.agency"), "node main() {}\n");
-    fs.mkdirSync(path.join(root, "node_modules"));
-    fs.writeFileSync(path.join(root, "node_modules", "big.js"), "x");
-    fs.mkdirSync(path.join(root, "runs"), { recursive: true });
-    fs.writeFileSync(path.join(root, "runs", "stale.txt"), "old");
-    fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "agency-lang" }));
-
-    const wsm = new WorkspaceManager(path.join(root, "runs", "optimize", "r", "ws"));
-    const ws = wsm.fork(root);
-
-    expect(fs.existsSync(path.join(ws.dir, "agent.agency"))).toBe(true);
-    expect(fs.existsSync(path.join(ws.dir, "node_modules"))).toBe(false); // excluded
-    expect(fs.existsSync(path.join(ws.dir, "runs"))).toBe(false);          // excluded → no self-copy
-    // package.json excluded so the agent's `agency-lang` self-import climbs to the real package root.
-    expect(fs.existsSync(path.join(ws.dir, "package.json"))).toBe(false);
-  });
-
-  it("forks when the workspace root is inside a custom-named runs dir (--runs-dir optimize-runs)", () => {
-    // Reproduces the integration-test layout: agent at the base dir, but the
-    // runs dir is named "optimize-runs", not "runs". The fork must still skip
-    // the subtree containing the workspace root or cpSync self-copies.
-    fs.writeFileSync(path.join(root, "agent.agency"), "node main() {}\n");
-    fs.mkdirSync(path.join(root, "optimize-runs"), { recursive: true });
-    fs.writeFileSync(path.join(root, "optimize-runs", "stale.txt"), "old");
-
-    const wsm = new WorkspaceManager(path.join(root, "optimize-runs", "smoke", "ws"));
-    const ws = wsm.fork(root);
-
-    expect(fs.existsSync(path.join(ws.dir, "agent.agency"))).toBe(true);
-    expect(fs.existsSync(path.join(ws.dir, "optimize-runs"))).toBe(false); // skipped → no self-copy
-  });
-
-  it("refuses paths that escape the workspace (traversal / absolute)", () => {
-    const src = path.join(root, "src");
-    fs.mkdirSync(src);
-    const wsm = new WorkspaceManager(path.join(root, "ws"));
-    const ws = wsm.fork(src);
-    expect(() => wsm.write(ws, "../escape.txt", "x")).toThrow(/escapes the workspace/);
-    expect(() => wsm.read(ws, "../../etc/passwd")).toThrow(/escapes the workspace/);
+  it("fork allocates no filesystem state — workspaces are pure cache identities now", () => {
+    const wsm = new WorkspaceManager();
+    const ws = wsm.fork();
+    expect(ws).toEqual({ key: "ws-1" });
   });
 
   it("writeBack writes changed champion files back to source", () => {
     const file = path.join(root, "a.agency");
     fs.writeFileSync(file, "original");
-    const wsm = new WorkspaceManager(path.join(root, "ws"));
+    const wsm = new WorkspaceManager();
     wsm.writeBack(sourceFor(file, "original", sha256Text("original")), { "a.agency": "mutated" });
     expect(fs.readFileSync(file, "utf8")).toBe("mutated");
   });
@@ -111,7 +41,7 @@ describe("WorkspaceManager", () => {
   it("writeBack aborts when a source file changed on disk since discovery", () => {
     const file = path.join(root, "a.agency");
     fs.writeFileSync(file, "original");
-    const wsm = new WorkspaceManager(path.join(root, "ws"));
+    const wsm = new WorkspaceManager();
     // sha recorded at discovery no longer matches the on-disk content
     expect(() => wsm.writeBack(sourceFor(file, "stale", sha256Text("stale")), { "a.agency": "mutated" }))
       .toThrow(/modified externally/);

--- a/packages/agency-lang/lib/optimize/workspace.ts
+++ b/packages/agency-lang/lib/optimize/workspace.ts
@@ -1,95 +1,27 @@
 import * as fs from "fs";
-import * as path from "path";
 
 import { sha256Text, type OptimizeTargetSet } from "./targets.js";
 
-export type Workspace = { dir: string; key: string };
+/** Per-candidate cache-partition token. `EvalCache` keys runs by
+ *  `(key, inputId)`; under the new model nothing on-disk lives at the workspace
+ *  itself — per-iteration artifacts live under `runs/<runId>/agent-runs/<key>/`,
+ *  created by `evalRunLoadedInputs` rather than here. */
+export type Workspace = { key: string };
 
-/**
- * Entries never copied into a workspace fork.
- *
- * `package.json` is excluded deliberately: the generated agent imports the
- * Agency runtime via the bare specifier `agency-lang`, which resolves by
- * self-reference to the *nearest* `package.json` named `agency-lang`. Copying
- * the package's own `package.json` into the workspace would make the workspace
- * that nearest scope — and resolve the runtime to the workspace's (excluded,
- * absent) `dist/`. Leaving it out lets the self-reference climb to the real
- * package root, so the forked agent resolves the runtime exactly as an
- * in-place run does.
- */
-const FORK_EXCLUDED = ["node_modules", ".git", "dist", "runs", ".worktrees", "package.json"];
-
-/** Owns per-iteration workspace directories and resolves paths against them. */
+/** Owns the per-candidate cache-identity counter. No filesystem ownership. */
 export class WorkspaceManager {
   private counter = 0;
-  constructor(private readonly rootDir: string) {}
 
-  /**
-   * Copy `sourceDir` into a fresh workspace directory, skipping heavy/irrelevant dirs.
-   *
-   * We copy top-level entries one by one (rather than `cpSync(sourceDir, dir)`)
-   * because the runs directory — and thus `dir` itself — usually lives *inside*
-   * `sourceDir` (so the forked agent resolves `node_modules` by walking up to the
-   * package root). A whole-directory copy would hit Node's "cannot copy into a
-   * subdirectory of self" guard. Beyond the static excludes, we also skip the
-   * top-level entry that actually contains the workspace root, so any runs-dir
-   * name (`runs`, `optimize-runs`, or a custom `--runs-dir`) is handled, not
-   * just the literal `runs`.
-   */
-  fork(sourceDir: string): Workspace {
+  /** Mint a fresh cache-partition token. */
+  fork(): Workspace {
     this.counter += 1;
-    const key = `ws-${this.counter}`;
-    const dir = path.join(this.rootDir, key);
-    fs.mkdirSync(dir, { recursive: true });
-    const containingEntry = this.topLevelEntryContainingRoot(sourceDir);
-    for (const entry of fs.readdirSync(sourceDir)) {
-      if (FORK_EXCLUDED.includes(entry)) continue;
-      if (entry === containingEntry) continue;
-      fs.cpSync(path.join(sourceDir, entry), path.join(dir, entry), { recursive: true });
-    }
-    return { dir, key };
-  }
-
-  /**
-   * The top-level entry of `sourceDir` whose subtree contains this manager's
-   * workspace root, or null when the root lives outside `sourceDir`. Skipping it
-   * during a fork prevents copying a directory into its own descendant.
-   */
-  private topLevelEntryContainingRoot(sourceDir: string): string | null {
-    const rel = path.relative(sourceDir, this.rootDir);
-    if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return null;
-    return rel.split(path.sep)[0];
-  }
-
-  read(ws: Workspace, relPath: string): string {
-    return fs.readFileSync(this.resolveWithin(ws, relPath), "utf8");
-  }
-
-  write(ws: Workspace, relPath: string, content: string): void {
-    const abs = this.resolveWithin(ws, relPath);
-    fs.mkdirSync(path.dirname(abs), { recursive: true });
-    fs.writeFileSync(abs, content);
-  }
-
-  /** Resolve `relPath` against the workspace and refuse paths that escape it (`..`, absolute). */
-  private resolveWithin(ws: Workspace, relPath: string): string {
-    const root = path.resolve(ws.dir);
-    const abs = path.resolve(root, relPath);
-    if (abs !== root && !abs.startsWith(root + path.sep)) {
-      throw new Error(`Path ${JSON.stringify(relPath)} escapes the workspace ${root}`);
-    }
-    return abs;
-  }
-
-  /** Materialize a file map (e.g. OptimizeSourceMutator.preview().files) into the workspace. */
-  applyFiles(ws: Workspace, files: Record<string, string>): void {
-    for (const [rel, source] of Object.entries(files)) this.write(ws, rel, source);
+    return { key: `ws-${this.counter}` };
   }
 
   /**
    * Write a champion file set back to the original sources, sha-checked: every
    * discovered file must still match its discovery-time hash, or the whole
-   * writeback aborts (as PR #283). Only changed files are written.
+   * writeback aborts. Only changed files are written. (Never took a Workspace.)
    */
   writeBack(source: OptimizeTargetSet, championFiles: Record<string, string>): void {
     for (const sf of Object.values(source.files)) {

--- a/packages/agency-lang/lib/utils/projectTree.test.ts
+++ b/packages/agency-lang/lib/utils/projectTree.test.ts
@@ -1,0 +1,59 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { copyProjectTree, PROJECT_COPY_EXCLUDES } from "./projectTree.js";
+
+describe("copyProjectTree", () => {
+  let root: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "cpt-"));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("copies files but skips excluded entries and the dir containing dest", () => {
+    const src = path.join(root, "src");
+    fs.mkdirSync(path.join(src, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(src, "a.txt"), "a");
+    fs.writeFileSync(path.join(src, "sub", "b.txt"), "b");
+    fs.mkdirSync(path.join(src, "node_modules"));
+    fs.writeFileSync(path.join(src, "node_modules", "junk"), "x");
+    // dest lives inside src under a top-level "runs" entry
+    const dest = path.join(src, "runs", "wd");
+
+    copyProjectTree(src, dest);
+
+    expect(fs.readFileSync(path.join(dest, "a.txt"), "utf8")).toBe("a");
+    expect(fs.readFileSync(path.join(dest, "sub", "b.txt"), "utf8")).toBe("b");
+    expect(fs.existsSync(path.join(dest, "node_modules"))).toBe(false);
+    expect(fs.existsSync(path.join(dest, "runs"))).toBe(false);
+    expect(PROJECT_COPY_EXCLUDES).toContain("package.json");
+  });
+
+  it("skips a non-runs top-level entry that contains dest (custom runs-dir name)", () => {
+    const src = path.join(root, "proj");
+    fs.mkdirSync(path.join(src, "optimize-runs"), { recursive: true });
+    fs.writeFileSync(path.join(src, "agent.agency"), "node main() { return 1 }\n");
+    const dest = path.join(src, "optimize-runs", "smoke", "wd");
+
+    copyProjectTree(src, dest);
+
+    expect(fs.existsSync(path.join(dest, "agent.agency"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "optimize-runs"))).toBe(false);
+  });
+
+  it("excludes package.json so a copied agent's agency-lang self-import climbs out", () => {
+    const src = path.join(root, "proj");
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, "package.json"), '{"name":"agency-lang"}');
+    fs.writeFileSync(path.join(src, "agent.agency"), "node main() { return 1 }\n");
+    const dest = path.join(root, "wd");
+
+    copyProjectTree(src, dest);
+
+    expect(fs.existsSync(path.join(dest, "agent.agency"))).toBe(true);
+    expect(fs.existsSync(path.join(dest, "package.json"))).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/utils/projectTree.ts
+++ b/packages/agency-lang/lib/utils/projectTree.ts
@@ -1,0 +1,45 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Entries never copied into a run/working directory. `package.json` is excluded
+ * deliberately so a copied agent's bare `agency-lang` self-import climbs to the
+ * real package root instead of binding to an absent local `dist/`.
+ *
+ * The static `runs` exclude is a convenience for the default config; users can
+ * override `--runs-dir` to any name, which is why `copyProjectTree` also skips
+ * the top-level entry that contains `destDir` (see `entryContainingDest`).
+ */
+export const PROJECT_COPY_EXCLUDES = [
+  "node_modules", ".git", "dist", "runs", ".worktrees",
+  ".agency-tmp", ".js-tmp", ".agency-memory",
+  "package.json",
+];
+
+/** The top-level entry of `srcDir` whose subtree contains `destDir`, or null
+ *  when `destDir` is outside `srcDir`. Skipping it avoids copying a directory
+ *  into its own descendant. Handles arbitrary runs-dir names (custom
+ *  `--runs-dir`, `optimize-runs`, etc.), not just the literal `runs`. */
+function entryContainingDest(srcDir: string, destDir: string): string | null {
+  const rel = path.relative(srcDir, destDir);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return null;
+  }
+  return rel.split(path.sep)[0];
+}
+
+/** Copy `srcDir`'s top-level entries into `destDir`, skipping heavy/irrelevant
+ *  entries and the one that would copy `destDir` into itself. */
+export function copyProjectTree(srcDir: string, destDir: string): void {
+  fs.mkdirSync(destDir, { recursive: true });
+  const skip = entryContainingDest(srcDir, destDir);
+  for (const entry of fs.readdirSync(srcDir)) {
+    if (PROJECT_COPY_EXCLUDES.includes(entry)) {
+      continue;
+    }
+    if (entry === skip) {
+      continue;
+    }
+    fs.cpSync(path.join(srcDir, entry), path.join(destDir, entry), { recursive: true });
+  }
+}


### PR DESCRIPTION
## Summary

Unify `agency eval run` and the optimizer on a single per-input working directory: each input's workdir is seeded from the agent's project tree, the optimizer's candidate files are overlaid, and the entry agent is compiled in place. After this PR, **module-dir == cwd == workdir** for every agent run, so reads, writes, and execs can never diverge across copies.

## What changed

- New `prepareRunDir(spec, workdirPath, config)` — the single seed → overlay → compile-in-place primitive (`lib/eval/runWorkdir.ts`).
- New shared `copyProjectTree` helper (`lib/utils/projectTree.ts`) replaces ad-hoc copy logic in both `WorkspaceManager.fork` and `OptimizeArtifacts.prepareWorkspace`. Unifies the excludes list, fixing a latent bug where `artifacts.ts` was missing `package.json` (which could bind the copied agent's `agency-lang` self-import to the wrong package root).
- `agency eval run` now compiles and runs each input inside its own workdir. `EvalRunLoadedInputsOptions` gains `seed: { dir, agentRelPath }` and `overlayFiles: Record<string, string>` so the optimizer can pass the spec verbatim (no second closure walk, no silent divergence from `source.baseDir`).
- `Workspace` shrinks to `{ key: string }` (a pure `EvalCache`-partition token). `WorkspaceManager` is now just a counter. `applyFiles`/`read`/`write`/`resolveWithin`/`rootDir` are gone — per-iteration on-disk artifacts live under `runs/<runId>/agent-runs/<key>/…` and are created by `evalRunLoadedInputs`, not here.
- `BaseOptimizer.evaluate(ws, source, files, inputs)` and `RunInput(ws, source, files, input, id)` now thread the candidate's complete file map instead of an `entryFile` string + an on-disk tree.
- `gepa` and `greedy` drop every `workspace.applyFiles` call; `Candidate.files` (already on both) is the overlay.

## Breaking changes

- `agency eval run`: when `working_dir` is set, it must contain the agent file (was: any directory was copied as a separate fixture). Enforced at runtime in `evalRunLoadedInputs`.
- The agent is now compiled once per input (was: once up front). Workdirs are isolated per input. Compile-per-input is intentional.
- `BaseOptimizerDeps.workspaceRoot` was removed and `Workspace` shrank to `{ key }`. External optimizers that touched `ws.dir`/`workspace.applyFiles` must migrate to passing files through `evaluate(ws, source, files, inputs)`.

## Verification

- `grep -rn "applyFiles\|ws\.dir\|workspace\.dir\|workspaceRoot" lib` → zero matches.
- `npx tsc --noEmit` clean.
- `npx vitest run lib/eval/ lib/cli/eval/ lib/optimize/ lib/utils/projectTree.test.ts` → 411/411 tests passing across 54 files.
- New tests:
  - `lib/utils/projectTree.test.ts` — copy + excludes + self-skip.
  - `lib/eval/runWorkdir.test.ts` — `prepareRunDir`.
  - `lib/cli/eval/run.workdir.test.ts` — module-dir == cwd, `working_dir` containment, seed↔working_dir mutual exclusion, **overlay overwrites the seed copy inside each workdir while the source tree stays untouched**.
  - `lib/optimize/baseOptimizer.workdir.test.ts` — optimizer passes `seed` + `overlayFiles` out-of-band; per-candidate `ws.key` partitions `runsDir`.

## Out of scope

`lib/optimize/loop.ts` still builds its own per-iteration workspace and seeds `prepareRunDir` from it (extra I/O, but correct). Migrating it onto overlays is a documented follow-up; Task 1's shared copy helper makes that future change smaller.

## Commits

- `32c1438e` — Add shared `copyProjectTree` helper; dedupe artifacts.ts copy logic
- `8a6db8c4` — Add `prepareRunDir`: seed + overlay + compile-in-workdir
- `722913a2` — Compile + run each eval input inside its own workdir
- `3836d316` — Optimizer: workspace is results-only; overlay candidate files into the workdir
- `a7b0d04b` — Gepa + greedy: drop `applyFiles`; pass `Candidate.files` through `evaluate`
- `bdd2cd4c` — Eval e2e overlay test + CHANGELOG entry
