### PR TITLE
Result-as-union: narrow Result via the discriminant engine (R1)

### DIFF
--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { parseAgency } from "../parser.js";
 import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck } from "./index.js";
-import { analyzeCondition, narrowToBranch, alwaysExits, postGuardFacts } from "./narrowing.js";
+import { analyzeCondition, alwaysExits, postGuardFacts } from "./narrowing.js";
 import { walkNodes } from "../utils/node.js";
 import type { Expression, IfElse } from "../types.js";
 import type { ResultType } from "../types/typeHints.js";
@@ -24,17 +24,36 @@ const firstIfCondition = (cond: string) => firstIf(`if (${cond}) { }`).condition
 const NO_FACTS = { then: [], else: [] };
 
 describe("analyzeCondition", () => {
-  it("isSuccess(r): then→success, else→failure", () => {
+  // isSuccess/isFailure (and `if (r.success)`) now narrow via a discriminant on
+  // the boolean `success` field (Result is consumed as a discriminated union).
+  const succ = (varName: string, keep: boolean) => ({
+    variableName: varName,
+    refine: {
+      kind: "discriminant",
+      prop: "success",
+      literal: { type: "booleanLiteralType", value: "true" },
+      keep,
+    },
+  });
+
+  it("isSuccess(r): then success==true, else success!=true", () => {
     expect(analyzeCondition(firstIfCondition("isSuccess(r)"))).toEqual({
-      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
-      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
+      then: [succ("r", true)],
+      else: [succ("r", false)],
     });
   });
 
-  it("isFailure(r): then→failure, else→success", () => {
+  it("isFailure(r): then success!=true, else success==true", () => {
     expect(analyzeCondition(firstIfCondition("isFailure(r)"))).toEqual({
-      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
-      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
+      then: [succ("r", false)],
+      else: [succ("r", true)],
+    });
+  });
+
+  it("if (r.success) truthiness → discriminant success==true", () => {
+    expect(analyzeCondition(firstIfCondition("r.success"))).toEqual({
+      then: [succ("r", true)],
+      else: [succ("r", false)],
     });
   });
 
@@ -55,17 +74,14 @@ describe("analyzeCondition", () => {
 
   it("negation swaps then/else", () => {
     expect(analyzeCondition(firstIfCondition("!isSuccess(r)"))).toEqual({
-      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
-      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
+      then: [succ("r", false)],
+      else: [succ("r", true)],
     });
   });
 
   it("conjunction unions then-facts, drops else-facts", () => {
     expect(analyzeCondition(firstIfCondition("isSuccess(a) && isSuccess(b)"))).toEqual({
-      then: [
-        { variableName: "a", refine: { kind: "resultBranch", branch: "success" } },
-        { variableName: "b", refine: { kind: "resultBranch", branch: "success" } },
-      ],
+      then: [succ("a", true), succ("b", true)],
       else: [],
     });
   });
@@ -73,17 +89,14 @@ describe("analyzeCondition", () => {
   it("disjunction unions else-facts, drops then-facts", () => {
     expect(analyzeCondition(firstIfCondition("isFailure(a) || isFailure(b)"))).toEqual({
       then: [],
-      else: [
-        { variableName: "a", refine: { kind: "resultBranch", branch: "success" } },
-        { variableName: "b", refine: { kind: "resultBranch", branch: "success" } },
-      ],
+      else: [succ("a", true), succ("b", true)],
     });
   });
 
   it("double negation is identity", () => {
     expect(analyzeCondition(firstIfCondition("!!isSuccess(r)"))).toEqual({
-      then: [{ variableName: "r", refine: { kind: "resultBranch", branch: "success" } }],
-      else: [{ variableName: "r", refine: { kind: "resultBranch", branch: "failure" } }],
+      then: [succ("r", true)],
+      else: [succ("r", false)],
     });
   });
 
@@ -142,31 +155,6 @@ describe("analyzeCondition", () => {
     const f = analyzeCondition(negated);
     expect(f.then).toEqual([disc(false)]); // !(== answer) → then is the complement
     expect(f.else).toEqual([disc(true)]);
-  });
-});
-
-describe("narrowToBranch", () => {
-  const rt: ResultType = {
-    type: "resultType",
-    successType: { type: "primitiveType", value: "number" },
-    failureType: { type: "primitiveType", value: "string" },
-  };
-
-  it.each(["success", "failure"] as const)("tags a copy as %s without mutating the original", (branch) => {
-    const narrowed = narrowToBranch(rt, branch);
-    expect(narrowed.narrowedBranch).toBe(branch);
-    expect(narrowed.successType).toEqual(rt.successType);
-    expect(narrowed.failureType).toEqual(rt.failureType);
-    expect(rt.narrowedBranch).toBeUndefined();
-  });
-
-  it("re-narrowing replaces the previous branch rather than stacking", () => {
-    // Inside `if (isSuccess(r)) { if (isFailure(r)) { ... } }`, the inner
-    // re-narrow must overwrite, not append, or downstream synthesis sees
-    // a stale branch tag.
-    const onceSuccess = narrowToBranch(rt, "success");
-    const reFailure = narrowToBranch(onceSuccess, "failure");
-    expect(reFailure.narrowedBranch).toBe("failure");
   });
 });
 
@@ -475,8 +463,12 @@ describe("alwaysExits", () => {
 describe("postGuardFacts", () => {
   it("then-exits, no else → else-facts apply after", () => {
     const node = firstIf(`  if (isFailure(r)) { return 0 }`);
+    // isFailure → else is success==true (Result narrows via discriminant on `success`).
     expect(postGuardFacts(node, analyzeCondition(node.condition))).toEqual([
-      { variableName: "r", refine: { kind: "resultBranch", branch: "success" } },
+      {
+        variableName: "r",
+        refine: { kind: "discriminant", prop: "success", literal: { type: "booleanLiteralType", value: "true" }, keep: true },
+      },
     ]);
   });
   it("neither branch exits → no facts after", () => {
@@ -844,5 +836,33 @@ node main() {
   if (n.code == 1.0) { let b = n.b }
 }`);
     expect(has(errs, /Property 'b' does not exist/)).toBe(1);
+  });
+});
+
+describe("Result-as-union (narrowing via discriminant)", () => {
+  it("if (r.success) narrows like isSuccess", () => {
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  if (r.success) { let n: string = r.value }
+}`);
+    expect(errs).toContain("Type 'number' is not assignable to type 'string' (assignment to 'n').");
+  });
+
+  it("match success/failure arms still type their binders", () => {
+    // Match arm bodies are expressions; witness the binder type by passing it to
+    // a helper whose param type mismatches (success v is number, failure e is string).
+    const errs = check(`${TRY_PARSE}
+def expectString(s: string) {}
+def expectNumber(n: number) {}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => expectString(v)
+    failure(e) => expectNumber(e)
+  }
+}`);
+    expect(errs.some((e) => /not assignable/.test(e) && /string/.test(e))).toBe(true);
+    expect(errs.some((e) => /not assignable/.test(e) && /number/.test(e))).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -1,6 +1,5 @@
 import type { AgencyNode, Expression, TypeAliasEntry, IfElse, VariableType } from "../types.js";
 import type {
-  ResultType,
   StringLiteralType,
   NumberLiteralType,
   BooleanLiteralType,
@@ -9,22 +8,26 @@ import { Scope } from "./scope.js";
 import { walkNodes } from "../utils/node.js";
 import { safeResolveType } from "./assignability.js";
 import { literalToType } from "./literalType.js";
+import { resultToObjectUnion } from "./resultUnion.js";
 import { unescapeStringLiteralValue } from "../parsers/parsers.js";
 
 /**
  * What a candidate narrows to. Tagged so a new narrowing form slots in as one
- * `narrowers`-table entry without touching the apply loop. `resultBranch` is
- * the `isSuccess`/`isFailure` Result narrowing; `discriminant` filters a union
- * by `v.prop == literal`.
+ * `narrowers`-table entry without touching the apply loop. `discriminant`
+ * filters a union by `v.prop == literal` — and now drives Result narrowing too
+ * (`isSuccess`/`isFailure`/`if (r.success)` all narrow on the `success` field,
+ * with Result viewed as a union via `resultToObjectUnion`).
+ *
+ * Kept as a (one-variant) discriminated union deliberately:
+ * `null-truthiness-narrowing` adds a `presence` variant and handler H3 may add
+ * more, each as one more `narrowers` entry.
  */
-export type Refine =
-  | { kind: "resultBranch"; branch: "success" | "failure" }
-  | {
-      kind: "discriminant";
-      prop: string;
-      literal: StringLiteralType | NumberLiteralType | BooleanLiteralType;
-      keep: boolean;
-    };
+export type Refine = {
+  kind: "discriminant";
+  prop: string;
+  literal: StringLiteralType | NumberLiteralType | BooleanLiteralType;
+  keep: boolean;
+};
 export type NarrowCandidate = { variableName: string; refine: Refine };
 export type ConditionFacts = { then: NarrowCandidate[]; else: NarrowCandidate[] };
 
@@ -40,10 +43,6 @@ const narrowers: {
     aliases: Record<string, TypeAliasEntry>,
   ) => VariableType | null;
 } = {
-  resultBranch: (r, current, aliases) => {
-    const resolved = safeResolveType(current, aliases);
-    return resolved.type === "resultType" ? narrowToBranch(resolved, r.branch) : null;
-  },
   discriminant: (r, current, aliases) =>
     narrowUnionByDiscriminant(current, r.prop, r.literal, r.keep, aliases),
 };
@@ -113,6 +112,22 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
     return NO_FACTS;
   }
 
+  // Member-access truthiness: `if (r.success)` ⇒ discriminant `r.success == true`.
+  // SCOPE: fires ONLY for a member access (`v.prop`), never a bare variable
+  // (`if (x)` is presence narrowing — see null-truthiness-narrowing-spec.md; do
+  // NOT generalize this to bare vars). Non-boolean discriminants make
+  // narrowUnionByDiscriminant return null, so this is a sound no-op there.
+  if (condition.type === "valueAccess") {
+    const acc = asDiscriminantAccess(condition);
+    if (!acc) return NO_FACTS;
+    const litTrue: BooleanLiteralType = { type: "booleanLiteralType", value: "true" };
+    const truthy = (keep: boolean): NarrowCandidate => ({
+      variableName: acc.variableName,
+      refine: { kind: "discriminant", prop: acc.prop, literal: litTrue, keep },
+    });
+    return { then: [truthy(true)], else: [truthy(false)] };
+  }
+
   if (condition.type !== "functionCall") return NO_FACTS;
   const fn = condition.functionName;
   if (fn !== "isSuccess" && fn !== "isFailure") return NO_FACTS;
@@ -120,17 +135,15 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
   const arg = condition.arguments[0];
   if (arg.type !== "variableName") return NO_FACTS;
   const name = arg.value;
-  const thenBranch = fn === "isSuccess" ? "success" : "failure";
-  const elseBranch = fn === "isSuccess" ? "failure" : "success";
-  return {
-    then: [{ variableName: name, refine: { kind: "resultBranch", branch: thenBranch } }],
-    else: [{ variableName: name, refine: { kind: "resultBranch", branch: elseBranch } }],
-  };
-}
-
-/** Return a copy of a ResultType tagged as narrowed to one branch. */
-export function narrowToBranch(rt: ResultType, branch: "success" | "failure"): ResultType {
-  return { ...rt, narrowedBranch: branch };
+  // isSuccess(r) ⇔ r.success == true ; isFailure(r) ⇔ r.success != true.
+  // Result is consumed as a discriminated union on `success` (resultUnion.ts).
+  const successLit: BooleanLiteralType = { type: "booleanLiteralType", value: "true" };
+  const keepThen = fn === "isSuccess";
+  const onSuccess = (keep: boolean): NarrowCandidate => ({
+    variableName: name,
+    refine: { kind: "discriminant", prop: "success", literal: successLit, keep },
+  });
+  return { then: [onSuccess(keepThen)], else: [onSuccess(!keepThen)] };
 }
 
 /**
@@ -186,7 +199,10 @@ export function narrowUnionByDiscriminant(
   keep: boolean,
   aliases: Record<string, TypeAliasEntry>,
 ): VariableType | null {
-  const resolved = safeResolveType(type, aliases);
+  let resolved = safeResolveType(type, aliases);
+  // Result is a discriminated union on `success` — view it as one so the same
+  // member-filter handles isSuccess/isFailure/`if (r.success)` narrowing.
+  if (resolved.type === "resultType") resolved = resultToObjectUnion(resolved, aliases);
   if (resolved.type !== "unionType") return null;
   const members = resolved.types;
   const kept = members.filter((m) => {
@@ -250,13 +266,9 @@ export function postGuardFacts(node: IfElse, facts: ConditionFacts): NarrowCandi
  *     or a nested function that shadows `r` would also trip the gate.
  *
  * Refinements are written with declareLocal so they vanish when the child
- * scope is dropped at branch exit and never leak to the function scope.
- *
- * A `let r2 = r` inside a narrowed branch does NOT propagate the marker
- * outside the block: `scope.declare()` calls `widenType()`, which for
- * `resultType` rebuilds the object without `narrowedBranch`
- * (assignability.ts:370). `r2.value` outside the block is therefore the
- * usual un-narrowed `any`. Locked in by a test in narrowing.test.ts.
+ * scope is dropped at branch exit and never leak to the function scope. A
+ * narrowed binding is the concrete member type (e.g. a Result's success-member
+ * object type), so nothing branch-specific persists once the child is dropped.
  */
 export function applyNarrowing(
   childScope: Scope,

--- a/packages/agency-lang/lib/typeChecker/resultUnion.ts
+++ b/packages/agency-lang/lib/typeChecker/resultUnion.ts
@@ -1,0 +1,54 @@
+import type {
+  ResultType,
+  UnionType,
+  VariableType,
+  TypeAliasEntry,
+} from "../types/typeHints.js";
+import { ANY_T, BOOLEAN_T, STRING_T, UNDEFINED_T } from "./primitives.js";
+
+const bool = (v: "true" | "false"): VariableType => ({
+  type: "booleanLiteralType",
+  value: v,
+});
+
+/**
+ * The canonical discriminated-union view of a Result, keyed on `success`.
+ * Single source of truth for "what fields a Result has" — mirrors the runtime
+ * shape in lib/runtime/result.ts. The type checker consumes Result through this
+ * (narrowing + field access) rather than special-casing `resultType`.
+ */
+export function resultToObjectUnion(
+  rt: ResultType,
+  _aliases: Record<string, TypeAliasEntry>,
+): UnionType {
+  return {
+    type: "unionType",
+    types: [
+      {
+        type: "objectType",
+        properties: [
+          { key: "success", value: bool("true") },
+          { key: "value", value: rt.successType },
+        ],
+      },
+      {
+        type: "objectType",
+        properties: [
+          { key: "success", value: bool("false") },
+          { key: "error", value: rt.failureType },
+          { key: "checkpoint", value: ANY_T },
+          { key: "retryable", value: BOOLEAN_T },
+          // runtime is `string | null` (result.ts); Agency has no `null`, so the
+          // surface type is `string | undefined`.
+          {
+            key: "functionName",
+            value: { type: "unionType", types: [STRING_T, UNDEFINED_T] },
+          },
+          // runtime is `Record<string, any> | null` (a record, not an array);
+          // typed `any` here — tighten to a Record type later if useful.
+          { key: "args", value: ANY_T },
+        ],
+      },
+    ],
+  };
+}

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -53,26 +53,13 @@ const RESULT_FIELDS = new Set<string>([
  * extraction is purely organizational.
  */
 function resolveResultFieldType(
-  resolved: ResultType,
+  _resolved: ResultType,
   fieldName: string,
 ): VariableType | "any" | null {
-  // Narrowed to the Success branch (inside an isSuccess guard).
-  if (resolved.narrowedBranch === "success") {
-    if (fieldName === "value") return resolved.successType;
-    if (fieldName === "success") return BOOLEAN_T;
-  }
-  // Narrowed to the Failure branch (isFailure guard, or the else of an
-  // isSuccess guard).
-  if (resolved.narrowedBranch === "failure") {
-    if (fieldName === "error") return resolved.failureType;
-    if (fieldName === "success") return BOOLEAN_T;
-    // `.value` on a known-Failure result is illegal at runtime; Increment 3
-    // turns this into an error. The Failure-only metadata fields
-    // (checkpoint/retryable/functionName/args) just fall through to the
-    // `RESULT_FIELDS → any` line below — we deliberately don't enumerate
-    // them: the existing fallthrough is already the correct, single-source-
-    // of-truth answer.
-  }
+  // Narrowed Results are now real member object types (narrowed via the
+  // discriminant engine), so this only sees UN-narrowed Results: keep the
+  // lenient `any` for known Result fields. Task 2 deletes this entirely and
+  // routes un-narrowed Results through strict union access.
   if (RESULT_FIELDS.has(fieldName)) return "any";
   return null;
 }

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -105,10 +105,6 @@ export type ResultType = {
   successType: VariableType;
   failureType: VariableType;
   tags?: Tag[];
-  // Set ONLY by the type checker's narrowing layer (lib/typeChecker/narrowing.ts)
-  // when a variable has been narrowed inside an isSuccess/isFailure guard.
-  // Never produced by parsing or return-type inference. isAssignable ignores it.
-  narrowedBranch?: "success" | "failure";
 };
 
 /**


### PR DESCRIPTION
## Result-as-union: narrowing via the discriminant engine (R1)

Consumes `Result` as the discriminated object union it already is at runtime (keyed on `success`), so narrowing rides the general discriminated-union machinery (D1) instead of bespoke Result code.

- New `resultToObjectUnion(rt)` — the canonical `{success:true,value:T} | {success:false,error:E,checkpoint,retryable,functionName,args}` view (mirrors `runtime/result.ts`).
- `isSuccess(r)` / `isFailure(r)` **and now `if (r.success)`** all narrow via a discriminant on `success` → the narrowed binding is a real member object type.
- **Retires** `narrowedBranch` (on `ResultType`), `narrowToBranch`, the `resultBranch` `Refine` variant, and the `narrowedBranch` reads in `resolveResultFieldType`.
- Net effect: a narrowed Result's off-branch access (e.g. `r.error` inside `if (isSuccess(r))`) now correctly errors (it's a real member object type); un-narrowed Result field access stays lenient (`any`) — **no breaking change**.

### Validation
- `npx vitest run lib/typeChecker/ lib/typeChecker.test.ts`: 919/919 pass.
- `npx tsc --noEmit`: clean. `pnpm run lint:structure`: clean.

### Scope note — the strict-access flip (R2) is intentionally NOT here

The plan's R2 (un-narrowed `r.value` → hard error, generalized to strict union member access) is **deferred**: it hit an architectural blocker. Narrowing is applied only in the scope-building pass (`walkScopeBody`'s child scopes), but field-access type-checking *also* happens in `checkExpressionsInScope` (`checker.ts:788`), which re-synths every `valueAccess` against the **flat, un-narrowed** scope. Under the old lenient access that returned `any` (harmless); under strict access it would emit a spurious "does not exist" on **guarded** code (`if (isSuccess(r)) { r.value }` gets both the correct narrowed type *and* a bogus un-narrowed error).

Delivering R2 correctly requires narrowing to be consistent across the checker's passes (e.g. a strict-mode flag threaded through `synthType`, or unifying field-access checking into the narrowing-aware walk) — a design decision worth making explicitly rather than hacking mid-PR. This PR is the clean, behavior-preserving R1 foundation; R2 follows once that's settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
