### PR TITLE
feat(typechecker): match exhaustiveness for Result + literal unions (B1)

### DIFF
--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -63,6 +63,26 @@ branch a compiler-enforced guarantee rather than a convention.
 - **Escape hatches** (no new syntax): an `if (isSuccess(r))` / `if (isFailure(r))`
   guard, `r catch …`, or `match (r) { … }`.
 
+## Match exhaustiveness
+
+A `match` over a **closed** value type — a `Result`, or a closed literal/value
+union (`"a" | "b"`) — that doesn't cover every case and has no `_` arm is a
+diagnostic, governed by `typechecker.matchExhaustiveness: "silent" | "warn" |
+"error"` (default `"silent"`; see [config](../../../misc/config.md)).
+
+- A shared `decomposeCases(type)` (`typeCases.ts`) enumerates a value type's
+  cases; `checkMatchExhaustiveness` (`matchExhaustiveness.ts`) reports the cases
+  the **un-guarded** arms leave uncovered. Effect sets enumerate via
+  `resolveEffectSet`, not here, so `decomposeCases` returns *open* for them.
+- **Conservative — never a false "missing case":** open types (`string`,
+  `number`, `any`, unions containing `any`, effect sets) are never required;
+  a guarded arm never counts toward coverage; a `_` (or un-guarded bare binder)
+  satisfies any match. **B1 scope:** Result + closed literal/value unions.
+  Object/tagged-union discriminant coverage (`{kind:"a"}`) is **B2** — until then
+  a non-discriminated object union is treated as un-coverable (no diagnostic).
+- The `match(x is …)` form is never checked (its lowered output carries no
+  `matchSource`), by construction.
+
 ## Current model: scope-chain narrowing
 
 Narrowing is produced as pure facts and applied via throwaway child scopes during

--- a/packages/agency-lang/docs/misc/config.md
+++ b/packages/agency-lang/docs/misc/config.md
@@ -68,6 +68,12 @@ This lets you prevent specific built-in functions from being generated in the ou
     Narrow first to access branch-specific members safely: an `if (isSuccess(r))` /
     `if (isFailure(r))` guard, `r catch …`, or `match (r) { … }`. Set to `"silent"`
     to restore the old lenient behavior (such accesses type as `any`).
+  - **`matchExhaustiveness`** (`"silent" | "warn" | "error"`): What to do when a
+    `match` over a closed value type (a `Result`, or a closed literal/value union
+    like `"a" | "b"`) doesn't cover every case and has no `_` arm. Default:
+    `"silent"`. Conservative: open types (`string`/`number`/`any`, effect sets)
+    are never required to be exhaustive; a guarded arm doesn't count toward
+    coverage; a `_` arm always satisfies it.
 
 **Example:**
 ```json

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -208,6 +208,17 @@ export interface AgencyConfig {
      * behavior.
      */
     strictMemberAccess?: "silent" | "warn" | "error";
+    /**
+     * Whether a `match` over a closed value type (a Result, or a closed
+     * literal/value union) that doesn't cover every case and has no `_` arm is
+     * a diagnostic:
+     * - "silent": no diagnostic (default)
+     * - "warn": emit a warning
+     * - "error": emit an error
+     * Conservative: open types (string/number/any, effect sets) are never
+     * required to be exhaustive; only a `_` arm satisfies them.
+     */
+    matchExhaustiveness?: "silent" | "warn" | "error";
   };
 
   /** Enable debugger mode — auto-inserts breakpoints before every step */
@@ -435,6 +446,7 @@ export const AgencyConfigSchema = z
         undefinedFunctions: z.enum(["silent", "warn", "error"]),
         undefinedVariables: z.enum(["silent", "warn", "error"]),
         strictMemberAccess: z.enum(["silent", "warn", "error"]),
+        matchExhaustiveness: z.enum(["silent", "warn", "error"]),
       })
       .partial(),
     debugger: z.boolean(),

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -218,7 +218,7 @@ function checkAssignmentsInScope(info: ScopeInfo, ctx: TypeCheckerContext): void
  * accept method-body nodes when info is the global scope, otherwise
  * those expressions never get checked.
  */
-function isInScope(scopes: WalkScope[], info: ScopeInfo): boolean {
+export function isInScope(scopes: WalkScope[], info: ScopeInfo): boolean {
   if (scopes.length === 0) return true;
   const innermostKey = getScopeKey(scopes[scopes.length - 1]);
   if (innermostKey === info.scopeKey) return true;

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -41,6 +41,7 @@ import {
   checkHandlerBodyInterrupts,
 } from "./interruptAnalysis.js";
 import { checkRaisesDeclarations } from "./raisesDiagnostic.js";
+import { checkMatchExhaustiveness } from "./matchExhaustiveness.js";
 import { checkEffectPayloads } from "./effectPayloadCheck.js";
 import type { SymbolTable } from "../symbolTable.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
@@ -324,6 +325,9 @@ export class TypeChecker {
 
     // 6d. Check interrupt payloads against `effect` declarations.
     checkEffectPayloads(scopes, ctx);
+
+    // 6e. Match exhaustiveness over closed value types (opt-in, default silent).
+    checkMatchExhaustiveness(scopes, ctx);
 
     // 7. Check for undefined function calls (config-controlled severity).
     checkUndefinedFunctions(scopes, ctx);

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -78,15 +78,16 @@ node main() {
   });
 
   it("warn: emitted as a warning, not an error", () => {
-    const parsed = parseAgency(`${TRY}
+    const src = `${TRY}
 node main() {
   let r = tryParse("ok")
   match (r) {
     success(v) => v
   }
-}`);
+}`;
+    const parsed = parseAgency(src);
     if (!parsed.success) throw new Error("parse");
-    const info = buildCompilationUnit(parsed.result, undefined, undefined, "");
+    const info = buildCompilationUnit(parsed.result, undefined, undefined, src);
     const errs = typeCheck(parsed.result, { typechecker: { matchExhaustiveness: "warn" } }, info).errors;
     expect(errs.some((e) => e.severity === "warning" && /not exhaustive/i.test(e.message))).toBe(true);
     expect(errs.some((e) => (e.severity ?? "error") === "error" && /not exhaustive/i.test(e.message))).toBe(false);

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { AgencyConfig } from "../config.js";
+
+function check(source: string, config: Partial<AgencyConfig> = {}): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, config, info).errors.map((e) => e.message);
+}
+
+const TRY = `
+def tryParse(s: string): Result<number, string> {
+  if (s == "ok") { return success(42) }
+  return failure("bad")
+}`;
+const ERROR = { typechecker: { matchExhaustiveness: "error" as const } };
+
+describe("match exhaustiveness — Result", () => {
+  it("error: missing the failure arm is non-exhaustive", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /failure/.test(e))).toBe(true);
+  });
+
+  it("error: both arms → exhaustive, no diagnostic", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+    failure(e) => 0
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error: a `_` catch-all clears it", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+    _ => 0
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error: a guarded failure arm does NOT count toward coverage", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+    failure(e) if (e == "x") => 0
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /failure/.test(e))).toBe(true);
+  });
+
+  it("silent (default): never reported", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+  }
+}`);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("warn: emitted as a warning, not an error", () => {
+    const parsed = parseAgency(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+  }
+}`);
+    if (!parsed.success) throw new Error("parse");
+    const info = buildCompilationUnit(parsed.result, undefined, undefined, "");
+    const errs = typeCheck(parsed.result, { typechecker: { matchExhaustiveness: "warn" } }, info).errors;
+    expect(errs.some((e) => e.severity === "warning" && /not exhaustive/i.test(e.message))).toBe(true);
+    expect(errs.some((e) => (e.severity ?? "error") === "error" && /not exhaustive/i.test(e.message))).toBe(false);
+  });
+});
+
+describe("match exhaustiveness — literal unions", () => {
+  // `describeCase` renders a string literal QUOTED (e.g. `"c"`), so assert the
+  // missing clause names the case precisely — a bare `/c/` would match many words.
+  it("error: missing a literal arm names the missing case", () => {
+    const errs = check(`
+def f(x: "a" | "b" | "c"): number {
+  match (x) {
+    "a" => 1
+    "b" => 2
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /missing\b.*"c"/.test(e))).toBe(true);
+  });
+
+  it("error: all literals covered → exhaustive", () => {
+    const errs = check(`
+def f(x: "a" | "b"): number {
+  match (x) {
+    "a" => 1
+    "b" => 2
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error: a `_` catch-all on a literal union clears it", () => {
+    const errs = check(`
+def f(x: "a" | "b"): number {
+  match (x) {
+    "a" => 1
+    _ => 0
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error: numeric literal union — missing case named", () => {
+    const errs = check(`
+def f(x: 1 | 2): number {
+  match (x) {
+    1 => 10
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /missing\b.*2/.test(e))).toBe(true);
+  });
+
+  it("error: a guarded literal arm does NOT count toward coverage", () => {
+    const errs = check(`
+def f(x: "a" | "b", cond: boolean): number {
+  match (x) {
+    "a" => 1
+    "b" if (cond) => 2
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /missing\b.*"b"/.test(e))).toBe(true);
+  });
+
+  it("escaped-string literal: pin armLiteral vs literalCase agreement", () => {
+    const errs = check(`
+def f(x: "a\\nb" | "c"): number {
+  match (x) {
+    "a\\nb" => 1
+    "c" => 2
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("type-alias scrutinee: resolves through getTypeAliases → safeResolveType", () => {
+    const errs = check(`
+type Status = "a" | "b"
+def f(s: Status): number {
+  match (s) {
+    "a" => 1
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /missing\b.*"b"/.test(e))).toBe(true);
+  });
+});
+
+describe("match exhaustiveness — open / unsupported (no false positives)", () => {
+  it("error config: match over a plain string is never reported (open)", () => {
+    const errs = check(`
+def f(x: string): number {
+  match (x) {
+    "a" => 1
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error config: match over a non-discriminated object union is not reported (B2 territory)", () => {
+    const errs = check(`
+type U = { a: string } | { b: number }
+def f(u: U): number {
+  match (u) {
+    { a } => 1
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error config: match over a plain boolean is open (not enumerated as true|false)", () => {
+    const errs = check(`
+def f(x: boolean): number {
+  match (x) {
+    true => 1
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+});
+
+describe("match exhaustiveness — coverage edge cases & structural", () => {
+  it("error: a bare-variable arm is a catch-all (exercises isCatchAll variableName branch)", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+    other => 0
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("error: a guarded success arm does NOT count (symmetric to guarded failure)", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) if (v > 0) => v
+    failure(e) => 0
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /success/.test(e))).toBe(true);
+  });
+
+  it("error: a match inside a def body is checked (function-scope coverage)", () => {
+    const errs = check(`${TRY}
+def use(): number {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+  }
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(true);
+  });
+
+  it("error: a match nested in an if body is visited (walkNodes recursion)", () => {
+    // match isn't an expression, so nest it in control flow rather than an arm.
+    const errs = check(`
+def f(x: "a" | "b"): number {
+  if (true) {
+    match (x) { "a" => 1 }
+  }
+  return 0
+}`, ERROR);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /missing\b.*"b"/.test(e))).toBe(true);
+  });
+
+  it("error: per-site — one exhaustive match + one not, only the latter reported", () => {
+    const errs = check(`
+def f(x: "a" | "b", y: "p" | "q"): number {
+  match (x) { "a" => 1
+ "b" => 2 }
+  match (y) { "p" => 1 }
+  return 0
+}`, ERROR);
+    const reported = errs.filter((e) => /not exhaustive/i.test(e));
+    expect(reported.length).toBe(1);
+    expect(reported[0]).toMatch(/missing\b.*"q"/);
+  });
+
+  it("behavior-preserving: silent default adds zero errors vs. the no-knob baseline", () => {
+    const src = `${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+  }
+}`;
+    const run = (config: Partial<AgencyConfig>) => {
+      const p = parseAgency(src);
+      if (!p.success) throw new Error("parse");
+      const info = buildCompilationUnit(p.result, undefined, undefined, src);
+      return typeCheck(p.result, config, info).errors.length;
+    };
+    expect(run({})).toBe(run({ typechecker: { matchExhaustiveness: "silent" } }));
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -1,0 +1,161 @@
+import type { AgencyNode, Expression, VariableType } from "../types.js";
+import type { MatchArmMeta, MatchBlockCase } from "../types/matchBlock.js";
+import type { SourceLocation } from "../types/base.js";
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import type { Scope } from "./scope.js";
+import { walkNodes } from "../utils/node.js";
+import { isInScope } from "./checker.js";
+import { synthType } from "./synthesizer.js";
+import { decomposeCases, type TypeCase, type CaseSet } from "./typeCases.js";
+
+type Severity = "silent" | "warn" | "error";
+type CaseValue = MatchArmMeta["caseValue"]; // MatchPattern | "_"
+type NormalizedArm = { caseValue: CaseValue; guarded: boolean };
+type MatchSite = {
+  scrutineeType: VariableType | "any";
+  arms: NormalizedArm[];
+  loc: SourceLocation | undefined;
+};
+
+/** A literal match arm's static value, or null if the arm isn't a static literal. */
+function armLiteral(cv: CaseValue): string | number | boolean | null {
+  if (cv === "_") return null;
+  if (cv.type === "number") return Number(cv.value);
+  if (cv.type === "boolean") return cv.value;
+  if (cv.type === "string") {
+    const segs = cv.segments;
+    if (segs.length === 1 && segs[0].type === "text") return segs[0].value;
+    return null; // interpolated → not a static literal case
+  }
+  return null;
+}
+
+/** True for a catch-all arm: the `_` default, or an un-guarded bare binding. */
+function isCatchAll(arm: NormalizedArm): boolean {
+  if (arm.guarded) return false;
+  if (arm.caseValue === "_") return true;
+  // A bare variable/binding pattern matches anything.
+  // Deliberately conservative: an empty `objectPattern` or a rest binding could
+  // also match everything, but we DON'T treat those as catch-alls here — missing
+  // them only suppresses the catch-all shortcut (→ at worst a missed "exhaustive"
+  // when one isn't required), never a false "missing case".
+  return arm.caseValue.type === "variableName";
+}
+
+/** Cases the un-guarded arms cover (B1: result patterns + literals). */
+function coveredCases(arms: NormalizedArm[]): TypeCase[] {
+  const covered: TypeCase[] = [];
+  for (const arm of arms) {
+    if (arm.guarded || arm.caseValue === "_") continue;
+    const cv = arm.caseValue;
+    if (cv.type === "resultPattern") {
+      covered.push({ kind: cv.kind === "success" ? "resultSuccess" : "resultFailure" });
+      continue;
+    }
+    const lit = armLiteral(cv);
+    if (lit !== null) covered.push({ kind: "literal", value: lit });
+  }
+  return covered;
+}
+
+function caseKey(c: TypeCase): string {
+  return c.kind === "literal" ? `literal:${typeof c.value}:${String(c.value)}` : c.kind;
+}
+
+function describeCase(c: TypeCase): string {
+  switch (c.kind) {
+    case "resultSuccess":
+      return "`success`";
+    case "resultFailure":
+      return "`failure`";
+    case "member":
+      return "an object case";
+    case "literal":
+      return typeof c.value === "string" ? `"${c.value}"` : String(c.value);
+  }
+}
+
+/**
+ * The cases a closed-type match leaves uncovered, or [] when no requirement
+ * applies: an open type, a union with any `member` case (B2 territory — no
+ * covering-arm rule yet), or a catch-all arm all yield [].
+ */
+function missingCases(arms: NormalizedArm[], caseSet: CaseSet): TypeCase[] {
+  if (!caseSet.closed) return [];
+  if (caseSet.cases.some((c) => c.kind === "member")) return [];
+  if (arms.some(isCatchAll)) return [];
+  const covered = new Set(coveredCases(arms).map(caseKey));
+  return caseSet.cases.filter((c) => !covered.has(caseKey(c)));
+}
+
+function checkSite(site: MatchSite, severity: Severity, ctx: TypeCheckerContext): void {
+  const caseSet = decomposeCases(site.scrutineeType, ctx.getTypeAliases());
+  const missing = missingCases(site.arms, caseSet);
+  if (missing.length === 0) {
+    return;
+  }
+  ctx.errors.push({
+    message: `match is not exhaustive: missing ${missing.map(describeCase).join(", ")}.`,
+    severity: severity === "warn" ? "warning" : "error",
+    loc: site.loc,
+  });
+}
+
+/** Normalize the two surviving match shapes to `(scrutineeType, arms)`. */
+function normalizeSite(
+  node: AgencyNode,
+  scope: Scope,
+  ctx: TypeCheckerContext,
+): MatchSite | null {
+  // Pattern-arm match: lowered to a `__scrutinee` temp carrying `matchSource`.
+  if (node.type === "assignment" && node.matchSource) {
+    // Synth the original scrutinee expression, NOT the temp's declared type:
+    // the temp's inference widens a literal union (`"a" | "b"` → `string`),
+    // which would make decomposeCases see an open type. `node.value` is the
+    // lowered scrutinee, so its synthesized type preserves the literal union.
+    const scrutineeType = synthType(node.value as Expression, scope, ctx);
+    const arms = node.matchSource.map((a) => ({
+      caseValue: a.caseValue,
+      guarded: a.guard !== undefined,
+    }));
+    return { scrutineeType, arms, loc: node.loc };
+  }
+  // Literal/identifier passthrough: a surviving `matchBlock` node.
+  if (node.type === "matchBlock") {
+    const scrutineeType = synthType(node.expression as Expression, scope, ctx);
+    const arms = node.cases
+      .filter((c): c is MatchBlockCase => c.type === "matchBlockCase")
+      .map((c) => ({ caseValue: c.caseValue, guarded: c.guard !== undefined }));
+    return { scrutineeType, arms, loc: node.loc };
+  }
+  return null;
+}
+
+/**
+ * Diagnostic: a `match` over a closed value type (Result or a closed
+ * literal/value union) that doesn't cover every case and has no `_` arm.
+ * Opt-in via `typechecker.matchExhaustiveness` (default `silent`). Conservative:
+ * open types and non-discriminated object unions are never reported (B1).
+ */
+export function checkMatchExhaustiveness(
+  scopes: ScopeInfo[],
+  ctx: TypeCheckerContext,
+): void {
+  const severity = (ctx.config.typechecker?.matchExhaustiveness ?? "silent") as Severity;
+  if (severity === "silent") {
+    return;
+  }
+  for (const info of scopes) {
+    ctx.withScope(info.scopeKey, () => {
+      for (const { node, scopes: nodeScopes } of walkNodes(info.body)) {
+        if (!isInScope(nodeScopes, info)) {
+          continue;
+        }
+        const site = normalizeSite(node, info.scope, ctx);
+        if (site) {
+          checkSite(site, severity, ctx);
+        }
+      }
+    });
+  }
+}

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -71,7 +71,10 @@ function describeCase(c: TypeCase): string {
     case "member":
       return "an object case";
     case "literal":
-      return typeof c.value === "string" ? `"${c.value}"` : String(c.value);
+      // JSON-encode so a string value renders quoted-and-escaped (a newline/quote
+      // can't make the diagnostic multi-line or ambiguous); numbers/booleans print
+      // bare (JSON.stringify(2) → "2", JSON.stringify(true) → "true").
+      return JSON.stringify(c.value);
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/typeCases.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { decomposeCases } from "./typeCases.js";
+import { STRING_T, NUMBER_T } from "./primitives.js";
+import type { VariableType } from "../types.js";
+import type { TypeAliasEntry } from "../types/typeHints.js";
+
+const RESULT: VariableType = {
+  type: "resultType",
+  successType: NUMBER_T,
+  failureType: STRING_T,
+};
+const lit = (value: string): VariableType => ({ type: "stringLiteralType", value });
+const numLit = (value: string): VariableType => ({ type: "numberLiteralType", value });
+const boolLit = (value: "true" | "false"): VariableType => ({ type: "booleanLiteralType", value });
+const union = (...types: VariableType[]): VariableType => ({ type: "unionType", types });
+
+describe("decomposeCases", () => {
+  it("Result → resultSuccess + resultFailure, closed", () => {
+    const r = decomposeCases(RESULT, {});
+    expect(r.closed).toBe(true);
+    expect(r.cases.map((c) => c.kind).sort()).toEqual(["resultFailure", "resultSuccess"]);
+  });
+
+  it("literal union '\"a\" | \"b\"' → two literal cases, closed", () => {
+    const r = decomposeCases(union(lit("a"), lit("b")), {});
+    expect(r.closed).toBe(true);
+    expect(r.cases).toEqual([
+      { kind: "literal", value: "a" },
+      { kind: "literal", value: "b" },
+    ]);
+  });
+
+  it("string → open (no cases)", () => {
+    expect(decomposeCases(STRING_T, {})).toEqual({ cases: [], closed: false });
+  });
+
+  it("any → open", () => {
+    expect(decomposeCases("any", {})).toEqual({ cases: [], closed: false });
+  });
+
+  it("union containing any → open", () => {
+    expect(decomposeCases(union(lit("a"), { type: "primitiveType", value: "any" }), {}).closed).toBe(false);
+  });
+
+  it("object union → member cases, closed (coverage is B2; enumeration is here)", () => {
+    const obj = (k: string): VariableType => ({
+      type: "objectType",
+      properties: [{ key: "kind", value: lit(k) }],
+    });
+    const r = decomposeCases(union(obj("a"), obj("b")), {});
+    expect(r.closed).toBe(true);
+    expect(r.cases.every((c) => c.kind === "member")).toBe(true);
+  });
+
+  it("effect-set union → open (owned by resolveEffectSet, never enumerated here)", () => {
+    const eff: VariableType = { type: "unionType", types: [lit("Timeout"), lit("Cancelled")], isEffectSet: true };
+    expect(decomposeCases(eff, {})).toEqual({ cases: [], closed: false });
+  });
+
+  it("number-literal union → two literal cases, closed", () => {
+    const r = decomposeCases(union(numLit("1"), numLit("2")), {});
+    expect(r.closed).toBe(true);
+    expect(r.cases).toEqual([
+      { kind: "literal", value: 1 },
+      { kind: "literal", value: 2 },
+    ]);
+  });
+
+  it("boolean-literal union → two literal cases, closed", () => {
+    const r = decomposeCases(union(boolLit("true"), boolLit("false")), {});
+    expect(r.closed).toBe(true);
+    expect(r.cases).toEqual([
+      { kind: "literal", value: true },
+      { kind: "literal", value: false },
+    ]);
+  });
+
+  it("type alias to a literal union resolves through safeResolveType", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      Status: { body: union(lit("a"), lit("b")) },
+    };
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "Status" };
+    const r = decomposeCases(ref, aliases);
+    expect(r.closed).toBe(true);
+    expect(r.cases).toEqual([
+      { kind: "literal", value: "a" },
+      { kind: "literal", value: "b" },
+    ]);
+  });
+
+  it("mixed literal + member union → [literal, member], closed (contract)", () => {
+    const obj: VariableType = { type: "objectType", properties: [{ key: "kind", value: lit("b") }] };
+    const r = decomposeCases(union(lit("a"), obj), {});
+    expect(r.closed).toBe(true);
+    expect(r.cases.map((c) => c.kind)).toEqual(["literal", "member"]);
+  });
+
+  it("non-union objectType → open (default fall-through)", () => {
+    const obj: VariableType = { type: "objectType", properties: [{ key: "a", value: STRING_T }] };
+    expect(decomposeCases(obj, {})).toEqual({ cases: [], closed: false });
+  });
+
+  it("boolean primitive → open (NOT enumerated as true|false)", () => {
+    expect(decomposeCases({ type: "primitiveType", value: "boolean" }, {})).toEqual({ cases: [], closed: false });
+  });
+
+  it("generic/parameterized type → open (conservative)", () => {
+    const g: VariableType = { type: "genericType", name: "Box", typeArgs: [STRING_T] };
+    expect(decomposeCases(g, {})).toEqual({ cases: [], closed: false });
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/typeCases.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.ts
@@ -1,5 +1,6 @@
 import type { VariableType, TypeAliasEntry } from "../types.js";
 import { safeResolveType } from "./assignability.js";
+import { unescapeStringLiteralValue } from "../parsers/parsers.js";
 
 export type TypeCase =
   | { kind: "resultSuccess" }
@@ -12,7 +13,10 @@ export type CaseSet = { cases: TypeCase[]; closed: boolean };
 const OPEN: CaseSet = { cases: [], closed: false };
 
 function literalCase(t: VariableType): TypeCase | null {
-  if (t.type === "stringLiteralType") return { kind: "literal", value: t.value };
+  // Unescape so a string-literal TYPE value (stored escaped, e.g. `a\nb`) keys
+  // identically to a match arm's text value (already unescaped, a real newline)
+  // — see matchExhaustiveness.armLiteral.
+  if (t.type === "stringLiteralType") return { kind: "literal", value: unescapeStringLiteralValue(t.value) };
   if (t.type === "numberLiteralType") return { kind: "literal", value: Number(t.value) };
   if (t.type === "booleanLiteralType") return { kind: "literal", value: t.value === "true" };
   return null;

--- a/packages/agency-lang/lib/typeChecker/typeCases.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.ts
@@ -1,0 +1,66 @@
+import type { VariableType, TypeAliasEntry } from "../types.js";
+import { safeResolveType } from "./assignability.js";
+
+export type TypeCase =
+  | { kind: "resultSuccess" }
+  | { kind: "resultFailure" }
+  | { kind: "member"; type: VariableType }
+  | { kind: "literal"; value: string | number | boolean };
+
+export type CaseSet = { cases: TypeCase[]; closed: boolean };
+
+const OPEN: CaseSet = { cases: [], closed: false };
+
+function literalCase(t: VariableType): TypeCase | null {
+  if (t.type === "stringLiteralType") return { kind: "literal", value: t.value };
+  if (t.type === "numberLiteralType") return { kind: "literal", value: Number(t.value) };
+  if (t.type === "booleanLiteralType") return { kind: "literal", value: t.value === "true" };
+  return null;
+}
+
+/**
+ * Enumerate the cases of a value type for exhaustiveness / future narrowing.
+ * `closed: false` means the type is open (string/number/any, a union containing
+ * `any`, an effect set, or any unrecognized shape) — exhaustiveness can only be
+ * satisfied by a `_` arm, never required. Effect sets are deliberately open here:
+ * their enumeration belongs to `resolveEffectSet` (handler-narrowing spec).
+ */
+export function decomposeCases(
+  type: VariableType | "any",
+  aliases: Record<string, TypeAliasEntry>,
+): CaseSet {
+  if (type === "any") return OPEN;
+  // safeResolveType yields ANY_T (a primitiveType "any"), never the string
+  // "any"; an unresolved/any type falls through to the default OPEN below.
+  const resolved = safeResolveType(type, aliases);
+
+  if (resolved.type === "resultType") {
+    // B1: the two Result branches as bespoke cases (the spec sanctions this; B2
+    // can route through resultToObjectUnion when member-coverage lands — not
+    // imported here to avoid a dead import).
+    return { cases: [{ kind: "resultSuccess" }, { kind: "resultFailure" }], closed: true };
+  }
+
+  if (resolved.type === "unionType") {
+    if (resolved.isEffectSet) return OPEN; // owned by resolveEffectSet, never re-walked
+    const cases: TypeCase[] = [];
+    for (const member of resolved.types) {
+      const rm = safeResolveType(member, aliases);
+      if (rm.type === "primitiveType" && rm.value === "any") {
+        return OPEN; // a union with an open member can't be required to be exhaustive
+      }
+      // A nested unionType member is deliberately pushed as a single `member`
+      // case (not flattened): checkSite then skips the whole match (member ⇒ no
+      // diagnostic), which is sound. Don't "fix" this by recursing without
+      // re-checking the coverage implications.
+      const litC = literalCase(rm);
+      cases.push(litC ?? { kind: "member", type: rm });
+    }
+    return { cases, closed: true };
+  }
+
+  // primitives (string/number/boolean/…), objectType, generics, etc. → open.
+  // NOTE: `boolean` is open here — it is NOT enumerated as `true | false`. Only
+  // a literal union (`true | false` written explicitly) decomposes to literals.
+  return OPEN;
+}


### PR DESCRIPTION
## Match exhaustiveness (B1)

A compile-time diagnostic that flags a `match` over a **closed** value type — a `Result`, or a closed literal/value union (`"a" | "b"`) — when it doesn't cover every case and has no `_` arm. Opt-in via `typechecker.matchExhaustiveness` (default `"silent"`), conservative by construction (never a false "missing case").

```agency
match (r) {            // r: Result<number, string>
  success(v) => v
}                      // matchExhaustiveness:"error" → "match is not exhaustive: missing `failure`."

match (x) {            // x: "a" | "b" | "c"
  "a" => 1
  "b" => 2
}                      // → "match is not exhaustive: missing \"c\"."
```

(Part A — the `matchSource` metadata this builds on — already merged. This is B1.)

### What changed

- **`decomposeCases`** (`typeCases.ts`) — enumerates a value type's cases: Result → success/failure; closed literal union → literal cases; object union → `member` cases; **open** for `string`/`number`/`any`, unions-with-`any`, and **effect sets** (owned by `resolveEffectSet`, never re-walked — no third enumerator).
- **`checkMatchExhaustiveness`** (`matchExhaustiveness.ts`) — normalizes the two surviving match shapes (the literal `matchBlock` node and the lowered scrutinee `assignment` carrying `matchSource`) to `(scrutineeType, arms)`, and reports the cases the **un-guarded** arms leave uncovered. Registered after `checkScopes`.
- **Config knob** `matchExhaustiveness: "silent" | "warn" | "error"` (default `silent`), mirroring `strictMemberAccess`.

### Conservative by construction (no false positives)

- Open types and effect sets → never required.
- A guarded arm never counts toward coverage; a `_` (or un-guarded bare binder) satisfies any match.
- A non-discriminated object union decomposes to `member` cases with no B1 covering rule → treated as un-coverable → **no diagnostic** (object/tagged-union discriminant coverage is **B2**).
- The `match(x is …)` form is never checked (its lowered output carries no `matchSource`), by construction.

### Two subtleties the tests pinned

- The `matchSource` scrutinee type is synth-ed from the **original scrutinee expression**, not the lowered temp's declared type — the temp's inference *widens* a literal union (`"a" | "b"` → `string`), which would otherwise hide the diagnostic.
- String-literal **type** values are stored escaped (`a\nb`) while match-arm text is unescaped (a real newline); `literalCase` unescapes so the two key identically.

### Tests

`typeCases.test.ts` (14) covers every `decomposeCases` branch — Result, string/number/boolean literal unions, alias resolution via `safeResolveType`, mixed literal+member, object union, effect-set/string/boolean/generic → open. `matchExhaustiveness.test.ts` (22) covers both match shapes, silent/warn/error routing, all the conservative cases (open, non-discriminated object, boolean-primitive, guarded arms, bare-variable catch-all, `_`), escaped strings, type-alias scrutinees, def-body + nested + multi-site walking, and a behavior-preserving check (silent == no-knob baseline). Full suite green at the `silent` default (6616 passing).

### Follow-ups (B2)

Object/tagged-union discriminant coverage (`{kind:"a"}` → member), and the data-gated `warn → error` default flip after a stdlib/fixture sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
