### PR TITLE
Don't enable agent memory for local models

### DIFF
--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -26,7 +26,7 @@ import {
  } from "./lib/defaultPolicy.agency"
 import { truncate, formatArgs, formatToolResponse } from "./lib/utils.agency"
 import { printLocalCatalog } from "std::agency/local"
-import { configureModels, configureLocalModel } from "./shared.agency"
+import { configureModels, configureLocalModel, enableAgentMemory } from "./shared.agency"
 import { codeAgent } from "./subagents/code.agency"
 import { explorerAgent } from "./subagents/explorer.agency"
 import { oracleAgent } from "./subagents/oracle.agency"
@@ -745,6 +745,9 @@ node main() {
     process.exit(0)
   } else if (localModel) {
     configureLocalModel(localModel)
+    // Intentionally do NOT enable memory for a local model: the llama-cpp
+    // provider has no embedding endpoint, so memory would only emit a
+    // "Tier-2 disabled" notice. std::memory calls no-op while it's off.
   } else {
     configureModels(
       args.flags.model ?? "",
@@ -752,6 +755,9 @@ node main() {
       args.flags.slowmodel ?? "",
       args.flags.provider ?? "",
     )
+    // Persistent knowledge graph — only for hosted providers (which have an
+    // embedding endpoint). Must run before any handler/REPL is installed.
+    enableAgentMemory()
   }
 
   // Positional args (everything after flags) are joined with spaces to

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -755,8 +755,11 @@ node main() {
       args.flags.slowmodel ?? "",
       args.flags.provider ?? "",
     )
-    // Persistent knowledge graph — only for hosted providers (which have an
-    // embedding endpoint). Must run before any handler/REPL is installed.
+    // Persistent knowledge graph — enabled for hosted providers, skipped for
+    // local models. (Some hosted providers, e.g. anthropic, still lack an
+    // embedding endpoint and just disable Tier-2 recall with a one-time
+    // notice; structured recall works regardless.) Must run before any
+    // handler/REPL is installed.
     enableAgentMemory()
   }
 

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -52,11 +52,7 @@ export static const AGENCY_AGENT_DIR = computeAgentDir()
 // (openai → text-embedding-3-small, google → text-embedding-004,
 // ollama → nomic-embed-text). Set `embeddings.model` explicitly to override.
 export def enableAgentMemory() {
-  const _ = enableMemory(
-    {
-    dir: "${AGENCY_AGENT_DIR}/memory"
-  },
-  ) with approve
+  enableMemory({ dir: "${AGENCY_AGENT_DIR}/memory" }) with approve
 }
 
 // The slow ("deep reasoning") model + its provider, set once by

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -39,23 +39,25 @@ export static const AGENCY_AGENT_DIR = computeAgentDir()
 // Persistent knowledge graph for every subagent. `setMemoryId(...)`
 // (called inside std::agent's router) scopes which graph their
 // `remember`/`recall` calls hit, so a single shared on-disk directory
-// cleanly hosts both. Using `static const _ = ...` is the documented
-// top-level pattern (see `stdlib/memory.agency`): the `with approve`
-// modifier needs an enclosing step path, which a bare top-level call
-// doesn't have. The underscore name signals "we want the side-effect,
-// not the value". We deliberately do NOT pin `embeddings.model`: the memory
-// layer derives the embedding model from the ACTIVE LLM provider (openai →
-// text-embedding-3-small, google → text-embedding-004, ollama → nomic-embed-text),
-// and disables Tier-2 (embedding-similarity) recall — with a one-time notice —
-// for providers that have no embedding endpoint (anthropic, and the llama-cpp
-// `--local-model` path). That keeps a local/offline run from making a doomed
-// remote embed call while structured recall keeps working. Set
-// `embeddings.model` explicitly to override.
-static const _memoryReady = enableMemory(
-  {
-  dir: "${AGENCY_AGENT_DIR}/memory"
-},
-) with approve
+// cleanly hosts both. `main()` calls this once, AFTER resolving the model,
+// so it can be skipped for `--local-model`: the llama-cpp provider has no
+// embedding endpoint, so enabling memory would only emit a one-time
+// "Tier-2 disabled" notice and add overhead. All `std::memory` calls
+// (`setMemoryId`/`recall`/`remember`) no-op when memory isn't enabled, so a
+// local run works fine without it. Calling `enableMemory(...)` from `main()`
+// is the documented pattern (see `stdlib/memory.agency`); `with approve`
+// auto-approves the dir creation and has the enclosing step path it needs
+// inside this def. We deliberately do NOT pin `embeddings.model`: for hosted
+// providers the memory layer derives it from the active LLM provider
+// (openai → text-embedding-3-small, google → text-embedding-004,
+// ollama → nomic-embed-text). Set `embeddings.model` explicitly to override.
+export def enableAgentMemory() {
+  const _ = enableMemory(
+    {
+    dir: "${AGENCY_AGENT_DIR}/memory"
+  },
+  ) with approve
+}
 
 // The slow ("deep reasoning") model + its provider, set once by
 // `configureModels()`. The deep subagents (oracle, explorer) read these.


### PR DESCRIPTION
## Summary

When the agent runs a local model (`--local-model`), it no longer enables persistent memory — so it stops emitting:

```
[memory] semantic recall (Tier-2) disabled: provider "llama-cpp" has no embedding endpoint. ...
```

A llama-cpp model has no embedding endpoint, so memory would only print that one-time notice and add overhead for no semantic-recall benefit.

## How

`enableMemory` used to be a module-init `static const` in `shared.agency` that ran unconditionally when the agent loaded — before `main()` had even parsed `--local-model`. This moves it into an exported `enableAgentMemory()` def that `main()` calls **only on the hosted-provider path**, after the model is resolved and before any handler/REPL is installed (so `with approve` still auto-approves the dir creation safely).

All `std::memory` functions (`setMemoryId`/`recall`/`remember`) no-op when memory isn't enabled, so a local run works fine without it — no guards needed at the call sites.

## Verification

- **Local** (`agency agent --local-model smollm2-135m --print …`): no `[memory]` notice; agent still replies. ✅
- **Hosted** (`agency agent --provider anthropic --print …`): memory **is** enabled — the Tier-2 notice still appears (anthropic also lacks an embedding endpoint) and the agent replies, exit 0 — confirming `enableAgentMemory()` runs correctly before handlers. ✅
- No agent test depended on the old module-init memory side-effect; compiled `.js` bundles are gitignored (only the `.agency` sources changed).

## Note / out of scope

This is scoped to `--local-model`, as requested. A **hosted anthropic** run still prints the Tier-2 notice (memory enabled, but anthropic has no embedding endpoint) — that's pre-existing, by-design behavior. Happy to suppress/soften that separately if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
