### PR TITLE
Improve local-model agent DX: rich catalog table + optional-value --local-model

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agency/local.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/local.md
@@ -21,7 +21,7 @@ export type DownloadedModel = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L21))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L22))
 
 ### ModelName
 
@@ -44,7 +44,7 @@ export type ModelName = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L26))
 
 ## Functions
 
@@ -58,7 +58,7 @@ True if smoltalk-llama-cpp is installed.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L38))
 
 ### resolveModelName
 
@@ -79,7 +79,7 @@ Map a curated short name or alias to its Hugging Face URI; pass URIs and
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L43))
 
 ### downloadModel
 
@@ -102,7 +102,7 @@ Download a model (curated name, alias, hf: URI) if not cached and return its
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L53))
 
 ### listDownloadedModels
 
@@ -122,7 +122,7 @@ List downloaded .gguf models.
 
 **Returns:** `DownloadedModel[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L64))
 
 ### listModelNames
 
@@ -134,7 +134,7 @@ List usable short names: curated built-ins and your aliases.
 
 **Returns:** `ModelName[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L73))
 
 ### aliasModel
 
@@ -156,7 +156,7 @@ Add a short-name alias for a model URI; returns the edited agency.json path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L78))
 
 ### unaliasModel
 
@@ -177,7 +177,7 @@ Remove a short-name alias; returns the inspected agency.json path (file
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L88))
 
 ### removeModel
 
@@ -199,7 +199,7 @@ Delete a downloaded model file; false if it was not present.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L98))
 
 ### registerLocalProvider
 
@@ -209,7 +209,7 @@ registerLocalProvider()
 
 Register the llama-cpp provider so local models can be used by llm().
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L108))
 
 ### registerLocalModel
 
@@ -232,4 +232,15 @@ Register the provider and ensure the model is downloaded; returns the local
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L113))
+
+### printLocalCatalog
+
+```ts
+printLocalCatalog()
+```
+
+Print the usable-model catalog (curated names + your aliases) as an
+  aligned table — the same listing as `agency local alias list`.
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L124))

--- a/packages/agency-lang/docs/site/stdlib/args.md
+++ b/packages/agency-lang/docs/site/stdlib/args.md
@@ -82,4 +82,4 @@ Parse `process.argv` against `schema`.
 
 **Returns:** [ParsedArgs](#parsedargs)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/args.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/args.agency#L120))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -711,7 +711,7 @@ node main() {
       },
       "local-model": {
         type: "string",
-        optionalValue: true,
+        optional: true,
         description: "Run a local model (downloads if needed): a curated short name, an hf: URI, or a .gguf path. Run without a value to list available models. Sets fast+slow to the local model and ignores --model/--provider/--fastmodel/--slowmodel. Requires: npm i -g smoltalk-llama-cpp"
       }
     }

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -25,6 +25,7 @@ import {
   recommendedAutoApprovePolicy,
  } from "./lib/defaultPolicy.agency"
 import { truncate, formatArgs, formatToolResponse } from "./lib/utils.agency"
+import { printLocalCatalog } from "std::agency/local"
 import { configureModels, configureLocalModel } from "./shared.agency"
 import { codeAgent } from "./subagents/code.agency"
 import { explorerAgent } from "./subagents/explorer.agency"
@@ -710,7 +711,8 @@ node main() {
       },
       "local-model": {
         type: "string",
-        description: "Run a local model (downloads if needed): a curated short name, an hf: URI, or a .gguf path. Sets fast+slow to the local model and ignores --model/--provider/--fastmodel/--slowmodel. Requires: npm i -g smoltalk-llama-cpp"
+        optionalValue: true,
+        description: "Run a local model (downloads if needed): a curated short name, an hf: URI, or a .gguf path. Run without a value to list available models. Sets fast+slow to the local model and ignores --model/--provider/--fastmodel/--slowmodel. Requires: npm i -g smoltalk-llama-cpp"
       }
     }
   },
@@ -727,11 +729,21 @@ node main() {
   // provider from API-key env vars and use that provider's defaults. The
   // fast model becomes the run-wide default via `setModel`; the slow
   // model is read by the deep-reasoning subagents (oracle, explorer).
-  // Resolve + apply the fast/slow models. Absent string flags read as
-  // `undefined`, and agency's `== null` does not match `undefined`, so
-  // normalize via `??` (which does treat `undefined` as nullish) to "".
-  const localModel = args.flags["local-model"] ?? ""
-  if (localModel != "") {
+  // `--local-model` is an optionalValue flag, giving three states:
+  //   absent  → `undefined` (compares false to both "" and null in agency)
+  //   bare    → "" (user wants to see the choices)
+  //   value   → the model name / hf: URI / .gguf path
+  // A bare flag lists the catalog and exits before any handlers/REPL start.
+  const localModel = args.flags["local-model"]
+  if (localModel == "") {
+    print("--local-model needs a model to run. Pick one of these short names:")
+    print("(or pass an hf: URI, a .gguf path, or an alias from `agency local alias add`)")
+    print("")
+    printLocalCatalog()
+    print("")
+    print("Example: agency agent --local-model smollm2-135m")
+    process.exit(0)
+  } else if (localModel) {
     configureLocalModel(localModel)
   } else {
     configureModels(

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -7,20 +7,9 @@ import {
   _unaliasModel,
   _removeModel,
   hasLocalModelSupport,
+  formatGB,
+  formatModelCatalog,
 } from "../stdlib/localModels.js";
-
-const BYTES_PER_GB = 1e9;
-
-function formatGB(bytes: number): string {
-  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
-}
-
-/** Context window in compact units: 8192 → "8K", 131072 → "128K", 1e7 → "10M". */
-function formatCtx(tokens: number): string {
-  if (tokens >= 1_000_000) return `${Math.round(tokens / 1_000_000)}M`;
-  if (tokens >= 1024) return `${Math.round(tokens / 1024)}K`;
-  return `${tokens}`;
-}
 
 /** Install-gate for I/O commands. Honors the AGENCY_LLAMA_PROVIDER_MODULE
  *  override the same way `requireSupport()` in `localModels.ts` does — a
@@ -94,22 +83,10 @@ export function runResolve(value: string): void {
 }
 
 export function runAliasList(): void {
-  // Curated entries print a fact line (params, category, size, context window,
-  // license) with the description on its own line — descriptions are too long
-  // for a single aligned table row. User aliases print name → target.
-  for (const m of _listModelNames()) {
-    if (m.source === "curated") {
-      const size = m.sizeBytes ? formatGB(m.sizeBytes) : "?";
-      const ctx = m.contextWindow ? `${formatCtx(m.contextWindow)} ctx` : "";
-      const facts = [m.params, m.category, size, ctx, m.license]
-        .filter(Boolean)
-        .join(" · ");
-      console.log(`${m.name}  (${facts})`);
-      if (m.description) console.log(`    ${m.description}`);
-    } else {
-      console.log(`${m.name} → ${m.target}  (alias)`);
-    }
-  }
+  // Aligned-table catalog (curated models + your aliases). The formatting
+  // lives in localModels.ts so the agent's bare `--local-model` output and
+  // this command render identically.
+  console.log(formatModelCatalog());
 }
 
 export function runAliasAdd(name: string, uri: string): void {

--- a/packages/agency-lang/lib/stdlib/args.test.ts
+++ b/packages/agency-lang/lib/stdlib/args.test.ts
@@ -1200,3 +1200,94 @@ describe("_parseArgsWith (end-to-end)", () => {
     ).toThrow(/v1 does not support negatable booleans/);
   });
 });
+
+describe("optionalValue flags", () => {
+  // A string flag whose value may be omitted. Bare → "", given → the value,
+  // absent → not present. Mirrors `agency agent --local-model`.
+  const schema: ArgsSchema = {
+    programName: "demo",
+    flags: {
+      model: { type: "string", optionalValue: true },
+      verbose: { type: "boolean", short: "v" },
+    },
+  };
+
+  it("yields \"\" when the flag is the last token (bare)", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--model"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("");
+  });
+
+  it("yields \"\" when the next token is another flag (bare)", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--model", "--verbose"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("");
+    expect(result!.flags.verbose).toBe(true);
+  });
+
+  it("yields \"\" for the explicit-empty --model= form", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--model="], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("");
+  });
+
+  it("yields the value when one is given", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--model", "smollm2-135m"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("smollm2-135m");
+  });
+
+  it("yields the value with the inline --model=value form", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--model=smollm2-135m"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("smollm2-135m");
+  });
+
+  it("is absent (not present) when the flag is not passed", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--verbose"], schema),
+    );
+    expect(ran).toBe(true);
+    expect("model" in result!.flags).toBe(false);
+  });
+
+  it("does not transform a look-alike positional after --", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["--model", "x", "--", "--model"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("x");
+    expect(result!.positionals).toEqual(["--model"]);
+  });
+
+  it("renders the value placeholder as optional in --help", () => {
+    const help = formatHelp(normalizeSchema(schema));
+    expect(help).toContain("--model [<string>]");
+  });
+
+  it("rejects optionalValue on a non-string flag", () => {
+    expect(() =>
+      validateSchema({
+        flags: { n: { type: "number", optionalValue: true } },
+      } as ArgsSchema),
+    ).toThrow(/optionalValue/);
+  });
+
+  it("rejects optionalValue combined with choices", () => {
+    expect(() =>
+      validateSchema({
+        flags: { m: { type: "string", optionalValue: true, choices: ["a", "b"] } },
+      } as ArgsSchema),
+    ).toThrow(/optionalValue/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/args.test.ts
+++ b/packages/agency-lang/lib/stdlib/args.test.ts
@@ -1201,13 +1201,13 @@ describe("_parseArgsWith (end-to-end)", () => {
   });
 });
 
-describe("optionalValue flags", () => {
+describe("optional (optional-value) flags", () => {
   // A string flag whose value may be omitted. Bare → "", given → the value,
   // absent → not present. Mirrors `agency agent --local-model`.
   const schema: ArgsSchema = {
     programName: "demo",
     flags: {
-      model: { type: "string", optionalValue: true },
+      model: { type: "string", short: "m", optional: true },
       verbose: { type: "boolean", short: "v" },
     },
   };
@@ -1275,19 +1275,53 @@ describe("optionalValue flags", () => {
     expect(help).toContain("--model [<string>]");
   });
 
-  it("rejects optionalValue on a non-string flag", () => {
-    expect(() =>
-      validateSchema({
-        flags: { n: { type: "number", optionalValue: true } },
-      } as ArgsSchema),
-    ).toThrow(/optionalValue/);
+  // Short aliases behave the same as the long form: bare → "", given → value.
+  it("yields \"\" for a bare short alias at end (-m)", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["-m"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("");
   });
 
-  it("rejects optionalValue combined with choices", () => {
+  it("yields \"\" for a bare short alias before another flag (-m --verbose)", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["-m", "--verbose"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("");
+    expect(result!.flags.verbose).toBe(true);
+  });
+
+  it("yields the value for a short alias with a separate value (-m x)", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["-m", "smollm2-135m"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("smollm2-135m");
+  });
+
+  it("yields the value for an attached short value (-mVALUE)", () => {
+    const { ran, result } = withMockedProcess(() =>
+      _parseArgsWith(["-msmollm2-135m"], schema),
+    );
+    expect(ran).toBe(true);
+    expect(result!.flags.model).toBe("smollm2-135m");
+  });
+
+  it("rejects optional on a non-string flag", () => {
     expect(() =>
       validateSchema({
-        flags: { m: { type: "string", optionalValue: true, choices: ["a", "b"] } },
+        flags: { n: { type: "number", optional: true } },
       } as ArgsSchema),
-    ).toThrow(/optionalValue/);
+    ).toThrow(/optional/);
+  });
+
+  it("rejects optional combined with choices", () => {
+    expect(() =>
+      validateSchema({
+        flags: { m: { type: "string", optional: true, choices: ["a", "b"] } },
+      } as ArgsSchema),
+    ).toThrow(/optional/);
   });
 });

--- a/packages/agency-lang/lib/stdlib/args.ts
+++ b/packages/agency-lang/lib/stdlib/args.ts
@@ -36,6 +36,12 @@ export type FlagSpec = {
   description?: string;
   choices?: string[];
   hidden?: boolean;
+  // String flags only: the value may be omitted. A bare `--flag` (last
+  // token, followed by another option, or `--flag=`) yields "" instead of
+  // raising a missing-value error, letting the program treat "present but
+  // empty" as a distinct state (e.g. "show me the choices"). Absent stays
+  // absent; a given value passes through unchanged.
+  optionalValue?: boolean;
 };
 
 export type FlagGroups = {
@@ -83,12 +89,13 @@ export type ParsedArgs = {
 // `hidden`) inherit their types via `Required<>`; the three with a
 // "missing" sentinel are spelled out below.
 export type NormalizedFlag = Required<
-  Omit<FlagSpec, "short" | "default" | "choices">
+  Omit<FlagSpec, "short" | "default" | "choices" | "optionalValue">
 > & {
   name: string;
   short: string | null;
   default: string | number | boolean | null;
   choices: string[] | null;
+  optionalValue: boolean;
 };
 
 export type NormalizedSchema = {
@@ -201,6 +208,22 @@ const SCHEMA_RULES: SchemaRule[] = [
       );
       return bad
         ? `flag --${bad[0]} has choices but is not a string flag`
+        : null;
+    },
+  },
+  {
+    // optionalValue only makes sense for string flags: a bare flag yields
+    // "", which a number can't coerce and a choices-constrained flag would
+    // reject. Booleans are already value-less.
+    name: "optionalValue only on string flags without choices",
+    check: (s) => {
+      const bad = Object.entries(s.flags).find(
+        ([, spec]) =>
+          spec.optionalValue === true &&
+          (spec.type !== "string" || spec.choices !== undefined),
+      );
+      return bad
+        ? `flag --${bad[0]} sets optionalValue but must be a string flag without choices`
         : null;
     },
   },
@@ -373,6 +396,7 @@ function normalizeFlag(name: string, spec: FlagSpec): NormalizedFlag {
     description: spec.description ?? "",
     choices: spec.choices ?? null,
     hidden: spec.hidden ?? false,
+    optionalValue: spec.optionalValue ?? false,
   };
 }
 
@@ -441,6 +465,45 @@ const ARGV_RULES: ArgvRule[] = [
     return { kind: "greedyValue", flag: name, raw: next };
   },
 ];
+
+// =============================================================================
+// expandOptionalFlags — let optionalValue flags appear without a value
+// =============================================================================
+//
+// Node's strict parseArgs has no optional-value concept: a string option
+// at end-of-args or followed by another option throws "argument missing".
+// We rewrite a bare optionalValue flag `--name` to `--name=` (empty value)
+// BEFORE any other stage runs, so the rest of the pipeline — preScan's
+// greedy/duplicate rules, Node's tokenizer, coercion — sees a normal
+// valued token and never has to special-case optionality. A flag is "bare"
+// when it's the last token or the next token is another option (`-`/`--`
+// prefixed); a `--name=...` (incl. empty `--name=`) already carries a value
+// and is left alone. Tokens after a standalone `--` are positionals and are
+// copied verbatim.
+export function expandOptionalFlags(
+  argv: string[],
+  schema: NormalizedSchema,
+): string[] {
+  const out: string[] = [];
+  let afterDoubleDash = false;
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (afterDoubleDash || token === "--") {
+      if (token === "--") afterDoubleDash = true;
+      out.push(token);
+      continue;
+    }
+    const flag = token.startsWith("--") ? schema.flagsByName[token.slice(2)] : undefined;
+    if (flag?.optionalValue === true) {
+      const next = argv[i + 1];
+      const bare = next === undefined || next === "--" || next.startsWith("-");
+      out.push(bare ? `${token}=` : token);
+    } else {
+      out.push(token);
+    }
+  }
+  return out;
+}
 
 export function preScanArgv(
   argv: string[],
@@ -804,6 +867,8 @@ function toRow(f: NormalizedFlag): OptionRow {
 
 function valuePlaceholder(f: NormalizedFlag): string {
   if (f.type === "boolean") return "";
+  // optionalValue flags show the value in brackets: `--model [<string>]`.
+  if (f.optionalValue) return ` [<${f.type}>]`;
   if (f.choices !== null) return ` <${f.choices.join("|")}>`;
   return ` <${f.type}>`;
 }
@@ -917,6 +982,10 @@ export function _parseArgsWith(
 ): ParsedArgs {
   validateSchema(schema); // throws on schema bugs
   const normalized = normalizeSchema(schema);
+
+  // Stage 0: rewrite bare optionalValue flags (`--model` → `--model=`) so
+  // every later stage sees an ordinary valued token.
+  argv = expandOptionalFlags(argv, normalized);
 
   // Stage 1: tokenize. Pre-scan rejects -n=v and --x --y greedy values.
   const preScan = preScanArgv(argv, normalized);

--- a/packages/agency-lang/lib/stdlib/args.ts
+++ b/packages/agency-lang/lib/stdlib/args.ts
@@ -41,7 +41,7 @@ export type FlagSpec = {
   // raising a missing-value error, letting the program treat "present but
   // empty" as a distinct state (e.g. "show me the choices"). Absent stays
   // absent; a given value passes through unchanged.
-  optionalValue?: boolean;
+  optional?: boolean;
 };
 
 export type FlagGroups = {
@@ -89,13 +89,13 @@ export type ParsedArgs = {
 // `hidden`) inherit their types via `Required<>`; the three with a
 // "missing" sentinel are spelled out below.
 export type NormalizedFlag = Required<
-  Omit<FlagSpec, "short" | "default" | "choices" | "optionalValue">
+  Omit<FlagSpec, "short" | "default" | "choices" | "optional">
 > & {
   name: string;
   short: string | null;
   default: string | number | boolean | null;
   choices: string[] | null;
-  optionalValue: boolean;
+  optional: boolean;
 };
 
 export type NormalizedSchema = {
@@ -212,18 +212,18 @@ const SCHEMA_RULES: SchemaRule[] = [
     },
   },
   {
-    // optionalValue only makes sense for string flags: a bare flag yields
+    // `optional` only makes sense for string flags: a bare flag yields
     // "", which a number can't coerce and a choices-constrained flag would
     // reject. Booleans are already value-less.
-    name: "optionalValue only on string flags without choices",
+    name: "optional only on string flags without choices",
     check: (s) => {
       const bad = Object.entries(s.flags).find(
         ([, spec]) =>
-          spec.optionalValue === true &&
+          spec.optional === true &&
           (spec.type !== "string" || spec.choices !== undefined),
       );
       return bad
-        ? `flag --${bad[0]} sets optionalValue but must be a string flag without choices`
+        ? `flag --${bad[0]} sets optional but must be a string flag without choices`
         : null;
     },
   },
@@ -396,7 +396,7 @@ function normalizeFlag(name: string, spec: FlagSpec): NormalizedFlag {
     description: spec.description ?? "",
     choices: spec.choices ?? null,
     hidden: spec.hidden ?? false,
-    optionalValue: spec.optionalValue ?? false,
+    optional: spec.optional ?? false,
   };
 }
 
@@ -467,19 +467,20 @@ const ARGV_RULES: ArgvRule[] = [
 ];
 
 // =============================================================================
-// expandOptionalFlags — let optionalValue flags appear without a value
+// expandOptionalFlags — let `optional` flags appear without a value
 // =============================================================================
 //
 // Node's strict parseArgs has no optional-value concept: a string option
 // at end-of-args or followed by another option throws "argument missing".
-// We rewrite a bare optionalValue flag `--name` to `--name=` (empty value)
-// BEFORE any other stage runs, so the rest of the pipeline — preScan's
-// greedy/duplicate rules, Node's tokenizer, coercion — sees a normal
-// valued token and never has to special-case optionality. A flag is "bare"
-// when it's the last token or the next token is another option (`-`/`--`
-// prefixed); a `--name=...` (incl. empty `--name=`) already carries a value
-// and is left alone. Tokens after a standalone `--` are positionals and are
-// copied verbatim.
+// We rewrite a bare `optional` flag to `--<name>=` (empty value) BEFORE any
+// other stage runs, so the rest of the pipeline — preScan's greedy/duplicate
+// rules, Node's tokenizer, coercion — sees a normal valued token and never
+// has to special-case optionality. A flag is "bare" when it's the last token
+// or the next token is another option (`-`/`--` prefixed). Token
+// classification reuses `flagNameOf`, so this handles long (`--name`) and
+// short (`-n`) forms uniformly — both rewrite to the long `--<name>=`. A token
+// that already carries a value (`--name=...`, `-nVALUE`) is left alone. Tokens
+// after a standalone `--` are positionals and are copied verbatim.
 export function expandOptionalFlags(
   argv: string[],
   schema: NormalizedSchema,
@@ -493,16 +494,27 @@ export function expandOptionalFlags(
       out.push(token);
       continue;
     }
-    const flag = token.startsWith("--") ? schema.flagsByName[token.slice(2)] : undefined;
-    if (flag?.optionalValue === true) {
+    const name = flagNameOf(token, schema);
+    const flag = name !== null ? schema.flagsByName[name] : undefined;
+    if (flag?.optional === true && !tokenHasAttachedValue(token)) {
       const next = argv[i + 1];
       const bare = next === undefined || next === "--" || next.startsWith("-");
-      out.push(bare ? `${token}=` : token);
-    } else {
-      out.push(token);
+      if (bare) {
+        out.push(`--${name}=`);
+        continue;
+      }
     }
+    out.push(token);
   }
   return out;
+}
+
+/** Whether a flag token already carries its value inline: `--name=value`
+ *  (incl. empty `--name=`) for long form, `-nVALUE` (attached) for short. A
+ *  bare `--name` / `-n` does not. */
+function tokenHasAttachedValue(token: string): boolean {
+  if (token.startsWith("--")) return token.includes("=");
+  return token.length > 2; // "-n" → bare; "-nVALUE" → attached
 }
 
 export function preScanArgv(
@@ -867,8 +879,8 @@ function toRow(f: NormalizedFlag): OptionRow {
 
 function valuePlaceholder(f: NormalizedFlag): string {
   if (f.type === "boolean") return "";
-  // optionalValue flags show the value in brackets: `--model [<string>]`.
-  if (f.optionalValue) return ` [<${f.type}>]`;
+  // optional-value flags show the value in brackets: `--model [<string>]`.
+  if (f.optional) return ` [<${f.type}>]`;
   if (f.choices !== null) return ` <${f.choices.join("|")}>`;
   return ` <${f.type}>`;
 }
@@ -983,7 +995,7 @@ export function _parseArgsWith(
   validateSchema(schema); // throws on schema bugs
   const normalized = normalizeSchema(schema);
 
-  // Stage 0: rewrite bare optionalValue flags (`--model` → `--model=`) so
+  // Stage 0: rewrite bare `optional` flags (`--model` → `--model=`) so
   // every later stage sees an ordinary valued token.
   argv = expandOptionalFlags(argv, normalized);
 

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -13,6 +13,7 @@ import {
   _localModelsSupported,
   resolveAliasConfigPath,
   resolveSmoltalkLlamaCppFromRoots,
+  formatModelCatalog,
 } from "./localModels.js";
 
 let dir: string;
@@ -229,5 +230,16 @@ describe("provider register + download (fake bundled module)", () => {
     process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
     expect(await _registerLocalModel("/abs/my.gguf", "/cache")).toBe("RESOLVED:/abs/my.gguf");
     expect(smoltalkPkg.getClient({ model: "m", provider: "llama-cpp" }).constructor.name).toBe("FakeLlama");
+  });
+});
+
+describe("formatModelCatalog", () => {
+  it("renders the curated models and has no trailing newline", () => {
+    const out = formatModelCatalog();
+    expect(out).toContain("smollm2-135m");
+    expect(out.endsWith("\n")).toBe(false);
+    // Blank lines separate models but never trail the block.
+    expect(out.endsWith("")).toBe(true);
+    expect(/\n\s*\n\s*$/.test(out)).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -500,8 +500,8 @@ function colWidth(header: string, values: string[]): number {
  *  fact row per curated model (params, category, size, context window,
  *  license), the description on a dimmed line below, a blank line between
  *  models. User aliases (which carry no metadata) follow in an ALIASES
- *  section as `name → target`. Returns the block as a string (no trailing
- *  newline beyond the inter-entry spacing) for a caller to print. */
+ *  section as `name → target`. Returns the block as a string with no trailing
+ *  newline (the caller's `console.log` adds exactly one). */
 export function formatModelCatalog(): string {
   const entries = _listModelNames();
   const curated = entries.filter((m) => m.source === "curated");
@@ -541,14 +541,17 @@ export function formatModelCatalog(): string {
 
     // LICENSE is the last column, so it needs no trailing pad.
     lines.push(ttyColor.bold(row("NAME", "PARAMS", "CATEGORY", "SIZE", "CTX", "LICENSE")));
-    for (const r of rows) {
+    rows.forEach((r, i) => {
+      // Blank line *between* models, not after the last one, so the joined
+      // string has no trailing newline (console.log adds exactly one).
+      if (i > 0) lines.push("");
       lines.push(row(r.name, r.params, r.category, r.size, r.ctx, r.license));
       if (r.description) lines.push(ttyColor.dim(`    ${r.description}`));
-      lines.push("");
-    }
+    });
   }
 
   if (aliases.length > 0) {
+    if (lines.length > 0) lines.push(""); // separate the table from ALIASES
     lines.push(ttyColor.bold("ALIASES"));
     for (const a of aliases) {
       lines.push(`${a.name} → ${a.target}`);

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -6,6 +6,7 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { findFileUp } from "../importPaths.js";
 import { loadProviderModuleByPath } from "../runtime/providerModules.js";
+import { ttyColor } from "../utils/termcolors.js";
 
 /** What a model is FOR — a single axis, orthogonal to size (size is conveyed
  *  by `params` / `sizeBytes`). Lets the CLI group + filter without parsing the
@@ -470,4 +471,95 @@ export async function _downloadModel(value: string, cacheDir: string = ""): Prom
 export async function _registerLocalModel(value: string, cacheDir: string = ""): Promise<string> {
   await _registerLocalProvider();
   return await _downloadModel(value, cacheDir);
+}
+
+// =============================================================================
+// Catalog rendering — shared by `agency local alias list` and the agent's
+// bare `--local-model` discovery output, so both show an identical table.
+// =============================================================================
+
+const BYTES_PER_GB = 1e9;
+
+export function formatGB(bytes: number): string {
+  return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
+}
+
+/** Context window in compact units: 8192 → "8K", 131072 → "128K", 1e7 → "10M". */
+export function formatCtx(tokens: number): string {
+  if (tokens >= 1_000_000) return `${Math.round(tokens / 1_000_000)}M`;
+  if (tokens >= 1024) return `${Math.round(tokens / 1024)}K`;
+  return `${tokens}`;
+}
+
+/** Width of a column: the longer of its header and its widest value. */
+function colWidth(header: string, values: string[]): number {
+  return Math.max(header.length, ...values.map((v) => v.length));
+}
+
+/** Render the usable-model list as an aligned table: a header row plus one
+ *  fact row per curated model (params, category, size, context window,
+ *  license), the description on a dimmed line below, a blank line between
+ *  models. User aliases (which carry no metadata) follow in an ALIASES
+ *  section as `name → target`. Returns the block as a string (no trailing
+ *  newline beyond the inter-entry spacing) for a caller to print. */
+export function formatModelCatalog(): string {
+  const entries = _listModelNames();
+  const curated = entries.filter((m) => m.source === "curated");
+  const aliases = entries.filter((m) => m.source === "alias");
+  const lines: string[] = [];
+
+  if (curated.length > 0) {
+    const rows = curated.map((m) => ({
+      name: m.name,
+      params: m.params ?? "",
+      category: m.category ?? "",
+      size: m.sizeBytes ? formatGB(m.sizeBytes) : "?",
+      ctx: m.contextWindow ? formatCtx(m.contextWindow) : "",
+      license: m.license ?? "",
+      description: m.description ?? "",
+    }));
+    // Computed widths so columns fit the actual data (names range from ~10
+    // to ~28 chars). SIZE and CTX are numeric, so they right-align.
+    const w = {
+      name: colWidth("NAME", rows.map((r) => r.name)),
+      params: colWidth("PARAMS", rows.map((r) => r.params)),
+      category: colWidth("CATEGORY", rows.map((r) => r.category)),
+      size: colWidth("SIZE", rows.map((r) => r.size)),
+      ctx: colWidth("CTX", rows.map((r) => r.ctx)),
+    };
+    const row = (
+      name: string,
+      params: string,
+      category: string,
+      size: string,
+      ctx: string,
+      license: string,
+    ): string =>
+      `${name.padEnd(w.name)}  ${params.padEnd(w.params)}  ${category.padEnd(
+        w.category,
+      )}  ${size.padStart(w.size)}  ${ctx.padStart(w.ctx)}  ${license}`;
+
+    // LICENSE is the last column, so it needs no trailing pad.
+    lines.push(ttyColor.bold(row("NAME", "PARAMS", "CATEGORY", "SIZE", "CTX", "LICENSE")));
+    for (const r of rows) {
+      lines.push(row(r.name, r.params, r.category, r.size, r.ctx, r.license));
+      if (r.description) lines.push(ttyColor.dim(`    ${r.description}`));
+      lines.push("");
+    }
+  }
+
+  if (aliases.length > 0) {
+    lines.push(ttyColor.bold("ALIASES"));
+    for (const a of aliases) {
+      lines.push(`${a.name} → ${a.target}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Print the model catalog to stdout. The agent's bare `--local-model`
+ *  path calls this through `std::agency/local`. */
+export function _printLocalCatalog(): void {
+  console.log(formatModelCatalog());
 }

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -9,6 +9,7 @@ import {
   _removeModel,
   _registerLocalProvider,
   _registerLocalModel,
+  _printLocalCatalog,
 } from "agency-lang/stdlib-lib/localModels.js"
 
 /** @module
@@ -118,4 +119,10 @@ export def registerLocalModel(value: string, cacheDir: string = ""): string {
   @param cacheDir - download dir (empty string = per-user cache)
   """
   return _registerLocalModel(value, cacheDir)
+}
+
+export def printLocalCatalog() {
+  """Print the usable-model catalog (curated names + your aliases) as an
+  aligned table — the same listing as `agency local alias list`."""
+  _printLocalCatalog()
 }

--- a/packages/agency-lang/stdlib/args.agency
+++ b/packages/agency-lang/stdlib/args.agency
@@ -53,7 +53,7 @@ import { _parseArgs } from "agency-lang/stdlib-lib/args.js"
     `default` is applied when the flag is absent (mutually exclusive with
     `required`). `choices` constrains string flags to a fixed set of
     case-sensitive values. `hidden` flags still parse but are omitted
-    from `--help`. `optionalValue` (string flags only, no `choices`) lets
+    from `--help`. `optional` (string flags only, no `choices`) lets
     the value be omitted: a bare `--flag` yields "" instead of a
     missing-value error, so "present but empty" is a distinct state from
     absent — useful for "show me the choices" affordances. */
@@ -65,7 +65,7 @@ type FlagSpec = {
   description?: string;
   choices?: string[];
   hidden?: boolean;
-  optionalValue?: boolean
+  optional?: boolean
 }
 
 /** Optional flag-group constraints. `exclusive` declares sets of

--- a/packages/agency-lang/stdlib/args.agency
+++ b/packages/agency-lang/stdlib/args.agency
@@ -53,7 +53,10 @@ import { _parseArgs } from "agency-lang/stdlib-lib/args.js"
     `default` is applied when the flag is absent (mutually exclusive with
     `required`). `choices` constrains string flags to a fixed set of
     case-sensitive values. `hidden` flags still parse but are omitted
-    from `--help`. */
+    from `--help`. `optionalValue` (string flags only, no `choices`) lets
+    the value be omitted: a bare `--flag` yields "" instead of a
+    missing-value error, so "present but empty" is a distinct state from
+    absent — useful for "show me the choices" affordances. */
 type FlagSpec = {
   type: "string" | "number" | "boolean";
   short?: string;
@@ -61,7 +64,8 @@ type FlagSpec = {
   required?: boolean;
   description?: string;
   choices?: string[];
-  hidden?: boolean
+  hidden?: boolean;
+  optionalValue?: boolean
 }
 
 /** Optional flag-group constraints. `exclusive` declares sets of


### PR DESCRIPTION
## Summary

Two DX follow-ups to the local-model agent support.

### 1. Readable model list
`agency local alias list` now renders an aligned table instead of a dense, unaligned parenthetical:

```
NAME                          PARAMS     CATEGORY       SIZE   CTX  LICENSE
smollm2-135m                  135M       general     0.10 GB    8K  apache-2.0
    Smallest practical chat model; used by our integration tests, runs anywhere.

qwen3.5-2b                    2B         general     1.28 GB  128K  apache-2.0
    Most popular modern small general model; runs on CPU comfortably.
```

Columns are computed to fit the data; SIZE/CTX right-align; the description sits on a dimmed line; blank lines separate entries. Header is bold on a TTY, plain when piped.

### 2. Discoverable `--local-model`
`agency agent --local-model` with **no value** now prints that catalog so users can see what to pick, instead of failing with a terse "missing value" parser error. A given value runs locally as before; absent uses the normal model resolution.

## How it works

Rather than a one-off CLI intercept, the bare-flag behavior is modeled in the parsing lib:

- **New `optionalValue` flag type in `std::args`** (string flags only): a bare `--flag` yields `""` instead of a missing-value error. Implemented as an argv pre-pass that rewrites `--flag` to `--flag=` before any other stage, so preScan, Node's tokenizer, and coercion are untouched. `--help` shows the value as optional (`[<string>]`).
- The agent declares `--local-model` as `optionalValue` and handles the tri-state directly (absent / `""` -> catalog + exit / value -> run local), keeping behavior next to the flag declaration.
- The catalog formatter is extracted into `localModels.ts` (`formatModelCatalog` / `_printLocalCatalog`, exposed as `printLocalCatalog()` in `std::agency/local`) so the CLI and the agent render an identical table.

## Testing

- 10 new `optionalValue` cases; full 140-test `std::args` suite green.
- Existing `cli/local` tests green; structural linter clean.
- Manually verified: bare flag lists + exits 0, bare-before-flag lists, valued runs a local model, absent uses normal models, `--help` shows `[<string>]`, piped output has no escape codes.

Note: two pre-existing `resolveSmoltalkLlamaCppFromRoots` test failures are environmental (the package is resolvable in this workspace) and reproduce on `main` independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
