### PR TITLE
fix(lowering): clone scrutinee per occurrence (match-over-Result spurious error)

### DIFF
--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -416,6 +416,30 @@ describe("temp uniqueness", () => {
     };
     expect(find(a)).toBe(find(b));
   });
+
+  it("emits a DISTINCT scrutinee node object per occurrence (flow-graph node identity)", () => {
+    // The flow checker keys narrowing on AST-node identity, so each lowered
+    // reference to the `__scrutinee` temp (every arm's isSuccess/isFailure guard
+    // and .value/.error binding) MUST be its own node object. Sharing one node
+    // collapsed all occurrences to a single flow position — see the match-over-
+    // Result regression in narrowing.test.ts.
+    const lowered = lower(
+      `let r = success(1)\nmatch (r) {\n  success(v) => v\n  failure(e) => e\n}`,
+    );
+    const scrutNodes: object[] = [];
+    const collect = (o: unknown): void => {
+      if (!o || typeof o !== "object") return;
+      const node = o as Record<string, unknown>;
+      if (node.type === "variableName" && typeof node.value === "string" && node.value.startsWith("__scrutinee")) {
+        scrutNodes.push(node);
+      }
+      for (const k of Object.keys(node)) collect(node[k]);
+    };
+    collect(lowered);
+    // Multiple references exist (guards + bindings) and every one is unique.
+    expect(scrutNodes.length).toBeGreaterThan(1);
+    expect(new Set(scrutNodes).size).toBe(scrutNodes.length);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -531,7 +531,7 @@ class PatternLowerer {
           return this.extractBindings(el, indexAccess(source, i, loc), declKind, loc);
         });
       case "variableName":
-        return [makeAssign(pattern.value, source, declKind, loc)];
+        return [makeAssign(pattern.value, cloneExpr(source), declKind, loc)];
       case "wildcardPattern":
       case "restPattern":
         return [];
@@ -603,7 +603,7 @@ function collectChecks(pattern: MatchPattern, source: Expression, checks: Expres
       break;
     default: {
       // Literal — equality check
-      checks.push(makeBinOp(source, "==", pattern as Expression, pattern.loc));
+      checks.push(makeBinOp(cloneExpr(source), "==", pattern as Expression, pattern.loc));
       break;
     }
   }
@@ -617,7 +617,7 @@ function resultCheckCall(
   return {
     type: "functionCall",
     functionName: kind === "success" ? "isSuccess" : "isFailure",
-    arguments: [source],
+    arguments: [cloneExpr(source)],
     loc: loc as SourceLocation,
   };
 }
@@ -728,18 +728,33 @@ function sliceCall(source: Expression, start: number, loc: SourceLocation | unde
   );
 }
 
+/**
+ * Deep-clone an expression before embedding it into generated AST. The pattern
+ * lowering reuses one scrutinee (`__scrutinee_N`) reference across every arm's
+ * condition and binding; embedding the SAME node object in multiple positions
+ * aliases it, and the flow checker keys narrowing on AST-node identity — so a
+ * shared scrutinee node would resolve to whichever branch the flow builder
+ * walked last (e.g. the `success` arm's `.value` narrowing against the `failure`
+ * member). Cloning at each embedding guarantees every occurrence is a distinct
+ * node, preserving the one-node-per-occurrence invariant the flow graph relies on.
+ */
+function cloneExpr<T extends Expression>(e: T): T {
+  return structuredClone(e);
+}
+
 function chainAccess(
   source: Expression,
   chain: AccessChainElement[],
   loc: SourceLocation | undefined,
 ): ValueAccess {
+  const base = cloneExpr(source);
   // If source is already a ValueAccess, append to its chain.
-  if (source.type === "valueAccess") {
-    return { ...source, chain: [...source.chain, ...chain] };
+  if (base.type === "valueAccess") {
+    return { ...base, chain: [...base.chain, ...chain] };
   }
   return {
     type: "valueAccess",
-    base: source as unknown as ValueAccess["base"],
+    base: base as unknown as ValueAccess["base"],
     chain,
     loc: loc as SourceLocation,
   };
@@ -769,7 +784,7 @@ function makeObjectRestCall(
   return {
     type: "functionCall",
     functionName: "__objectRest",
-    arguments: [source, keysArray],
+    arguments: [cloneExpr(source), keysArray],
     loc: loc as SourceLocation,
   };
 }

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -411,6 +411,28 @@ node main() {
 }`);
     expect(errs.some((e) => /not assignable/.test(e))).toBe(true);
   });
+
+  it("a clean match over a Result produces NO spurious error (node-identity regression)", () => {
+    // REGRESSION: pattern lowering reused ONE `__scrutinee` node object across
+    // every arm's isSuccess/isFailure guard and .value/.error binding. The flow
+    // graph keys narrowing on AST-node identity, so all occurrences collapsed to
+    // whichever branch the flow builder walked last (the failure arm) — and the
+    // success arm's `.value` was then checked against the failure member, raising
+    // a spurious "Property 'value' does not exist on '{ success: false, … }'".
+    // Each occurrence must be a distinct node (cloned at embedding in
+    // patternLowering). The existing arm tests above assert a specific error
+    // *exists* (binder inference, via the separate child-scope path); they never
+    // asserted the ABSENCE of the spurious flow-check error — this does.
+    const errs = check(`${TRY_PARSE}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+    failure(e) => e
+  }
+}`);
+    expect(errs).toEqual([]);
+  });
 });
 
 describe("Result narrowing — combinators", () => {


### PR DESCRIPTION
## What

Fixes the spurious type error on `match` over a `Result` that I flagged during the enforced-Result-safety work (PR #366):

```agency
match (r) {           // r: Result<number, string>
  success(v) => v
  failure(e) => e
}
```

emitted **`Property 'value' does not exist on type '{ success: false, error: string, … }'`** — i.e. the `success` arm's `.value` was being checked against the *failure* member. It reproduced regardless of `strictMemberAccess` (pre-existing; not introduced by the safety flip).

## Root cause

Pattern lowering (`patternLowering.ts`) builds one `__scrutinee_N` `variableName` node and embeds **that same object** as the base of every arm's guard and binding:

```
const __scrutinee_1 = r
if (isSuccess(__scrutinee_1)) { const v = __scrutinee_1.value; … }   // arg + base = same node
else if (isFailure(__scrutinee_1)) { const e = __scrutinee_1.error; … }  // arg + base = same node
```

All four `__scrutinee_1` references were the **same node identity**. The flow checker keys narrowing on AST-node identity (`flowOf` is a `WeakMap<node, FlowNode>`), so every occurrence collapsed to a single flow position — whichever branch the flow builder walked last (the `failure` arm, narrowed `keep=false`). The `success` arm's `.value` then resolved against the failure member.

This violated the one-node-per-occurrence invariant the flow graph relies on (the same invariant `flowNarrowing.test.ts`'s "keyed on the AST nodes the checker sees" guard protects).

## Fix

Deep-clone the scrutinee expression at each embedding point (`cloneExpr` in `chainAccess`, `resultCheckCall`, the object-rest call, the variable-binding base case, and the literal-equality check). Every occurrence is now a distinct node object. The AST structure is unchanged, so **codegen is byte-identical** (full suite green, no fixture drift).

## Tests

- `narrowing.test.ts`: a clean match-over-Result now type-checks with **zero** errors. The existing match-arm tests only asserted a specific error *exists* (binder inference, which goes through the separate child-scope path and was always correct); they never asserted the *absence* of the spurious flow-check error — that gap is why this hid.
- `patternLowering.test.ts`: a lowering-level invariant test that every `__scrutinee` occurrence is a distinct node object.

Full suite: 6580 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
