### PR TITLE
feat(typechecker): declarative flow-graph builder (flowBuilder.ts) — flow-checker PR 1b

### DIFF
--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -6,6 +6,7 @@ import {
   applyRefine,
   wrapFacts,
   mergeFlows,
+  widenAtLoopBackEdge,
   type FlowNode,
   type FlowEnvironment,
 } from "./flow.js";
@@ -241,5 +242,25 @@ describe("mergeFlows", () => {
     const merged = mergeFlows([a, b]);
     expect(merged.kind).toBe("join");
     if (merged.kind === "join") expect(merged.prev).toEqual([a, b]);
+  });
+});
+
+describe("widenAtLoopBackEdge", () => {
+  it("widens a var reassigned in the body to the union of before and after", () => {
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    const loopEntry: FlowNode = { kind: "start", scope };
+    const bodyEnd: FlowNode = { kind: "assign", prev: loopEntry, ref: ref("x"), type: NUM };
+    const widened = widenAtLoopBackEdge(loopEntry, bodyEnd, ["x"], env(scope));
+    expect(widened.kind).toBe("loop");
+    expect(typeAt(ref("x"), widened, env(scope))).toEqual({ type: "unionType", types: [STR, NUM] });
+  });
+
+  it("passes an unchanged var through as its pre-loop type", () => {
+    const scope = new Scope("t");
+    scope.declare("x", STR);
+    const loopEntry: FlowNode = { kind: "start", scope };
+    const widened = widenAtLoopBackEdge(loopEntry, loopEntry, ["x"], env(scope));
+    expect(typeAt(ref("x"), widened, env(scope))).toEqual(STR);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -178,3 +178,38 @@ export function mergeFlows(flows: FlowNode[]): FlowNode {
   if (live.length === 1) return live[0];
   return { kind: "join", prev: live };
 }
+
+/**
+ * Widen at a loop back-edge. For each name, compute its pre-loop and body-end
+ * type; if they differ (the body reassigned it) widen to their union, else pass
+ * the pre-loop type through. Sound: never under-widens a variable the body
+ * changed. Can over-widen when a narrowing actually holds across iterations —
+ * acceptable, documented (no fixpoint).
+ *
+ * The unchanged-check uses `JSON.stringify` equality (same as `uniteTypes`) and
+ * does NOT resolve type aliases — two structurally-different-but-equivalent
+ * aliased types read as "changed" and pessimistically widen. Same caveat as
+ * `uniteTypes`; revisit alongside it.
+ */
+export function widenAtLoopBackEdge(
+  loopEntry: FlowNode,
+  bodyEnd: FlowNode,
+  names: string[],
+  env: FlowEnvironment,
+): FlowNode {
+  // Null-prototype dict: keys are variable names, so a name like "__proto__"
+  // must not invoke the prototype setter on write (matches the read-side guard
+  // in typeAt's `loop` case and scope.ts's own-property discipline).
+  const widened: Record<string, ScopeType> = Object.create(null);
+  for (const name of names) {
+    const r: Reference = { variable: name, chain: [] };
+    const before = typeAt(r, loopEntry, env);
+    const after = bodyEnd.kind === "exit" ? before : typeAt(r, bodyEnd, env);
+    if (JSON.stringify(before) === JSON.stringify(after)) {
+      widened[referenceKey(r)] = before;
+    } else {
+      widened[referenceKey(r)] = uniteTypes([before, after], env.typeAliases);
+    }
+  }
+  return { kind: "loop", prev: loopEntry, widened };
+}

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -99,6 +99,25 @@ describe("buildFlowGraph — linear", () => {
       }
     }
   });
+
+  it("INVARIANT holds across slice / computed-key / index positions", () => {
+    // `lo`/`hi` live inside a slice; `key` inside a computed key — both were
+    // missed before expressionChildren covered slice + computedKey.
+    const body = parseBody(
+      `let arr = [10, 20, 30]\nlet lo = 0\nlet hi = 2\nlet part = arr[lo:hi]\nlet key = "k"\nlet obj = { [key]: part }\nprint(obj[key])`,
+    );
+    const scope = new Scope("t");
+    for (const name of ["arr", "lo", "hi", "part", "key", "obj"]) {
+      scope.declare(name, NUM);
+    }
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    for (const { node } of walkNodes(body)) {
+      if (node.type === "variableName" || node.type === "valueAccess") {
+        expect(env.flowOf.get(node), `flowOf missing for ${node.type}`).toBeDefined();
+      }
+    }
+  });
 });
 
 describe("buildFlowGraph — ifElse", () => {

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parseAgency } from "../parser.js";
 import { Scope } from "./scope.js";
-import { typeAt, type FlowEnvironment } from "./flow.js";
+import { typeAt, type FlowEnvironment, type FlowNode } from "./flow.js";
 import { buildFlowGraph } from "./flowBuilder.js";
 import { walkNodes } from "../utils/node.js";
 import type { AgencyNode, VariableType } from "../types.js";
@@ -41,6 +41,20 @@ function find(body: AgencyNode[], pred: (n: AgencyNode) => boolean): AgencyNode 
     }
   }
   throw new Error("node not found");
+}
+
+/** True if a `loop` node is reachable from `f` via the prev-chain. */
+function reachesLoop(f: FlowNode): boolean {
+  if (f.kind === "loop") {
+    return true;
+  }
+  if (f.kind === "join") {
+    return f.prev.some(reachesLoop);
+  }
+  if (f.kind === "start" || f.kind === "exit") {
+    return false;
+  }
+  return reachesLoop(f.prev);
 }
 
 describe("buildFlowGraph — linear", () => {
@@ -124,5 +138,18 @@ describe("buildFlowGraph — ifElse", () => {
     const tailPrint = find(body, (n) => n.type === "functionCall" && n.functionName === "print");
     const rRef = find([tailPrint], (n) => n.type === "variableName" && n.value === "r");
     expect(typeAt(ref("r"), env.flowOf.get(rRef)!, env)).toEqual(memberA);
+  });
+});
+
+describe("buildFlowGraph — loops", () => {
+  it("a while loop builds a loop node on the back-edge", () => {
+    // Red under Task 1/2 (linear recursion → no loop node); green after Step 7.
+    const body = parseBody(`while (cond) {\n  x = 1\n}\nprint(x)`);
+    const scope = new Scope("t");
+    scope.declare("cond", { type: "primitiveType", value: "boolean" });
+    scope.declare("x", NUM);
+    const env = freshEnv(scope);
+    const end = buildFlowGraph(body, { kind: "start", scope }, env);
+    expect(reachesLoop(end)).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -153,3 +153,36 @@ describe("buildFlowGraph — loops", () => {
     expect(reachesLoop(end)).toBe(true);
   });
 });
+
+describe("attachExpressionsToFlow — short-circuit", () => {
+  const memberA: VariableType = {
+    type: "objectType",
+    properties: [
+      { key: "kind", value: { type: "stringLiteralType", value: "a" } },
+      { key: "v", value: STR },
+    ],
+  };
+  const memberB: VariableType = {
+    type: "objectType",
+    properties: [
+      { key: "kind", value: { type: "stringLiteralType", value: "b" } },
+      { key: "v", value: NUM },
+    ],
+  };
+  const ab: VariableType = { type: "unionType", types: [memberA, memberB] };
+
+  it("RHS of && sees the LHS's then-narrowing", () => {
+    const body = parseBody(`let z = u.kind == "a" && u.kind == "a"`);
+    const scope = new Scope("t");
+    scope.declare("u", ab);
+    scope.declare("z", { type: "primitiveType", value: "boolean" });
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    const andExpr = find(
+      body,
+      (n) => n.type === "binOpExpression" && n.operator === "&&",
+    ) as Extract<AgencyNode, { type: "binOpExpression" }>;
+    const rightU = find([andExpr.right as AgencyNode], (n) => n.type === "valueAccess");
+    expect(typeAt(ref("u"), env.flowOf.get(rightU)!, env)).toEqual(memberA);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -34,6 +34,15 @@ function freshEnv(
 
 const ref = (variable: string) => ({ variable, chain: [] as string[] });
 
+function find(body: AgencyNode[], pred: (n: AgencyNode) => boolean): AgencyNode {
+  for (const { node } of walkNodes(body)) {
+    if (pred(node)) {
+      return node;
+    }
+  }
+  throw new Error("node not found");
+}
+
 describe("buildFlowGraph — linear", () => {
   it("assign nodes carry the scope's type at the end of a straight-line body", () => {
     const body = parseBody(`let x = 5\nlet y = "hi"`);
@@ -75,5 +84,45 @@ describe("buildFlowGraph — linear", () => {
         expect(env.flowOf.get(node), `flowOf missing for ${node.type}`).toBeDefined();
       }
     }
+  });
+});
+
+describe("buildFlowGraph — ifElse", () => {
+  const memberA: VariableType = {
+    type: "objectType",
+    properties: [
+      { key: "kind", value: { type: "stringLiteralType", value: "a" } },
+      { key: "v", value: STR },
+    ],
+  };
+  const memberB: VariableType = {
+    type: "objectType",
+    properties: [
+      { key: "kind", value: { type: "stringLiteralType", value: "b" } },
+      { key: "v", value: NUM },
+    ],
+  };
+  const ab: VariableType = { type: "unionType", types: [memberA, memberB] };
+
+  it("narrows inside the then-branch at the access site", () => {
+    const body = parseBody(`if (u.kind == "a") {\n  print(u)\n}`);
+    const scope = new Scope("t");
+    scope.declare("u", ab);
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    const insidePrint = find(body, (n) => n.type === "functionCall" && n.functionName === "print");
+    const uRef = find([insidePrint], (n) => n.type === "variableName" && n.value === "u");
+    expect(typeAt(ref("u"), env.flowOf.get(uRef)!, env)).toEqual(memberA);
+  });
+
+  it("post-guard: after a returning then-branch, the tail sees the complement member", () => {
+    const body = parseBody(`if (r.kind == "b") {\n  return r\n}\nprint(r)`);
+    const scope = new Scope("t");
+    scope.declare("r", ab);
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    const tailPrint = find(body, (n) => n.type === "functionCall" && n.functionName === "print");
+    const rRef = find([tailPrint], (n) => n.type === "variableName" && n.value === "r");
+    expect(typeAt(ref("r"), env.flowOf.get(rRef)!, env)).toEqual(memberA);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { Scope } from "./scope.js";
+import { typeAt, type FlowEnvironment } from "./flow.js";
+import { buildFlowGraph } from "./flowBuilder.js";
+import { walkNodes } from "../utils/node.js";
+import type { AgencyNode, VariableType } from "../types.js";
+
+const NUM: VariableType = { type: "primitiveType", value: "number" };
+const STR: VariableType = { type: "primitiveType", value: "string" };
+
+// Wrap snippets in a function so `return` is valid and we exercise a real
+// per-scope body. Tests hand-build the Scope, so the wrapper's emptiness is fine.
+function parseBody(src: string): AgencyNode[] {
+  const r = parseAgency(`def __f() {\n${src}\n}`);
+  if (!r.success) {
+    throw new Error(`parse failed: ${r.message}`);
+  }
+  const fn = r.result.nodes.find((n) => n.type === "function");
+  if (!fn || fn.type !== "function") {
+    throw new Error("expected a function");
+  }
+  return fn.body;
+}
+
+// `typeAliases` defaults to {} for forward-compat: real `buildFlowGraphs`
+// passes `ctx.getTypeAliases()`, so alias-typed tests can too.
+function freshEnv(
+  scope: Scope,
+  typeAliases: FlowEnvironment["typeAliases"] = {},
+): FlowEnvironment {
+  return { scope, flowOf: new WeakMap(), typeAliases, memo: new WeakMap() };
+}
+
+const ref = (variable: string) => ({ variable, chain: [] as string[] });
+
+describe("buildFlowGraph — linear", () => {
+  it("assign nodes carry the scope's type at the end of a straight-line body", () => {
+    const body = parseBody(`let x = 5\nlet y = "hi"`);
+    const scope = new Scope("t");
+    scope.declare("x", NUM);
+    scope.declare("y", STR);
+    const env = freshEnv(scope);
+    const end = buildFlowGraph(body, { kind: "start", scope }, env);
+    expect(typeAt(ref("x"), end, env)).toEqual(NUM);
+    expect(typeAt(ref("y"), end, env)).toEqual(STR);
+  });
+
+  it("a return statement ends the body in an exit node", () => {
+    const body = parseBody(`return x`);
+    const scope = new Scope("t");
+    const env = freshEnv(scope);
+    const end = buildFlowGraph(body, { kind: "start", scope }, env);
+    expect(end.kind).toBe("exit");
+  });
+
+  it("stops at unreachable code after a return (no throw, even with a later loop)", () => {
+    const body = parseBody(`return x\nwhile (c) {\n  y = 1\n}`);
+    const scope = new Scope("t");
+    scope.declare("c", { type: "primitiveType", value: "boolean" });
+    scope.declare("y", NUM);
+    const env = freshEnv(scope);
+    expect(() => buildFlowGraph(body, { kind: "start", scope }, env)).not.toThrow();
+  });
+
+  it("INVARIANT: every variableName / valueAccess gets a flowOf entry", () => {
+    const body = parseBody(`let x = 5\nprint(x)\nlet z = x`);
+    const scope = new Scope("t");
+    scope.declare("x", NUM);
+    scope.declare("z", NUM);
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    for (const { node } of walkNodes(body)) {
+      if (node.type === "variableName" || node.type === "valueAccess") {
+        expect(env.flowOf.get(node), `flowOf missing for ${node.type}`).toBeDefined();
+      }
+    }
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -57,10 +57,16 @@ export function attachExpressionsToFlow(
  */
 export function assignedNames(body: AgencyNode[]): string[] {
   const names: string[] = [];
-  for (const { node } of walkNodes(body)) {
+  for (const { node, ancestors } of walkNodes(body)) {
+    // Assignments inside a nested function/graphNode rebind a variable in THAT
+    // definition's scope, not the loop's — skip them so the back-edge doesn't
+    // widen names unnecessarily.
+    const insideNestedDef = ancestors.some(
+      (a) => a.type === "function" || a.type === "graphNode",
+    );
     const isBareRebind =
       node.type === "assignment" && !node.accessChain && !node.pattern;
-    if (isBareRebind && !names.includes(node.variableName)) {
+    if (!insideNestedDef && isBareRebind && !names.includes(node.variableName)) {
       names.push(node.variableName);
     }
   }
@@ -78,7 +84,9 @@ type StatementRuleTable = {
 
 const statementRules: StatementRuleTable = {
   assignment: (node, flow, env) => {
-    attachExpressionsToFlow(node.value as AgencyNode, flow, env);
+    // Attaches the RHS and any access-chain operands (e.g. `obj[i()] = v`),
+    // both covered by expressionChildren(assignment).
+    attachExpressionsToFlow(node, flow, env);
     // Only a bare `x = …` / `let x = …` rebinds the variable. Skip access-chain
     // writes (`obj.x = 5` — a mutation, not a rebind; matches walkScopeBody)
     // and destructuring patterns (`node.variableName` not meaningful). The RHS
@@ -140,11 +148,13 @@ const statementRules: StatementRuleTable = {
     return afterBody;
   },
 
-  // Match arms are conservative: each arm builds from the current flow, and the
-  // post-match flow is unchanged (match-arm narrowing is a separate track).
-  // `c.body` is a single node (matchBlock.ts:12), wrapped in `[]` to reuse
-  // buildFlowGraph — same shape as walkScopeBody (scopes.ts:470).
+  // Match arms are conservative: the scrutinee's refs attach to the current
+  // flow, each arm builds from it, and the post-match flow is unchanged
+  // (match-arm narrowing is a separate track). `c.body` is a single node
+  // (matchBlock.ts:12), wrapped in `[]` to reuse buildFlowGraph — same shape as
+  // walkScopeBody (scopes.ts:470).
   matchBlock: (node, flow, env) => {
+    attachExpressionsToFlow(node.expression as AgencyNode, flow, env);
     for (const c of node.cases) {
       if (c.type !== "comment" && c.type !== "newLine") {
         buildFlowGraph([c.body], flow, env);
@@ -160,10 +170,26 @@ const statementRules: StatementRuleTable = {
     }
     return flow;
   },
+
+  // `with …` / `static …` wrap a single statement — thread flow through it so a
+  // wrapped if/loop/assignment is modeled properly (walkScopeBody handles
+  // neither, so this is the only place their bodies get flow).
+  withModifier: (node, flow, env) => buildFlowGraph([node.statement], flow, env),
+  staticStatement: (node, flow, env) => buildFlowGraph([node.statement], flow, env),
 };
 
-/** Statements with no rule (e.g. `importStatement`) leave the flow unchanged. */
-const passThrough = (_node: AgencyNode, flow: FlowNode): FlowNode => flow;
+/**
+ * Statements with no explicit flow semantics (`interruptStatement`,
+ * `gotoStatement`, `newExpression`, bare expression statements, …) leave the
+ * flow unchanged but STILL attach their expression references — otherwise their
+ * `variableName`/`valueAccess` nodes would miss the `flowOf` invariant. Any node
+ * kind not in `statementRules` routes here, so the invariant is robust to node
+ * kinds not individually enumerated.
+ */
+const passThrough = (node: AgencyNode, flow: FlowNode, env: FlowEnvironment): FlowNode => {
+  attachExpressionsToFlow(node, flow, env);
+  return flow;
+};
 
 /**
  * Build the flow graph for one body. A pure fold: each statement's rule maps

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -3,7 +3,13 @@ import { Scope, type ScopeType } from "./scope.js";
 import { expressionChildren, walkNodes } from "../utils/node.js";
 import type { ScopeInfo, TypeCheckerContext } from "./types.js";
 import { analyzeCondition } from "./narrowing.js";
-import { type FlowNode, type FlowEnvironment, wrapFacts, mergeFlows } from "./flow.js";
+import {
+  type FlowNode,
+  type FlowEnvironment,
+  wrapFacts,
+  mergeFlows,
+  widenAtLoopBackEdge,
+} from "./flow.js";
 
 /**
  * Attach `flow` to every variable-referencing node inside an expression. The
@@ -89,16 +95,19 @@ const statementRules: StatementRuleTable = {
     return mergeFlows([thenEnd, elseEnd]);
   },
 
-  // Task 3 adds widening. For now, recurse the body linearly.
   whileLoop: (node, flow, env) => {
     attachExpressionsToFlow(node.condition as AgencyNode, flow, env);
-    buildFlowGraph(node.body, flow, env);
-    return flow;
+    const facts = analyzeCondition(node.condition);
+    const bodyEnd = buildFlowGraph(node.body, wrapFacts(flow, facts.then), env);
+    return wrapFacts(
+      widenAtLoopBackEdge(flow, bodyEnd, assignedNames(node.body), env),
+      facts.else,
+    );
   },
   forLoop: (node, flow, env) => {
     attachExpressionsToFlow(node.iterable as AgencyNode, flow, env);
-    buildFlowGraph(node.body, flow, env);
-    return flow;
+    const bodyEnd = buildFlowGraph(node.body, flow, env);
+    return widenAtLoopBackEdge(flow, bodyEnd, assignedNames(node.body), env);
   },
 
   // Intra-scope blocks thread flow through their body.

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -1,0 +1,181 @@
+import type { AgencyNode } from "../types.js";
+import { Scope, type ScopeType } from "./scope.js";
+import { expressionChildren, walkNodes } from "../utils/node.js";
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import { type FlowNode, type FlowEnvironment } from "./flow.js";
+
+/**
+ * Attach `flow` to every variable-referencing node inside an expression. The
+ * leaf rule (set `flowOf` on `variableName`/`valueAccess`) plus a recurse over
+ * `expressionChildren` is the whole walk. Short-circuit operators get per-side
+ * flow in Task 4 as a special case ahead of this general path.
+ */
+export function attachExpressionsToFlow(
+  node: AgencyNode | null | undefined,
+  flow: FlowNode,
+  env: FlowEnvironment,
+): void {
+  if (!node) {
+    return;
+  }
+  if (node.type === "variableName" || node.type === "valueAccess") {
+    env.flowOf.set(node, flow);
+  }
+  for (const child of expressionChildren(node)) {
+    attachExpressionsToFlow(child, flow, env);
+  }
+}
+
+/**
+ * Names of variables a body rebinds (for loop widening). Bare `x = …` only —
+ * access-chain mutations and destructuring patterns are excluded, matching the
+ * `assignment` rule below.
+ */
+export function assignedNames(body: AgencyNode[]): string[] {
+  const names: string[] = [];
+  for (const { node } of walkNodes(body)) {
+    const isBareRebind =
+      node.type === "assignment" && !node.accessChain && !node.pattern;
+    if (isBareRebind && !names.includes(node.variableName)) {
+      names.push(node.variableName);
+    }
+  }
+  return names;
+}
+
+/** statement kind → its flow transformation. The "what". */
+type StatementRuleTable = {
+  [K in AgencyNode["type"]]?: (
+    node: Extract<AgencyNode, { type: K }>,
+    flow: FlowNode,
+    env: FlowEnvironment,
+  ) => FlowNode;
+};
+
+const statementRules: StatementRuleTable = {
+  assignment: (node, flow, env) => {
+    attachExpressionsToFlow(node.value as AgencyNode, flow, env);
+    // Only a bare `x = …` / `let x = …` rebinds the variable. Skip access-chain
+    // writes (`obj.x = 5` — a mutation, not a rebind; matches walkScopeBody)
+    // and destructuring patterns (`node.variableName` not meaningful). The RHS
+    // is still attached above; PR 2 must not trust assign nodes for these.
+    if (node.accessChain || node.pattern) {
+      return flow;
+    }
+    return {
+      kind: "assign",
+      prev: flow,
+      ref: { variable: node.variableName, chain: [] },
+      type: env.scope.lookup(node.variableName) ?? "any",
+    };
+  },
+
+  returnStatement: (node, flow, env) => {
+    attachExpressionsToFlow(node.value, flow, env);
+    return { kind: "exit" };
+  },
+
+  // Task 2 replaces this with wrapFacts + mergeFlows. For now, recurse both
+  // bodies linearly so refs get attached; flow passes through.
+  ifElse: (node, flow, env) => {
+    attachExpressionsToFlow(node.condition as AgencyNode, flow, env);
+    buildFlowGraph(node.thenBody, flow, env);
+    if (node.elseBody) {
+      buildFlowGraph(node.elseBody, flow, env);
+    }
+    return flow;
+  },
+
+  // Task 3 adds widening. For now, recurse the body linearly.
+  whileLoop: (node, flow, env) => {
+    attachExpressionsToFlow(node.condition as AgencyNode, flow, env);
+    buildFlowGraph(node.body, flow, env);
+    return flow;
+  },
+  forLoop: (node, flow, env) => {
+    attachExpressionsToFlow(node.iterable as AgencyNode, flow, env);
+    buildFlowGraph(node.body, flow, env);
+    return flow;
+  },
+
+  // Intra-scope blocks thread flow through their body.
+  messageThread: (node, flow, env) => buildFlowGraph(node.body, flow, env),
+  parallelBlock: (node, flow, env) => buildFlowGraph(node.body, flow, env),
+  seqBlock: (node, flow, env) => buildFlowGraph(node.body, flow, env),
+
+  handleBlock: (node, flow, env) => {
+    const afterBody = buildFlowGraph(node.body, flow, env);
+    if (node.handler.kind === "inline") {
+      buildFlowGraph(node.handler.body, afterBody, env);
+    }
+    return afterBody;
+  },
+
+  // Match arms are conservative: each arm builds from the current flow, and the
+  // post-match flow is unchanged (match-arm narrowing is a separate track).
+  // `c.body` is a single node (matchBlock.ts:12), wrapped in `[]` to reuse
+  // buildFlowGraph — same shape as walkScopeBody (scopes.ts:470).
+  matchBlock: (node, flow, env) => {
+    for (const c of node.cases) {
+      if (c.type !== "comment" && c.type !== "newLine") {
+        buildFlowGraph([c.body], flow, env);
+      }
+    }
+    return flow;
+  },
+
+  functionCall: (node, flow, env) => {
+    attachExpressionsToFlow(node, flow, env);
+    if (node.block) {
+      buildFlowGraph(node.block.body, flow, env);
+    }
+    return flow;
+  },
+};
+
+/** Statements with no rule (e.g. `importStatement`) leave the flow unchanged. */
+const passThrough = (_node: AgencyNode, flow: FlowNode): FlowNode => flow;
+
+/**
+ * Build the flow graph for one body. A pure fold: each statement's rule maps
+ * the incoming flow to the next. Once `flow` is `exit`, the remaining
+ * statements are unreachable, so the rule is not applied (no node is built
+ * rooted at `exit`, where typeAt throws; dead-code refs go unattached, which
+ * is harmless — PR 2 falls back to scope.lookup for nodes with no flow).
+ */
+export function buildFlowGraph(
+  nodes: AgencyNode[],
+  entry: FlowNode,
+  env: FlowEnvironment,
+): FlowNode {
+  return nodes.reduce<FlowNode>((flow, node) => {
+    if (flow.kind === "exit") {
+      return flow;
+    }
+    const rule = (statementRules[node.type] ?? passThrough) as (
+      node: AgencyNode,
+      flow: FlowNode,
+      env: FlowEnvironment,
+    ) => FlowNode;
+    return rule(node, flow, env);
+  }, entry);
+}
+
+/**
+ * Pass entry: build a flow graph per scope, sharing one `flowOf`/`memo` across
+ * the whole check so PR 2 can look up any node. Each scope's build env carries
+ * that scope (typeAt reads scope from `start` nodes, not `env.scope`, so the
+ * shared graph state is safe). Stores a representative env on `ctx`; nothing
+ * consults it yet (PR 1b is behavior-preserving).
+ */
+export function buildFlowGraphs(scopes: ScopeInfo[], ctx: TypeCheckerContext): void {
+  const flowOf: WeakMap<AgencyNode, FlowNode> = new WeakMap();
+  const memo: WeakMap<FlowNode, Record<string, ScopeType>> = new WeakMap();
+  const typeAliases = ctx.getTypeAliases();
+  for (const info of scopes) {
+    const env: FlowEnvironment = { scope: info.scope, flowOf, typeAliases, memo };
+    buildFlowGraph(info.body, { kind: "start", scope: info.scope }, env);
+  }
+  const rootScope = scopes[0]?.scope ?? new Scope("global");
+  ctx.flowEnv = { scope: rootScope, flowOf, typeAliases, memo };
+}

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -2,7 +2,8 @@ import type { AgencyNode } from "../types.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { expressionChildren, walkNodes } from "../utils/node.js";
 import type { ScopeInfo, TypeCheckerContext } from "./types.js";
-import { type FlowNode, type FlowEnvironment } from "./flow.js";
+import { analyzeCondition } from "./narrowing.js";
+import { type FlowNode, type FlowEnvironment, wrapFacts, mergeFlows } from "./flow.js";
 
 /**
  * Attach `flow` to every variable-referencing node inside an expression. The
@@ -75,15 +76,17 @@ const statementRules: StatementRuleTable = {
     return { kind: "exit" };
   },
 
-  // Task 2 replaces this with wrapFacts + mergeFlows. For now, recurse both
-  // bodies linearly so refs get attached; flow passes through.
   ifElse: (node, flow, env) => {
     attachExpressionsToFlow(node.condition as AgencyNode, flow, env);
-    buildFlowGraph(node.thenBody, flow, env);
-    if (node.elseBody) {
-      buildFlowGraph(node.elseBody, flow, env);
-    }
-    return flow;
+    const facts = analyzeCondition(node.condition);
+    const thenEnd = buildFlowGraph(node.thenBody, wrapFacts(flow, facts.then), env);
+    const elseStart = wrapFacts(flow, facts.else);
+    const elseEnd = node.elseBody
+      ? buildFlowGraph(node.elseBody, elseStart, env)
+      : elseStart;
+    // Post-guard narrowing falls out: a returning branch ends in `exit`, which
+    // mergeFlows drops, leaving the surviving branch's (narrowed) flow.
+    return mergeFlows([thenEnd, elseEnd]);
   },
 
   // Task 3 adds widening. For now, recurse the body linearly.

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -25,6 +25,23 @@ export function attachExpressionsToFlow(
   if (!node) {
     return;
   }
+  // Short-circuit: the RHS of `&&` runs only when the LHS is truthy (then-facts);
+  // the RHS of `||` only when the LHS is falsy (else-facts). Recurse through
+  // this same function (not the flow-agnostic child walk) so the split holds at
+  // any nesting depth.
+  if (
+    node.type === "binOpExpression" &&
+    (node.operator === "&&" || node.operator === "||")
+  ) {
+    attachExpressionsToFlow(node.left as AgencyNode, flow, env);
+    const leftFacts = analyzeCondition(node.left);
+    const rightFlow = wrapFacts(
+      flow,
+      node.operator === "&&" ? leftFacts.then : leftFacts.else,
+    );
+    attachExpressionsToFlow(node.right as AgencyNode, rightFlow, env);
+    return;
+  }
   if (node.type === "variableName" || node.type === "valueAccess") {
     env.flowOf.set(node, flow);
   }

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -28,6 +28,7 @@ import { validateTypeReferences } from "./validate.js";
 import { applySuppressions, parseSuppressions } from "./suppression.js";
 import { inferReturnTypes } from "./inference.js";
 import { buildScopes } from "./scopes.js";
+import { buildFlowGraphs } from "./flowBuilder.js";
 import { checkScopes } from "./checker.js";
 import { isAssignable as _isAssignable } from "./assignability.js";
 import { inferReturnTypeFor } from "./inference.js";
@@ -290,6 +291,9 @@ export class TypeChecker {
 
     // 3. Build scopes (collects variable types and checks assignments)
     const scopes = buildScopes(ctx);
+
+    // 3b. Build the flow graph (PR 1b — populated, not yet consulted).
+    buildFlowGraphs(scopes, ctx);
 
     // 4. Check function calls, return types, and expressions
     checkScopes(scopes, ctx);

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -21,6 +21,7 @@ import { formatTypeHint } from "../utils/formatType.js";
 import { checkType, getBlockSlot } from "./utils.js";
 import { NUMBER_T } from "./primitives.js";
 import { analyzeCondition, walkWithNarrowing, postGuardFacts } from "./narrowing.js";
+import { expressionChildren } from "../utils/node.js";
 
 export function buildScopes(ctx: TypeCheckerContext): ScopeInfo[] {
   const scopes: ScopeInfo[] = [];
@@ -292,85 +293,11 @@ function checkConstMutations(
     });
   }
 
-  switch (node.type) {
-    case "binOpExpression":
-      checkConstMutations(node.left as AgencyNode, scope, ctx);
-      checkConstMutations(node.right as AgencyNode, scope, ctx);
-      break;
-    case "assignment":
-      checkConstMutations(node.value as AgencyNode, scope, ctx);
-      break;
-    case "returnStatement":
-      checkConstMutations(node.value as AgencyNode | undefined, scope, ctx);
-      break;
-    case "ifElse":
-      checkConstMutations(node.condition as AgencyNode, scope, ctx);
-      break;
-    case "whileLoop":
-      checkConstMutations(node.condition as AgencyNode, scope, ctx);
-      break;
-    case "forLoop":
-      checkConstMutations(node.iterable as AgencyNode, scope, ctx);
-      break;
-    case "functionCall":
-      for (const arg of node.arguments) {
-        const value =
-          arg.type === "splat" || arg.type === "namedArgument"
-            ? arg.value
-            : arg;
-        checkConstMutations(value as AgencyNode, scope, ctx);
-      }
-      break;
-    case "valueAccess":
-      checkConstMutations(node.base as AgencyNode, scope, ctx);
-      for (const element of node.chain) {
-        if (element.kind === "index") {
-          checkConstMutations(element.index as AgencyNode, scope, ctx);
-        } else if (element.kind === "methodCall") {
-          checkConstMutations(element.functionCall as AgencyNode, scope, ctx);
-        }
-      }
-      break;
-    case "agencyArray":
-      for (const item of node.items) {
-        const value = item.type === "splat" ? item.value : item;
-        checkConstMutations(value as AgencyNode, scope, ctx);
-      }
-      break;
-    case "agencyObject":
-      for (const entry of node.entries) {
-        const value =
-          "type" in entry && entry.type === "splat"
-            ? entry.value
-            : (entry as { value: AgencyNode }).value;
-        checkConstMutations(value as AgencyNode, scope, ctx);
-      }
-      break;
-    case "string":
-    case "multiLineString":
-      for (const seg of node.segments) {
-        if (seg.type === "interpolation") {
-          checkConstMutations(seg.expression as AgencyNode, scope, ctx);
-        }
-      }
-      break;
-    case "tryExpression":
-      checkConstMutations(node.call as AgencyNode, scope, ctx);
-      break;
-    case "newExpression":
-      for (const arg of node.arguments) {
-        checkConstMutations(arg as AgencyNode, scope, ctx);
-      }
-      break;
-    case "interruptStatement":
-      for (const arg of node.arguments) {
-        const value =
-          arg.type === "splat" || arg.type === "namedArgument"
-            ? arg.value
-            : arg;
-        checkConstMutations(value as AgencyNode, scope, ctx);
-      }
-      break;
+  // Recurse via the shared expressionChildren walker (lib/utils/node.ts) — the
+  // single source of truth for "what are this node's expression children",
+  // also used by the flow builder's attachExpressionsToFlow.
+  for (const child of expressionChildren(node)) {
+    checkConstMutations(child, scope, ctx);
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -91,6 +91,9 @@ export type TypeCheckerContext = {
    *  interrupt call-graph analysis) can use a reliable per-file
    *  identity instead of looking names up in the global symbol table. */
   currentFile?: string;
+  /** Flow graph built by `buildFlowGraphs` (PR 1b). Populated but not yet
+   *  consulted — PR 2 routes `synthValueAccess` through `typeAt`. */
+  flowEnv?: import("./flow.js").FlowEnvironment;
   getTypeAliases(): Record<string, TypeAliasEntry>;
   withScope<T>(key: string, fn: () => T): T;
   inferReturnTypeFor(

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -1,4 +1,5 @@
 import {
+  AccessChainElement,
   AgencyNode,
   Expression,
   InterpolationSegment,
@@ -51,7 +52,7 @@ export function expressionChildren(node: AgencyNode): AgencyNode[] {
     case "binOpExpression":
       return [node.left, node.right];
     case "assignment":
-      return [node.value];
+      return [node.value, ...accessChainExpressions(node.accessChain)];
     case "returnStatement":
       return node.value ? [node.value] : [];
     case "ifElse":
@@ -63,21 +64,36 @@ export function expressionChildren(node: AgencyNode): AgencyNode[] {
     case "functionCall":
     case "interruptStatement":
       return node.arguments.map(unwrapCallArg);
-    case "valueAccess": {
-      const children: AgencyNode[] = [node.base];
-      for (const el of node.chain) {
-        if (el.kind === "index") {
-          children.push(el.index);
-        } else if (el.kind === "methodCall") {
-          children.push(el.functionCall);
+    case "gotoStatement":
+      return [node.nodeCall];
+    case "withModifier":
+    case "staticStatement":
+      return [node.statement];
+    case "matchBlock":
+      // The scrutinee. Case patterns + bodies are visited via walkScopeBody /
+      // the flow builder's matchBlock rule, not here.
+      return [node.expression];
+    case "valueAccess":
+      return [node.base, ...accessChainExpressions(node.chain)];
+    case "agencyArray":
+      return node.items.map((item) => (item.type === "splat" ? item.value : item));
+    case "agencyObject": {
+      const children: AgencyNode[] = [];
+      for (const entry of node.entries) {
+        if ("type" in entry && entry.type === "splat") {
+          children.push(entry.value);
+        } else {
+          // Non-splat entries are key/value; computedKey is optional. Cast
+          // mirrors getAllVariablesInBody (the union isn't cleanly narrowable).
+          const kv = entry as { computedKey?: Expression; value: Expression };
+          if (kv.computedKey) {
+            children.push(kv.computedKey);
+          }
+          children.push(kv.value);
         }
       }
       return children;
     }
-    case "agencyArray":
-      return node.items.map((item) => (item.type === "splat" ? item.value : item));
-    case "agencyObject":
-      return node.entries.map((entry) => entry.value);
     case "string":
     case "multiLineString": {
       const children: AgencyNode[] = [];
@@ -93,8 +109,30 @@ export function expressionChildren(node: AgencyNode): AgencyNode[] {
     case "newExpression":
       return node.arguments;
     default:
+      // Leaves (variableName, literals, …), comments, patterns, and nested
+      // definitions (function/graphNode) have no expression children here.
       return [];
   }
+}
+
+/** Expression operands carried by an access chain (`a[i]`, `a[i:j]`, `a.m(x)`). */
+function accessChainExpressions(chain: AccessChainElement[] | undefined): AgencyNode[] {
+  const out: AgencyNode[] = [];
+  for (const el of chain ?? []) {
+    if (el.kind === "index") {
+      out.push(el.index);
+    } else if (el.kind === "slice") {
+      if (el.start) {
+        out.push(el.start);
+      }
+      if (el.end) {
+        out.push(el.end);
+      }
+    } else if (el.kind === "methodCall") {
+      out.push(el.functionCall);
+    }
+  }
+  return out;
 }
 
 /** Convert a function call argument to string. */

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -38,6 +38,65 @@ function unwrapCallArg(arg: Expression | SplatExpression | NamedArgument): Expre
   return arg;
 }
 
+/**
+ * The immediate *expression* children of any AST node — the single source of
+ * truth for "what sub-expressions does this node contain". Consumed by
+ * `attachExpressionsToFlow` (flow builder) and `checkConstMutations`
+ * (scopes.ts) so neither re-implements the per-node-kind recursion. Returns
+ * `[]` for leaves and for nested definitions (`function`/`graphNode`), which
+ * own their scope and are walked separately.
+ */
+export function expressionChildren(node: AgencyNode): AgencyNode[] {
+  switch (node.type) {
+    case "binOpExpression":
+      return [node.left, node.right];
+    case "assignment":
+      return [node.value];
+    case "returnStatement":
+      return node.value ? [node.value] : [];
+    case "ifElse":
+      return [node.condition];
+    case "whileLoop":
+      return [node.condition];
+    case "forLoop":
+      return [node.iterable];
+    case "functionCall":
+    case "interruptStatement":
+      return node.arguments.map(unwrapCallArg);
+    case "valueAccess": {
+      const children: AgencyNode[] = [node.base];
+      for (const el of node.chain) {
+        if (el.kind === "index") {
+          children.push(el.index);
+        } else if (el.kind === "methodCall") {
+          children.push(el.functionCall);
+        }
+      }
+      return children;
+    }
+    case "agencyArray":
+      return node.items.map((item) => (item.type === "splat" ? item.value : item));
+    case "agencyObject":
+      return node.entries.map((entry) => entry.value);
+    case "string":
+    case "multiLineString": {
+      const children: AgencyNode[] = [];
+      for (const seg of node.segments) {
+        if (seg.type === "interpolation") {
+          children.push(seg.expression);
+        }
+      }
+      return children;
+    }
+    case "tryExpression":
+      return [node.call];
+    case "newExpression":
+      return node.arguments;
+    default:
+      return [];
+  }
+}
+
 /** Convert a function call argument to string. */
 function callArgToString(arg: Expression | SplatExpression | NamedArgument): string {
   if (arg.type === "splat") {


### PR DESCRIPTION
## Summary

Constructs the flow graph from the AST — populates `env.flowOf` (expression node → its `FlowNode`) for every scope, using the PR 1a machinery — **without consulting it anywhere** (`synthType` still uses `scope.lookup`). This is **PR 1, Part B** of the flow-typed checker. Behavior-preserving: the graph is built and discarded, ready for PR 2 to route `synthValueAccess` through `typeAt`.

`walkScopeBody`'s flow/narrowing logic is **untouched**. Post-guard narrowing is not replicated — it falls out of `mergeFlows` dropping `exit` predecessors.

## Declarative design

Structured per `docs/dev/anti-patterns.md` (no imperative switch-and-mutate, no order-dependent mutable state, no duplicated walkers):

- **`statementRules`** — a dispatch table (`node.type → (node, flow, env) => nextFlow`), mirroring the `narrowers` table in `narrowing.ts`. `buildFlowGraph` is a single `reduce` over a body that applies the matching rule and short-circuits once `flow` is `exit`. No mutable `let flow`.
- **`expressionChildren(node)`** (new, in `lib/utils/node.ts`) — one shared "node → expression children" table. Both the flow builder's `attachExpressionsToFlow` and `checkConstMutations` consume it, so the per-node-kind AST recursion lives in exactly one place. Task 5 migrates `checkConstMutations` onto it (−73 lines), gated on byte-identical const diagnostics.
- Adding a statement kind = one `statementRules` entry; adding an expression-containing node kind = one `expressionChildren` entry.

## What is included

- `expressionChildren` shared walker + `attachExpressionsToFlow` (variable-reference attachment; per-side flow for `&&`/`||` at any depth).
- `buildFlowGraph` (statement-rule fold; reachability short-circuit on `exit`) + `buildFlowGraphs` (per-scope, shared `flowOf`/`memo`, stores `ctx.flowEnv`).
- `ifElse` (narrow + join + free post-guard), `whileLoop`/`forLoop` widening via new `widenAtLoopBackEdge` (flow.ts), short-circuit operands.
- Pass wired into the pipeline after `buildScopes`; `TypeCheckerContext.flowEnv` added.

## Known gaps (harmless while unused; documented for PR 2)

- Destructuring / access-chain assignments produce no `assign` node (the `assignment` rule skips `node.pattern`/`node.accessChain`).
- Sub-scoped bodies share the parent `scope` (mirrors `walkScopeBody`), so an `assign` inside them resolves via the parent scope.
- No control-flow nodes for `try`/`catch` or a handler's interrupt effect.

## Testing

- `flowBuilder.test.ts` (new) — linear assigns, dead-code-after-return, the flow-attachment invariant, `ifElse` narrowing + post-guard, loop-node back-edge, `&&` RHS narrowing.
- `flow.test.ts` — `widenAtLoopBackEdge` cases.
- `make` clean; `npx tsc --noEmit` clean; `pnpm run lint:structure` clean.
- `pnpm test:run` — **6508 passed, 0 failed**. Behavior-preserving: `walkScopeBody` untouched, `buildFlowGraphs` emits nothing, `checkConstMutations` diagnostics unchanged.

## Out of scope (PR 2)

Route `synthValueAccess` through `typeAt`; decide reassigned-variable precision (current `assign` types come from `scope.lookup`); test triage as the narrowing the old child-scope path missed begins to fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
