### PR TITLE
feat(lowering): preserve match structure as Assignment.matchSource

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-06-27-match-metadata-preservation.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-27-match-metadata-preservation.md
@@ -1,0 +1,198 @@
+# Match Metadata Preservation (Part A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop discarding the original `match` structure during pattern lowering — carry it on the lowered scrutinee assignment as an optional `matchSource` field — so a later type-checker pass can do exhaustiveness checking. No behavior change.
+
+**Architecture:** `lowerMatchBlock` rewrites a pattern-arm `match` into `[scrutineeAssign, ifChain]` and currently drops the `MatchBlock`. Add `matchSource?: MatchBlock` to the `Assignment` type and set it on the synthetic scrutinee assignment. Codegen and every downstream pass ignore the field; it exists only for the type checker.
+
+**Scope note (intentional):** Only the **pattern-arm** path of `lowerMatchBlock` is tagged. The separate `match (x is …)` form has its own lowering path (`lowerMatchIsForm`, `lib/lowering/patternLowering.ts:292`) and is **deliberately not** tagged here — Part A targets pattern-arm exhaustiveness. A future consumer must not assume the is-form scrutinee carries `matchSource`.
+
+**Tech Stack:** TypeScript, vitest. This is the prerequisite for both `match-exhaustiveness-spec.md` (B1/B2) and `handler-narrowing-spec.md` — but it ships and is reviewable on its own.
+
+## Global Constraints
+
+- NEVER use dynamic imports. Use `type` aliases not `interface`. (CLAUDE.md)
+- This is a vitest **unit** change: `npx vitest run <path>`, NOT the agency execution runner.
+- **No behavior change.** Codegen output must be byte-identical; the field is additive and read by nobody yet. Verify the full lowering + typecheck suites stay green.
+- **Verified facts (do not re-derive):**
+  - `Assignment` is at `lib/types.ts:173`; `MatchBlock` is **already imported** at `lib/types.ts:20` (no new import / no new cycle).
+  - `lowerMatchBlock`'s pattern-arm path builds `scrutineeAssign` at `lib/lowering/patternLowering.ts:279-285` and always emits it (`return ifChain ? [scrutineeAssign, ifChain] : [scrutineeAssign]`). `node` in scope there is the original `MatchBlock`.
+  - The literal-passthrough path returns the `matchBlock` node unchanged — it needs no tag (the structure is already intact).
+  - Lowering test helpers exist in `lib/lowering/patternLowering.test.ts`: `lower(source)` (lowers a `node main()` body) and `parseAgency(src, {}, false, false)` (parse with lowering OFF). `liftCallbackBlocks` is in `lib/preprocessors/liftCallbacks.ts`; callback-block syntax is `callback("hook") as data { … }`.
+  - The test file **already imports** `AgencyNode`, `Assignment`, and `MatchBlock` from `../types.js` (lines 12-18). Do NOT re-import them — a duplicate `Assignment` import is a TS2300 error that `tsc --noEmit` (Step 6) will reject.
+
+---
+
+## File Structure
+
+- **Modify** `lib/types.ts` — add `matchSource?: MatchBlock` to `Assignment`.
+- **Modify** `lib/lowering/patternLowering.ts` — set `matchSource: node` on the scrutinee assignment in `lowerMatchBlock`.
+- **Modify** `lib/lowering/patternLowering.test.ts` — presence test + survives-lifting test.
+
+---
+
+### Task 1: Preserve the match structure on the lowered scrutinee assignment
+
+**Files:**
+- Modify: `lib/types.ts:173` (the `Assignment` type)
+- Modify: `lib/lowering/patternLowering.ts:279-285` (`lowerMatchBlock` scrutinee assignment)
+- Test: `lib/lowering/patternLowering.test.ts`
+
+**Interfaces:**
+- Produces: `Assignment.matchSource?: MatchBlock` — set only by `lowerMatchBlock`'s pattern-arm path; consumed later by the exhaustiveness diagnostic (not in this plan).
+
+- [ ] **Step 1: Add the `matchSource` field to `Assignment`**
+
+In `lib/types.ts`, in the `Assignment` type (starts at line 173), add the field (after `exported?: boolean;`):
+
+```ts
+  tags?: Tag[];
+  exported?: boolean;
+  /** Set by pattern lowering on the synthetic scrutinee binding of a lowered
+   *  `match` with pattern arms. Lets the type checker recover the original arm
+   *  structure (exhaustiveness; future match-native narrowing) even though the
+   *  executable form is the lowered if-chain. Holds the *un-lowered* MatchBlock,
+   *  so its case bodies are pre-lowering — consumers must read only the arm
+   *  patterns (`caseValue`/`guard`), never the bodies. Ignored by codegen.
+   *  `MatchBlock` is already imported at the top of this file. */
+  matchSource?: MatchBlock;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+In `lib/lowering/patternLowering.test.ts`, add ONLY these imports at the top (alongside the existing ones). `AgencyNode`, `Assignment`, and `MatchBlock` are already imported from `../types.js` — do NOT re-import them. Use `walkNodesArray` (not the `walkNodes` generator) so the helper can use `.find(...)`:
+
+```ts
+import { walkNodesArray } from "../utils/node.js";
+import { liftCallbackBlocks } from "../preprocessors/liftCallbacks.js";
+import type { ResultPattern } from "../types/pattern.js";
+```
+
+Then append this describe block at the end of the file:
+
+```ts
+describe("match metadata preservation (matchSource)", () => {
+  function findTaggedAssignment(nodes: AgencyNode[]): Assignment | undefined {
+    const hit = walkNodesArray(nodes).find(
+      ({ node }) => node.type === "assignment" && node.matchSource,
+    );
+    return hit?.node as Assignment | undefined;
+  }
+
+  it("tags the lowered scrutinee assignment with the original match", () => {
+    const lowered = lower(`
+let r = foo()
+match (r) {
+  success(v) => print(v)
+  failure(e) => print(e)
+}
+`);
+    const tagged = findTaggedAssignment(lowered);
+    expect(tagged).toBeDefined();
+    expect(tagged?.matchSource?.type).toBe("matchBlock");
+    const cases = tagged?.matchSource?.cases.filter(
+      (c) => c.type === "matchBlockCase",
+    );
+    expect(cases?.length).toBe(2); // success + failure arms preserved
+    // Assert structure carried through, not just the arm count: the first arm
+    // is a `success(...)` result pattern.
+    const first = cases?.[0];
+    const pattern =
+      first?.type === "matchBlockCase" ? first.caseValue : undefined;
+    expect(pattern !== "_" && (pattern as ResultPattern)?.kind).toBe("success");
+  });
+
+  it("survives liftCallbackBlocks (match nested in a callback block)", () => {
+    // Uses parseAgency + lowerPatterns directly rather than the `lower(...)`
+    // helper: `lower` wraps its input in a `node main()` body, but we want the
+    // callback block as the top-level shape fed to liftCallbackBlocks so the
+    // lift actually moves it. Do NOT "simplify" this back to `lower(...)`.
+    const src = `callback("onNodeStart") as data {
+  let r = foo()
+  match (r) {
+    success(v) => print(v)
+    failure(e) => print(e)
+  }
+}
+`;
+    const parsed = parseAgency(src, {}, false, false);
+    if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+    const loweredProgram = {
+      ...parsed.result,
+      nodes: lowerPatterns(parsed.result.nodes),
+    };
+    const lifted = liftCallbackBlocks(loweredProgram);
+    expect(findTaggedAssignment(lifted.nodes)).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run lib/lowering/patternLowering.test.ts -t "matchSource"`
+Expected: both tests FAIL — `matchSource` is never set, so `findTaggedAssignment` returns `undefined`. (Step 1 makes them *compile*; the behavior is still missing.)
+
+- [ ] **Step 4: Set `matchSource` on the scrutinee assignment**
+
+In `lib/lowering/patternLowering.ts`, in `lowerMatchBlock`'s pattern-arm path, add the field to the `scrutineeAssign` literal (currently lines 279-285):
+
+```ts
+    const scrutineeAssign: Assignment = {
+      type: "assignment",
+      variableName: scrutineeName,
+      declKind: "const",
+      value: node.expression,
+      loc: node.loc,
+      matchSource: node,
+    };
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run lib/lowering/patternLowering.test.ts`
+Expected: PASS (the two new tests plus all existing lowering tests).
+
+- [ ] **Step 6: Verify no behavior change downstream**
+
+The only plausible regression is a test that structurally serializes/compares whole `Assignment` nodes (e.g. an AST-JSON golden). The one such test in the repo is
+`lib/preprocessors/typescriptPreprocessor.integration.test.ts` (it `JSON.stringify`s the preprocessed AST against `tests/typescriptPreprocessor/*.json` fixtures). It must run. Codegen ignores the field, so generated-TS fixtures are unaffected — but run the backends/typechecker suites too as a backstop.
+
+Run: `npx vitest run lib/preprocessors/ lib/lowering/ lib/typeChecker/ lib/backends/ 2>&1 | tee /tmp/partA.log`
+Expected: PASS (no regressions). If anything fails, inspect `/tmp/partA.log` — a failure here means some pass is structurally-comparing whole `Assignment` nodes (e.g. a snapshot/golden), which would need the field excluded or the fixture regenerated. (If time permits, the fully safe check is the whole unit suite: `npx vitest run`.)
+
+Run: `npx tsc --noEmit`
+Expected: clean. (This is what catches a stray duplicate import or type mismatch.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/types.ts lib/lowering/patternLowering.ts lib/lowering/patternLowering.test.ts
+git commit -F - <<'EOF'
+feat(lowering): preserve match structure as Assignment.matchSource
+
+Pattern lowering rewrites a pattern-arm `match` into a scrutinee-temp +
+if-chain, discarding the original MatchBlock before the type checker runs.
+Tag the scrutinee assignment with the original match so a later exhaustiveness
+pass (and future match-native narrowing) can recover the arm structure.
+Additive optional field, ignored by codegen — no behavior change.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (`match-exhaustiveness-spec.md` Part A):**
+- `Assignment.matchSource` added, `MatchBlock` already imported → Step 1. ✓
+- Tag set on the pattern-arm scrutinee assignment; literal path and is-form path unchanged → Step 4 + Scope note. ✓
+- Presence test + survives-lifting test → Step 2. ✓
+- No behavior change (codegen/downstream untouched) → Step 6 guards it. ✓
+
+**Placeholder scan:** none — every code step shows complete code; every run step shows command + expected outcome.
+
+**Type consistency:** `matchSource?: MatchBlock` is the same name/type in `types.ts`, in the `scrutineeAssign` literal, and in the test's `node.matchSource` access. `findTaggedAssignment` narrows on `node.type === "assignment" && node.matchSource`, so the `.matchSource`/`.cases` accesses typecheck. The test reuses the file's existing `AgencyNode`/`Assignment`/`MatchBlock` imports and adds only `walkNodesArray`, `liftCallbackBlocks`, `ResultPattern`.
+
+**Risk to watch (Step 6):** the only plausible regression is a test that structurally compares or snapshots whole `Assignment` nodes and would now see an extra field. The repo's one AST-JSON golden test lives in `lib/preprocessors/`, so Step 6 runs that directory explicitly (no pattern-arm `match` exists in its fixtures today, so nothing is expected to break); if a future fixture does, exclude `matchSource` from the comparison or regenerate the golden rather than dropping the field.

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-27-match-metadata-preservation.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-27-match-metadata-preservation.md
@@ -2,6 +2,22 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Post-review revision (after code review on the PR).** Three changes from the
+> body below were adopted from review and are what actually shipped:
+> 1. `matchSource` stores a **slim, deep-cloned, body-free** arm snapshot
+>    (`MatchArmMeta[]` = `{ caseValue, guard }[]`, defined in `types/matchBlock.ts`),
+>    **not** the live `MatchBlock`. This fixes (a) retaining every un-lowered case
+>    body through codegen and (b) aliasing live AST that scope resolution mutates
+>    in place (`matchSource` shared `node.expression`/`guard` objects with the
+>    emitted if-chain). The "consumers must not read bodies" caveat is gone.
+> 2. The scrutinee value is now `this.lowerExpression(node.expression)` (was
+>    `node.expression` raw) — a pre-existing codegen crash where a nested `is` in a
+>    compound match head (e.g. `match ((r is success) && y) { … }`) survived
+>    unlowered into codegen ("Unhandled Agency node type: isExpression").
+> 3. Doc comments now state that only the pattern-arm path is tagged; the
+>    literal-passthrough and `is`-form paths are intentionally untagged, and the
+>    eventual consumer must handle all three shapes.
+
 **Goal:** Stop discarding the original `match` structure during pattern lowering — carry it on the lowered scrutinee assignment as an optional `matchSource` field — so a later type-checker pass can do exhaustiveness checking. No behavior change.
 
 **Architecture:** `lowerMatchBlock` rewrites a pattern-arm `match` into `[scrutineeAssign, ifChain]` and currently drops the `MatchBlock`. Add `matchSource?: MatchBlock` to the `Assignment` type and set it on the synthetic scrutinee assignment. Codegen and every downstream pass ignore the field; it exists only for the type checker.

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -19,6 +19,9 @@ import type {
 } from "../types.js";
 import type { BinOpExpression } from "../types/binop.js";
 import type { ValueAccess } from "../types/access.js";
+import { walkNodesArray } from "../utils/node.js";
+import { liftCallbackBlocks } from "../preprocessors/liftCallbacks.js";
+import type { ResultPattern } from "../types/pattern.js";
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -649,5 +652,60 @@ describe("result patterns", () => {
       });
       expect(eAccess.chain).toEqual([{ kind: "property", name: "error" }]);
     });
+  });
+});
+
+describe("match metadata preservation (matchSource)", () => {
+  function findTaggedAssignment(nodes: AgencyNode[]): Assignment | undefined {
+    const hit = walkNodesArray(nodes).find(
+      ({ node }) => node.type === "assignment" && node.matchSource,
+    );
+    return hit?.node as Assignment | undefined;
+  }
+
+  it("tags the lowered scrutinee assignment with the original match", () => {
+    const lowered = lower(`
+let r = foo()
+match (r) {
+  success(v) => print(v)
+  failure(e) => print(e)
+}
+`);
+    const tagged = findTaggedAssignment(lowered);
+    expect(tagged).toBeDefined();
+    expect(tagged?.matchSource?.type).toBe("matchBlock");
+    const cases = tagged?.matchSource?.cases.filter(
+      (c) => c.type === "matchBlockCase",
+    );
+    expect(cases?.length).toBe(2); // success + failure arms preserved
+    // Assert structure carried through, not just the arm count: the first arm
+    // is a `success(...)` result pattern.
+    const first = cases?.[0];
+    const pattern =
+      first?.type === "matchBlockCase" ? first.caseValue : undefined;
+    expect(pattern !== "_" && (pattern as ResultPattern)?.kind).toBe("success");
+  });
+
+  it("survives liftCallbackBlocks (match nested in a callback block)", () => {
+    // Uses parseAgency + lowerPatterns directly rather than the `lower(...)`
+    // helper: `lower` wraps its input in a `node main()` body, but we want the
+    // callback block as the top-level shape fed to liftCallbackBlocks so the
+    // lift actually moves it. Do NOT "simplify" this back to `lower(...)`.
+    const src = `callback("onNodeStart") as data {
+  let r = foo()
+  match (r) {
+    success(v) => print(v)
+    failure(e) => print(e)
+  }
+}
+`;
+    const parsed = parseAgency(src, {}, false, false);
+    if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+    const loweredProgram = {
+      ...parsed.result,
+      nodes: lowerPatterns(parsed.result.nodes),
+    };
+    const lifted = liftCallbackBlocks(loweredProgram);
+    expect(findTaggedAssignment(lifted.nodes)).toBeDefined();
   });
 });

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -673,17 +673,32 @@ match (r) {
 `);
     const tagged = findTaggedAssignment(lowered);
     expect(tagged).toBeDefined();
-    expect(tagged?.matchSource?.type).toBe("matchBlock");
-    const cases = tagged?.matchSource?.cases.filter(
-      (c) => c.type === "matchBlockCase",
-    );
-    expect(cases?.length).toBe(2); // success + failure arms preserved
-    // Assert structure carried through, not just the arm count: the first arm
-    // is a `success(...)` result pattern.
-    const first = cases?.[0];
-    const pattern =
-      first?.type === "matchBlockCase" ? first.caseValue : undefined;
+    const arms = tagged?.matchSource;
+    expect(arms?.length).toBe(2); // success + failure arms preserved
+    // Structure carried through, not just the arm count: the first arm is a
+    // `success(...)` result pattern.
+    const pattern = arms?.[0]?.caseValue;
     expect(pattern !== "_" && (pattern as ResultPattern)?.kind).toBe("success");
+    // Slim snapshot: arms carry only the matcher metadata, never the body.
+    expect(arms?.[0]).not.toHaveProperty("body");
+  });
+
+  it("lowers a nested `is` in the match head — no isExpression survives", () => {
+    // Regression: a nested `is` in a compound scrutinee must be lowered to a
+    // boolean condition; if it survives raw, codegen has no isExpression
+    // handler and crashes ("Unhandled Agency node type: isExpression").
+    const lowered = lower(`
+let r = foo()
+let y = true
+match ((r is success) && y) {
+  success(v) => print("s")
+  failure(e) => print("f")
+}
+`);
+    const survived = walkNodesArray(lowered).some(
+      ({ node }) => node.type === "isExpression",
+    );
+    expect(survived).toBe(false);
   });
 
   it("survives liftCallbackBlocks (match nested in a callback block)", () => {

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -280,9 +280,21 @@ class PatternLowerer {
       type: "assignment",
       variableName: scrutineeName,
       declKind: "const",
-      value: node.expression,
+      // Lower the scrutinee like any other assignment value, so a nested
+      // `is` in a compound head (e.g. `match ((x is A) && y) { … }`) is
+      // rewritten to its boolean condition instead of surviving raw into
+      // codegen, which has no isExpression handler.
+      value: this.lowerExpression(node.expression),
       loc: node.loc,
-      matchSource: node,
+      // Carry a slim, deep-cloned, body-free snapshot of the arms for a later
+      // exhaustiveness pass. Cloned so we neither retain the un-lowered case
+      // bodies nor alias live AST that scope resolution mutates in place. See
+      // Assignment.matchSource.
+      matchSource: structuredClone(
+        node.cases
+          .filter((c): c is MatchBlockCase => c.type === "matchBlockCase")
+          .map((c) => ({ caseValue: c.caseValue, guard: c.guard })),
+      ),
     };
     const scrutineeRef = varRef(scrutineeName, node.loc);
 

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -282,6 +282,7 @@ class PatternLowerer {
       declKind: "const",
       value: node.expression,
       loc: node.loc,
+      matchSource: node,
     };
     const scrutineeRef = varRef(scrutineeName, node.loc);
 

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -187,6 +187,14 @@ export type Assignment = BaseNode & {
   value: Expression | MessageThread;
   tags?: Tag[];
   exported?: boolean;
+  /** Set by pattern lowering on the synthetic scrutinee binding of a lowered
+   *  `match` with pattern arms. Lets the type checker recover the original arm
+   *  structure (exhaustiveness; future match-native narrowing) even though the
+   *  executable form is the lowered if-chain. Holds the *un-lowered* MatchBlock,
+   *  so its case bodies are pre-lowering — consumers must read only the arm
+   *  patterns (`caseValue`/`guard`), never the bodies. Ignored by codegen.
+   *  `MatchBlock` is already imported at the top of this file. */
+  matchSource?: MatchBlock;
 };
 
 export function globalScope(): Scope {

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -17,7 +17,7 @@ import { ExportFromStatement } from "./types/exportFromStatement.js";
 import { ForLoop } from "./types/forLoop.js";
 import { Keyword } from "./types/keyword.js";
 import { Literal, RawCode, RegexLiteral } from "./types/literals.js";
-import { MatchBlock } from "./types/matchBlock.js";
+import { MatchArmMeta, MatchBlock } from "./types/matchBlock.js";
 import { MessageThread } from "./types/messageThread.js";
 import { ReturnStatement } from "./types/returnStatement.js";
 import { GotoStatement } from "./types/gotoStatement.js";
@@ -188,13 +188,18 @@ export type Assignment = BaseNode & {
   tags?: Tag[];
   exported?: boolean;
   /** Set by pattern lowering on the synthetic scrutinee binding of a lowered
-   *  `match` with pattern arms. Lets the type checker recover the original arm
-   *  structure (exhaustiveness; future match-native narrowing) even though the
-   *  executable form is the lowered if-chain. Holds the *un-lowered* MatchBlock,
-   *  so its case bodies are pre-lowering — consumers must read only the arm
-   *  patterns (`caseValue`/`guard`), never the bodies. Ignored by codegen.
-   *  `MatchBlock` is already imported at the top of this file. */
-  matchSource?: MatchBlock;
+   *  `match` with pattern arms. A deep-cloned, body-free snapshot of the arms,
+   *  so the type checker can recover the original arm structure (exhaustiveness;
+   *  future match-native narrowing) even though the executable form is the
+   *  lowered if-chain. Cloned and slimmed deliberately: it neither retains the
+   *  un-lowered case bodies nor aliases live AST that later passes mutate in
+   *  place. Ignored by codegen.
+   *
+   *  Only the pattern-arm lowering path sets this. The other two "this was a
+   *  match" shapes are intentionally untagged: a literal/identifier match stays
+   *  as a `matchBlock` node (read directly), and the `is`-form match is
+   *  guard-based. A consumer must recognize all three deliberately. */
+  matchSource?: MatchArmMeta[];
 };
 
 export function globalScope(): Scope {

--- a/packages/agency-lang/lib/types/matchBlock.ts
+++ b/packages/agency-lang/lib/types/matchBlock.ts
@@ -17,3 +17,13 @@ export type MatchBlock = BaseNode & {
   expression: Expression | IsExpression;
   cases: (MatchBlockCase | AgencyComment | NewLine)[];
 };
+
+/** Slim, lowering-preserved metadata for a single match arm: just the matcher
+ *  pattern and optional guard, with the body dropped. A deep-cloned array of
+ *  these is carried on the lowered scrutinee `Assignment` as `matchSource` (see
+ *  there) so a later type-checker pass can recover the arm structure without
+ *  retaining or aliasing the un-lowered case bodies. */
+export type MatchArmMeta = {
+  caseValue: MatchPattern | DefaultCase;
+  guard?: Expression;
+};


### PR DESCRIPTION
## What

Pattern lowering rewrites a pattern-arm `match` into a synthetic scrutinee
binding + an `if`-chain, discarding the original `MatchBlock` before the type
checker ever runs. That makes match exhaustiveness checking impossible
downstream, because the arm structure is gone.

This change carries the arm structure forward by tagging the lowered scrutinee
assignment with `matchSource?: MatchArmMeta[]` — a **slim, deep-cloned,
body-free** snapshot of the arms (`{ caseValue, guard }[]`).

- `lib/types/matchBlock.ts` — new `MatchArmMeta` type (`{ caseValue, guard }`).
- `lib/types.ts` — add `matchSource?: MatchArmMeta[]` to `Assignment`.
- `lib/lowering/patternLowering.ts` — set `matchSource` to a `structuredClone`d
  arm snapshot in `lowerMatchBlock`'s pattern-arm path.
- `lib/lowering/patternLowering.test.ts` — shape test, survives-lifting test,
  nested-`is` regression test.

This is **Part A** — the prerequisite for `match-exhaustiveness-spec.md` (B1/B2)
and `handler-narrowing-spec.md`. It ships and is reviewable on its own.

## Updated after review

- **Slim deep clone, not the live node.** `matchSource` originally held the live
  `MatchBlock`, which (a) retained every un-lowered case body alive through
  codegen and (b) aliased AST that scope resolution mutates in place
  (`matchSource.expression`/`guard` were the same objects as the emitted
  if-chain's). It now stores a `structuredClone`d `{ caseValue, guard }[]`, which
  severs both hazards. Safe to change the shape — nothing consumes it yet.
- **Nested-`is` codegen crash fixed.** The scrutinee value is now lowered via
  `lowerExpression` instead of stored raw. Previously a nested `is` in a compound
  match head (e.g. `match ((r is success) && y) { … }`) survived unlowered into
  codegen, which has no `isExpression` handler → `Unhandled Agency node type:
  isExpression`. This aligns the scrutinee binding with how `lowerAssignment`
  already lowers every other assignment value. Pre-existing bug, on the touched
  line.

## Scope notes

- Only the **pattern-arm** path is tagged. The literal-passthrough match stays a
  `matchBlock` node (read directly) and the `is`-form is guard-based — both
  intentionally untagged. Documented on the field; the future consumer must
  handle all three shapes.

## No behavior change (common path)

The field is additive, optional, and read by **nobody** yet — codegen and every
downstream pass ignore it. The only generated-output change is the nested-`is`
fix, which turns a hard crash into correct output.

## Verification

- `npx vitest run lib/lowering/patternLowering.test.ts` — 34 passed.
- `npx vitest run lib/preprocessors/ lib/lowering/ lib/typeChecker/ lib/backends/`
  — 1140 passed. The single failure is a pre-existing fresh-worktree env issue
  (`agency-lang/stdlib` subpath not resolvable in a worktree checkout); it
  reproduces on the base commit without this change and passes in a clean/CI
  build.
- `npx tsc --noEmit` — clean.
- Manual: `match ((r is success) && y) { … }` compiles instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
