### PR TITLE
Fix stdlib evalRun: create the per-input workdir

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Jun 25 2026
+
+### Eval / Optimize
+- Fixed `std::agency/eval` `evalRun`: the workdir is now created for the stdlib path, which runs an already-compiled agent and so bypasses the CLI's `prepareRunDir` that otherwise materializes it. Previously the subprocess spawned with a non-existent cwd and failed with `ENOENT`.
+
 ## Jun 24 2026 — v0.6.4
 
 ### Language / Typechecker

--- a/packages/agency-lang/lib/stdlib/agencyEval.ts
+++ b/packages/agency-lang/lib/stdlib/agencyEval.ts
@@ -80,7 +80,13 @@ export function _prepareInput(
   input: Input,
 ): AgencyPrepareResult {
   try {
-    return { ok: true, prepared: prepareInput(state, input) };
+    const prepared = prepareInput(state, input);
+    // The stdlib evalRun runs an already-compiled agent, so it bypasses the
+    // CLI's prepareRunDir (seed + overlay + compile) that would otherwise
+    // materialize the workdir. There is nothing to seed here — the workdir is
+    // just an isolated cwd for the subprocess — so create it explicitly.
+    fs.mkdirSync(prepared.workdirPath, { recursive: true });
+    return { ok: true, prepared };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[evalRun] prepare failed for input ${input.id ?? ""}: ${message}`);


### PR DESCRIPTION
## Problem

CI was failing on `tests/agency/subprocess/eval-run-basic.test.json`: the test expected `true` but got `false` because the eval subprocess failed with `spawn node ENOENT`.

## Root cause

The unify commit `39e204f1` ("Unify eval + optimize on a single per-input working directory") deliberately removed the `mkdirSync(workdirPath)` from `prepareInput`, moving workdir materialization into `prepareRunDir` (seed-copy + overlay + compile, where `copyProjectTree` mkdirs the dir). That was correct for the **CLI path**, which was migrated to route through `runEvalInput` → `prepareRunDir`.

But the **stdlib `evalRun` path** (`std::agency/eval`) was never migrated. It runs an *already-compiled* agent, so it has nothing to seed and intentionally skips `prepareRunDir` — calling `_prepareInput` → `prepareInput` (now allocate-only) and then spawning the subprocess directly with `cwd: prepared.workdirPath`. With the mkdir gone, that cwd never existed, so `spawn` failed with `ENOENT` → `okCount: 0, errorCount: 1` → the test's `okCount == 1 && errorCount == 0` returned `false`.

## Fix

Rather than reverting the deliberate removal in `prepareInput`, materialize the empty workdir at the stdlib boundary in `_prepareInput` (`lib/stdlib/agencyEval.ts`) — the precompiled path's stand-in for `prepareRunDir`. `prepareInput` stays allocate-only as intended.

## Testing

- `pnpm run a test tests/agency/subprocess/eval-run-basic.agency` now passes.
- The 25 unit tests across `runArtifacts.test.ts`, `agencyEval.test.ts`, `runWorkdir.test.ts`, and `run.workdir.test.ts` still pass (CLI path unregressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
