### PR TITLE
Verify SHA-256 of downloaded local models against pinned hashes

### DIFF
--- a/.github/workflows/local-model.yml
+++ b/.github/workflows/local-model.yml
@@ -6,8 +6,9 @@
 #
 # Security:
 # - All third-party actions pinned to SHA (same pins as test-with-llm.yml).
-# - smoltalk-llama-cpp is installed with --save=false at a pinned version;
-#   it is NOT in package.json (so user `pnpm install` doesn't pull node-llama-cpp).
+# - smoltalk-llama-cpp is installed ad-hoc at a pinned version in CI only;
+#   it is NOT in the committed package.json (so user `pnpm install` doesn't
+#   pull node-llama-cpp).
 # - Models cache key is scoped to the model name + version; no restore-keys
 #   (a partial / poisoned cache must not be used as a fallback).
 # - Test verifies the downloaded GGUF's SHA256 against a committed expected
@@ -58,11 +59,15 @@ jobs:
       - name: Build
         run: make
 
-      # Install smoltalk-llama-cpp ONLY here, at a pinned version, without
-      # mutating package.json or the lockfile. --save=false keeps both clean.
+      # Install smoltalk-llama-cpp ONLY here, at a pinned version. pnpm 9's
+      # `add` rejects `--save=false` (ERR_PNPM_OPTION_NOT_SUPPORTED), so we add
+      # it directly: the package.json / lockfile edits it makes live only on the
+      # ephemeral CI runner and are never committed, and no later step runs a
+      # `--frozen-lockfile` check. It stays out of the *committed* manifests,
+      # which is what keeps a normal `pnpm install` from pulling node-llama-cpp.
       - name: Install smoltalk-llama-cpp (pinned, off-lockfile)
         working-directory: packages/agency-lang
-        run: pnpm add --save=false smoltalk-llama-cpp@${{ env.SMOLTALK_LLAMA_CPP_VERSION }}
+        run: pnpm add smoltalk-llama-cpp@${{ env.SMOLTALK_LLAMA_CPP_VERSION }}
 
       # Cache the downloaded GGUF + the node-llama-cpp prebuilt binary.
       # Scoped to the model name; no restore-keys — a partial/poisoned cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Pipeline and architecture:
 - `docs/dev/locations.md` — How `loc.line` / `loc.col` / parse-mode template offset interact
 - `docs/dev/validation-annotations.md` — `@validate(...)` and `@jsonSchema(...)` internals: tag merging, `__agency_descriptor` contract, descriptor tree, runtime walker
 - `docs/dev/async-context.md` — `agencyStore` AsyncLocalStorage frame and `getRuntimeContext()` pattern for stdlib TS helpers
+- `docs/dev/local-models.md` — Local-model support: provider, name resolution, catalog refresh, and SHA-256 download verification
 
 Other references:
 - `docs/misc/TESTING.md` — Full testing guide (unit tests, fixtures, execution tests, agency-js tests)

--- a/packages/agency-lang/data/model-catalog.json
+++ b/packages/agency-lang/data/model-catalog.json
@@ -8,7 +8,8 @@
       "category": "general",
       "contextWindow": 8192,
       "license": "apache-2.0",
-      "description": "Smallest practical chat model; used by our integration tests, runs anywhere."
+      "description": "Smallest practical chat model; used by our integration tests, runs anywhere.",
+      "sha256": "ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747"
     },
     "qwen3.5-0.8b": {
       "uri": "hf:unsloth/Qwen3.5-0.8B-GGUF:Q4_K_M",
@@ -17,7 +18,8 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Tiny model from Alibaba's current generation; good edge-device default."
+      "description": "Tiny model from Alibaba's current generation; good edge-device default.",
+      "sha256": "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
     },
     "qwen3.5-2b": {
       "uri": "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
@@ -26,7 +28,8 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Most popular modern small general model; runs on CPU comfortably."
+      "description": "Most popular modern small general model; runs on CPU comfortably.",
+      "sha256": "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
     },
     "qwen3.5-4b": {
       "uri": "hf:unsloth/Qwen3.5-4B-GGUF:Q4_K_M",
@@ -35,7 +38,8 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Strong multilingual small general workhorse from Alibaba."
+      "description": "Strong multilingual small general workhorse from Alibaba.",
+      "sha256": "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4"
     },
     "qwen3.5-9b": {
       "uri": "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
@@ -44,7 +48,8 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Modern medium general model with strong tool use; 128K context."
+      "description": "Modern medium general model with strong tool use; 128K context.",
+      "sha256": "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8"
     },
     "gpt-oss-20b": {
       "uri": "hf:unsloth/gpt-oss-20b-GGUF:Q4_K_M",
@@ -53,7 +58,8 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "OpenAI's open-weights release; balanced general model for ~16 GB machines."
+      "description": "OpenAI's open-weights release; balanced general model for ~16 GB machines.",
+      "sha256": "c27536640e410032865dc68781d80a08b98f8db5e93575919af8ccc0568aeb4f"
     },
     "mistral-small-3.1": {
       "uri": "hf:unsloth/Mistral-Small-3.1-24B-Instruct-2503-GGUF:Q4_K_M",
@@ -62,7 +68,8 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Mistral's general 24B base model (also Devstral's foundation); broad utility."
+      "description": "Mistral's general 24B base model (also Devstral's foundation); broad utility.",
+      "sha256": "6d670773c3908584349d41a5048d1472226b593c881fd394e8ac196c802e81e2"
     },
     "qwen3.5-27b": {
       "uri": "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
@@ -71,7 +78,8 @@
       "category": "general",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Modern dense general 27B; the practical ceiling for most workstations."
+      "description": "Modern dense general 27B; the practical ceiling for most workstations.",
+      "sha256": "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806"
     },
     "deepseek-r1-distill-llama-8b": {
       "uri": "hf:unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q4_K_M",
@@ -80,7 +88,8 @@
       "category": "reasoning",
       "contextWindow": 131072,
       "license": "mit",
-      "description": "Chain-of-thought distill into Llama-8B; best small reasoning model."
+      "description": "Chain-of-thought distill into Llama-8B; best small reasoning model.",
+      "sha256": "0addb1339a82385bcd973186cd80d18dcc71885d45eabd899781a118d03827d9"
     },
     "phi-4-reasoning": {
       "uri": "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
@@ -89,7 +98,8 @@
       "category": "reasoning",
       "contextWindow": 32768,
       "license": "mit",
-      "description": "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic."
+      "description": "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic.",
+      "sha256": "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032"
     },
     "devstral-small-2507": {
       "uri": "hf:mistralai/Devstral-Small-2507_gguf:Q4_K_M",
@@ -98,7 +108,8 @@
       "category": "coding",
       "contextWindow": 131072,
       "license": "apache-2.0",
-      "description": "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release."
+      "description": "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release.",
+      "sha256": "1bcc2b1b7b7ea3168ba2dbe782432c464f2240598bd193930122c41b117c1796"
     },
     "qwen3-coder-30b-a3b": {
       "uri": "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",
@@ -107,7 +118,8 @@
       "category": "coding",
       "contextWindow": 262144,
       "license": "apache-2.0",
-      "description": "Qwen's MoE coder (3.3B active); strong agentic coding + 256K context."
+      "description": "Qwen's MoE coder (3.3B active); strong agentic coding + 256K context.",
+      "sha256": "fadc3e5f8d42bf7e894a785b05082e47daee4df26680389817e2093056f088ad"
     },
     "nomic-embed-text": {
       "uri": "hf:nomic-ai/nomic-embed-text-v1.5-GGUF:Q4_K_M",
@@ -116,7 +128,8 @@
       "category": "embedding",
       "contextWindow": 8192,
       "license": "apache-2.0",
-      "description": "Returns 768-dim embeddings; pair with a chat model for RAG."
+      "description": "Returns 768-dim embeddings; pair with a chat model for RAG.",
+      "sha256": "d4e388894e09cf3816e8b0896d81d265b55e7a9fff9ab03fe8bf4ef5e11295ac"
     }
   }
 }

--- a/packages/agency-lang/docs/dev/local-models.md
+++ b/packages/agency-lang/docs/dev/local-models.md
@@ -1,0 +1,71 @@
+# Local models
+
+How `agency`'s local-model support is wired, end to end.
+
+## Provider
+
+Local inference runs through `smoltalk`'s `llama-cpp` provider, registered on
+demand from the bundled `lib/stdlib/providers/llama-cpp.mjs` (which wraps
+`node-llama-cpp`). Registration is lazy (`_registerLocalProvider`); nothing
+loads `node-llama-cpp` until a local model is actually used.
+
+## Name resolution
+
+`_resolveModelName(value)` maps a value to a model URI/path:
+
+1. A `.gguf` path or an `hf:`/`https:` URI passes through unchanged.
+2. An alias in `client.modelAliases` (nearest `agency.json`) wins next — a
+   value is either a bare URI string or an object
+   `{ uri, …metadata, source?, sha256? }`.
+3. Otherwise a curated short name in `CURATED_LOCAL_MODELS`.
+
+`_listModelNames` merges curated + aliases (alias wins on a name clash) for the
+`agency local alias list` table and the agent's `--local-model` discovery output.
+
+## Catalog refresh
+
+`agency local refresh [url]` (`_refreshCatalog`) fetches a JSON catalog and
+writes its models into `client.modelAliases` as `source:"remote"` aliases,
+preserving the user's own aliases. The seed catalog lives at
+`data/model-catalog.json` and is served from `main`. See `docs/site/cli/local.md`.
+
+## Download + verification
+
+`_downloadModel(value)` resolves the URI and calls the provider's
+`resolveModel`, which downloads via `node-llama-cpp` (single file, or sharded —
+see below). We then verify integrity:
+
+- A known-good SHA-256 is **pinned** per curated/catalog model (in
+  `CURATED_LOCAL_MODELS` and `data/model-catalog.json`), minted by
+  `scripts/genModelHashes.ts` from Hugging Face's `X-Linked-ETag` header (which
+  equals the file's content sha256 — verified end-to-end against a real
+  download).
+- After a **fresh** download (detected via a cache-dir snapshot,
+  `snapshotFreshness` — we never re-hash an already-present file), we
+  stream-hash the file and compare it to the pin (`verifyModelFile`).
+- On a mismatch the file is renamed to `<file>.gguf.invalidSha` (kept for
+  inspection, not loaded) and an error is thrown.
+- Verification is **opportunistic**: models with no pin (user aliases, raw
+  URIs) are simply not verified. A user alias may opt in by setting its own
+  `sha256` on the alias object; it never borrows a curated model's hash.
+
+Because we verify only freshly-downloaded files, a pin change (e.g. via
+`agency local refresh`) does **not** retroactively re-check a file you already
+have cached. Run `agency local remove <name>` to force a fresh, verified
+re-download.
+
+### Sharded models are NOT verified yet
+
+`node-llama-cpp` handles two multi-part layouts: GGUF-split keeps the parts as
+separate files; binary-split splices them into one combined file. Our pin is a
+single content sha256, which only applies to **single-file** models — the entire
+curated Q4_K_M set is single-file. Sharded models therefore carry no pin and are
+**skipped** by verification. Extending coverage (per-part hashes for GGUF-split;
+compute-and-pin for binary-split) is tracked in
+[issue #348](https://github.com/egonSchiele/agency-lang/issues/348).
+
+## Tests
+
+See `docs/dev/local-model-integration.md` for the real-download integration
+suite; the deterministic unit tests live in `lib/stdlib/localModels.test.ts`,
+`lib/cli/local.test.ts`, and `tests/agency-js/local-model/`.

--- a/packages/agency-lang/docs/dev/local-models.md
+++ b/packages/agency-lang/docs/dev/local-models.md
@@ -54,6 +54,23 @@ Because we verify only freshly-downloaded files, a pin change (e.g. via
 have cached. Run `agency local remove <name>` to force a fresh, verified
 re-download.
 
+### Updating the pins
+
+**When you add a curated model, change a model's `uri`/quant, or an upstream
+repo re-uploads its GGUF, re-run the minting script** so the pinned hash matches
+the file users will download:
+
+```bash
+cd packages/agency-lang
+make build && node ./dist/scripts/genModelHashes.js
+```
+
+It HEADs each model's HF resolve URL, rewrites `data/model-catalog.json` with
+the fresh `sha256` values, and prints the lines to paste into
+`CURATED_LOCAL_MODELS`. A stale pin makes a legitimate file fail verification,
+so treat the script as the source of truth and the committed hashes as a
+snapshot.
+
 ### Sharded models are NOT verified yet
 
 `node-llama-cpp` handles two multi-part layouts: GGUF-split keeps the parts as

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-27-local-model-sha256-verification.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-27-local-model-sha256-verification.md
@@ -1,0 +1,820 @@
+# Local-model SHA-256 verification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a local model is downloaded, hash the file and verify it against a known-good SHA-256 pinned in the catalog, quarantining a mismatch before it can be loaded.
+
+**Architecture:** Add an optional `sha256` to the model metadata types (curated + catalog + alias). In `_downloadModel`, detect a *fresh* download (cache-dir snapshot before/after `resolveModel`) and, when a pin exists for that name, stream-hash the file and compare; on mismatch rename it to `<file>.gguf.invalidSha` and throw. Pins are minted by a maintainer-run script from Hugging Face's `X-Linked-ETag` (= the file's content sha256), with no multi-GB downloads.
+
+**Tech Stack:** TypeScript (`lib/stdlib/localModels.ts`), `node:crypto` (streaming sha256), zod (catalog schema), vitest. Generation script uses global `fetch`.
+
+## Global Constraints
+
+- NEVER use dynamic imports in `lib/` source. `fetch`/`crypto`/`fs` are used directly.
+- Use objects instead of maps; arrays instead of sets *except* where a `Set` is the natural fit (filename membership); `type` instead of `interface`.
+- Pin source: Hugging Face `X-Linked-ETag` header (= content sha256). NEVER use the `etag` / `X-Xet-Hash` header (a different chunk hash).
+- Verify the **actual downloaded bytes**, never a header, at verify time.
+- Verify **once, on fresh download** — never re-hash an already-present file (no marker file).
+- On mismatch: **rename** `<file>` → `<file>.invalidSha` (keep for inspection), then throw. Never delete.
+- **Opportunistic**: verify only when a pin exists; otherwise skip silently.
+- v1: **single-file models only**; sharded models carry no pin and are skipped (issue #348).
+- Pin in BOTH `CURATED_LOCAL_MODELS` and `data/model-catalog.json`.
+- Own-property checks (`Object.hasOwn`), never `in` / bare index, when testing membership of a JSON-derived map keyed by model name.
+- Run `make build` after changing `lib/` TS. Save test output to a file when running suites. Do not run the full agency suite.
+- The 2 pre-existing `resolveSmoltalkLlamaCppFromRoots` test failures are environmental (they fail on `main` too) — ignore them.
+
+---
+
+### Task 1: Thread `sha256` through the metadata types
+
+Add an optional `sha256` everywhere a model's metadata travels, so a pin can be stored (curated + catalog) and flows through refresh into a remote alias.
+
+**Files:**
+- Modify: `packages/agency-lang/lib/stdlib/localModels.ts` (`ModelInfo`, `AliasObject`, `ModelNameEntry`, `EntryMeta`, `metaFrom`, `CatalogModel`, `CatalogModelSchema`, `parseCatalog` reassembly)
+- Test: `packages/agency-lang/lib/stdlib/localModels.test.ts`
+
+**Interfaces:**
+- Consumes: existing `parseCatalog`, `_listModelNames`, `_refreshCatalog`.
+- Produces: `sha256?: string` on `ModelInfo`, `AliasObject`, `CatalogModel`, `ModelNameEntry`; `parseCatalog` carries it; `_listModelNames` surfaces it; `_refreshCatalog` writes it into remote aliases (already flows via `{ ...model, source: "remote" }`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `localModels.test.ts` (the `parseCatalog` and `_refreshCatalog` describes already exist; add these cases inside them or as new `it`s near them):
+
+```ts
+it("parseCatalog keeps a valid sha256 and drops a non-string one", () => {
+  const out = parseCatalog(
+    JSON.stringify({
+      version: 1,
+      models: {
+        good: { uri: "hf:org/g:Q4_K_M", sha256: "abc123" },
+        bad: { uri: "hf:org/b:Q4_K_M", sha256: 123 },
+      },
+    }),
+  );
+  expect(out.good.sha256).toBe("abc123");
+  expect(out.bad.sha256).toBeUndefined(); // wrong type dropped, entry kept
+});
+
+it("_refreshCatalog writes the catalog sha256 into the remote alias", async () => {
+  fs.writeFileSync(aliasFile, "{}");
+  await _refreshCatalog({
+    file: aliasFile,
+    fetcher: async () =>
+      JSON.stringify({ version: 1, models: { m: { uri: "hf:org/m:Q4_K_M", sha256: "deadbeef" } } }),
+  });
+  const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+  expect(cfg.client.modelAliases.m.sha256).toBe("deadbeef");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run lib/stdlib/localModels.test.ts -t "sha256|writes the catalog sha256" 2>&1 | tee /tmp/v1.log`
+Expected: FAIL — `out.good.sha256` is undefined (schema strips it); the alias has no `sha256`.
+
+- [ ] **Step 3: Add `sha256` to the four types**
+
+In `ModelInfo` (after `license`):
+
+```ts
+  license: string;
+  /** Pinned content SHA-256 (hex) of the resolved single-file GGUF, used to
+   *  verify the download. Absent for sharded models (see issue #348). */
+  sha256?: string;
+```
+
+In `AliasObject` (after `description`):
+
+```ts
+  description?: string;
+  sha256?: string;
+```
+
+In `ModelNameEntry` (after `license`):
+
+```ts
+  license?: string;
+  sha256?: string;
+```
+
+In `CatalogModel` (after `description`):
+
+```ts
+  description?: string;
+  sha256?: string;
+```
+
+- [ ] **Step 4: Add `sha256` to `EntryMeta`, `metaFrom`, the zod schema, and the `parseCatalog` reassembly**
+
+`EntryMeta` (add `"sha256"` to the `Pick`):
+
+```ts
+type EntryMeta = Pick<
+  ModelNameEntry,
+  "params" | "sizeBytes" | "category" | "description" | "contextWindow" | "license" | "sha256"
+>;
+```
+
+In `metaFrom`, after the `license` copy:
+
+```ts
+  if (src.license !== undefined) out.license = src.license;
+  if (src.sha256 !== undefined) out.sha256 = src.sha256;
+  return out;
+```
+
+In `CatalogModelSchema`, after the `description` line:
+
+```ts
+  description: z.string().optional().catch(undefined),
+  sha256: z.string().optional().catch(undefined),
+});
+```
+
+In `parseCatalog`'s `compact({...})` reassembly, after `description: d.description,`:
+
+```ts
+        description: d.description,
+        sha256: d.sha256,
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run lib/stdlib/localModels.test.ts -t "sha256|writes the catalog sha256" 2>&1 | tee /tmp/v1.log`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+npx tsc --noEmit 2>&1 | grep -i localModels || echo "tsc clean"
+git add packages/agency-lang/lib/stdlib/localModels.ts packages/agency-lang/lib/stdlib/localModels.test.ts
+git commit -m "Thread optional sha256 through model metadata types"
+```
+
+---
+
+### Task 2: Verification primitives
+
+Pure, independently-testable helpers: stream-hash a file, verify against an expected hash (quarantine on mismatch), and look up a pin by model name.
+
+**Files:**
+- Modify: `packages/agency-lang/lib/stdlib/localModels.ts` (add `import { createHash }`; add `fileSha256`, `verifyModelFile`, `pinnedSha256`, `listGgufBasenames`)
+- Test: `packages/agency-lang/lib/stdlib/localModels.test.ts`
+
+**Interfaces:**
+- Consumes: `isGgufPath`, `isModelUri`, `readModelAliases`, `CURATED_LOCAL_MODELS`, `fs`.
+- Produces:
+  - `function fileSha256(filePath: string): Promise<string>` (hex)
+  - `function verifyModelFile(filePath: string, expected: string, name: string): Promise<void>` (resolves on match; on mismatch renames to `<filePath>.invalidSha` and throws)
+  - `function pinnedSha256(value: string, file?: string): string | undefined`
+  - `function listGgufBasenames(dir: string): Set<string>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` to `localModels.test.ts` (add `import { createHash } from "node:crypto";` at the top of the file):
+
+```ts
+describe("model file verification", () => {
+  it("fileSha256 matches node:crypto over the same bytes", async () => {
+    const p = path.join(dir, "m.gguf");
+    fs.writeFileSync(p, "hello-bytes");
+    const expected = createHash("sha256").update("hello-bytes").digest("hex");
+    expect(await fileSha256(p)).toBe(expected);
+  });
+
+  it("verifyModelFile resolves on a match", async () => {
+    const p = path.join(dir, "m.gguf");
+    fs.writeFileSync(p, "good");
+    const sha = createHash("sha256").update("good").digest("hex");
+    await expect(verifyModelFile(p, sha, "m")).resolves.toBeUndefined();
+    expect(fs.existsSync(p)).toBe(true); // left in place
+  });
+
+  it("verifyModelFile quarantines + throws on a mismatch", async () => {
+    const p = path.join(dir, "m.gguf");
+    fs.writeFileSync(p, "tampered");
+    await expect(verifyModelFile(p, "0".repeat(64), "m")).rejects.toThrow(/SHA-256 verification failed/);
+    expect(fs.existsSync(p)).toBe(false); // moved aside
+    expect(fs.existsSync(p + ".invalidSha")).toBe(true); // kept for inspection
+  });
+
+  it("pinnedSha256: curated, alias-object wins, string-alias + raw → undefined", () => {
+    const k = Object.keys(CURATED_LOCAL_MODELS)[0];
+    // Curated entries don't carry a sha256 in the test build, so this is undefined…
+    expect(pinnedSha256(k, aliasFile)).toBe(CURATED_LOCAL_MODELS[k].sha256);
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({
+        client: { modelAliases: { obj: { uri: "hf:o/x:Q4", sha256: "aa" }, str: "hf:o/y:Q4" } } },
+      }),
+    );
+    expect(pinnedSha256("obj", aliasFile)).toBe("aa"); // alias object hash
+    expect(pinnedSha256("str", aliasFile)).toBeUndefined(); // string alias has none
+    expect(pinnedSha256("hf:o/z:Q4", aliasFile)).toBeUndefined(); // raw uri
+    expect(pinnedSha256("/abs/x.gguf", aliasFile)).toBeUndefined(); // raw path
+  });
+
+  it("pinnedSha256: a user alias shadowing a curated name uses the alias (not curated)", () => {
+    const k = Object.keys(CURATED_LOCAL_MODELS)[0];
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { [k]: "hf:mine/custom:Q4" } } }),
+    );
+    // string alias governs → no pin (must NOT fall back to the curated hash)
+    expect(pinnedSha256(k, aliasFile)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run lib/stdlib/localModels.test.ts -t "model file verification" 2>&1 | tee /tmp/v2.log`
+Expected: FAIL — helpers not defined.
+
+- [ ] **Step 3: Add the `createHash` import**
+
+At the top of `localModels.ts`, after the existing `node:` imports:
+
+```ts
+import { createHash } from "node:crypto";
+```
+
+- [ ] **Step 4: Implement the helpers**
+
+Add near the `_downloadModel` area of `localModels.ts` (before `_downloadModel`):
+
+```ts
+/** Stream-hash a file's SHA-256 (hex), never buffering the whole file. */
+export function fileSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+/** Verify `filePath` against the expected hex SHA-256. On mismatch, rename the
+ *  file to `<filePath>.invalidSha` (kept for inspection; won't be picked up, so
+ *  the next run re-downloads) and throw. */
+export async function verifyModelFile(
+  filePath: string,
+  expected: string,
+  name: string,
+): Promise<void> {
+  const actual = await fileSha256(filePath);
+  if (actual === expected) return;
+  const quarantine = `${filePath}.invalidSha`;
+  try {
+    fs.renameSync(filePath, quarantine);
+  } catch {
+    /* best effort: leave the file where it is */
+  }
+  throw new Error(
+    `SHA-256 verification failed for "${name}": expected ${expected}, got ${actual}. ` +
+      `The downloaded file was moved to ${quarantine} for inspection and will be re-downloaded next time.`,
+  );
+}
+
+/** The pinned SHA-256 for a model name/alias, or undefined when none is known
+ *  (raw uri/path, string alias, alias/curated without a hash, or a sharded
+ *  model). An alias entry governs the name entirely — a user alias shadowing a
+ *  curated name must NOT borrow the curated hash. */
+export function pinnedSha256(value: string, file: string = ""): string | undefined {
+  if (isGgufPath(value) || isModelUri(value)) return undefined;
+  const aliases = readModelAliases(file);
+  if (Object.hasOwn(aliases, value)) {
+    const v = aliases[value];
+    return typeof v === "object" ? v.sha256 : undefined;
+  }
+  return CURATED_LOCAL_MODELS[value]?.sha256;
+}
+
+/** The set of `*.gguf` filenames already in `dir` (empty if it doesn't exist).
+ *  Used to tell a fresh download from a cache hit. */
+export function listGgufBasenames(dir: string): Set<string> {
+  if (!fs.existsSync(dir)) return new Set();
+  return new Set(fs.readdirSync(dir).filter((f) => f.endsWith(".gguf")));
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run lib/stdlib/localModels.test.ts -t "model file verification" 2>&1 | tee /tmp/v2.log`
+Expected: PASS (the curated-hash assertion passes because curated entries have no `sha256` yet — both sides are `undefined`).
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+npx tsc --noEmit 2>&1 | grep -i localModels || echo "tsc clean"
+git add packages/agency-lang/lib/stdlib/localModels.ts packages/agency-lang/lib/stdlib/localModels.test.ts
+git commit -m "Add SHA-256 verification primitives (fileSha256/verifyModelFile/pinnedSha256)"
+```
+
+---
+
+### Task 3: Verify on fresh download in `_downloadModel`
+
+Wire verification into the download path: hash the file only when it was just downloaded and a pin exists.
+
+**Files:**
+- Modify: `packages/agency-lang/lib/stdlib/localModels.ts` (`_downloadModel`)
+- Test: `packages/agency-lang/lib/stdlib/localModels.test.ts` (update the existing fake-provider `describe`)
+
+**Interfaces:**
+- Consumes: `listGgufBasenames`, `pinnedSha256`, `verifyModelFile` (Task 2); existing `_resolveModelName`, `resolveCacheDir`, `bundledLlamaModule`, `requireSupport`, `exposeResolvedLlamaCppPath`.
+- Produces: `_downloadModel(value, cacheDir)` now verifies a freshly-downloaded, pinned file before returning.
+
+- [ ] **Step 1: Update the fake provider to write a real file, and rewrite the existing assertions**
+
+The current fake `resolveModel` returns a non-file string (`"RESOLVED:" + target`), which can't be hashed. Replace the `fakeModule()` body in `localModels.test.ts` so `resolveModel` writes a real `.gguf` into the cache dir and returns its path:
+
+```ts
+  function fakeModule(): string {
+    const p = path.join(here2, "__tmp_fakellama.mjs");
+    fs.writeFileSync(p, `import { BaseClient } from "smoltalk";
+      import * as fs from "node:fs";
+      import * as path from "node:path";
+      class FakeLlama extends BaseClient { async textSync() { return { success: true, value: { output: "x", toolCalls: [] } }; } }
+      export function register({ registerProvider }) { registerProvider("llama-cpp", FakeLlama); }
+      export async function resolveModel(target, dir) {
+        fs.mkdirSync(dir, { recursive: true });
+        const file = path.join(dir, "model.gguf");
+        fs.writeFileSync(file, "FAKE:" + target);
+        return file;
+      }`);
+    fakes.push(p);
+    return p;
+  }
+```
+
+Then update the two existing assertions that expected the old `"RESOLVED:"` string. Replace:
+
+```ts
+  it("downloads (resolves) a curated name to a path", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    const k = Object.keys(CURATED_LOCAL_MODELS)[0];
+    expect(await _downloadModel(k, "/cache")).toBe("RESOLVED:" + CURATED_LOCAL_MODELS[k].uri);
+  });
+  it("registerLocalModel registers and returns the resolved path", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    expect(await _registerLocalModel("/abs/my.gguf", "/cache")).toBe("RESOLVED:/abs/my.gguf");
+    expect(smoltalkPkg.getClient({ model: "m", provider: "llama-cpp" }).constructor.name).toBe("FakeLlama");
+  });
+```
+
+with (use a temp cache dir; raw inputs have no pin, so verification is skipped and these stay about resolution):
+
+```ts
+  it("downloads (resolves) a uri to a real path", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    const out = await _downloadModel("hf:org/repo:Q4", dir); // raw uri → no pin
+    expect(out).toBe(path.join(dir, "model.gguf"));
+    expect(fs.existsSync(out)).toBe(true);
+  });
+  it("registerLocalModel registers and returns the resolved path", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    const out = await _registerLocalModel("/abs/my.gguf", dir); // raw path → no pin
+    expect(out).toBe(path.join(dir, "model.gguf"));
+    expect(smoltalkPkg.getClient({ model: "m", provider: "llama-cpp" }).constructor.name).toBe("FakeLlama");
+  });
+```
+
+- [ ] **Step 2: Add the verification integration tests**
+
+Add to the same `describe` (these `chdir` into `dir` so `_downloadModel`'s `pinnedSha256(value, "")` / `_resolveModelName` find the temp `agency.json`):
+
+```ts
+  it("verifies a freshly-downloaded pinned model (match → ok)", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    const target = "hf:org/x:Q4";
+    const sha = createHash("sha256").update("FAKE:" + target).digest("hex");
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { mymodel: { uri: target, sha256: sha } } } }));
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const out = await _downloadModel("mymodel", dir);
+      expect(fs.existsSync(out)).toBe(true);
+      expect(fs.existsSync(out + ".invalidSha")).toBe(false);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it("quarantines a freshly-downloaded model whose hash is wrong", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { mymodel: { uri: "hf:org/x:Q4", sha256: "0".repeat(64) } } } }));
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      await expect(_downloadModel("mymodel", dir)).rejects.toThrow(/SHA-256 verification failed/);
+      expect(fs.existsSync(path.join(dir, "model.gguf"))).toBe(false);
+      expect(fs.existsSync(path.join(dir, "model.gguf.invalidSha"))).toBe(true);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it("does NOT re-verify an already-present (cache-hit) file", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    // Pre-create the model file so it's in the before-snapshot → treated as cached.
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "model.gguf"), "pre-existing");
+    // A deliberately-wrong pin would fail IF it verified — it must be skipped.
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { mymodel: { uri: "hf:org/x:Q4", sha256: "0".repeat(64) } } } }));
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      await expect(_downloadModel("mymodel", dir)).resolves.toBe(path.join(dir, "model.gguf"));
+      expect(fs.existsSync(path.join(dir, "model.gguf.invalidSha"))).toBe(false);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run lib/stdlib/localModels.test.ts -t "fake bundled module" 2>&1 | tee /tmp/v3.log`
+Expected: FAIL — the match/quarantine tests fail because `_downloadModel` doesn't verify yet (and the cache-hit test may pass incidentally).
+
+- [ ] **Step 4: Wire verification into `_downloadModel`**
+
+Replace the body of `_downloadModel` (currently ends with `return await mod.resolveModel(target, resolveCacheDir(cacheDir));`):
+
+```ts
+export async function _downloadModel(value: string, cacheDir: string = ""): Promise<string> {
+  requireSupport();
+  exposeResolvedLlamaCppPath();
+  const target = _resolveModelName(value);
+  const dir = resolveCacheDir(cacheDir);
+  const fsPath = bundledLlamaModule();
+  let mod: LlamaBundle;
+  try {
+    // eslint-disable-next-line no-restricted-syntax -- on-demand load of the optional provider module
+    mod = (await import(pathToFileURL(fsPath).href)) as LlamaBundle;
+  } catch (err) {
+    throw new Error(`Failed to load the local-model provider: ${(err as Error).message}`);
+  }
+  if (typeof mod.resolveModel !== "function") {
+    throw new Error(`Local-model provider module must export resolveModel().`);
+  }
+  // Snapshot the cache dir so we can tell a fresh download from a cache hit and
+  // verify the bytes only once, right after they're downloaded.
+  const before = listGgufBasenames(dir);
+  const resolved = await mod.resolveModel(target, dir);
+  const expected = pinnedSha256(value);
+  if (expected !== undefined && !before.has(path.basename(resolved))) {
+    await verifyModelFile(resolved, expected, value);
+  }
+  return resolved;
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run lib/stdlib/localModels.test.ts -t "fake bundled module" 2>&1 | tee /tmp/v3.log`
+Expected: PASS (all fake-provider tests, including the three new verification cases).
+
+- [ ] **Step 6: Run the whole localModels + cli suites for regressions**
+
+Run: `npx vitest run lib/stdlib/localModels.test.ts lib/cli/local.test.ts 2>&1 | tee /tmp/v3-all.log`
+Expected: all PASS except the 2 known-environmental `resolveSmoltalkLlamaCppFromRoots` failures.
+
+- [ ] **Step 7: Typecheck + commit**
+
+```bash
+npx tsc --noEmit 2>&1 | grep -i localModels || echo "tsc clean"
+git add packages/agency-lang/lib/stdlib/localModels.ts packages/agency-lang/lib/stdlib/localModels.test.ts
+git commit -m "Verify SHA-256 of freshly-downloaded local models in _downloadModel"
+```
+
+---
+
+### Task 4: Hash-generation script + populate real pins
+
+A maintainer-run script that mints pins from `X-Linked-ETag` and writes them into the catalog; then run it to fill in the real hashes for the curated set.
+
+**Files:**
+- Create: `packages/agency-lang/scripts/genModelHashes.ts`
+- Modify: `packages/agency-lang/lib/stdlib/localModels.ts` (`CURATED_LOCAL_MODELS` — paste the generated hashes)
+- Modify: `packages/agency-lang/data/model-catalog.json` (regenerated with hashes)
+- Test: `packages/agency-lang/lib/stdlib/genModelHashes.test.ts` (parsing logic only, injected fetcher)
+
+**Interfaces:**
+- Consumes: `CURATED_LOCAL_MODELS`, `ModelInfo`.
+- Produces: `parseHfUri(uri): { user, repo, quant } | null` and `pickSingleQuantFile(files: string[], quant: string): string | null` (exported for testing); a `main()` that fetches + writes.
+
+- [ ] **Step 1: Write the failing test for the pure parsing helpers**
+
+Create `packages/agency-lang/lib/stdlib/genModelHashes.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseHfUri, pickSingleQuantFile } from "../../scripts/genModelHashes.js";
+
+describe("genModelHashes helpers", () => {
+  it("parseHfUri splits hf:user/repo:quant", () => {
+    expect(parseHfUri("hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M")).toEqual({
+      user: "unsloth",
+      repo: "Qwen3.5-2B-GGUF",
+      quant: "Q4_K_M",
+    });
+  });
+  it("parseHfUri returns null for non-hf or file-form uris", () => {
+    expect(parseHfUri("https://x/y.gguf")).toBeNull();
+    expect(parseHfUri("/abs/m.gguf")).toBeNull();
+    expect(parseHfUri("hf:user/repo/file.gguf")).toBeNull(); // file-form, not :quant
+  });
+  it("pickSingleQuantFile returns the lone matching gguf, else null", () => {
+    expect(
+      pickSingleQuantFile(["README.md", "Model-Q4_K_M.gguf", "Model-Q8_0.gguf"], "Q4_K_M"),
+    ).toBe("Model-Q4_K_M.gguf");
+    // sharded → more than one match → null (no pin)
+    expect(
+      pickSingleQuantFile(["m-Q4_K_M-00001-of-00002.gguf", "m-Q4_K_M-00002-of-00002.gguf"], "Q4_K_M"),
+    ).toBeNull();
+    expect(pickSingleQuantFile(["only-Q8_0.gguf"], "Q4_K_M")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run lib/stdlib/genModelHashes.test.ts 2>&1 | tee /tmp/v4.log`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the script**
+
+Create `packages/agency-lang/scripts/genModelHashes.ts`:
+
+```ts
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CURATED_LOCAL_MODELS } from "../lib/stdlib/localModels.js";
+
+/** Split `hf:user/repo:quant` (the curated short form). Returns null for the
+ *  file-form (`hf:user/repo/file.gguf`), https, or local paths. */
+export function parseHfUri(uri: string): { user: string; repo: string; quant: string } | null {
+  const m = /^hf:([^/]+)\/([^/:]+):([^/]+)$/.exec(uri);
+  if (!m) return null;
+  return { user: m[1], repo: m[2], quant: m[3] };
+}
+
+/** The lone `.gguf` whose name contains `quant`; null if zero or many (a sharded
+ *  model has many → we record no pin for it). */
+export function pickSingleQuantFile(files: string[], quant: string): string | null {
+  const matches = files.filter((f) => f.endsWith(".gguf") && f.includes(quant));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+async function repoFiles(user: string, repo: string): Promise<string[]> {
+  const res = await fetch(`https://huggingface.co/api/models/${user}/${repo}`);
+  if (!res.ok) throw new Error(`HF API ${res.status} for ${user}/${repo}`);
+  const json = (await res.json()) as { siblings?: { rfilename: string }[] };
+  return (json.siblings ?? []).map((s) => s.rfilename);
+}
+
+/** HEAD the resolve URL and read X-Linked-ETag (= the file's content sha256).
+ *  NEVER use `etag`/`x-xet-hash` (a different chunk hash). */
+async function fetchSha256(user: string, repo: string, file: string): Promise<string | null> {
+  const url = `https://huggingface.co/${user}/${repo}/resolve/main/${encodeURIComponent(file)}`;
+  const res = await fetch(url, { method: "HEAD", redirect: "follow" });
+  const etag = res.headers.get("x-linked-etag");
+  if (!etag) return null;
+  return etag.replace(/"/g, "");
+}
+
+async function main(): Promise<void> {
+  const out: Record<string, string> = {};
+  for (const [name, info] of Object.entries(CURATED_LOCAL_MODELS)) {
+    const parsed = parseHfUri(info.uri);
+    if (!parsed) {
+      console.warn(`skip ${name}: not an hf:user/repo:quant uri`);
+      continue;
+    }
+    const files = await repoFiles(parsed.user, parsed.repo);
+    const file = pickSingleQuantFile(files, parsed.quant);
+    if (!file) {
+      console.warn(`skip ${name}: not a single-file ${parsed.quant} gguf (sharded?)`);
+      continue;
+    }
+    const sha = await fetchSha256(parsed.user, parsed.repo, file);
+    if (!sha) {
+      console.warn(`skip ${name}: no X-Linked-ETag`);
+      continue;
+    }
+    out[name] = sha;
+    console.log(`${name}: ${sha}`);
+  }
+
+  // Rewrite the seed catalog with the new sha256 values. Resolved from cwd
+  // (run this script from the `packages/agency-lang` directory) so it edits the
+  // SOURCE data file whether run from `dist/` or via tsx.
+  const catalogPath = path.resolve("data/model-catalog.json");
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8"));
+  for (const [name, sha] of Object.entries(out)) {
+    if (catalog.models[name]) catalog.models[name].sha256 = sha;
+  }
+  fs.writeFileSync(catalogPath, JSON.stringify(catalog, null, 2) + "\n");
+
+  console.log("\n--- paste these into CURATED_LOCAL_MODELS ---");
+  for (const [name, sha] of Object.entries(out)) console.log(`  ${name}: sha256 "${sha}"`);
+}
+
+// Run only when invoked directly.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `npx vitest run lib/stdlib/genModelHashes.test.ts 2>&1 | tee /tmp/v4.log`
+Expected: PASS.
+
+- [ ] **Step 5: Build, then run the script to mint real hashes**
+
+Run from the `packages/agency-lang` directory (so the script's cwd-relative
+`data/model-catalog.json` write hits the source file):
+
+```bash
+export PATH="$PWD/node_modules/.bin:$PATH"
+make build > /tmp/v4-build.log 2>&1 && echo BUILD_OK
+node ./dist/scripts/genModelHashes.js 2>&1 | tee /tmp/v4-hashes.log
+```
+Expected: one `name: <64-hex>` line per single-file curated model (≈13), and `data/model-catalog.json` rewritten with `sha256` fields. (Network required.)
+
+- [ ] **Step 6: Paste the hashes into `CURATED_LOCAL_MODELS`**
+
+For each line printed under "paste these into CURATED_LOCAL_MODELS", add a `sha256:` field to the matching entry in `CURATED_LOCAL_MODELS` in `lib/stdlib/localModels.ts`, e.g.:
+
+```ts
+  "smollm2-135m": {
+    uri: "hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
+    params: "135M", sizeBytes: 105_000_000, category: "general",
+    contextWindow: 8192, license: "apache-2.0",
+    sha256: "<the hex from the script>",
+    description: "Smallest practical chat model; used by our integration tests, runs anywhere.",
+  },
+```
+
+- [ ] **Step 7: Verify the catalog and curated agree**
+
+```bash
+export PATH="$PWD/node_modules/.bin:$PATH"
+make build > /tmp/v4-build2.log 2>&1 && echo BUILD_OK
+node -e '
+const fs=require("fs");
+const { CURATED_LOCAL_MODELS } = require("./packages/agency-lang/dist/lib/stdlib/localModels.js");
+const cat = JSON.parse(fs.readFileSync("packages/agency-lang/data/model-catalog.json","utf8"));
+let bad=0;
+for (const [n,info] of Object.entries(CURATED_LOCAL_MODELS)) {
+  const c = (cat.models[n]||{}).sha256, k = info.sha256;
+  if (k && c && k!==c) { console.log("MISMATCH", n); bad++; }
+}
+console.log(bad? "MISMATCH found" : "curated and catalog sha256 agree");
+'
+```
+Expected: `curated and catalog sha256 agree`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/agency-lang/scripts/genModelHashes.ts packages/agency-lang/lib/stdlib/genModelHashes.test.ts packages/agency-lang/lib/stdlib/localModels.ts packages/agency-lang/data/model-catalog.json
+git commit -m "Add genModelHashes script and pin curated model sha256 hashes"
+```
+
+---
+
+### Task 5: Developer documentation
+
+A developer overview of the local-model system, including the SHA-verification behavior and the sharded gap.
+
+**Files:**
+- Create: `packages/agency-lang/docs/dev/local-models.md`
+- Modify: `CLAUDE.md` (doc index)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Write `docs/dev/local-models.md`**
+
+Create `packages/agency-lang/docs/dev/local-models.md`:
+
+```markdown
+# Local models
+
+How `agency`'s local-model support is wired, end to end.
+
+## Provider
+
+Local inference runs through `smoltalk`'s `llama-cpp` provider, registered on
+demand from the bundled `lib/stdlib/providers/llama-cpp.mjs` (which wraps
+`node-llama-cpp`). Registration is lazy (`_registerLocalProvider`); nothing
+loads `node-llama-cpp` until a local model is actually used.
+
+## Name resolution
+
+`_resolveModelName(value)` maps a value to a model URI/path:
+
+1. A `.gguf` path or an `hf:`/`https:` URI passes through unchanged.
+2. An alias in `client.modelAliases` (nearest `agency.json`) wins next — a
+   value is either a bare URI string or an object `{ uri, …metadata, source?, sha256? }`.
+3. Otherwise a curated short name in `CURATED_LOCAL_MODELS`.
+
+`_listModelNames` merges curated + aliases (alias wins on a name clash) for the
+`agency local alias list` table and the agent's `--local-model` discovery output.
+
+## Catalog refresh
+
+`agency local refresh [url]` (`_refreshCatalog`) fetches a JSON catalog and
+writes its models into `client.modelAliases` as `source:"remote"` aliases,
+preserving the user's own aliases. The seed catalog lives at
+`data/model-catalog.json` and is served from `main`. See `docs/site/cli/local.md`.
+
+## Download + verification
+
+`_downloadModel(value)` resolves the URI and calls the provider's
+`resolveModel`, which downloads via `node-llama-cpp` (single file, or sharded —
+see below). We then verify integrity:
+
+- A known-good SHA-256 is **pinned** per curated/catalog model (in
+  `CURATED_LOCAL_MODELS` and `data/model-catalog.json`), minted by
+  `scripts/genModelHashes.ts` from Hugging Face's `X-Linked-ETag` header (which
+  equals the file's content sha256).
+- After a **fresh** download (detected via a cache-dir snapshot — we never
+  re-hash an already-present file), we stream-hash the file and compare it to
+  the pin (`verifyModelFile`).
+- On a mismatch the file is renamed to `<file>.gguf.invalidSha` (kept for
+  inspection, not loaded) and an error is thrown.
+- Verification is **opportunistic**: models with no pin (user aliases, raw
+  URIs) are simply not verified.
+
+### Sharded models are NOT verified yet
+
+`node-llama-cpp` handles two multi-part layouts: GGUF-split keeps the parts as
+separate files; binary-split splices them into one combined file. Our pin is a
+single content sha256, which only applies to **single-file** models — the entire
+curated Q4_K_M set is single-file. Sharded models therefore carry no pin and are
+**skipped** by verification. Extending coverage (per-part hashes for GGUF-split;
+compute-and-pin for binary-split) is tracked in
+[issue #348](https://github.com/egonSchiele/agency-lang/issues/348).
+
+## Tests
+
+See `docs/dev/local-model-integration.md` for the real-download integration
+suite; the deterministic unit tests live in `lib/stdlib/localModels.test.ts`,
+`lib/cli/local.test.ts`, and `tests/agency-js/local-model/`.
+```
+
+- [ ] **Step 2: Add the doc to the `CLAUDE.md` index**
+
+In the root `CLAUDE.md`, under "Pipeline and architecture" (or the nearest doc list), add:
+
+```markdown
+- `docs/dev/local-models.md` — Local-model support: provider, name resolution, catalog refresh, and SHA-256 download verification
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agency-lang/docs/dev/local-models.md CLAUDE.md
+git commit -m "Document local-model system + SHA-256 verification"
+```
+
+---
+
+## Final verification (run after all tasks)
+
+- [ ] Build + suites + lint:
+```bash
+export PATH="$PWD/node_modules/.bin:$PATH"
+make build > /tmp/final-build.log 2>&1 && echo BUILD_OK
+npx vitest run lib/stdlib/localModels.test.ts lib/stdlib/genModelHashes.test.ts lib/cli/local.test.ts 2>&1 | tee /tmp/final-tests.log
+pnpm run lint:structure 2>&1 | tail -3
+```
+Expected: build OK; all pass except the 2 known-environmental `resolveSmoltalkLlamaCppFromRoots` failures; lint clean.
+
+- [ ] Smoke test (real download of the smallest model, verifies against its pin):
+```bash
+AGENCY_MODELS_DIR=$(mktemp -d) node ./dist/scripts/agency.js local download smollm2-135m 2>&1 | tail -3
+```
+Expected: downloads + exits 0 (verification passes). Tamper check: re-run after truncating the file → expect a `SHA-256 verification failed` error and a `.invalidSha` file. (Optional — needs network + ~105 MB.)
+
+---
+
+## Self-review notes (already checked)
+
+- **Spec coverage:** schema (Task 1), verification primitives (Task 2), verify-on-fresh-download in `_downloadModel` (Task 3), generation script + real pins in both curated and catalog (Task 4), dev doc + sharded caveat + #348 link (Task 5). All spec sections map to a task.
+- **Type consistency:** `sha256?: string` added uniformly to `ModelInfo`/`AliasObject`/`CatalogModel`/`ModelNameEntry`; `fileSha256`/`verifyModelFile`/`pinnedSha256`/`listGgufBasenames` defined in Task 2 are used in Task 3 with the same signatures; `parseHfUri`/`pickSingleQuantFile` defined and tested in Task 4.
+- **Pinning correctness:** `pinnedSha256` uses an own-property check so a user alias governs its name and never borrows a curated hash (tested).
+- **Verify-once:** the cache-dir snapshot makes a cache hit skip hashing (tested), so startup with a present model pays nothing.
+- **Header discipline:** the script reads `X-Linked-ETag` only, never `etag`/`x-xet-hash`.
+- **Known caveat:** the 2 `resolveSmoltalkLlamaCppFromRoots` tests fail environmentally, unrelated to this work.
+```

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-27-local-model-sha256-verification.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-27-local-model-sha256-verification.md
@@ -159,7 +159,7 @@ git commit -m "Thread optional sha256 through model metadata types"
 Pure, independently-testable helpers: stream-hash a file, verify against an expected hash (quarantine on mismatch), and look up a pin by model name.
 
 **Files:**
-- Modify: `packages/agency-lang/lib/stdlib/localModels.ts` (add `import { createHash }`; add `fileSha256`, `verifyModelFile`, `pinnedSha256`, `listGgufBasenames`)
+- Modify: `packages/agency-lang/lib/stdlib/localModels.ts` (add `import { createHash }`; add `fileSha256`, `verifyModelFile`, `pinnedSha256`, `snapshotFreshness`)
 - Test: `packages/agency-lang/lib/stdlib/localModels.test.ts`
 
 **Interfaces:**
@@ -168,7 +168,8 @@ Pure, independently-testable helpers: stream-hash a file, verify against an expe
   - `function fileSha256(filePath: string): Promise<string>` (hex)
   - `function verifyModelFile(filePath: string, expected: string, name: string): Promise<void>` (resolves on match; on mismatch renames to `<filePath>.invalidSha` and throws)
   - `function pinnedSha256(value: string, file?: string): string | undefined`
-  - `function listGgufBasenames(dir: string): Set<string>`
+  - `type FreshnessProbe = (resolved: string) => boolean`
+  - `function snapshotFreshness(dir: string): FreshnessProbe`
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -201,7 +202,8 @@ describe("model file verification", () => {
 
   it("pinnedSha256: curated, alias-object wins, string-alias + raw → undefined", () => {
     const k = Object.keys(CURATED_LOCAL_MODELS)[0];
-    // Curated entries don't carry a sha256 in the test build, so this is undefined…
+    // Curated lookup mirrors the curated entry's sha256 — undefined before the
+    // Task 4 pins are added, hex after; this assertion holds in both states.
     expect(pinnedSha256(k, aliasFile)).toBe(CURATED_LOCAL_MODELS[k].sha256);
     fs.writeFileSync(
       aliasFile,
@@ -245,20 +247,31 @@ import { createHash } from "node:crypto";
 Add near the `_downloadModel` area of `localModels.ts` (before `_downloadModel`):
 
 ```ts
-/** Stream-hash a file's SHA-256 (hex), never buffering the whole file. */
+/** Stream-hash a file's SHA-256 (hex), never buffering the whole file. The
+ *  `update` is guarded so a synchronous throw in the data handler rejects the
+ *  promise instead of escaping it. */
 export function fileSha256(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const hash = createHash("sha256");
     const stream = fs.createReadStream(filePath);
     stream.on("error", reject);
-    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("data", (chunk) => {
+      try {
+        hash.update(chunk);
+      } catch (err) {
+        stream.destroy();
+        reject(err as Error);
+      }
+    });
     stream.on("end", () => resolve(hash.digest("hex")));
   });
 }
 
 /** Verify `filePath` against the expected hex SHA-256. On mismatch, rename the
  *  file to `<filePath>.invalidSha` (kept for inspection; won't be picked up, so
- *  the next run re-downloads) and throw. */
+ *  the next run re-downloads) and throw. A failed rename is logged (not
+ *  swallowed) and reflected in the thrown message, so a tampered file left in
+ *  place is never invisible. */
 export async function verifyModelFile(
   filePath: string,
   expected: string,
@@ -267,21 +280,26 @@ export async function verifyModelFile(
   const actual = await fileSha256(filePath);
   if (actual === expected) return;
   const quarantine = `${filePath}.invalidSha`;
+  let moved = true;
   try {
     fs.renameSync(filePath, quarantine);
-  } catch {
-    /* best effort: leave the file where it is */
+  } catch (err) {
+    moved = false;
+    console.warn(`Could not move "${filePath}" to "${quarantine}" after SHA-256 mismatch:`, err);
   }
   throw new Error(
     `SHA-256 verification failed for "${name}": expected ${expected}, got ${actual}. ` +
-      `The downloaded file was moved to ${quarantine} for inspection and will be re-downloaded next time.`,
+      (moved
+        ? `The downloaded file was moved to ${quarantine} for inspection and will be re-downloaded next time.`
+        : `The downloaded file at ${filePath} could NOT be moved aside — delete it manually before re-running.`),
   );
 }
 
 /** The pinned SHA-256 for a model name/alias, or undefined when none is known
  *  (raw uri/path, string alias, alias/curated without a hash, or a sharded
  *  model). An alias entry governs the name entirely — a user alias shadowing a
- *  curated name must NOT borrow the curated hash. */
+ *  curated name must NOT borrow the curated hash, but a user MAY opt in by
+ *  setting their own `sha256` on the alias object. */
 export function pinnedSha256(value: string, file: string = ""): string | undefined {
   if (isGgufPath(value) || isModelUri(value)) return undefined;
   const aliases = readModelAliases(file);
@@ -292,11 +310,18 @@ export function pinnedSha256(value: string, file: string = ""): string | undefin
   return CURATED_LOCAL_MODELS[value]?.sha256;
 }
 
-/** The set of `*.gguf` filenames already in `dir` (empty if it doesn't exist).
- *  Used to tell a fresh download from a cache hit. */
-export function listGgufBasenames(dir: string): Set<string> {
-  if (!fs.existsSync(dir)) return new Set();
-  return new Set(fs.readdirSync(dir).filter((f) => f.endsWith(".gguf")));
+/** Was the resolved file freshly downloaded (not already cached)? */
+export type FreshnessProbe = (resolved: string) => boolean;
+
+/** Snapshot the cache dir, returning a probe that reports whether a resolved
+ *  path is newly downloaded. node-llama-cpp stores models FLAT in `dir` with a
+ *  prefixed filename — no per-repo subdirs (verified against its
+ *  `buildHuggingFaceFilePrefix`) — so matching by basename is correct. */
+export function snapshotFreshness(dir: string): FreshnessProbe {
+  const present = fs.existsSync(dir)
+    ? new Set(fs.readdirSync(dir).filter((f) => f.endsWith(".gguf")))
+    : new Set<string>();
+  return (resolved) => !present.has(path.basename(resolved));
 }
 ```
 
@@ -324,8 +349,10 @@ Wire verification into the download path: hash the file only when it was just do
 - Test: `packages/agency-lang/lib/stdlib/localModels.test.ts` (update the existing fake-provider `describe`)
 
 **Interfaces:**
-- Consumes: `listGgufBasenames`, `pinnedSha256`, `verifyModelFile` (Task 2); existing `_resolveModelName`, `resolveCacheDir`, `bundledLlamaModule`, `requireSupport`, `exposeResolvedLlamaCppPath`.
+- Consumes: `snapshotFreshness`, `pinnedSha256`, `verifyModelFile` (Task 2); existing `_resolveModelName`, `resolveCacheDir`, `bundledLlamaModule`, `requireSupport`, `exposeResolvedLlamaCppPath`.
 - Produces: `_downloadModel(value, cacheDir)` now verifies a freshly-downloaded, pinned file before returning.
+
+> No new dynamic imports are introduced. The existing `await import(pathToFileURL(fsPath).href)` that loads the optional provider module keeps its `eslint-disable-next-line no-restricted-syntax` comment and is unchanged.
 
 - [ ] **Step 1: Update the fake provider to write a real file, and rewrite the existing assertions**
 
@@ -461,12 +488,13 @@ export async function _downloadModel(value: string, cacheDir: string = ""): Prom
   if (typeof mod.resolveModel !== "function") {
     throw new Error(`Local-model provider module must export resolveModel().`);
   }
-  // Snapshot the cache dir so we can tell a fresh download from a cache hit and
-  // verify the bytes only once, right after they're downloaded.
-  const before = listGgufBasenames(dir);
+  // Snapshot freshness BEFORE resolving so we verify the bytes only once, right
+  // after a real download (a cache hit is skipped — the file can't change on
+  // disk between runs).
+  const wasFresh = snapshotFreshness(dir);
   const resolved = await mod.resolveModel(target, dir);
   const expected = pinnedSha256(value);
-  if (expected !== undefined && !before.has(path.basename(resolved))) {
+  if (expected !== undefined && wasFresh(resolved)) {
     await verifyModelFile(resolved, expected, value);
   }
   return resolved;
@@ -551,6 +579,11 @@ Expected: FAIL — module not found.
 Create `packages/agency-lang/scripts/genModelHashes.ts`:
 
 ```ts
+// genModelHashes — mint pinned SHA-256 hashes for the curated models from
+// Hugging Face's X-Linked-ETag header (= the file's content sha256). This
+// script is the source of truth; the sha256 values committed in
+// CURATED_LOCAL_MODELS and data/model-catalog.json are a snapshot — re-run it
+// whenever an upstream repo re-uploads a file and the pin changes.
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -667,13 +700,15 @@ For each line printed under "paste these into CURATED_LOCAL_MODELS", add a `sha2
 
 - [ ] **Step 7: Verify the catalog and curated agree**
 
+Run from `packages/agency-lang` (same cwd as Step 5):
+
 ```bash
 export PATH="$PWD/node_modules/.bin:$PATH"
 make build > /tmp/v4-build2.log 2>&1 && echo BUILD_OK
 node -e '
 const fs=require("fs");
-const { CURATED_LOCAL_MODELS } = require("./packages/agency-lang/dist/lib/stdlib/localModels.js");
-const cat = JSON.parse(fs.readFileSync("packages/agency-lang/data/model-catalog.json","utf8"));
+const { CURATED_LOCAL_MODELS } = require("./dist/lib/stdlib/localModels.js");
+const cat = JSON.parse(fs.readFileSync("data/model-catalog.json","utf8"));
 let bad=0;
 for (const [n,info] of Object.entries(CURATED_LOCAL_MODELS)) {
   const c = (cat.models[n]||{}).sha256, k = info.sha256;
@@ -688,7 +723,11 @@ Expected: `curated and catalog sha256 agree`.
 
 ```bash
 git add packages/agency-lang/scripts/genModelHashes.ts packages/agency-lang/lib/stdlib/genModelHashes.test.ts packages/agency-lang/lib/stdlib/localModels.ts packages/agency-lang/data/model-catalog.json
-git commit -m "Add genModelHashes script and pin curated model sha256 hashes"
+git commit -m "Add genModelHashes script and pin curated model sha256 hashes
+
+The committed hashes are a snapshot minted from Hugging Face's X-Linked-ETag;
+genModelHashes.ts is the source of truth — re-run it when an upstream repo
+re-uploads a file and the pin changes."
 ```
 
 ---
@@ -754,7 +793,12 @@ see below). We then verify integrity:
 - On a mismatch the file is renamed to `<file>.gguf.invalidSha` (kept for
   inspection, not loaded) and an error is thrown.
 - Verification is **opportunistic**: models with no pin (user aliases, raw
-  URIs) are simply not verified.
+  URIs) are simply not verified. A user alias may opt in by setting its own
+  `sha256` on the alias object; it never borrows a curated model's hash.
+- We verify only freshly-downloaded files, never re-hashing an already-cached
+  one. So if `agency local refresh` changes a model's pin while you already have
+  the old file cached, the cached file is *not* retroactively re-checked — run
+  `agency local remove <name>` to force a fresh, verified re-download.
 
 ### Sharded models are NOT verified yet
 
@@ -775,7 +819,7 @@ suite; the deterministic unit tests live in `lib/stdlib/localModels.test.ts`,
 
 - [ ] **Step 2: Add the doc to the `CLAUDE.md` index**
 
-In the root `CLAUDE.md`, under "Pipeline and architecture" (or the nearest doc list), add:
+In the root `CLAUDE.md`, under "Pipeline and architecture" (or the nearest doc list), add the line below. (`AGENTS.md` is a symlink to `CLAUDE.md`, so this single edit covers both.)
 
 ```markdown
 - `docs/dev/local-models.md` — Local-model support: provider, name resolution, catalog refresh, and SHA-256 download verification
@@ -803,18 +847,29 @@ Expected: build OK; all pass except the 2 known-environmental `resolveSmoltalkLl
 
 - [ ] Smoke test (real download of the smallest model, verifies against its pin):
 ```bash
-AGENCY_MODELS_DIR=$(mktemp -d) node ./dist/scripts/agency.js local download smollm2-135m 2>&1 | tail -3
+export MODELS=$(mktemp -d)
+AGENCY_MODELS_DIR=$MODELS node ./dist/scripts/agency.js local download smollm2-135m 2>&1 | tail -3
 ```
-Expected: downloads + exits 0 (verification passes). Tamper check: re-run after truncating the file → expect a `SHA-256 verification failed` error and a `.invalidSha` file. (Optional — needs network + ~105 MB.)
+Expected: downloads + exits 0 (verification passes against the pinned hash).
+
+  Tamper check (must force a *fresh* download — verify-once skips an existing
+  file): remove the cached file, corrupt the catalog pin, and re-download into
+  the same dir so the new download is verified against the bad pin:
+```bash
+rm -f "$MODELS"/*.gguf
+# temporarily set CURATED smollm2-135m sha256 to "0"*64 (or edit data/model-catalog.json + refresh)
+AGENCY_MODELS_DIR=$MODELS node ./dist/scripts/agency.js local download smollm2-135m 2>&1 | tail -3
+```
+Expected: a `SHA-256 verification failed` error and a `*.gguf.invalidSha` file left in `$MODELS`. (Optional — needs network + ~105 MB; revert the pin edit afterward.)
 
 ---
 
 ## Self-review notes (already checked)
 
 - **Spec coverage:** schema (Task 1), verification primitives (Task 2), verify-on-fresh-download in `_downloadModel` (Task 3), generation script + real pins in both curated and catalog (Task 4), dev doc + sharded caveat + #348 link (Task 5). All spec sections map to a task.
-- **Type consistency:** `sha256?: string` added uniformly to `ModelInfo`/`AliasObject`/`CatalogModel`/`ModelNameEntry`; `fileSha256`/`verifyModelFile`/`pinnedSha256`/`listGgufBasenames` defined in Task 2 are used in Task 3 with the same signatures; `parseHfUri`/`pickSingleQuantFile` defined and tested in Task 4.
+- **Type consistency:** `sha256?: string` added uniformly to `ModelInfo`/`AliasObject`/`CatalogModel`/`ModelNameEntry`; `fileSha256`/`verifyModelFile`/`pinnedSha256`/`snapshotFreshness` defined in Task 2 are used in Task 3 with the same signatures; `parseHfUri`/`pickSingleQuantFile` defined and tested in Task 4.
 - **Pinning correctness:** `pinnedSha256` uses an own-property check so a user alias governs its name and never borrows a curated hash (tested).
-- **Verify-once:** the cache-dir snapshot makes a cache hit skip hashing (tested), so startup with a present model pays nothing.
+- **Verify-once:** `snapshotFreshness(dir)` returns a probe so the call site reads `wasFresh(resolved)`; a cache hit skips hashing (tested), so startup with a present model pays nothing. node-llama-cpp stores files flat in the dir (verified against `buildHuggingFaceFilePrefix`), so basename matching is correct.
 - **Header discipline:** the script reads `X-Linked-ETag` only, never `etag`/`x-xet-hash`.
 - **Known caveat:** the 2 `resolveSmoltalkLlamaCppFromRoots` tests fail environmentally, unrelated to this work.
 ```

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-27-local-model-sha256-verification-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-27-local-model-sha256-verification-design.md
@@ -1,0 +1,184 @@
+# Design: SHA-256 verification for local-model downloads
+
+Date: 2026-06-27
+Status: Approved (pending spec review)
+
+## Goal
+
+After a local model is downloaded, verify the file's SHA-256 against a
+known-good hash pinned in the model catalog, so a tampered or corrupted GGUF is
+caught before it's ever loaded. Pins are sourced cheaply from Hugging Face (no
+multi-GB downloads at catalog-generation time) and the actual downloaded bytes
+are hashed at verify time.
+
+## Background / research (settled facts)
+
+- **node-llama-cpp does not verify checksums.** Its `resolveModelFile({verify})`
+  only re-checks file presence/size; there's no sha256 anywhere in its dist. Its
+  downloader (`ipull`) validates `content-length` only. This matches the
+  ecosystem norm (huggingface_hub doesn't enforce sha256 by default; llama.cpp
+  has it only as open feature requests) — cryptographic verification against a
+  *known-good* hash is the application's job. We are that layer.
+- **The pin source is `X-Linked-ETag`.** A `HEAD` on a model's
+  `…/resolve/<rev>/<file>.gguf` returns `X-Linked-ETag`, which equals the file's
+  content SHA-256 — for both LFS- and Xet-stored repos (the `etag`/`X-Xet-Hash`
+  headers are a *different* chunk hash; do not use them). Verified end-to-end:
+  for SmolLM2-135M, `X-Linked-ETag` == `sha256(downloaded file)` exactly.
+- **Sharding.** node-llama-cpp keeps GGUF-split parts (`-00001-of-N.gguf`) as
+  separate files (each has its own content sha256) but splices binary-split
+  parts (`.partNofM`) into one combined file (no single per-part hash). Our
+  entire curated Q4_K_M catalog is **single-file** (confirmed: even the 18.5 GB
+  Qwen3-Coder-30B is one file). So v1 verifies single-file models only;
+  sharded models are skipped (tracked in issue #348).
+
+## Decisions
+
+1. **Verify the actual downloaded bytes** against the pinned hash. The header is
+   used only at generation time to *mint* the pin; at verify time we hash the
+   file on disk.
+2. **Verify once, on download** — not on every startup. No marker file. We
+   detect a fresh download by snapshotting the cache dir before/after
+   `resolveModel`; an already-present file is assumed previously verified and is
+   not re-hashed (the file doesn't change locally).
+3. **On mismatch, rename** `<file>.gguf` → `<file>.gguf.invalidSha` (so it isn't
+   picked up and triggers a clean re-download next time, but is left for the
+   user to inspect) and throw a clear error.
+4. **Opportunistic.** Verify when a pin exists; skip with a one-time note
+   otherwise (sharded, user aliases, raw URIs).
+5. **Pin in both** `CURATED_LOCAL_MODELS` and the seed catalog, so the default
+   offline `--local-model <name>` (no refresh) is verified too.
+6. **v1 single-file only.** One `sha256` string per entry; sharded skipped.
+
+## Schema changes
+
+Add an optional `sha256` everywhere a model's metadata travels:
+
+- `ModelInfo` (curated): `sha256?: string` (the pinned content hash).
+- `CatalogModel` + `CatalogModelSchema` (zod): `sha256: z.string().optional().catch(undefined)`.
+- `AliasObject`: `sha256?: string` (so refreshed remote aliases carry it — it
+  already flows through `_refreshCatalog`'s `{ ...model, source: "remote" }`).
+- `ModelNameEntry` + `metaFrom`: include `sha256` so it surfaces in listings
+  (optional; not displayed, but keeps the projection complete).
+
+## Verification flow (`lib/stdlib/localModels.ts`)
+
+A pure helper:
+
+```ts
+/** Stream-hash a file's SHA-256 (hex). */
+export async function fileSha256(path: string): Promise<string>
+
+/** Verify `path` against `expected` (hex sha256). On mismatch, rename the file
+ *  to `<path>.invalidSha` (left for inspection) and throw. */
+export async function verifyModelFile(path: string, expected: string, name: string): Promise<void>
+```
+
+`fileSha256` streams via `crypto.createHash("sha256")` + `fs.createReadStream`
+(never buffers the whole file). `verifyModelFile` renames on mismatch
+(`fs.renameSync(path, path + ".invalidSha")`) and throws
+`SHA-256 verification failed for "<name>": expected <e>, got <a>. The file was kept at <path>.invalidSha for inspection.`
+
+Pin lookup:
+
+```ts
+/** The pinned sha256 for a model name/alias, or undefined when none is known
+ *  (raw uri/path, user alias without a hash, or a sharded model). */
+export function pinnedSha256(value: string, file?: string): string | undefined
+```
+
+`pinnedSha256` mirrors `_resolveModelName`'s lookup: an alias object's `sha256`
+wins, else the curated entry's `sha256`, else undefined. A raw `hf:`/`https:`/
+`.gguf` value has no entry → undefined → skip.
+
+`_downloadModel` integration (verify only on fresh download):
+
+```ts
+export async function _downloadModel(value, cacheDir = "") {
+  // … resolve provider as today …
+  const dir = resolveCacheDir(cacheDir);
+  const before = listGgufBasenames(dir);           // {} when dir absent
+  const path = await mod.resolveModel(target, dir);
+  const expected = pinnedSha256(value, "");
+  const freshlyDownloaded = !before.has(basename(path));
+  if (expected !== undefined && freshlyDownloaded) {
+    await verifyModelFile(path, expected, value);
+  }
+  return path;
+}
+```
+
+`listGgufBasenames(dir)` returns the set of `*.gguf` filenames already present
+(empty if the dir doesn't exist). A cache hit (file already there) → not fresh →
+skip. A genuine download → fresh → verify once.
+
+## Generating the pins (maintainer dev script)
+
+`scripts/genModelHashes.ts` (run by a maintainer, not CI; analogous to seeding
+`model-catalog.json`):
+
+For each `CURATED_LOCAL_MODELS` entry whose `uri` is `hf:user/repo:quant`:
+1. List the repo's files via the HF API (`/api/models/<user>/<repo>`).
+2. Find the GGUF matching the quant (`*<QUANT>*.gguf`). **Exactly one** → single
+   file; **zero or many** → sharded/ambiguous → skip (no pin, warn).
+3. `HEAD` `https://huggingface.co/<user>/<repo>/resolve/main/<file>` and read
+   `X-Linked-ETag` → strip quotes → that's the `sha256`.
+4. Write `sha256` into the curated entry and the seed `model-catalog.json`.
+
+The script prints the curated `sha256` values to paste into
+`CURATED_LOCAL_MODELS` (hand-maintained, 13 entries, infrequent) and rewrites
+`data/model-catalog.json`. It does **no** multi-GB downloads.
+
+## Failure & edge behavior
+
+- **Mismatch** → file renamed to `.invalidSha`, hard error; `--local-model`
+  already exits on a failed setup, so it surfaces cleanly and never loads.
+- **No pin** (sharded, user alias, raw uri) → skip silently (verification is
+  best-effort; no output, so normal unpinned use isn't noisy).
+- **Cache hit** → no re-hash (verify-once-on-download).
+- **Catalog pin changed** (model updated via `refresh`) → the cached file is the
+  *old* file; on the next genuine download of the new bytes it's verified against
+  the new pin. (We do not re-hash existing files, so a stale cached file is not
+  retroactively re-checked — acceptable: changing the pin doesn't force eviction,
+  but any fresh fetch is verified.)
+
+## Documentation
+
+- **New `docs/dev/local-models.md`** — a developer overview of the whole
+  local-model system: provider registration (`llama-cpp.mjs` / smoltalk),
+  name resolution (curated / alias / `hf:`/`.gguf`), download + resolve
+  (`_downloadModel` → node-llama-cpp), the generalized alias model, catalog
+  refresh, and **this** SHA-256 verification. Explicitly states: **we do not
+  verify SHAs for sharded models yet** (link issue #348). The existing
+  `docs/dev/local-model-integration.md` (integration-test focused) is linked
+  from it.
+- Add the new doc to the doc index in `CLAUDE.md`.
+
+## Testing
+
+- `fileSha256` / `verifyModelFile`: a small temp file with known content/hash.
+  match → resolves; mismatch → file renamed to `.invalidSha` + throws; the
+  original path no longer exists.
+- `pinnedSha256`: curated hit, alias-object hit (wins over curated), raw uri →
+  undefined.
+- `_downloadModel` verify-on-fresh-download: extend the existing fake-provider
+  pattern (`AGENCY_LLAMA_PROVIDER_MODULE`) so the fake `resolveModel` writes a
+  file with known bytes into the cache dir. Assert: pinned + matching hash →
+  ok; pinned + mismatched → renamed + throws; **second call with the file
+  already present → no re-verify** (e.g. a deliberately-wrong pin is *not*
+  enforced on the cache-hit path); no pin → skipped.
+- No multi-GB downloads in any test.
+
+## Out of scope (→ issue #348)
+
+- GGUF-split per-part verification and binary-split compute-and-pin.
+- Re-verifying already-cached files / eviction on pin change.
+
+## File-by-file
+
+- `lib/stdlib/localModels.ts` — `sha256` on the types + zod schema;
+  `fileSha256`, `verifyModelFile`, `pinnedSha256`, `listGgufBasenames`;
+  `_downloadModel` integration.
+- `scripts/genModelHashes.ts` — new maintainer script.
+- `data/model-catalog.json` — regenerated with `sha256` per model.
+- `lib/stdlib/localModels.test.ts` — verification + pin-lookup + fresh-download tests.
+- `docs/dev/local-models.md` — new overview doc; `CLAUDE.md` doc index updated.

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-27-local-model-sha256-verification-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-27-local-model-sha256-verification-design.md
@@ -43,8 +43,8 @@ are hashed at verify time.
 3. **On mismatch, rename** `<file>.gguf` → `<file>.gguf.invalidSha` (so it isn't
    picked up and triggers a clean re-download next time, but is left for the
    user to inspect) and throw a clear error.
-4. **Opportunistic.** Verify when a pin exists; skip with a one-time note
-   otherwise (sharded, user aliases, raw URIs).
+4. **Opportunistic.** Verify when a pin exists; skip silently otherwise
+   (sharded, user aliases, raw URIs) — see the "No pin" case below.
 5. **Pin in both** `CURATED_LOCAL_MODELS` and the seed catalog, so the default
    offline `--local-model <name>` (no refresh) is verified too.
 6. **v1 single-file only.** One `sha256` string per entry; sharded skipped.

--- a/packages/agency-lang/lib/stdlib/genModelHashes.test.ts
+++ b/packages/agency-lang/lib/stdlib/genModelHashes.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { parseHfUri, pickSingleQuantFile } from "../../scripts/genModelHashes.js";
+
+describe("genModelHashes helpers", () => {
+  it("parseHfUri splits hf:user/repo:quant", () => {
+    expect(parseHfUri("hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M")).toEqual({
+      user: "unsloth",
+      repo: "Qwen3.5-2B-GGUF",
+      quant: "Q4_K_M",
+    });
+  });
+  it("parseHfUri returns null for non-hf or file-form uris", () => {
+    expect(parseHfUri("https://x/y.gguf")).toBeNull();
+    expect(parseHfUri("/abs/m.gguf")).toBeNull();
+    expect(parseHfUri("hf:user/repo/file.gguf")).toBeNull(); // file-form, not :quant
+  });
+  it("pickSingleQuantFile returns the lone matching gguf, else null", () => {
+    expect(
+      pickSingleQuantFile(["README.md", "Model-Q4_K_M.gguf", "Model-Q8_0.gguf"], "Q4_K_M"),
+    ).toBe("Model-Q4_K_M.gguf");
+    // sharded → more than one match → null (no pin)
+    expect(
+      pickSingleQuantFile(["m-Q4_K_M-00001-of-00002.gguf", "m-Q4_K_M-00002-of-00002.gguf"], "Q4_K_M"),
+    ).toBeNull();
+    expect(pickSingleQuantFile(["only-Q8_0.gguf"], "Q4_K_M")).toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -210,9 +210,16 @@ describe("provider register + download (fake bundled module)", () => {
   function fakeModule(): string {
     const p = path.join(here2, "__tmp_fakellama.mjs");
     fs.writeFileSync(p, `import { BaseClient } from "smoltalk";
+      import * as fs from "node:fs";
+      import * as path from "node:path";
       class FakeLlama extends BaseClient { async textSync() { return { success: true, value: { output: "x", toolCalls: [] } }; } }
       export function register({ registerProvider }) { registerProvider("llama-cpp", FakeLlama); }
-      export async function resolveModel(target) { return "RESOLVED:" + target; }`);
+      export async function resolveModel(target, dir) {
+        fs.mkdirSync(dir, { recursive: true });
+        const file = path.join(dir, "model.gguf");
+        fs.writeFileSync(file, "FAKE:" + target);
+        return file;
+      }`);
     fakes.push(p);
     return p;
   }
@@ -228,15 +235,64 @@ describe("provider register + download (fake bundled module)", () => {
     await _registerLocalProvider();
     expect(smoltalkPkg.getClient({ model: "m", provider: "llama-cpp" }).constructor.name).toBe("FakeLlama");
   });
-  it("downloads (resolves) a curated name to a path", async () => {
+  it("downloads (resolves) a uri to a real path", async () => {
     process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
-    const k = Object.keys(CURATED_LOCAL_MODELS)[0];
-    expect(await _downloadModel(k, "/cache")).toBe("RESOLVED:" + CURATED_LOCAL_MODELS[k].uri);
+    const out = await _downloadModel("hf:org/repo:Q4", dir); // raw uri → no pin
+    expect(out).toBe(path.join(dir, "model.gguf"));
+    expect(fs.existsSync(out)).toBe(true);
   });
   it("registerLocalModel registers and returns the resolved path", async () => {
     process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
-    expect(await _registerLocalModel("/abs/my.gguf", "/cache")).toBe("RESOLVED:/abs/my.gguf");
+    const out = await _registerLocalModel("/abs/my.gguf", dir); // raw path → no pin
+    expect(out).toBe(path.join(dir, "model.gguf"));
     expect(smoltalkPkg.getClient({ model: "m", provider: "llama-cpp" }).constructor.name).toBe("FakeLlama");
+  });
+
+  it("verifies a freshly-downloaded pinned model (match → ok)", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    const target = "hf:org/x:Q4";
+    const sha = createHash("sha256").update("FAKE:" + target).digest("hex");
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { mymodel: { uri: target, sha256: sha } } } }));
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const out = await _downloadModel("mymodel", dir);
+      expect(fs.existsSync(out)).toBe(true);
+      expect(fs.existsSync(out + ".invalidSha")).toBe(false);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it("quarantines a freshly-downloaded model whose hash is wrong", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { mymodel: { uri: "hf:org/x:Q4", sha256: "0".repeat(64) } } } }));
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      await expect(_downloadModel("mymodel", dir)).rejects.toThrow(/SHA-256 verification failed/);
+      expect(fs.existsSync(path.join(dir, "model.gguf"))).toBe(false);
+      expect(fs.existsSync(path.join(dir, "model.gguf.invalidSha"))).toBe(true);
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+
+  it("does NOT re-verify an already-present (cache-hit) file", async () => {
+    process.env.AGENCY_LLAMA_PROVIDER_MODULE = fakeModule();
+    // Pre-create the model file so it's in the before-snapshot → treated as cached.
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "model.gguf"), "pre-existing");
+    // A deliberately-wrong pin would fail IF it verified — it must be skipped.
+    fs.writeFileSync(aliasFile, JSON.stringify({ client: { modelAliases: { mymodel: { uri: "hf:org/x:Q4", sha256: "0".repeat(64) } } } }));
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      await expect(_downloadModel("mymodel", dir)).resolves.toBe(path.join(dir, "model.gguf"));
+      expect(fs.existsSync(path.join(dir, "model.gguf.invalidSha"))).toBe(false);
+    } finally {
+      process.chdir(cwd);
+    }
   });
 });
 

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -474,18 +474,21 @@ describe("parseCatalog", () => {
     expect(out.m.sizeBytes).toBeUndefined(); // "big" is not a number → dropped
   });
 
-  it("keeps a valid sha256 and drops a non-string one", () => {
+  it("keeps a valid 64-hex sha256 (lowercased) and drops malformed ones", () => {
+    const upper = "A".repeat(64);
     const out = parseCatalog(
       JSON.stringify({
         version: 1,
         models: {
-          good: { uri: "hf:org/g:Q4_K_M", sha256: "abc123" },
-          bad: { uri: "hf:org/b:Q4_K_M", sha256: 123 },
+          good: { uri: "hf:org/g:Q4_K_M", sha256: upper },
+          tooShort: { uri: "hf:org/s:Q4_K_M", sha256: "abc123" },
+          notString: { uri: "hf:org/n:Q4_K_M", sha256: 123 },
         },
       }),
     );
-    expect(out.good.sha256).toBe("abc123");
-    expect(out.bad.sha256).toBeUndefined(); // wrong type dropped, entry kept
+    expect(out.good.sha256).toBe("a".repeat(64)); // valid → normalized lowercase, entry kept
+    expect(out.tooShort.sha256).toBeUndefined(); // not 64-hex → dropped, entry kept
+    expect(out.notString.sha256).toBeUndefined(); // wrong type → dropped, entry kept
   });
 });
 
@@ -574,14 +577,15 @@ describe("_refreshCatalog", () => {
   });
 
   it("writes the catalog sha256 into the remote alias", async () => {
+    const sha = "deadbeef".repeat(8); // a valid 64-hex sha256
     fs.writeFileSync(aliasFile, "{}");
     await _refreshCatalog({
       file: aliasFile,
       fetcher: async () =>
-        JSON.stringify({ version: 1, models: { m: { uri: "hf:org/m:Q4_K_M", sha256: "deadbeef" } } }),
+        JSON.stringify({ version: 1, models: { m: { uri: "hf:org/m:Q4_K_M", sha256: sha } } }),
     });
     const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
-    expect(cfg.client.modelAliases.m.sha256).toBe("deadbeef");
+    expect(cfg.client.modelAliases.m.sha256).toBe(sha);
   });
 
   it("does not treat a prototype-named model as a user collision", async () => {
@@ -628,6 +632,14 @@ describe("model file verification", () => {
     const sha = createHash("sha256").update("good").digest("hex");
     await expect(verifyModelFile(p, sha, "m")).resolves.toBeUndefined();
     expect(fs.existsSync(p)).toBe(true); // left in place
+  });
+
+  it("verifyModelFile matches an uppercase expected hash (case-insensitive)", async () => {
+    const p = path.join(dir, "m.gguf");
+    fs.writeFileSync(p, "good");
+    const sha = createHash("sha256").update("good").digest("hex").toUpperCase();
+    await expect(verifyModelFile(p, sha, "m")).resolves.toBeUndefined();
+    expect(fs.existsSync(p)).toBe(true);
   });
 
   it("verifyModelFile quarantines + throws on a mismatch", async () => {

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -413,6 +413,20 @@ describe("parseCatalog", () => {
     expect(out.m.params).toBeUndefined(); // 7 is not a string → dropped
     expect(out.m.sizeBytes).toBeUndefined(); // "big" is not a number → dropped
   });
+
+  it("keeps a valid sha256 and drops a non-string one", () => {
+    const out = parseCatalog(
+      JSON.stringify({
+        version: 1,
+        models: {
+          good: { uri: "hf:org/g:Q4_K_M", sha256: "abc123" },
+          bad: { uri: "hf:org/b:Q4_K_M", sha256: 123 },
+        },
+      }),
+    );
+    expect(out.good.sha256).toBe("abc123");
+    expect(out.bad.sha256).toBeUndefined(); // wrong type dropped, entry kept
+  });
 });
 
 describe("_refreshCatalog", () => {
@@ -497,6 +511,17 @@ describe("_refreshCatalog", () => {
     ).rejects.toThrow(/valid JSON/);
     const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
     expect(cfg.client.modelAliases.keep).toBe("hf:k:Q4_K_M");
+  });
+
+  it("writes the catalog sha256 into the remote alias", async () => {
+    fs.writeFileSync(aliasFile, "{}");
+    await _refreshCatalog({
+      file: aliasFile,
+      fetcher: async () =>
+        JSON.stringify({ version: 1, models: { m: { uri: "hf:org/m:Q4_K_M", sha256: "deadbeef" } } }),
+    });
+    const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
+    expect(cfg.client.modelAliases.m.sha256).toBe("deadbeef");
   });
 
   it("does not treat a prototype-named model as a user collision", async () => {

--- a/packages/agency-lang/lib/stdlib/localModels.test.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { createHash } from "node:crypto";
 import {
   CURATED_LOCAL_MODELS,
   _resolveModelName,
@@ -17,6 +18,9 @@ import {
   resolveCatalogUrl,
   parseCatalog,
   _refreshCatalog,
+  fileSha256,
+  verifyModelFile,
+  pinnedSha256,
 } from "./localModels.js";
 
 let dir: string;
@@ -551,5 +555,62 @@ describe("_refreshCatalog", () => {
     expect(r.added).toEqual(["m"]);
     const cfg = JSON.parse(fs.readFileSync(aliasFile, "utf8"));
     expect(cfg.client.modelAliases.m).toEqual({ uri: "hf:org/m:Q4_K_M", params: "2B", source: "remote" });
+  });
+});
+
+describe("model file verification", () => {
+  it("fileSha256 matches node:crypto over the same bytes", async () => {
+    const p = path.join(dir, "m.gguf");
+    fs.writeFileSync(p, "hello-bytes");
+    const expected = createHash("sha256").update("hello-bytes").digest("hex");
+    expect(await fileSha256(p)).toBe(expected);
+  });
+
+  it("verifyModelFile resolves on a match", async () => {
+    const p = path.join(dir, "m.gguf");
+    fs.writeFileSync(p, "good");
+    const sha = createHash("sha256").update("good").digest("hex");
+    await expect(verifyModelFile(p, sha, "m")).resolves.toBeUndefined();
+    expect(fs.existsSync(p)).toBe(true); // left in place
+  });
+
+  it("verifyModelFile quarantines + throws on a mismatch", async () => {
+    const p = path.join(dir, "m.gguf");
+    fs.writeFileSync(p, "tampered");
+    await expect(verifyModelFile(p, "0".repeat(64), "m")).rejects.toThrow(/SHA-256 verification failed/);
+    expect(fs.existsSync(p)).toBe(false); // moved aside
+    expect(fs.existsSync(p + ".invalidSha")).toBe(true); // kept for inspection
+  });
+
+  it("pinnedSha256: curated, alias-object wins, string-alias + raw → undefined", () => {
+    const k = Object.keys(CURATED_LOCAL_MODELS)[0];
+    // Curated lookup mirrors the curated entry's sha256 — undefined before the
+    // Task 4 pins are added, hex after; this assertion holds in both states.
+    expect(pinnedSha256(k, aliasFile)).toBe(CURATED_LOCAL_MODELS[k].sha256);
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({
+        client: {
+          modelAliases: {
+            obj: { uri: "hf:o/x:Q4", sha256: "aa" },
+            str: "hf:o/y:Q4",
+          },
+        },
+      }),
+    );
+    expect(pinnedSha256("obj", aliasFile)).toBe("aa"); // alias object hash
+    expect(pinnedSha256("str", aliasFile)).toBeUndefined(); // string alias has none
+    expect(pinnedSha256("hf:o/z:Q4", aliasFile)).toBeUndefined(); // raw uri
+    expect(pinnedSha256("/abs/x.gguf", aliasFile)).toBeUndefined(); // raw path
+  });
+
+  it("pinnedSha256: a user alias shadowing a curated name uses the alias (not curated)", () => {
+    const k = Object.keys(CURATED_LOCAL_MODELS)[0];
+    fs.writeFileSync(
+      aliasFile,
+      JSON.stringify({ client: { modelAliases: { [k]: "hf:mine/custom:Q4" } } }),
+    );
+    // string alias governs → no pin (must NOT fall back to the curated hash)
+    expect(pinnedSha256(k, aliasFile)).toBeUndefined();
   });
 });

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import { findFileUp } from "../importPaths.js";
 import { loadProviderModuleByPath } from "../runtime/providerModules.js";
@@ -858,6 +859,82 @@ export async function _registerLocalProvider(): Promise<void> {
   requireSupport();
   exposeResolvedLlamaCppPath();
   await loadProviderModuleByPath(bundledLlamaModule());
+}
+
+/** Stream-hash a file's SHA-256 (hex), never buffering the whole file. The
+ *  `update` is guarded so a synchronous throw in the data handler rejects the
+ *  promise instead of escaping it. */
+export function fileSha256(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = fs.createReadStream(filePath);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => {
+      try {
+        hash.update(chunk);
+      } catch (err) {
+        stream.destroy();
+        reject(err as Error);
+      }
+    });
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+/** Verify `filePath` against the expected hex SHA-256. On mismatch, rename the
+ *  file to `<filePath>.invalidSha` (kept for inspection; won't be picked up, so
+ *  the next run re-downloads) and throw. A failed rename is logged (not
+ *  swallowed) and reflected in the thrown message. */
+export async function verifyModelFile(
+  filePath: string,
+  expected: string,
+  name: string,
+): Promise<void> {
+  const actual = await fileSha256(filePath);
+  if (actual === expected) return;
+  const quarantine = `${filePath}.invalidSha`;
+  let moved = true;
+  try {
+    fs.renameSync(filePath, quarantine);
+  } catch (err) {
+    moved = false;
+    console.warn(`Could not move "${filePath}" to "${quarantine}" after SHA-256 mismatch:`, err);
+  }
+  throw new Error(
+    `SHA-256 verification failed for "${name}": expected ${expected}, got ${actual}. ` +
+      (moved
+        ? `The downloaded file was moved to ${quarantine} for inspection and will be re-downloaded next time.`
+        : `The downloaded file at ${filePath} could NOT be moved aside — delete it manually before re-running.`),
+  );
+}
+
+/** The pinned SHA-256 for a model name/alias, or undefined when none is known
+ *  (raw uri/path, string alias, alias/curated without a hash, or a sharded
+ *  model). An alias entry governs the name entirely — a user alias shadowing a
+ *  curated name must NOT borrow the curated hash, but a user MAY opt in by
+ *  setting their own `sha256` on the alias object. */
+export function pinnedSha256(value: string, file: string = ""): string | undefined {
+  if (isGgufPath(value) || isModelUri(value)) return undefined;
+  const aliases = readModelAliases(file);
+  if (Object.hasOwn(aliases, value)) {
+    const v = aliases[value];
+    return typeof v === "object" ? v.sha256 : undefined;
+  }
+  return CURATED_LOCAL_MODELS[value]?.sha256;
+}
+
+/** Was the resolved file freshly downloaded (not already cached)? */
+export type FreshnessProbe = (resolved: string) => boolean;
+
+/** Snapshot the cache dir, returning a probe that reports whether a resolved
+ *  path is newly downloaded. node-llama-cpp stores models FLAT in `dir` with a
+ *  prefixed filename — no per-repo subdirs (verified against its
+ *  `buildHuggingFaceFilePrefix`) — so matching by basename is correct. */
+export function snapshotFreshness(dir: string): FreshnessProbe {
+  const present = fs.existsSync(dir)
+    ? new Set(fs.readdirSync(dir).filter((f) => f.endsWith(".gguf")))
+    : new Set<string>();
+  return (resolved) => !present.has(path.basename(resolved));
 }
 
 /** Resolve a name/uri/path to a local .gguf path, downloading if needed. */

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -444,7 +444,14 @@ const CatalogModelSchema = z.object({
   contextWindow: z.number().optional().catch(undefined),
   license: z.string().optional().catch(undefined),
   description: z.string().optional().catch(undefined),
-  sha256: z.string().optional().catch(undefined),
+  // Must be a 64-hex SHA-256; normalized to lowercase. A malformed value (from
+  // an untrusted catalog) is dropped via `.catch`, not stored as a bad pin.
+  sha256: z
+    .string()
+    .regex(/^[0-9a-fA-F]{64}$/)
+    .transform((s) => s.toLowerCase())
+    .optional()
+    .catch(undefined),
 });
 
 // Top-level catalog shape: a supported version + a name→entry object. Entries
@@ -903,8 +910,11 @@ export async function verifyModelFile(
   expected: string,
   name: string,
 ): Promise<void> {
+  // `fileSha256` returns lowercase hex; normalize the expected pin so a
+  // valid-but-uppercase hash (e.g. from a hand-written alias) still matches.
+  const want = expected.toLowerCase();
   const actual = await fileSha256(filePath);
-  if (actual === expected) return;
+  if (actual === want) return;
   const quarantine = `${filePath}.invalidSha`;
   let moved = true;
   try {

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -35,6 +35,9 @@ export type ModelInfo = {
    *  (apache-2.0 / mit); restrictively-licensed models (gemma, llama) are
    *  intentionally excluded. */
   license: string;
+  /** Pinned content SHA-256 (hex) of the resolved single-file GGUF, used to
+   *  verify the download. Absent for sharded models (see issue #348). */
+  sha256?: string;
 };
 
 /** Curated short-name → ModelInfo catalog. Permissive licenses only
@@ -230,6 +233,7 @@ export type AliasObject = {
   contextWindow?: number;
   license?: string;
   description?: string;
+  sha256?: string;
 };
 
 export type AliasValue = string | AliasObject;
@@ -255,6 +259,7 @@ export type ModelNameEntry = {
   description?: string;
   contextWindow?: number;
   license?: string;
+  sha256?: string;
 };
 
 export function _resolveModelName(value: string, file: string = ""): string {
@@ -278,7 +283,7 @@ export function _resolveModelName(value: string, file: string = ""): string {
 
 type EntryMeta = Pick<
   ModelNameEntry,
-  "params" | "sizeBytes" | "category" | "description" | "contextWindow" | "license"
+  "params" | "sizeBytes" | "category" | "description" | "contextWindow" | "license" | "sha256"
 >;
 
 /** Project the optional display-metadata fields off any source shape
@@ -295,6 +300,7 @@ function metaFrom(src: string | Partial<EntryMeta>): EntryMeta {
   if (src.description !== undefined) out.description = src.description;
   if (src.contextWindow !== undefined) out.contextWindow = src.contextWindow;
   if (src.license !== undefined) out.license = src.license;
+  if (src.sha256 !== undefined) out.sha256 = src.sha256;
   return out;
 }
 
@@ -388,6 +394,7 @@ export type CatalogModel = {
   contextWindow?: number;
   license?: string;
   description?: string;
+  sha256?: string;
 };
 
 /** Resolve the catalog URL: explicit arg → env → config → built-in default. */
@@ -423,6 +430,7 @@ const CatalogModelSchema = z.object({
   contextWindow: z.number().optional().catch(undefined),
   license: z.string().optional().catch(undefined),
   description: z.string().optional().catch(undefined),
+  sha256: z.string().optional().catch(undefined),
 });
 
 // Top-level catalog shape: a supported version + a name→entry object. Entries
@@ -486,6 +494,7 @@ export function parseCatalog(text: string): Record<string, CatalogModel> {
           contextWindow: d.contextWindow,
           license: d.license,
           description: d.description,
+          sha256: d.sha256,
         }),
       };
       return [name, model];

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -47,48 +47,56 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   // ── General ─────────────────────────────────────────────────────────────
   "smollm2-135m": {
     uri: "hf:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M",
+    sha256: "ed5fa30c487b282ec156c29062f1222e5c20875a944ac98289dbd242e947f747",
     params: "135M", sizeBytes: 105_000_000, category: "general",
     contextWindow: 8192, license: "apache-2.0",
     description: "Smallest practical chat model; used by our integration tests, runs anywhere.",
   },
   "qwen3.5-0.8b": {
     uri: "hf:unsloth/Qwen3.5-0.8B-GGUF:Q4_K_M",
+    sha256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517",
     params: "0.8B", sizeBytes: 500_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Tiny model from Alibaba's current generation; good edge-device default.",
   },
   "qwen3.5-2b": {
     uri: "hf:unsloth/Qwen3.5-2B-GGUF:Q4_K_M",
+    sha256: "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
     params: "2B", sizeBytes: 1_280_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Most popular modern small general model; runs on CPU comfortably.",
   },
   "qwen3.5-4b": {
     uri: "hf:unsloth/Qwen3.5-4B-GGUF:Q4_K_M",
+    sha256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
     params: "4B", sizeBytes: 2_400_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Strong multilingual small general workhorse from Alibaba.",
   },
   "qwen3.5-9b": {
     uri: "hf:unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
+    sha256: "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8",
     params: "9B", sizeBytes: 5_500_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Modern medium general model with strong tool use; 128K context.",
   },
   "gpt-oss-20b": {
     uri: "hf:unsloth/gpt-oss-20b-GGUF:Q4_K_M",
+    sha256: "c27536640e410032865dc68781d80a08b98f8db5e93575919af8ccc0568aeb4f",
     params: "20B", sizeBytes: 12_000_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "OpenAI's open-weights release; balanced general model for ~16 GB machines.",
   },
   "mistral-small-3.1": {
     uri: "hf:unsloth/Mistral-Small-3.1-24B-Instruct-2503-GGUF:Q4_K_M",
+    sha256: "6d670773c3908584349d41a5048d1472226b593c881fd394e8ac196c802e81e2",
     params: "24B", sizeBytes: 14_000_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Mistral's general 24B base model (also Devstral's foundation); broad utility.",
   },
   "qwen3.5-27b": {
     uri: "hf:unsloth/Qwen3.5-27B-GGUF:Q4_K_M",
+    sha256: "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806",
     params: "27B", sizeBytes: 16_000_000_000, category: "general",
     contextWindow: 131072, license: "apache-2.0",
     description: "Modern dense general 27B; the practical ceiling for most workstations.",
@@ -97,12 +105,14 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   // ── Reasoning ───────────────────────────────────────────────────────────
   "deepseek-r1-distill-llama-8b": {
     uri: "hf:unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF:Q4_K_M",
+    sha256: "0addb1339a82385bcd973186cd80d18dcc71885d45eabd899781a118d03827d9",
     params: "8B", sizeBytes: 4_920_000_000, category: "reasoning",
     contextWindow: 131072, license: "mit",
     description: "Chain-of-thought distill into Llama-8B; best small reasoning model.",
   },
   "phi-4-reasoning": {
     uri: "hf:unsloth/Phi-4-reasoning-GGUF:Q4_K_M",
+    sha256: "960d3870b218f91116c55bf81dc313e6cdbce31b1047bb2bc8bc7ea47899b032",
     params: "14B", sizeBytes: 9_050_000_000, category: "reasoning",
     contextWindow: 32768, license: "mit",
     description: "Microsoft's reasoning-tuned 14B; competitive with much larger models on math/logic.",
@@ -111,12 +121,14 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   // ── Coding ──────────────────────────────────────────────────────────────
   "devstral-small-2507": {
     uri: "hf:mistralai/Devstral-Small-2507_gguf:Q4_K_M",
+    sha256: "1bcc2b1b7b7ea3168ba2dbe782432c464f2240598bd193930122c41b117c1796",
     params: "24B", sizeBytes: 14_300_000_000, category: "coding",
     contextWindow: 131072, license: "apache-2.0",
     description: "Mistral's official coding-agent GGUF; #1 open-source on SWE-Bench at release.",
   },
   "qwen3-coder-30b-a3b": {
     uri: "hf:unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_M",
+    sha256: "fadc3e5f8d42bf7e894a785b05082e47daee4df26680389817e2093056f088ad",
     params: "30B (A3B)", sizeBytes: 19_000_000_000, category: "coding",
     contextWindow: 262144, license: "apache-2.0",
     description: "Qwen's MoE coder (3.3B active); strong agentic coding + 256K context.",
@@ -125,6 +137,7 @@ export const CURATED_LOCAL_MODELS: Record<string, ModelInfo> = {
   // ── Embedding ───────────────────────────────────────────────────────────
   "nomic-embed-text": {
     uri: "hf:nomic-ai/nomic-embed-text-v1.5-GGUF:Q4_K_M",
+    sha256: "d4e388894e09cf3816e8b0896d81d265b55e7a9fff9ab03fe8bf4ef5e11295ac",
     params: "137M", sizeBytes: 89_000_000, category: "embedding",
     contextWindow: 8192, license: "apache-2.0",
     description: "Returns 768-dim embeddings; pair with a chat model for RAG.",

--- a/packages/agency-lang/lib/stdlib/localModels.ts
+++ b/packages/agency-lang/lib/stdlib/localModels.ts
@@ -942,6 +942,7 @@ export async function _downloadModel(value: string, cacheDir: string = ""): Prom
   requireSupport();
   exposeResolvedLlamaCppPath();
   const target = _resolveModelName(value);
+  const dir = resolveCacheDir(cacheDir);
   const fsPath = bundledLlamaModule();
   let mod: LlamaBundle;
   try {
@@ -953,7 +954,16 @@ export async function _downloadModel(value: string, cacheDir: string = ""): Prom
   if (typeof mod.resolveModel !== "function") {
     throw new Error(`Local-model provider module must export resolveModel().`);
   }
-  return await mod.resolveModel(target, resolveCacheDir(cacheDir));
+  // Snapshot freshness BEFORE resolving so we verify the bytes only once, right
+  // after a real download (a cache hit is skipped — the file can't change on
+  // disk between runs).
+  const wasFresh = snapshotFreshness(dir);
+  const resolved = await mod.resolveModel(target, dir);
+  const expected = pinnedSha256(value);
+  if (expected !== undefined && wasFresh(resolved)) {
+    await verifyModelFile(resolved, expected, value);
+  }
+  return resolved;
 }
 
 /** Convenience: register the provider + ensure the model is downloaded. */

--- a/packages/agency-lang/scripts/genModelHashes.ts
+++ b/packages/agency-lang/scripts/genModelHashes.ts
@@ -35,7 +35,10 @@ async function repoFiles(user: string, repo: string): Promise<string[]> {
  *  to the CDN, not the final CDN response. NEVER use `etag`/`x-xet-hash` (a
  *  different chunk hash). */
 async function fetchSha256(user: string, repo: string, file: string): Promise<string | null> {
-  const url = `https://huggingface.co/${user}/${repo}/resolve/main/${encodeURIComponent(file)}`;
+  // Encode per path segment so a subdir in `rfilename` (e.g. `gguf/model.gguf`)
+  // keeps its slashes — `encodeURIComponent` on the whole path would break it.
+  const encodedFile = file.split("/").map(encodeURIComponent).join("/");
+  const url = `https://huggingface.co/${user}/${repo}/resolve/main/${encodedFile}`;
   const res = await fetch(url, { method: "HEAD", redirect: "manual" });
   const etag = res.headers.get("x-linked-etag");
   if (!etag) return null;

--- a/packages/agency-lang/scripts/genModelHashes.ts
+++ b/packages/agency-lang/scripts/genModelHashes.ts
@@ -1,0 +1,88 @@
+// genModelHashes — mint pinned SHA-256 hashes for the curated models from
+// Hugging Face's X-Linked-ETag header (= the file's content sha256). This
+// script is the source of truth; the sha256 values committed in
+// CURATED_LOCAL_MODELS and data/model-catalog.json are a snapshot — re-run it
+// whenever an upstream repo re-uploads a file and the pin changes.
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CURATED_LOCAL_MODELS } from "../lib/stdlib/localModels.js";
+
+/** Split `hf:user/repo:quant` (the curated short form). Returns null for the
+ *  file-form (`hf:user/repo/file.gguf`), https, or local paths. */
+export function parseHfUri(uri: string): { user: string; repo: string; quant: string } | null {
+  const m = /^hf:([^/]+)\/([^/:]+):([^/]+)$/.exec(uri);
+  if (!m) return null;
+  return { user: m[1], repo: m[2], quant: m[3] };
+}
+
+/** The lone `.gguf` whose name contains `quant`; null if zero or many (a sharded
+ *  model has many → we record no pin for it). */
+export function pickSingleQuantFile(files: string[], quant: string): string | null {
+  const matches = files.filter((f) => f.endsWith(".gguf") && f.includes(quant));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+async function repoFiles(user: string, repo: string): Promise<string[]> {
+  const res = await fetch(`https://huggingface.co/api/models/${user}/${repo}`);
+  if (!res.ok) throw new Error(`HF API ${res.status} for ${user}/${repo}`);
+  const json = (await res.json()) as { siblings?: { rfilename: string }[] };
+  return (json.siblings ?? []).map((s) => s.rfilename);
+}
+
+/** HEAD the resolve URL and read X-Linked-ETag (= the file's content sha256).
+ *  Uses `redirect: "manual"` because the header lives on huggingface.co's 302
+ *  to the CDN, not the final CDN response. NEVER use `etag`/`x-xet-hash` (a
+ *  different chunk hash). */
+async function fetchSha256(user: string, repo: string, file: string): Promise<string | null> {
+  const url = `https://huggingface.co/${user}/${repo}/resolve/main/${encodeURIComponent(file)}`;
+  const res = await fetch(url, { method: "HEAD", redirect: "manual" });
+  const etag = res.headers.get("x-linked-etag");
+  if (!etag) return null;
+  return etag.replace(/"/g, "");
+}
+
+async function main(): Promise<void> {
+  const out: Record<string, string> = {};
+  for (const [name, info] of Object.entries(CURATED_LOCAL_MODELS)) {
+    const parsed = parseHfUri(info.uri);
+    if (!parsed) {
+      console.warn(`skip ${name}: not an hf:user/repo:quant uri`);
+      continue;
+    }
+    const files = await repoFiles(parsed.user, parsed.repo);
+    const file = pickSingleQuantFile(files, parsed.quant);
+    if (!file) {
+      console.warn(`skip ${name}: not a single-file ${parsed.quant} gguf (sharded?)`);
+      continue;
+    }
+    const sha = await fetchSha256(parsed.user, parsed.repo, file);
+    if (!sha) {
+      console.warn(`skip ${name}: no X-Linked-ETag`);
+      continue;
+    }
+    out[name] = sha;
+    console.log(`${name}: ${sha}`);
+  }
+
+  // Rewrite the seed catalog with the new sha256 values. Resolved from cwd
+  // (run this script from the `packages/agency-lang` directory) so it edits the
+  // SOURCE data file whether run from `dist/` or via tsx.
+  const catalogPath = path.resolve("data/model-catalog.json");
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8"));
+  for (const [name, sha] of Object.entries(out)) {
+    if (catalog.models[name]) catalog.models[name].sha256 = sha;
+  }
+  fs.writeFileSync(catalogPath, JSON.stringify(catalog, null, 2) + "\n");
+
+  console.log("\n--- paste these into CURATED_LOCAL_MODELS ---");
+  for (const [name, sha] of Object.entries(out)) console.log(`  ${name}: sha256 "${sha}"`);
+}
+
+// Run only when invoked directly.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Verifies a downloaded local model's SHA-256 against a known-good hash pinned in the catalog, quarantining a mismatch before the file can ever be loaded. This is the follow-up to the catalog-refresh work (#347) and to the URL-pinning discussion: rather than pinning brittle per-file URLs, we pin a reviewed content hash and verify the actual bytes.

Implements the approved spec/plan in `docs/superpowers/`.

## How it works

- **Pinned hash per model.** An optional `sha256` is threaded through the model metadata (`ModelInfo` / `CatalogModel` / `AliasObject`), stored in both `CURATED_LOCAL_MODELS` and `data/model-catalog.json`, and flows through `agency local refresh` into remote aliases.
- **Minted from `X-Linked-ETag`.** `scripts/genModelHashes.ts` HEADs each model's HF resolve URL and reads `X-Linked-ETag` — which equals the file's content sha256 (verified end-to-end), works for LFS- and Xet-stored repos, and needs no multi-GB downloads. All 13 curated models pinned.
- **Verify the real bytes, once, on fresh download.** In `_downloadModel`, a cache-dir snapshot (`snapshotFreshness`) detects a genuine download; we then stream-hash the file (`fileSha256`) and compare to the pin (`verifyModelFile`). An already-cached file is never re-hashed, so startup stays fast.
- **On mismatch:** the file is renamed to `<file>.gguf.invalidSha` (kept for inspection, not loaded) and a clear error is thrown. A failed rename is logged, not swallowed.
- **Opportunistic:** models with no pin (user aliases, raw URIs) are skipped silently. A user alias may opt in with its own `sha256`; it never borrows a curated hash.

## Scope

Single-file GGUF models only — which is the entire curated Q4_K_M set (confirmed: even the 18.5 GB Qwen3-Coder-30B is one file). Sharded models carry no pin and are skipped; extending coverage is tracked in #348.

## Testing

- New unit tests: `parseCatalog`/refresh thread `sha256`; `fileSha256`/`verifyModelFile`/`pinnedSha256` (match, quarantine, own-property pin lookup); `_downloadModel` verify-on-fresh-download (match → ok, wrong hash → quarantine + throw, cache-hit → skipped); `genModelHashes` helpers.
- Suites green: `localModels`, `genModelHashes`, `cli/local` (the 2 `resolveSmoltalkLlamaCppFromRoots` failures are pre-existing/environmental, reproduce on `main`).
- `tsc --noEmit` clean; structural linter clean.
- **Live smoke:** `agency local download smollm2-135m` really downloaded 105 MB, verified against the pinned hash, exited 0 — no `.invalidSha`.

## Notes

- The committed hashes are a snapshot; `genModelHashes.ts` is the source of truth — re-run it when an upstream repo re-uploads a file.
- A pin change (via `refresh`) doesn't retroactively re-check an already-cached file; `agency local remove <name>` forces a verified re-download. Documented in `docs/dev/local-models.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
