### PR TITLE
Record token usage for free/local models (footer showed ↑0 ↓0, no model)

### DIFF
--- a/packages/agency-lang/lib/runtime/state/globalStore.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.ts
@@ -50,8 +50,9 @@ export class GlobalStore {
       // updateTokenStats on every LLM call (across all branches, which
       // pointer-share this object), so subagent spend lands here too.
       // Read by the REPL footer (distinct models used this turn) and
-      // `/cost` (cumulative per-model breakdown).
-      models: {},
+      // `/cost` (cumulative per-model breakdown). Null-prototype so a
+      // provider-supplied model name (e.g. `__proto__`) can't pollute it.
+      models: Object.create(null),
       usage: {
         inputTokens: 0,
         outputTokens: 0,

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -114,6 +114,24 @@ describe("updateTokenStats per-model breakdown", () => {
     expect(globals.getTokenStats().usage.totalTokens).toBe(15);
   });
 
+  it("records usage + model even when cost is undefined (free/local models)", () => {
+    // A local llama-cpp model has no pricing, so the completion's `cost` is
+    // undefined. The token usage must still be recorded (otherwise the agent
+    // footer shows ↑0 ↓0 and no model name).
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(15, 7), cost: undefined, model: "smollm2-135m" });
+    const stats = globals.getTokenStats();
+    expect(stats.usage.inputTokens).toBe(15);
+    expect(stats.usage.outputTokens).toBe(7);
+    expect(stats.usage.totalTokens).toBe(22);
+    expect(stats.models["smollm2-135m"]).toEqual({
+      inputTokens: 15,
+      outputTokens: 7,
+      totalCost: 0,
+    });
+    expect(stats.cost.totalCost).toBe(0);
+  });
+
   it("backfills the models slot for token-stats restored from older checkpoints", () => {
     const globals = GlobalStore.withTokenStats();
     // Simulate a checkpoint written before per-model tracking existed.

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -132,6 +132,17 @@ describe("updateTokenStats per-model breakdown", () => {
     expect(stats.cost.totalCost).toBe(0);
   });
 
+  it("does not pollute the prototype when a model is named __proto__", () => {
+    const globals = GlobalStore.withTokenStats();
+    updateTokenStats({ globals, usage: usage(1, 1), cost: cost(0.001), model: "__proto__" });
+    // The object prototype is untouched (no `inputTokens` leaked onto it).
+    expect(({} as Record<string, unknown>).inputTokens).toBeUndefined();
+    // …and the entry is recorded as a normal own key.
+    const models = globals.getTokenStats().models;
+    expect(Object.prototype.hasOwnProperty.call(models, "__proto__")).toBe(true);
+    expect(models["__proto__"]).toEqual({ inputTokens: 1, outputTokens: 1, totalCost: 0.001 });
+  });
+
   it("backfills the models slot for token-stats restored from older checkpoints", () => {
     const globals = GlobalStore.withTokenStats();
     // Simulate a checkpoint written before per-model tracking existed.

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -146,8 +146,13 @@ export function updateTokenStats(args: {
   cost: any;
   model?: string;
 }): void {
-  const { globals, usage, cost, model } = args;
-  if (!usage || !cost) return;
+  const { globals, usage, model } = args;
+  // `usage` is required, but `cost` may legitimately be absent: a free/local
+  // model (e.g. llama-cpp) has no pricing, so the completion carries token
+  // usage with no cost. Treat a missing cost as zero rather than dropping the
+  // usage — otherwise the agent footer shows ↑0 ↓0 and no model name.
+  if (!usage) return;
+  const cost = args.cost ?? {};
   const tokenStats = globals.get(GlobalStore.INTERNAL_MODULE, "__tokenStats");
   // Accumulate a per-model usage breakdown. Every LLM call (including
   // subagent/tool branches, which pointer-share this object) lands here,

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -140,10 +140,24 @@ export function normalizeModelUsage(rawModels: unknown): ModelUsage[] {
   return out;
 }
 
+/** The token-usage fields `updateTokenStats` reads (all optional — providers
+ *  vary, and a free/local model has no cost). */
+type StatUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
+  totalTokens?: number;
+};
+type StatCost = {
+  inputCost?: number;
+  outputCost?: number;
+  totalCost?: number;
+};
+
 export function updateTokenStats(args: {
   globals: GlobalStore;
-  usage: any;
-  cost: any;
+  usage: StatUsage | null | undefined;
+  cost?: StatCost | null;
   model?: string;
 }): void {
   const { globals, usage, model } = args;
@@ -160,7 +174,12 @@ export function updateTokenStats(args: {
   // attribute spend per model. Defensive against an absent `models` slot
   // for token-stats objects restored from older checkpoints.
   if (model) {
-    if (!tokenStats.models) tokenStats.models = {};
+    // Null-prototype so a provider-supplied model name like `__proto__` becomes
+    // a plain own key instead of mutating the object's prototype. Migrate a
+    // plain-`{}` map (fresh or restored-from-JSON) the first time we write.
+    if (!tokenStats.models || Object.getPrototypeOf(tokenStats.models) !== null) {
+      tokenStats.models = Object.assign(Object.create(null), tokenStats.models);
+    }
     const m = tokenStats.models[model] ??
       (tokenStats.models[model] = { inputTokens: 0, outputTokens: 0, totalCost: 0 });
     m.inputTokens += usage.inputTokens || 0;

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -11,6 +11,7 @@ const {
   readMultiline,
   modelsUsedThisTurn,
   fmtModels,
+  prettyModel,
 } = _internal;
 
 /** Build a snapshot shaped like `readTokenSnapshot`'s return value from
@@ -241,5 +242,40 @@ describe("fmtModels (footer cap)", () => {
 
   it("renders a single model plainly", () => {
     expect(fmtModels(["opus-4.8"])).toBe("opus-4.8");
+  });
+
+  it("prettifies a local GGUF model name", () => {
+    expect(fmtModels(["hf_unsloth_SmolLM2-135M-Instruct.Q4_K_M.gguf"])).toBe(
+      "SmolLM2-135M-Instruct",
+    );
+  });
+});
+
+describe("prettyModel", () => {
+  it("leaves a hosted model id untouched", () => {
+    expect(prettyModel("claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(prettyModel("gpt-5-mini")).toBe("gpt-5-mini");
+  });
+
+  it("reduces a node-llama-cpp download filename to the model name", () => {
+    expect(prettyModel("hf_unsloth_SmolLM2-135M-Instruct.Q4_K_M.gguf")).toBe(
+      "SmolLM2-135M-Instruct",
+    );
+  });
+
+  it("strips a full path and the .gguf extension", () => {
+    expect(prettyModel("/home/u/.agency-agent/models/hf_mistralai_Devstral-Small-2507.Q4_K_M.gguf")).toBe(
+      "Devstral-Small-2507",
+    );
+  });
+
+  it("keeps a non-quant version segment (only strips real quants)", () => {
+    expect(prettyModel("hf_nomic-ai_nomic-embed-text-v1.5.Q4_K_M.gguf")).toBe(
+      "nomic-embed-text-v1.5",
+    );
+  });
+
+  it("handles a plain local .gguf path with no hf_ prefix or quant", () => {
+    expect(prettyModel("/models/my-custom-model.gguf")).toBe("my-custom-model");
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -573,10 +573,27 @@ function fmtElapsed(ms: number): string {
  *  can't blow out the single-line footer. (Use `/cost` for the full
  *  per-model breakdown.) */
 const FOOTER_MODEL_CAP = 3;
+// Known GGUF quantization suffixes (e.g. `.Q4_K_M`, `.Q8_0`, `.IQ4_XS`, `.F16`).
+// Conservative on purpose: only strip a trailing segment that clearly names a
+// quant, so a real model-name segment (e.g. `…-v1.5`, `…-7B`) is left intact.
+const QUANT_SUFFIX = /\.(?:I?Q\d[\w]*|F16|F32|BF16)$/i;
+
+/** A readable footer label for a model. Hosted model IDs pass through
+ *  unchanged; a local GGUF path/filename is reduced to its model name —
+ *  `…/hf_unsloth_SmolLM2-135M-Instruct.Q4_K_M.gguf` → `SmolLM2-135M-Instruct` —
+ *  by taking the basename and dropping node-llama-cpp's `hf_<user>_` prefix,
+ *  the `.gguf` extension, and the quant suffix. */
+function prettyModel(name: string): string {
+  if (!name.endsWith(".gguf")) return name;
+  const base = (name.split(/[\\/]/).pop() ?? name).replace(/\.gguf$/, "");
+  return base.replace(/^hf_[^_]+_/, "").replace(QUANT_SUFFIX, "");
+}
+
 function fmtModels(models: string[]): string {
-  if (models.length <= FOOTER_MODEL_CAP) return models.join(", ");
-  const shown = models.slice(0, FOOTER_MODEL_CAP).join(", ");
-  return `${shown} +${models.length - FOOTER_MODEL_CAP} more`;
+  const pretty = models.map(prettyModel);
+  if (pretty.length <= FOOTER_MODEL_CAP) return pretty.join(", ");
+  const shown = pretty.slice(0, FOOTER_MODEL_CAP).join(", ");
+  return `${shown} +${pretty.length - FOOTER_MODEL_CAP} more`;
 }
 
 async function printFooter(
@@ -1064,6 +1081,7 @@ export const _internal = {
   readMultiline,
   modelsUsedThisTurn,
   fmtModels,
+  prettyModel,
 };
 
 export function _clearScreen(): void {


### PR DESCRIPTION
## Diagnosis

**This is our bug, not smoltalk-llama-cpp.** smoltalk-llama-cpp correctly computes and returns token usage for local models (verified: a turn produced 22 tokens via its `tokenMeter`).

The summary line dropped the model name and token counts because of `updateTokenStats` in `lib/runtime/utils.ts`:

```ts
if (!usage || !cost) return;
```

A local (llama-cpp) model has no pricing, so `calculateCost()` returns `undefined` → the completion's `cost` is `undefined` → this guard **returns before recording usage** into the global per-model token stats that the agent footer reads. Result:

- `tokenStats.usage.inputTokens/outputTokens` stay 0 → `↑0 ↓0`
- `tokenStats.models` stays empty → no model name (and the footer's `modelsUsedThisTurn` filter drops any model with 0 token/cost delta)
- cost `$0.0000` (genuinely free — that part is fine)

The per-*branch* accumulator (`getTokens()`) showed 22 the whole time because it's updated on a separate line in `prompt.ts` that isn't gated on cost — which is what made the two disagree.

## Fix

Require only `usage`; treat a missing `cost` as zero (`args.cost ?? {}`). Hosted providers always carry a cost object, so they're unaffected; free/local models now record their token usage and model.

## Verification

- New unit test: usage with `cost: undefined` still records aggregate tokens + the per-model entry (cost 0).
- Live local-model repro before → after:
  - before: `getModelCosts().length: 0`
  - after: `getModelCosts().length: 1`, `inTok=14 outTok=8` for the model — so the footer now shows `↑14 ↓8 … · <model>`.
- Full `utils`/`agencyLlm` runtime suites green; tsc + structural linter clean.

## Note (possible follow-up)

The model now displays as the resolved GGUF filename (e.g. `SmolLM2-135M-Instruct.Q4_K_M.gguf`) — functional, but not the curated short name (`smollm2-135m`). Prettifying the local-model label in the footer would be a separate, optional change (the clean name isn't available at the completion-recording layer). Happy to do it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
