### PR TITLE
Nullish unification: one nothing-value (null)

### DIFF
--- a/packages/agency-lang/docs/dev/null-and-undefined.md
+++ b/packages/agency-lang/docs/dev/null-and-undefined.md
@@ -235,8 +235,8 @@ today, so `x == null` would miss `undefined`. Three options:
   JS coercion footguns like `5 == "5"` can't arise). Complete and type-free at
   codegen, and a genuine safety improvement — but a *large* change touching
   every comparison in the corpus, with its own migration.
-- **D3 — runtime helper (chosen):** compile `==` to `__eq(a, b)` and `!=` to
-  `!__eq(a, b)`, where:
+- **D3 — runtime helper (chosen):** compile `==`/`===` to `__eq(a, b)` and
+  `!=`/`!==` to `!__eq(a, b)`, where:
 
   ```ts
   export function __eq(a: unknown, b: unknown): boolean {
@@ -256,8 +256,12 @@ Why `__eq` is correct: `a == null` (loose) is true for exactly `null` and
 `undefined` and nothing else (not `0`, `""`, `false`, `NaN`). So `(a == null &&
 b == null)` means "both nullish," while `a === b` handles everything else
 exactly. For any value `x`, `__eq(x, null) === __eq(x, undefined)`, and for two
-non-nullish values `__eq` is identical to `===`. `===`/`!==` remain strict as an
-explicit "exact" escape hatch.
+non-nullish values `__eq` is identical to `===`. **All four equality operators
+lower to `__eq`; there is no strict escape hatch.** A strict `===` would only let
+you distinguish `null` from `undefined` — the exact distinction this project
+removes — and would be a footgun (`x === null` silently missing an interop
+`undefined`). `===`/`!==` remain parseable as stylistic aliases of `==`/`!=` but
+compile identically.
 
 ## Consequences and how specific cases resolve
 

--- a/packages/agency-lang/docs/dev/null-and-undefined.md
+++ b/packages/agency-lang/docs/dev/null-and-undefined.md
@@ -1,0 +1,308 @@
+# `null` and `undefined` in Agency
+
+This document explains a deliberate language-design decision: **Agency has one
+nothing-value, `null`, and treats `undefined` as identical to it.** It records
+what we decided, the alternatives we weighed, and *why* we chose unification —
+because this question resurfaces often and the reasoning is subtle.
+
+The concrete implementation is specified in
+[`docs/superpowers/specs/2026-06-28-nullish-unification-design.md`](../superpowers/specs/2026-06-28-nullish-unification-design.md).
+This doc is the "why"; that spec is the "what."
+
+## The decision in one paragraph
+
+There is exactly one nothing-value in Agency: `null`. Users cannot write
+`undefined` as a value (the parser has no `undefinedParser`, only a
+`nullParser`). Optionality is `T | null`. At runtime, `null` and `undefined`
+compare equal (via the `__eq` helper), and `undefined` arriving from the JS
+runtime or TypeScript interop is absorbed into `null`. `undefined` is never a
+distinct concept a user has to reason about.
+
+## Background: why this even comes up
+
+Agency compiles to TypeScript/JavaScript, which famously has **two**
+nothing-values. This leaked into Agency incoherently:
+
+- The **type** representation of optionality was `undefined`: `key?: T`
+  desugared to `T | undefined`, and `isOptionalType` keyed on `"undefined"`.
+- But the **Zod codegen** already emitted `null`: both `null` and `undefined`
+  primitive types mapped to `z.null()`.
+
+So the type system said one thing and the runtime did another. On top of that,
+the `null` literal synthesized to `any`, assignability treated `null` and
+`undefined` as distinct primitives, and `schema(T).parse({})` was broken for
+optional keys (a missing key is `undefined` at runtime, but the generated schema
+only accepted `string | null`). The language had inherited JS's two-value wart
+without inheriting a coherent story for it.
+
+## The conceptual distinction (and why it's a trap)
+
+`null` and `undefined` *can* be given distinct meanings, and many TypeScript
+style guides do:
+
+- `undefined` = "uninitialized / not present / never set."
+- `null` = "intentionally set to no value."
+
+This is a real, defensible distinction. It even has a sharper cousin that
+TypeScript exposes via the `exactOptionalPropertyTypes` flag: the difference
+between a key being **absent** and a key being **present but `undefined`**.
+
+The trap is that this distinction is **mostly useless in practice and a
+constant source of friction**:
+
+- Most developers can't articulate when to return `void` vs `null` vs
+  `undefined` for "no value" — they feel equivalent, so every codebase invents
+  its own convention and then has to police it.
+- TypeScript itself treats `key?: T` and `key: T | undefined` as interchangeable
+  *by default*. The precise distinction is opt-in via
+  `exactOptionalPropertyTypes`, and — tellingly — that flag is deliberately
+  **not** part of the `strict` family. The TS team kept it separate because it
+  is too disruptive to turn on for everyone. In practice the large majority of
+  codebases never enable it. The "absent vs present-undefined" distinction is a
+  narrow, advanced concern (object spread/merge clobbering fields, PATCH
+  semantics where `null` = "clear" and absent = "don't touch") that does not
+  apply to Agency's audience of agent-workflow authors.
+
+So the distinction is sound in theory, rarely useful in practice, and a reliable
+source of confusion. That is exactly the kind of thing a new language should
+drop if it can.
+
+## What other languages do
+
+We surveyed how other languages handle "nothing," because it reframes the whole
+question:
+
+| Language | Nothing-values | Notes |
+|---|---|---|
+| **Python** | One (`None`) | A missing dict key / unbound name is an *error*, not a second nothing-value. |
+| **Ruby** | One (`nil`) | Unset instance var → `nil`; unset local → `NameError`. |
+| **Rust** | Zero (free) | No null. `Option<T>` = `Some(T) \| None`; the compiler *forces* you to handle `None`. |
+| **Haskell** | Zero (free) | No null references. `Maybe a = Just a \| Nothing`. (`undefined`/⊥ is a divergent error term, not a comparable value.) |
+| **Zig** | Two (`null` + `undefined`) | But crisply split: `null` is the value of optionals (`?T`); `undefined` is *only* an "uninitialized memory" marker — not a value you pass around or compare, and reading it is a bug caught in safe builds. |
+
+Two conclusions:
+
+1. **JS's two-nothing-values design is near-universally regretted and unique to
+   JS.** Brendan Eich and essentially everyone consider it a mistake. It
+   survives only because JS cannot break backward compatibility. Every language
+   designed from scratch picked **one** nothing-value (Python/Ruby) or **zero,
+   type-wrapped** (Rust/Haskell).
+
+2. **The one language that keeps both (Zig) does not use `undefined` as a
+   general empty value.** It gives `undefined` a single narrow job
+   (uninitialized) and makes `null` the thing you program with. Agency has no
+   "declare a variable without initializing it" pattern — `let`/`const` always
+   take a value — so even Zig's narrow justification for `undefined` does not
+   exist here.
+
+**Agency is not bound by JS's backward-compatibility constraint.** TypeScript has
+to live with JS's warts to stay compatible; Agency is a separate language that
+merely *compiles to* JS. So Agency can do what the from-scratch languages did:
+have one nothing-value.
+
+## The key fact that constrains the design
+
+Even though Agency can *choose* to have one nothing-value, it **cannot make
+`undefined` not exist at runtime**, because it compiles to JavaScript and JS
+produces `undefined` everywhere regardless of the surface language:
+
+- a missing object key reads as `undefined`
+- an out-of-bounds array index → `undefined`
+- a function that falls off the end without returning → `undefined`
+- optional chaining `a?.b` → `undefined`
+- any TypeScript interop can hand back `undefined`
+
+This rules out the naive "just pretend `undefined` doesn't exist" approach: if
+the type system declared `undefined` impossible while the runtime kept producing
+it, you would get values flowing through the program that the types say can't
+exist — an unsoundness hole, and the *worst* outcome (the confusion isn't
+removed, just hidden).
+
+The design therefore does not *ignore* `undefined` — it **absorbs** it. `null`
+and `undefined` are made to behave identically everywhere a user can observe
+them, and `undefined` is normalized to `null` where it enters typed data.
+
+## Alternatives considered
+
+### A. Full TypeScript parity (keep both, distinct)
+
+Add an `undefined` literal so users can write it; keep `null` and `undefined` as
+distinct values with distinct meanings.
+
+Rejected. It imports the exact wart we wanted to remove. The "absent vs
+present-undefined" precision it buys is the narrow, advanced concern Agency's
+users don't have, and it forces every user to learn and police a convention they
+mostly find useless. It is also *not* what most TypeScript developers experience
+day to day (default TS blurs `?` and `| undefined`).
+
+### B. Zig-style split (`null` is the value, `undefined` only uninitialized)
+
+Keep `undefined` as a narrow "uninitialized" marker, rarely written.
+
+Rejected. Agency has no declare-without-initialize pattern, so the one job that
+justifies `undefined` in Zig does not exist here. It would be machinery with no
+use case.
+
+### C. A nominal `Option`/`Maybe` type (Rust/Haskell style)
+
+Drop `null` entirely; absence is `Option<T>` with forced unwrapping.
+
+Rejected for this project. The thing sketched in discussion — `Maybe<T>`
+meaning "T or null," assignable directly from a bare value or `null` — is **not**
+the Rust/Haskell `Option`. In Rust you cannot write `let x: Option<i32> = 5`;
+you must wrap (`Some(5)`) and cannot use the value until you unwrap it. *That
+friction is the entire source of the safety.* What was sketched is just
+`T | null` with a nicer name, which buys nothing on its own.
+
+The real safety win — forcing you to handle absence before using a value — comes
+from the **type checker being strict about nullable access**, not from the
+runtime representation or the type's name. You can get full `Option`-grade
+safety while compiling to plain `T | null`, purely by making the checker reject
+`x.foo` on a possibly-null `x` until it's narrowed. A nominal `Option` type
+would be a much larger, more ceremonious change that fights Agency's
+TS-flavored syntax and compile target, for the same safety. So strict nullable
+checking (see "Relationship to null safety" below) is the chosen path, not a
+nominal `Option`.
+
+See the next section for the fuller decision on a built-in `Maybe` type
+specifically.
+
+## Should Agency have a built-in `Maybe` type?
+
+We considered adding a built-in `Maybe<T>` (a.k.a. `Option`) — a `some(T)` /
+`none` wrapper analogous to Agency's existing `Result<T, E>`. **Decision: no.**
+`T | null` plus strict null checking (Project 2) is the one way to express
+optionality.
+
+The attraction was real: a `Maybe` type forces you to unwrap absence, it could
+chain with the pipe operator, and it could be a named domain type for
+"something or nothing" return values (including tool results, where `Result`
+already works well). But each advantage is weaker than it first appears once you
+account for what Agency already has or is already building:
+
+1. **Forced unwrapping is already delivered by strict null checking.** Once the
+   checker rejects member access on a `T | null` until it's narrowed, you cannot
+   use a possibly-absent value without handling absence. `Maybe`'s headline
+   safety feature adds essentially nothing over strict-checked `T | null` — the
+   safety comes from the checker, not the wrapper.
+
+2. **Pipes are already `Result`-native.** `synthPipe` wraps every pipe's output
+   in a `resultType`; the pipe operator is designed around `Result`. So
+   "a wrapper that pipes well with short-circuiting" is not a gap — `Result`
+   already is that, and a "might be absent" pipeline can model absence as
+   `failure`. A second pipe-friendly wrapper would be redundant.
+
+3. **Tools are better served by `T | null` than by `Maybe`.** A tool returning
+   `T | null` maps directly onto the LLM structured-output schema, where `null`
+   is *exactly* how optionality is encoded (required + nullable). A tool
+   returning `Maybe<T>` would need a new `some`/`none` representation in the
+   JSON schema — strictly *more* complex than the null encoding the provider
+   already wants.
+
+Against those weak gains, a built-in `Maybe` carries real costs:
+
+- **It reintroduces the fork this project exists to remove.** We eliminated
+  "`null` or `undefined`?"; adding `Maybe` creates "`T | null` or `Maybe<T>`?"
+  at every optional value.
+- **It reopens the absent-vs-null distinction we deliberately killed:**
+  `Maybe<T>` where `T` admits null distinguishes `none` from `some(null)`.
+- **Large surface:** new type, constructors, pattern-matching, narrowing,
+  `Result`/pipe interop, LLM-schema mapping, tool integration, docs.
+
+The only world where `Maybe` clearly wins is **all-in, Rust/Haskell style**: no
+nullable type at all, absence expressed *only* as `Maybe<T>`, `null` not
+writable. That is principled and fork-free — but it contradicts the `T | null`
+direction chosen here (and the preference for being able to write `null` and
+keep `key?:` simple), and it is a much larger, separate project. The genuinely
+bad option is the **half-measure** — shipping *both* `T | null` and `Maybe<T>` —
+which is the worst of both worlds: two overlapping ways to say the same thing.
+
+If heavy pain ever shows up specifically in *optional* pipelines, the better
+levers to revisit are null-aware pipe sugar or wider `Result` use — not a third
+optional concept.
+
+### D. How to make equality treat `null` and `undefined` the same
+
+Sub-decision within the chosen design. Agency compiles `==` to strict `===`
+today, so `x == null` would miss `undefined`. Three options:
+
+- **D1 — syntactic null-literal rule:** compile `==`/`!=` to loose only when an
+  operand is the literal `null`. Easy and type-free, but misses value-to-value
+  comparisons where one side is a runtime `undefined` not written as the
+  literal.
+- **D2 — loose `==` everywhere + add operand type-checking:** make `==` loose
+  globally and add a new rule that equality operands must be type-compatible (so
+  JS coercion footguns like `5 == "5"` can't arise). Complete and type-free at
+  codegen, and a genuine safety improvement — but a *large* change touching
+  every comparison in the corpus, with its own migration.
+- **D3 — runtime helper (chosen):** compile `==` to `__eq(a, b)` and `!=` to
+  `!__eq(a, b)`, where:
+
+  ```ts
+  export function __eq(a: unknown, b: unknown): boolean {
+    return a === b || (a == null && b == null);
+  }
+  ```
+
+We chose **D3**. It is type-independent at the comparison site (no inference
+needed, so it works even when an operand's type is unknown or a union),
+complete (handles value-to-value cases, not just the literal), and avoids JS's
+cross-type coercion quirks entirely. Because operands are passed as arguments
+they are **evaluated exactly once** — an inline `a === b || (a == null && b ==
+null)` would double-evaluate side-effecting operands. D2 was rejected as too
+large for this project; D1 was rejected for the value-to-value gap.
+
+Why `__eq` is correct: `a == null` (loose) is true for exactly `null` and
+`undefined` and nothing else (not `0`, `""`, `false`, `NaN`). So `(a == null &&
+b == null)` means "both nullish," while `a === b` handles everything else
+exactly. For any value `x`, `__eq(x, null) === __eq(x, undefined)`, and for two
+non-nullish values `__eq` is identical to `===`. `===`/`!==` remain strict as an
+explicit "exact" escape hatch.
+
+## Consequences and how specific cases resolve
+
+- **Unsetting an object key:** set it to `null`. There is no meaningful
+  difference between "key absent" and "key = null." True key *removal* (so it
+  disappears from `Object.keys`/`in`) is a separate operation Agency does not
+  have and rarely needs, under the guiding rule **"check the value, not the
+  key's presence."**
+- **Default parameters are unaffected.** Agency detects "argument not passed"
+  with a dedicated `__UNSET` sentinel (neither `null` nor `undefined`), so
+  unifying the nothing-values does not change default-parameter behavior:
+  `f()` applies the default; `f(null)` passes `null`.
+- **TS interop returning `undefined`:** the type normalizes to `null`, and a
+  null check catches the runtime `undefined` via `__eq`. The one observable
+  sharp edge is passing an actually-`undefined` value *back* into TS code that
+  strictly distinguishes `=== undefined` from `=== null` — rare, and a
+  documentation note rather than a code path.
+- **`schema({ foo?: string }).parse({})` → `{ foo: null }`.** The parse/
+  validation schema accepts a missing optional key and coalesces it to `null`,
+  giving a predictable shape where every declared key is present. (The LLM
+  structured-output schema is separate and keeps optional keys as required +
+  nullable, because OpenAI structured output requires every field to be
+  `required`, with optionality expressible only as a union with null.)
+
+## Relationship to null safety
+
+Unifying the nothing-values is **Project 1**. It deliberately does *not* make
+Agency null-*safe*: today the type checker lets you access a member on a
+possibly-null value with no error (like TypeScript with `strictNullChecks`
+off).
+
+Strict null checking — forcing you to narrow a `T | null` before using it — is
+**Project 2**, and it is where the real safety payoff lives. It rides on the
+existing narrowing engine and roadmap: retarget `null-truthiness-narrowing-spec`
+from `undefined` to `null`, and make `strictMemberAccess` treat a possibly-null
+access as an error until narrowed. That combination gives Rust/`Option`-grade
+safety on top of the clean one-value runtime model, without a nominal `Option`
+type.
+
+## Summary
+
+Agency has one nothing-value, `null`, because: every from-scratch language chose
+one (or zero); JS's two-value design is a regretted wart Agency is free to drop;
+the `null`/`undefined` distinction is sound in theory but a practical source of
+friction its users don't need; and `undefined` is unavoidable at the JS runtime
+boundary, so the right move is to *absorb* it into `null` (one writable value,
+equal at runtime, normalized in typed data) rather than to either keep both or
+pretend `undefined` doesn't exist.

--- a/packages/agency-lang/docs/site/stdlib/agency/eval.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/eval.md
@@ -117,7 +117,7 @@ export type EvalRunResult = {
 ```ts
 export type EvalValue = {
   value: any;
-  threadId: string | null;
+  threadId?: string;
   tMs: number;
   truncated?: boolean
 }

--- a/packages/agency-lang/docs/site/stdlib/markdown.md
+++ b/packages/agency-lang/docs/site/stdlib/markdown.md
@@ -276,7 +276,7 @@ A fenced or indented code block. `language` is the info string for fenced
 export type CodeBlock = {
   type: "code-block";
   content: string;
-  language: string | null
+  language?: string
 }
 ```
 

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -12,9 +12,9 @@ name: "memory"
 export type MemoryConfig = {
   dir: string;
   model?: string;
-  autoExtract?: { interval: number | undefined };
-  compaction?: { trigger: "token" | "messages" | undefined; threshold: number | undefined };
-  embeddings?: { model: string | undefined }
+  autoExtract?: { interval: number | null };
+  compaction?: { trigger: "token" | "messages" | null; threshold: number | null };
+  embeddings?: { model: string | null }
 }
 ```
 

--- a/packages/agency-lang/docs/site/stdlib/statelog.md
+++ b/packages/agency-lang/docs/site/stdlib/statelog.md
@@ -11,7 +11,7 @@ name: "statelog"
 ```ts
 export type StatelogEvalValue = {
   value: any;
-  threadId: string | null;
+  threadId?: string;
   tMs: number;
   truncated?: boolean
 }

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -24,10 +24,10 @@ export type ModelCost = {
 ```ts
 export type GuardFailureData = {
   type: string;
-  maxCost: number | null;
-  actualCost: number | null;
-  maxTime: number | null;
-  actualTime: number | null
+  maxCost?: number;
+  actualCost?: number;
+  maxTime?: number;
+  actualTime?: number
 }
 ```
 

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification-review.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification-review.md
@@ -1,0 +1,69 @@
+# Review: Nullish Unification Plan (2026-06-28)
+
+Reviewer: Amp (Sonnet 4.5)
+Plan: [`2026-06-28-nullish-unification.md`](./2026-06-28-nullish-unification.md)
+Spec: [`../specs/2026-06-28-nullish-unification-design.md`](../specs/2026-06-28-nullish-unification-design.md)
+
+## Verdict
+
+Plan is **executable as-is** and well-structured. The cited line numbers and code snippets match real source (verified at `typescriptBuilder.ts:1064-1072`, `:1525-1534`, `parsers.ts:1049-1076`, `imports.mustache`, `ir/builders.ts:675` for `ts.not`). Recommend three pre-execution edits below.
+
+## Real concerns
+
+### 1. Task ordering risk between Tasks 3 and 5 (AST-shape gap)
+
+Task 3 makes `objectPropertyParser` produce `T | null`, but Task 5 (which retargets `UNDEFINED_T`/`isOptionalType` to `null`) doesn't land until after Task 4. Between Task 3 and Task 5, the type checker still keys on `"undefined"`, so an optional key is silently *not optional* from the checker's POV.
+
+Any `make fixtures` or typecheck run between those tasks is unreliable, and any failing intermediate assertion is hard to attribute.
+
+**Fix:** Bundle Tasks 3, 4, 5 into a single commit, OR explicitly state in the plan: "do not regenerate fixtures or run typechecker tests until after Task 5."
+
+### 2. Task 5 Step 9 grep is too narrow
+
+`grep -i "UNDEFINED_T\|undef"` won't catch string-literal type references like `value: "undefined"` or `t.value === "undefined"` scattered through the type checker.
+
+**Fix:** Add a second-pass grep before declaring no stragglers:
+
+```bash
+grep -rn '"undefined"' lib/typeChecker/ | grep -v "typeof.*undefined"
+```
+
+Same critique applies to Task 9 Step 2 — its grep excludes `errors.ts`/`asyncContext.ts` without justification and skips `stdlib/` entirely. Stdlib `.agency` files using `key?: T` or `: undefined` should round-trip clean, but worth verifying explicitly.
+
+### 3. Task 8 nested test misses the recursion case
+
+Spec §Testing requires:
+
+```
+parse({ a: {} })   →   { a: { b: null } }
+```
+
+The plan's `optionalKeyNested.agency` only verifies the outer-coalesce case (`parse({})`). 
+
+**Fix:** Add a second test variant that passes `{a: {}}` and asserts `r.value.a.b == null` to confirm the recursive thread of `optionalKeyMode`.
+
+## Smaller nits
+
+- **Task 2 Step 4** says "modify `imports.mustache:26-27`" but line 26 is the `Schema, __validateType, ...` line; the actual edit target (`success, failure, ..., __catchResult,`) is line 25. The instruction body correctly identifies the line by content, so this is a stale line reference, not a real bug.
+- **Task 7** uses a `formatAgency` helper without confirming it exists — the plan acknowledges this in fallback prose. Worth a 30-second check up front rather than discovering it at execution time.
+- **Sharp-edge doc note from spec §4** (users who need `=== undefined` use `===`) isn't included anywhere in the implementation. Add to Task 9 or to `docs/dev/null-and-undefined.md`.
+- **Task 9 Step 6** `git add` path `../../null-truthiness-narrowing-spec.md` assumes a specific repo layout. Plan already advises `git status` first — fine.
+
+## What's done well
+
+- TDD structure (failing → impl → passing) every task.
+- Tasks are independently committable with focused diffs.
+- Honest self-review section with one explicit user judgment call (Task 6 deferrable).
+- `__eq(a, b) = a === b || (a == null && b == null)` formulation is correct, side-effect-safe (operands evaluated once via helper), and the truth-table test covers the symmetry property `__eq(x, null) === __eq(x, undefined)`.
+- Defers strict-null-checking, narrowing, `null`-literal-type, and `delete` cleanly to Project 2, in alignment with the spec's Non-goals.
+- Coordination notes with the flow-typed checker and `never` work (spec §6) are honored — no narrowing or `analyzeCondition` changes leak into this PR.
+
+## Minimum recommended pre-execution edits
+
+1. Merge Tasks 3+4+5 into a single commit (or block fixture regen + typechecker test runs until after Task 5).
+2. Broaden the `"undefined"` string-literal grep in Tasks 5 Step 9 and Task 9 Step 2; include `stdlib/`.
+3. Add the recursive-coalesce variant (`{a: {}}` → `{a: {b: null}}`) to Task 8.
+
+Optional but cheap:
+- Add the `===` escape-hatch doc note (spec §4) somewhere in Task 9.
+- Verify `formatAgency` exists before starting Task 7.

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification.md
@@ -1,0 +1,984 @@
+# Nullish Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Agency have one nothing-value (`null`) by flipping optionality's type representation from `T | undefined` to `T | null`, absorbing runtime `undefined` into `null` via an `__eq` equality helper, and fixing `schema(T).parse({})` to coalesce missing optional keys to `null`.
+
+**Architecture:** Three coordinated changes. (1) The parser stops producing the `undefined` primitive — `key?: T` desugars to `T | null` and the `undefined` type keyword normalizes to `null` at parse time. (2) Codegen lowers `==`/`!=` to a runtime `__eq(a, b)` helper that treats `null`/`undefined` as one value, so runtime `undefined` from JS interop is caught by `null` checks. (3) The validation/parse Zod mapper makes nullable object keys optional-with-default-null. Strict null checking and null narrowing are explicitly deferred to Project 2.
+
+**Tech Stack:** TypeScript, tarsec parser combinators (`lib/parsers/`), the TsNode IR + builders (`lib/ir/`), Zod codegen (`lib/backends/typescriptGenerator/`), typestache templates (`lib/templates/`), vitest, the Agency execution-test runner.
+
+**Reference docs:**
+- Spec: [`docs/superpowers/specs/2026-06-28-nullish-unification-design.md`](../specs/2026-06-28-nullish-unification-design.md)
+- Rationale: [`docs/dev/null-and-undefined.md`](../../dev/null-and-undefined.md)
+
+## Global Constraints
+
+- NEVER use dynamic imports.
+- Use objects instead of maps; arrays instead of sets; `type` instead of `interface`.
+- NEVER force-push or amend commits.
+- Only modify `.mustache` template files, never the generated `.ts` — after editing a `.mustache`, run `pnpm run templates` to regenerate.
+- Run `make` to build before running Agency execution tests or regenerating fixtures (the CLI runs from `dist/`).
+- Agency execution tests run with `pnpm run a test <file>` (NOT `pnpm test:run`). TypeScript/vitest unit tests run with `pnpm test:run <file>`.
+- End every commit message with this line (write the message to a file and pass it with `git commit -F`, because apostrophes on the command line break):
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Do not run the full Agency test suite locally (slow/expensive); run only the specific tests named in each task.
+
+## Scope note (deferred — do NOT implement here)
+
+Per the spec's Non-goals: no strict null checking, no null narrowing, no equality-operand type-checking, no `null`-literal-synthesizes-to-`null` change, no `delete`, no `Maybe` type. These belong to Project 2.
+
+---
+
+### Task 1: `__eq` runtime equality helper
+
+**Files:**
+- Create: `lib/runtime/eq.ts`
+- Modify: `lib/runtime/index.ts` (add export)
+- Test: `lib/runtime/eq.test.ts`
+
+**Interfaces:**
+- Produces: `export function __eq(a: unknown, b: unknown): boolean` — `true` when both operands are nullish (`null`/`undefined`) or strictly equal; otherwise behaves exactly like `===`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/eq.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { __eq } from "./eq.js";
+
+describe("__eq", () => {
+  it("treats null and undefined as equal", () => {
+    expect(__eq(null, undefined)).toBe(true);
+    expect(__eq(undefined, null)).toBe(true);
+    expect(__eq(null, null)).toBe(true);
+    expect(__eq(undefined, undefined)).toBe(true);
+  });
+
+  it("keeps non-nullish values distinct from nullish", () => {
+    expect(__eq(0, null)).toBe(false);
+    expect(__eq(0, undefined)).toBe(false);
+    expect(__eq("", null)).toBe(false);
+    expect(__eq(false, null)).toBe(false);
+    expect(__eq(5, null)).toBe(false);
+  });
+
+  it("matches === for non-nullish values", () => {
+    expect(__eq(5, 5)).toBe(true);
+    expect(__eq("a", "a")).toBe(true);
+    expect(__eq(5, 6)).toBe(false);
+    expect(__eq("a", "b")).toBe(false);
+    const obj = { x: 1 };
+    expect(__eq(obj, obj)).toBe(true);
+    expect(__eq({ x: 1 }, { x: 1 })).toBe(false); // reference equality
+    expect(__eq(NaN, NaN)).toBe(false); // same as ===
+  });
+
+  it("is symmetric for any value against null vs undefined", () => {
+    for (const x of [0, "", false, 5, "a", null, undefined, NaN]) {
+      expect(__eq(x, null)).toBe(__eq(x, undefined));
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/eq.test.ts`
+Expected: FAIL — cannot resolve `./eq.js` / `__eq` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/runtime/eq.ts`:
+
+```ts
+/**
+ * Equality with unified nullish semantics. `null` and `undefined` are one
+ * nothing-value in Agency, so `==`/`!=` lower to this helper instead of
+ * strict `===`/`!==`. For two non-nullish values it is identical to `===`;
+ * the only difference is that `null` and `undefined` compare equal.
+ *
+ * `a == null` (loose) is true for exactly `null` and `undefined` (never `0`,
+ * `""`, `false`, `NaN`), so `(a == null && b == null)` means "both nullish."
+ *
+ * See docs/dev/null-and-undefined.md.
+ */
+export function __eq(a: unknown, b: unknown): boolean {
+  return a === b || (a == null && b == null);
+}
+```
+
+- [ ] **Step 4: Add the runtime export**
+
+In `lib/runtime/index.ts`, add this line near the other helper exports (e.g. after the `export { Schema, __validateType } from "./schema.js";` line):
+
+```ts
+export { __eq } from "./eq.js";
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm test:run lib/runtime/eq.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/runtime/eq.ts lib/runtime/eq.test.ts lib/runtime/index.ts
+git commit -F /tmp/commit-eq.txt
+```
+
+(Write the message to `/tmp/commit-eq.txt` first, ending with the Co-Authored-By line from Global Constraints.)
+
+---
+
+### Task 2: Lower `==`/`!=` to `__eq` in codegen
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts:1064-1072` (the equality branch of binop codegen)
+- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache:26-27` (add `__eq` to the runtime import list)
+- Regenerate: `lib/templates/backends/typescriptGenerator/imports.ts` (via `pnpm run templates` — do not edit by hand)
+- Test: `tests/agency/nullish-eq.agency` + `tests/agency/nullish-eq.test.json`
+
+**Interfaces:**
+- Consumes: `__eq` from Task 1 (runtime export) and `ts.call`/`ts.id`/`ts.not` from `lib/ir/builders.ts` (`call(callee, args)`, `id(name)`, `not(condition)`).
+- Produces: generated code where Agency `a == b` emits `__eq(a, b)` and `a != b` emits `!__eq(a, b)`; `===`/`!==` remain strict.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/agency/nullish-eq.agency` (an optional key is `null` when absent at runtime; `== null` must catch it, and `==` between a present-null and an absent-key value must be true):
+
+```
+node main() {
+  let obj: { a?: string } = {}
+  let absent = obj.a
+  if (absent == null) {
+    if (null == absent) {
+      return "absent is null"
+    }
+  }
+  return "wrong"
+}
+```
+
+Create `tests/agency/nullish-eq.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"absent is null\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Build and run the test to verify it fails**
+
+Run: `make && pnpm run a test tests/agency/nullish-eq.agency`
+Expected: FAIL — today `obj.a` (a missing key) is `undefined` at runtime and `absent == null` compiles to `absent === null`, which is `false`, so the node returns `"wrong"`.
+
+- [ ] **Step 3: Implement the codegen change**
+
+In `lib/backends/typescriptBuilder.ts`, replace the equality branch (currently):
+
+```ts
+    const leftNode = this.processNode(node.left);
+    const rightNode = this.processNode(node.right);
+    // Agency uses strict equality/inequality: == → ===, != → !==
+    const emitOp = node.operator === "==" ? "===" :
+      node.operator === "!=" ? "!==" : node.operator;
+    return ts.binOp(leftNode, emitOp, rightNode, {
+      parenLeft: this.needsParensLeft(node.left, node.operator),
+      parenRight: this.needsParensRight(node.right, node.operator),
+    });
+```
+
+with:
+
+```ts
+    const leftNode = this.processNode(node.left);
+    const rightNode = this.processNode(node.right);
+    // `==` / `!=` use unified nullish equality via the `__eq` runtime helper
+    // (null and undefined compare equal). `===` / `!==` stay strict as the
+    // explicit "exact" escape hatch. See docs/dev/null-and-undefined.md.
+    if (node.operator === "==" || node.operator === "!=") {
+      const eq = ts.call(ts.id("__eq"), [leftNode, rightNode]);
+      return node.operator === "==" ? eq : ts.not(eq);
+    }
+    return ts.binOp(leftNode, node.operator, rightNode, {
+      parenLeft: this.needsParensLeft(node.left, node.operator),
+      parenRight: this.needsParensRight(node.right, node.operator),
+    });
+```
+
+- [ ] **Step 4: Add `__eq` to the generated import list**
+
+In `lib/templates/backends/typescriptGenerator/imports.mustache`, find the line:
+
+```
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+```
+
+and add `__eq` to the imported names, e.g. change the nearby line:
+
+```
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+```
+
+to:
+
+```
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
+```
+
+Then regenerate the template output:
+
+Run: `pnpm run templates`
+Verify `__eq` now appears in `lib/templates/backends/typescriptGenerator/imports.ts`.
+
+- [ ] **Step 5: Rebuild, regenerate fixtures, run the test**
+
+Run: `make && make fixtures && pnpm run a test tests/agency/nullish-eq.agency`
+Expected: PASS — `obj.a` is `undefined`, `__eq(undefined, null)` is `true`.
+
+- [ ] **Step 6: Verify the codegen fixture suite still matches**
+
+Run: `pnpm test:run lib/backends/typescriptBuilder.integration.test.ts`
+Expected: PASS (fixtures were regenerated in Step 5 to use `__eq` and the new import).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder.ts lib/templates/backends/typescriptGenerator/imports.mustache lib/templates/backends/typescriptGenerator/imports.ts tests/agency/nullish-eq.agency tests/agency/nullish-eq.test.json tests/typescriptGenerator
+git commit -F /tmp/commit-eq-codegen.txt
+```
+
+---
+
+### Task 3: Flip `key?: T` desugaring to `T | null`
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts:1049-1076` (`objectPropertyParser`, the optional-key branches)
+- Test: `lib/parsers/typeHints.test.ts` (add cases to the `objectPropertyParser` describe block, ~line 916)
+
+**Interfaces:**
+- Produces: parsing `key?: T` yields `ObjectProperty { key, value: { type: "unionType", types: [T, { type: "primitiveType", value: "null" }] } }`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `lib/parsers/typeHints.test.ts`, inside the `objectPropertyParser` `testCases` array, add these two cases:
+
+```ts
+    {
+      input: "foo?: string",
+      expected: {
+        success: true,
+        result: {
+          key: "foo",
+          value: {
+            type: "unionType",
+            types: [
+              { type: "primitiveType", value: "string" },
+              { type: "primitiveType", value: "null" },
+            ],
+          },
+        },
+      },
+    },
+    {
+      input: "bar?: string | number",
+      expected: {
+        success: true,
+        result: {
+          key: "bar",
+          value: {
+            type: "unionType",
+            types: [
+              { type: "primitiveType", value: "string" },
+              { type: "primitiveType", value: "number" },
+              { type: "primitiveType", value: "null" },
+            ],
+          },
+        },
+      },
+    },
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/parsers/typeHints.test.ts`
+Expected: FAIL — the parser currently appends `{ value: "undefined" }`, not `"null"`.
+
+- [ ] **Step 3: Implement the parser change**
+
+In `lib/parsers/parsers.ts`, in `objectPropertyParser`, change both `undefined` literals to `null`. The union-append branch:
+
+```ts
+    if (value.type === "unionType") {
+      // If it's already a union, just add null to the list of types
+      return success(
+        {
+          key,
+          value: {
+            type: "unionType",
+            types: [
+              ...value.types,
+              { type: "primitiveType", value: "null" },
+            ],
+          },
+        },
+        result.rest,
+      );
+    }
+```
+
+and the non-union branch:
+
+```ts
+    // If it's not a union, create a new union with the original type and null
+    return success(
+      {
+        key,
+        value: {
+          type: "unionType",
+          types: [value, { type: "primitiveType", value: "null" }],
+        },
+      },
+      result.rest,
+    );
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/parsers/typeHints.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/typeHints.test.ts
+git commit -F /tmp/commit-optional-key.txt
+```
+
+---
+
+### Task 4: Normalize the `undefined` type keyword to `null` at parse time
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts:853-874` (`primitiveTypeParser`)
+- Test: `lib/parsers/typeHints.test.ts` (add a case to the `primitiveTypeParser` tests)
+
+**Interfaces:**
+- Produces: parsing the type keyword `undefined` yields `{ type: "primitiveType", value: "null" }`. All other primitive keywords are unchanged. The *value* `undefined` is still not parseable (no value-level parser is added).
+
+- [ ] **Step 1: Write the failing test**
+
+In `lib/parsers/typeHints.test.ts`, find the `primitiveTypeParser` describe block and add this test (match the file's existing assertion style; if the block uses a `testCases` array, add an entry, otherwise add an `it`):
+
+```ts
+  it("normalizes the `undefined` type keyword to null", () => {
+    const result = primitiveTypeParser("undefined");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqualWithoutLoc({
+        type: "primitiveType",
+        value: "null",
+      });
+    }
+  });
+
+  it("still parses the `null` type keyword as null", () => {
+    const result = primitiveTypeParser("null");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqualWithoutLoc({
+        type: "primitiveType",
+        value: "null",
+      });
+    }
+  });
+```
+
+Ensure `primitiveTypeParser` is imported at the top of the test file (it is exported from `lib/parsers/parsers.ts`); add it to the existing import from `./parsers.js` if missing.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/parsers/typeHints.test.ts`
+Expected: FAIL — `undefined` currently parses to `{ value: "undefined" }`.
+
+- [ ] **Step 3: Implement the parser change**
+
+In `lib/parsers/parsers.ts`, wrap `primitiveTypeParser` in a `map` that rewrites `undefined` → `null` (the value `undefined` keyword stays in the `or(...)` so it is still *accepted*, just normalized). `map` is already imported (line 30):
+
+```ts
+export const primitiveTypeParser: Parser<PrimitiveType> = memo(
+  "primitiveTypeParser",
+  map(
+    seqC(
+      set("type", "primitiveType"),
+      capture(
+        or(
+          str("number"),
+          str("string"),
+          str("boolean"),
+          str("undefined"),
+          str("void"),
+          str("null"),
+          str("any"),
+          str("unknown"),
+          str("object"),
+          str("function"),
+          str("regex"),
+        ),
+        "value",
+      ),
+    ),
+    (r: PrimitiveType) => (r.value === "undefined" ? { ...r, value: "null" } : r),
+  ),
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/parsers/typeHints.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/typeHints.test.ts
+git commit -F /tmp/commit-undef-keyword.txt
+```
+
+---
+
+### Task 5: Repoint type-checker `UNDEFINED_T` / `"undefined"` sites to `null`
+
+**Files:**
+- Modify: `lib/typeChecker/primitives.ts:8` (add `NULL_T`, remove `UNDEFINED_T`)
+- Modify: `lib/typeChecker/synthesizer.ts:26,866` (import + `elementOrUndef` return)
+- Modify: `lib/typeChecker/builtins.ts:8,17` (the `optional` helper)
+- Modify: `lib/typeChecker/primitiveMembers.ts:113,154,160` (built-in member return unions)
+- Modify: `lib/typeChecker/assignability.ts:403` (`isOptionalType`)
+- Test: `lib/typeChecker/assignability.test.ts` (or create `lib/typeChecker/nullish.test.ts`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `export const NULL_T: VariableType = { type: "primitiveType", value: "null" }`. `isOptionalType` returns `true` for a `null` member. Built-in members that returned `T | undefined` now return `T | null`. `UNDEFINED_T` no longer exists.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/typeChecker/nullish.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isAssignable } from "./assignability.js";
+import { NULL_T } from "./primitives.js";
+
+describe("nullish unification in the type checker", () => {
+  const STRING_T = { type: "primitiveType", value: "string" } as const;
+
+  it("NULL_T is the null primitive", () => {
+    expect(NULL_T).toEqual({ type: "primitiveType", value: "null" });
+  });
+
+  it("null is assignable to string | null", () => {
+    const target = { type: "unionType", types: [STRING_T, NULL_T] } as const;
+    expect(isAssignable(NULL_T, target, {})).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/typeChecker/nullish.test.ts`
+Expected: FAIL — `NULL_T` is not exported from `./primitives.js`.
+
+- [ ] **Step 3: Add `NULL_T` and remove `UNDEFINED_T`**
+
+In `lib/typeChecker/primitives.ts`, replace:
+
+```ts
+export const UNDEFINED_T: VariableType = { type: "primitiveType", value: "undefined" };
+```
+
+with:
+
+```ts
+export const NULL_T: VariableType = { type: "primitiveType", value: "null" };
+```
+
+- [ ] **Step 4: Repoint `synthesizer.ts`**
+
+In `lib/typeChecker/synthesizer.ts:26`, change the import `import { UNDEFINED_T, VOID_T } from "./primitives.js";` to `import { NULL_T, VOID_T } from "./primitives.js";`. At line 866, change:
+
+```ts
+  if (cbKind === "elementOrUndef") {
+    return { type: "unionType", types: [elementT, NULL_T] };
+  }
+```
+
+(Leave the `isNullishPrimitive` helper at line ~313-316 untouched — it already accepts both `"null"` and `"undefined"` and serves as a defensive backstop.)
+
+- [ ] **Step 5: Repoint `builtins.ts`**
+
+In `lib/typeChecker/builtins.ts`, change the import alias `UNDEFINED_T as undef` to `NULL_T as nullT`, and update the `optional` helper:
+
+```ts
+const optional = (t: VariableType): VariableType => ({
+  type: "unionType",
+  types: [t, nullT],
+});
+```
+
+(Update any other use of `undef` in this file to `nullT`.)
+
+- [ ] **Step 6: Repoint `primitiveMembers.ts`**
+
+In `lib/typeChecker/primitiveMembers.ts`, at lines 113, 154, and 160, change each `{ type: "primitiveType", value: "undefined" }` to `{ type: "primitiveType", value: "null" }`.
+
+- [ ] **Step 7: Repoint `isOptionalType`**
+
+In `lib/typeChecker/assignability.ts:403`, change:
+
+```ts
+    return resolved.value === "null" || resolved.value === "any";
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `pnpm test:run lib/typeChecker/nullish.test.ts lib/typeChecker/assignability.test.ts`
+Expected: PASS. If `assignability.test.ts` has cases asserting `undefined`-based optionality, update them to `null`.
+
+- [ ] **Step 9: Typecheck the package to catch stragglers**
+
+Run: `pnpm test:run` is too broad; instead build to surface any remaining `UNDEFINED_T` references:
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "UNDEFINED_T\|undef" || echo "no stragglers"`
+Expected: `no stragglers`. Fix any remaining references (repoint to `NULL_T`).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/typeChecker/primitives.ts lib/typeChecker/synthesizer.ts lib/typeChecker/builtins.ts lib/typeChecker/primitiveMembers.ts lib/typeChecker/assignability.ts lib/typeChecker/nullish.test.ts lib/typeChecker/assignability.test.ts
+git commit -F /tmp/commit-repoint.txt
+```
+
+---
+
+### Task 6: Type optional parameters as `T | null`
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts:4136-4174` (`functionParameterParser`, the optional handling)
+- Modify: `lib/backends/typescriptBuilder.ts:1525-1534` (`paramSchemaContribution`, avoid a redundant `.nullable()`)
+- Test: `lib/parsers/function.test.ts` (parser) and `lib/backends/toolSchemaContribution.test.ts` (schema)
+
+**Interfaces:**
+- Consumes: the optional-parameter desugaring already injects `defaultValue = { type: "null" }` for `x?: T` with no explicit default.
+- Produces: an optional parameter `x?: T` has `typeHint` widened to `{ type: "unionType", types: [T, { type:"primitiveType", value:"null" }] }`. Its tool schema is `z.union([<T>, z.null()])` (no double `.nullable()`).
+
+- [ ] **Step 1: Write the failing test**
+
+In `lib/parsers/function.test.ts`, add a test asserting an optional typed parameter widens its `typeHint` (match the file's existing parse-assertion helper; this shows the shape to assert):
+
+```ts
+it("widens an optional parameter's type hint to T | null", () => {
+  const result = functionParameterParser("x?: number");
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.result.typeHint).toEqualWithoutLoc({
+      type: "unionType",
+      types: [
+        { type: "primitiveType", value: "number" },
+        { type: "primitiveType", value: "null" },
+      ],
+    });
+    // default value still injected so the runtime resolves an omitted arg to null
+    expect(result.result.defaultValue).toEqualWithoutLoc({ type: "null" });
+  }
+});
+```
+
+Ensure `functionParameterParser` is imported from `./parsers.js` in the test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/parsers/function.test.ts`
+Expected: FAIL — `typeHint` is currently the bare `number`, not a union with `null`.
+
+- [ ] **Step 3: Implement the parser change**
+
+In `lib/parsers/parsers.ts`, in the `functionParameterParser` `map` callback (the `(result: any) => { ... }` at ~line 4165), replace the body so that an optional parameter both injects the null default *and* widens the type hint:
+
+```ts
+    (result: any) => {
+      const { __optional, validated: _validated, ...rest } = result;
+      if (__optional) {
+        if (!rest.defaultValue) {
+          rest.defaultValue = { type: "null" };
+        }
+        if (rest.typeHint) {
+          const nullT = { type: "primitiveType", value: "null" };
+          rest.typeHint =
+            rest.typeHint.type === "unionType"
+              ? { type: "unionType", types: [...rest.typeHint.types, nullT] }
+              : { type: "unionType", types: [rest.typeHint, nullT] };
+        }
+      }
+      if (_validated) rest.validated = true;
+      return rest as FunctionParameter;
+    },
+```
+
+- [ ] **Step 4: Avoid a redundant `.nullable()` in the tool schema**
+
+In `lib/backends/typescriptBuilder.ts`, in `paramSchemaContribution`, replace the scalar tail (currently):
+
+```ts
+    let zod = this.zodSchemaFor(typeHint);
+    if (param.defaultValue) {
+      const defaultStr = expressionToString(param.defaultValue);
+      zod += `.nullable().describe(${JSON.stringify("Default: " + defaultStr)})`;
+    }
+    return { kind: "scalar", zod };
+```
+
+with:
+
+```ts
+    let zod = this.zodSchemaFor(typeHint);
+    if (param.defaultValue) {
+      const defaultStr = expressionToString(param.defaultValue);
+      // A widened optional param (`x?: T` → `T | null`) is already nullable;
+      // only add `.nullable()` for params whose type is not already nullable
+      // (e.g. an explicit default `x: T = 5`), so the LLM may omit them.
+      const alreadyNullable =
+        typeHint.type === "unionType" &&
+        typeHint.types.some(
+          (t) => t.type === "primitiveType" && t.value === "null",
+        );
+      if (!alreadyNullable) zod += ".nullable()";
+      zod += `.describe(${JSON.stringify("Default: " + defaultStr)})`;
+    }
+    return { kind: "scalar", zod };
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test:run lib/parsers/function.test.ts lib/backends/toolSchemaContribution.test.ts`
+Expected: PASS. If `toolSchemaContribution.test.ts` asserts the old `z.X().nullable()` shape for an optional param, update it to the new `z.union([z.X(), z.null()])` shape.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/function.test.ts lib/backends/typescriptBuilder.ts lib/backends/toolSchemaContribution.test.ts
+git commit -F /tmp/commit-optional-param.txt
+```
+
+---
+
+### Task 7: Formatter emits `key?:` for `T | null` properties
+
+**Files:**
+- Modify: `lib/backends/agencyGenerator.ts:625-645` (`stringifyProp`)
+- Test: `lib/backends/agencyGenerator.test.ts`
+
+**Interfaces:**
+- Produces: the Agency formatter renders an object property whose type is `T | null` back as `key?: T` (round-trip), instead of `key: T | null`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `lib/backends/agencyGenerator.test.ts`, add a round-trip test (match the file's existing format/parse helpers; conceptually):
+
+```ts
+it("round-trips an optional key as key?: T", () => {
+  const src = "type Foo = { foo?: string }";
+  const formatted = formatAgency(src); // use the file's existing format helper
+  expect(formatted).toContain("foo?: string");
+  expect(formatted).not.toContain("foo: string | null");
+});
+```
+
+If the test file has no `formatAgency` helper, follow the existing pattern in that file for parsing then running `AgencyGenerator` and asserting on the output string.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/backends/agencyGenerator.test.ts`
+Expected: FAIL — `stringifyProp` currently detects a `undefined` member for the `?:` shorthand, so a `T | null` property is printed as `foo: string | null`.
+
+- [ ] **Step 3: Implement the formatter change**
+
+In `lib/backends/agencyGenerator.ts`, in `stringifyProp`, change the detection (and the filter) from `"undefined"` to `"null"`:
+
+```ts
+  private stringifyProp(prop: ObjectProperty): string {
+    const isUnionWithNull =
+      prop.value.type === "unionType" &&
+      prop.value.types.some(
+        (t) => t.type === "primitiveType" && t.value === "null",
+      );
+
+    if (isUnionWithNull) {
+      const nonNullTypes = (prop.value as any).types.filter(
+        (t: VariableType) =>
+          !(t.type === "primitiveType" && t.value === "null"),
+      );
+      const unionWithoutNull: VariableType =
+        nonNullTypes.length === 1
+          ? nonNullTypes[0]
+          : { type: "unionType", types: nonNullTypes };
+```
+
+(Continue using `unionWithoutNull` wherever the old code used `unionWithoutUndefined` further down in the method — rename the remaining references in this method consistently.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/backends/agencyGenerator.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/backends/agencyGenerator.ts lib/backends/agencyGenerator.test.ts
+git commit -F /tmp/commit-formatter.txt
+```
+
+---
+
+### Task 8: `schema(T).parse(...)` coalesces missing optional keys to `null`
+
+**Files:**
+- Modify: `lib/backends/typescriptGenerator/typeToZodSchema.ts` (`mapTypeToSchema` / `mapTypeToSchemaInner` / the two public mappers — thread an optional-key mode)
+- Test: `tests/agency/validation/optionalKeyCoalesce.agency` + `.test.json`, plus nested/already-nullable variants
+
+**Interfaces:**
+- Consumes: optional object keys are now `T | null` unions (Task 3).
+- Produces: `mapTypeToValidationSchema` emits, for an object property whose type includes a `null` member, a Zod schema that accepts a *missing* key and coalesces it to `null` (`<schema>.optional().default(null)`). `mapTypeToZodSchema` (the LLM path) is unchanged — keys stay required + nullable.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/agency/validation/optionalKeyCoalesce.agency`:
+
+```
+node main() {
+  const s = schema({ foo?: string })
+  const r = s.parse({})
+  if (isSuccess(r)) {
+    if (r.value.foo == null) {
+      return "coalesced to null"
+    }
+    return "present but not null"
+  }
+  return "parse failed"
+}
+```
+
+Create `tests/agency/validation/optionalKeyCoalesce.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"coalesced to null\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema({foo?: string}).parse({}) yields { foo: null }"
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Build and run the test to verify it fails**
+
+Run: `make && pnpm run a test tests/agency/validation/optionalKeyCoalesce.agency`
+Expected: FAIL — today the optional key compiles to `z.union([z.string(), z.null()])` with the key required, so `parse({})` returns a `failure` (missing key) and the node returns `"parse failed"`.
+
+- [ ] **Step 3: Thread an optional-key mode through the schema mapper**
+
+In `lib/backends/typescriptGenerator/typeToZodSchema.ts`, add a mode parameter that distinguishes the LLM mapper from the validation mapper, and apply the coalescing only in validation mode.
+
+Add a type alias near the top of the file:
+
+```ts
+type OptionalKeyMode = "required-nullable" | "optional-coalesce";
+```
+
+Thread `optionalKeyMode` through `mapTypeToSchema`, `mapTypeToSchemaInner`, and `recurse`/`mapTypeToSchemaInner` recursive calls (default it to `"required-nullable"` so existing internal calls are unaffected). In the `objectType` branch, after computing `inner2` and `appendMeta(...)` for each property, wrap nullable properties when in coalesce mode. Replace the property `.map(...)` body's final assembly:
+
+```ts
+        const propSchema = appendMeta(inner2, mergedTags);
+        const isNullableProp =
+          prop.value.type === "unionType" &&
+          prop.value.types.some(
+            (t) => t.type === "primitiveType" && t.value === "null",
+          );
+        const finalProp =
+          optionalKeyMode === "optional-coalesce" && isNullableProp
+            ? `${propSchema}.optional().default(null)`
+            : propSchema;
+        const str = `"${prop.key.replace(/"/g, '\\"')}": ${finalProp}`;
+        return str;
+```
+
+Update the two public mappers to pass the mode:
+
+```ts
+export function mapTypeToZodSchema(
+  variableType: VariableType,
+  typeAliases: Record<string, VariableType>,
+  typeAliasesFull?: Record<string, TypeAliasEntry>,
+): string {
+  return mapTypeToSchema(
+    variableType,
+    typeAliases,
+    (vt, ta) => mapTypeToZodSchema((vt as any).successType, ta, typeAliasesFull),
+    typeAliasesFull,
+    "required-nullable",
+  );
+}
+
+export function mapTypeToValidationSchema(
+  variableType: VariableType,
+  typeAliases: Record<string, VariableType>,
+  typeAliasesFull?: Record<string, TypeAliasEntry>,
+): string {
+  return mapTypeToSchema(
+    variableType,
+    typeAliases,
+    (vt, ta) => {
+      const successSchema = mapTypeToValidationSchema(
+        (vt as any).successType,
+        ta,
+        typeAliasesFull,
+      );
+      return `z.union([z.object({ __type: z.literal("resultType"), success: z.literal(true), value: ${successSchema} }), z.object({ __type: z.literal("resultType"), success: z.literal(false), error: z.any() })])`;
+    },
+    typeAliasesFull,
+    "optional-coalesce",
+  );
+}
+```
+
+Update `mapTypeToSchema` and `mapTypeToSchemaInner` signatures to accept and forward `optionalKeyMode: OptionalKeyMode` (thread it into every recursive `mapTypeToSchemaInner` / `recurse` call inside the function so nested objects coalesce too).
+
+- [ ] **Step 4: Rebuild and run the test to verify it passes**
+
+Run: `make && pnpm run a test tests/agency/validation/optionalKeyCoalesce.agency`
+Expected: PASS.
+
+- [ ] **Step 5: Add nested and already-nullable variants**
+
+Create `tests/agency/validation/optionalKeyNested.agency`:
+
+```
+node main() {
+  const s = schema({ a?: { b?: string } })
+  const r = s.parse({})
+  if (isSuccess(r)) {
+    if (r.value.a == null) {
+      return "outer coalesced"
+    }
+    return "outer present"
+  }
+  return "parse failed"
+}
+```
+
+Create `tests/agency/validation/optionalKeyNested.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"outer coalesced\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "missing outer optional object coalesces to null (no recursion into b)"
+    }
+  ]
+}
+```
+
+Run: `pnpm run a test tests/agency/validation/optionalKeyNested.agency`
+Expected: PASS.
+
+- [ ] **Step 6: Confirm the LLM mapper path is unchanged**
+
+Run: `pnpm test:run lib/backends/toolSchemaContribution.test.ts`
+Expected: PASS — LLM tool schemas still emit required + nullable keys (no `.optional().default(null)`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/backends/typescriptGenerator/typeToZodSchema.ts tests/agency/validation/optionalKeyCoalesce.agency tests/agency/validation/optionalKeyCoalesce.test.json tests/agency/validation/optionalKeyNested.agency tests/agency/validation/optionalKeyNested.test.json
+git commit -F /tmp/commit-schema-coalesce.txt
+```
+
+---
+
+### Task 9: Final sweep — fixtures, fixture-source repoint, spec retarget, targeted suites
+
+**Files:**
+- Regenerate: `tests/typescriptGenerator/**` (via `make fixtures`)
+- Modify: any `.agency`/`.test.ts` fixtures or tests asserting `| undefined` types (repoint to `| null`)
+- Modify: `null-truthiness-narrowing-spec.md` at the repo root (retarget note)
+
+**Interfaces:** none (cleanup + verification).
+
+- [ ] **Step 1: Rebuild and regenerate all fixtures**
+
+Run: `make && make fixtures`
+Expected: completes; `git status` shows regenerated fixtures under `tests/typescriptGenerator/`.
+
+- [ ] **Step 2: Find lingering `| undefined` type references in tests/fixtures**
+
+Run: `grep -rn "value: \"undefined\"\|| undefined\|: undefined\b" tests/ lib/ --include="*.ts" --include="*.agency" | grep -v "typeof.*undefined\|!== undefined\|=== undefined\|== \"undefined\"\|!= undefined" | grep -vi "errors.ts\|asyncContext.ts"`
+Expected: review each hit. Repoint *type-level* `undefined` (optionality) to `null`; leave *runtime* `undefined` JS-guard checks (`typeof x !== "undefined"`, `x === undefined` in TS source) alone.
+
+- [ ] **Step 3: Retarget the null-truthiness narrowing spec note**
+
+In `null-truthiness-narrowing-spec.md` (repo root), update the "Summary" and "Background" so optionality is described as `T | null` (not `T | undefined`) and `isOptionalType`/the member-filter key on the `null` primitive. Add a one-line note: "Representation flipped to `null` by the nullish-unification project (`packages/agency-lang/docs/superpowers/specs/2026-06-28-nullish-unification-design.md`)."
+
+- [ ] **Step 4: Run the affected unit suites**
+
+Run: `pnpm test:run lib/parsers/typeHints.test.ts lib/parsers/function.test.ts lib/typeChecker/nullish.test.ts lib/typeChecker/assignability.test.ts lib/backends/agencyGenerator.test.ts lib/backends/toolSchemaContribution.test.ts lib/backends/typescriptBuilder.integration.test.ts lib/runtime/eq.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Run the affected Agency execution tests**
+
+Run: `pnpm run a test tests/agency/nullish-eq.agency && pnpm run a test tests/agency/validation/optionalKeyCoalesce.agency && pnpm run a test tests/agency/validation/optionalKeyNested.agency && pnpm run a test tests/agency/validation/schemaBuiltin.agency`
+Expected: all PASS (the last confirms the existing schema path still works).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/typescriptGenerator ../../null-truthiness-narrowing-spec.md tests lib
+git commit -F /tmp/commit-final-sweep.txt
+```
+
+(Adjust the `git add` for the spec to its actual repo-root relative path from the package dir; verify with `git status` before committing.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 representation flip → Tasks 3 (key?:), 4 (undefined keyword), 5 (UNDEFINED_T/isOptionalType), 6 (optional params). ✓
+- §2 `__eq` → Tasks 1 (helper) + 2 (codegen + import wiring). ✓
+- §3 schema parse coalescing → Task 8 (with nested + LLM-unchanged checks). ✓
+- §4 TS interop → covered transitively: user-written `undefined` type annotations normalize via Task 4 (the parser is the single ingestion point for type keywords); runtime interop `undefined` is caught by `__eq` (Task 2). No separate `.d.ts` import path exists in the codebase, so no additional task is needed. ✓
+- §5 migration/fixture sweep + spec retarget → Task 9. ✓
+- §6 flow-checker coordination → no code in P1; the narrowing-recognizer-unaffected and `null`-literal-stays-`any` points are honored by *not* changing `analyzeCondition` or the `null` literal synth (kept in Non-goals). ✓
+- Testing section (basic/nested/already-nullable parse, `__eq` truth table, optional param → null, `??`) → Tasks 1, 6, 8. Note: the "already-nullable optional key" and `??` cases are covered by the `__eq`/coalesce logic; an explicit `??` test is optional and omitted to avoid redundancy with the existing `synthNullishCoalesce` behavior (unchanged by this project).
+
+**Placeholder scan:** No TBD/TODO; every code step shows real code; every command shows expected output. ✓
+
+**Type consistency:** `__eq(a: unknown, b: unknown): boolean` used identically in Tasks 1–2. `NULL_T` defined in Task 5, consumed in Task 5 tests. `OptionalKeyMode` defined and threaded in Task 8. Optional-key union shape `{ type:"unionType", types:[T, {primitiveType,"null"}] }` consistent across Tasks 3, 6, 7, 8. ✓
+
+**One judgment call surfaced for the user:** Task 6 (optional-parameter type widening) is the fiddliest piece — it changes optional-param tool-schema output and may require updating `toolSchemaContribution.test.ts` assertions. It is included to honor spec §1, but could be deferred to Project 2 (the param *value* is already `null`; only the static type precision is at stake). Flag for the user if they prefer a smaller first PR.

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification.md
@@ -137,7 +137,7 @@ git commit -F /tmp/commit-eq.txt
 
 **Files:**
 - Modify: `lib/backends/typescriptBuilder.ts:1064-1072` (the equality branch of binop codegen)
-- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache:26-27` (add `__eq` to the runtime import list)
+- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache:25` (the `success, failure, ..., __catchResult,` line — add `__eq` to the runtime import list)
 - Regenerate: `lib/templates/backends/typescriptGenerator/imports.ts` (via `pnpm run templates` — do not edit by hand)
 - Test: `tests/agency/nullish-eq.agency` + `tests/agency/nullish-eq.test.json`
 
@@ -277,6 +277,15 @@ git commit -F /tmp/commit-eq-codegen.txt
 
 **Interfaces:**
 - Produces: parsing `key?: T` yields `ObjectProperty { key, value: { type: "unionType", types: [T, { type: "primitiveType", value: "null" }] } }`.
+
+> **Task-group ordering (Tasks 3–5):** Tasks 3, 4, and 5 form a unit — after
+> Task 3 flips the parser to `T | null` but before Task 5 retargets the checker
+> off `"undefined"`, the type checker still keys on `"undefined"`, so an optional
+> key looks non-optional to the checker. Each of these tasks' own unit tests
+> (parser/typechecker-unit) is self-contained and safe to run, but do **not**
+> run `make fixtures` or a package-wide typecheck *between* Tasks 3 and 5 — the
+> intermediate state is internally inconsistent and failures are hard to
+> attribute. Land 3 → 4 → 5 in sequence, then resume fixture/typecheck runs.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -566,9 +575,15 @@ Expected: PASS. If `assignability.test.ts` has cases asserting `undefined`-based
 
 - [ ] **Step 9: Typecheck the package to catch stragglers**
 
-Run: `pnpm test:run` is too broad; instead build to surface any remaining `UNDEFINED_T` references:
-Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "UNDEFINED_T\|undef" || echo "no stragglers"`
-Expected: `no stragglers`. Fix any remaining references (repoint to `NULL_T`).
+First surface any remaining `UNDEFINED_T` identifier references via the compiler:
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "UNDEFINED_T\|undef" || echo "no UNDEFINED_T refs"`
+Expected: `no UNDEFINED_T refs`.
+
+Then a second pass for string-literal `"undefined"` *type* references the
+compiler won't flag (the identifier sweep misses `value: "undefined"` and
+`t.value === "undefined"`):
+Run: `grep -rn '"undefined"' lib/typeChecker/ --include="*.ts" | grep -v ".test.ts" | grep -v "typeof"`
+Expected: only the *defensive backstop* matches remain (e.g. `isNullishPrimitive` in `synthesizer.ts`, `isNullableType` in `validationDescriptor.ts`, which intentionally accept both `"null"` and `"undefined"`). Repoint any *optionality* references to `"null"`; leave the dual-accepting backstops alone.
 
 - [ ] **Step 10: Commit**
 
@@ -701,18 +716,25 @@ git commit -F /tmp/commit-optional-param.txt
 
 - [ ] **Step 1: Write the failing test**
 
-In `lib/backends/agencyGenerator.test.ts`, add a round-trip test (match the file's existing format/parse helpers; conceptually):
+In `lib/backends/agencyGenerator.test.ts`, add a round-trip test. The file has
+no `formatAgency` helper; it uses `parseAgency(input, {}, false)` then
+`new AgencyGenerator().generate(parseResult.result)` and asserts on
+`result.output` (both `parseAgency` and `AgencyGenerator` are already imported).
+Follow that pattern:
 
 ```ts
 it("round-trips an optional key as key?: T", () => {
-  const src = "type Foo = { foo?: string }";
-  const formatted = formatAgency(src); // use the file's existing format helper
-  expect(formatted).toContain("foo?: string");
-  expect(formatted).not.toContain("foo: string | null");
+  const parseResult = parseAgency("type Foo = { foo?: string }", {}, false);
+  expect(parseResult.success).toBe(true);
+  if (!parseResult.success) return;
+
+  const generator = new AgencyGenerator();
+  const result = generator.generate(parseResult.result);
+
+  expect(result.output).toContain("foo?: string");
+  expect(result.output).not.toContain("string | null");
 });
 ```
-
-If the test file has no `formatAgency` helper, follow the existing pattern in that file for parsing then running `AgencyGenerator` and asserting on the output string.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -917,6 +939,48 @@ Create `tests/agency/validation/optionalKeyNested.test.json`:
 Run: `pnpm run a test tests/agency/validation/optionalKeyNested.agency`
 Expected: PASS.
 
+Then add the *recursive* variant that exercises the inner level (spec §Testing
+requires `parse({ a: {} })` → `{ a: { b: null } }` — this confirms
+`optionalKeyMode` is threaded into nested objects, not just applied at the top).
+
+Create `tests/agency/validation/optionalKeyRecursive.agency`:
+
+```
+node main() {
+  const s = schema({ a?: { b?: string } })
+  const r = s.parse({ a: {} })
+  if (isSuccess(r)) {
+    if (r.value.a != null) {
+      if (r.value.a.b == null) {
+        return "inner coalesced"
+      }
+      return "inner present"
+    }
+    return "outer null"
+  }
+  return "parse failed"
+}
+```
+
+Create `tests/agency/validation/optionalKeyRecursive.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"inner coalesced\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "parse({a: {}}) coalesces the inner missing optional key to null"
+    }
+  ]
+}
+```
+
+Run: `pnpm run a test tests/agency/validation/optionalKeyRecursive.agency`
+Expected: PASS — confirms the recursive thread of `optionalKeyMode`.
+
 - [ ] **Step 6: Confirm the LLM mapper path is unchanged**
 
 Run: `pnpm test:run lib/backends/toolSchemaContribution.test.ts`
@@ -925,7 +989,7 @@ Expected: PASS — LLM tool schemas still emit required + nullable keys (no `.op
 - [ ] **Step 7: Commit**
 
 ```bash
-git add lib/backends/typescriptGenerator/typeToZodSchema.ts tests/agency/validation/optionalKeyCoalesce.agency tests/agency/validation/optionalKeyCoalesce.test.json tests/agency/validation/optionalKeyNested.agency tests/agency/validation/optionalKeyNested.test.json
+git add lib/backends/typescriptGenerator/typeToZodSchema.ts tests/agency/validation/optionalKeyCoalesce.agency tests/agency/validation/optionalKeyCoalesce.test.json tests/agency/validation/optionalKeyNested.agency tests/agency/validation/optionalKeyNested.test.json tests/agency/validation/optionalKeyRecursive.agency tests/agency/validation/optionalKeyRecursive.test.json
 git commit -F /tmp/commit-schema-coalesce.txt
 ```
 
@@ -945,10 +1009,14 @@ git commit -F /tmp/commit-schema-coalesce.txt
 Run: `make && make fixtures`
 Expected: completes; `git status` shows regenerated fixtures under `tests/typescriptGenerator/`.
 
-- [ ] **Step 2: Find lingering `| undefined` type references in tests/fixtures**
+- [ ] **Step 2: Find lingering `| undefined` type references in tests/fixtures/stdlib**
 
-Run: `grep -rn "value: \"undefined\"\|| undefined\|: undefined\b" tests/ lib/ --include="*.ts" --include="*.agency" | grep -v "typeof.*undefined\|!== undefined\|=== undefined\|== \"undefined\"\|!= undefined" | grep -vi "errors.ts\|asyncContext.ts"`
-Expected: review each hit. Repoint *type-level* `undefined` (optionality) to `null`; leave *runtime* `undefined` JS-guard checks (`typeof x !== "undefined"`, `x === undefined` in TS source) alone.
+Run: `grep -rn 'value: "undefined"\|| undefined\|: undefined\b' tests/ lib/ --include="*.ts" --include="*.agency" | grep -v "typeof\|!== undefined\|=== undefined\|!= undefined\|== undefined"`
+Expected: review each hit. The content filter (not file-name exclusions) drops runtime JS-guards (`typeof x !== "undefined"`, `x === undefined` in TS source such as `errors.ts`/`asyncContext.ts`). Repoint any remaining *type-level* `undefined` (optionality) to `null`; leave runtime guards alone.
+
+Then explicitly confirm the stdlib Agency sources contain no `undefined` type tokens (they should use `key?:`, which is fine):
+Run: `grep -rn "undefined" lib/stdlib --include="*.agency" || echo "stdlib clean"`
+Expected: `stdlib clean`.
 
 - [ ] **Step 3: Retarget the null-truthiness narrowing spec note**
 
@@ -990,4 +1058,15 @@ git commit -F /tmp/commit-final-sweep.txt
 
 **Type consistency:** `__eq(a: unknown, b: unknown): boolean` used identically in Tasks 1–2. `NULL_T` defined in Task 5, consumed in Task 5 tests. `OptionalKeyMode` defined and threaded in Task 8. Optional-key union shape `{ type:"unionType", types:[T, {primitiveType,"null"}] }` consistent across Tasks 3, 6, 7, 8. ✓
 
-**One judgment call surfaced for the user:** Task 6 (optional-parameter type widening) is the fiddliest piece — it changes optional-param tool-schema output and may require updating `toolSchemaContribution.test.ts` assertions. It is included to honor spec §1, but could be deferred to Project 2 (the param *value* is already `null`; only the static type precision is at stake). Flag for the user if they prefer a smaller first PR.
+**One judgment call surfaced for the user:** Task 6 (optional-parameter type widening) is the fiddliest piece — it changes optional-param tool-schema output and may require updating `toolSchemaContribution.test.ts` assertions. It is included to honor spec §1, but could be deferred to Project 2 (the param *value* is already `null`; only the static type precision is at stake). Per user direction, **Task 6 is kept**.
+
+## Review incorporation (2026-06-28)
+
+Addressed an external plan review (`2026-06-28-nullish-unification-review.md`):
+
+- **Tasks 3–5 ordering risk** → added an explicit task-group note: do not run `make fixtures` or a package-wide typecheck between Tasks 3 and 5 (intermediate state is internally inconsistent).
+- **Too-narrow straggler grep** → Task 5 Step 9 now adds a string-literal `"undefined"` pass; Task 9 Step 2 drops the unjustified file-name exclusions in favor of content filters and adds an explicit `lib/stdlib` `.agency` check.
+- **Missing recursion test** → Task 8 now adds `optionalKeyRecursive` (`parse({a: {}})` → `{a: {b: null}}`) to exercise the threaded `optionalKeyMode`.
+- **`formatAgency` helper** → Task 7 now uses the real `parseAgency` + `AgencyGenerator().generate()` pattern (verified present in `agencyGenerator.test.ts`).
+- **Stale `imports.mustache` line ref** → corrected to line 25.
+- **`===` escape-hatch doc note (optional nit)** → moot: the escape hatch was removed entirely (both `==` and `===` lower to `__eq`); there is no longer a way — or need — to document distinguishing `null` from `undefined`.

--- a/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-06-28-nullish-unification.md
@@ -143,7 +143,7 @@ git commit -F /tmp/commit-eq.txt
 
 **Interfaces:**
 - Consumes: `__eq` from Task 1 (runtime export) and `ts.call`/`ts.id`/`ts.not` from `lib/ir/builders.ts` (`call(callee, args)`, `id(name)`, `not(condition)`).
-- Produces: generated code where Agency `a == b` emits `__eq(a, b)` and `a != b` emits `!__eq(a, b)`; `===`/`!==` remain strict.
+- Produces: generated code where Agency `a == b` and `a === b` both emit `__eq(a, b)`, and `a != b` and `a !== b` both emit `!__eq(a, b)`. There is no strict-equality escape hatch (`===`/`!==` are stylistic aliases that compile identically to `==`/`!=`).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -154,7 +154,9 @@ node main() {
   let obj: { a?: string } = {}
   let absent = obj.a
   if (absent == null) {
-    if (null == absent) {
+    // `===` must also catch the (runtime-undefined) absent key — no strict
+    // escape hatch; both operators unify null and undefined.
+    if (absent === null) {
       return "absent is null"
     }
   }
@@ -203,12 +205,19 @@ with:
 ```ts
     const leftNode = this.processNode(node.left);
     const rightNode = this.processNode(node.right);
-    // `==` / `!=` use unified nullish equality via the `__eq` runtime helper
-    // (null and undefined compare equal). `===` / `!==` stay strict as the
-    // explicit "exact" escape hatch. See docs/dev/null-and-undefined.md.
-    if (node.operator === "==" || node.operator === "!=") {
+    // All equality operators use unified nullish equality via the `__eq`
+    // runtime helper (null and undefined compare equal). There is no strict
+    // escape hatch: `===`/`!==` are stylistic aliases that compile identically
+    // to `==`/`!=`. See docs/dev/null-and-undefined.md.
+    if (
+      node.operator === "==" ||
+      node.operator === "===" ||
+      node.operator === "!=" ||
+      node.operator === "!=="
+    ) {
       const eq = ts.call(ts.id("__eq"), [leftNode, rightNode]);
-      return node.operator === "==" ? eq : ts.not(eq);
+      const negated = node.operator === "!=" || node.operator === "!==";
+      return negated ? ts.not(eq) : eq;
     }
     return ts.binOp(leftNode, node.operator, rightNode, {
       parenLeft: this.needsParensLeft(node.left, node.operator),

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-28-nullish-unification-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-28-nullish-unification-design.md
@@ -161,9 +161,14 @@ information at the comparison site.
   reduce to "is `x` nullish?"), and for two non-nullish values `__eq` is
   identical to `===`.
 
-- Codegen (`typescriptBuilder.ts:1067–1068`): `==` → `__eq(left, right)`, `!=`
-  → `!__eq(left, right)`. **`===`/`!==` stay strict** as the explicit "exact"
-  escape hatch. `<`, `>`, `<=`, `>=`, `=~`, `!~` are untouched.
+- Codegen (`typescriptBuilder.ts:1067–1068`): **all four equality operators
+  lower to `__eq`** — `==` and `===` → `__eq(left, right)`, `!=` and `!==` →
+  `!__eq(left, right)`. There is deliberately **no strict-equality escape
+  hatch**: since `null` and `undefined` are one value, distinguishing them is
+  never desirable, and a strict `=== null` would be a footgun that silently
+  misses an interop `undefined` — the exact bug this project fixes. `===`/`!==`
+  remain parseable as stylistic aliases of `==`/`!=` (for users with JS habits)
+  but compile identically. `<`, `>`, `<=`, `>=`, `=~`, `!~` are untouched.
 
 - Using a helper (not an inline `a === b || (a == null && b == null)`) is
   deliberate: operands are passed as arguments and therefore **evaluated
@@ -206,13 +211,12 @@ The two existing Zod mappers stay split by purpose:
   checks against `null` and type-checks.
 - A runtime `undefined` flowing in from interop is caught by `__eq` (§2): `x ==
   null` is true for it.
-- Documented sharp edge: passing an actually-`undefined` value *back* into TS
-  code that strictly distinguishes `=== undefined` from `=== null` is the one
-  rare case where the absorption is observable. The surface escape hatch is
-  `===` / `!==`, which are parseable Agency operators (`parsers.ts:2628–2629`)
-  and stay strict (they pass through codegen unchanged), so a user who genuinely
-  needs to distinguish `null` from `undefined` can still write `x === null`. This
-  is a doc note, not a code change.
+- Documented sharp edge: Agency intentionally provides **no way** to distinguish
+  `null` from `undefined` — both `==` and `===` unify them via `__eq`, and the
+  value `undefined` is unwritable. In the rare case of passing a value back into
+  TS code that strictly distinguishes `=== undefined` from `=== null`, Agency
+  cannot express that distinction. This is an accepted, by-design consequence of
+  unification, not a supported scenario — a doc note, not a code change.
 
 ### §5 Migration & coordination
 
@@ -241,8 +245,12 @@ coordination points:
 - **Narrowing recognition is unaffected by the `==`→`__eq` codegen change.**
   `analyzeCondition` keys on the AST operator `==` / `!=` (`narrowing.ts:99`),
   which is upstream of codegen, so `if (x == null)` is recognized regardless of
-  how `==` lowers. And the unified-null semantics of `__eq` *match* what
-  null-narrowing does: stripping the `null` member catches both a runtime `null`
+  how `==` lowers. **Note for Project 2:** because `===`/`!==` now unify too
+  (both lower to `__eq`), the null-narrowing recognizer must treat `=== null` /
+  `!== null` identically to `== null` / `!= null` — add the strict operators to
+  the recognizer alongside the loose ones. And the unified-null semantics of
+  `__eq` *match* what null-narrowing does: stripping the `null` member catches
+  both a runtime `null`
   and an interop `undefined`. The old `T | undefined` representation would have
   made the narrowing and the runtime disagree — another reason to land this
   first.

--- a/packages/agency-lang/docs/superpowers/specs/2026-06-28-nullish-unification-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-28-nullish-unification-design.md
@@ -1,0 +1,298 @@
+# Design: Nullish Unification (Project 1)
+
+## Summary
+
+Agency currently has an incoherent treatment of `null` and `undefined`. This
+project makes Agency have **one nothing-value: `null`.** `undefined` is never
+writable by users (already true) and is *absorbed* into `null` wherever it
+arises from the JS runtime or TypeScript interop. The type-level representation
+of optionality flips from `T | undefined` to `T | null`, so the type system
+finally matches the `null` the codegen already emits.
+
+This is **Project 1** of a two-project arc. **Project 2 — null safety**
+(flow-sensitive null narrowing + strict member access on possibly-null values)
+is explicitly out of scope here and folds into the existing narrowing roadmap
+(see `null-truthiness-narrowing-spec.md` and the `strictMemberAccess` work in
+`result-as-union-spec.md`).
+
+The **rationale** for treating `null` and `undefined` as one value — the
+cross-language survey, the alternatives we weighed, and why we rejected each —
+is documented separately in
+[`docs/dev/null-and-undefined.md`](../../dev/null-and-undefined.md). This spec
+is the "what"; that doc is the "why."
+
+## Motivation
+
+### The current mess (verified against source)
+
+Agency today is internally inconsistent about which nothing-value it uses:
+
+- **Type representation of optionality is `undefined`.** `key?: T` desugars to
+  `T | undefined` (`parsers.ts` `objectPropertyParser`, ~line 1049–1076);
+  `UNDEFINED_T = { primitiveType, "undefined" }` (`primitives.ts:8`);
+  `isOptionalType` keys on `"undefined"` (`assignability.ts:403`).
+- **But the Zod codegen already emits `null`.** Both `null` and `undefined`
+  primitive types map to `z.null()` (`typeToZodSchema.ts:92–95`).
+
+So the *type* says `undefined` while the *runtime* produces `null`. The two
+halves of the compiler disagree.
+
+- **`undefined` is not writable as a value.** There is a `nullParser` but no
+  `undefinedParser` (`parsers.ts:813`); `undefined` only exists as a *type*
+  keyword (`primitiveTypeParser`, ~line 862). Users like this — code containing
+  the value `undefined` simply does not parse.
+- **Assignability treats `null` and `undefined` as distinct, incompatible
+  primitives** (strict `value === value`, `assignability.ts:519–524`).
+- **The `null` literal synthesizes to `any`** (no `case "null"` in
+  `synthType`; falls through to `default: return "any"`).
+- **Equality compiles strict.** `==` → `===`, `!=` → `!==`
+  (`typescriptBuilder.ts:1067–1068`), and equality operands are **not
+  type-checked at all** (`BOOLEAN_OPS.has(op)` just returns `BOOLEAN_T`,
+  `synthesizer.ts:247`).
+- **`schema(T).parse({})` is broken for optional keys.** `schema(T)` compiles
+  through `mapTypeToValidationSchema` (`typescriptBuilder.ts:790`), so an
+  optional key `k?: string` becomes `z.union([z.string(), z.null()])` —
+  `.nullable()` semantics, which *rejects a missing key*. Parsing `{}` against
+  `{ k?: string }` therefore fails today.
+
+### Why unify rather than match TypeScript
+
+Cross-language research: every language designed without JS's backward-compat
+constraint picked **one** nothing-value (Python `None`, Ruby `nil`) or **zero,
+type-wrapped** (Rust `Option`, Haskell `Maybe`). The one language that keeps
+both (Zig) gives `undefined` a single narrow job — uninitialized memory — and
+makes `null` the value you actually program with. JS's two-nothing-values design
+is near-universally regretted and survives only because JS cannot break
+backward compatibility. Agency has no such constraint, so it can drop the wart.
+
+Crucially, Agency compiles to JS, so `undefined` *exists at runtime* whether or
+not the surface language acknowledges it (missing keys, optional chaining,
+out-of-bounds index, functions that fall off the end, TS interop). The design
+therefore does not *pretend* `undefined` is absent — that would be unsound.
+Instead it makes `null` **absorb** `undefined`: they compare equal, and
+`undefined` is normalized to `null` where it enters typed data.
+
+## Goals
+
+- One surface nothing-value: `null`. `undefined` stays unwritable as a value.
+- Optionality's type representation is `T | null` (was `T | undefined`).
+- `null` and `undefined` compare equal at runtime, so a single null check
+  catches a runtime `undefined` (e.g. from interop).
+- `schema(T).parse({})` succeeds for optional keys, coalescing a missing key to
+  `null`.
+- TS interop types containing `undefined` read as `null` in the type checker.
+- The LLM structured-output path is unchanged (already `null`, forced by
+  provider constraints).
+
+## Non-goals (deferred to Project 2 / existing roadmap)
+
+- **Strict null checking** — making `x.foo` on a possibly-null `x` a hard error
+  until narrowed (`strictMemberAccess` on the null member).
+- **Null narrowing** — `if (x == null)` / `if (x)` removing the null member
+  inside a branch. This is `null-truthiness-narrowing-spec.md`, retargeted from
+  `undefined` to `null`.
+- **Type-checking equality operands** — `==` / `!=` operands are not type-checked
+  today (`BOOLEAN_OPS` short-circuits to `BOOLEAN_T`, `synthesizer.ts:247`), so
+  `5 == "5"` type-checks clean. This project does not change that. It is a real
+  gap for an agent-feedback language and a natural co-resident of the flow
+  checker (you have `T | null` types and narrowing right there), so it belongs
+  with the Project 2 / strict-checking work — recorded here so it is not lost.
+- Making the `null` literal synthesize to the `null` type (currently `any`).
+  This only matters once strict checking lands and drags in
+  declaration-widening questions; left as-is in P1.
+- A `delete` operation for object keys (unneeded under "check the value, not the
+  key's presence").
+- A nominal `Option`/`Maybe` type (rejected — strict-checked `T | null` gives
+  the same safety without the ceremony; what was sketched as `Maybe<T>` is just
+  `T | null` with a different name, and the safety comes from the checker, not
+  the representation).
+
+## Design
+
+### §1 Type-representation flip
+
+- `objectPropertyParser`: `key?: T` desugars to `T | null` (was `T |
+  undefined`). When `T` is already a union, append `null` instead of
+  `undefined`.
+- Optional parameter `x?: T` (no default) types as `T | null`. (The runtime
+  already assigns the `null` *value* via the `{ type: "null" }` default the
+  parser injects, `parsers.ts:4167–4169`; this aligns the static type.)
+- Retire `UNDEFINED_T` in favor of `NULL_T`. Audit every reference to
+  `UNDEFINED_T` and the `"undefined"` primitive string in the type checker and
+  repoint to `null`.
+- `isOptionalType` keys on `null` (and `any`), `assignability.ts:403`.
+- The `undefined` **type keyword** stays parseable but **normalizes to `null`**.
+  **Normalize eagerly at the ingestion boundary** — the type-keyword parser and
+  the TS-interop import path rewrite `{ primitiveType, "undefined" }` to `null`
+  as the type is constructed/imported, so the stored AST never contains an
+  `undefined` primitive. Keep the lazy `resolveType` normalization only as a
+  backstop. This is deliberate: a stray un-normalized `undefined` primitive would
+  mismatch `null` in any code that inspects a type *structurally without
+  resolving first* — `formatType` (an error message showing `| undefined`),
+  union dedup/equality, type-keyed caches, and the assignability fast-paths that
+  match `.value` before `safeResolveType`. Lazy-only normalization makes the §1
+  "audit every reference" sweep load-bearing for *correctness*, not just
+  tidiness, and the risk compounds once the flow checker's `uniteTypes` dedups
+  union members at joins (a stray `undefined` member that fails to collapse into
+  `null` becomes `T | null | undefined` and defeats null-narrowing). The *value*
+  `undefined` remains unparseable (no `undefinedParser` is added). This lets an
+  imported TS type `string | undefined` read as `string | null`.
+- Assignability: once `undefined` types normalize to `null`, the strict
+  primitive-equality rule (`assignability.ts:519–524`) needs no special case —
+  there is only `null`.
+
+### §2 Runtime equality: the `__eq` helper
+
+Equality must treat `null` and `undefined` as one without needing operand type
+information at the comparison site.
+
+- Add `__eq(a, b)` to the runtime (`lib/runtime/`):
+
+  ```ts
+  export function __eq(a: unknown, b: unknown): boolean {
+    return a === b || (a == null && b == null);
+  }
+  ```
+
+  `a == null` (loose) is true for exactly `null` and `undefined` and nothing
+  else (not `0`, `""`, `false`, `NaN`). So `(a == null && b == null)` means
+  "both nullish," and `a === b` handles every other case exactly. Verified
+  property: for any value `x`, `__eq(x, null) === __eq(x, undefined)` (both
+  reduce to "is `x` nullish?"), and for two non-nullish values `__eq` is
+  identical to `===`.
+
+- Codegen (`typescriptBuilder.ts:1067–1068`): `==` → `__eq(left, right)`, `!=`
+  → `!__eq(left, right)`. **`===`/`!==` stay strict** as the explicit "exact"
+  escape hatch. `<`, `>`, `<=`, `>=`, `=~`, `!~` are untouched.
+
+- Using a helper (not an inline `a === b || (a == null && b == null)`) is
+  deliberate: operands are passed as arguments and therefore **evaluated
+  exactly once**, so expressions with side effects are not double-evaluated.
+
+- Behavior change is confined to nullish values: every non-null comparison
+  remains identical to today's strict `===`, so existing programs do not
+  regress.
+
+`??` (`synthNullishCoalesce`) already strips both `null` and `undefined`; no
+change needed.
+
+### §3 The schema feature (`schema(T).parse(...)`)
+
+The two existing Zod mappers stay split by purpose:
+
+- **LLM mapper** (`mapTypeToZodSchema`): optional key → `z.union([T,
+  z.null()])` (required + nullable). **Unchanged** — OpenAI structured output
+  requires every field to be `required`, with optionality expressed only as a
+  union with null.
+
+- **Parse/validation mapper** (`mapTypeToValidationSchema`, used by `schema(T)`
+  and `!` validation): an optional key becomes **truly optional and coalesces a
+  missing key to `null`**, so the parsed object has every declared key present:
+
+  ```
+  schema({ foo?: string }).parse({})   →   { foo: null }
+  ```
+
+  Intended Zod shape (exact encoding pinned in the implementation plan): accept
+  a missing key, accept `null`, and normalize the result to `null` — e.g.
+  `z.union([T, z.null()]).optional()` followed by a transform that maps
+  `undefined → null`, or `.default(null)`. The chosen encoding must round-trip
+  `{}` → `{ foo: null }` and `{ foo: "x" }` → `{ foo: "x" }`.
+
+### §4 TypeScript interop
+
+- TS types carrying `undefined` (e.g. a function returning `string |
+  undefined`) normalize to `null` at the type boundary (§1), so Agency code
+  checks against `null` and type-checks.
+- A runtime `undefined` flowing in from interop is caught by `__eq` (§2): `x ==
+  null` is true for it.
+- Documented sharp edge: passing an actually-`undefined` value *back* into TS
+  code that strictly distinguishes `=== undefined` from `=== null` is the one
+  rare case where the absorption is observable. The surface escape hatch is
+  `===` / `!==`, which are parseable Agency operators (`parsers.ts:2628–2629`)
+  and stay strict (they pass through codegen unchanged), so a user who genuinely
+  needs to distinguish `null` from `undefined` can still write `x === null`. This
+  is a doc note, not a code change.
+
+### §5 Migration & coordination
+
+- `null-truthiness-narrowing-spec.md` must be retargeted from `undefined` to
+  `null` before it is implemented. It is the last, as-yet-unbuilt item on the
+  narrowing roadmap and already anticipates this flip ("If a `null` primitive is
+  ever added, the same member-filter applies to it"), so coordination risk is
+  low.
+- Existing `key?:` types shift from `T | undefined` to `T | null`. The runtime
+  was already `null`-centric via Zod, so behavior is stable.
+- The `===` → `__eq` change for `==` is the main runtime behavior shift and is
+  strictly *more* correct (null checks now also catch `undefined`).
+- Sweep fixtures and tests that reference `undefined` types and repoint them to
+  `null`.
+
+### §6 Coordination with the flow checker and the `never` type
+
+This project lands **before** the flow-typed checker work
+(`2026-06-29-flow-typed-checker-design.md`) and its null/truthiness narrowing
+follow-on. Landing nullish-first is deliberate: it lets the narrowing recognizer
+be written once against `null`, takes the `T | undefined` → `T | null` fixture
+churn before the flow PRs add more narrowing fixtures, and makes the runtime and
+the type representation agree so narrowing and `__eq` cannot disagree. Four
+coordination points:
+
+- **Narrowing recognition is unaffected by the `==`→`__eq` codegen change.**
+  `analyzeCondition` keys on the AST operator `==` / `!=` (`narrowing.ts:99`),
+  which is upstream of codegen, so `if (x == null)` is recognized regardless of
+  how `==` lowers. And the unified-null semantics of `__eq` *match* what
+  null-narrowing does: stripping the `null` member catches both a runtime `null`
+  and an interop `undefined`. The old `T | undefined` representation would have
+  made the narrowing and the runtime disagree — another reason to land this
+  first.
+- **The "`null` literal synthesizes to `any`" non-goal does not block
+  null-narrowing.** Recognition is syntactic (it keys on the `null` literal AST
+  node, not its synthesized type), and the union member to strip is the real
+  `null` primitive in `T | null`, not the literal's type. So deferring the
+  literal-type fix to Project 2 is safe for the flow checker.
+- **`never` composition (once the flow checker's PR 0 lands).** With a real
+  bottom type, null-narrowing produces precise dead-branch signals:
+  `if (x != null)` on `x: null` → `never`; `if (x == null)` on a non-nullable
+  `x: string` → the then-branch is `never` (a provably impossible null check).
+  Nullish unification + `never` + null-narrowing together give TS-grade "this
+  null check can't happen" diagnostics. This is intentional, not accidental — the
+  flip to `T | null` is the precondition.
+- **`stripNullable`'s empty sentinel.** `stripNullable` returns JS `undefined`
+  for "nothing left after stripping nullish" (`synthesizer.ts:323`). That is fine
+  in P1, but once the `never` type exists the conceptually correct result is
+  `never`. Flag it for revisit with the `never` PR rather than leaving it
+  `any`-ish; not a P1 change.
+
+## Testing
+
+Agency execution tests (no LLM required):
+
+- `schema({ foo?: string }).parse({})` → `{ foo: null }`; `parse({ foo: "x" })`
+  → `{ foo: "x" }`.
+- Nested optional coalescing: `schema({ a?: { b?: string } }).parse({})` →
+  `{ a: null }` (coalesce only the missing level — no recursion into `b`);
+  `parse({ a: {} })` → `{ a: { b: null } }`.
+- Already-nullable optional key: `schema({ k?: string | null }).parse({})` →
+  `{ k: null }` (the duplicate `null` member dedups; the default still applies).
+- A null check (`x == null` / `x != null`) catches a runtime `undefined`
+  surfaced via interop or a missing key.
+- `__eq` truth table: `null`/`undefined` equal each other; `0`/`""`/`false`
+  remain distinct from nullish; non-null comparisons match `===`.
+- Optional parameter without an argument resolves to `null`.
+- `??` over a `T | null` value.
+
+Type-checker unit tests:
+
+- `key?: T` synthesizes `T | null`.
+- The `undefined` type keyword normalizes to `null` (incl. an imported TS
+  `string | undefined` reading as `string | null`).
+- `isOptionalType` returns true for `null`.
+
+## Open implementation details (for the plan, not blocking design)
+
+- Exact Zod encoding for parse-side optional-key coalescing (§3).
+- Full inventory of `UNDEFINED_T` / `"undefined"` references to repoint (§1).
+- Whether any runtime/stdlib helper currently depends on `==` compiling to
+  `===` in a way that the `__eq` switch would change (expected: none, since
+  `__eq` only differs on nullish).

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -734,3 +734,17 @@ describe("AgencyGenerator - string delimiter round-tripping", () => {
     expect(out).toBe('"hello"');
   });
 });
+
+describe("AgencyGenerator - optional key shorthand (nullish unification)", () => {
+  it("round-trips an optional key as key?: T", () => {
+    const parseResult = parseAgency("type Foo = { foo?: string }", {}, false);
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) return;
+
+    const generator = new AgencyGenerator();
+    const result = generator.generate(parseResult.result);
+
+    expect(result.output).toContain("foo?: string");
+    expect(result.output).not.toContain("string | null");
+  });
+});

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -623,22 +623,22 @@ export class AgencyGenerator {
   // Type system methods
 
   private stringifyProp(prop: ObjectProperty): string {
-    const isUnionWithUndefined =
+    const isUnionWithNull =
       prop.value.type === "unionType" &&
       prop.value.types.some(
-        (t) => t.type === "primitiveType" && t.value === "undefined",
+        (t) => t.type === "primitiveType" && t.value === "null",
       );
 
-    if (isUnionWithUndefined) {
-      const nonUndefinedTypes = (prop.value as any).types.filter(
+    if (isUnionWithNull) {
+      const nonNullTypes = (prop.value as any).types.filter(
         (t: VariableType) =>
-          !(t.type === "primitiveType" && t.value === "undefined"),
+          !(t.type === "primitiveType" && t.value === "null"),
       );
-      const unionWithoutUndefined: VariableType =
-        nonUndefinedTypes.length === 1
-          ? nonUndefinedTypes[0]
-          : { type: "unionType", types: nonUndefinedTypes };
-      let str = `${prop.key}?: ${variableTypeToString(unionWithoutUndefined, this.typeAliases, true)}`;
+      const unionWithoutNull: VariableType =
+        nonNullTypes.length === 1
+          ? nonNullTypes[0]
+          : { type: "unionType", types: nonNullTypes };
+      let str = `${prop.key}?: ${variableTypeToString(unionWithoutNull, this.typeAliases, true)}`;
       if (prop.description) {
         str += ` # ${prop.description}`;
       }

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1063,10 +1063,21 @@ export class TypeScriptBuilder {
     }
     const leftNode = this.processNode(node.left);
     const rightNode = this.processNode(node.right);
-    // Agency uses strict equality/inequality: == → ===, != → !==
-    const emitOp = node.operator === "==" ? "===" :
-      node.operator === "!=" ? "!==" : node.operator;
-    return ts.binOp(leftNode, emitOp, rightNode, {
+    // All equality operators use unified nullish equality via the `__eq`
+    // runtime helper (null and undefined compare equal). There is no strict
+    // escape hatch: `===`/`!==` are stylistic aliases that compile identically
+    // to `==`/`!=`. See docs/dev/null-and-undefined.md.
+    if (
+      node.operator === "==" ||
+      node.operator === "===" ||
+      node.operator === "!=" ||
+      node.operator === "!=="
+    ) {
+      const eq = ts.call(ts.id("__eq"), [leftNode, rightNode]);
+      const negated = node.operator === "!=" || node.operator === "!==";
+      return negated ? ts.not(eq) : eq;
+    }
+    return ts.binOp(leftNode, node.operator, rightNode, {
       parenLeft: this.needsParensLeft(node.left, node.operator),
       parenRight: this.needsParensRight(node.right, node.operator),
     });

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1540,7 +1540,16 @@ export class TypeScriptBuilder {
     let zod = this.zodSchemaFor(typeHint);
     if (param.defaultValue) {
       const defaultStr = expressionToString(param.defaultValue);
-      zod += `.nullable().describe(${JSON.stringify("Default: " + defaultStr)})`;
+      // A widened optional param (`x?: T` → `T | null`) is already nullable;
+      // only add `.nullable()` for params whose type is not already nullable
+      // (e.g. an explicit default `x: T = 5`), so the LLM may omit them.
+      const alreadyNullable =
+        typeHint.type === "unionType" &&
+        typeHint.types.some(
+          (t) => t.type === "primitiveType" && t.value === "null",
+        );
+      if (!alreadyNullable) zod += ".nullable()";
+      zod += `.describe(${JSON.stringify("Default: " + defaultStr)})`;
     }
     return { kind: "scalar", zod };
   }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.test.ts
@@ -261,3 +261,71 @@ describe("appendMeta", () => {
     expect(out).toMatch(/description:\s*"user email"/);
   });
 });
+
+describe("optional-key coalescing (validation mapper)", () => {
+  const optionalStringObj: VariableType = {
+    type: "objectType",
+    properties: [
+      {
+        key: "foo",
+        value: {
+          type: "unionType",
+          types: [
+            { type: "primitiveType", value: "string" },
+            { type: "primitiveType", value: "null" },
+          ],
+        },
+      },
+    ],
+  };
+
+  it("validation mapper makes a T | null key optional and coalesces to null", () => {
+    const out = mapTypeToValidationSchema(optionalStringObj, {});
+    expect(out).toContain(".optional().default(null)");
+  });
+
+  it("LLM mapper keeps a T | null key required (no optional/default)", () => {
+    const out = mapTypeToZodSchema(optionalStringObj, {});
+    expect(out).not.toContain(".optional()");
+    expect(out).not.toContain(".default(null)");
+  });
+
+  it("keeps .meta() the final call in the chain for a tagged optional key", () => {
+    const objWithTaggedOptional: VariableType = {
+      type: "objectType",
+      properties: [
+        {
+          key: "foo",
+          value: {
+            type: "unionType",
+            types: [
+              { type: "primitiveType", value: "string" },
+              { type: "primitiveType", value: "null" },
+            ],
+            tags: [
+              {
+                type: "tag",
+                name: "jsonSchema",
+                arguments: [
+                  {
+                    type: "agencyObject",
+                    entries: [
+                      {
+                        key: "description",
+                        value: { type: "string", segments: [{ type: "text", value: "a foo" }] },
+                      },
+                    ],
+                  },
+                ],
+              } as unknown as Tag,
+            ],
+          },
+        },
+      ],
+    };
+    const out = mapTypeToValidationSchema(objWithTaggedOptional, {});
+    // .meta(...) must be the last call — it must appear AFTER .default(null),
+    // otherwise Zod drops the metadata from toJSONSchema().
+    expect(out).toContain(".default(null).meta(");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -171,20 +171,21 @@ function mapTypeToSchemaInner(
         if (prop.description) {
           inner2 += `.describe("${escape(prop.description)}")`;
         }
-        let propSchema = appendMeta(inner2, mergedTags);
         // Optional key (a `T | null` property): in validation/parse mode make
         // the key optional and coalesce a missing key to null, so
         // `schema(T).parse({})` succeeds with every declared key present. The
         // LLM path keeps it required+nullable (provider constraint).
+        // This MUST be applied before `appendMeta` so any `.meta(...)` stays the
+        // final call in the chain (Zod drops metadata otherwise).
         const isNullableProp =
           prop.value.type === "unionType" &&
           prop.value.types.some(
             (t) => t.type === "primitiveType" && t.value === "null",
           );
         if (optionalKeyMode === "optional-coalesce" && isNullableProp) {
-          propSchema = `${propSchema}.optional().default(null)`;
+          inner2 += `.optional().default(null)`;
         }
-        const str = `"${prop.key.replace(/"/g, '\\"')}": ${propSchema}`;
+        const str = `"${prop.key.replace(/"/g, '\\"')}": ${appendMeta(inner2, mergedTags)}`;
         return str;
       })
       .join(", ");

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -52,14 +52,26 @@ export function appendMeta(schemaExpr: string, tags: Tag[] | undefined): string 
  * concatenation per `mergeTagSets`) instead of letting Zod's chained
  * `.meta()` overwrite the alias-level metadata.
  */
+/**
+ * How an optional object key (a property typed `T | null`) is encoded:
+ * - `required-nullable`: the key stays required and nullable
+ *   (`z.union([T, z.null()])`). Used for the LLM structured-output path,
+ *   because OpenAI strict mode requires every field to be `required`.
+ * - `optional-coalesce`: the key becomes optional and a missing key
+ *   coalesces to `null` (`...optional().default(null)`). Used for the
+ *   validation/parse path so `schema(T).parse({})` succeeds.
+ */
+type OptionalKeyMode = "required-nullable" | "optional-coalesce";
+
 function mapTypeToSchema(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
   resultHandler: (vt: VariableType, ta: Record<string, VariableType>) => string,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
+  optionalKeyMode: OptionalKeyMode = "required-nullable",
 ): string {
   return appendMeta(
-    mapTypeToSchemaInner(variableType, typeAliases, resultHandler, typeAliasesFull),
+    mapTypeToSchemaInner(variableType, typeAliases, resultHandler, typeAliasesFull, optionalKeyMode),
     variableType.tags,
   );
 }
@@ -69,10 +81,11 @@ function mapTypeToSchemaInner(
   typeAliases: Record<string, VariableType>,
   resultHandler: (vt: VariableType, ta: Record<string, VariableType>) => string,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
+  optionalKeyMode: OptionalKeyMode = "required-nullable",
 ): string {
   const recurse = (vt: VariableType) =>
     appendMeta(
-      mapTypeToSchemaInner(vt, typeAliases, resultHandler, typeAliasesFull),
+      mapTypeToSchemaInner(vt, typeAliases, resultHandler, typeAliasesFull, optionalKeyMode),
       vt.tags,
     );
 
@@ -149,6 +162,7 @@ function mapTypeToSchemaInner(
           typeAliases,
           resultHandler,
           typeAliasesFull,
+          optionalKeyMode,
         );
         // .describe(...) must come BEFORE .meta(...) — Zod requires
         // .meta() to be the final call in the chain or the metadata is
@@ -157,7 +171,20 @@ function mapTypeToSchemaInner(
         if (prop.description) {
           inner2 += `.describe("${escape(prop.description)}")`;
         }
-        const str = `"${prop.key.replace(/"/g, '\\"')}": ${appendMeta(inner2, mergedTags)}`;
+        let propSchema = appendMeta(inner2, mergedTags);
+        // Optional key (a `T | null` property): in validation/parse mode make
+        // the key optional and coalesce a missing key to null, so
+        // `schema(T).parse({})` succeeds with every declared key present. The
+        // LLM path keeps it required+nullable (provider constraint).
+        const isNullableProp =
+          prop.value.type === "unionType" &&
+          prop.value.types.some(
+            (t) => t.type === "primitiveType" && t.value === "null",
+          );
+        if (optionalKeyMode === "optional-coalesce" && isNullableProp) {
+          propSchema = `${propSchema}.optional().default(null)`;
+        }
+        const str = `"${prop.key.replace(/"/g, '\\"')}": ${propSchema}`;
         return str;
       })
       .join(", ");
@@ -186,6 +213,7 @@ function mapTypeToSchemaInner(
         typeAliases,
         resultHandler,
         typeAliasesFull,
+        optionalKeyMode,
       );
     }
     return variableType.aliasName;
@@ -220,6 +248,7 @@ export function mapTypeToZodSchema(
     typeAliases,
     (vt, ta) => mapTypeToZodSchema((vt as any).successType, ta, typeAliasesFull),
     typeAliasesFull,
+    "required-nullable",
   );
 }
 
@@ -245,5 +274,6 @@ export function mapTypeToValidationSchema(
       return `z.union([z.object({ __type: z.literal("resultType"), success: z.literal(true), value: ${successSchema} }), z.object({ __type: z.literal("resultType"), success: z.literal(false), error: z.any() })])`;
     },
     typeAliasesFull,
+    "optional-coalesce",
   );
 }

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   functionParser,
+  functionParameterParser,
   docStringParser,
   graphNodeParser,
   messageThreadParser,
@@ -2016,7 +2017,13 @@ describe("functionParser", () => {
             {
               type: "functionParameter",
               name: "y",
-              typeHint: { type: "primitiveType", value: "number" },
+              typeHint: {
+                type: "unionType",
+                types: [
+                  { type: "primitiveType", value: "number" },
+                  { type: "primitiveType", value: "null" },
+                ],
+              },
               defaultValue: { type: "null" },
             },
           ],
@@ -3606,6 +3613,39 @@ describe("bang (!) validated type annotations", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.result.returnTypeValidated).toBeUndefined();
+    }
+  });
+});
+
+describe("functionParameterParser optional params (nullish unification)", () => {
+  it("widens an optional parameter's type hint to T | null", () => {
+    const result = functionParameterParser("x?: number");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.typeHint).toEqualWithoutLoc({
+        type: "unionType",
+        types: [
+          { type: "primitiveType", value: "number" },
+          { type: "primitiveType", value: "null" },
+        ],
+      });
+      // default value still injected so the runtime resolves an omitted arg to null
+      expect(result.result.defaultValue).toEqualWithoutLoc({ type: "null" });
+    }
+  });
+
+  it("appends null to an optional union-typed parameter", () => {
+    const result = functionParameterParser("x?: number | string");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.typeHint).toEqualWithoutLoc({
+        type: "unionType",
+        types: [
+          { type: "primitiveType", value: "number" },
+          { type: "primitiveType", value: "string" },
+          { type: "primitiveType", value: "null" },
+        ],
+      });
     }
   });
 });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1047,7 +1047,7 @@ export const objectPropertyParser: Parser<ObjectProperty> = memo(
     }
 
     if (value.type === "unionType") {
-      // If it's already a union, just add undefined to the list of types
+      // If it's already a union, just add null to the list of types
       return success(
         {
           key,
@@ -1055,7 +1055,7 @@ export const objectPropertyParser: Parser<ObjectProperty> = memo(
             type: "unionType",
             types: [
               ...value.types,
-              { type: "primitiveType", value: "undefined" },
+              { type: "primitiveType", value: "null" },
             ],
           },
         },
@@ -1063,13 +1063,13 @@ export const objectPropertyParser: Parser<ObjectProperty> = memo(
       );
     }
 
-    // If it's not a union, create a new union with the original type and undefined
+    // If it's not a union, create a new union with the original type and null
     return success(
       {
         key,
         value: {
           type: "unionType",
-          types: [value, { type: "primitiveType", value: "undefined" }],
+          types: [value, { type: "primitiveType", value: "null" }],
         },
       },
       result.rest,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4180,10 +4180,14 @@ export const functionParameterParser: Parser<FunctionParameter> = memo(
         rest.defaultValue = { type: "null" };
         if (rest.typeHint) {
           const nullT = { type: "primitiveType", value: "null" };
-          rest.typeHint =
+          const existingMembers =
             rest.typeHint.type === "unionType"
-              ? { type: "unionType", types: [...rest.typeHint.types, nullT] }
-              : { type: "unionType", types: [rest.typeHint, nullT] };
+              ? rest.typeHint.types
+              : [rest.typeHint];
+          rest.typeHint = {
+            type: "unionType",
+            types: [...existingMembers, nullT],
+          };
         }
       }
       if (_validated) rest.validated = true;

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4171,8 +4171,20 @@ export const functionParameterParser: Parser<FunctionParameter> = memo(
     ),
     (result: any) => {
       const { __optional, validated: _validated, ...rest } = result;
+      // An optional param with no explicit default resolves to null when the
+      // arg is omitted. Inject that default AND widen the static type to
+      // `T | null` so the type matches the runtime value (nullish unification).
+      // When an explicit default is present (e.g. `x?: string = "hi"`), the
+      // value is never null, so neither the default nor the widening applies.
       if (__optional && !rest.defaultValue) {
         rest.defaultValue = { type: "null" };
+        if (rest.typeHint) {
+          const nullT = { type: "primitiveType", value: "null" };
+          rest.typeHint =
+            rest.typeHint.type === "unionType"
+              ? { type: "unionType", types: [...rest.typeHint.types, nullT] }
+              : { type: "unionType", types: [rest.typeHint, nullT] };
+        }
       }
       if (_validated) rest.validated = true;
       return rest as FunctionParameter;

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -852,24 +852,31 @@ export function simpleLiteralParser(input: string): ParserResult<Literal> {
 
 export const primitiveTypeParser: Parser<PrimitiveType> = memo(
   "primitiveTypeParser",
-  seqC(
-    set("type", "primitiveType"),
-    capture(
-      or(
-        str("number"),
-        str("string"),
-        str("boolean"),
-        str("undefined"),
-        str("void"),
-        str("null"),
-        str("any"),
-        str("unknown"),
-        str("object"),
-        str("function"),
-        str("regex"),
+  map(
+    seqC(
+      set("type", "primitiveType"),
+      capture(
+        or(
+          str("number"),
+          str("string"),
+          str("boolean"),
+          str("undefined"),
+          str("void"),
+          str("null"),
+          str("any"),
+          str("unknown"),
+          str("object"),
+          str("function"),
+          str("regex"),
+        ),
+        "value",
       ),
-      "value",
     ),
+    // Nullish unification: the `undefined` type keyword is accepted (e.g. from
+    // imported TS type annotations) but normalized to `null` at parse time, so
+    // the stored AST never contains an `undefined` primitive. The *value*
+    // `undefined` remains unparseable. See docs/dev/null-and-undefined.md.
+    (r: PrimitiveType) => (r.value === "undefined" ? { ...r, value: "null" } : r),
   ),
 );
 

--- a/packages/agency-lang/lib/parsers/typeHints.test.ts
+++ b/packages/agency-lang/lib/parsers/typeHints.test.ts
@@ -57,6 +57,22 @@ describe("primitiveTypeParser", () => {
       },
     },
     {
+      input: "null",
+      expected: {
+        success: true,
+        result: { type: "primitiveType", value: "null" },
+      },
+    },
+    {
+      // `undefined` is accepted as a type keyword but normalized to `null`
+      // (nullish unification — there is one nothing-value).
+      input: "undefined",
+      expected: {
+        success: true,
+        result: { type: "primitiveType", value: "null" },
+      },
+    },
+    {
       input: "invalid",
       expected: { success: false },
     },

--- a/packages/agency-lang/lib/parsers/typeHints.test.ts
+++ b/packages/agency-lang/lib/parsers/typeHints.test.ts
@@ -999,6 +999,39 @@ describe("objectPropertyParser", () => {
       },
     },
     {
+      input: "foo?: string",
+      expected: {
+        success: true,
+        result: {
+          key: "foo",
+          value: {
+            type: "unionType",
+            types: [
+              { type: "primitiveType", value: "string" },
+              { type: "primitiveType", value: "null" },
+            ],
+          },
+        },
+      },
+    },
+    {
+      input: "bar?: string | number",
+      expected: {
+        success: true,
+        result: {
+          key: "bar",
+          value: {
+            type: "unionType",
+            types: [
+              { type: "primitiveType", value: "string" },
+              { type: "primitiveType", value: "number" },
+              { type: "primitiveType", value: "null" },
+            ],
+          },
+        },
+      },
+    },
+    {
       input: "x number",
       expected: { success: false },
     },

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
@@ -441,8 +441,9 @@ describe("desugar → codegen snapshot", () => {
     //    over the arm name strings.
     expect(ts).toMatch(/runner\d*\.fork\(\s*\d+\s*,\s*\[\s*`arm_0`\s*,\s*`arm_1`\s*\]/);
     // 2. Each arm is dispatched by a string-equality check on the arm param.
-    expect(ts).toMatch(/__arm_0\s*===?\s*`arm_0`/);
-    expect(ts).toMatch(/__arm_0\s*===?\s*`arm_1`/);
+    //    Equality lowers to the __eq runtime helper (nullish unification).
+    expect(ts).toMatch(/__eq\(\s*[^,]*__arm_0\s*,\s*`arm_0`\s*\)/);
+    expect(ts).toMatch(/__eq\(\s*[^,]*__arm_0\s*,\s*`arm_1`\s*\)/);
     // 3. Bindings (a from arm 0, b and c from the seq arm) are hoisted and
     //    assigned from __arms_0 indexed access.
     expect(ts).toMatch(/__arms_0\[0\]\.a/);

--- a/packages/agency-lang/lib/runtime/eq.test.ts
+++ b/packages/agency-lang/lib/runtime/eq.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { __eq } from "./eq.js";
+
+describe("__eq", () => {
+  it("treats null and undefined as equal", () => {
+    expect(__eq(null, undefined)).toBe(true);
+    expect(__eq(undefined, null)).toBe(true);
+    expect(__eq(null, null)).toBe(true);
+    expect(__eq(undefined, undefined)).toBe(true);
+  });
+
+  it("keeps non-nullish values distinct from nullish", () => {
+    expect(__eq(0, null)).toBe(false);
+    expect(__eq(0, undefined)).toBe(false);
+    expect(__eq("", null)).toBe(false);
+    expect(__eq(false, null)).toBe(false);
+    expect(__eq(5, null)).toBe(false);
+  });
+
+  it("matches === for non-nullish values", () => {
+    expect(__eq(5, 5)).toBe(true);
+    expect(__eq("a", "a")).toBe(true);
+    expect(__eq(5, 6)).toBe(false);
+    expect(__eq("a", "b")).toBe(false);
+    const obj = { x: 1 };
+    expect(__eq(obj, obj)).toBe(true);
+    expect(__eq({ x: 1 }, { x: 1 })).toBe(false); // reference equality
+    expect(__eq(NaN, NaN)).toBe(false); // same as ===
+  });
+
+  it("is symmetric for any value against null vs undefined", () => {
+    for (const x of [0, "", false, 5, "a", null, undefined, NaN]) {
+      expect(__eq(x, null)).toBe(__eq(x, undefined));
+    }
+  });
+});

--- a/packages/agency-lang/lib/runtime/eq.ts
+++ b/packages/agency-lang/lib/runtime/eq.ts
@@ -1,0 +1,14 @@
+/**
+ * Equality with unified nullish semantics. `null` and `undefined` are one
+ * nothing-value in Agency, so `==`/`!=` (and `===`/`!==`) lower to this helper
+ * instead of strict `===`/`!==`. For two non-nullish values it is identical to
+ * `===`; the only difference is that `null` and `undefined` compare equal.
+ *
+ * `a == null` (loose) is true for exactly `null` and `undefined` (never `0`,
+ * `""`, `false`, `NaN`), so `(a == null && b == null)` means "both nullish."
+ *
+ * See docs/dev/null-and-undefined.md.
+ */
+export function __eq(a: unknown, b: unknown): boolean {
+  return a === b || (a == null && b == null);
+}

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -140,6 +140,7 @@ export {
 } from "./result.js";
 export type { ResultValue, ResultSuccess, ResultFailure } from "./result.js";
 export { Schema, __validateType } from "./schema.js";
+export { __eq } from "./eq.js";
 export {
   __validateChain,
   __validateChainRecursive,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -27,7 +27,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4564,7 +4564,7 @@ describe("TypeChecker", () => {
   describe("v2: bang (!) validation", () => {
     const num: VariableType = { type: "primitiveType", value: "number" };
     const str: VariableType = { type: "primitiveType", value: "string" };
-    const undef: VariableType = { type: "primitiveType", value: "undefined" };
+    const nullish: VariableType = { type: "primitiveType", value: "null" };
     const person: VariableType = {
       type: "objectType",
       properties: [{ key: "name", value: str }],
@@ -5542,12 +5542,12 @@ describe("TypeChecker", () => {
     it("allows omitting an optional object property when calling a function", () => {
       // type Opts = { model?: string, temperature?: number }
       // def use(o: Opts) {}; use({ model: "gpt-4" })
-      const undef: VariableType = { type: "primitiveType", value: "undefined" };
+      const nullish: VariableType = { type: "primitiveType", value: "null" };
       const opts: VariableType = {
         type: "objectType",
         properties: [
-          { key: "model", value: { type: "unionType", types: [str, undef] } },
-          { key: "temperature", value: { type: "unionType", types: [num, undef] } },
+          { key: "model", value: { type: "unionType", types: [str, nullish] } },
+          { key: "temperature", value: { type: "unionType", types: [num, nullish] } },
         ],
       };
       const program: AgencyProgram = {
@@ -5578,12 +5578,12 @@ describe("TypeChecker", () => {
 
     it("still rejects omitting a required object property", () => {
       // type Opts = { model: string, temperature?: number }; use({}) — model required.
-      const undef: VariableType = { type: "primitiveType", value: "undefined" };
+      const nullish: VariableType = { type: "primitiveType", value: "null" };
       const opts: VariableType = {
         type: "objectType",
         properties: [
           { key: "model", value: str },
-          { key: "temperature", value: { type: "unionType", types: [num, undef] } },
+          { key: "temperature", value: { type: "unionType", types: [num, nullish] } },
         ],
       };
       const program: AgencyProgram = {
@@ -5812,7 +5812,7 @@ describe("TypeChecker", () => {
       const opts: VariableType = {
         type: "objectType",
         properties: [
-          { key: "model", value: { type: "unionType", types: [str, undef] } },
+          { key: "model", value: { type: "unionType", types: [str, nullish] } },
         ],
       };
       const program: AgencyProgram = {
@@ -5852,7 +5852,7 @@ describe("TypeChecker", () => {
             aliasedType: {
               type: "objectType",
               properties: [
-                { key: "a", value: { type: "unionType", types: [str, undef] } },
+                { key: "a", value: { type: "unionType", types: [str, nullish] } },
               ],
             },
           },

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -390,9 +390,9 @@ export function widenType(vt: VariableType | "any"): VariableType | "any" {
 }
 
 /**
- * A type that admits `undefined` as a value, so the corresponding object
+ * A type that admits `null` as a value, so the corresponding object
  * property may be absent from the source. Covers the `key?: T` desugaring
- * (parsed as `T | undefined`) plus `any`, which subsumes undefined.
+ * (parsed as `T | null`) plus `any`, which subsumes null.
  */
 function isOptionalType(
   vt: VariableType,
@@ -400,7 +400,7 @@ function isOptionalType(
 ): boolean {
   const resolved = safeResolveType(vt, typeAliases);
   if (resolved.type === "primitiveType")
-    return resolved.value === "undefined" || resolved.value === "any";
+    return resolved.value === "null" || resolved.value === "any";
   if (resolved.type === "unionType")
     return resolved.types.some((t) => isOptionalType(t, typeAliases));
   return false;

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -5,7 +5,7 @@ import {
   BOOLEAN_T as boolean,
   NUMBER_T as number,
   STRING_T as string,
-  UNDEFINED_T as undef,
+  NULL_T as nullT,
   VOID_T as voidT,
 } from "./primitives.js";
 
@@ -14,7 +14,7 @@ const anyArray = { type: "arrayType", elementType: ANY_T } as const;
 
 const optional = (t: VariableType): VariableType => ({
   type: "unionType",
-  types: [t, undef],
+  types: [t, nullT],
 });
 
 /**

--- a/packages/agency-lang/lib/typeChecker/nullish.test.ts
+++ b/packages/agency-lang/lib/typeChecker/nullish.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { isAssignable } from "./assignability.js";
+import { NULL_T } from "./primitives.js";
+import type { VariableType } from "../types.js";
+
+describe("nullish unification in the type checker", () => {
+  const STRING_T: VariableType = { type: "primitiveType", value: "string" };
+
+  it("NULL_T is the null primitive", () => {
+    expect(NULL_T).toEqual({ type: "primitiveType", value: "null" });
+  });
+
+  it("null is assignable to string | null", () => {
+    const target: VariableType = {
+      type: "unionType",
+      types: [STRING_T, NULL_T],
+    };
+    expect(isAssignable(NULL_T, target, {})).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/primitiveMembers.ts
+++ b/packages/agency-lang/lib/typeChecker/primitiveMembers.ts
@@ -110,7 +110,7 @@ const STRING_MEMBERS: Record<string, PrimitiveMember> = {
 
   // Regex
   match:       { kind: "method", sig: {
-    params: [REGEX_T], returnType: { type: "unionType", types: [stringArray, { type: "primitiveType", value: "undefined" }] },
+    params: [REGEX_T], returnType: { type: "unionType", types: [stringArray, { type: "primitiveType", value: "null" }] },
   } },
 };
 
@@ -151,13 +151,13 @@ const ARRAY_MEMBERS: Record<string, PrimitiveMember> = {
   pop:         { kind: "method", sig: (r) => ({
     params: [], returnType: {
       type: "unionType",
-      types: [elementOf(r), { type: "primitiveType", value: "undefined" }],
+      types: [elementOf(r), { type: "primitiveType", value: "null" }],
     },
   }) },
   shift:       { kind: "method", sig: (r) => ({
     params: [], returnType: {
       type: "unionType",
-      types: [elementOf(r), { type: "primitiveType", value: "undefined" }],
+      types: [elementOf(r), { type: "primitiveType", value: "null" }],
     },
   }) },
   reverse:     { kind: "method", sig: (r) => ({ params: [], returnType: r }) },

--- a/packages/agency-lang/lib/typeChecker/primitiveMembers.ts
+++ b/packages/agency-lang/lib/typeChecker/primitiveMembers.ts
@@ -220,7 +220,7 @@ export function resolvePropertyType(
  *   "arrayU"      — `Array<U>`. e.g. `map`.
  *   "sameArray"   — `Array<T>` (callback's return is irrelevant). `filter`/`sort`.
  *   "void"        — `void`. `forEach`.
- *   "elementOrUndef" — `T | undefined`. `find`.
+ *   "elementOrNull" — `T | null`. `find`.
  *   "boolean"     — boolean. `some`/`every`.
  *   "flatten"     — `Array<U>` where the callback's return is `Array<U>` —
  *                   we unwrap one level. `flatMap`.
@@ -236,7 +236,7 @@ export const ARRAY_CALLBACK_METHOD_KINDS = {
   map: "arrayU",
   filter: "sameArray",
   forEach: "void",
-  find: "elementOrUndef",
+  find: "elementOrNull",
   some: "boolean",
   every: "boolean",
   sort: "sameArray",

--- a/packages/agency-lang/lib/typeChecker/primitives.ts
+++ b/packages/agency-lang/lib/typeChecker/primitives.ts
@@ -5,5 +5,5 @@ export const NUMBER_T: VariableType = { type: "primitiveType", value: "number" }
 export const BOOLEAN_T: VariableType = { type: "primitiveType", value: "boolean" };
 export const REGEX_T: VariableType = { type: "primitiveType", value: "regex" };
 export const VOID_T: VariableType = { type: "primitiveType", value: "void" };
-export const UNDEFINED_T: VariableType = { type: "primitiveType", value: "undefined" };
+export const NULL_T: VariableType = { type: "primitiveType", value: "null" };
 export const ANY_T: VariableType = { type: "primitiveType", value: "any" };

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -23,7 +23,7 @@ import type { BuiltinSignature } from "./types.js";
 import { walkNodes } from "../utils/node.js";
 import { uniqBy } from "../utils.js";
 import type { BlockArgument } from "../types/blockArgument.js";
-import { UNDEFINED_T, VOID_T } from "./primitives.js";
+import { NULL_T, VOID_T } from "./primitives.js";
 
 /** Names treated as Result constructors (synth parameterizes ResultType from arg). */
 const RESULT_CONSTRUCTORS = new Set<string>(["success", "failure"]);
@@ -863,7 +863,7 @@ function synthArrayCallbackMethod(
   if (cbKind === "void") return VOID_T;
   if (cbKind === "boolean") return BOOLEAN_T;
   if (cbKind === "elementOrUndef") {
-    return { type: "unionType", types: [elementT, UNDEFINED_T] };
+    return { type: "unionType", types: [elementT, NULL_T] };
   }
 
   // The remaining kinds (`arrayU`, `flatten`, `reduce`) all need the

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -862,7 +862,7 @@ function synthArrayCallbackMethod(
   if (cbKind === "sameArray") return receiver;
   if (cbKind === "void") return VOID_T;
   if (cbKind === "boolean") return BOOLEAN_T;
-  if (cbKind === "elementOrUndef") {
+  if (cbKind === "elementOrNull") {
     return { type: "unionType", types: [elementT, NULL_T] };
   }
 

--- a/packages/agency-lang/tests/agency/nullish-eq.agency
+++ b/packages/agency-lang/tests/agency/nullish-eq.agency
@@ -1,0 +1,12 @@
+node main() {
+  let obj: { a?: string } = {}
+  let absent = obj.a
+  if (absent == null) {
+    // `===` must also catch the (runtime-undefined) absent key — no strict
+    // escape hatch; both operators unify null and undefined.
+    if (absent === null) {
+      return "absent is null"
+    }
+  }
+  return "wrong"
+}

--- a/packages/agency-lang/tests/agency/nullish-eq.test.json
+++ b/packages/agency-lang/tests/agency/nullish-eq.test.json
@@ -1,0 +1,10 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"absent is null\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/optionalKeyCoalesce.agency
+++ b/packages/agency-lang/tests/agency/validation/optionalKeyCoalesce.agency
@@ -1,0 +1,11 @@
+node main() {
+  const s = schema({ foo?: string })
+  const r = s.parse({})
+  if (isSuccess(r)) {
+    if (r.value.foo == null) {
+      return "coalesced to null"
+    }
+    return "present but not null"
+  }
+  return "parse failed"
+}

--- a/packages/agency-lang/tests/agency/validation/optionalKeyCoalesce.test.json
+++ b/packages/agency-lang/tests/agency/validation/optionalKeyCoalesce.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"coalesced to null\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema({foo?: string}).parse({}) yields { foo: null }"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/optionalKeyNested.agency
+++ b/packages/agency-lang/tests/agency/validation/optionalKeyNested.agency
@@ -1,0 +1,11 @@
+node main() {
+  const s = schema({ a?: { b?: string } })
+  const r = s.parse({})
+  if (isSuccess(r)) {
+    if (r.value.a == null) {
+      return "outer coalesced"
+    }
+    return "outer present"
+  }
+  return "parse failed"
+}

--- a/packages/agency-lang/tests/agency/validation/optionalKeyNested.test.json
+++ b/packages/agency-lang/tests/agency/validation/optionalKeyNested.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"outer coalesced\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "missing outer optional object coalesces to null (no recursion into b)"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/optionalKeyRecursive.agency
+++ b/packages/agency-lang/tests/agency/validation/optionalKeyRecursive.agency
@@ -1,0 +1,14 @@
+node main() {
+  const s = schema({ a?: { b?: string } })
+  const r = s.parse({ a: {} })
+  if (isSuccess(r)) {
+    if (r.value.a != null) {
+      if (r.value.a.b == null) {
+        return "inner coalesced"
+      }
+      return "inner present"
+    }
+    return "outer null"
+  }
+  return "parse failed"
+}

--- a/packages/agency-lang/tests/agency/validation/optionalKeyRecursive.test.json
+++ b/packages/agency-lang/tests/agency/validation/optionalKeyRecursive.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"inner coalesced\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "parse({a: {}}) coalesces the inner missing optional key to null"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -24,7 +24,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -24,7 +24,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -24,7 +24,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -24,7 +24,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -24,7 +24,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -24,7 +24,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -23,7 +23,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -190,7 +190,7 @@ __stack.locals.sum = 0;
 await runner.ifElse(0, [
 
   {
-    condition: async () => i % 3 === 0 || i % 5 === 0,
+    condition: async () => __eq(i % 3, 0) || __eq(i % 5, 0),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + i;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -196,7 +196,7 @@ __stack.locals.sum = 0;
 await runner.ifElse(0, [
 
   {
-    condition: async () => __stack.locals.a % 2 === 0,
+    condition: async () => __eq(__stack.locals.a % 2, 0),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + __stack.locals.a;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -190,7 +190,7 @@ __stack.locals.n = 600851475143;
 __stack.locals.d = 2;
       });
       await runner.whileLoop(3, async () => __stack.locals.d * __stack.locals.d <= __stack.locals.n, async (runner) => {
-await runner.whileLoop(0, async () => __stack.locals.n % __stack.locals.d === 0, async (runner) => {
+await runner.whileLoop(0, async () => __eq(__stack.locals.n % __stack.locals.d, 0), async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.n = __stack.locals.n / __stack.locals.d;
           });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -228,7 +228,7 @@ __stack.locals.right = __stack.locals.s.length - 1;
 await runner.ifElse(0, [
 
   {
-    condition: async () => __stack.locals.s[__stack.locals.left] !== __stack.locals.s[__stack.locals.right],
+    condition: async () => !__eq(__stack.locals.s[__stack.locals.left], __stack.locals.s[__stack.locals.right]),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -227,7 +227,7 @@ __stack.locals.x = __stack.args.a;
       await runner.step(2, async (runner) => {
 __stack.locals.y = __stack.args.b;
       });
-      await runner.whileLoop(3, async () => __stack.locals.y !== 0, async (runner) => {
+      await runner.whileLoop(3, async () => !__eq(__stack.locals.y, 0), async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.temp = __stack.locals.y;
         });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -246,7 +246,7 @@ return;
       await runner.ifElse(3, [
 
   {
-    condition: async () => __stack.args.n % 2 === 0 || __stack.args.n % 3 === 0,
+    condition: async () => __eq(__stack.args.n % 2, 0) || __eq(__stack.args.n % 3, 0),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -264,7 +264,7 @@ __stack.locals.i = 5;
 await runner.ifElse(0, [
 
   {
-    condition: async () => __stack.args.n % __stack.locals.i === 0 || __stack.args.n % (__stack.locals.i + 2) === 0,
+    condition: async () => __eq(__stack.args.n % __stack.locals.i, 0) || __eq(__stack.args.n % (__stack.locals.i + 2), 0),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -219,7 +219,7 @@ await callHook({
       await runner.ifElse(1, [
 
   {
-    condition: async () => __stack.args.c === `1`,
+    condition: async () => __eq(__stack.args.c, `1`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -233,7 +233,7 @@ return;
       await runner.ifElse(2, [
 
   {
-    condition: async () => __stack.args.c === `2`,
+    condition: async () => __eq(__stack.args.c, `2`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -247,7 +247,7 @@ return;
       await runner.ifElse(3, [
 
   {
-    condition: async () => __stack.args.c === `3`,
+    condition: async () => __eq(__stack.args.c, `3`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -261,7 +261,7 @@ return;
       await runner.ifElse(4, [
 
   {
-    condition: async () => __stack.args.c === `4`,
+    condition: async () => __eq(__stack.args.c, `4`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -275,7 +275,7 @@ return;
       await runner.ifElse(5, [
 
   {
-    condition: async () => __stack.args.c === `5`,
+    condition: async () => __eq(__stack.args.c, `5`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -289,7 +289,7 @@ return;
       await runner.ifElse(6, [
 
   {
-    condition: async () => __stack.args.c === `6`,
+    condition: async () => __eq(__stack.args.c, `6`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -303,7 +303,7 @@ return;
       await runner.ifElse(7, [
 
   {
-    condition: async () => __stack.args.c === `7`,
+    condition: async () => __eq(__stack.args.c, `7`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -317,7 +317,7 @@ return;
       await runner.ifElse(8, [
 
   {
-    condition: async () => __stack.args.c === `8`,
+    condition: async () => __eq(__stack.args.c, `8`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -331,7 +331,7 @@ return;
       await runner.ifElse(9, [
 
   {
-    condition: async () => __stack.args.c === `9`,
+    condition: async () => __eq(__stack.args.c, `9`),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -197,7 +197,7 @@ __stack.locals.c = 1000 - __stack.locals.a - __stack.locals.b;
 await runner.ifElse(1, [
 
   {
-    condition: async () => __stack.locals.a * __stack.locals.a + __stack.locals.b * __stack.locals.b === __stack.locals.c * __stack.locals.c,
+    condition: async () => __eq(__stack.locals.a * __stack.locals.a + __stack.locals.b * __stack.locals.b, __stack.locals.c * __stack.locals.c),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 runner.halt({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -246,7 +246,7 @@ return;
       await runner.ifElse(3, [
 
   {
-    condition: async () => __stack.args.n % 2 === 0 || __stack.args.n % 3 === 0,
+    condition: async () => __eq(__stack.args.n % 2, 0) || __eq(__stack.args.n % 3, 0),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -264,7 +264,7 @@ __stack.locals.i = 5;
 await runner.ifElse(0, [
 
   {
-    condition: async () => __stack.args.n % __stack.locals.i === 0 || __stack.args.n % (__stack.locals.i + 2) === 0,
+    condition: async () => __eq(__stack.args.n % __stack.locals.i, 0) || __eq(__stack.args.n % (__stack.locals.i + 2), 0),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -340,7 +340,7 @@ __stack.locals.result = `no`;
       await runner.ifElse(20, [
 
   {
-    condition: async () => __stack.locals.a === 1,
+    condition: async () => __eq(__stack.locals.a, 1),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `one`;
@@ -349,7 +349,7 @@ __stack.locals.result = `one`;
   },
 
   {
-    condition: async () => __stack.locals.a === 2,
+    condition: async () => __eq(__stack.locals.a, 2),
     body: async (runner) => {
 await runner.step(1, async (runner) => {
 __stack.locals.result = `two`;

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -37,7 +37,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -163,7 +163,7 @@ async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET) {
+async function __greet_impl(name: string, greeting: string | null | typeof __UNSET = __UNSET) {
   const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
@@ -316,7 +316,7 @@ const greet = __AgencyFunction.create({
   toolDefinition: {
     name: "greet",
     description: "No description provided.",
-    schema: z.object({"name": z.string(), "greeting": z.string().nullable().describe("Default: null"), })
+    schema: z.object({"name": z.string(), "greeting": z.union([z.string(), z.null()]).describe("Default: null"), })
   },
   safe: false,
   exported: false

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -514,7 +514,7 @@ await callHook({
       await runner.ifElse(1, [
 
   {
-    condition: async () => __stack.args.b === 0,
+    condition: async () => __eq(__stack.args.b, 0),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -23,7 +23,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -23,7 +23,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -344,7 +344,7 @@ __stack.locals.x = 1;
       await runner.ifElse(2, [
 
   {
-    condition: async () => __stack.locals.x === 1,
+    condition: async () => __eq(__stack.locals.x, 1),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.y = 2;

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,


### PR DESCRIPTION
## Nullish Unification (Project 1)

Makes Agency have **one nothing-value: `null`.** `undefined` stays unwritable as a value and is *absorbed* into `null` wherever it arises from the JS runtime or TypeScript interop. The type-level representation of optionality flips from `T | undefined` to `T | null`, so the type system finally matches the `null` the codegen already emits.

Design rationale (cross-language survey, alternatives, why not a `Maybe` type): `packages/agency-lang/docs/dev/null-and-undefined.md`. Spec: `docs/superpowers/specs/2026-06-28-nullish-unification-design.md`. Plan: `docs/superpowers/plans/2026-06-28-nullish-unification.md`.

### What changed

- **Runtime `__eq` helper** — `a === b || (a == null && b == null)`. `null` and `undefined` compare equal; identical to `===` for non-nullish values.
- **Equality codegen** — `==`, `===`, `!=`, `!==` all lower to `__eq`. No strict escape hatch; `===`/`!==` are stylistic aliases. This is what lets a single `== null` check catch a runtime `undefined` from interop or a missing key.
- **Parser** — `key?: T` desugars to `T | null`; the `undefined` type keyword is accepted (e.g. from imported TS types) but normalized to `null` at parse time; optional params `x?: T` widen to `T | null`.
- **Type checker** — `UNDEFINED_T` retired for `NULL_T`; `isOptionalType`, built-in member return types, and the `optional` helper all key on `null`.
- **Formatter** — renders `T | null` properties with the canonical `key?: T` shorthand (round-trips, and cleans up generated stdlib docs).
- **Schema feature** — `schema(T).parse({})` now coalesces a missing optional key to `null` (recursively), so `schema({ foo?: string }).parse({})` → `{ foo: null }`. The LLM structured-output path is unchanged (keys stay required + nullable per OpenAI strict mode), via a threaded `optionalKeyMode`.

### Out of scope (deferred to Project 2 / the narrowing roadmap)

Strict null checking (`strictMemberAccess` on the null member), null narrowing (retarget `null-truthiness-narrowing-spec` to `null`), equality-operand type-checking, the `null`-literal-synthesizes-to-`null` change, `delete`, and a nominal `Option`/`Maybe` type. See the spec's Non-goals.

### Follow-up

- The untracked `null-truthiness-narrowing-spec.md` working file should be retargeted from `undefined` to `null` before it is implemented (the requirement is recorded in spec §5/§6). It isn't a tracked repo file, so it's not part of this PR.

### Testing

New tests: `__eq` truth table; `tests/agency/nullish-eq` (a `== null`/`=== null` check catches an absent/undefined key); `tests/agency/validation/optionalKey{Coalesce,Nested,Recursive}` (parse coalescing). Updated parser/formatter/tool-schema unit tests.

Verified locally (CI runs the full suite): `lib/parsers` (1480), `lib/typeChecker` (721), `lib/backends` (300), `lib/runtime/eq`, the codegen integration fixtures (30), `tsc --noEmit`, and the structural linter — all green; the named Agency execution tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
