### PR TITLE
feat(typechecker): discriminated-union narrowing (D1 + D2)

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Language / Typechecker
+- Discriminated-union narrowing: `if (v.kind == "answer")` (or `!=`) now narrows `v` to the matching union member(s) in the then-branch and the complement in the else-branch; `match` arms narrow bound fields via the lowered scrutinee. Composes with `!`/`&&`/`||`/early-return/`while`.
+  - **Migration (typechecker-enabled projects only):** inside such a guard, accessing a property that exists on a *different* member is now an error — previously union property access was lenient. This is the intended behavior; update the access or guard accordingly.
+
 ## Jun 24 2026 — v0.6.4
 
 ### Language / Typechecker

--- a/packages/agency-lang/docs/dev/typechecker.md
+++ b/packages/agency-lang/docs/dev/typechecker.md
@@ -259,6 +259,31 @@ for its then- and else-branches. It recognizes a single `isSuccess(x)` /
 match is unambiguous), and composes over boolean combinators: `!c` swaps
 then/else, `a && b` unions then-facts, `a || b` unions else-facts.
 
+Each candidate carries a tagged `Refine` (`{ variableName, refine }`) and is
+applied through a declarative `narrowers` table keyed by `refine.kind` — so a
+new narrowing form is one table entry, not a change to the apply loop. The two
+forms today are `resultBranch` (above) and `discriminant`.
+
+**Discriminated-union narrowing:** `analyzeCondition` also recognizes
+`v.prop == literal` / `v.prop != literal` over a bare variable (either operand
+order; string/number/boolean literals via the shared `literalToType`).
+`narrowUnionByDiscriminant` then filters the union's members by that literal
+discriminant property — `if (r.kind == "answer")` narrows `r` to the matching
+member(s) in the then-branch and the complement in the else-branch. Like Result
+narrowing it is sound/conservative: a member whose discriminant property isn't a
+*matching-kind literal type* (a plain `string`, a wider union, a different
+literal kind) can't be proven disjoint, so it is kept — and narrowing to `never`
+(or to the full set) is suppressed entirely (returns "no narrowing"). Match arms
+come for free: `match (r) { { kind: "answer", data } => … }` lowers to
+`const __s = r; if (__s.kind == "answer") { const data = __s.data; … }`, so the
+bound field `data` reads the narrowed temp with no match-specific code.
+
+Two limitations: (1) only *bound fields* of the scrutinee narrow — the scrutinee
+variable in the source isn't re-typed, only the lowered temp; (2) a mixed union
+with a non-literal discriminant member (`{ kind: "a" } | { kind: string }`)
+doesn't narrow, by design (the `string` member can't be excluded). The `is`-form
+match (`match (x is …)`) is guard-based and intentionally untagged.
+
 `walkScopeBody` applies the facts by walking each branch in a `scope.child()`
 whose refinements are written with `declareLocal` — so they never leak past the
 branch, while real declarations inside the branch still flow to the function

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-27-discriminated-union-narrowing.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-27-discriminated-union-narrowing.md
@@ -1,0 +1,561 @@
+# Discriminated-Union Narrowing (D1 + D2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Post-review revision.** Folds in three reviews (`.review.md`, `.anti-patterns.md`, `.tests.md`): (A) reuse existing literal *types* instead of a parallel `LiteralValue`; (B) declarative `narrowers` dispatch table; corrected match-arm witnessing test; added coverage (boolean/numeric/3+member/scope-leak/while/post-guard/&&/!/non-union); **the binding hint is deferred** (the gated version needs an `ObjectType` narrowing marker that conflicts with `result-as-union` removing `narrowedBranch` — not worth it now; the unconditional version misfires on plain-object typos).
+
+> **Second-review correction (verified against `main`).** `synthType` does **not** currently convert numeric/boolean literals to literal types — only the *string* case yields a `stringLiteralType`; `number`/`unitLiteral` → `NUMBER_T` and `boolean` → `BOOLEAN_T` (`synthesizer.ts:142-164`). So the DRY refactor of `synthType` is scoped to the **string case only** (Task 2 Step 1); routing `number`/`boolean` through `literalToType` would change inference (`let x = 42` → literal `42` instead of `number`) and break the "type-checker-only / no behavior change" guarantee. `literalToType` itself still produces all three literal types — the recognizer needs them, and the numeric/boolean narrowing tests rely on the **type parser** (not `synthType`) producing literal types in `{ code: 1 }` / `{ ok: true }` annotations, which it does.
+
+**Goal:** Narrow a union-typed variable when a branch tests its discriminant — `if (r.kind == "answer") { … }` narrows `r` to the matching member(s). Foundation for the rest of the narrowing program.
+
+**Architecture:** Extend the merged Increment 1–2 engine (`lib/typeChecker/narrowing.ts`). Generalize `NarrowCandidate` to a tagged `{ refine }` (`resultBranch | discriminant`); dispatch via a declarative `narrowers` table; teach `analyzeCondition` to recognize `v.prop == literal` / `!= literal`; add `narrowUnionByDiscriminant`. Type-checker-only — no AST/codegen change, so interrupts are unaffected.
+
+**Tech Stack:** TypeScript, vitest. Spec: `discriminated-union-narrowing-spec.md` (repo root).
+
+## Global Constraints
+
+- NEVER use dynamic imports. Use `type` aliases not `interface`. No one-line `if`s (anti-patterns.md). (CLAUDE.md)
+- vitest **unit** tests: `npx vitest run <path>`, NOT the agency runner.
+- **Type-checker-only.** No lowering/codegen change. Merged Result narrowing must stay behavior-identical (its e2e tests in `narrowing.test.ts` are the Task 1 gate).
+- **Sound: false-negative only.** Never exclude a member that could match; never narrow to `never`; non-union/unknown → no narrowing. Variable-keyed scrutinee only.
+- **DRY:** reuse existing literal-type construction and `safeResolveType`; do not build a parallel literal system.
+- **Verified facts (live on `main`):**
+  - `narrowing.ts`: `NarrowCandidate = { variableName; branch }`, `ConditionFacts = { then; else }`, `analyzeCondition(condition: Expression): ConditionFacts`, `applyNarrowing(childScope, candidates, branchBody, typeAliases)`, `narrowToBranch(rt, branch)`, `isReassignedIn(body, name)`; `safeResolveType` imported from `./assignability.js`. `NarrowCandidate` is consumed **only** inside `narrowing.ts` (scopes.ts uses the helpers, never `.branch`) — so `tsc` is a reliable gate for the Task 1 rename.
+  - `ValueAccess = { type:"valueAccess"; base; chain }`; `v.kind` = base `{type:"variableName", value:"v"}` + one `{kind:"property", name:"kind"}`.
+  - Literal AST → literal type: in `synthType` (`synthesizer.ts:142-164`) **only the string case** yields a literal type today — string with `segments.length===1 && segments[0].type==="text"` → `{type:"stringLiteralType", value}` (else `STRING_T`). `number`/`unitLiteral` → `NUMBER_T`; `boolean` → `BOOLEAN_T` (general types, **not** literal types). `literalToType` (this plan) intentionally produces all three (`number` → `{type:"numberLiteralType", value: e.value}` where the AST `number` node's `value` is a **string**; `boolean` → `{type:"booleanLiteralType", value: e.value?"true":"false"}`) for the recognizer — but `synthType` is only refactored on its string case (see Task 2 Step 1).
+  - Discriminant literal types in union members come from the **type-annotation parser**, not `synthType`: `{ kind: "answer" }` → `stringLiteralType`, `{ code: 1 }` → `numberLiteralType` (`value:"1"`), `{ ok: true }` → `booleanLiteralType` (`value:"true"`). Verified via `pnpm run ast`. This is what the numeric/boolean e2e narrowing tests depend on.
+  - Literal types: `stringLiteralType`/`numberLiteralType` (`value: string`), `booleanLiteralType` (`value:"true"|"false"`). `ObjectType.properties: {key, value}[]`.
+  - `synthValueAccess`: lenient `unionType` branch (`synthesizer.ts:648-672`) returns the prop's type from members that have it (errors only if none do); strict `objectType` branch (`:673-683`) errors "Property … does not exist". The witnessing tests exploit this: narrowing to a single member makes an other-member field error.
+
+---
+
+## File Structure
+
+- **Create** `lib/typeChecker/literalType.ts` — `literalToType(expr)` shared by the recognizer and (refactored) `synthesizer.ts`.
+- **Modify** `lib/typeChecker/narrowing.ts` — `Refine`/`NarrowCandidate`; `narrowers` table dispatch; discriminant recognizer; `narrowUnionByDiscriminant`.
+- **Modify** `lib/typeChecker/synthesizer.ts` — reuse `literalToType` for the **string** case at `:145-150` only (DRY); leave `number`/`boolean` returning `NUMBER_T`/`BOOLEAN_T` (behavior-preserving).
+- **Modify** `lib/typeChecker/narrowing.test.ts` — update existing `analyzeCondition` unit tests; add discriminant unit + e2e + match-arm tests.
+
+---
+
+### Task 1: Tagged `Refine` + declarative `narrowers` dispatch (behavior-preserving)
+
+Pure refactor: Result narrowing works identically; only representation + dispatch change so the discriminant variant slots in (Task 2) and future variants (presence; removing resultBranch) are one table edit.
+
+**Files:** Modify `lib/typeChecker/narrowing.ts`; Test `lib/typeChecker/narrowing.test.ts`.
+
+**Interfaces:**
+- Produces: `Refine = { kind:"resultBranch"; branch:"success"|"failure" } | { kind:"discriminant"; prop:string; literal: StringLiteralType|NumberLiteralType|BooleanLiteralType; keep:boolean }`; `NarrowCandidate = { variableName:string; refine: Refine }`; a `narrowers` table `{ [K in Refine["kind"]]: (refine, current, aliases) => VariableType | null }`.
+
+- [ ] **Step 1: Update existing `analyzeCondition` unit tests to the `refine` shape**
+
+In `narrowing.test.ts`, wrap every `{ variableName, branch }` expectation as `{ variableName, refine: { kind: "resultBranch", branch } }` — the `isSuccess`/`isFailure`/`!`/`&&`/`||`/double-negation cases. `produces no candidates` cases stay `{ then: [], else: [] }`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `npx vitest run lib/typeChecker/narrowing.test.ts -t "analyzeCondition"` — Expected: FAIL (code still emits `{ variableName, branch }`).
+
+- [ ] **Step 3: Add the types + table; update `analyzeCondition` + `applyNarrowing`**
+
+In `narrowing.ts` add the imports `import type { VariableType } from "../types.js";` and `import type { StringLiteralType, NumberLiteralType, BooleanLiteralType } from "../types/typeHints.js";`, then:
+
+```ts
+export type Refine =
+  | { kind: "resultBranch"; branch: "success" | "failure" }
+  | {
+      kind: "discriminant";
+      prop: string;
+      literal: StringLiteralType | NumberLiteralType | BooleanLiteralType;
+      keep: boolean;
+    };
+export type NarrowCandidate = { variableName: string; refine: Refine };
+
+// "what": given a refine + the variable's current type, the narrowed type (or null).
+// "how" (loop, reassignment gate, declareLocal) lives in applyNarrowing.
+const narrowers: {
+  [K in Refine["kind"]]: (
+    refine: Extract<Refine, { kind: K }>,
+    current: VariableType,
+    aliases: Record<string, TypeAliasEntry>,
+  ) => VariableType | null;
+} = {
+  resultBranch: (r, current, aliases) => {
+    const resolved = safeResolveType(current, aliases);
+    return resolved.type === "resultType" ? narrowToBranch(resolved, r.branch) : null;
+  },
+  // discriminant added in Task 2
+  discriminant: () => null,
+};
+```
+
+Update the `isSuccess`/`isFailure` return in `analyzeCondition`:
+
+```ts
+  return {
+    then: [{ variableName: name, refine: { kind: "resultBranch", branch: thenBranch } }],
+    else: [{ variableName: name, refine: { kind: "resultBranch", branch: elseBranch } }],
+  };
+```
+
+Replace the body of `applyNarrowing`'s loop with the declarative dispatch:
+
+```ts
+  for (const cand of candidates) {
+    const current = childScope.lookup(cand.variableName);
+    if (!current || current === "any") continue;
+    if (isReassignedIn(branchBody, cand.variableName)) continue;
+    const narrow = narrowers[cand.refine.kind];
+    const narrowed = narrow(cand.refine as never, current, typeAliases);
+    if (narrowed !== null) childScope.declareLocal(cand.variableName, narrowed);
+  }
+```
+
+- [ ] **Step 4: Run the full narrowing suite (Result equivalence gate)**
+
+Run: `npx vitest run lib/typeChecker/narrowing.test.ts 2>&1 | tee /tmp/d1t1.log` — Expected: PASS; **all existing Result e2e tests pass unchanged**. A failure means the dispatch diverged from the old Result path.
+
+- [ ] **Step 5: tsc + commit**
+
+Run: `npx tsc --noEmit` — Expected: clean.
+
+```bash
+git add lib/typeChecker/narrowing.ts lib/typeChecker/narrowing.test.ts
+git commit -F - <<'EOF'
+refactor(typechecker): tagged Refine + declarative narrowers dispatch
+
+NarrowCandidate becomes { refine } (resultBranch | discriminant), dispatched
+via a narrowers table keyed by refine.kind. Splits the "what to narrow to"
+from the "how" (loop, reassignment gate, declareLocal). Behavior-preserving;
+the discriminant entry is wired next.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 2: Discriminant narrowing engine (Form 1)
+
+**Files:** Create `lib/typeChecker/literalType.ts`; Modify `lib/typeChecker/narrowing.ts`, `lib/typeChecker/synthesizer.ts`; Test `lib/typeChecker/narrowing.test.ts`.
+
+**Interfaces:**
+- Produces: `literalToType(e: Expression): StringLiteralType | NumberLiteralType | BooleanLiteralType | null`; `analyzeCondition` recognizes `v.prop ==/!= literal`; `narrowUnionByDiscriminant(type, prop, literal, keep, aliases): VariableType | null`.
+
+- [ ] **Step 1: Verify the literal AST shape, then extract `literalToType` (DRY)**
+
+First confirm the canonical literal shape (Concern: template literals): `pnpm run ast` on a file containing `if (r.kind == "answer") {}` — confirm `"answer"` is `{type:"string", segments:[{type:"text", value:"answer"}]}`. (A bare `` `answer` `` template with no holes may differ; if so, document non-coverage — do not special-case it in D1.)
+
+Create `lib/typeChecker/literalType.ts`:
+
+```ts
+import type { Expression } from "../types.js";
+import type {
+  StringLiteralType,
+  NumberLiteralType,
+  BooleanLiteralType,
+} from "../types/typeHints.js";
+
+/** Convert a literal expression to its literal type, or null if not a simple
+ *  literal. Single source of truth — `synthType`'s literal cases also use it. */
+export function literalToType(
+  e: Expression,
+): StringLiteralType | NumberLiteralType | BooleanLiteralType | null {
+  if (e.type === "string" && e.segments.length === 1 && e.segments[0].type === "text") {
+    return { type: "stringLiteralType", value: e.segments[0].value };
+  }
+  if (e.type === "number") {
+    return { type: "numberLiteralType", value: e.value };
+  }
+  if (e.type === "boolean") {
+    return { type: "booleanLiteralType", value: e.value ? "true" : "false" };
+  }
+  return null;
+}
+```
+
+Refactor **only the `string` case** of `synthType` (`synthesizer.ts:145-150`) to delegate to `literalToType` — that is the lone case that already produces a literal type, so this is behavior-preserving:
+
+```ts
+    case "string":
+      return literalToType(expr) ?? STRING_T;
+```
+
+**Do NOT touch the `number`/`unitLiteral` or `boolean` cases** — they must keep returning `NUMBER_T`/`BOOLEAN_T`. Routing them through `literalToType` would make `synthType` infer literal types (`let x = 42` → `42` instead of `number`), a real behavior change that violates the type-checker-only guarantee and regresses inference/assignability tests. `literalToType` still returns all three literal types; only the recognizer (Step 4) consumes the numeric/boolean ones. Run `npx vitest run lib/typeChecker/ 2>&1 | tee /tmp/d1-synth.log` to confirm no regression (string-literal inference unchanged; number/boolean untouched).
+
+- [ ] **Step 2: Write the failing recognizer unit tests**
+
+Append to the `analyzeCondition` describe:
+
+```ts
+const disc = (keep: boolean, value = "answer", prop = "kind") => ({
+  variableName: "r",
+  refine: { kind: "discriminant", prop, literal: { type: "stringLiteralType", value }, keep },
+});
+
+it.each([
+  ['r.kind == "answer"', true, false],
+  ['"answer" == r.kind', true, false],   // operand swap
+  ['r.kind != "answer"', false, true],
+  ['"answer" != r.kind', false, true],   // operand swap, !=
+])("recognizes %s", (src, thenKeep, elseKeep) => {
+  const f = analyzeCondition(firstIfCondition(src));
+  expect(f.then[0]).toEqual(disc(thenKeep));
+  expect(f.else[0]).toEqual(disc(elseKeep));
+});
+
+it("recognizes numeric and boolean discriminants", () => {
+  expect(analyzeCondition(firstIfCondition("n.code == 1")).then[0].refine).toEqual(
+    { kind: "discriminant", prop: "code", literal: { type: "numberLiteralType", value: "1" }, keep: true },
+  );
+  expect(analyzeCondition(firstIfCondition("r.ok == true")).then[0].refine).toEqual(
+    { kind: "discriminant", prop: "ok", literal: { type: "booleanLiteralType", value: "true" }, keep: true },
+  );
+});
+
+it.each([
+  "r.kind == s.kind",      // both member access
+  "x == 1",                // no member access
+  'r.a.kind == "x"',       // nested member — out of scope
+  "r.kind == r.text",      // same var both sides, no literal
+  'r.kind == undefined',   // undefined is a variableName, not a literal
+])("produces no candidates for %s", (src) => {
+  expect(analyzeCondition(firstIfCondition(src))).toEqual({ then: [], else: [] });
+});
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `npx vitest run lib/typeChecker/narrowing.test.ts -t "analyzeCondition"` — Expected: the new cases FAIL (no `==`/`!=` handling).
+
+- [ ] **Step 4: Add the recognizer to `analyzeCondition`**
+
+In `narrowing.ts`, import `literalToType` and add `asDiscriminantAccess`:
+
+```ts
+function asDiscriminantAccess(e: Expression): { variableName: string; prop: string } | null {
+  if (e.type !== "valueAccess") return null;
+  if (e.base.type !== "variableName") return null;
+  if (e.chain.length !== 1) return null;
+  const el = e.chain[0];
+  if (el.kind !== "property") return null;
+  return { variableName: e.base.value, prop: el.name };
+}
+```
+
+Inside the `binOpExpression` block, before its final `return NO_FACTS`:
+
+```ts
+    if (condition.operator === "==" || condition.operator === "!=") {
+      const acc = asDiscriminantAccess(condition.left) ?? asDiscriminantAccess(condition.right);
+      const lit = literalToType(condition.right) ?? literalToType(condition.left);
+      if (!acc || !lit) return NO_FACTS;
+      const keepThen = condition.operator === "==";
+      const mk = (keep: boolean): NarrowCandidate => ({
+        variableName: acc.variableName,
+        refine: { kind: "discriminant", prop: acc.prop, literal: lit, keep },
+      });
+      return { then: [mk(keepThen)], else: [mk(!keepThen)] };
+    }
+```
+
+Run: `npx vitest run lib/typeChecker/narrowing.test.ts -t "analyzeCondition"` — Expected: PASS.
+
+- [ ] **Step 5: Write the failing e2e tests**
+
+Append a new describe. Fixtures use the witnessing strategy; assertions use `.filter(...).length` for precision.
+
+```ts
+const REPLY = `
+type Reply = { kind: "answer", text: string } | { kind: "clarify", question: string }
+def mk(): Reply { return { kind: "answer", text: "x" } }
+`;
+const has = (errs: string[], re: RegExp) => errs.filter((e) => re.test(e)).length;
+const noQuestion = /question.*does not exist|does not exist.*question/;
+const noText = /\btext\b.*does not exist|does not exist.*\btext\b/;
+
+describe("discriminated-union narrowing — if/else", () => {
+  it("narrows to the matching member in then; complement in else", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer") { let q = r.question } else { let t = r.text }
+}`);
+    expect(has(errs, noQuestion)).toBe(1); // then: r is answer → no `question`
+    expect(has(errs, noText)).toBe(1);     // else: r is clarify → no `text`
+  });
+
+  it("does NOT narrow outside the guard (control)", () => {
+    const errs = check(`${REPLY}
+node main() { let r = mk()\n  let q = r.question }`);
+    expect(has(errs, noQuestion)).toBe(0); // lenient union access
+  });
+
+  it("does NOT leak narrowing past the block", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer") { }
+  let q = r.question
+}`);
+    expect(has(errs, noQuestion)).toBe(0);
+  });
+
+  it("skips narrowing when the variable is reassigned in the branch", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer") { r = mk()\n    let q = r.question }
+}`);
+    expect(has(errs, noQuestion)).toBe(0);
+  });
+
+  it("narrows via != (then is complement)", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind != "answer") { let t = r.text }
+}`);
+    expect(has(errs, noText)).toBe(1); // then: r is clarify → no `text`
+  });
+
+  it("narrows in a while body", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  while (r.kind == "answer") { let q = r.question }
+}`);
+    expect(has(errs, noQuestion)).toBe(1);
+  });
+
+  it("narrows after an early-return guard (postGuardFacts × discriminant)", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind != "answer") { return }
+  let q = r.question
+}`);
+    expect(has(errs, noQuestion)).toBe(1); // r is answer below the guard
+  });
+
+  it("composes with && and !", () => {
+    const andErrs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer" && true) { let q = r.question }
+}`);
+    expect(has(andErrs, noQuestion)).toBe(1);
+    const notErrs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (!(r.kind == "answer")) { let t = r.text }
+}`);
+    expect(has(notErrs, noText)).toBe(1); // !(==answer) then → complement (clarify) → no text
+  });
+});
+
+describe("discriminated-union narrowing — literal kinds & shapes", () => {
+  it("narrows a boolean discriminant (foundation for r.success)", () => {
+    const errs = check(`
+type Tag = { ok: true, v: number } | { ok: false, err: string }
+def mkT(): Tag { return { ok: true, v: 1 } }
+node main() {
+  let t = mkT()
+  if (t.ok == true) { let e = t.err }
+}`);
+    expect(has(errs, /\berr\b.*does not exist|does not exist.*\berr\b/)).toBe(1);
+  });
+
+  it("narrows a numeric discriminant", () => {
+    const errs = check(`
+type N = { code: 1, a: number } | { code: 2, b: string }
+def mkN(): N { return { code: 1, a: 1 } }
+node main() {
+  let n = mkN()
+  if (n.code == 1) { let b = n.b }
+}`);
+    expect(has(errs, /\bb\b.*does not exist|does not exist.*\bb\b/)).toBe(1);
+  });
+
+  it("narrows a 3-member union to a 2-member union", () => {
+    const errs = check(`
+type T = { k: "a", x: number } | { k: "b", y: string } | { k: "c", z: boolean }
+def mkT3(): T { return { k: "a", x: 1 } }
+node main() {
+  let t = mkT3()
+  if (t.k != "a") { let x = t.x }
+}`);
+    // then: t is {b}|{c}; neither has `x` → error.
+    expect(has(errs, /\bx\b.*does not exist|does not exist.*\bx\b/)).toBe(1);
+  });
+
+  it("is a no-op on a non-union scrutinee", () => {
+    const errs = check(`
+node main() {
+  let p: { kind: string, n: number } = { kind: "x", n: 1 }
+  if (p.kind == "x") { let n = p.n }
+}`);
+    expect(errs.filter((e) => /does not exist/.test(e)).length).toBe(0);
+  });
+
+  it("does NOT narrow a mixed union with a non-literal discriminant member", () => {
+    const errs = check(`
+type Mixed = { kind: "a", x: number } | { kind: string, y: number }
+def mkM(): Mixed { return { kind: "a", x: 1 } }
+node main() {
+  let m = mkM()
+  if (m.kind == "a") { let y = m.y }
+}`);
+    // {kind:string} can't be proven disjoint → kept → no narrowing → m.y fine.
+    expect(errs.filter((e) => /does not exist/.test(e)).length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 6: Run to verify the positive cases fail**
+
+Run: `npx vitest run lib/typeChecker/narrowing.test.ts -t "discriminated-union narrowing"` — Expected: the narrowing-positive tests FAIL (no member filtering yet); control/leak/reassignment/non-union/mixed pass.
+
+- [ ] **Step 7: Add `narrowUnionByDiscriminant` + the `narrowers` discriminant entry**
+
+In `narrowing.ts`:
+
+```ts
+function literalTypeMatches(
+  t: VariableType,
+  literal: StringLiteralType | NumberLiteralType | BooleanLiteralType,
+  aliases: Record<string, TypeAliasEntry>,
+): "yes" | "no" | "unknown" {
+  const r = safeResolveType(t, aliases);
+  if (r.type !== literal.type) return "unknown"; // non-literal prop, literal union, or kind mismatch
+  return r.value === literal.value ? "yes" : "no";
+}
+
+/**
+ * Filter a union's members by `prop == literal` (keep) or `prop != literal`
+ * (!keep). Sound/conservative: drops only provably-excluded members; never
+ * narrows to `never`; non-union → null (no narrowing).
+ */
+export function narrowUnionByDiscriminant(
+  type: VariableType,
+  prop: string,
+  literal: StringLiteralType | NumberLiteralType | BooleanLiteralType,
+  keep: boolean,
+  aliases: Record<string, TypeAliasEntry>,
+): VariableType | null {
+  const resolved = safeResolveType(type, aliases);
+  if (resolved.type !== "unionType") return null;
+  const members = resolved.types;
+  const kept = members.filter((m) => {
+    const rm = safeResolveType(m, aliases);
+    const propType =
+      rm.type === "objectType"
+        ? rm.properties.find((p) => p.key === prop)?.value
+        : undefined;
+    const match = propType ? literalTypeMatches(propType, literal, aliases) : "unknown";
+    return keep ? match !== "no" : match !== "yes";
+  });
+  if (kept.length === members.length || kept.length === 0) return null;
+  return kept.length === 1 ? kept[0] : { type: "unionType", types: kept };
+}
+```
+
+Replace the `discriminant: () => null` placeholder in the `narrowers` table:
+
+```ts
+  discriminant: (r, current, aliases) =>
+    narrowUnionByDiscriminant(current, r.prop, r.literal, r.keep, aliases),
+```
+
+- [ ] **Step 8: Run the e2e tests**
+
+Run: `npx vitest run lib/typeChecker/narrowing.test.ts -t "discriminated-union narrowing"` — Expected: PASS (all).
+
+- [ ] **Step 9: Full suite + tsc**
+
+Run: `npx vitest run lib/typeChecker/ 2>&1 | tee /tmp/d1t2.log` — Expected: PASS.
+Run: `npx tsc --noEmit` — Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/typeChecker/literalType.ts lib/typeChecker/narrowing.ts lib/typeChecker/synthesizer.ts lib/typeChecker/narrowing.test.ts
+git commit -F - <<'EOF'
+feat(typechecker): discriminated-union narrowing on `v.prop == literal`
+
+Recognize `v.prop ==/!= literal` over a bare variable; filter the union's
+members via narrowUnionByDiscriminant (sound — drops only provably-excluded
+members, never narrows to never). Reuses literal-type construction (new shared
+literalToType, also used by synthType). Composes with !/&&/||/early-return/while.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 3: Match-arm narrowing (D2) — confirm it's free
+
+`match (r) { {kind:"answer", data} => use(data) }` lowers to `const __s = r; if (__s.kind == "answer") { const data = __s.data; … }`. Task 2's narrowing of `__s` types the binder — no new production code.
+
+**Files:** Test `lib/typeChecker/narrowing.test.ts`; docs.
+
+- [ ] **Step 1: Write the match-arm test (witnessing requires same-field/different-type)**
+
+A field that exists on *one* member would type the same with or without narrowing (lenient union access). Use a field on *both* members with *different* types, and assert the **narrowed** message:
+
+```ts
+describe("discriminated-union narrowing — match arms", () => {
+  it("types a bound field per arm via the narrowed temp", () => {
+    const errs = check(`
+type Reply = { kind: "answer", data: string } | { kind: "clarify", data: number }
+def mkR(): Reply { return { kind: "answer", data: "x" } }
+node main() {
+  let r = mkR()
+  match (r) {
+    { kind: "answer", data } => { let n: number = data }
+    { kind: "clarify", data } => { let s: string = data }
+  }
+}`);
+    // Narrowed: answer.data is string (not string|number) → exact message.
+    expect(errs).toContain("Type 'string' is not assignable to type 'number' (assignment to 'n').");
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 's').");
+    // Guard against the non-test failure mode: the un-narrowed union message must NOT appear.
+    expect(errs.some((e) => /string \| number|number \| string/.test(e))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — should already pass (free via Task 2)**
+
+Run: `npx vitest run lib/typeChecker/narrowing.test.ts -t "match arms"` — Expected: PASS. The "free" premise was verified against `main`: `collectChecks` (`patternLowering.ts:606`) lowers a literal-valued object-pattern field to `makeBinOp(source, "==", literal)`, i.e. `__s.kind == "answer"`, which Step 4's recognizer matches. If it FAILS, there are two possible causes — (a) the lowered condition isn't a `v.prop == literal` the recognizer sees (inspect with `pnpm run ast`/preprocess on the match), or (b) the binder isn't reading the narrowed temp. Investigate either; do NOT add match-specific narrowing code.
+
+- [ ] **Step 3: Docs + commit**
+
+In `docs/dev/typechecker.md`, add a paragraph: discriminated-union narrowing (`v.prop == lit` narrows `v`; match arms narrow bound fields via the lowered temp); the two limitations (bound-fields-only; mixed unions with a non-literal discriminant member don't narrow). Opportunistically: the stale `synthesizer.ts:633-639` comment says "Until isSuccess/isFailure narrowing lands (Tier 2 PR B)…" — Result narrowing has landed; update that one line if convenient.
+
+> **Deferred (was spec D2's binding hint):** a "bind it in the pattern" hint on unbound other-variant access is NOT in this plan. The correct (gated) version needs an `ObjectType` narrowing marker, which conflicts with `result-as-union` removing `narrowedBranch`; the unconditional version misfires on plain-object typos (reviews). Revisit after `result-as-union` settles the type-marker question.
+
+```bash
+git add lib/typeChecker/narrowing.test.ts docs/dev/typechecker.md
+git commit -F - <<'EOF'
+test(typechecker): match-arm discriminated-union narrowing is free via the temp
+
+match arms narrow bound fields with no new code (Task 2 narrows the lowered
+scrutinee temp; binders read it). Witnessed with a same-field/different-type
+union so the test actually depends on narrowing. Docs updated.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** auto-detect discriminant (T2 recognizer); generalized candidate + declarative dispatch (T1, anti-patterns B); Form 1 then/else/!/&&/while/early-return (T2 e2e); Form 2 match arms free (T3); boolean/numeric/3-member/non-union/mixed coverage (T2); scope-leak + reassignment + control (T2); DRY literal types via `literalToType` (anti-patterns A); binding hint **deferred** with rationale.
+
+**Placeholder scan:** none — complete code + commands throughout.
+
+**Type consistency:** `Refine`/`NarrowCandidate`/`narrowers` (T1) consumed in T2's dispatch entry; `literalToType` / `narrowUnionByDiscriminant` / `literalTypeMatches` signatures consistent between definition and call sites; literal stored as `StringLiteralType|NumberLiteralType|BooleanLiteralType` everywhere (no `LiteralValue`).
+
+**Risks:** (1) The `synthesizer.ts` refactor is **scoped to the string case only** — `number`/`boolean` keep returning `NUMBER_T`/`BOOLEAN_T`, because `synthType` does not produce numeric/boolean literal types today and changing that would regress inference (T2 Step 1, corrected after second review). The full `lib/typeChecker/` suite gates it. (2) Template-literal-no-holes coverage — verified/documented at T2 Step 1, not special-cased. (3) Witnessing tests depend on lenient union access (`synthValueAccess` union branch errors only when no member has the prop, `synthesizer.ts:648-672`); if `result-as-union` strict-access later changes it, these assertions need revisiting (noted). (4) Numeric/boolean narrowing depends on the type-annotation parser emitting literal types for `{ code: 1 }` / `{ ok: true }` — verified via `pnpm run ast`.

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -332,6 +332,55 @@ export const stringTextSegmentParser: Parser<TextSegment> = map(
 // preserved verbatim — both the backslash and the character — so existing
 // strings containing literal `\` followed by non-escape characters are
 // unaffected. This is the same behavior as Python's regular strings.
+/** Map the char after a `\` to its unescaped form. Unknown escapes are
+ *  preserved verbatim (`\` + char) so e.g. regex source keeps working. */
+export function unescapeStringChar(next: string): string {
+  switch (next) {
+    case "\\":
+      return "\\";
+    case '"':
+      return '"';
+    case "'":
+      return "'";
+    case "`":
+      return "`";
+    case "n":
+      return "\n";
+    case "t":
+      return "\t";
+    case "r":
+      return "\r";
+    case "0":
+      return "\0";
+    default:
+      return "\\" + next;
+  }
+}
+
+/** Unescape a raw string-literal body using the same escape table the string
+ *  expression parser applies. A string in *type* position (e.g. a discriminant
+ *  tag `{ kind: "a\tb" }`) is captured raw, while the same literal in
+ *  *expression* position is unescaped — normalize the raw form through this to
+ *  compare them. Mirrors `stringTextSegmentParserFor` (`\${` → `${`; unknown
+ *  escapes preserved). */
+export function unescapeStringLiteralValue(raw: string): string {
+  let out = "";
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i] === "\\" && i + 1 < raw.length) {
+      if (raw[i + 1] === "$" && raw[i + 2] === "{") {
+        out += "${";
+        i += 2;
+        continue;
+      }
+      out += unescapeStringChar(raw[i + 1]);
+      i += 1;
+      continue;
+    }
+    out += raw[i];
+  }
+  return out;
+}
+
 const stringTextSegmentParserFor = (delim: '"' | "'" | "`"): Parser<TextSegment> =>
   (input: string): ParserResult<TextSegment> => {
     let i = 0;
@@ -350,17 +399,7 @@ const stringTextSegmentParserFor = (delim: '"' | "'" | "`"): Parser<TextSegment>
           i += 3;
           continue;
         }
-        switch (next) {
-          case "\\": value += "\\"; break;
-          case '"': value += '"'; break;
-          case "'": value += "'"; break;
-          case "`": value += "`"; break;
-          case "n": value += "\n"; break;
-          case "t": value += "\t"; break;
-          case "r": value += "\r"; break;
-          case "0": value += "\0"; break;
-          default: value += "\\" + next; break;
-        }
+        value += unescapeStringChar(next);
         i += 2;
         continue;
       }

--- a/packages/agency-lang/lib/typeChecker/literalType.ts
+++ b/packages/agency-lang/lib/typeChecker/literalType.ts
@@ -1,0 +1,27 @@
+import type { Expression } from "../types.js";
+import type {
+  StringLiteralType,
+  NumberLiteralType,
+  BooleanLiteralType,
+} from "../types/typeHints.js";
+
+/** Convert a literal expression to its literal type, or null if not a simple
+ *  literal. Single source of truth — `synthType`'s string-literal case also
+ *  uses it, and the discriminant-narrowing recognizer uses the numeric/boolean
+ *  cases. Note: `synthType` deliberately does NOT route its number/boolean
+ *  cases here (those stay `NUMBER_T`/`BOOLEAN_T`); only the recognizer needs
+ *  literal types for `number`/`boolean`. */
+export function literalToType(
+  e: Expression,
+): StringLiteralType | NumberLiteralType | BooleanLiteralType | null {
+  if (e.type === "string" && e.segments.length === 1 && e.segments[0].type === "text") {
+    return { type: "stringLiteralType", value: e.segments[0].value };
+  }
+  if (e.type === "number") {
+    return { type: "numberLiteralType", value: e.value };
+  }
+  if (e.type === "boolean") {
+    return { type: "booleanLiteralType", value: e.value ? "true" : "false" };
+  }
+  return null;
+}

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -26,15 +26,15 @@ const NO_FACTS = { then: [], else: [] };
 describe("analyzeCondition", () => {
   it("isSuccess(r): then→success, else→failure", () => {
     expect(analyzeCondition(firstIfCondition("isSuccess(r)"))).toEqual({
-      then: [{ variableName: "r", branch: "success" }],
-      else: [{ variableName: "r", branch: "failure" }],
+      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
+      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
     });
   });
 
   it("isFailure(r): then→failure, else→success", () => {
     expect(analyzeCondition(firstIfCondition("isFailure(r)"))).toEqual({
-      then: [{ variableName: "r", branch: "failure" }],
-      else: [{ variableName: "r", branch: "success" }],
+      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
+      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
     });
   });
 
@@ -55,16 +55,16 @@ describe("analyzeCondition", () => {
 
   it("negation swaps then/else", () => {
     expect(analyzeCondition(firstIfCondition("!isSuccess(r)"))).toEqual({
-      then: [{ variableName: "r", branch: "failure" }],
-      else: [{ variableName: "r", branch: "success" }],
+      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
+      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
     });
   });
 
   it("conjunction unions then-facts, drops else-facts", () => {
     expect(analyzeCondition(firstIfCondition("isSuccess(a) && isSuccess(b)"))).toEqual({
       then: [
-        { variableName: "a", branch: "success" },
-        { variableName: "b", branch: "success" },
+        { variableName: "a", refine: { kind: "resultBranch", branch: "success" } },
+        { variableName: "b", refine: { kind: "resultBranch", branch: "success" } },
       ],
       else: [],
     });
@@ -74,16 +74,16 @@ describe("analyzeCondition", () => {
     expect(analyzeCondition(firstIfCondition("isFailure(a) || isFailure(b)"))).toEqual({
       then: [],
       else: [
-        { variableName: "a", branch: "success" },
-        { variableName: "b", branch: "success" },
+        { variableName: "a", refine: { kind: "resultBranch", branch: "success" } },
+        { variableName: "b", refine: { kind: "resultBranch", branch: "success" } },
       ],
     });
   });
 
   it("double negation is identity", () => {
     expect(analyzeCondition(firstIfCondition("!!isSuccess(r)"))).toEqual({
-      then: [{ variableName: "r", branch: "success" }],
-      else: [{ variableName: "r", branch: "failure" }],
+      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
+      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
     });
   });
 });
@@ -419,7 +419,7 @@ describe("postGuardFacts", () => {
   it("then-exits, no else → else-facts apply after", () => {
     const node = firstIf(`  if (isFailure(r)) { return 0 }`);
     expect(postGuardFacts(node, analyzeCondition(node.condition))).toEqual([
-      { variableName: "r", branch: "success" },
+      { variableName: "r", refine: { kind: "resultBranch", branch: "success" } },
     ]);
   });
   it("neither branch exits → no facts after", () => {

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -817,3 +817,32 @@ node main() {
     expect(errs.some((e) => /string \| number|number \| string/.test(e))).toBe(false);
   });
 });
+
+describe("discriminated-union narrowing — literal normalization (soundness)", () => {
+  // Regression: a discriminant tag with an escape is stored raw in type
+  // position (`a\tb`) but unescaped in expression position (`a⇥b`). Without
+  // normalization the matching member is wrongly dropped → no narrowing → the
+  // other member's field types leniently → 0 errors. Normalized, the matching
+  // member is kept and narrowed → accessing the *other* member's field errors.
+  it("keeps the matching member when the discriminant tag has an escape", () => {
+    const errs = check(`
+type E = { kind: "a\\tb", x: number } | { kind: "c", y: string }
+def mkE(): E { return { kind: "a\\tb", x: 1 } }
+node main() {
+  let e = mkE()
+  if (e.kind == "a\\tb") { let y = e.y }
+}`);
+    expect(has(errs, /Property 'y' does not exist/)).toBe(1);
+  });
+
+  it("matches numeric discriminants numerically (1 vs 1.0)", () => {
+    const errs = check(`
+type N2 = { code: 1, a: number } | { code: 2, b: string }
+def mkN2(): N2 { return { code: 1, a: 1 } }
+node main() {
+  let n = mkN2()
+  if (n.code == 1.0) { let b = n.b }
+}`);
+    expect(has(errs, /Property 'b' does not exist/)).toBe(1);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -789,3 +789,31 @@ node main() {
     expect(errs.filter((e) => /does not exist/.test(e)).length).toBe(0);
   });
 });
+
+describe("discriminated-union narrowing — match arms", () => {
+  it("types a bound field per arm via the narrowed temp", () => {
+    const errs = check(`
+type Reply = { kind: "answer", data: string } | { kind: "clarify", data: number }
+def mkR(): Reply { return { kind: "answer", data: "x" } }
+node main() {
+  let r = mkR()
+  match (r) {
+    { kind: "answer", data } => let n: number = data
+    { kind: "clarify", data } => let s: string = data
+  }
+}`);
+    // Narrowed per arm: answer.data is `string`, clarify.data is `number` —
+    // each exact, not the `string | number` union. (Substring `.some` rather
+    // than `toContain`: the assignment-context suffix "(assignment to 'x')" is
+    // only emitted for the first arm's lowered position, not the else arm —
+    // a cosmetic message detail, irrelevant to the narrowing under test.)
+    expect(errs.some((e) => e.includes("Type 'string' is not assignable to type 'number'"))).toBe(
+      true,
+    );
+    expect(errs.some((e) => e.includes("Type 'number' is not assignable to type 'string'"))).toBe(
+      true,
+    );
+    // Guard against the non-test failure mode: the un-narrowed union message must NOT appear.
+    expect(errs.some((e) => /string \| number|number \| string/.test(e))).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -4,7 +4,7 @@ import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck } from "./index.js";
 import { analyzeCondition, narrowToBranch, alwaysExits, postGuardFacts } from "./narrowing.js";
 import { walkNodes } from "../utils/node.js";
-import type { IfElse } from "../types.js";
+import type { Expression, IfElse } from "../types.js";
 import type { ResultType } from "../types/typeHints.js";
 
 // Parse a snippet and return the first ifElse node in main. Uses the shared
@@ -85,6 +85,63 @@ describe("analyzeCondition", () => {
       then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
       else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
     });
+  });
+
+  const disc = (keep: boolean, value = "answer", prop = "kind") => ({
+    variableName: "r",
+    refine: { kind: "discriminant", prop, literal: { type: "stringLiteralType", value }, keep },
+  });
+
+  it.each([
+    ['r.kind == "answer"', true, false],
+    ['"answer" == r.kind', true, false], // operand swap
+    ['r.kind != "answer"', false, true],
+    ['"answer" != r.kind', false, true], // operand swap, !=
+  ])("recognizes %s", (src, thenKeep, elseKeep) => {
+    const f = analyzeCondition(firstIfCondition(src));
+    expect(f.then[0]).toEqual(disc(thenKeep));
+    expect(f.else[0]).toEqual(disc(elseKeep));
+  });
+
+  it("recognizes numeric and boolean discriminants", () => {
+    expect(analyzeCondition(firstIfCondition("n.code == 1")).then[0].refine).toEqual({
+      kind: "discriminant",
+      prop: "code",
+      literal: { type: "numberLiteralType", value: "1" },
+      keep: true,
+    });
+    expect(analyzeCondition(firstIfCondition("r.ok == true")).then[0].refine).toEqual({
+      kind: "discriminant",
+      prop: "ok",
+      literal: { type: "booleanLiteralType", value: "true" },
+      keep: true,
+    });
+  });
+
+  it.each([
+    "r.kind == s.kind", // both member access
+    "x == 1", // no member access
+    'r.a.kind == "x"', // nested member — out of scope
+    "r.kind == r.text", // same var both sides, no literal
+    "r.kind == undefined", // undefined is a variableName, not a literal
+  ])("produces no candidates for %s", (src) => {
+    expect(analyzeCondition(firstIfCondition(src))).toEqual({ then: [], else: [] });
+  });
+
+  it("composes ! with a discriminant (swaps then/else)", () => {
+    // Agency has no `!(expr)` syntax, so build the negation directly: the parser
+    // desugars `!x` to a binOp { operator:"!", left:<true>, right:x }. This
+    // proves the generic `!` swap composes with discriminant facts.
+    const inner = firstIfCondition('r.kind == "answer"');
+    const negated: Expression = {
+      type: "binOpExpression",
+      operator: "!",
+      left: { type: "boolean", value: true },
+      right: inner,
+    };
+    const f = analyzeCondition(negated);
+    expect(f.then).toEqual([disc(false)]); // !(== answer) → then is the complement
+    expect(f.else).toEqual([disc(true)]);
   });
 });
 
@@ -584,5 +641,151 @@ node main() {
 }`);
     expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'w').");
     expect(errs).not.toContain("(assignment to 'n')");
+  });
+});
+
+const REPLY = `
+type Reply = { kind: "answer", text: string } | { kind: "clarify", question: string }
+def mk(): Reply { return { kind: "answer", text: "x" } }
+`;
+const has = (errs: string[], re: RegExp) => errs.filter((e) => re.test(e)).length;
+// Anchor on the `Property 'X' does not exist` access error specifically — a
+// looser regex spuriously matches the *other* member's field name as rendered
+// inside the type (`… on type '{ kind: "clarify", question: string }'`).
+const noQuestion = /Property 'question' does not exist/;
+const noText = /Property 'text' does not exist/;
+
+describe("discriminated-union narrowing — if/else", () => {
+  it("narrows to the matching member in then; complement in else", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer") { let q = r.question } else { let t = r.text }
+}`);
+    expect(has(errs, noQuestion)).toBe(1); // then: r is answer → no `question`
+    expect(has(errs, noText)).toBe(1);     // else: r is clarify → no `text`
+  });
+
+  it("does NOT narrow outside the guard (control)", () => {
+    const errs = check(`${REPLY}
+node main() { let r = mk()\n  let q = r.question }`);
+    expect(has(errs, noQuestion)).toBe(0); // lenient union access
+  });
+
+  it("does NOT leak narrowing past the block", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer") { }
+  let q = r.question
+}`);
+    expect(has(errs, noQuestion)).toBe(0);
+  });
+
+  it("skips narrowing when the variable is reassigned in the branch", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer") { r = mk()\n    let q = r.question }
+}`);
+    expect(has(errs, noQuestion)).toBe(0);
+  });
+
+  it("narrows via != (then is complement)", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind != "answer") { let t = r.text }
+}`);
+    expect(has(errs, noText)).toBe(1); // then: r is clarify → no `text`
+  });
+
+  it("narrows in a while body", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  while (r.kind == "answer") { let q = r.question }
+}`);
+    expect(has(errs, noQuestion)).toBe(1);
+  });
+
+  it("narrows after an early-return guard (postGuardFacts × discriminant)", () => {
+    const errs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind != "answer") { return }
+  let q = r.question
+}`);
+    expect(has(errs, noQuestion)).toBe(1); // r is answer below the guard
+  });
+
+  it("composes with && (then-facts union)", () => {
+    const andErrs = check(`${REPLY}
+node main() {
+  let r = mk()
+  if (r.kind == "answer" && true) { let q = r.question }
+}`);
+    expect(has(andErrs, noQuestion)).toBe(1);
+    // NOTE: `!` composition is covered by the analyzeCondition unit test
+    // "composes ! with a discriminant" rather than e2e — Agency has no
+    // `!(expr)` syntax (the parser rejects a `!` before a parenthesized
+    // group), so `!(r.kind == "answer")` is not expressible in source.
+  });
+});
+
+describe("discriminated-union narrowing — literal kinds & shapes", () => {
+  it("narrows a boolean discriminant (foundation for r.success)", () => {
+    const errs = check(`
+type Tag = { ok: true, v: number } | { ok: false, err: string }
+def mkT(): Tag { return { ok: true, v: 1 } }
+node main() {
+  let t = mkT()
+  if (t.ok == true) { let e = t.err }
+}`);
+    expect(has(errs, /\berr\b.*does not exist|does not exist.*\berr\b/)).toBe(1);
+  });
+
+  it("narrows a numeric discriminant", () => {
+    const errs = check(`
+type N = { code: 1, a: number } | { code: 2, b: string }
+def mkN(): N { return { code: 1, a: 1 } }
+node main() {
+  let n = mkN()
+  if (n.code == 1) { let b = n.b }
+}`);
+    expect(has(errs, /\bb\b.*does not exist|does not exist.*\bb\b/)).toBe(1);
+  });
+
+  it("narrows a 3-member union to a 2-member union", () => {
+    const errs = check(`
+type T = { k: "a", x: number } | { k: "b", y: string } | { k: "c", z: boolean }
+def mkT3(): T { return { k: "a", x: 1 } }
+node main() {
+  let t = mkT3()
+  if (t.k != "a") { let x = t.x }
+}`);
+    // then: t is {b}|{c}; neither has `x` → error.
+    expect(has(errs, /\bx\b.*does not exist|does not exist.*\bx\b/)).toBe(1);
+  });
+
+  it("is a no-op on a non-union scrutinee", () => {
+    const errs = check(`
+node main() {
+  let p: { kind: string, n: number } = { kind: "x", n: 1 }
+  if (p.kind == "x") { let n = p.n }
+}`);
+    expect(errs.filter((e) => /does not exist/.test(e)).length).toBe(0);
+  });
+
+  it("does NOT narrow a mixed union with a non-literal discriminant member", () => {
+    const errs = check(`
+type Mixed = { kind: "a", x: number } | { kind: string, y: number }
+def mkM(): Mixed { return { kind: "a", x: 1 } }
+node main() {
+  let m = mkM()
+  if (m.kind == "a") { let y = m.y }
+}`);
+    // {kind:string} can't be proven disjoint → kept → no narrowing → m.y fine.
+    expect(errs.filter((e) => /does not exist/.test(e)).length).toBe(0);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -9,12 +9,13 @@ import { Scope } from "./scope.js";
 import { walkNodes } from "../utils/node.js";
 import { safeResolveType } from "./assignability.js";
 import { literalToType } from "./literalType.js";
+import { unescapeStringLiteralValue } from "../parsers/parsers.js";
 
 /**
  * What a candidate narrows to. Tagged so a new narrowing form slots in as one
  * `narrowers`-table entry without touching the apply loop. `resultBranch` is
- * the `isSuccess`/`isFailure` Result narrowing; `discriminant` (wired in the
- * next increment) filters a union by `v.prop == literal`.
+ * the `isSuccess`/`isFailure` Result narrowing; `discriminant` filters a union
+ * by `v.prop == literal`.
  */
 export type Refine =
   | { kind: "resultBranch"; branch: "success" | "failure" }
@@ -146,7 +147,31 @@ function literalTypeMatches(
 ): "yes" | "no" | "unknown" {
   const r = safeResolveType(t, aliases);
   if (r.type !== literal.type) return "unknown"; // non-literal prop, literal union, or kind mismatch
-  return r.value === literal.value ? "yes" : "no";
+  return literalValuesEqual(r, literal) ? "yes" : "no";
+}
+
+/**
+ * Compare two same-kind literal-type values, normalizing for the fact that the
+ * member's type-position value (`a`) is parsed differently from the
+ * expression-position discriminant (`b`):
+ *  - strings: the type parser captures escapes raw (`a\tb`) while the
+ *    expression parser unescapes them (`a⇥b`) — unescape `a` before comparing,
+ *    or an escaped discriminant tag would wrongly drop the matching member.
+ *  - numbers: compare numerically so `1` and `1.0` (both valid literal tags)
+ *    are equal despite different source text.
+ *  - booleans: already canonical (`"true"`/`"false"`).
+ */
+function literalValuesEqual(
+  a: StringLiteralType | NumberLiteralType | BooleanLiteralType,
+  b: StringLiteralType | NumberLiteralType | BooleanLiteralType,
+): boolean {
+  if (a.type === "stringLiteralType") {
+    return unescapeStringLiteralValue(a.value) === b.value;
+  }
+  if (a.type === "numberLiteralType") {
+    return Number(a.value) === Number(b.value);
+  }
+  return a.value === b.value;
 }
 
 /**
@@ -242,15 +267,26 @@ export function applyNarrowing(
   for (const cand of candidates) {
     const current = childScope.lookup(cand.variableName);
     if (!current || current === "any") continue;
-    // Soundness gate: a branch that reassigns the variable may change its type
-    // mid-branch, so don't narrow it (whole-body scan, conservative).
-    if (isReassignedIn(branchBody, cand.variableName)) continue;
     // "what to narrow to" is delegated to the refine's narrower. Each narrower
     // resolves through type-alias variables itself (mirrors synthValueAccess) so
     // alias-typed scrutinees still narrow; null means "leave the type as-is".
-    const narrow = narrowers[cand.refine.kind];
-    const narrowed = narrow(cand.refine as never, current, typeAliases);
-    if (narrowed !== null) childScope.declareLocal(cand.variableName, narrowed);
+    // Run it first: most `v.prop == literal` candidates aren't unions and bail
+    // here, so we skip the (more expensive) whole-body reassignment walk.
+    // The cast widens the table entry — indexing by `refine.kind` can't be
+    // statically correlated with the matching `refine` variant — but the call
+    // is sound: `narrowers[k]` is only ever invoked with the variant whose
+    // `kind` is `k`.
+    const narrow = narrowers[cand.refine.kind] as (
+      refine: Refine,
+      current: VariableType,
+      aliases: Record<string, TypeAliasEntry>,
+    ) => VariableType | null;
+    const narrowed = narrow(cand.refine, current, typeAliases);
+    if (narrowed === null) continue;
+    // Soundness gate: a branch that reassigns the variable may change its type
+    // mid-branch, so don't narrow it (whole-body scan, conservative).
+    if (isReassignedIn(branchBody, cand.variableName)) continue;
+    childScope.declareLocal(cand.variableName, narrowed);
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -8,6 +8,7 @@ import type {
 import { Scope } from "./scope.js";
 import { walkNodes } from "../utils/node.js";
 import { safeResolveType } from "./assignability.js";
+import { literalToType } from "./literalType.js";
 
 /**
  * What a candidate narrows to. Tagged so a new narrowing form slots in as one
@@ -42,9 +43,26 @@ const narrowers: {
     const resolved = safeResolveType(current, aliases);
     return resolved.type === "resultType" ? narrowToBranch(resolved, r.branch) : null;
   },
-  // discriminant added in the next increment.
-  discriminant: () => null,
+  discriminant: (r, current, aliases) =>
+    narrowUnionByDiscriminant(current, r.prop, r.literal, r.keep, aliases),
 };
+
+/**
+ * Recognize a single `v.prop` member access over a *bare variable* (exactly one
+ * property hop). Returns null for anything else — nested access (`a.b.c`), a
+ * non-variable base, index/call chains, etc. Variable-keyed only, so the
+ * narrowed scrutinee is statically the same binding at the access site.
+ */
+function asDiscriminantAccess(
+  e: Expression,
+): { variableName: string; prop: string } | null {
+  if (e.type !== "valueAccess") return null;
+  if (e.base.type !== "variableName") return null;
+  if (e.chain.length !== 1) return null;
+  const el = e.chain[0];
+  if (el.kind !== "property") return null;
+  return { variableName: e.base.value, prop: el.name };
+}
 
 /**
  * Inspect a (post-lowering) boolean condition and report the narrowing
@@ -77,6 +95,20 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
       const r = analyzeCondition(condition.right);
       return { then: [], else: [...l.else, ...r.else] };
     }
+    if (condition.operator === "==" || condition.operator === "!=") {
+      // `v.prop == literal` / `!= literal` over a bare variable. Either operand
+      // order is accepted. then-branch keeps the matching member(s) for `==`
+      // (and the complement for `!=`); the else-branch is the inverse.
+      const acc = asDiscriminantAccess(condition.left) ?? asDiscriminantAccess(condition.right);
+      const lit = literalToType(condition.right) ?? literalToType(condition.left);
+      if (!acc || !lit) return NO_FACTS;
+      const keepThen = condition.operator === "==";
+      const mk = (keep: boolean): NarrowCandidate => ({
+        variableName: acc.variableName,
+        refine: { kind: "discriminant", prop: acc.prop, literal: lit, keep },
+      });
+      return { then: [mk(keepThen)], else: [mk(!keepThen)] };
+    }
     return NO_FACTS;
   }
 
@@ -98,6 +130,51 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
 /** Return a copy of a ResultType tagged as narrowed to one branch. */
 export function narrowToBranch(rt: ResultType, branch: "success" | "failure"): ResultType {
   return { ...rt, narrowedBranch: branch };
+}
+
+/**
+ * Does a member's discriminant-property type equal the tested literal?
+ * `"yes"`/`"no"` only when the property is itself the *same kind* of literal
+ * type; anything else (a non-literal prop type, a union, a different literal
+ * kind) is `"unknown"` — which keeps the member on both sides, preserving
+ * soundness.
+ */
+function literalTypeMatches(
+  t: VariableType,
+  literal: StringLiteralType | NumberLiteralType | BooleanLiteralType,
+  aliases: Record<string, TypeAliasEntry>,
+): "yes" | "no" | "unknown" {
+  const r = safeResolveType(t, aliases);
+  if (r.type !== literal.type) return "unknown"; // non-literal prop, literal union, or kind mismatch
+  return r.value === literal.value ? "yes" : "no";
+}
+
+/**
+ * Filter a union's members by `prop == literal` (keep) or `prop != literal`
+ * (!keep). Sound/conservative: drops only provably-excluded members; never
+ * narrows to `never`; non-union → null (no narrowing).
+ */
+export function narrowUnionByDiscriminant(
+  type: VariableType,
+  prop: string,
+  literal: StringLiteralType | NumberLiteralType | BooleanLiteralType,
+  keep: boolean,
+  aliases: Record<string, TypeAliasEntry>,
+): VariableType | null {
+  const resolved = safeResolveType(type, aliases);
+  if (resolved.type !== "unionType") return null;
+  const members = resolved.types;
+  const kept = members.filter((m) => {
+    const rm = safeResolveType(m, aliases);
+    const propType =
+      rm.type === "objectType"
+        ? rm.properties.find((p) => p.key === prop)?.value
+        : undefined;
+    const match = propType ? literalTypeMatches(propType, literal, aliases) : "unknown";
+    return keep ? match !== "no" : match !== "yes";
+  });
+  if (kept.length === members.length || kept.length === 0) return null;
+  return kept.length === 1 ? kept[0] : { type: "unionType", types: kept };
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -1,13 +1,50 @@
-import type { AgencyNode, Expression, TypeAliasEntry, IfElse } from "../types.js";
-import type { ResultType } from "../types/typeHints.js";
+import type { AgencyNode, Expression, TypeAliasEntry, IfElse, VariableType } from "../types.js";
+import type {
+  ResultType,
+  StringLiteralType,
+  NumberLiteralType,
+  BooleanLiteralType,
+} from "../types/typeHints.js";
 import { Scope } from "./scope.js";
 import { walkNodes } from "../utils/node.js";
 import { safeResolveType } from "./assignability.js";
 
-export type NarrowCandidate = { variableName: string; branch: "success" | "failure" };
+/**
+ * What a candidate narrows to. Tagged so a new narrowing form slots in as one
+ * `narrowers`-table entry without touching the apply loop. `resultBranch` is
+ * the `isSuccess`/`isFailure` Result narrowing; `discriminant` (wired in the
+ * next increment) filters a union by `v.prop == literal`.
+ */
+export type Refine =
+  | { kind: "resultBranch"; branch: "success" | "failure" }
+  | {
+      kind: "discriminant";
+      prop: string;
+      literal: StringLiteralType | NumberLiteralType | BooleanLiteralType;
+      keep: boolean;
+    };
+export type NarrowCandidate = { variableName: string; refine: Refine };
 export type ConditionFacts = { then: NarrowCandidate[]; else: NarrowCandidate[] };
 
 const NO_FACTS: ConditionFacts = { then: [], else: [] };
+
+// "what": given a refine + the variable's current (pre-resolved) type, the
+// narrowed type, or null for "no narrowing". The "how" (child scope,
+// reassignment gate, declareLocal) lives in applyNarrowing.
+const narrowers: {
+  [K in Refine["kind"]]: (
+    refine: Extract<Refine, { kind: K }>,
+    current: VariableType,
+    aliases: Record<string, TypeAliasEntry>,
+  ) => VariableType | null;
+} = {
+  resultBranch: (r, current, aliases) => {
+    const resolved = safeResolveType(current, aliases);
+    return resolved.type === "resultType" ? narrowToBranch(resolved, r.branch) : null;
+  },
+  // discriminant added in the next increment.
+  discriminant: () => null,
+};
 
 /**
  * Inspect a (post-lowering) boolean condition and report the narrowing
@@ -53,8 +90,8 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
   const thenBranch = fn === "isSuccess" ? "success" : "failure";
   const elseBranch = fn === "isSuccess" ? "failure" : "success";
   return {
-    then: [{ variableName: name, branch: thenBranch }],
-    else: [{ variableName: name, branch: elseBranch }],
+    then: [{ variableName: name, refine: { kind: "resultBranch", branch: thenBranch } }],
+    else: [{ variableName: name, refine: { kind: "resultBranch", branch: elseBranch } }],
   };
 }
 
@@ -128,15 +165,15 @@ export function applyNarrowing(
   for (const cand of candidates) {
     const current = childScope.lookup(cand.variableName);
     if (!current || current === "any") continue;
-    // Resolve through type-alias variables (`let r: R = …` where
-    // `type R = Result<…>` is stored as `typeAliasVariable`, not `resultType`).
-    // Mirrors `synthValueAccess`, which also resolves before its Result check —
-    // without this, alias-typed Results silently never narrow, leaving them
-    // unfixable under Increment 3's hard-error flip.
-    const resolved = safeResolveType(current, typeAliases);
-    if (resolved.type !== "resultType") continue;
+    // Soundness gate: a branch that reassigns the variable may change its type
+    // mid-branch, so don't narrow it (whole-body scan, conservative).
     if (isReassignedIn(branchBody, cand.variableName)) continue;
-    childScope.declareLocal(cand.variableName, narrowToBranch(resolved, cand.branch));
+    // "what to narrow to" is delegated to the refine's narrower. Each narrower
+    // resolves through type-alias variables itself (mirrors synthValueAccess) so
+    // alias-typed scrutinees still narrow; null means "leave the type as-is".
+    const narrow = narrowers[cand.refine.kind];
+    const narrowed = narrow(cand.refine as never, current, typeAliases);
+    if (narrowed !== null) childScope.declareLocal(cand.variableName, narrowed);
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -7,6 +7,7 @@ import type {
 import { formatTypeHint } from "../utils/formatType.js";
 import { BUILTIN_FUNCTION_TYPES, AGENCY_FUNCTION_METHOD_TYPES } from "./builtins.js";
 import { isAssignable, safeResolveType } from "./assignability.js";
+import { literalToType } from "./literalType.js";
 import { resultTypeForValidation } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
@@ -142,12 +143,12 @@ export function synthType(
     case "number":
     case "unitLiteral":
       return NUMBER_T;
-    case "string": {
-      if (expr.segments.length === 1 && expr.segments[0].type === "text") {
-        return { type: "stringLiteralType", value: expr.segments[0].value };
-      }
-      return STRING_T;
-    }
+    case "string":
+      // Single source of truth for string→literal-type; shared with the
+      // discriminant-narrowing recognizer. number/boolean intentionally stay
+      // NUMBER_T/BOOLEAN_T above (synthType does not infer numeric/boolean
+      // literal types).
+      return literalToType(expr) ?? STRING_T;
     case "multiLineString":
       return STRING_T;
     case "boolean":

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -632,12 +632,12 @@ export function synthValueAccess(
     switch (element.kind) {
       case "property": {
         // Result<T, E>: allow access to runtime fields without flow narrowing.
-        // Until isSuccess/isFailure narrowing lands (Tier 2 PR B), users have
-        // no way to safely unwrap a Result. Treating these field accesses as
+        // isSuccess/isFailure narrowing has landed (lib/typeChecker/narrowing.ts),
+        // so inside a guard .value/.error already type precisely; OUTSIDE a guard
+        // there is still no proven branch, so treating these field accesses as
         // `any` keeps real Result code from flooding with spurious "property
-        // does not exist" errors. Once narrowing lands, this can be tightened
-        // so .value is only valid on the Success branch and .error/etc. are
-        // only valid on Failure.
+        // does not exist" errors. Tightening the un-narrowed access into a hard
+        // error is a later increment.
         if (resolved.type === "resultType") {
           const resolution = resolveResultFieldType(resolved, element.name);
           if (resolution === "any") return "any";


### PR DESCRIPTION
## What

Narrow a union-typed variable when a branch tests its literal discriminant:
`if (r.kind == "answer") { … }` narrows `r` to the matching member(s) in the
then-branch and the complement in the else-branch. Foundation for the rest of
the narrowing program. Type-checker-only — no lowering/codegen change.

### Task 1 — tagged `Refine` + declarative dispatch (behavior-preserving)
`NarrowCandidate` becomes `{ variableName, refine }` where `refine` is a tagged
union (`resultBranch | discriminant`), applied via a `narrowers` table keyed by
`refine.kind`. Splits "what to narrow to" from the "how" (child scope,
reassignment gate, `declareLocal`). Existing `isSuccess`/`isFailure` Result
narrowing is unchanged — its full e2e suite is the gate.

### Task 2 — discriminant engine
- `analyzeCondition` recognizes `v.prop == literal` / `!= literal` over a bare
  variable (either operand order; string/number/boolean literals).
- `narrowUnionByDiscriminant` filters the union's members. **Sound /
  false-negative-only**: drops only provably-excluded members (a member whose
  discriminant prop isn't a matching-kind literal type can't be proven disjoint,
  so it's kept), and never narrows to `never` or to the full set.
- Composes with `&&` / `||` / `!` / early-return / `while`.
- New shared `literalToType` (`literalType.ts`); `synthType`'s **string** case
  now delegates to it.

### Task 3 — match arms are free
`match (r) { { kind: "answer", data } => … }` lowers to
`const __s = r; if (__s.kind == "answer") { const data = __s.data; … }`, so
Task 2 narrows the temp and the bound field types per arm — no match-specific
code. Witnessed with a same-field/different-type union.

## Notes / decisions from review

- **`synthType` DRY scope (corrected during review):** `synthType` does *not*
  produce numeric/boolean literal types today (`number`→`NUMBER_T`,
  `boolean`→`BOOLEAN_T`); only `string` yields a literal type. So only the
  string case delegates to `literalToType` — routing number/boolean through it
  would change inference (`let x = 42` → literal `42`) and break the
  no-behavior-change guarantee. `literalToType` still returns all three literal
  types; the numeric/boolean ones are consumed only by the recognizer, and the
  union members' discriminant literal types come from the **type-annotation
  parser** (verified), not `synthType`.
- **Agency has no `!(expr)` syntax** (the parser rejects `!` before a
  parenthesized group), so `!`-with-discriminant is covered by an
  `analyzeCondition` unit test rather than e2e.
- **Match-arm bodies** are single statements (no block body), so the witness
  uses `let n: number = data`; the `(assignment to 'x')` suffix is only emitted
  for the first lowered arm, so the test asserts by substring.
- Two documented limitations: only *bound fields* narrow (the source scrutinee
  var isn't re-typed, only the lowered temp); a mixed union with a non-literal
  discriminant member doesn't narrow. The `is`-form match stays untagged.
- The deferred "bind it in the pattern" hint (spec D2) is **not** in this PR;
  rationale retained in the plan.

## Verification

- `lib/typeChecker/` — **717 passed**, `npx tsc --noEmit` clean.
- `lib/backends/` + `lib/preprocessors/` — **414 passed** (the lone failure is a
  pre-existing fresh-worktree env issue: `agency-lang/stdlib` subpath not
  resolvable in a worktree checkout; it reproduces on `main` and passes in CI's
  clean build).
- Result-narrowing e2e suite unchanged (Task 1 behavior-preserving gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
