### PR TITLE
fix: router specs without explicit type + tavily array length

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agent.md
+++ b/packages/agency-lang/docs/site/stdlib/agent.md
@@ -343,4 +343,4 @@ Run one user turn through a multi-specialist agent. Owns the hop
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L345))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L347))

--- a/packages/agency-lang/stdlib/agent.agency
+++ b/packages/agency-lang/stdlib/agent.agency
@@ -281,11 +281,13 @@ def runOneTurnPrompt(
   """
   let reply = ""
   const spec = config.agents[category]
-  if (spec.type != "prompt") {
+  if (spec.type == "agent") {
     // Unreachable in practice: routeIteration() sends agent-type specs to
     // runOneTurnAgent, so only prompt-type specs reach here. The guard narrows
     // `spec` to PromptSpec so its prompt-only fields (systemPrompt / tools /
-    // memory) type-check without an un-narrowed-union error.
+    // memory) type-check without an un-narrowed-union error. Bailing only on
+    // the "agent" case (rather than `!= "prompt"`) keeps a spec whose `type`
+    // is omitted on the prompt path, matching routeIteration's dispatch.
     return reply
   }
   thread(label: category, summarize: true, session: category) {

--- a/packages/agency-lang/tests/integration/stdlib-sandbox/credential/tavily.agency
+++ b/packages/agency-lang/tests/integration/stdlib-sandbox/credential/tavily.agency
@@ -6,7 +6,7 @@ node main() {
   // std::search interrupt so the request actually goes out.
   handle {
     const results = tavilySearch("TypeScript programming language", count: 3)
-    if (length(results) == 0) {
+    if (results.length == 0) {
       return "tavily failed: no results"
     }
     const first = results[0]


### PR DESCRIPTION
## What

Fixes two unrelated CI failures on `main`. Both reproduce locally (the router one was masked by a stale `dist/` until `make` was re-run).

## 1. `build` job — 3 router execution tests returned empty replies

`router-basic`, `router-fallback`, and `router-handoff` all failed with an empty (`""`) reply.

**Root cause:** the Result-safety commit added a narrowing guard to `runOneTurnPrompt` in `stdlib/agent.agency`:

```
if (spec.type != "prompt") { return reply }   // reply is ""
```

The router agent specs are written as `{ systemPrompt, tools }` with **no `type` field**, so `spec.type` is `undefined` and `undefined != "prompt"` is true → it returns `""` immediately. This contradicts `routeIteration`, which dispatches `spec.type === "agent"` to the agent path and **everything else (including a missing `type`) to the prompt path**. The two guards disagreed; specs without `type` fell into the gap.

**Fix:** align the guard with the dispatcher — bail only on the genuine agent case. This still narrows `spec` to `PromptSpec` for the type checker:

```
if (spec.type == "agent") { return reply }
```

## 2. `integration-credentials` job — tavily test crashed

`tavily.agency` called `length(results)`, but `length` is not a function in Agency (the compiler warned `Function 'length' is not defined`), producing a runtime `ReferenceError: length is not defined`. Array length is a property.

**Fix:** `length(results)` → `results.length`.

## Verification

- `AGENCY_USE_TEST_LLM_PROVIDER=1 agency test tests/agency/router-{basic,fallback,handoff}` → 3/3 pass after `make`.
- `tavily.agency` compiles cleanly; generated condition is now `results.length` (live test itself needs `TAVILY_API_KEY`, only available in the `integration-credentials` job).

Generated `stdlib/agent.js` / `tavily.js` are gitignored; CI regenerates them via `make`. `docs/site/stdlib/agent.md` is a `make`-regenerated source line-number bump.

## Follow-up (not in this PR)

The router specs still emit a non-fatal type warning because `PromptSpec.type` is required but the specs omit it. The runtime now tolerates this. Making `type` optional with a `"prompt"` default would silence the warning and make the no-`type` form first-class, but that's a design change beyond unbreaking CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
