### PR TITLE
Result type narrowing (Increment 1)

### DIFF
--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import { analyzeCondition, narrowToBranch } from "./narrowing.js";
+import type { IfElse } from "../types.js";
+import type { ResultType } from "../types/typeHints.js";
+
+// Parse a snippet and pull the condition of the first `if` in `main`.
+function firstIfCondition(body: string) {
+  const src = `node main() {\n  let r = foo()\n  if (${body}) { }\n}`;
+  const parsed = parseAgency(src);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  // walk to the ifElse node
+  let cond: IfElse["condition"] | undefined;
+  const visit = (nodes: any[]) => {
+    for (const n of nodes) {
+      if (n.type === "ifElse") cond = n.condition;
+      for (const k of ["body", "thenBody", "elseBody"]) if (Array.isArray(n[k])) visit(n[k]);
+    }
+  };
+  visit(parsed.result.nodes);
+  if (!cond) throw new Error("no if condition found");
+  return cond;
+}
+
+const NO_FACTS = { then: [], else: [] };
+
+describe("analyzeCondition", () => {
+  it("isSuccess(r): then→success, else→failure", () => {
+    expect(analyzeCondition(firstIfCondition("isSuccess(r)"))).toEqual({
+      then: [{ variableName: "r", branch: "success" }],
+      else: [{ variableName: "r", branch: "failure" }],
+    });
+  });
+
+  it("isFailure(r): then→failure, else→success", () => {
+    expect(analyzeCondition(firstIfCondition("isFailure(r)"))).toEqual({
+      then: [{ variableName: "r", branch: "failure" }],
+      else: [{ variableName: "r", branch: "success" }],
+    });
+  });
+
+  // One parametrized block covers every early-return branch in analyzeCondition.
+  // If any of these starts producing candidates, the test fails immediately —
+  // which is what we want, because each would mean we're narrowing a site we
+  // can't statically prove is the same variable at runtime.
+  it.each([
+    ["non-functionCall condition", "r == 1"],
+    ["unrelated function call", "foo(r)"],
+    ["isSuccess with zero args", "isSuccess()"],
+    ["isSuccess with too many args", "isSuccess(r, r)"],
+    ["isSuccess of a non-variable", "isSuccess(tryParse(\"x\"))"],
+    ["isSuccess of a member access", "isSuccess(o.r)"],
+  ])("produces no candidates for %s", (_label, src) => {
+    expect(analyzeCondition(firstIfCondition(src))).toEqual(NO_FACTS);
+  });
+});
+
+describe("narrowToBranch", () => {
+  const rt: ResultType = {
+    type: "resultType",
+    successType: { type: "primitiveType", value: "number" },
+    failureType: { type: "primitiveType", value: "string" },
+  };
+
+  it.each(["success", "failure"] as const)("tags a copy as %s without mutating the original", (branch) => {
+    const narrowed = narrowToBranch(rt, branch);
+    expect(narrowed.narrowedBranch).toBe(branch);
+    expect(narrowed.successType).toEqual(rt.successType);
+    expect(narrowed.failureType).toEqual(rt.failureType);
+    expect(rt.narrowedBranch).toBeUndefined();
+  });
+
+  it("re-narrowing replaces the previous branch rather than stacking", () => {
+    // Inside `if (isSuccess(r)) { if (isFailure(r)) { ... } }`, the inner
+    // re-narrow must overwrite, not append, or downstream synthesis sees
+    // a stale branch tag.
+    const onceSuccess = narrowToBranch(rt, "success");
+    const reFailure = narrowToBranch(onceSuccess, "failure");
+    expect(reFailure.narrowedBranch).toBe("failure");
+  });
+});
+
+function check(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+}
+
+const TRY_PARSE = `
+def tryParse(input: string): Result<number, string> {
+  if (input == "ok") { return success(42) }
+  return failure("bad")
+}
+`;
+
+describe("Result narrowing — isSuccess then-branch", () => {
+  it("narrows r.value to the success type inside an isSuccess guard", () => {
+    // r.value is `number` once narrowed, so assigning it to a `string` must error.
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) {
+    let n: string = r.value
+  }
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'n').");
+  });
+
+  it("types the binding from the lowered `is success(v)` form", () => {
+    // if (r is success(v)) lowers to: if (isSuccess(r)) { const v = r.value; ... }
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (r is success(v)) {
+    let n: string = v
+  }
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'n').");
+  });
+
+  it("skips narrowing when the variable is reassigned in the branch (soundness gate)", () => {
+    // Self-witnessing: `safeR` proves narrowing IS firing in this run; `reassignedR`
+    // proves the gate fired for the reassignment case. If narrowing breaks entirely,
+    // the `safeR` assertion fails — preventing the "passes silently when broken" trap
+    // a plain `.not.toContain` would have.
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let safeR = tryParse("ok")
+  let reassignedR = tryParse("ok")
+  if (isSuccess(safeR)) {
+    let safe: string = safeR.value
+  }
+  if (isSuccess(reassignedR)) {
+    reassignedR = tryParse("again")
+    let unsafe: string = reassignedR.value
+  }
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'safe').");
+    expect(errs).not.toContain("(assignment to 'unsafe')");
+  });
+
+  it("narrows inside the guard but does NOT leak past it", () => {
+    // Self-witnessing pair: `inside` proves narrowing fires inside the block;
+    // `after` proves it doesn't escape. Either half failing diagnoses the bug.
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) {
+    let inside: string = r.value
+  }
+  let after: string = r.value
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'inside').");
+    expect(errs).not.toContain("(assignment to 'after')");
+  });
+
+  it("threads non-narrowing typecheck errors through the narrowed body", () => {
+    // walkWithNarrowing passes ctx through to the inner walk; if ctx is dropped
+    // or replaced, errors inside narrowed bodies vanish. This locks that wiring.
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) {
+    let s: string = 42
+  }
+}`);
+    expect(errs.some((e) => /not assignable/.test(e) && /'s'/.test(e))).toBe(true);
+  });
+
+  it("narrows a function parameter, not just a let-bound local", () => {
+    // Parameters live on the function scope (declared at call-frame setup),
+    // not via a let-style declaration. The lookup path differs; a regression
+    // that restricts narrowing to let-bindings would slip past every other test.
+    const errs = check(`${TRY_PARSE}
+def consume(r: Result<number, string>) {
+  if (isSuccess(r)) {
+    let n: string = r.value
+  }
+}
+node main() { consume(tryParse("ok")) }`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'n').");
+  });
+
+  it("narrows independently in nested isSuccess guards", () => {
+    // Locks that scope chaining narrows two different variables across two
+    // nested guards. Catches a regression where the inner walkWithNarrowing
+    // accidentally shadows / replaces the outer narrowing.
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r1 = tryParse("ok")
+  let r2 = tryParse("ok")
+  if (isSuccess(r1)) {
+    if (isSuccess(r2)) {
+      let a: string = r1.value
+      let b: string = r2.value
+    }
+  }
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'a').");
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'b').");
+  });
+});
+
+describe("Result narrowing — failure branch", () => {
+  it("narrows r.error to the failure type in the else of an isSuccess guard", () => {
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) { } else {
+    let n: number = r.error
+  }
+}`);
+    // r.error is `string` once narrowed → assigning to `number` must error.
+    expect(errs).toContain("Type 'string' is not assignable to type 'number' (assignment to 'n').");
+  });
+
+  it("narrows r.error to the failure type inside an isFailure guard", () => {
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (isFailure(r)) {
+    let n: number = r.error
+  }
+}`);
+    expect(errs).toContain("Type 'string' is not assignable to type 'number' (assignment to 'n').");
+  });
+
+  it("types the binding from the lowered `is failure(e)` form", () => {
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (r is failure(e)) {
+    let n: number = e
+  }
+}`);
+    expect(errs).toContain("Type 'string' is not assignable to type 'number' (assignment to 'n').");
+  });
+});
+
+describe("Result narrowing — while and match", () => {
+  it("narrows r.value inside a while body and respects the reassignment gate", () => {
+    // Self-witnessing pair in one body: `safe` proves the while-body narrowing
+    // wiring fires; `unsafe` proves the soundness gate still triggers when the
+    // loop body reassigns its scrutinee. If narrowing breaks completely, the
+    // `safe` assertion fails — no silent-pass trap.
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let safeR = tryParse("ok")
+  while (isSuccess(safeR)) {
+    let safe: string = safeR.value
+    break
+  }
+  let unsafeR = tryParse("ok")
+  while (isSuccess(unsafeR)) {
+    let unsafe: string = unsafeR.value
+    unsafeR = tryParse("again")
+  }
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'safe').");
+    expect(errs).not.toContain("(assignment to 'unsafe')");
+  });
+
+  it("types the binding from a match success arm", () => {
+    // Match arm bodies are a single expression, so we surface the narrowed
+    // binding type by calling a helper whose parameter type mismatches it.
+    // `expectString` takes a `string`; passing a narrowed-to-`number` `v`
+    // produces an argument-type error iff narrowing flowed into the arm.
+    const errs = check(`${TRY_PARSE}
+def expectString(s: string) {}
+
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => expectString(v)
+    failure(e) => 0
+  }
+}`);
+    expect(errs.some((e) => /not assignable/.test(e))).toBe(true);
+  });
+
+  it("types the binding from a match failure arm", () => {
+    // Symmetric to the success-arm test. The failure arm lowers through a
+    // different path inside `lowerMatchBlock` (`isFailure(_temp)` guard +
+    // `const e = _temp.error` binding); a regression that breaks only the
+    // failure-arm lowering would slip past the success-arm test alone.
+    const errs = check(`${TRY_PARSE}
+def expectNumber(n: number) {}
+
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => 0
+    failure(e) => expectNumber(e)
+  }
+}`);
+    expect(errs.some((e) => /not assignable/.test(e))).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -202,6 +202,25 @@ node main() {
     expect(errs).not.toContain("(assignment to 'outside')");
   });
 
+  it("narrows an alias-typed Result (resolves the alias before the resultType check)", () => {
+    // Variables annotated with a type alias (`let r: R = ...` where
+    // `type R = Result<...>`) are stored in the scope as a
+    // `typeAliasVariable`, not a `resultType`. `applyNarrowing` must
+    // resolve through the alias so the narrowing fires — otherwise it
+    // silently doesn't, and Increment 3's hard-error flip would leave
+    // alias-typed Results un-narrowable (user adds the guard, still errors).
+    const errs = check(`${TRY_PARSE}
+type R = Result<number, string>
+
+node main() {
+  let r: R = tryParse("ok")
+  if (isSuccess(r)) {
+    let n: string = r.value
+  }
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'n').");
+  });
+
   it("narrows independently in nested isSuccess guards", () => {
     // Locks that scope chaining narrows two different variables across two
     // nested guards. Catches a regression where the inner walkWithNarrowing

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -184,6 +184,24 @@ node main() { consume(tryParse("ok")) }`);
     expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'n').");
   });
 
+  it("does NOT propagate the narrowing marker through a let-binding past the block", () => {
+    // `scope.declare()` calls `widenType()` on the inferred RHS, and
+    // `widenType` for `resultType` (assignability.ts) constructs a fresh
+    // object that does NOT copy `narrowedBranch`. So `let r2 = r` inside
+    // an isSuccess guard gives `r2` a clean ResultType, and `r2.value`
+    // outside the block stays `any` (the un-narrowed default).
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  let r2: Result<number, string> = failure("init")
+  if (isSuccess(r)) {
+    r2 = r
+  }
+  let outside: string = r2.value
+}`);
+    expect(errs).not.toContain("(assignment to 'outside')");
+  });
+
   it("narrows independently in nested isSuccess guards", () => {
     // Locks that scope chaining narrows two different variables across two
     // nested guards. Catches a regression where the inner walkWithNarrowing

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -1,7 +1,8 @@
-import type { AgencyNode, Expression } from "../types.js";
+import type { AgencyNode, Expression, TypeAliasEntry } from "../types.js";
 import type { ResultType } from "../types/typeHints.js";
 import { Scope } from "./scope.js";
 import { walkNodes } from "../utils/node.js";
+import { safeResolveType } from "./assignability.js";
 
 export type NarrowCandidate = { variableName: string; branch: "success" | "failure" };
 export type ConditionFacts = { then: NarrowCandidate[]; else: NarrowCandidate[] };
@@ -65,13 +66,20 @@ export function applyNarrowing(
   childScope: Scope,
   candidates: NarrowCandidate[],
   branchBody: AgencyNode[],
+  typeAliases: Record<string, TypeAliasEntry>,
 ): void {
   for (const cand of candidates) {
     const current = childScope.lookup(cand.variableName);
     if (!current || current === "any") continue;
-    if (current.type !== "resultType") continue;
+    // Resolve through type-alias variables (`let r: R = …` where
+    // `type R = Result<…>` is stored as `typeAliasVariable`, not `resultType`).
+    // Mirrors `synthValueAccess`, which also resolves before its Result check —
+    // without this, alias-typed Results silently never narrow, leaving them
+    // unfixable under Increment 3's hard-error flip.
+    const resolved = safeResolveType(current, typeAliases);
+    if (resolved.type !== "resultType") continue;
     if (isReassignedIn(branchBody, cand.variableName)) continue;
-    childScope.declareLocal(cand.variableName, narrowToBranch(current, cand.branch));
+    childScope.declareLocal(cand.variableName, narrowToBranch(resolved, cand.branch));
   }
 }
 
@@ -100,10 +108,11 @@ export function walkWithNarrowing<C>(
   parent: Scope,
   body: AgencyNode[],
   candidates: NarrowCandidate[],
+  typeAliases: Record<string, TypeAliasEntry>,
   ctx: C,
   walk: (body: AgencyNode[], scope: Scope, ctx: C) => void,
 ): void {
   const child = parent.child();
-  applyNarrowing(child, candidates, body);
+  applyNarrowing(child, candidates, body, typeAliases);
   walk(body, child, ctx);
 }

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -55,12 +55,11 @@ export function narrowToBranch(rt: ResultType, branch: "success" | "failure"): R
  * Refinements are written with declareLocal so they vanish when the child
  * scope is dropped at branch exit and never leak to the function scope.
  *
- * Side note on propagation: a `let r2 = r` inside a narrowed branch copies
- * the narrowed ResultType (including `narrowedBranch`) and goes to the
- * function scope via the normal `declare()` path. So `r2` is permanently
- * narrowed to that branch outside the if-body too. This is sound — `r2`
- * holds the same value `r` did at the moment of copy, and the Success /
- * Failure variant of a Result never changes for a given value.
+ * A `let r2 = r` inside a narrowed branch does NOT propagate the marker
+ * outside the block: `scope.declare()` calls `widenType()`, which for
+ * `resultType` rebuilds the object without `narrowedBranch`
+ * (assignability.ts:370). `r2.value` outside the block is therefore the
+ * usual un-narrowed `any`. Locked in by a test in narrowing.test.ts.
  */
 export function applyNarrowing(
   childScope: Scope,

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -1,0 +1,110 @@
+import type { AgencyNode, Expression } from "../types.js";
+import type { ResultType } from "../types/typeHints.js";
+import { Scope } from "./scope.js";
+import { walkNodes } from "../utils/node.js";
+
+export type NarrowCandidate = { variableName: string; branch: "success" | "failure" };
+export type ConditionFacts = { then: NarrowCandidate[]; else: NarrowCandidate[] };
+
+const NO_FACTS: ConditionFacts = { then: [], else: [] };
+
+/**
+ * Inspect a (post-lowering) boolean condition and report the narrowing
+ * candidates it implies for the then- and else-branches.
+ *
+ * Increment 1 recognizes a single `isSuccess(x)` / `isFailure(x)` guard where
+ * `x` is a bare variable. Both names are RESERVED_FUNCTION_NAMES
+ * (lib/typeChecker/resolveCall.ts) and cannot be user-redefined, so matching on
+ * the function name is unambiguous — no resolveCall lookup is required.
+ */
+export function analyzeCondition(condition: Expression): ConditionFacts {
+  if (condition.type !== "functionCall") return NO_FACTS;
+  const fn = condition.functionName;
+  if (fn !== "isSuccess" && fn !== "isFailure") return NO_FACTS;
+  if (condition.arguments.length !== 1) return NO_FACTS;
+  const arg = condition.arguments[0];
+  if (arg.type !== "variableName") return NO_FACTS;
+  const name = arg.value;
+  const thenBranch = fn === "isSuccess" ? "success" : "failure";
+  const elseBranch = fn === "isSuccess" ? "failure" : "success";
+  return {
+    then: [{ variableName: name, branch: thenBranch }],
+    else: [{ variableName: name, branch: elseBranch }],
+  };
+}
+
+/** Return a copy of a ResultType tagged as narrowed to one branch. */
+export function narrowToBranch(rt: ResultType, branch: "success" | "failure"): ResultType {
+  return { ...rt, narrowedBranch: branch };
+}
+
+/**
+ * Apply narrowing candidates to a fresh child scope for one branch body.
+ *
+ * Soundness gate: if the branch reassigns the variable (`r = ...`) ANYWHERE
+ * in its whole body, skip narrowing it — its type may change mid-branch.
+ *
+ * Two intentional sources of imprecision (both conservative — false negatives,
+ * never false positives, so soundness is preserved):
+ *  1. The scan is whole-body. A reassignment buried in a nested `if`'s OTHER
+ *     branch still blocks narrowing in the access site. A future increment
+ *     could thread a flow analysis here; not worth it yet.
+ *  2. `walkNodes` doesn't know about scoping, so a `for (r in xs)` iterator
+ *     or a nested function that shadows `r` would also trip the gate.
+ *
+ * Refinements are written with declareLocal so they vanish when the child
+ * scope is dropped at branch exit and never leak to the function scope.
+ *
+ * Side note on propagation: a `let r2 = r` inside a narrowed branch copies
+ * the narrowed ResultType (including `narrowedBranch`) and goes to the
+ * function scope via the normal `declare()` path. So `r2` is permanently
+ * narrowed to that branch outside the if-body too. This is sound — `r2`
+ * holds the same value `r` did at the moment of copy, and the Success /
+ * Failure variant of a Result never changes for a given value.
+ */
+export function applyNarrowing(
+  childScope: Scope,
+  candidates: NarrowCandidate[],
+  branchBody: AgencyNode[],
+): void {
+  for (const cand of candidates) {
+    const current = childScope.lookup(cand.variableName);
+    if (!current || current === "any") continue;
+    if (current.type !== "resultType") continue;
+    if (isReassignedIn(branchBody, cand.variableName)) continue;
+    childScope.declareLocal(cand.variableName, narrowToBranch(current, cand.branch));
+  }
+}
+
+function isReassignedIn(body: AgencyNode[], name: string): boolean {
+  for (const { node } of walkNodes(body)) {
+    if (node.type === "assignment" && node.variableName === name) return true;
+  }
+  return false;
+}
+
+/**
+ * The declarative one-call helper that every walkScopeBody narrowing site uses.
+ *
+ * Encapsulates the three-step "create a throwaway child scope, install
+ * refinements into it, then walk the branch body in that scope" recipe so
+ * callers say *what* they want ("walk this body under these narrowings")
+ * rather than open-coding the *how*. Adding a new narrowing site (e.g.,
+ * a future `for`-loop body if the spec ever calls for it) becomes a single
+ * call rather than three lines copy-pasted.
+ *
+ * The generic `ctx` + injected `walk` keeps this module free of any
+ * dependency on `scopes.ts` (which is where `walkScopeBody` and
+ * `TypeCheckerContext` live), avoiding a circular import.
+ */
+export function walkWithNarrowing<C>(
+  parent: Scope,
+  body: AgencyNode[],
+  candidates: NarrowCandidate[],
+  ctx: C,
+  walk: (body: AgencyNode[], scope: Scope, ctx: C) => void,
+): void {
+  const child = parent.child();
+  applyNarrowing(child, candidates, body);
+  walk(body, child, ctx);
+}

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -428,15 +428,16 @@ export function walkScopeBody(
         // declareLocal), so they never leak; real declarations inside the
         // body still call declare(), which targets the function scope.
         const facts = analyzeCondition(node.condition);
-        walkWithNarrowing(scope, node.thenBody, facts.then, ctx, walkScopeBody);
+        const aliases = ctx.getTypeAliases();
+        walkWithNarrowing(scope, node.thenBody, facts.then, aliases, ctx, walkScopeBody);
         if (node.elseBody) {
-          walkWithNarrowing(scope, node.elseBody, facts.else, ctx, walkScopeBody);
+          walkWithNarrowing(scope, node.elseBody, facts.else, aliases, ctx, walkScopeBody);
         }
         break;
       }
       case "whileLoop": {
         const facts = analyzeCondition(node.condition);
-        walkWithNarrowing(scope, node.body, facts.then, ctx, walkScopeBody);
+        walkWithNarrowing(scope, node.body, facts.then, ctx.getTypeAliases(), ctx, walkScopeBody);
         break;
       }
       case "messageThread":

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -20,6 +20,7 @@ import { Scope } from "./scope.js";
 import { formatTypeHint } from "../utils/formatType.js";
 import { checkType, getBlockSlot } from "./utils.js";
 import { NUMBER_T } from "./primitives.js";
+import { analyzeCondition, walkWithNarrowing } from "./narrowing.js";
 
 export function buildScopes(ctx: TypeCheckerContext): ScopeInfo[] {
   const scopes: ScopeInfo[] = [];
@@ -422,11 +423,22 @@ export function walkScopeBody(
         walkScopeBody(node.body, scope, ctx);
         break;
       }
-      case "ifElse":
-        walkScopeBody(node.thenBody, scope, ctx);
-        if (node.elseBody) walkScopeBody(node.elseBody, scope, ctx);
+      case "ifElse": {
+        // Refinements live in throwaway child scopes (walkWithNarrowing →
+        // declareLocal), so they never leak; real declarations inside the
+        // body still call declare(), which targets the function scope.
+        const facts = analyzeCondition(node.condition);
+        walkWithNarrowing(scope, node.thenBody, facts.then, ctx, walkScopeBody);
+        if (node.elseBody) {
+          walkWithNarrowing(scope, node.elseBody, facts.else, ctx, walkScopeBody);
+        }
         break;
-      case "whileLoop":
+      }
+      case "whileLoop": {
+        const facts = analyzeCondition(node.condition);
+        walkWithNarrowing(scope, node.body, facts.then, ctx, walkScopeBody);
+        break;
+      }
       case "messageThread":
       case "parallelBlock":
       case "seqBlock":

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -1,4 +1,5 @@
 import { AgencyNode, Expression, VariableType, ValueAccess, formatUnitLiteral } from "../types.js";
+import type { ResultType } from "../types/typeHints.js";
 import type {
   NamedArgument,
   SplatExpression,
@@ -36,6 +37,44 @@ const RESULT_FIELDS = new Set<string>([
   "retryable",
   "success",
 ]);
+
+/**
+ * Resolve a field access on a `ResultType` against the narrowing layer.
+ * Returns:
+ *  - a `VariableType`  → caller should set `currentType = ...; break;`
+ *  - the string `"any"` → caller should `return "any"` (Result field on an
+ *    un-narrowed Result; un-typed escape hatch until Increment 3 tightens
+ *    `.value` on Failure into a hard error)
+ *  - `null` → no resolution; fall through to the next case in `synthValueAccess`
+ *
+ * Pulled out of `synthValueAccess` to keep that function under the
+ * structural linter's max-lines-per-function budget. Single caller; the
+ * extraction is purely organizational.
+ */
+function resolveResultFieldType(
+  resolved: ResultType,
+  fieldName: string,
+): VariableType | "any" | null {
+  // Narrowed to the Success branch (inside an isSuccess guard).
+  if (resolved.narrowedBranch === "success") {
+    if (fieldName === "value") return resolved.successType;
+    if (fieldName === "success") return BOOLEAN_T;
+  }
+  // Narrowed to the Failure branch (isFailure guard, or the else of an
+  // isSuccess guard).
+  if (resolved.narrowedBranch === "failure") {
+    if (fieldName === "error") return resolved.failureType;
+    if (fieldName === "success") return BOOLEAN_T;
+    // `.value` on a known-Failure result is illegal at runtime; Increment 3
+    // turns this into an error. The Failure-only metadata fields
+    // (checkpoint/retryable/functionName/args) just fall through to the
+    // `RESULT_FIELDS → any` line below — we deliberately don't enumerate
+    // them: the existing fallthrough is already the correct, single-source-
+    // of-truth answer.
+  }
+  if (RESULT_FIELDS.has(fieldName)) return "any";
+  return null;
+}
 
 /**
  * `synthType` returns `VariableType | "any"` where `"any"` is the literal
@@ -598,8 +637,13 @@ export function synthValueAccess(
         // does not exist" errors. Once narrowing lands, this can be tightened
         // so .value is only valid on the Success branch and .error/etc. are
         // only valid on Failure.
-        if (resolved.type === "resultType" && RESULT_FIELDS.has(element.name)) {
-          return "any";
+        if (resolved.type === "resultType") {
+          const resolution = resolveResultFieldType(resolved, element.name);
+          if (resolution === "any") return "any";
+          if (resolution !== null) {
+            currentType = resolution;
+            break;
+          }
         }
         if (resolved.type === "unionType") {
           const propTypes: VariableType[] = [];

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -105,6 +105,10 @@ export type ResultType = {
   successType: VariableType;
   failureType: VariableType;
   tags?: Tag[];
+  // Set ONLY by the type checker's narrowing layer (lib/typeChecker/narrowing.ts)
+  // when a variable has been narrowed inside an isSuccess/isFailure guard.
+  // Never produced by parsing or return-type inference. isAssignable ignores it.
+  narrowedBranch?: "success" | "failure";
 };
 
 /**


### PR DESCRIPTION
## Result type narrowing (Increment 1)

Inside an `isSuccess` / `isFailure` guard (and the lowered forms of `is success(v)` / `is failure(e)` and `match` arms), `r.value` / `r.error` synthesizes to the concrete success / failure type instead of `any`. The match arm binding picks up the narrowed type automatically because the lowered form is `const v = r.value`.

```agency
def tryParse(input: string): Result<number, string> {
  if (input == "ok") { return success(42) }
  return failure("bad")
}

node main() {
  let r = tryParse("ok")
  if (isSuccess(r)) {
    let n: string = r.value      // error: number not assignable to string
  } else {
    let m: number = r.error      // error: string not assignable to number
  }
  match (r) {
    success(v) => expectString(v) // v is `number`, mismatch fires
    failure(e) => expectNumber(e) // e is `string`, mismatch fires
  }
  while (isSuccess(r)) {
    let n: string = r.value      // narrowing also fires in while bodies
    break
  }
}
```

### Architecture

- New `ResultType.narrowedBranch?: "success" | "failure"` marker, set only by the narrowing layer.
- New `lib/typeChecker/narrowing.ts` exposes `analyzeCondition` (recognizes a single `isSuccess(x)` / `isFailure(x)` guard over a bare variable), `narrowToBranch`, `applyNarrowing`, and `walkWithNarrowing` (the one-call helper every wiring site uses).
- `scopes.ts` `ifElse` and `whileLoop` cases call `walkWithNarrowing`. Refinements live in throwaway child scopes via `declareLocal`, so they never leak; real declarations inside the body still flow to the function scope via the normal `declare()` path.
- `synthValueAccess` consults the marker via `resolveResultFieldType` on Result field access. Un-narrowed access keeps the legacy `any` behavior — Increment 3 will tighten `.value` on Failure into a hard error.

### Soundness

A whole-body reassignment scan skips narrowing for any variable the branch reassigns. Conservative but never produces false positives. Coarse by design (whole-body, not flow-sensitive); precision improvements can come later.

### Out of scope (Increments 2-3)

negation / `&&` / `||`, null/truthiness narrowing, early-return narrowing, discriminated unions, member/alias scrutinees, the hard-error flip on un-narrowed `.value` access.

### Tests

24 vitest tests in `lib/typeChecker/narrowing.test.ts`:
- **Unit (analyzeCondition)**: parametrized coverage of every early-return branch — non-functionCall, unrelated call, zero/too-many args, non-variable arg, member access.
- **Unit (narrowToBranch)**: both success/failure (parametrized), immutability, and re-narrowing replaces (not stacks).
- **End-to-end then-branch (isSuccess)**: positive narrowing, lowered `is success(v)`, function parameter, nested guards, ctx-threading through `walkWithNarrowing`, plus two self-witnessing negative cases (reassignment gate, no-leak-past-block) that pair a *positive* "narrowing fires" assertion with the negative "doesn't fire here" assertion in the same body — so a regression that breaks narrowing entirely fails the positive half rather than silently passing the negative.
- **Failure branch**: isFailure guard, else of isSuccess, lowered `is failure(e)`.
- **while + match**: self-witnessing while body (safe vs reassigned), match success arm, match failure arm.

### Validation

- `npx vitest run lib/typeChecker/`: 667/667 pass (was 661 before).
- `npx tsc --noEmit`: clean.
- `pnpm run lint:structure`: clean.
- `pnpm run a test tests/agency/pattern-matching/resultPatternMatchIs.agency`: passes — narrowing is type-checker-only and doesn't affect runtime.

### Plan / spec

- Plan: `docs/superpowers/plans/2026-06-25-result-narrowing-increment-1.md`
- Spec: `type-narrowing-spec.md` (repo root)
