### PR TITLE
Add 'agency local refresh': refreshable local-model catalog

### DIFF
--- a/packages/agency-lang/data/model-catalog.json
+++ b/packages/agency-lang/data/model-catalog.json
@@ -1,0 +1,122 @@
+{
+  "version": 1,
+  "models": {
+    "smollm2-135m": {
+      "uri": "hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
+      "params": "135M",
+      "sizeBytes": 105000000,
+      "category": "general",
+      "contextWindow": 8192,
+      "license": "apache-2.0",
+      "description": "Smallest practical chat model; used by our integration tests, runs anywhere."
+    },
+    "qwen3.5-0.8b": {
+      "uri": "hf:unsloth/Qwen3.5-0.8B-GGUF:Q4_K_M",
+      "params": "0.8B",
+      "sizeBytes": 500000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Tiny model from Alibaba's current generation; good edge-device default."
+    },
+    "qwen3.5-2b": {
+      "uri": "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
+      "params": "2B",
+      "sizeBytes": 1280000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Most popular modern small general model; runs on CPU comfortably."
+    },
+    "qwen3.5-4b": {
+      "uri": "hf:unsloth/Qwen3.5-4B-GGUF:Q4_K_M",
+      "params": "4B",
+      "sizeBytes": 2400000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Strong multilingual small general workhorse from Alibaba."
+    },
+    "qwen3.5-9b": {
+      "uri": "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
+      "params": "9B",
+      "sizeBytes": 5500000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Modern medium general model with strong tool use; 128K context."
+    },
+    "gpt-oss-20b": {
+      "uri": "hf:unsloth/gpt-oss-20b-GGUF:Q4_K_M",
+      "params": "20B",
+      "sizeBytes": 12000000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "OpenAI's open-weights release; balanced general model for ~16 GB machines."
+    },
+    "mistral-small-3.1": {
+      "uri": "hf:unsloth/Mistral-Small-3.1-24B-Instruct-2503-GGUF:Q4_K_M",
+      "params": "24B",
+      "sizeBytes": 14000000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Mistral's general 24B base model (also Devstral's foundation); broad utility."
+    },
+    "qwen3.5-27b": {
+      "uri": "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
+      "params": "27B",
+      "sizeBytes": 16000000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Modern dense general 27B; the practical ceiling for most workstations."
+    },
+    "deepseek-r1-distill-llama-8b": {
+      "uri": "hf:unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q4_K_M",
+      "params": "8B",
+      "sizeBytes": 4920000000,
+      "category": "reasoning",
+      "contextWindow": 131072,
+      "license": "mit",
+      "description": "Chain-of-thought distill into Llama-8B; best small reasoning model."
+    },
+    "phi-4-reasoning": {
+      "uri": "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
+      "params": "14B",
+      "sizeBytes": 9050000000,
+      "category": "reasoning",
+      "contextWindow": 32768,
+      "license": "mit",
+      "description": "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic."
+    },
+    "devstral-small-2507": {
+      "uri": "hf:mistralai/Devstral-Small-2507_gguf:Q4_K_M",
+      "params": "24B",
+      "sizeBytes": 14300000000,
+      "category": "coding",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release."
+    },
+    "qwen3-coder-30b-a3b": {
+      "uri": "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",
+      "params": "30B (A3B)",
+      "sizeBytes": 19000000000,
+      "category": "coding",
+      "contextWindow": 262144,
+      "license": "apache-2.0",
+      "description": "Qwen's MoE coder (3.3B active); strong agentic coding + 256K context."
+    },
+    "nomic-embed-text": {
+      "uri": "hf:nomic-ai/nomic-embed-text-v1.5-GGUF:Q4_K_M",
+      "params": "137M",
+      "sizeBytes": 89000000,
+      "category": "embedding",
+      "contextWindow": 8192,
+      "license": "apache-2.0",
+      "description": "Returns 768-dim embeddings; pair with a chat model for RAG."
+    }
+  }
+}

--- a/packages/agency-lang/docs/site/cli/local.md
+++ b/packages/agency-lang/docs/site/cli/local.md
@@ -34,9 +34,28 @@ agency agent --local-model qwen3.5-2b     # download (if needed) + run locally
 | `agency local download <value>` | Download a model if not already cached; prints the source it resolved to and the local path. `<value>` may be a curated short name, an alias, an `hf:` URI, or an existing `.gguf` path. |
 | `agency local remove <name>` | Delete a downloaded `.gguf` from the cache. |
 | `agency local resolve <value>` | Show what a name/alias maps to, without downloading. |
+| `agency local refresh [url]` | Fetch the remote model catalog and update the `source:"remote"` aliases in `agency.json`. Adds/updates models from the catalog, removes ones it dropped, and skips any name you've aliased yourself (printing what it would have set). |
 | `agency local alias list` | List usable short names. Curated entries show params, category, size, context window, and license (with the description on the next line); your aliases show their target. |
 | `agency local alias add <name> <uri>` | Add a short-name alias. Prints the `agency.json` path that was edited. |
 | `agency local alias remove <name>` | Remove a short-name alias. Prints the `agency.json` path that was inspected (the file is left untouched if the alias wasn't present). |
+
+### Refreshing the catalog
+
+`agency local refresh` pulls a JSON catalog of recommended models and writes them
+into `client.modelAliases` as rich, `source:"remote"`-tagged entries, so new model
+recommendations arrive without upgrading agency. Your own hand-added aliases are
+never overwritten — on a name clash the command keeps yours and prints the remote
+value it skipped.
+
+URL resolution (first wins): the `[url]` argument, `AGENCY_MODEL_CATALOG_URL`,
+`client.modelCatalogUrl` in `agency.json`, then the built-in default
+(`raw.githubusercontent.com/egonSchiele/agency-lang/main/packages/agency-lang/data/model-catalog.json`).
+
+> **Heads-up:** the first refresh writes one tagged entry per catalog model
+> into `client.modelAliases`, so a freshly-refreshed `agency.json` will be
+> noticeably larger than before. The entries are tagged with `"source": "remote"`
+> — anything *without* that tag (your own aliases) is never touched. Re-running
+> `agency local refresh` overwrites only the `source:"remote"` entries.
 
 ### Where things live
 
@@ -46,8 +65,8 @@ agency agent --local-model qwen3.5-2b     # download (if needed) + run locally
 
 ### Config
 
-Aliases and the models cache dir live under `client` and are read at runtime,
-so edits take effect on the next call:
+Aliases, the models cache dir, and the catalog URL live under `client` and are
+read at runtime, so edits take effect on the next call:
 
 ```jsonc
 {
@@ -55,7 +74,10 @@ so edits take effect on the next call:
     "modelAliases": {
       "my7b": "hf:Qwen/Qwen2.5-7B-Instruct-GGUF:Q4_K_M"
     },
-    "modelsDir": "/data/agency-models"
+    "modelsDir": "/data/agency-models",
+    // Override the URL `agency local refresh` fetches the model catalog from.
+    // Defaults to the catalog committed in the agency repo.
+    "modelCatalogUrl": "https://example.com/my-model-catalog.json"
   }
 }
 ```

--- a/packages/agency-lang/docs/site/cli/local.md
+++ b/packages/agency-lang/docs/site/cli/local.md
@@ -50,6 +50,10 @@ value it skipped.
 URL resolution (first wins): the `[url]` argument, `AGENCY_MODEL_CATALOG_URL`,
 `client.modelCatalogUrl` in `agency.json`, then the built-in default
 (`raw.githubusercontent.com/egonSchiele/agency-lang/main/packages/agency-lang/data/model-catalog.json`).
+A remote URL must be `https://` (an `http://` source is rejected). The source
+may also be a **local file path** or `file://` URL — e.g.
+`agency local refresh ./my-catalog.json` — which reads the catalog from disk
+without any network call.
 
 > **Heads-up:** the first refresh writes one tagged entry per catalog model
 > into `client.modelAliases`, so a freshly-refreshed `agency.json` will be

--- a/packages/agency-lang/docs/site/stdlib/agency/local.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/local.md
@@ -21,7 +21,7 @@ export type DownloadedModel = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L22))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L23))
 
 ### ModelName
 
@@ -44,7 +44,50 @@ export type ModelName = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L27))
+
+### SkippedAlias
+
+A catalog model whose name collided with one of your own aliases: refresh
+ *  kept your alias (`keptUri`) and did not write the catalog's `remoteUri`.
+
+```ts
+/** A catalog model whose name collided with one of your own aliases: refresh
+ *  kept your alias (`keptUri`) and did not write the catalog's `remoteUri`. */
+export type SkippedAlias = {
+  name: string;
+  keptUri: string;
+  remoteUri: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L133))
+
+### RefreshResult
+
+The outcome of `refreshCatalog`. The name lists partition the catalog's
+ *  managed (`source:"remote"`) entries by what changed; `skipped` are entries
+ *  yielded to your own aliases; `modelCount` is the total catalog size, so
+ *  `added + updated + unchanged + skipped == modelCount`.
+
+```ts
+/** The outcome of `refreshCatalog`. The name lists partition the catalog's
+ *  managed (`source:"remote"`) entries by what changed; `skipped` are entries
+ *  yielded to your own aliases; `modelCount` is the total catalog size, so
+ *  `added + updated + unchanged + skipped == modelCount`. */
+export type RefreshResult = {
+  url: string;
+  file: string;
+  added: string[];
+  updated: string[];
+  unchanged: string[];
+  removed: string[];
+  skipped: SkippedAlias[];
+  modelCount: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L143))
 
 ## Functions
 
@@ -58,7 +101,7 @@ True if smoltalk-llama-cpp is installed.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L39))
 
 ### resolveModelName
 
@@ -79,7 +122,7 @@ Map a curated short name or alias to its Hugging Face URI; pass URIs and
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L44))
 
 ### downloadModel
 
@@ -102,7 +145,7 @@ Download a model (curated name, alias, hf: URI) if not cached and return its
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L54))
 
 ### listDownloadedModels
 
@@ -122,7 +165,7 @@ List downloaded .gguf models.
 
 **Returns:** `DownloadedModel[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L65))
 
 ### listModelNames
 
@@ -134,7 +177,7 @@ List usable short names: curated built-ins and your aliases.
 
 **Returns:** `ModelName[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L74))
 
 ### aliasModel
 
@@ -156,7 +199,7 @@ Add a short-name alias for a model URI; returns the edited agency.json path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L79))
 
 ### unaliasModel
 
@@ -177,7 +220,7 @@ Remove a short-name alias; returns the inspected agency.json path (file
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L89))
 
 ### removeModel
 
@@ -199,7 +242,7 @@ Delete a downloaded model file; false if it was not present.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L99))
 
 ### registerLocalProvider
 
@@ -209,7 +252,7 @@ registerLocalProvider()
 
 Register the llama-cpp provider so local models can be used by llm().
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L109))
 
 ### registerLocalModel
 
@@ -232,7 +275,7 @@ Register the provider and ensure the model is downloaded; returns the local
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L114))
 
 ### printLocalCatalog
 
@@ -243,4 +286,32 @@ printLocalCatalog()
 Print the usable-model catalog (curated names + your aliases) as an
   aligned table — the same listing as `agency local alias list`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L125))
+
+### refreshCatalog
+
+```ts
+refreshCatalog(url: string): RefreshResult
+```
+
+Fetch the remote model catalog and update the `source:"remote"` aliases in
+  the nearest `agency.json` from it. Adds/updates models from the catalog,
+  removes ones it dropped, and skips (keeping yours) any name you've aliased
+  yourself. Your hand-added aliases are never overwritten. Throws on a
+  fetch/parse/validation failure, leaving `agency.json` untouched.
+
+  This is the same operation as the `agency local refresh` CLI command.
+
+  @param url - catalog URL override; empty string uses the
+    `AGENCY_MODEL_CATALOG_URL` env var, then `client.modelCatalogUrl` in
+    `agency.json`, then the built-in default.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| url | `string` | "" |
+
+**Returns:** [RefreshResult](#refreshresult)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L154))

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-27-model-catalog-refresh-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-27-model-catalog-refresh-design.md
@@ -1,0 +1,211 @@
+# Design: Refreshable local-model catalog (`agency local refresh`)
+
+Date: 2026-06-27
+Status: Approved (pending spec review)
+
+## Goal
+
+Let users pull an updated list of recommended local models from a GitHub-hosted
+JSON blob and have those models appear in `agency local alias list` and resolve
+via `agency agent --local-model <name>` — **without upgrading the agency
+package**. New/updated model recommendations ship by editing one file on `main`.
+
+The hardcoded `CURATED_LOCAL_MODELS` constant stays as an offline base layer; the
+refreshed data layers on top through the existing alias-merge path.
+
+## Decisions (from brainstorming)
+
+1. **Don't replace `CURATED_LOCAL_MODELS`.** Layer refreshed data on top via the
+   alias mechanism. The constant remains the always-available offline base.
+2. **Generalize the alias model** to optionally carry rich metadata. No
+   backwards compatibility is required, so the stored shape changes freely.
+3. **Store refreshed entries in `agency.json` `client.modelAliases`, tagged**
+   `source: "remote"`. Re-refresh rewrites only tagged entries; the user's own
+   (untagged) aliases are never touched.
+4. **Collision rule:** if a remote model's name equals one of the user's own
+   aliases, the user's alias wins — the remote entry is skipped and a notice
+   prints **both** the kept value and the remote value that was rejected.
+5. **Source URL:** baked-in default with overrides (CLI arg → env → config →
+   default). Canonical file lives in-repo, served raw from `main`.
+
+## 1. Generalized alias model
+
+A value in `client.modelAliases` becomes `string | AliasObject`:
+
+- **string** — the URI, as today (hand-edit shorthand):
+  `"my7b": "hf:Qwen/Qwen2.5-7B-Instruct-GGUF:Q4_K_M"`
+- **object** — `AliasObject`:
+
+```ts
+type AliasObject = {
+  uri: string;                 // required: hf: / https: URI or .gguf path
+  source?: "remote";           // present ⇒ refresh-managed; absent ⇒ user-owned
+  params?: string;
+  sizeBytes?: number;
+  category?: ModelCategory;
+  contextWindow?: number;
+  license?: string;
+  description?: string;
+};
+```
+
+Only `uri` is required; all metadata is optional. The address field is named
+`uri` to match `ModelInfo` and the catalog blob (not `target`).
+
+Touch points in `lib/stdlib/localModels.ts`:
+
+- `readModelAliases` → `Record<string, string | AliasObject>`.
+- New `normalizeAlias(name, value)` → `{ name, uri, source, ...metadata }`.
+- `_resolveModelName` reads `uri` from either string or object form (alias still
+  wins over curated, as today via `aliasTarget ?? curated?.uri`).
+- `_listModelNames` merges curated + aliases, **deduped by name, alias wins**, so
+  a remote `qwen3.5-2b` shadows the built-in and shows once. Metadata flows from
+  the alias object into the existing optional fields of `ModelNameEntry`.
+- `_aliasModel` (used by `agency local alias add`) keeps writing a **string**
+  alias (user-owned, no `source`). Unchanged surface.
+
+Edge case: a user string-alias whose name equals a curated model shadows it
+fully (alias wins) and, lacking metadata, renders in the bare `ALIASES` section
+rather than the table. This is rare and acceptable; refreshed entries always
+carry metadata, so they always render richly.
+
+## 2. Catalog JSON format & source
+
+Canonical file: `packages/agency-lang/data/model-catalog.json`, served raw from
+`main`. Seeded by serializing today's `CURATED_LOCAL_MODELS` into the schema
+below (the constant and the file may diverge over time — the constant is the
+offline base, the file is the live source).
+
+```json
+{
+  "version": 1,
+  "models": {
+    "qwen3.5-2b": {
+      "uri": "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
+      "params": "2B",
+      "sizeBytes": 1280000000,
+      "category": "general",
+      "contextWindow": 131072,
+      "license": "apache-2.0",
+      "description": "Most popular modern small general model; runs on CPU comfortably."
+    }
+  }
+}
+```
+
+- `version` (number) gates forward compatibility: refresh accepts `1` and refuses
+  anything greater with a clear "upgrade agency" message.
+- `models` is an object keyed by model name (mirrors `CURATED_LOCAL_MODELS`).
+
+**URL resolution** (first wins):
+
+1. CLI arg: `agency local refresh <url>`
+2. env: `AGENCY_MODEL_CATALOG_URL`
+3. config: `client.modelCatalogUrl` in the nearest `agency.json`
+4. built-in default:
+   `https://raw.githubusercontent.com/egonSchiele/agency-lang/main/packages/agency-lang/data/model-catalog.json`
+
+## 3. The `agency local refresh [url]` command
+
+Algorithm (in `_refreshCatalog`, see §5 for the injectable seams):
+
+1. Resolve the URL via the precedence above.
+2. `fetch` over HTTPS with an `AbortController` timeout (~15s) and a response
+   size cap (~5 MB). Require `res.ok`; HTTPS-only for remote URLs (an injected
+   fetcher bypasses this for tests).
+3. Parse + validate:
+   - **Blob-level** (abort the whole refresh on failure, leaving `agency.json`
+     untouched): valid JSON, `version` supported, `models` is an object.
+   - **Entry-level** (skip the offending entry with a warning, keep going):
+     `uri` is a non-empty `hf:`/`https:`/`.gguf` value. Metadata fields are
+     type-checked leniently — a bad field is dropped, the entry is kept.
+4. Partition existing `modelAliases` into **managed** (`source === "remote"`) and
+   **user** (everything else). Drop all managed entries.
+5. For each model in the blob:
+   - If its name collides with a **user** entry → **skip**, record
+     `{ name, keptValue, remoteUri }`.
+   - Else write `{ uri, source: "remote", ...metadata }`.
+6. Write `agency.json`. On any failure before this point, the file is untouched.
+7. Print, per skip:
+
+   ```
+   Skipped "qwen3.5-2b": kept your alias (hf:my/custom-qwen:Q4_K_M);
+     remote would have set hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M
+   ```
+
+   then a summary:
+
+   ```
+   Refreshed N models from <url> → <agency.json path>
+     (A added, U updated, R removed, S skipped)
+   ```
+
+   where, with `blobNames` = blob model names, `skipped` = blob names colliding
+   with user entries, `applied` = `blobNames − skipped`, `oldManaged` = previous
+   `source:"remote"` names: `added = applied − oldManaged`,
+   `updated = applied ∩ oldManaged`, `removed = oldManaged − blobNames`.
+
+8. Exit 0 on success (collisions are expected, not errors); exit 1 only on
+   fetch/parse/blob-validation failure.
+
+**No install gate.** Refreshing is metadata-only, so it works without
+`smoltalk-llama-cpp` (like `alias add`/`list`, unlike `download`/`remove`).
+
+## 4. How the list renders
+
+`formatModelCatalog` (already extracted to `localModels.ts`):
+
+- **Table** = every entry with metadata: curated built-ins + rich/remote
+  aliases, deduped by name with the alias winning.
+- **`ALIASES` section** = only metadata-less (plain `name→uri`) aliases.
+
+So refreshed models render in the aligned table exactly like curated ones; the
+agent's bare `--local-model` output (which calls the same formatter) gets them
+for free.
+
+## 5. Testing & security
+
+**Injectable seams** (no live network in tests, mirrors the existing
+`_aliasModel(file)` pattern): `_refreshCatalog({ url?, fetcher?, file? })` where
+`fetcher(url) => Promise<string>` defaults to the real HTTPS fetch, and `file`
+defaults to the resolved `agency.json`.
+
+Test coverage:
+
+- URL-resolution precedence (arg > env > config > default).
+- Blob validation: well-formed, malformed JSON, unsupported `version`, `models`
+  not an object, per-entry bad `uri` skipped-with-warning.
+- Merge writer: drops old managed, preserves user aliases, **skips collisions and
+  reports kept + remote values**, removes models dropped from the blob, computes
+  added/updated/removed/skipped correctly.
+- `_resolveModelName` / `_listModelNames` with object aliases (alias wins).
+- `formatModelCatalog` renders rich/remote aliases in the table.
+
+**Security**: the default URL is the project's own repo over HTTPS. Refresh only
+stores `name→uri` + display metadata; the URI is not acted upon until a separate
+explicit `--local-model <name>` / `local download` (the existing download trust
+boundary). HTTPS-only + response-size cap + timeout guard the fetch. A failed or
+malformed refresh never mutates `agency.json`.
+
+## File-by-file changes
+
+- `lib/stdlib/localModels.ts` — `AliasObject` type; `normalizeAlias`; update
+  `readModelAliases`, `_resolveModelName`, `_listModelNames`, `formatModelCatalog`;
+  add `catalogUrl` resolution + `_refreshCatalog`.
+- `lib/cli/local.ts` — `runRefresh(url?)` calling `_refreshCatalog`, printing the
+  skip notices + summary.
+- `scripts/agency.ts` — wire `local refresh [url]`.
+- `packages/agency-lang/data/model-catalog.json` — new seed file from
+  `CURATED_LOCAL_MODELS`.
+- `docs/site/cli/local.md` — document `refresh`, the URL precedence, and the
+  rich-alias / `source:"remote"` storage.
+- `docs/misc/config.md` (or the config reference) — note `client.modelCatalogUrl`.
+- Tests: new `lib/stdlib/localModels.refresh.test.ts`; update existing
+  `localModels.test.ts` for object aliases.
+
+## Out of scope (YAGNI)
+
+- Auto-refresh / refresh-on-a-schedule. Manual command only.
+- Signing/checksums of the catalog beyond HTTPS.
+- A dev script to regenerate `model-catalog.json` from `CURATED_LOCAL_MODELS`
+  (optional later; the initial file is committed by hand).

--- a/packages/agency-lang/lib/cli/local.test.ts
+++ b/packages/agency-lang/lib/cli/local.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { aliasAdd, aliasList, aliasRemove } from "./local.js";
+import { aliasAdd, aliasList, aliasRemove, formatRefreshOutput } from "./local.js";
 
 let dir: string;
 let aliasFile: string;
@@ -30,5 +30,27 @@ describe("agency local CLI helpers", () => {
     } finally {
       log.mockRestore();
     }
+  });
+});
+
+describe("formatRefreshOutput", () => {
+  it("renders skip notices (kept + remote) and a summary line", () => {
+    const lines = formatRefreshOutput({
+      url: "https://x/c.json",
+      file: "/tmp/agency.json",
+      added: ["a", "b"],
+      updated: [],
+      unchanged: ["c"],
+      removed: ["old"],
+      skipped: [{ name: "dupe", keptUri: "hf:mine:Q4_K_M", remoteUri: "hf:remote:Q4_K_M" }],
+      modelCount: 4, // a, b, c, dupe (= added + updated + unchanged + skipped)
+    });
+    expect(lines[0]).toBe('Skipped "dupe": kept your alias (hf:mine:Q4_K_M);');
+    expect(lines[1]).toBe("  remote would have set hf:remote:Q4_K_M");
+    // Summary mentions total catalog size, then breakdown.
+    expect(lines.some((l) => l.includes("4 models from https://x/c.json"))).toBe(true);
+    expect(
+      lines.some((l) => l.includes("2 added, 0 updated, 1 unchanged, 1 removed, 1 skipped")),
+    ).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -9,6 +9,8 @@ import {
   hasLocalModelSupport,
   formatGB,
   formatModelCatalog,
+  _refreshCatalog,
+  type RefreshResult,
 } from "../stdlib/localModels.js";
 
 /** Install-gate for I/O commands. Honors the AGENCY_LLAMA_PROVIDER_MODULE
@@ -95,4 +97,34 @@ export function runAliasAdd(name: string, uri: string): void {
 
 export function runAliasRemove(name: string): void {
   aliasRemove(name);
+}
+
+/** Format the lines `runRefresh` prints. Pure so it can be unit-tested without
+ *  a network call. `r.modelCount` is the size of the catalog blob; the
+ *  breakdown line accounts for every entry exactly once (added + updated +
+ *  unchanged + skipped = modelCount). */
+export function formatRefreshOutput(r: RefreshResult): string[] {
+  const lines: string[] = [];
+  for (const s of r.skipped) {
+    lines.push(`Skipped "${s.name}": kept your alias (${s.keptUri});`);
+    lines.push(`  remote would have set ${s.remoteUri}`);
+  }
+  lines.push(`Refreshed ${r.modelCount} models from ${r.url} → ${r.file}`);
+  lines.push(
+    `  (${r.added.length} added, ${r.updated.length} updated, ` +
+      `${r.unchanged.length} unchanged, ${r.removed.length} removed, ` +
+      `${r.skipped.length} skipped)`,
+  );
+  return lines;
+}
+
+export async function runRefresh(url?: string): Promise<void> {
+  let result: RefreshResult;
+  try {
+    result = await _refreshCatalog({ url: url ?? "" });
+  } catch (err) {
+    console.error(`Refresh failed: ${(err as Error).message}`);
+    process.exit(1);
+  }
+  for (const line of formatRefreshOutput(result)) console.log(line);
 }

--- a/packages/agency-lang/lib/cli/local.ts
+++ b/packages/agency-lang/lib/cli/local.ts
@@ -12,6 +12,7 @@ import {
   _refreshCatalog,
   type RefreshResult,
 } from "../stdlib/localModels.js";
+import { ttyColor } from "../utils/termcolors.js";
 
 /** Install-gate for I/O commands. Honors the AGENCY_LLAMA_PROVIDER_MODULE
  *  override the same way `requireSupport()` in `localModels.ts` does — a
@@ -102,18 +103,23 @@ export function runAliasRemove(name: string): void {
 /** Format the lines `runRefresh` prints. Pure so it can be unit-tested without
  *  a network call. `r.modelCount` is the size of the catalog blob; the
  *  breakdown line accounts for every entry exactly once (added + updated +
- *  unchanged + skipped = modelCount). */
+ *  unchanged + skipped = modelCount). Color is applied via `ttyColor`, which
+ *  is a no-op when stdout isn't a TTY — so piped output (and these unit tests)
+ *  stay plain. */
 export function formatRefreshOutput(r: RefreshResult): string[] {
   const lines: string[] = [];
   for (const s of r.skipped) {
-    lines.push(`Skipped "${s.name}": kept your alias (${s.keptUri});`);
-    lines.push(`  remote would have set ${s.remoteUri}`);
+    lines.push(`Skipped ${ttyColor.yellow(`"${s.name}"`)}: kept your alias (${ttyColor.dim(s.keptUri)});`);
+    lines.push(`  remote would have set ${ttyColor.dim(s.remoteUri)}`);
   }
-  lines.push(`Refreshed ${r.modelCount} models from ${r.url} → ${r.file}`);
   lines.push(
-    `  (${r.added.length} added, ${r.updated.length} updated, ` +
-      `${r.unchanged.length} unchanged, ${r.removed.length} removed, ` +
-      `${r.skipped.length} skipped)`,
+    `Refreshed ${ttyColor.bold(String(r.modelCount))} models from ` +
+      `${ttyColor.cyan(r.url)} → ${ttyColor.cyan(r.file)}`,
+  );
+  lines.push(
+    `  (${ttyColor.green(`${r.added.length} added`)}, ${r.updated.length} updated, ` +
+      `${r.unchanged.length} unchanged, ${ttyColor.red(`${r.removed.length} removed`)}, ` +
+      `${ttyColor.yellow(`${r.skipped.length} skipped`)})`,
   );
   return lines;
 }

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -280,3 +280,42 @@ describe("object-valued aliases", () => {
     expect(matches[0].source).toBe("alias");
   });
 });
+
+describe("formatModelCatalog with rich aliases", () => {
+  it("renders a metadata-bearing alias in the table and a plain alias under ALIASES", () => {
+    // Point alias resolution at a temp agency.json via cwd so the function
+    // (which takes no file arg) picks it up.
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      fs.writeFileSync(
+        aliasFile,
+        JSON.stringify({
+          client: {
+            modelAliases: {
+              "rich-model": {
+                uri: "hf:org/rich:Q4_K_M",
+                params: "7B",
+                sizeBytes: 4_000_000_000,
+                category: "general",
+                contextWindow: 131072,
+                license: "apache-2.0",
+                description: "A rich remote alias.",
+                source: "remote",
+              },
+              "plain-model": "hf:org/plain:Q4_K_M",
+            },
+          },
+        }),
+      );
+      const out = formatModelCatalog();
+      // Rich alias is a table row (its params show up on the same line as its name).
+      const richLine = out.split("\n").find((l) => l.includes("rich-model"));
+      expect(richLine).toContain("7B");
+      // Plain alias appears under ALIASES as name → uri, NOT as a table row.
+      expect(out).toContain("plain-model → hf:org/plain:Q4_K_M");
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -243,3 +243,40 @@ describe("formatModelCatalog", () => {
     expect(/\n\s*\n\s*$/.test(out)).toBe(false);
   });
 });
+
+describe("object-valued aliases", () => {
+  it("resolves an object alias to its uri", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { foo: { uri: "hf:org/repo:Q4_K_M" } } } }),
+    );
+    expect(_resolveModelName("foo", aliasFile)).toBe("hf:org/repo:Q4_K_M");
+  });
+
+  it("resolves a string alias to its uri (back-compat shape)", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { bar: "hf:org/bar:Q4_K_M" } } }),
+    );
+    expect(_resolveModelName("bar", aliasFile)).toBe("hf:org/bar:Q4_K_M");
+  });
+
+  it("lists an object alias with its metadata and dedupes by name (alias wins)", () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({
+        client: {
+          modelAliases: {
+            "smollm2-135m": { uri: "hf:custom/smol:Q4_K_M", params: "999M", source: "remote" },
+          },
+        },
+      }),
+    );
+    const entries = _listModelNames(aliasFile);
+    const matches = entries.filter((e) => e.name === "smollm2-135m");
+    expect(matches.length).toBe(1); // deduped: alias shadows the curated built-in
+    expect(matches[0].target).toBe("hf:custom/smol:Q4_K_M");
+    expect(matches[0].params).toBe("999M");
+    expect(matches[0].source).toBe("alias");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -16,6 +16,7 @@ import {
   formatModelCatalog,
   resolveCatalogUrl,
   parseCatalog,
+  _refreshCatalog,
 } from "./localModels.js";
 
 let dir: string;
@@ -375,5 +376,90 @@ describe("parseCatalog", () => {
     } finally {
       warn.mockRestore();
     }
+  });
+});
+
+describe("_refreshCatalog", () => {
+  const blob = (models: Record<string, any>) => JSON.stringify({ version: 1, models });
+
+  it("writes blob models as source:remote aliases and reports them added", async () => {
+    fs.writeFileSync(aliasFile, "{}");
+    const r = await _refreshCatalog({
+      file: aliasFile,
+      fetcher: async () => blob({ "qwen3.5-2b": { uri: "hf:org/q:Q4_K_M", params: "2B" } }),
+    });
+    expect(r.added).toEqual(["qwen3.5-2b"]);
+    expect(r.modelCount).toBe(1); // total catalog entries
+    const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+    expect(cfg.client.modelAliases["qwen3.5-2b"]).toEqual({
+      uri: "hf:org/q:Q4_K_M", params: "2B", source: "remote",
+    });
+  });
+
+  it("skips a name that collides with a user alias; modelCount still counts the entry", async () => {
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { "qwen3.5-2b": "hf:mine/custom:Q4_K_M" } } }),
+    );
+    const r = await _refreshCatalog({
+      file: aliasFile,
+      fetcher: async () => blob({ "qwen3.5-2b": { uri: "hf:org/remote:Q4_K_M" } }),
+    });
+    expect(r.skipped).toEqual([
+      { name: "qwen3.5-2b", keptUri: "hf:mine/custom:Q4_K_M", remoteUri: "hf:org/remote:Q4_K_M" },
+    ]);
+    expect(r.added).toEqual([]);
+    expect(r.modelCount).toBe(1); // catalog had 1 entry, even though we skipped it
+    const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+    expect(cfg.client.modelAliases["qwen3.5-2b"]).toBe("hf:mine/custom:Q4_K_M");
+  });
+
+  it("classifies re-runs: unchanged when value matches, updated when it differs, removed when absent", async () => {
+    fs.writeFileSync(aliasFile, "{}");
+    // First run: seed two managed entries.
+    await _refreshCatalog({
+      file: aliasFile,
+      fetcher: async () => blob({
+        a: { uri: "hf:org/a:Q4_K_M", params: "1B" },
+        b: { uri: "hf:org/b:Q4_K_M" },
+      }),
+    });
+    // Second run: `a` unchanged, `b` dropped, `c` added with same-uri but no
+    // metadata change vs first run (it's new — `added`), and `a` gets a new
+    // params value (this is the actual `updated` case).
+    const r = await _refreshCatalog({
+      file: aliasFile,
+      fetcher: async () => blob({
+        a: { uri: "hf:org/a:Q4_K_M", params: "2B" }, // metadata changed
+        c: { uri: "hf:org/c:Q4_K_M" },               // new
+      }),
+    });
+    expect(r.added).toEqual(["c"]);
+    expect(r.updated).toEqual(["a"]);
+    expect(r.unchanged).toEqual([]);
+    expect(r.removed).toEqual(["b"]);
+    const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+    expect(cfg.client.modelAliases.b).toBeUndefined();
+    expect(cfg.client.modelAliases.a.params).toBe("2B");
+  });
+
+  it("reports unchanged when a re-run writes a byte-identical value", async () => {
+    fs.writeFileSync(aliasFile, "{}");
+    const fetcher = async () => blob({ a: { uri: "hf:org/a:Q4_K_M", params: "1B" } });
+    await _refreshCatalog({ file: aliasFile, fetcher });
+    const r = await _refreshCatalog({ file: aliasFile, fetcher });
+    expect(r.added).toEqual([]);
+    expect(r.updated).toEqual([]);
+    expect(r.unchanged).toEqual(["a"]);
+    expect(r.removed).toEqual([]);
+  });
+
+  it("leaves agency.json untouched when the blob is invalid", async () => {
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { keep: "hf:k:Q4_K_M" } } }));
+    await expect(
+      _refreshCatalog({ file: aliasFile, fetcher: async () => "{not json" }),
+    ).rejects.toThrow(/valid JSON/);
+    const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+    expect(cfg.client.modelAliases.keep).toBe("hf:k:Q4_K_M");
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -14,6 +14,8 @@ import {
   resolveAliasConfigPath,
   resolveSmoltalkLlamaCppFromRoots,
   formatModelCatalog,
+  resolveCatalogUrl,
+  parseCatalog,
 } from "./localModels.js";
 
 let dir: string;
@@ -316,6 +318,62 @@ describe("formatModelCatalog with rich aliases", () => {
       expect(out).toContain("plain-model → hf:org/plain:Q4_K_M");
     } finally {
       process.chdir(cwd);
+    }
+  });
+});
+
+describe("resolveCatalogUrl", () => {
+  afterEach(() => { delete process.env.AGENCY_MODEL_CATALOG_URL; });
+
+  it("uses the explicit arg first", () => {
+    expect(resolveCatalogUrl("https://x/y.json", aliasFile)).toBe("https://x/y.json");
+  });
+  it("falls back to the env var", () => {
+    process.env.AGENCY_MODEL_CATALOG_URL = "https://env/c.json";
+    expect(resolveCatalogUrl("", aliasFile)).toBe("https://env/c.json");
+  });
+  it("then the config, then the default", () => {
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelCatalogUrl: "https://cfg/c.json" } }));
+    expect(resolveCatalogUrl("", aliasFile)).toBe("https://cfg/c.json");
+    fs.writeFileSync(aliasFile, "{}");
+    expect(resolveCatalogUrl("", aliasFile)).toContain("raw.githubusercontent.com/egonSchiele/agency-lang");
+  });
+});
+
+describe("parseCatalog", () => {
+  const good = JSON.stringify({
+    version: 1,
+    models: { "m1": { uri: "hf:org/m1:Q4_K_M", params: "2B", sizeBytes: 1, category: "general" } },
+  });
+  it("parses a valid catalog", () => {
+    const out = parseCatalog(good);
+    expect(out["m1"].uri).toBe("hf:org/m1:Q4_K_M");
+    expect(out["m1"].params).toBe("2B");
+  });
+  it("throws on invalid JSON", () => {
+    expect(() => parseCatalog("{not json")).toThrow(/valid JSON/);
+  });
+  it("throws on an unsupported version", () => {
+    expect(() => parseCatalog(JSON.stringify({ version: 2, models: {} }))).toThrow(/version/);
+  });
+  it("throws when models is not an object", () => {
+    expect(() => parseCatalog(JSON.stringify({ version: 1, models: [] }))).toThrow(/models/);
+  });
+  it("skips an entry with a bad uri but keeps the good ones", () => {
+    const mixed = JSON.stringify({
+      version: 1,
+      models: { bad: { uri: "ftp://nope" }, good: { uri: "hf:org/g:Q4_K_M" } },
+    });
+    // Silence the expected `console.warn("[catalog] skipping …")` so the
+    // suite output stays clean; also asserts the warn fires.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const out = parseCatalog(mixed);
+      expect(out.bad).toBeUndefined();
+      expect(out.good.uri).toBe("hf:org/g:Q4_K_M");
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "bad"'));
+    } finally {
+      warn.mockRestore();
     }
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -377,6 +377,42 @@ describe("parseCatalog", () => {
       warn.mockRestore();
     }
   });
+
+  it("rejects an http: uri (insecure) but accepts hf:/https:/.gguf", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const out = parseCatalog(
+        JSON.stringify({
+          version: 1,
+          models: {
+            insecure: { uri: "http://example.com/m.gguf" },
+            secureHttps: { uri: "https://example.com/m.gguf" },
+            hf: { uri: "hf:org/m:Q4_K_M" },
+            gguf: { uri: "/abs/path/m.gguf" },
+          },
+        }),
+      );
+      expect(out.insecure).toBeUndefined();
+      expect(out.secureHttps.uri).toBe("https://example.com/m.gguf");
+      expect(out.hf.uri).toBe("hf:org/m:Q4_K_M");
+      expect(out.gguf.uri).toBe("/abs/path/m.gguf");
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping "insecure"'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("drops a wrongly-typed metadata field but keeps the entry (lenient)", () => {
+    const out = parseCatalog(
+      JSON.stringify({
+        version: 1,
+        models: { m: { uri: "hf:org/m:Q4_K_M", params: 7, sizeBytes: "big" } },
+      }),
+    );
+    expect(out.m.uri).toBe("hf:org/m:Q4_K_M");
+    expect(out.m.params).toBeUndefined(); // 7 is not a string → dropped
+    expect(out.m.sizeBytes).toBeUndefined(); // "big" is not a number → dropped
+  });
 });
 
 describe("_refreshCatalog", () => {
@@ -461,5 +497,34 @@ describe("_refreshCatalog", () => {
     ).rejects.toThrow(/valid JSON/);
     const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
     expect(cfg.client.modelAliases.keep).toBe("hf:k:Q4_K_M");
+  });
+
+  it("does not treat a prototype-named model as a user collision", async () => {
+    fs.writeFileSync(aliasFile, "{}");
+    // "toString" exists on Object.prototype, so a naive `name in userAliases`
+    // would falsely report a collision. With own-property checks it's added.
+    const r = await _refreshCatalog({
+      file: aliasFile,
+      fetcher: async () => blob({ toString: { uri: "hf:org/ts:Q4_K_M" } }),
+    });
+    expect(r.added).toEqual(["toString"]);
+    expect(r.skipped).toEqual([]);
+    const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+    expect(cfg.client.modelAliases.toString.uri).toBe("hf:org/ts:Q4_K_M");
+  });
+
+  it("reads the catalog from a local file path via the default fetcher (no network)", async () => {
+    // Integration-ish: exercises the real fetchCatalog file branch + parse +
+    // merge, with no fetcher injected and no HTTP.
+    fs.writeFileSync(aliasFile, "{}");
+    const catalogPath = path.join(dir, "catalog.json");
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({ version: 1, models: { m: { uri: "hf:org/m:Q4_K_M", params: "2B" } } }),
+    );
+    const r = await _refreshCatalog({ url: catalogPath, file: aliasFile });
+    expect(r.added).toEqual(["m"]);
+    const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+    expect(cfg.client.modelAliases.m).toEqual({ uri: "hf:org/m:Q4_K_M", params: "2B", source: "remote" });
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -204,9 +204,31 @@ function writeJson(file: string, value: unknown): void {
   fs.writeFileSync(file, JSON.stringify(value, null, 2) + "\n");
 }
 
-export function readModelAliases(file: string = ""): Record<string, string> {
+/** A model alias value: either the bare URI (hand-edit shorthand) or an
+ *  object carrying the URI plus optional display metadata. `source: "remote"`
+ *  marks an entry written by `agency local refresh` (see `_refreshCatalog`);
+ *  hand-added aliases have no `source`. */
+export type AliasObject = {
+  uri: string;
+  source?: "remote";
+  params?: string;
+  sizeBytes?: number;
+  category?: ModelCategory;
+  contextWindow?: number;
+  license?: string;
+  description?: string;
+};
+
+export type AliasValue = string | AliasObject;
+
+/** The URI an alias points at, regardless of string/object form. */
+export function aliasUri(value: AliasValue): string {
+  return typeof value === "string" ? value : value.uri;
+}
+
+export function readModelAliases(file: string = ""): Record<string, AliasValue> {
   const cfg = readJson(resolveAliasFile(file));
-  return (cfg.client?.modelAliases ?? {}) as Record<string, string>;
+  return (cfg.client?.modelAliases ?? {}) as Record<string, AliasValue>;
 }
 
 /** Entry returned by `_listModelNames`. */
@@ -227,7 +249,8 @@ export function _resolveModelName(value: string, file: string = ""): string {
     return value;
   }
   const aliases = readModelAliases(file);
-  const aliasTarget = aliases[value];
+  const aliasVal = aliases[value];
+  const aliasTarget = aliasVal === undefined ? undefined : aliasUri(aliasVal);
   const curated = CURATED_LOCAL_MODELS[value];
   const mapped = aliasTarget ?? curated?.uri;
   if (!mapped) {
@@ -240,24 +263,43 @@ export function _resolveModelName(value: string, file: string = ""): string {
   return mapped;
 }
 
+type EntryMeta = Pick<
+  ModelNameEntry,
+  "params" | "sizeBytes" | "category" | "description" | "contextWindow" | "license"
+>;
+
+/** Project the optional display-metadata fields off any source shape
+ *  (`ModelInfo` or `AliasObject`). Returns only defined fields so the
+ *  spread below doesn't introduce stray `undefined` keys. */
+function metaFrom(src: Partial<EntryMeta>): EntryMeta {
+  const out: EntryMeta = {};
+  if (src.params !== undefined) out.params = src.params;
+  if (src.sizeBytes !== undefined) out.sizeBytes = src.sizeBytes;
+  if (src.category !== undefined) out.category = src.category;
+  if (src.description !== undefined) out.description = src.description;
+  if (src.contextWindow !== undefined) out.contextWindow = src.contextWindow;
+  if (src.license !== undefined) out.license = src.license;
+  return out;
+}
+
 export function _listModelNames(file: string = ""): ModelNameEntry[] {
-  const curated: ModelNameEntry[] = Object.entries(CURATED_LOCAL_MODELS).map(
-    ([name, info]) => ({
+  const curatedEntries: ModelNameEntry[] = Object.entries(CURATED_LOCAL_MODELS).map(
+    ([name, info]) => ({ name, target: info.uri, source: "curated", ...metaFrom(info) }),
+  );
+  const aliasEntries: ModelNameEntry[] = Object.entries(readModelAliases(file)).map(
+    ([name, value]) => ({
       name,
-      target: info.uri,
-      source: "curated",
-      params: info.params,
-      sizeBytes: info.sizeBytes,
-      category: info.category,
-      description: info.description,
-      contextWindow: info.contextWindow,
-      license: info.license,
+      target: aliasUri(value),
+      source: "alias",
+      ...(typeof value === "object" ? metaFrom(value) : {}),
     }),
   );
-  const aliases: ModelNameEntry[] = Object.entries(readModelAliases(file)).map(
-    ([name, target]) => ({ name, target, source: "alias" }),
+  // Alias wins on name collision: the alias entry overwrites the curated one
+  // in the object literal because it comes later. `Object.values` then yields
+  // exactly one entry per name.
+  return Object.values(
+    Object.fromEntries([...curatedEntries, ...aliasEntries].map((e) => [e.name, e])),
   );
-  return [...curated, ...aliases];
 }
 
 export function _aliasModel(name: string, uri: string, file: string = ""): string {

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { z } from "zod";
 import { findFileUp } from "../importPaths.js";
 import { loadProviderModuleByPath } from "../runtime/providerModules.js";
 import { ttyColor } from "../utils/termcolors.js";
@@ -157,6 +158,18 @@ function isModelUri(v: string): boolean {
   return /^(hf:|https?:)/.test(v);
 }
 
+/** A model URI we'll accept from the *remote catalog*. Stricter than
+ *  `isModelUri`: any `scheme://` URL must be `https://` (so an overridden or
+ *  untrusted catalog can't point a download at a plaintext, MITM-able
+ *  endpoint — not even an `http://…/x.gguf`). Otherwise accept an `hf:` URI or
+ *  a local `.gguf` path. */
+function isCatalogUri(v: string): boolean {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(v)) {
+    return /^https:\/\//.test(v);
+  }
+  return v.startsWith("hf:") || isGgufPath(v);
+}
+
 /** The agency.json that owns aliases: nearest `agency.json` walking up from
  *  `startDir` (cwd by default); falls back to `~/agency.json` when none is
  *  found. Exported so the CLI can echo it on every write. */
@@ -269,9 +282,12 @@ type EntryMeta = Pick<
 >;
 
 /** Project the optional display-metadata fields off any source shape
- *  (`ModelInfo` or `AliasObject`). Returns only defined fields so the
- *  spread below doesn't introduce stray `undefined` keys. */
-function metaFrom(src: Partial<EntryMeta>): EntryMeta {
+ *  (`ModelInfo`, or an alias which may be a bare URI string). A string alias
+ *  carries no metadata, so it yields `{}` — which is why the call sites can
+ *  pass an `AliasValue` directly without a `typeof` guard. Returns only
+ *  defined fields so the spread doesn't introduce stray `undefined` keys. */
+function metaFrom(src: string | Partial<EntryMeta>): EntryMeta {
+  if (typeof src === "string") return {};
   const out: EntryMeta = {};
   if (src.params !== undefined) out.params = src.params;
   if (src.sizeBytes !== undefined) out.sizeBytes = src.sizeBytes;
@@ -291,7 +307,7 @@ export function _listModelNames(file: string = ""): ModelNameEntry[] {
       name,
       target: aliasUri(value),
       source: "alias",
-      ...(typeof value === "object" ? metaFrom(value) : {}),
+      ...metaFrom(value),
     }),
   );
   // Alias wins on name collision: the alias entry overwrites the curated one
@@ -394,30 +410,30 @@ const CATALOG_FETCH_TIMEOUT_MS = 15_000;
  *  5 MB cap guards against a misconfigured URL serving an arbitrary file. */
 const CATALOG_MAX_BYTES = 5_000_000;
 
-// Field-shape narrowers used by `parseCatalog`. Returning `undefined` for a
-// wrongly-typed field lets the resulting object literal drop the key
-// entirely (see the `Object.fromEntries(...filter(defined))` pattern below).
-function pickString(v: unknown): string | undefined {
-  return typeof v === "string" ? v : undefined;
-}
-function pickNumber(v: unknown): number | undefined {
-  return typeof v === "number" ? v : undefined;
-}
-function pickCategory(v: unknown): ModelCategory | undefined {
-  // `CATALOG_CATEGORIES` is a `readonly` tuple of literal types, so its
-  // `includes` rejects an arbitrary `unknown` — cast to a plain string
-  // array for the membership check, then narrow back.
-  if (typeof v !== "string") {
-    return undefined;
-  }
-  if (!(CATALOG_CATEGORIES as readonly string[]).includes(v)) {
-    return undefined;
-  }
-  return v as ModelCategory;
-}
+// One catalog entry. zod does the structural validation + coercion; the merge
+// reassembles a canonical-order object from `.data` (see `parseCatalog`). The
+// metadata fields are `.optional().catch(undefined)` so a wrongly-typed field
+// is dropped rather than failing the whole entry (lenient metadata); a
+// missing/insecure `uri` fails the entry (it's then skipped + warned).
+const CatalogModelSchema = z.object({
+  uri: z.string().refine(isCatalogUri, "uri must be an hf:/https: URI or a .gguf path"),
+  params: z.string().optional().catch(undefined),
+  sizeBytes: z.number().optional().catch(undefined),
+  category: z.enum(CATALOG_CATEGORIES).optional().catch(undefined),
+  contextWindow: z.number().optional().catch(undefined),
+  license: z.string().optional().catch(undefined),
+  description: z.string().optional().catch(undefined),
+});
+
+// Top-level catalog shape: a supported version + a name→entry object. Entries
+// are validated individually (below) so one bad entry is skipped, not fatal.
+const CatalogTopSchema = z.object({
+  version: z.literal(SUPPORTED_CATALOG_VERSION),
+  models: z.record(z.string(), z.unknown()),
+});
 
 /** Strip keys whose value is `undefined` so the resulting object is JSON-clean
- *  (no `"params": undefined` after `JSON.stringify`). */
+ *  (no `"params": undefined` after `JSON.stringify`) and in canonical order. */
 function compact<T extends Record<string, unknown>>(o: T): Partial<T> {
   return Object.fromEntries(Object.entries(o).filter(([, v]) => v !== undefined)) as Partial<T>;
 }
@@ -428,59 +444,117 @@ function compact<T extends Record<string, unknown>>(o: T): Partial<T> {
  *  `uri` is missing/invalid; metadata fields with the wrong type are dropped
  *  but the entry is kept. */
 export function parseCatalog(text: string): Record<string, CatalogModel> {
-  let raw: any;
+  let raw: unknown;
   try {
     raw = JSON.parse(text);
   } catch (err) {
     throw new Error(`catalog is not valid JSON: ${(err as Error).message}`);
   }
-  if (typeof raw !== "object" || raw === null) {
+  const top = CatalogTopSchema.safeParse(raw);
+  if (!top.success) {
+    // Map zod's first issue to a precise, user-facing message.
+    const path = top.error.issues[0]?.path[0];
+    if (path === "version") {
+      throw new Error(
+        `unsupported catalog version ${JSON.stringify((raw as any)?.version)}; this ` +
+          `agency supports version ${SUPPORTED_CATALOG_VERSION}. Upgrade agency.`,
+      );
+    }
+    if (path === "models") {
+      throw new Error("catalog.models must be an object keyed by model name");
+    }
     throw new Error("catalog must be a JSON object");
   }
-  if (raw.version !== SUPPORTED_CATALOG_VERSION) {
-    throw new Error(
-      `unsupported catalog version ${JSON.stringify(raw.version)}; this agency ` +
-        `supports version ${SUPPORTED_CATALOG_VERSION}. Upgrade agency.`,
-    );
-  }
-  if (typeof raw.models !== "object" || raw.models === null || Array.isArray(raw.models)) {
-    throw new Error("catalog.models must be an object keyed by model name");
-  }
-  // Project each blob entry into either a validated `CatalogModel` (kept) or
-  // `null` (skipped + warned). The final `Object.fromEntries` drops the
-  // `null` pairs, leaving only the valid models.
-  const entries: ([string, CatalogModel] | null)[] = Object.entries(
-    raw.models as Record<string, any>,
-  ).map(([name, entry]) => {
-    if (typeof entry !== "object" || entry === null) {
-      console.warn(`[catalog] skipping "${name}": entry is not an object`);
-      return null;
-    }
-    const uri = entry.uri;
-    if (typeof uri !== "string" || !(isModelUri(uri) || isGgufPath(uri))) {
-      console.warn(`[catalog] skipping "${name}": invalid uri ${JSON.stringify(uri)}`);
-      return null;
-    }
-    const model: CatalogModel = {
-      uri,
-      ...compact({
-        params: pickString(entry.params),
-        sizeBytes: pickNumber(entry.sizeBytes),
-        category: pickCategory(entry.category),
-        contextWindow: pickNumber(entry.contextWindow),
-        license: pickString(entry.license),
-        description: pickString(entry.description),
-      }),
-    };
-    return [name, model];
-  });
+  // Validate each entry independently; a bad entry is skipped + warned, not
+  // fatal. Rebuild a canonical-order `CatalogModel` from the validated data.
+  const entries: ([string, CatalogModel] | null)[] = Object.entries(top.data.models).map(
+    ([name, entry]) => {
+      const parsed = CatalogModelSchema.safeParse(entry);
+      if (!parsed.success) {
+        console.warn(
+          `[catalog] skipping "${name}": ${parsed.error.issues[0]?.message ?? "invalid entry"}`,
+        );
+        return null;
+      }
+      const d = parsed.data;
+      const model: CatalogModel = {
+        uri: d.uri,
+        ...compact({
+          params: d.params,
+          sizeBytes: d.sizeBytes,
+          category: d.category,
+          contextWindow: d.contextWindow,
+          license: d.license,
+          description: d.description,
+        }),
+      };
+      return [name, model];
+    },
+  );
   return Object.fromEntries(entries.filter((e): e is [string, CatalogModel] => e !== null));
 }
 
-/** Default fetcher: HTTPS-only GET with a bounded timeout and body cap. */
+/** If `url` names a local file (a `file://` URL or a plain filesystem path —
+ *  i.e. not an `hf:`/`http(s)://` URL), return its path; else null. Lets refresh
+ *  read a catalog from disk (`agency local refresh ./catalog.json`), which also
+ *  makes the merge logic integration-testable without a network round-trip. */
+function catalogLocalPath(url: string): string | null {
+  if (url.startsWith("file://")) return fileURLToPath(url);
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url) || url.startsWith("hf:")) return null;
+  return url;
+}
+
+/** Read a local catalog file, enforcing the byte cap up front via `stat`. */
+function readCatalogFile(path: string): string {
+  const size = fs.statSync(path).size;
+  if (size > CATALOG_MAX_BYTES) {
+    throw new Error(`catalog file too large (${size} bytes; cap ${CATALOG_MAX_BYTES} bytes)`);
+  }
+  return fs.readFileSync(path, "utf-8");
+}
+
+/** Stream a response body, enforcing the byte cap as chunks arrive so a
+ *  large/malicious body can't be fully buffered first. Mirrors the capped
+ *  reader in `lib/stdlib/http.ts`; counts raw bytes (`byteLength`), not
+ *  UTF-16 code units. */
+async function readBodyCapped(res: Response, url: string, maxBytes: number): Promise<string> {
+  if (!res.body) return "";
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  const chunks: string[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new Error(`catalog from ${url} exceeds ${maxBytes} bytes`);
+      }
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      /* already released */
+    }
+  }
+  chunks.push(decoder.decode());
+  return chunks.join("");
+}
+
+/** Default fetcher: a local file path / `file://` URL is read from disk;
+ *  otherwise an HTTPS-only GET with a bounded timeout and a streamed byte cap.
+ *  `http:` (and other non-https URL schemes) are rejected. */
 export async function fetchCatalog(url: string): Promise<string> {
+  const localPath = catalogLocalPath(url);
+  if (localPath !== null) {
+    return readCatalogFile(localPath);
+  }
   if (!url.startsWith("https://")) {
-    throw new Error(`catalog URL must be https: ${url}`);
+    throw new Error(`catalog URL must be https or a local file path: ${url}`);
   }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), CATALOG_FETCH_TIMEOUT_MS);
@@ -489,13 +563,7 @@ export async function fetchCatalog(url: string): Promise<string> {
     if (!res.ok) {
       throw new Error(`fetch failed: HTTP ${res.status} ${res.statusText}`);
     }
-    const text = await res.text();
-    if (text.length > CATALOG_MAX_BYTES) {
-      throw new Error(
-        `catalog too large (${text.length} bytes; cap ${CATALOG_MAX_BYTES} bytes)`,
-      );
-    }
-    return text;
+    return await readBodyCapped(res, url, CATALOG_MAX_BYTES);
   } finally {
     clearTimeout(timer);
   }
@@ -549,7 +617,12 @@ function classifyEntry(
   userAliases: Record<string, AliasValue>,
   oldManaged: Record<string, AliasObject>,
 ): Classification {
-  if (name in userAliases) {
+  // Own-property checks (not `name in ...` / bare index access): a catalog
+  // model named like a prototype member (`toString`, `__proto__`, …) must not
+  // be treated as a collision with — or a previous value from — an inherited
+  // property the user never set.
+  const has = (o: object, k: string): boolean => Object.prototype.hasOwnProperty.call(o, k);
+  if (has(userAliases, name)) {
     return {
       kind: "skipped",
       name,
@@ -557,7 +630,7 @@ function classifyEntry(
     };
   }
   const value: AliasObject = { ...model, source: "remote" };
-  const prev = oldManaged[name];
+  const prev = has(oldManaged, name) ? oldManaged[name] : undefined;
   if (prev === undefined) {
     return { kind: "added", name, value };
   }

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -501,6 +501,146 @@ export async function fetchCatalog(url: string): Promise<string> {
   }
 }
 
+/** Merge a complete `modelAliases` map into a config object (spread, like
+ *  `withAlias` but replaces the whole map). */
+function withModelAliases(
+  cfg: Record<string, any>,
+  aliases: Record<string, AliasValue>,
+): Record<string, any> {
+  return { ...cfg, client: { ...(cfg.client ?? {}), modelAliases: aliases } };
+}
+
+export type SkippedAlias = { name: string; keptUri: string; remoteUri: string };
+
+export type RefreshResult = {
+  url: string;
+  file: string;
+  added: string[];
+  updated: string[];
+  unchanged: string[];
+  removed: string[];
+  skipped: SkippedAlias[];
+  modelCount: number;
+};
+
+/** One verdict per catalog entry. The merge ("what to write, what to report")
+ *  is a `map` from catalog entries to `Classification`s; everything else is a
+ *  filter/project on the resulting array. This is the entire policy of
+ *  refresh — keep it pure and testable in isolation. */
+type Classification =
+  | { kind: "skipped"; name: string; entry: SkippedAlias }
+  | { kind: "added"; name: string; value: AliasObject }
+  | { kind: "updated"; name: string; value: AliasObject }
+  | { kind: "unchanged"; name: string; value: AliasObject };
+
+/** Stable JSON for value-equality. The merge writes objects with consistent
+ *  key order via the spread below (`{ ...model, source: "remote" }`), so a
+ *  deep equality check via `JSON.stringify` is sufficient for managed-entry
+ *  diffing without pulling in `node:util.isDeepStrictEqual`. */
+function sameManagedValue(prev: AliasObject, next: AliasObject): boolean {
+  return JSON.stringify(prev) === JSON.stringify(next);
+}
+
+/** Classify one catalog entry against the previous state. Pure: no I/O, no
+ *  mutation, deterministic. Tested via `_refreshCatalog`'s end-to-end tests. */
+function classifyEntry(
+  name: string,
+  model: CatalogModel,
+  userAliases: Record<string, AliasValue>,
+  oldManaged: Record<string, AliasObject>,
+): Classification {
+  if (name in userAliases) {
+    return {
+      kind: "skipped",
+      name,
+      entry: { name, keptUri: aliasUri(userAliases[name]), remoteUri: model.uri },
+    };
+  }
+  const value: AliasObject = { ...model, source: "remote" };
+  const prev = oldManaged[name];
+  if (prev === undefined) {
+    return { kind: "added", name, value };
+  }
+  if (sameManagedValue(prev, value)) {
+    return { kind: "unchanged", name, value };
+  }
+  return { kind: "updated", name, value };
+}
+
+/** Predicate factory for declarative filtering by `Classification.kind`. */
+function isKind<K extends Classification["kind"]>(k: K) {
+  return (c: Classification): c is Extract<Classification, { kind: K }> => c.kind === k;
+}
+
+/** Fetch + validate the catalog, then rewrite the `source:"remote"` aliases in
+ *  agency.json from it. User-owned aliases are preserved and win on name
+ *  collisions (the remote entry is skipped). Throws (leaving the file
+ *  untouched) on fetch/parse/validation failure. */
+export async function _refreshCatalog(
+  opts: { url?: string; fetcher?: (url: string) => Promise<string>; file?: string } = {},
+): Promise<RefreshResult> {
+  const file = resolveAliasFile(opts.file ?? "");
+  const url = resolveCatalogUrl(opts.url ?? "", file);
+  const fetcher = opts.fetcher ?? fetchCatalog;
+
+  // Fetch + validate BEFORE reading/writing agency.json, so a failure leaves
+  // the file untouched.
+  const text = await fetcher(url);
+  const models = parseCatalog(text);
+
+  // Read aliases through the canonical helper (single source of truth for
+  // "how aliases come out of agency.json"). `cfg` is needed separately to
+  // round-trip non-alias fields back into the file on write.
+  const cfg = readJson(file);
+  const existing = readModelAliases(file);
+
+  // Partition existing aliases by who manages them.
+  const userAliases: Record<string, AliasValue> = Object.fromEntries(
+    Object.entries(existing).filter(([, v]) => !(typeof v === "object" && v.source === "remote")),
+  );
+  const oldManaged: Record<string, AliasObject> = Object.fromEntries(
+    Object.entries(existing).filter(
+      (e): e is [string, AliasObject] => typeof e[1] === "object" && e[1].source === "remote",
+    ),
+  );
+
+  // The entire merge policy: classify each catalog entry once. Everything
+  // downstream is a filter/project on this array.
+  const classifications: Classification[] = Object.entries(models).map(([name, model]) =>
+    classifyEntry(name, model, userAliases, oldManaged),
+  );
+
+  const namesIn = <K extends Classification["kind"]>(k: K): string[] =>
+    classifications.filter(isKind(k)).map((c) => c.name);
+
+  const added = namesIn("added");
+  const updated = namesIn("updated");
+  const unchanged = namesIn("unchanged");
+  const skipped = classifications.filter(isKind("skipped")).map((c) => c.entry);
+
+  // What ends up in `client.modelAliases`: user aliases (untouched) plus
+  // every non-skipped classification's value.
+  const writtenManaged: Record<string, AliasValue> = Object.fromEntries(
+    classifications.filter((c) => c.kind !== "skipped").map((c) => [c.name, (c as { value: AliasObject }).value]),
+  );
+  const next: Record<string, AliasValue> = { ...userAliases, ...writtenManaged };
+
+  const surviving = [...added, ...updated, ...unchanged];
+  const removed = Object.keys(oldManaged).filter((n) => !surviving.includes(n));
+
+  writeJson(file, withModelAliases(cfg, next));
+  return {
+    url,
+    file,
+    added,
+    updated,
+    unchanged,
+    removed,
+    skipped,
+    modelCount: Object.keys(models).length,
+  };
+}
+
 // Cached so we don't shell out repeatedly per process.
 let cachedGlobalRoots: string[] | null = null;
 

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -353,6 +353,154 @@ export function _removeModel(name: string, cacheDir: string = ""): boolean {
   return true;
 }
 
+// =============================================================================
+// Remote catalog — fetch + validate the GitHub-hosted model list.
+// =============================================================================
+
+export const DEFAULT_CATALOG_URL =
+  "https://raw.githubusercontent.com/egonSchiele/agency-lang/main/packages/agency-lang/data/model-catalog.json";
+
+const SUPPORTED_CATALOG_VERSION = 1;
+
+/** A validated entry from the remote catalog. Mirrors `AliasObject` minus the
+ *  `source` tag (which `_refreshCatalog` adds on write). */
+export type CatalogModel = {
+  uri: string;
+  params?: string;
+  sizeBytes?: number;
+  category?: ModelCategory;
+  contextWindow?: number;
+  license?: string;
+  description?: string;
+};
+
+/** Resolve the catalog URL: explicit arg → env → config → built-in default. */
+export function resolveCatalogUrl(explicit: string = "", file: string = ""): string {
+  if (explicit !== "") return explicit;
+  if (process.env.AGENCY_MODEL_CATALOG_URL) return process.env.AGENCY_MODEL_CATALOG_URL;
+  const configured = readJson(resolveAliasFile(file)).client?.modelCatalogUrl;
+  if (typeof configured === "string" && configured.length > 0) return configured;
+  return DEFAULT_CATALOG_URL;
+}
+
+const CATALOG_CATEGORIES = ["general", "coding", "reasoning", "embedding"] as const;
+
+/** Bound on how long the default fetcher will wait for the remote catalog
+ *  before aborting. Long enough to tolerate slow CI mirrors; short enough
+ *  that a hung server doesn't lock up the CLI. */
+const CATALOG_FETCH_TIMEOUT_MS = 15_000;
+
+/** Bound on catalog body size. The seed catalog is well under 10 KB; a
+ *  5 MB cap guards against a misconfigured URL serving an arbitrary file. */
+const CATALOG_MAX_BYTES = 5_000_000;
+
+// Field-shape narrowers used by `parseCatalog`. Returning `undefined` for a
+// wrongly-typed field lets the resulting object literal drop the key
+// entirely (see the `Object.fromEntries(...filter(defined))` pattern below).
+function pickString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+function pickNumber(v: unknown): number | undefined {
+  return typeof v === "number" ? v : undefined;
+}
+function pickCategory(v: unknown): ModelCategory | undefined {
+  // `CATALOG_CATEGORIES` is a `readonly` tuple of literal types, so its
+  // `includes` rejects an arbitrary `unknown` — cast to a plain string
+  // array for the membership check, then narrow back.
+  if (typeof v !== "string") {
+    return undefined;
+  }
+  if (!(CATALOG_CATEGORIES as readonly string[]).includes(v)) {
+    return undefined;
+  }
+  return v as ModelCategory;
+}
+
+/** Strip keys whose value is `undefined` so the resulting object is JSON-clean
+ *  (no `"params": undefined` after `JSON.stringify`). */
+function compact<T extends Record<string, unknown>>(o: T): Partial<T> {
+  return Object.fromEntries(Object.entries(o).filter(([, v]) => v !== undefined)) as Partial<T>;
+}
+
+/** Parse + validate the catalog JSON. Throws on blob-level problems (bad JSON,
+ *  unsupported version, `models` not an object) so refresh aborts without
+ *  touching agency.json. Skips an individual entry (with a warning) when its
+ *  `uri` is missing/invalid; metadata fields with the wrong type are dropped
+ *  but the entry is kept. */
+export function parseCatalog(text: string): Record<string, CatalogModel> {
+  let raw: any;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    throw new Error(`catalog is not valid JSON: ${(err as Error).message}`);
+  }
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("catalog must be a JSON object");
+  }
+  if (raw.version !== SUPPORTED_CATALOG_VERSION) {
+    throw new Error(
+      `unsupported catalog version ${JSON.stringify(raw.version)}; this agency ` +
+        `supports version ${SUPPORTED_CATALOG_VERSION}. Upgrade agency.`,
+    );
+  }
+  if (typeof raw.models !== "object" || raw.models === null || Array.isArray(raw.models)) {
+    throw new Error("catalog.models must be an object keyed by model name");
+  }
+  // Project each blob entry into either a validated `CatalogModel` (kept) or
+  // `null` (skipped + warned). The final `Object.fromEntries` drops the
+  // `null` pairs, leaving only the valid models.
+  const entries: ([string, CatalogModel] | null)[] = Object.entries(
+    raw.models as Record<string, any>,
+  ).map(([name, entry]) => {
+    if (typeof entry !== "object" || entry === null) {
+      console.warn(`[catalog] skipping "${name}": entry is not an object`);
+      return null;
+    }
+    const uri = entry.uri;
+    if (typeof uri !== "string" || !(isModelUri(uri) || isGgufPath(uri))) {
+      console.warn(`[catalog] skipping "${name}": invalid uri ${JSON.stringify(uri)}`);
+      return null;
+    }
+    const model: CatalogModel = {
+      uri,
+      ...compact({
+        params: pickString(entry.params),
+        sizeBytes: pickNumber(entry.sizeBytes),
+        category: pickCategory(entry.category),
+        contextWindow: pickNumber(entry.contextWindow),
+        license: pickString(entry.license),
+        description: pickString(entry.description),
+      }),
+    };
+    return [name, model];
+  });
+  return Object.fromEntries(entries.filter((e): e is [string, CatalogModel] => e !== null));
+}
+
+/** Default fetcher: HTTPS-only GET with a bounded timeout and body cap. */
+export async function fetchCatalog(url: string): Promise<string> {
+  if (!url.startsWith("https://")) {
+    throw new Error(`catalog URL must be https: ${url}`);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), CATALOG_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`fetch failed: HTTP ${res.status} ${res.statusText}`);
+    }
+    const text = await res.text();
+    if (text.length > CATALOG_MAX_BYTES) {
+      throw new Error(
+        `catalog too large (${text.length} bytes; cap ${CATALOG_MAX_BYTES} bytes)`,
+      );
+    }
+    return text;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Cached so we don't shell out repeatedly per process.
 let cachedGlobalRoots: string[] | null = null;
 

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -546,8 +546,15 @@ function colWidth(header: string, values: string[]): number {
  *  newline (the caller's `console.log` adds exactly one). */
 export function formatModelCatalog(): string {
   const entries = _listModelNames();
-  const curated = entries.filter((m) => m.source === "curated");
-  const aliases = entries.filter((m) => m.source === "alias");
+  const hasMetadata = (m: ModelNameEntry): boolean =>
+    m.params !== undefined ||
+    m.sizeBytes !== undefined ||
+    m.category !== undefined ||
+    m.contextWindow !== undefined ||
+    m.license !== undefined ||
+    m.description !== undefined;
+  const curated = entries.filter(hasMetadata); // table rows: built-ins + rich aliases
+  const aliases = entries.filter((m) => !hasMetadata(m)); // plain name→uri only
   const lines: string[] = [];
 
   if (curated.length > 0) {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -42,6 +42,7 @@ import {
   runDownload as localDownload,
   runRemove as localRemove,
   runResolve as localResolve,
+  runRefresh as localRefresh,
   runAliasList as localAliasList,
   runAliasAdd as localAliasAdd,
   runAliasRemove as localAliasRemove,
@@ -877,6 +878,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(localRemove);
   localCmd.command("resolve").description("Show what a name/alias resolves to").argument("<value>")
     .action(localResolve);
+  localCmd.command("refresh").description("Refresh the model catalog from the remote source")
+    .argument("[url]", "Override the catalog URL (else env/config/default)").action(localRefresh);
   const aliasCmd = localCmd.command("alias").description("Manage model name aliases");
   aliasCmd.command("list").description("List usable short names (curated + aliases)").action(localAliasList);
   aliasCmd.command("add").description("Add a short-name alias").argument("<name>").argument("<uri>")

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -10,6 +10,7 @@ import {
   _registerLocalProvider,
   _registerLocalModel,
   _printLocalCatalog,
+  _refreshCatalog,
 } from "agency-lang/stdlib-lib/localModels.js"
 
 /** @module
@@ -125,4 +126,44 @@ export def printLocalCatalog() {
   """Print the usable-model catalog (curated names + your aliases) as an
   aligned table — the same listing as `agency local alias list`."""
   _printLocalCatalog()
+}
+
+/** A catalog model whose name collided with one of your own aliases: refresh
+ *  kept your alias (`keptUri`) and did not write the catalog's `remoteUri`. */
+export type SkippedAlias = {
+  name: string,
+  keptUri: string,
+  remoteUri: string,
+}
+
+/** The outcome of `refreshCatalog`. The name lists partition the catalog's
+ *  managed (`source:"remote"`) entries by what changed; `skipped` are entries
+ *  yielded to your own aliases; `modelCount` is the total catalog size, so
+ *  `added + updated + unchanged + skipped == modelCount`. */
+export type RefreshResult = {
+  url: string,
+  file: string,
+  added: string[],
+  updated: string[],
+  unchanged: string[],
+  removed: string[],
+  skipped: SkippedAlias[],
+  modelCount: number,
+}
+
+export def refreshCatalog(url: string = ""): RefreshResult {
+  """
+  Fetch the remote model catalog and update the `source:"remote"` aliases in
+  the nearest `agency.json` from it. Adds/updates models from the catalog,
+  removes ones it dropped, and skips (keeping yours) any name you've aliased
+  yourself. Your hand-added aliases are never overwritten. Throws on a
+  fetch/parse/validation failure, leaving `agency.json` untouched.
+
+  This is the same operation as the `agency local refresh` CLI command.
+
+  @param url - catalog URL override; empty string uses the
+    `AGENCY_MODEL_CATALOG_URL` env var, then `client.modelCatalogUrl` in
+    `agency.json`, then the built-in default.
+  """
+  return _refreshCatalog({ url: url })
 }


### PR DESCRIPTION
## Summary

Adds `agency local refresh [url]`, which fetches a GitHub-hosted JSON catalog of recommended local models and layers it onto the local model list — so new model recommendations ship by editing one file on `main`, no package upgrade needed.

Implements the approved spec (`docs/superpowers/specs/2026-06-27-model-catalog-refresh-design.md`).

## How it works

- **Generalized aliases.** A `client.modelAliases` value is now `string | AliasObject`; the object form carries a `uri` plus optional metadata (`params`/`sizeBytes`/`category`/…) and a `source: "remote"` tag. `CURATED_LOCAL_MODELS` stays as the hardcoded base layer. `_listModelNames` dedupes by name (alias wins); `formatModelCatalog` shows any metadata-bearing entry (built-ins + rich aliases) in the table.
- **`agency local refresh`.** Resolves the catalog URL (CLI arg → `AGENCY_MODEL_CATALOG_URL` → `client.modelCatalogUrl` → built-in default), fetches over HTTPS (timeout + 5 MB cap), validates (`version` gate; strict `uri`, lenient metadata). It then drops the previously-managed (`source:"remote"`) entries and writes the catalog's models back as tagged aliases — **skipping any name you've aliased yourself** (your value wins; the skipped remote value is printed). Fetch/parse/validation failure leaves `agency.json` untouched.
- **Diff reporting.** Each run reports `added / updated / unchanged / removed / skipped`; a no-op re-fetch reports everything `unchanged`.
- **Seed catalog.** `packages/agency-lang/data/model-catalog.json` is seeded from `CURATED_LOCAL_MODELS` and is what the default URL serves.

## Output example

```
Skipped "smollm2-135m": kept your alias (hf:mine/keep:Q4_K_M);
  remote would have set hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M
Refreshed 13 models from <url> → <agency.json>
  (12 added, 0 updated, 0 unchanged, 0 removed, 1 skipped)
```

## Testing

- New unit tests for object-form alias resolve/list/dedupe, rich-alias rendering, URL precedence, `parseCatalog` (valid / bad JSON / bad version / non-object models / bad-uri skip), the `_refreshCatalog` engine (added/updated/unchanged/removed, user-collision skip, non-destructive on invalid blob), and `formatRefreshOutput`.
- Full suites green: `localModels`, `cli/local`, `args` (184 pass; the 2 `resolveSmoltalkLlamaCppFromRoots` failures are pre-existing/environmental and reproduce on `main`).
- `tsc --noEmit` clean, structural linter clean.
- End-to-end smoke: the committed seed file flows through `_refreshCatalog` (13 models, user collision preserved, remote entries written with full metadata).

## Notes

- The default URL points at the seed file on `main`, so a **live** `agency local refresh` only works once this merges. Build/tests don't depend on it (they inject a fetcher).
- Implemented TDD per the plan (`docs/superpowers/plans/2026-06-27-model-catalog-refresh.md`), one commit per task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
