### PR TITLE
feat(typechecker): flow-graph machinery (flow.ts) — flow-checker PR 1a

### DIFF
--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -4,6 +4,8 @@ import {
   uniteTypes,
   typeAt,
   applyRefine,
+  wrapFacts,
+  mergeFlows,
   type FlowNode,
   type FlowEnvironment,
 } from "./flow.js";
@@ -167,5 +169,54 @@ describe("typeAt", () => {
     const e = env(scope);
     expect(typeAt(ref("x"), start, e)).toEqual(STR);
     expect(typeAt(ref("x"), start, e)).toEqual(STR);
+  });
+});
+
+describe("wrapFacts", () => {
+  it("returns the flow unchanged for no candidates", () => {
+    const start: FlowNode = { kind: "start", scope: new Scope("t") };
+    expect(wrapFacts(start, [])).toBe(start);
+  });
+
+  it("wraps one narrow node per candidate and narrows through it", () => {
+    const scope = new Scope("t");
+    scope.declare("u", ab);
+    const start: FlowNode = { kind: "start", scope };
+    const wrapped = wrapFacts(start, [
+      {
+        variableName: "u",
+        refine: {
+          kind: "discriminant",
+          prop: "kind",
+          literal: { type: "stringLiteralType", value: "a" },
+          keep: true,
+        },
+      },
+    ]);
+    expect(wrapped.kind).toBe("narrow");
+    expect(typeAt(ref("u"), wrapped, env(scope))).toEqual(memberA);
+  });
+});
+
+describe("mergeFlows", () => {
+  it("drops exit predecessors and returns the lone live flow", () => {
+    const start: FlowNode = { kind: "start", scope: new Scope("t") };
+    const exit: FlowNode = { kind: "exit" };
+    expect(mergeFlows([exit, start])).toBe(start);
+  });
+
+  it("all-exit merges to exit (dead code after)", () => {
+    expect(mergeFlows([{ kind: "exit" }, { kind: "exit" }])).toEqual({ kind: "exit" });
+  });
+
+  it("two live flows merge to a join", () => {
+    // Real merges share a scope (both branches of one `if`). Use the same
+    // Scope here to avoid suggesting cross-scope merges are valid.
+    const scope = new Scope("t");
+    const a: FlowNode = { kind: "start", scope };
+    const b: FlowNode = { kind: "assign", prev: a, ref: ref("x"), type: STR };
+    const merged = mergeFlows([a, b]);
+    expect(merged.kind).toBe("join");
+    if (merged.kind === "join") expect(merged.prev).toEqual([a, b]);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -170,6 +170,29 @@ describe("typeAt", () => {
     expect(typeAt(ref("x"), start, e)).toEqual(STR);
     expect(typeAt(ref("x"), start, e)).toEqual(STR);
   });
+
+  it("memo does not false-hit on a reserved-word ref (toString)", () => {
+    // After caching one ref on a node, a query for a ref named "toString" must
+    // not read Object.prototype.toString from a plain-object cache.
+    const scope = new Scope("t");
+    scope.declare("x", NUM);
+    scope.declare("toString", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const e = env(scope);
+    typeAt(ref("x"), start, e); // populate the memo for `start`
+    expect(typeAt(ref("toString"), start, e)).toEqual(STR);
+  });
+
+  it("loop widened lookup does not false-hit on a reserved-word ref", () => {
+    // `widened` maps only "x"; a query for "toString" must fall through to the
+    // predecessor, not read Object.prototype.toString.
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    scope.declare("toString", NUM);
+    const start: FlowNode = { kind: "start", scope };
+    const loop: FlowNode = { kind: "loop", prev: start, widened: { x: STR } };
+    expect(typeAt(ref("toString"), loop, env(scope))).toEqual(NUM);
+  });
 });
 
 describe("wrapFacts", () => {

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { referenceKey, uniteTypes } from "./flow.js";
+import { NEVER_T } from "./primitives.js";
+import type { VariableType } from "../types.js";
+
+const STR: VariableType = { type: "primitiveType", value: "string" };
+const NUM: VariableType = { type: "primitiveType", value: "number" };
+
+describe("referenceKey", () => {
+  it("is the bare variable for an empty chain", () => {
+    expect(referenceKey({ variable: "x", chain: [] })).toBe("x");
+  });
+  it("dotted-joins a non-empty chain", () => {
+    expect(referenceKey({ variable: "u", chain: ["profile", "email"] })).toBe("u.profile.email");
+  });
+});
+
+describe("uniteTypes", () => {
+  it("any dominates", () => {
+    expect(uniteTypes(["any", STR], {})).toBe("any");
+  });
+  it("drops never members (identity element)", () => {
+    expect(uniteTypes([NEVER_T, STR], {})).toEqual(STR);
+  });
+  it("an all-never (or empty) union is never", () => {
+    expect(uniteTypes([NEVER_T, NEVER_T], {})).toEqual(NEVER_T);
+    expect(uniteTypes([], {})).toEqual(NEVER_T);
+  });
+  it("dedupes structurally and unwraps a single member", () => {
+    expect(uniteTypes([STR, STR], {})).toEqual(STR);
+  });
+  it("builds a union of distinct members", () => {
+    expect(uniteTypes([STR, NUM], {})).toEqual({ type: "unionType", types: [STR, NUM] });
+  });
+  it("preserves literal members (does not widen to primitives)", () => {
+    const litA: VariableType = { type: "stringLiteralType", value: "a" };
+    const litB: VariableType = { type: "stringLiteralType", value: "b" };
+    expect(uniteTypes([litA, litB], {})).toEqual({
+      type: "unionType",
+      types: [litA, litB],
+    });
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { referenceKey, uniteTypes } from "./flow.js";
+import {
+  referenceKey,
+  uniteTypes,
+  typeAt,
+  applyRefine,
+  type FlowNode,
+  type FlowEnvironment,
+} from "./flow.js";
+import { Scope } from "./scope.js";
 import { NEVER_T } from "./primitives.js";
 import type { VariableType } from "../types.js";
 
@@ -39,5 +47,125 @@ describe("uniteTypes", () => {
       type: "unionType",
       types: [litA, litB],
     });
+  });
+});
+
+function env(scope: Scope): FlowEnvironment {
+  return { scope, flowOf: new WeakMap(), typeAliases: {}, memo: new WeakMap() };
+}
+const ref = (variable: string) => ({ variable, chain: [] as string[] });
+
+// A discriminated union: { kind: "a", v: string } | { kind: "b", v: number }
+const memberA: VariableType = {
+  type: "objectType",
+  properties: [
+    { key: "kind", value: { type: "stringLiteralType", value: "a" } },
+    { key: "v", value: STR },
+  ],
+};
+const memberB: VariableType = {
+  type: "objectType",
+  properties: [
+    { key: "kind", value: { type: "stringLiteralType", value: "b" } },
+    { key: "v", value: NUM },
+  ],
+};
+const ab: VariableType = { type: "unionType", types: [memberA, memberB] };
+
+describe("applyRefine", () => {
+  it("filters a union by a literal discriminant", () => {
+    const refine = {
+      kind: "discriminant" as const,
+      prop: "kind",
+      literal: { type: "stringLiteralType" as const, value: "a" },
+      keep: true,
+    };
+    expect(applyRefine(ab, refine, {})).toEqual(memberA);
+  });
+});
+
+describe("typeAt", () => {
+  it("start: returns the scope type, or any for an unknown variable", () => {
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    expect(typeAt(ref("x"), start, env(scope))).toEqual(STR);
+    expect(typeAt(ref("y"), start, env(scope))).toBe("any");
+  });
+
+  it("assign: overrides the matching reference only", () => {
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const assign: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    expect(typeAt(ref("x"), assign, env(scope))).toEqual(NUM);
+  });
+
+  it("narrow: applies the refinement to the matching reference", () => {
+    const scope = new Scope("t");
+    scope.declare("u", ab);
+    const start: FlowNode = { kind: "start", scope };
+    const narrow: FlowNode = {
+      kind: "narrow",
+      prev: start,
+      ref: ref("u"),
+      refine: {
+        kind: "discriminant",
+        prop: "kind",
+        literal: { type: "stringLiteralType", value: "a" },
+        keep: true,
+      },
+    };
+    expect(typeAt(ref("u"), narrow, env(scope))).toEqual(memberA);
+  });
+
+  it("narrow: any base is not narrowed", () => {
+    const scope = new Scope("t"); // u undefined -> any
+    const start: FlowNode = { kind: "start", scope };
+    const narrow: FlowNode = {
+      kind: "narrow",
+      prev: start,
+      ref: ref("u"),
+      refine: {
+        kind: "discriminant",
+        prop: "kind",
+        literal: { type: "stringLiteralType", value: "a" },
+        keep: true,
+      },
+    };
+    expect(typeAt(ref("u"), narrow, env(scope))).toBe("any");
+  });
+
+  it("join: unites the predecessors", () => {
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const b: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a, b] };
+    expect(typeAt(ref("x"), join, env(scope))).toEqual({ type: "unionType", types: [STR, NUM] });
+  });
+
+  it("loop: a widened entry overrides, others fall through", () => {
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const loop: FlowNode = { kind: "loop", prev: start, widened: { x: NUM } };
+    expect(typeAt(ref("x"), loop, env(scope))).toEqual(NUM);
+  });
+
+  it("exit: throws (unreachable)", () => {
+    const scope = new Scope("t");
+    const exit: FlowNode = { kind: "exit" };
+    expect(() => typeAt(ref("x"), exit, env(scope))).toThrow();
+  });
+
+  it("memoizes: repeated queries return the same result", () => {
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const e = env(scope);
+    expect(typeAt(ref("x"), start, e)).toEqual(STR);
+    expect(typeAt(ref("x"), start, e)).toEqual(STR);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -1,0 +1,83 @@
+import type { AgencyNode, TypeAliasEntry, VariableType } from "../types.js";
+import type { Refine } from "./narrowing.js";
+import { Scope, type ScopeType } from "./scope.js";
+import { NEVER_T } from "./primitives.js";
+import { isNever } from "./assignability.js";
+
+// NOTE: `narrowUnionByDiscriminant` and `NarrowCandidate` are added in Task 2
+// and Task 3 respectively, alongside the code that uses them. Keeping each
+// commit's imports tight to its surface area.
+
+/**
+ * A normalized reference path — the bound thing being narrowed. Today the
+ * builder only emits empty chains (bare variables); the `chain` is reserved so
+ * property-path narrowing (`if (user.profile != null) { user.profile.email }`)
+ * can be added without revisiting `FlowNode` or `typeAt`'s signature.
+ */
+export type Reference = { variable: string; chain: string[] };
+
+/** Stable string key for a reference (map keys, equality). */
+export function referenceKey(ref: Reference): string {
+  return ref.chain.length === 0 ? ref.variable : `${ref.variable}.${ref.chain.join(".")}`;
+}
+
+/**
+ * A program point. Type checking builds and discards this graph per check; it
+ * NEVER appears in AST output, so it cannot affect lowering, codegen, or
+ * interrupt handling. (See the flow-typed checker spec, "Interrupt safety".)
+ */
+export type FlowNode =
+  | { kind: "start"; scope: Scope }
+  | { kind: "assign"; prev: FlowNode; ref: Reference; type: ScopeType }
+  | { kind: "narrow"; prev: FlowNode; ref: Reference; refine: Refine }
+  | { kind: "join"; prev: FlowNode[] }
+  | { kind: "loop"; prev: FlowNode; widened: Record<string, ScopeType> }
+  | { kind: "exit" };
+
+export type FlowEnvironment = {
+  scope: Scope;
+  flowOf: WeakMap<AgencyNode, FlowNode>;
+  typeAliases: Record<string, TypeAliasEntry>;
+  /**
+   * Per-flow-node, per-reference-key memo for typeAt. WeakMap because keys are
+   * FlowNode identities; without it, nested joins/loops re-walk super-linearly.
+   *
+   * SOUNDNESS CONTRACT: a `FlowEnvironment` is valid only for a single
+   * type-check pass. The cache is keyed by FlowNode identity, but `start` nodes
+   * read `scope.lookup(...)` — if the underlying `Scope` mutates (a new
+   * declaration is added, a type is rebound) after a `start`-rooted query has
+   * been memoized, the cache will return stale results. Discard the env (or
+   * call `env.memo = new WeakMap()`) at any point where the scope contents
+   * could have changed.
+   */
+  memo: WeakMap<FlowNode, Record<string, ScopeType>>;
+};
+
+/**
+ * Union construction for flow joins. `any` dominates (a branch we can't type
+ * makes the join untyped); `never` is the identity element (drops out); members
+ * are deduped structurally; a single survivor unwraps; an empty union is
+ * `never`. Literal members are preserved (not widened to primitives) so a
+ * discriminant union survives a join with full precision.
+ *
+ * KNOWN LIMITATION (PR 1a): dedup is by `JSON.stringify` structural equality
+ * and does NOT resolve type aliases. Two members that resolve to the same
+ * underlying type via different aliases will both survive. PR 2 will hit this
+ * the moment alias-typed locals flow through a join — fix then by resolving
+ * with `_aliases` before keying.
+ */
+export function uniteTypes(
+  types: ScopeType[],
+  _aliases: Record<string, TypeAliasEntry>,
+): ScopeType {
+  if (types.some((t) => t === "any")) return "any";
+  const concrete = (types as VariableType[]).filter((t) => !isNever(t));
+  if (concrete.length === 0) return NEVER_T;
+  const seen: Record<string, VariableType> = {};
+  for (const t of concrete) {
+    const key = JSON.stringify(t);
+    if (!(key in seen)) seen[key] = t;
+  }
+  const uniques = Object.values(seen);
+  return uniques.length === 1 ? uniques[0] : { type: "unionType", types: uniques };
+}

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -1,5 +1,5 @@
 import type { AgencyNode, TypeAliasEntry, VariableType } from "../types.js";
-import type { Refine } from "./narrowing.js";
+import type { Refine, NarrowCandidate } from "./narrowing.js";
 import { narrowUnionByDiscriminant } from "./narrowing.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { NEVER_T } from "./primitives.js";
@@ -137,4 +137,34 @@ function computeTypeAt(
     case "exit":
       throw new Error("typeAt called on an unreachable (exit) flow node");
   }
+}
+
+/**
+ * Wrap `flow` in a `narrow` node for each candidate (innermost = first). With no
+ * candidates the flow is returned unchanged. Used by the builder (PR 1b) to turn
+ * a branch's ConditionFacts into flow nodes.
+ */
+export function wrapFacts(flow: FlowNode, candidates: NarrowCandidate[]): FlowNode {
+  return candidates.reduce<FlowNode>(
+    (prev, c) => ({
+      kind: "narrow",
+      prev,
+      ref: { variable: c.variableName, chain: [] },
+      refine: c.refine,
+    }),
+    flow,
+  );
+}
+
+/**
+ * Merge control-flow branch ends. `exit` predecessors (e.g. a branch that
+ * `return`ed) are dropped: reaching the code after a merge means a live branch
+ * got here. No live branches → `exit` (the after-code is unreachable). One →
+ * itself. Two or more → a `join`.
+ */
+export function mergeFlows(flows: FlowNode[]): FlowNode {
+  const live = flows.filter((f) => f.kind !== "exit");
+  if (live.length === 0) return { kind: "exit" };
+  if (live.length === 1) return live[0];
+  return { kind: "join", prev: live };
 }

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -1,5 +1,6 @@
 import type { AgencyNode, TypeAliasEntry, VariableType } from "../types.js";
 import type { Refine } from "./narrowing.js";
+import { narrowUnionByDiscriminant } from "./narrowing.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { NEVER_T } from "./primitives.js";
 import { isNever } from "./assignability.js";
@@ -80,4 +81,60 @@ export function uniteTypes(
   }
   const uniques = Object.values(seen);
   return uniques.length === 1 ? uniques[0] : { type: "unionType", types: uniques };
+}
+
+/**
+ * Refine a (non-any) type by a single discriminant. Returns the narrowed type,
+ * or null for "no narrowing" — `narrowUnionByDiscriminant` already views Result
+ * as a union (resultUnion.ts) and is sound/conservative.
+ */
+export function applyRefine(
+  base: VariableType,
+  refine: Refine,
+  aliases: Record<string, TypeAliasEntry>,
+): VariableType | null {
+  return narrowUnionByDiscriminant(base, refine.prop, refine.literal, refine.keep, aliases);
+}
+
+/**
+ * The type of `ref` at flow node `at`. The single oracle every pass consults.
+ * Memoized per (flow node, reference key).
+ */
+export function typeAt(ref: Reference, at: FlowNode, env: FlowEnvironment): ScopeType {
+  const key = referenceKey(ref);
+  const perNode = env.memo.get(at);
+  const cached = perNode?.[key];
+  if (cached !== undefined) return cached;
+  const result = computeTypeAt(ref, key, at, env);
+  if (perNode) perNode[key] = result;
+  else env.memo.set(at, { [key]: result });
+  return result;
+}
+
+function computeTypeAt(
+  ref: Reference,
+  key: string,
+  at: FlowNode,
+  env: FlowEnvironment,
+): ScopeType {
+  switch (at.kind) {
+    case "start":
+      // Non-empty chains (property-path narrowing) are a follow-on; today every
+      // reference has an empty chain, so this is a bare scope lookup.
+      return at.scope.lookup(ref.variable) ?? "any";
+    case "assign":
+      return referenceKey(at.ref) === key ? at.type : typeAt(ref, at.prev, env);
+    case "narrow": {
+      if (referenceKey(at.ref) !== key) return typeAt(ref, at.prev, env);
+      const base = typeAt(ref, at.prev, env);
+      if (base === "any") return "any";
+      return applyRefine(base, at.refine, env.typeAliases) ?? base;
+    }
+    case "join":
+      return uniteTypes(at.prev.map((p) => typeAt(ref, p, env)), env.typeAliases);
+    case "loop":
+      return at.widened[key] ?? typeAt(ref, at.prev, env);
+    case "exit":
+      throw new Error("typeAt called on an unreachable (exit) flow node");
+  }
 }

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -102,12 +102,18 @@ export function applyRefine(
  */
 export function typeAt(ref: Reference, at: FlowNode, env: FlowEnvironment): ScopeType {
   const key = referenceKey(ref);
-  const perNode = env.memo.get(at);
-  const cached = perNode?.[key];
+  let perNode = env.memo.get(at);
+  if (perNode === undefined) {
+    // Null-prototype dict: keys are source identifiers (variable names), so a
+    // ref named "__proto__" / "toString" / "constructor" must not collide with
+    // Object.prototype on read. Mirrors scope.ts's own-property discipline.
+    perNode = Object.create(null) as Record<string, ScopeType>;
+    env.memo.set(at, perNode);
+  }
+  const cached = perNode[key];
   if (cached !== undefined) return cached;
   const result = computeTypeAt(ref, key, at, env);
-  if (perNode) perNode[key] = result;
-  else env.memo.set(at, { [key]: result });
+  perNode[key] = result;
   return result;
 }
 
@@ -133,7 +139,11 @@ function computeTypeAt(
     case "join":
       return uniteTypes(at.prev.map((p) => typeAt(ref, p, env)), env.typeAliases);
     case "loop":
-      return at.widened[key] ?? typeAt(ref, at.prev, env);
+      // Own-property check: `at.widened` may be a plain object, so a ref named
+      // "__proto__" / "toString" must not read from Object.prototype.
+      return Object.prototype.hasOwnProperty.call(at.widened, key)
+        ? at.widened[key]
+        : typeAt(ref, at.prev, env);
     case "exit":
       throw new Error("typeAt called on an unreachable (exit) flow node");
   }


### PR DESCRIPTION
## Summary

Builds the **pure flow-graph machinery** (`lib/typeChecker/flow.ts`) — the foundation for flow-typed narrowing. This is **PR 1, Part A** of the flow-typed checker: the data model and the `typeAt(reference, flowNode)` resolution oracle, with **no production wiring**. Nothing imports `flow.ts` except its own test, so the change is additive and behavior-preserving.

The AST flow-builder (interleaving construction into `walkScopeBody`, per-node flow attachments, invariant assertions, `widenAtLoopBackEdge`) is **Part B** — the next PR. It's split out because the builder touches the hot path and carries the test-triage risk, whereas this machinery is pure and fully unit-testable in isolation.

## What is included

- `Reference` / `referenceKey` — narrowing is keyed on a reference *path* (`{ variable, chain }`), not a bare name; `chain` is reserved for property-path narrowing (`if (user.profile != null)`) without a future data-model migration.
- `FlowNode` — `start` / `assign` / `narrow` / `join` / `loop` / `exit`.
- `FlowEnvironment` — declaration scope + `flowOf` (AST node → flow point) + a `typeAt` memo. The memo carries an explicit single-pass soundness contract in a code comment.
- `typeAt(ref, at, env)` — the single oracle, memoized per `(flow node, reference key)`.
- `applyRefine` — a one-line wrapper over `narrowUnionByDiscriminant` (which already handles `Result` via `resultToObjectUnion`).
- `uniteTypes` — join construction: `any` dominates, `never` is the identity element (drops out; empty union → `never`), structural dedup, single-member unwrap, literal members preserved.
- `wrapFacts` / `mergeFlows` — turn `ConditionFacts` into `narrow` nodes; merge branch ends (dropping `exit` predecessors).

## Reconciliation with the spec

The design spec predates R1 and PR 0, so the machinery is **simpler** than the spec text describes, and this PR reflects current `main`:

- `Refine` is a single `discriminant` variant (R1 retired `resultBranch`), so `applyRefine` is a wrapper, not a dispatch table.
- `never` / `isNever` (PR 0) exist, so `uniteTypes` uses `never` as its identity today.
- Per CLAUDE.md "objects over Maps", string-keyed maps are `Record<string, T>`; `WeakMap` is used only where keys are object identities (`flowOf`, `memo`).

## Testing

- `lib/typeChecker/flow.test.ts` — **22 tests** over hand-built flow graphs: `referenceKey`, `uniteTypes` (any/never/dedup/literal-preservation), `applyRefine`, `typeAt` across every node kind (start/assign/narrow/join/loop/exit + memoization), `wrapFacts`, `mergeFlows`.
- `npx tsc --noEmit` — clean.
- `pnpm test:run` (full lib suite, built via `make`) — **6496 passed, 0 failed**. Additive: `flow.ts` is imported only by its test.

## Out of scope (next PRs)

- **PR 1b:** the AST flow-builder + `walkScopeBody` interleaving + invariant assertions + `widenAtLoopBackEdge` (needs the builder's reassigned-vs-narrowed signal).
- **PR 2:** route `synthValueAccess` through `typeAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
