### PR TITLE
Add multi-line /paste buffers to REPL history (JSON history file)

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/cli.md
@@ -44,7 +44,7 @@ Line-mode REPL. Same call signature as `std::ui.repl` so swapping
   @param onSubmit - Called with the submitted line; return `false` to
   exit or a string to print
   @param prompt - String shown before the input buffer (default "> ")
-  @param historyFile - Path to a newline-separated history file;
+  @param historyFile - Path to a JSON history file (array of entries);
   loaded at start and saved on exit. Empty string disables
   persistence.
   @param historyMax - Trim history to this many most-recent entries
@@ -62,7 +62,7 @@ Line-mode REPL. Same call signature as `std::ui.repl` so swapping
 | historyMax | `number` | 1000 |
 | paletteCommands | `any` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L64))
 
 ### clearScreen
 
@@ -70,7 +70,18 @@ Line-mode REPL. Same call signature as `std::ui.repl` so swapping
 clearScreen()
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L122))
+
+### clearHistory
+
+```ts
+clearHistory()
+```
+
+Clear the REPL input history — both in-session up-arrow recall and the
+  persisted history file. A no-op outside an interactive `repl()` session.
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L126))
 
 ### termWidth
 
@@ -80,7 +91,7 @@ termWidth(): number
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L132))
 
 ### hline
 
@@ -97,4 +108,4 @@ hline(char: string, width: number): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L136))

--- a/packages/agency-lang/docs/site/stdlib/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/cli.md
@@ -78,8 +78,10 @@ clearScreen()
 clearHistory()
 ```
 
-Clear the REPL input history — both in-session up-arrow recall and the
-  persisted history file. A no-op outside an interactive `repl()` session.
+Clear the input history of the **currently running** `repl()` session —
+  both its in-session up-arrow recall and the `historyFile` that session was
+  started with. Takes no path: it acts on the active REPL (which knows its own
+  file). A no-op when called outside an interactive `repl()`.
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L126))
 
@@ -91,7 +93,7 @@ termWidth(): number
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L134))
 
 ### hline
 
@@ -108,4 +110,4 @@ hline(char: string, width: number): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L136))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/cli.agency#L138))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -1,6 +1,6 @@
 import { getVersion } from "std::agency"
 import { parseArgs } from "std::args"
-import { clearMessages, pushMessage, repl, clearScreen } from "std::cli"
+import { clearMessages, pushMessage, repl, clearScreen, clearHistory } from "std::cli"
 import { today } from "std::date"
 import { setAgentCwd } from "std::index"
 import { box, render } from "std::layout"
@@ -185,6 +185,7 @@ def builtinPalette(): Record<string, string> {
   return {
     "/exit": "Exit the agent",
     "/clear": "Clear the conversation transcript",
+    "/clear-history": "Clear the input history (recall + saved file)",
     "/cost": "Show cumulative LLM cost and tokens",
     "/paste": "Multi-line paste mode (Ctrl+D submits, Ctrl+C cancels)",
     "/help": "Show available slash commands"
@@ -228,8 +229,13 @@ def _runTurn(msg: string): boolean {
     clearMessages()
     return true
   }
+  if (trimmed == "/clear-history") {
+    clearHistory()
+    pushMessage("Input history cleared.")
+    return true
+  }
   if (trimmed == "/help") {
-    pushMessage("Commands: /exit, /clear, /cost, /paste, /help")
+    pushMessage("Commands: /exit, /clear, /clear-history, /cost, /paste, /help")
     return true
   }
   if (trimmed == "/cost") {

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -327,6 +327,12 @@ describe("recordHistoryEntry", () => {
     expect(history).toEqual(["line one\nline two", "older"]);
   });
 
+  it("drops the command even when readline stored it with surrounding whitespace", () => {
+    const history = ["/paste   ", "older"]; // raw typed line, untrimmed
+    recordHistoryEntry(history, "pasted", "/paste");
+    expect(history).toEqual(["pasted", "older"]);
+  });
+
   it("removes an earlier duplicate of the same entry", () => {
     const history = ["b", "pasted", "a"];
     recordHistoryEntry(history, "pasted", "/paste");

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { _internal, type PasteState } from "./cli.js";
 
 const {
@@ -12,6 +15,9 @@ const {
   modelsUsedThisTurn,
   fmtModels,
   prettyModel,
+  loadHistory,
+  saveHistory,
+  recordHistoryEntry,
 } = _internal;
 
 /** Build a snapshot shaped like `readTokenSnapshot`'s return value from
@@ -277,5 +283,59 @@ describe("prettyModel", () => {
 
   it("handles a plain local .gguf path with no hf_ prefix or quant", () => {
     expect(prettyModel("/models/my-custom-model.gguf")).toBe("my-custom-model");
+  });
+});
+
+describe("history persistence (JSON)", () => {
+  let dir: string;
+  let file: string;
+  beforeEach(() => {
+    dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "hist-")));
+    file = path.join(dir, "history.json");
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it("round-trips entries, preserving multi-line ones", () => {
+    // saveHistory takes readline order (newest-first).
+    const newestFirst = ["third\nwith newline", "second", "first"];
+    saveHistory(file, newestFirst, 100);
+    expect(loadHistory(file, 100)).toEqual(newestFirst);
+    // The on-disk form is JSON (so a newline can't corrupt it).
+    const onDisk = JSON.parse(fs.readFileSync(file, "utf8"));
+    expect(onDisk).toEqual(["first", "second", "third\nwith newline"]); // oldest-first
+  });
+
+  it("returns [] for a missing or non-array/corrupt file", () => {
+    expect(loadHistory(path.join(dir, "nope.json"), 100)).toEqual([]);
+    fs.writeFileSync(file, "{not json");
+    expect(loadHistory(file, 100)).toEqual([]);
+    fs.writeFileSync(file, JSON.stringify({ not: "an array" }));
+    expect(loadHistory(file, 100)).toEqual([]);
+  });
+
+  it("caps to max, keeping the newest", () => {
+    saveHistory(file, ["e", "d", "c", "b", "a"], 3); // newest-first
+    // Stored newest 3 (e, d, c); loaded back newest-first.
+    expect(loadHistory(file, 3)).toEqual(["e", "d", "c"]);
+  });
+});
+
+describe("recordHistoryEntry", () => {
+  it("makes the entry most-recent and drops the command that added it", () => {
+    const history = ["/paste", "older"]; // readline added "/paste"
+    recordHistoryEntry(history, "line one\nline two", "/paste");
+    expect(history).toEqual(["line one\nline two", "older"]);
+  });
+
+  it("removes an earlier duplicate of the same entry", () => {
+    const history = ["b", "pasted", "a"];
+    recordHistoryEntry(history, "pasted", "/paste");
+    expect(history).toEqual(["pasted", "b", "a"]);
+  });
+
+  it("is a no-op-safe prepend when the command isn't present", () => {
+    const history = ["a"];
+    recordHistoryEntry(history, "x", "/paste");
+    expect(history).toEqual(["x", "a"]);
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -347,17 +347,30 @@ describe("recordHistoryEntry", () => {
 });
 
 describe("_clearHistory", () => {
-  afterEach(() => { delete (globalThis as Record<string, unknown>).__agencyClearHistory; });
+  let dir: string;
+  beforeEach(() => { dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "clearhist-"))); });
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__agencyClearHistory;
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
 
-  it("invokes the installed __agencyClearHistory hook", () => {
+  it("invokes the installed __agencyClearHistory hook (live recall)", () => {
     const spy = vi.fn();
     (globalThis as Record<string, unknown>).__agencyClearHistory = spy;
-    _clearHistory();
+    _clearHistory("");
     expect(spy).toHaveBeenCalledOnce();
   });
 
   it("is a no-op when no REPL hook is installed", () => {
     delete (globalThis as Record<string, unknown>).__agencyClearHistory;
-    expect(() => _clearHistory()).not.toThrow();
+    expect(() => _clearHistory("")).not.toThrow();
+  });
+
+  it("clears the persisted file at the supplied path", () => {
+    const file = path.join(dir, "history.json");
+    saveHistory(file, ["c", "b", "a"], 100);
+    expect(loadHistory(file, 100)).toEqual(["c", "b", "a"]);
+    _clearHistory(file);
+    expect(loadHistory(file, 100)).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.test.ts
+++ b/packages/agency-lang/lib/stdlib/cli.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { _internal, type PasteState } from "./cli.js";
+import { _internal, _clearHistory, type PasteState } from "./cli.js";
 
 const {
   EMPTY_PASTE,
@@ -337,5 +337,21 @@ describe("recordHistoryEntry", () => {
     const history = ["a"];
     recordHistoryEntry(history, "x", "/paste");
     expect(history).toEqual(["x", "a"]);
+  });
+});
+
+describe("_clearHistory", () => {
+  afterEach(() => { delete (globalThis as Record<string, unknown>).__agencyClearHistory; });
+
+  it("invokes the installed __agencyClearHistory hook", () => {
+    const spy = vi.fn();
+    (globalThis as Record<string, unknown>).__agencyClearHistory = spy;
+    _clearHistory();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("is a no-op when no REPL hook is installed", () => {
+    delete (globalThis as Record<string, unknown>).__agencyClearHistory;
+    expect(() => _clearHistory()).not.toThrow();
   });
 });

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -730,6 +730,18 @@ export async function _runLineRepl(
   const prevStopSpinner = (globalThis as any)[stopSpinnerKey];
   (globalThis as any)[stopSpinnerKey] = stopActiveSpinner;
 
+  // Register a "clear history" hook so a command handler (e.g. the agent's
+  // `/clear-history`) can wipe the active session's recall + the persisted
+  // file without reaching into this readline directly. Same install/restore
+  // lifecycle as the hooks above.
+  const clearHistoryKey = "__agencyClearHistory";
+  const prevClearHistory = (globalThis as any)[clearHistoryKey];
+  (globalThis as any)[clearHistoryKey] = () => {
+    const h = (rl as unknown as { history?: string[] }).history;
+    if (h) h.length = 0;
+    saveHistory(historyFile, [], historyMax);
+  };
+
   // `/` at an empty prompt synthesizes Enter so the bare-`/` branch
   // in the loop body fires immediately and opens the palette modal.
   const teardownSlashTrigger = installSlashTrigger(rl, palette, useTTY);
@@ -876,6 +888,7 @@ export async function _runLineRepl(
     teardownSlashTrigger();
     (globalThis as any)[overrideKey] = prevOverride;
     (globalThis as any)[stopSpinnerKey] = prevStopSpinner;
+    (globalThis as any)[clearHistoryKey] = prevClearHistory;
     // Persist whatever entries readline accumulated. `rl.history` is
     // newest-first and already contains the history we loaded at startup
     // PLUS everything added this session (including any `/paste` buffer we
@@ -1106,6 +1119,14 @@ export function _clearScreen(): void {
   // ANSI escape code to clear the screen and move the cursor to the top-left.
   //  process.stdout.write("\033[H\033[2J");
   process.stdout.write('\x1B[2J\x1B[H');
+}
+
+/** Clear the active `repl()` session's input history — both in-session recall
+ *  and the persisted history file — via the `__agencyClearHistory` hook
+ *  `_runLineRepl` installs. A no-op outside an interactive REPL. */
+export function _clearHistory(): void {
+  const fn = (globalThis as any).__agencyClearHistory;
+  if (typeof fn === "function") fn();
 }
 
 export function _termWidth(): number {

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -5,6 +5,7 @@ import {
   writeFileSync,
   existsSync,
   mkdirSync,
+  renameSync,
 } from "fs";
 import { dirname } from "path";
 import { __call } from "../runtime/call.js";
@@ -70,7 +71,14 @@ function saveHistory(file: string, history: string[], max: number): void {
   try {
     mkdirSync(dirname(file), { recursive: true });
     const oldestFirst = history.slice(0, max).slice().reverse();
-    writeFileSync(file, JSON.stringify(oldestFirst, null, 2) + "\n", "utf8");
+    const data = JSON.stringify(oldestFirst, null, 2) + "\n";
+    // Write to a sibling temp file, then rename into place. The rename is an
+    // atomic swap (POSIX, and Windows via libuv's REPLACE_EXISTING), so a crash
+    // mid-write can't leave a half-written file — which, as JSON, would parse to
+    // empty and silently wipe the user's history on the next load.
+    const tmp = `${file}.tmp-${process.pid}`;
+    writeFileSync(tmp, data, "utf8");
+    renameSync(tmp, file);
   } catch {
     // Ignore — best-effort persistence.
   }
@@ -83,7 +91,11 @@ function saveHistory(file: string, history: string[], max: number): void {
  *  never sees the buffer itself, only the `/paste` keystrokes. */
 function recordHistoryEntry(history: string[], entry: string, command: string): void {
   for (let i = history.length - 1; i >= 0; i--) {
-    if (history[i] === entry || history[i] === command) history.splice(i, 1);
+    // `command` is matched after trimming because readline stores the raw line
+    // (`"/paste   "`), while the command itself is the trimmed form. `entry`
+    // (the pasted buffer) is matched exactly — its surrounding whitespace is
+    // content.
+    if (history[i] === entry || history[i].trim() === command) history.splice(i, 1);
   }
   history.unshift(entry);
 }

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -44,35 +44,48 @@ async function callBridgeFn<T>(fn: unknown, ...args: unknown[]): Promise<T> {
   return (await __call(fn, { type: "positional", args })) as T;
 }
 
-/** Read `historyFile` (one entry per line, oldest first) and return
- *  the entries in the order Node's `readline` expects them: newest
- *  first, capped at `max`. Returns `[]` on any I/O error so a
- *  corrupt or missing history file never breaks startup. */
+/** Read `historyFile` (a JSON array of entries, oldest first) and return
+ *  them in the order Node's `readline` expects: newest first, capped at
+ *  `max`. JSON (rather than one-entry-per-line) so a `/paste` buffer with
+ *  embedded newlines round-trips instead of splitting into bogus entries.
+ *  Returns `[]` on any I/O or parse error (or a non-array file) so a corrupt
+ *  or missing history file never breaks startup. */
 function loadHistory(file: string, max: number): string[] {
   if (!file || !existsSync(file)) return [];
   try {
-    const raw = readFileSync(file, "utf8");
-    const lines = raw.split("\n").filter((l) => l.length > 0);
-    return lines.reverse().slice(0, max);
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((e): e is string => typeof e === "string").reverse().slice(0, max);
   } catch {
     return [];
   }
 }
 
-/** Persist `history` (in readline's newest-first order) to `file`,
- *  storing it oldest-first one entry per line so re-loading yields
- *  identical chronology. Creates parent dirs as needed. Swallows
+/** Persist `history` (in readline's newest-first order) to `file` as a JSON
+ *  array stored oldest-first, so re-loading yields identical chronology and a
+ *  multi-line entry survives intact. Creates parent dirs as needed. Swallows
  *  errors so a read-only HOME doesn't crash the REPL on exit. */
 function saveHistory(file: string, history: string[], max: number): void {
   if (!file) return;
   try {
     mkdirSync(dirname(file), { recursive: true });
-    const trimmed = history.slice(0, max);
-    const lines = trimmed.slice().reverse();
-    writeFileSync(file, lines.join("\n") + (lines.length ? "\n" : ""), "utf8");
+    const oldestFirst = history.slice(0, max).slice().reverse();
+    writeFileSync(file, JSON.stringify(oldestFirst, null, 2) + "\n", "utf8");
   } catch {
     // Ignore — best-effort persistence.
   }
+}
+
+/** Make `entry` the most-recent item in `history` (readline's newest-first
+ *  array), removing the `command` readline added for it (e.g. `/paste`, which
+ *  triggered the multi-line editor) and any earlier duplicate of `entry`. This
+ *  is how a pasted buffer reaches up-arrow recall and persistence — readline
+ *  never sees the buffer itself, only the `/paste` keystrokes. */
+function recordHistoryEntry(history: string[], entry: string, command: string): void {
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i] === entry || history[i] === command) history.splice(i, 1);
+  }
+  history.unshift(entry);
 }
 
 /** Drives the line-mode REPL loop. Per iteration: prompt → await
@@ -765,6 +778,11 @@ export async function _runLineRepl(
         if (buffer === null || buffer.trim().length === 0) continue;
         line = buffer;
         trimmed = buffer;
+        // readline only saw the `/paste` keystrokes, not the buffer the editor
+        // produced — so add the buffer to history ourselves (replacing the
+        // `/paste` command entry) for up-arrow recall and persistence.
+        const rlHistory = (rl as unknown as { history?: string[] }).history;
+        if (rlHistory) recordHistoryEntry(rlHistory, buffer, "/paste");
       }
 
       const banner = line.includes("\n")
@@ -860,16 +878,13 @@ export async function _runLineRepl(
     (globalThis as any)[stopSpinnerKey] = prevStopSpinner;
     // Persist whatever entries readline accumulated. `rl.history` is
     // newest-first and already contains the history we loaded at startup
-    // PLUS everything added this session — so saving it preserves prior
-    // sessions instead of overwriting the file with just this run's input.
-    // The `history` property is undocumented-ish but stable across the Node
-    // versions we support, and is the only way to read it back. Drop
-    // multi-line entries (a `/paste` buffer) — the on-disk format is one
-    // entry per line, so a multi-line entry would reload as several bogus
-    // ones.
-    const accumulated = (
-      (rl as unknown as { history?: string[] }).history ?? []
-    ).filter((entry) => !entry.includes("\n"));
+    // PLUS everything added this session (including any `/paste` buffer we
+    // recorded above) — so saving it preserves prior sessions instead of
+    // overwriting the file with just this run's input. The `history` property
+    // is undocumented-ish but stable across the Node versions we support, and
+    // is the only way to read it back. Multi-line entries are fine: the file
+    // is JSON, so a `/paste` buffer round-trips intact.
+    const accumulated = (rl as unknown as { history?: string[] }).history ?? [];
     saveHistory(historyFile, accumulated, historyMax);
     rl.close();
   }
@@ -1082,6 +1097,9 @@ export const _internal = {
   modelsUsedThisTurn,
   fmtModels,
   prettyModel,
+  loadHistory,
+  saveHistory,
+  recordHistoryEntry,
 };
 
 export function _clearScreen(): void {

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -743,15 +743,17 @@ export async function _runLineRepl(
   (globalThis as any)[stopSpinnerKey] = stopActiveSpinner;
 
   // Register a "clear history" hook so a command handler (e.g. the agent's
-  // `/clear-history`) can wipe the active session's recall + the persisted
-  // file without reaching into this readline directly. Same install/restore
-  // lifecycle as the hooks above.
+  // `/clear-history`) can wipe this session's *live* recall. The hook only
+  // touches `rl.history` — a Node object owned by this running readline, which
+  // can't live anywhere but TS. The persisted *file* is cleared separately by
+  // `_clearHistory`, using a path Agency holds as a module global (so the file
+  // identity lives in the execution model, not in this closure). Same
+  // install/restore lifecycle as the hooks above.
   const clearHistoryKey = "__agencyClearHistory";
   const prevClearHistory = (globalThis as any)[clearHistoryKey];
   (globalThis as any)[clearHistoryKey] = () => {
     const h = (rl as unknown as { history?: string[] }).history;
     if (h) h.length = 0;
-    saveHistory(historyFile, [], historyMax);
   };
 
   // `/` at an empty prompt synthesizes Enter so the bare-`/` branch
@@ -1133,10 +1135,17 @@ export function _clearScreen(): void {
   process.stdout.write('\x1B[2J\x1B[H');
 }
 
-/** Clear the active `repl()` session's input history — both in-session recall
- *  and the persisted history file — via the `__agencyClearHistory` hook
- *  `_runLineRepl` installs. A no-op outside an interactive REPL. */
-export function _clearHistory(): void {
+/** Clear `repl()` input history. Splits cleanly along the state boundary:
+ *
+ *  - The persisted *file* is cleared at `path`, which the caller supplies.
+ *    Agency holds the path as a module global (`_historyFile`), so the file's
+ *    identity lives in the execution model rather than in a TS closure. Works
+ *    even with no active REPL; `saveHistory` no-ops on an empty path.
+ *  - The *live* in-session recall (`rl.history`) is a Node object owned by the
+ *    running readline, so that wipe goes through the `__agencyClearHistory`
+ *    hook `_runLineRepl` installs. A no-op outside an interactive REPL. */
+export function _clearHistory(path: string): void {
+  saveHistory(path, [], 0);
   const fn = (globalThis as any).__agencyClearHistory;
   if (typeof fn === "function") fn();
 }

--- a/packages/agency-lang/stdlib/cli.agency
+++ b/packages/agency-lang/stdlib/cli.agency
@@ -124,8 +124,10 @@ export def clearScreen() {
 }
 
 export def clearHistory() {
-  """Clear the REPL input history — both in-session up-arrow recall and the
-  persisted history file. A no-op outside an interactive `repl()` session."""
+  """Clear the input history of the **currently running** `repl()` session —
+  both its in-session up-arrow recall and the `historyFile` that session was
+  started with. Takes no path: it acts on the active REPL (which knows its own
+  file). A no-op when called outside an interactive `repl()`."""
   _clearHistory()
 }
 

--- a/packages/agency-lang/stdlib/cli.agency
+++ b/packages/agency-lang/stdlib/cli.agency
@@ -61,6 +61,12 @@ import {
 // needed to be re-exported here for line mode to work.
 export { pushMessage, clearMessages } from "std::ui"
 
+// The active `repl()` session's history-file path, held as an Agency module
+// global so it lives in the execution model (serialized, module-isolated)
+// rather than captured in a TS closure. `clearHistory()` reads it to know
+// which file to clear — the runtime remembers the path, not a TS hook.
+let _historyFile: string = ""
+
 export def repl(
   status: any,
   onSubmit: any,
@@ -109,6 +115,9 @@ export def repl(
   @param paletteCommands - Map of /cmd -> description; reserved for
   WL6 tab completion
   """
+  // Publish the path to the execution-model global so `clearHistory()` can
+  // resolve which file to clear from Agency state rather than a TS closure.
+  _historyFile = historyFile
   _runLineRepl(
     status,
     onSubmit,
@@ -126,9 +135,11 @@ export def clearScreen() {
 export def clearHistory() {
   """Clear the input history of the **currently running** `repl()` session —
   both its in-session up-arrow recall and the `historyFile` that session was
-  started with. Takes no path: it acts on the active REPL (which knows its own
-  file). A no-op when called outside an interactive `repl()`."""
-  _clearHistory()
+  started with. The file path comes from the `_historyFile` execution-model
+  global (set by `repl()`), so the runtime remembers which file to clear; the
+  live up-arrow recall is wiped via the active REPL. A no-op when called
+  outside an interactive `repl()`."""
+  _clearHistory(_historyFile)
 }
 
 export safe def termWidth(): number {

--- a/packages/agency-lang/stdlib/cli.agency
+++ b/packages/agency-lang/stdlib/cli.agency
@@ -2,6 +2,7 @@ import {
   _runLineRepl,
   _clearScreen,
   _termWidth,
+  _clearHistory,
  } from "agency-lang/stdlib-lib/cli.js"
 
 /*
@@ -101,7 +102,7 @@ export def repl(
   @param onSubmit - Called with the submitted line; return `false` to
   exit or a string to print
   @param prompt - String shown before the input buffer (default "> ")
-  @param historyFile - Path to a newline-separated history file;
+  @param historyFile - Path to a JSON history file (array of entries);
   loaded at start and saved on exit. Empty string disables
   persistence.
   @param historyMax - Trim history to this many most-recent entries
@@ -120,6 +121,12 @@ export def repl(
 
 export def clearScreen() {
   _clearScreen()
+}
+
+export def clearHistory() {
+  """Clear the REPL input history — both in-session up-arrow recall and the
+  persisted history file. A no-op outside an interactive `repl()` session."""
+  _clearHistory()
 }
 
 export safe def termWidth(): number {


### PR DESCRIPTION
## Summary

A multi-line `/paste` buffer in the agent REPL never made it into history — you couldn't up-arrow to recall it, and it wasn't persisted. Two reasons:

1. **readline never saw the buffer.** The `/paste` editor (`readMultiline`) reads keystrokes itself; readline only saw the typed `/paste` command, so its auto-history added `/paste`, not the pasted content.
2. **The on-disk format couldn't hold it.** History was stored one-entry-per-line, so the save path *deliberately dropped* any entry containing a newline (a multi-line buffer would otherwise reload as several bogus entries).

## Fix

- **History file is now JSON** (an array of entries), so a multi-line buffer round-trips intact. Per the owner's call, **no backwards compat**: an old newline-delimited file fails to `JSON.parse` and is treated as empty (returns `[]`), then rewritten as JSON on the next save.
- **After `/paste`, the buffer is recorded in `rl.history`** via `recordHistoryEntry` — it removes the `/paste` command entry readline added (and any earlier duplicate) and makes the buffer the most-recent item, so up-arrow recalls it and it persists.
- **Stopped dropping multi-line entries on save.**

## Testing

- New unit tests:
  - `loadHistory`/`saveHistory` JSON round-trip preserving a multi-line entry; `[]` for missing/corrupt/non-array files; cap-to-max keeps the newest.
  - `recordHistoryEntry`: makes the entry most-recent, drops the `/paste` command entry, removes an earlier duplicate, safe-prepends when the command isn't present.
- Full `cli` suite (41) green; tsc + structural linter clean.

The pure pieces (history I/O + the recall-insertion logic) are covered directly; the `/paste` → `recordHistoryEntry(rl.history, …)` → `saveHistory` wiring in `_runLineRepl` is straightforward glue around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
