### PR TITLE
feat(typechecker): flow-aware synthType — route variable resolution through typeAt (flow-checker PR 2)

### DIFF
--- a/packages/agency-lang/lib/typeChecker/assignability.test.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.test.ts
@@ -206,3 +206,32 @@ describe("unresolved typeAliasVariable assignability", () => {
     expect(isAssignable(colorRef, undefinedFoo, aliases)).toBe(false);
   });
 });
+
+describe("narrowed Result member assignable to Result type", () => {
+  const resultT: VariableType = {
+    type: "resultType",
+    successType: STRING_T,
+    failureType: STRING_T,
+  };
+  // The success member shape produced by resultToObjectUnion narrowing.
+  const successMember: VariableType = {
+    type: "objectType",
+    properties: [
+      { key: "success", value: { type: "booleanLiteralType", value: "true" } },
+      { key: "value", value: STRING_T },
+    ],
+  };
+
+  it("a narrowed success member is assignable back to the Result type", () => {
+    // e.g. `return parsed` after `if (isFailure(parsed)) return` narrowed it.
+    expect(isAssignable(successMember, resultT, {})).toBe(true);
+  });
+
+  it("an unrelated object is not assignable to the Result type", () => {
+    const other: VariableType = {
+      type: "objectType",
+      properties: [{ key: "nope", value: STRING_T }],
+    };
+    expect(isAssignable(other, resultT, {})).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -4,6 +4,7 @@ import { substituteTypeParams } from "./substitute.js";
 import { mapTypes } from "./typeWalker.js";
 import { mergeTagSets } from "./mergeTags.js";
 import { applyValueArgs } from "./valueParamSubstitution.js";
+import { resultToObjectUnion } from "./resultUnion.js";
 
 /**
  * Public resolveType: normalizes a VariableType by resolving type-alias
@@ -601,6 +602,21 @@ export function isAssignable(
     return (
       isAssignable(resolvedSource.successType, resolvedTarget.successType, typeAliases) &&
       isAssignable(resolvedSource.failureType, resolvedTarget.failureType, typeAliases)
+    );
+  }
+
+  // A narrowed Result *member* (object form, produced by viewing Result as a
+  // discriminated union via resultToObjectUnion) is assignable back to the
+  // Result type it came from — e.g. `return parsed` where `parsed` was narrowed
+  // to `{ success: true, value: T }` by an `isFailure` early-return guard. The
+  // flow checker (PR 2) surfaces this on returns/args/assignments. Expand the
+  // target Result to its object union and check structurally. Only when the
+  // source is NOT itself a Result (that case is handled covariantly above).
+  if (resolvedTarget.type === "resultType" && resolvedSource.type !== "resultType") {
+    return isAssignable(
+      resolvedSource,
+      resultToObjectUnion(resolvedTarget, typeAliases),
+      typeAliases,
     );
   }
 

--- a/packages/agency-lang/lib/typeChecker/flowNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowNarrowing.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import { walkNodes } from "../utils/node.js";
+import type { AgencyProgram, AgencyNode } from "../types.js";
+
+// Parse + full pipeline; returns errors AND the (post-check) result so tests
+// can inspect ctx.flowEnv. The parsed program is returned too, so a test can
+// grab the exact node objects the checker walked (identity guard).
+function run(source: string): {
+  errors: string[];
+  result: ReturnType<typeof typeCheck>;
+  program: AgencyProgram;
+} {
+  const parsed = parseAgency(source);
+  if (!parsed.success) {
+    throw new Error(`parse failed: ${parsed.message}`);
+  }
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  const result = typeCheck(parsed.result, {}, info);
+  return { errors: result.errors.map((e) => e.message), result, program: parsed.result };
+}
+
+const check = (source: string): string[] => run(source).errors;
+
+describe("flow narrowing is consistent across passes (PR 2)", () => {
+  const R = `type R = { kind: "a", v: string } | { kind: "b", v: number }`;
+
+  it("a narrowed member access types precisely as a function argument", () => {
+    // checkFunctionCallsInScope (Phase B) synths the arg; before PR 2 it used
+    // the flat scope and saw `string | number`, mis-erroring against `string`.
+    const errors = check(`
+${R}
+def takesString(s: string): void { }
+def f(r: R): void {
+  if (r.kind == "a") {
+    takesString(r.v)
+  }
+}`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a narrowed member access types precisely as a return value", () => {
+    // NOTE: g has an *annotated* return type, so this tests Phase B CHECKING,
+    // not inference. Do not rewrite to an unannotated return and assert a
+    // tightened inferred type — Phase A inference still uses scope.lookup
+    // (flowEnv is unset during inferReturnTypes), so the inferred type stays
+    // wide until PR 3. See "Notes for PR 3".
+    const errors = check(`
+${R}
+def g(r: R): string {
+  if (r.kind == "a") {
+    return r.v
+  }
+  return "x"
+}`);
+    expect(errors).toEqual([]);
+  });
+
+  it("RHS of && sees the LHS narrowing", () => {
+    // The right `r.v` is attached (1b) to a flow wrapped with the LHS
+    // then-facts; before PR 2 the arg-check synths it flat → string | number.
+    const errors = check(`
+${R}
+def takesStringReturnsBool(s: string): boolean { return true }
+def h(r: R): void {
+  let ok = r.kind == "a" && takesStringReturnsBool(r.v)
+}`);
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("flow graph identity + reassignment (PR 2 guards)", () => {
+  const R = `type R = { kind: "a", v: string } | { kind: "b", v: number }`;
+
+  it("GUARD: the flow graph is keyed on the AST nodes the checker sees", () => {
+    // If a future AST rewrite between buildFlowGraphs and checkScopes breaks
+    // node identity, narrowing silently falls back to scope.lookup — this fails
+    // loudly instead. Grab the parsed `r` reference and assert it has a flow.
+    const { result, program } = run(`
+${R}
+def f(r: R): void {
+  if (r.kind == "a") {
+    print(r.v)
+  }
+}`);
+    let rRef: AgencyNode | undefined;
+    for (const { node } of walkNodes(program.nodes)) {
+      if (node.type === "variableName" && node.value === "r") {
+        rRef = node;
+      }
+    }
+    expect(rRef).toBeDefined();
+    expect(result.flowEnv?.flowOf.get(rRef!)).toBeDefined();
+  });
+
+  it("PIN: a reassigned variable resolves to its declared type (no per-position)", () => {
+    // assign nodes carry scope.lookup (the final declared type), so typeAt is
+    // not flow-sensitive across reassignments yet. Pins current behavior; see
+    // the reassigned-precision caveat in "Notes for PR 3".
+    const errors = check(`
+def f(): void {
+  let x: number = 1
+  x = 2
+  let y: number = x
+}`);
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -352,6 +352,7 @@ export class TypeChecker {
       scopes,
       interruptEffectsByFunction,
       interruptCallGraph,
+      flowEnv: ctx.flowEnv,
     };
   }
 

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -108,7 +108,16 @@ export function synthType(
         if (ctx.flowEnv) {
           const flow = ctx.flowEnv.flowOf.get(expr);
           if (flow) {
-            return typeAt({ variable: expr.value, chain: [] }, flow, ctx.flowEnv);
+            // Resolve against the CURRENT scope's type aliases
+            // (ctx.getTypeAliases() tracks ctx.withScope), not the global
+            // snapshot captured once in buildFlowGraphs — a scope that overrides
+            // an alias must narrow against its own set. Safe with the shared
+            // memo: each flow node belongs to one scope, so it is only ever
+            // queried under that scope's alias context.
+            return typeAt({ variable: expr.value, chain: [] }, flow, {
+              ...ctx.flowEnv,
+              typeAliases: ctx.getTypeAliases(),
+            });
           }
         }
         return scopeType;

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -7,6 +7,7 @@ import type {
 import { formatTypeHint } from "../utils/formatType.js";
 import { BUILTIN_FUNCTION_TYPES, AGENCY_FUNCTION_METHOD_TYPES } from "./builtins.js";
 import { isAssignable, isNever, safeResolveType } from "./assignability.js";
+import { typeAt } from "./flow.js";
 import { literalToType } from "./literalType.js";
 import { resultTypeForValidation } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
@@ -95,7 +96,23 @@ export function synthType(
   switch (expr.type) {
     case "variableName": {
       const scopeType = scope.lookup(expr.value);
-      if (scopeType) return scopeType;
+      if (scopeType) {
+        // Flow-sensitive narrowing: when a flow node is attached to this exact
+        // reference node (populated by buildFlowGraphs; present during
+        // checkScopes / Phase B), resolve through typeAt so narrowed types are
+        // consistent across passes. Relies on AST node identity — the flowOf
+        // WeakMap is keyed on the same node object the synthesizer receives. No
+        // flow node (buildScopes / inference, before flowEnv exists, or a
+        // synthetic node) → the declared scope type, unchanged. Only narrows a
+        // *variable* (scopeType found); the ref-resolution below is untouched.
+        if (ctx.flowEnv) {
+          const flow = ctx.flowEnv.flowOf.get(expr);
+          if (flow) {
+            return typeAt({ variable: expr.value, chain: [] }, flow, ctx.flowEnv);
+          }
+        }
+        return scopeType;
+      }
       const fnDef = ctx.functionDefs[expr.value];
       if (fnDef) {
         return {

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -29,6 +29,10 @@ export type TypeCheckResult = {
   scopes: ScopeInfo[];
   interruptEffectsByFunction: Record<string, InterruptEffect[]>;
   interruptCallGraph: InterruptCallGraph;
+  /** The flow graph built during the check (PR 1b). Exposed for tests/tooling
+   *  (identity guard now; LSP hover / PR 4 later). Undefined if the check threw
+   *  before buildFlowGraphs. */
+  flowEnv?: import("./flow.js").FlowEnvironment;
 };
 
 export type ScopeInfo = {

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -1,4 +1,5 @@
 import type { Scope } from "./scope.js";
+import type { FlowEnvironment } from "./flow.js";
 import { AgencyConfig } from "../config.js";
 import {
   AgencyNode,
@@ -32,7 +33,7 @@ export type TypeCheckResult = {
   /** The flow graph built during the check (PR 1b). Exposed for tests/tooling
    *  (identity guard now; LSP hover / PR 4 later). Undefined if the check threw
    *  before buildFlowGraphs. */
-  flowEnv?: import("./flow.js").FlowEnvironment;
+  flowEnv?: FlowEnvironment;
 };
 
 export type ScopeInfo = {
@@ -97,7 +98,7 @@ export type TypeCheckerContext = {
   currentFile?: string;
   /** Flow graph built by `buildFlowGraphs` (PR 1b). Populated but not yet
    *  consulted — PR 2 routes `synthValueAccess` through `typeAt`. */
-  flowEnv?: import("./flow.js").FlowEnvironment;
+  flowEnv?: FlowEnvironment;
   getTypeAliases(): Record<string, TypeAliasEntry>;
   withScope<T>(key: string, fn: () => T): T;
   inferReturnTypeFor(


### PR DESCRIPTION
## Summary

Makes `synthType` consult the flow graph: when a flow node is attached to a variable reference, its type resolves through `typeAt` instead of `scope.lookup`. This makes narrowing **consistent across every pass** — killing the Phase A / Phase B disagreement that blocked enforced Result safety. **PR 2** of the flow-typed checker; the first behavior-*changing* PR.

## How it works

- One change in `synthType`'s `variableName` case: if `ctx.flowEnv` has a flow node for the reference, return `typeAt({ variable, chain: [] }, flow, ctx.flowEnv)`; otherwise `scope.lookup`. Only narrows a *variable* (where `scope.lookup` found one) — function/node/import-ref resolution is untouched.
- `ctx.flowEnv` is populated by `buildFlowGraphs`, which runs *after* `buildScopes`, so the flow path is naturally active only during `checkScopes` (**Phase B**). Phase A keeps its existing child-scope narrowing (PR 3 retires it). No `walkScopeBody` change here.
- Routing the `variableName` case (not `synthValueAccess`) covers member-access bases *and* bare refs (function args, returns, `&&`/`||` RHS) — which is what actually fixes Phase B.

**Observable change:** spurious Phase B errors disappear. `checkFunctionCallsInScope` / `checkReturnTypesInScope` synth args/returns against the flat scope today, so a narrowed member access used as an argument (`takesString(r.v)` inside `if (r.kind == "a")`) currently mis-reports "not assignable". Now `r` narrows and the type is precise.

## Included fix: narrowed Result member → Result type (discovered in triage)

Routing returns/args through `typeAt` surfaced a real false positive: a `Result` narrowed to its success/failure **member object** (via `resultToObjectUnion`) was no longer assignable to the declared `Result` type. `stdlib/policy.agency`'s `return parsed` — where `parsed` was narrowed to `{ success: true, value: any }` by an `if (isFailure(parsed)) return` guard — newly mis-errored against `Result<Policy, ParsePolicyFailure>`. A narrowed member *is* a valid Result. Fix in `assignability.ts`: when the target is a `Result` and the source is not, expand the target via `resultToObjectUnion` and check structurally (mirrors how narrowing already views Result as a union). This is a small scope addition beyond the literal plan, but required — returning/passing a narrowed Result is extremely common.

## Load-bearing invariant

`flowOf` is a `WeakMap<AgencyNode, FlowNode>` keyed on AST node identity. `synthType` looks up by the node it receives during `checkScopes`, so **no pass between `buildFlowGraphs` and `checkScopes` may clone/rewrap variable-reference nodes** (pattern lowering runs before the checker, so the AST is stable today). A new guard test asserts the parsed `r` node has a flow entry, so a future rewrite fails loudly instead of silently losing narrowing.

## Testing

- New `flowNarrowing.test.ts`: cross-pass narrowing (arg / return / `&&` RHS — each was red before with `'string | number' not assignable to 'string'`), the AST-identity guard, and a reassigned-variable pin (assign nodes carry the final declared type — flow isn't per-position yet; revisit in PR 3).
- New `assignability.test.ts` cases: narrowed Result member ⊆ Result type; unrelated object ⊄ Result.
- `make` clean; `npx tsc --noEmit` clean; `pnpm run lint:structure` clean.
- `pnpm test:run` — **6516 passed, 0 failed**. The only suite change was the `stdlib/policy` fixture, fixed at the root (assignability) rather than by editing the fixture.

## Out of scope (PR 3)

Retire the Phase A child-scope mechanism (`walkWithNarrowing`/`applyNarrowing`/`narrowers`/`postGuardFacts`) — requires making Phase A flow-aware too. Between PR 2 and PR 3 the two narrowing impls run side-by-side and must agree; PR 3 should add a Phase-A-vs-Phase-B agreement test before deleting the child-scope path. The reassigned-variable precision question also stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
