### PR TITLE
feat(typechecker): narrow single-hop member-path scrutinees

### DIFF
--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -28,14 +28,16 @@ flow-typed checker work and the four narrowing specs at the repo root.
 |---|---|---|
 | `isSuccess(r)` / `isFailure(r)` on a bare variable | ✅ | then- and else-branch; `r.value` / `r.error` type precisely |
 | `r.prop == literal` / `!= literal` on a bare variable | ✅ | discriminated-union member filter (either operand order; string/number/boolean literals) |
+| Same guards on a **single-hop member-path** scrutinee (`b.r`, `e.payload`) | ✅ | M1 — `isSuccess(b.r)`, `b.r.kind == "x"`, `b.r != null` narrow the path; `b.r.value` then types precisely. One hop only (`base.prop`); see the nested-access row for multi-hop |
 | `match` arm **bound fields** | ✅ | free via lowering to a `__s` temp — no match-specific code |
 | `!c`, `a && b`, `a || b` combinators | ✅ | `!` swaps then/else; `&&` unions then-facts; `\|\|` unions else-facts |
 | Post-guard / early-return (`if (isFailure(r)) { return }` ⇒ `r` is Success after) | ✅ | `alwaysExits` counts only `return` (conservative) |
-| Nested-access scrutinee (`a.b.c`, `obj.field`) | ❌ | single-hop **bare variable** only |
+| Single-hop member-path scrutinee (`obj.field`) | ✅ | M1 — see the member-path row above |
+| Multi-hop / index nested scrutinee (`a.b.c`, `arr[0]`) | ❌ | M2 follow-on — `Reference.chain` only encodes one property hop today (`asPathReference`'s one-hop ceiling); index segments aren't yet representable |
 | The scrutinee *variable* in a `match` arm (vs a bound field) | ❌ | only bound fields narrow; the source var isn't re-typed |
 | Mixed union with a non-literal discriminant member | ❌ | by design — the `string` member can't be proven disjoint |
 | Narrowing to `never` (dead-branch detection) | ❌ | suppressed today; **planned** with the flow model + `never` |
-| `null` / truthiness (`if (x != null)`, `if (x == null)`, `if (x)`) | ✅ | strips/keeps the `null` member of a `T \| null` optional; bare-variable scrutinee only. `x != null` / `x == null` are exact and narrow **both** branches. Bare `if (x)` narrows **only the then-branch** to non-null: the runtime uses JS truthiness, so a falsy `x` may be `""`/`0`/`false` (not just `null`), so the else-branch (and the post-`while` region) is left unnarrowed — narrowing it to `null` would be unsound. `if (x)` is accepted as a condition for optionals (an opt-in carve-out from the boolean-only condition rule — see `checkConditionType`). |
+| `null` / truthiness (`if (x != null)`, `if (x == null)`, `if (x)`) | ✅ | strips/keeps the `null` member of a `T \| null` optional; bare variable or single-hop member-path scrutinee (`c.timeout`). `x != null` / `x == null` are exact and narrow **both** branches. Bare `if (x)` narrows **only the then-branch** to non-null: the runtime uses JS truthiness, so a falsy `x` may be `""`/`0`/`false` (not just `null`), so the else-branch (and the post-`while` region) is left unnarrowed — narrowing it to `null` would be unsound. `if (x)` is accepted as a condition for optionals (an opt-in carve-out from the boolean-only condition rule — see `checkConditionType`). |
 | `typeof` / value-kind split of plain unions (`number \| string`) | ❌ | **planned fast-follow** — needs surface syntax |
 | User-defined type guards (`def isFoo(x): x is Foo`) | ❌ | **planned fast-follow** — needs `x is T` syntax |
 | Aliased condition (`const ok = isSuccess(r); if (ok) …`) | ❌ | **planned** — no new syntax, smarter `analyzeCondition` |
@@ -157,6 +159,24 @@ scan skips narrowing any variable the branch (or the post-guard tail) reassigns,
 since its type could change. The `narrowedBranch` marker on `ResultType` is set only
 by this layer and is stripped by `widenType`, so it never leaks through `declare()`
 into a function's inferred return type.
+
+**Member-path prefix invalidation (M1).** A narrowing of `box.r` is keyed on the
+whole path. Reassigning the path *or any prefix of it* drops the narrowing: after
+`box = …` (or `box.r = …`), `box.r` re-resolves from the reassigned base, not the
+stale narrowed flow. `typeAt`'s `assign` case detects this via `isPrefixOf(at.ref,
+ref)` and re-resolves through `resolvePath`; the `loop` back-edge case does the same
+when the body widened the base var. A *sibling* assignment (`box.q = …`) is **not** a
+prefix, so it correctly leaves `box.r` narrowed. `flowHasNarrowFor` — the gate
+`synthValueAccess` uses before short-circuiting a path read through `typeAt` — applies
+the same prefix rule, so an un-guarded (or re-bound) `box.r.value` still hits the
+structural walk's strict-member-access diagnostic.
+
+Strict member access is itself flow-sensitive, so `strictMemberAccessSeverity`
+returns `silent` whenever `ctx.flowEnv` is unset — i.e. during the pre-flow inference
+passes (return-type inference; scope-building, where an untyped `let v = b.r.value`
+synthesizes its RHS to declare `v`). Emitting there would be a false positive on
+narrowed access; the flow-aware `checkScopes` pass re-synthesizes every value access
+and is the single source of the diagnostic.
 
 Un-narrowed `Result` field access still synthesizes to `any` (the legacy escape
 hatch in `synthValueAccess`); tightening that into a hard error is a later increment

--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -32,7 +32,6 @@ flow-typed checker work and the four narrowing specs at the repo root.
 | `match` arm **bound fields** | ✅ | free via lowering to a `__s` temp — no match-specific code |
 | `!c`, `a && b`, `a || b` combinators | ✅ | `!` swaps then/else; `&&` unions then-facts; `\|\|` unions else-facts |
 | Post-guard / early-return (`if (isFailure(r)) { return }` ⇒ `r` is Success after) | ✅ | `alwaysExits` counts only `return` (conservative) |
-| Single-hop member-path scrutinee (`obj.field`) | ✅ | M1 — see the member-path row above |
 | Multi-hop / index nested scrutinee (`a.b.c`, `arr[0]`) | ❌ | M2 follow-on — `Reference.chain` only encodes one property hop today (`asPathReference`'s one-hop ceiling); index segments aren't yet representable |
 | The scrutinee *variable* in a `match` arm (vs a bound field) | ❌ | only bound fields narrow; the source var isn't re-typed |
 | Mixed union with a non-literal discriminant member | ❌ | by design — the `string` member can't be proven disjoint |

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -7,6 +7,8 @@ import {
   wrapFacts,
   mergeFlows,
   widenAtLoopBackEdge,
+  flowHasNarrowFor,
+  isPrefixOf,
   type FlowNode,
   type FlowEnvironment,
 } from "./flow.js";
@@ -208,7 +210,7 @@ describe("wrapFacts", () => {
     const start: FlowNode = { kind: "start", scope };
     const wrapped = wrapFacts(start, [
       {
-        variableName: "u",
+        ref: { variable: "u", chain: [] },
         refine: {
           kind: "discriminant",
           prop: "kind",
@@ -262,5 +264,195 @@ describe("widenAtLoopBackEdge", () => {
     const loopEntry: FlowNode = { kind: "start", scope };
     const widened = widenAtLoopBackEdge(loopEntry, loopEntry, ["x"], env(scope));
     expect(typeAt(ref("x"), widened, env(scope))).toEqual(STR);
+  });
+});
+
+// ── Property paths (M1) ─────────────────────────────────────────────────────
+const RESULT: VariableType = { type: "resultType", successType: NUM, failureType: STR };
+// box : { r: Result<number, string> }
+const boxType: VariableType = { type: "objectType", properties: [{ key: "r", value: RESULT }] };
+const pathRef = (variable: string, ...chain: string[]) => ({ variable, chain });
+const successRefine = {
+  kind: "discriminant" as const,
+  prop: "success",
+  literal: { type: "booleanLiteralType" as const, value: "true" as const },
+  keep: true,
+};
+const boxScope = () => {
+  const s = new Scope("p");
+  s.declare("box", boxType);
+  return s;
+};
+
+describe("typeAt — property paths (M1)", () => {
+  it("start: plain one-hop resolves to the property type (no narrowing)", () => {
+    const s = boxScope();
+    expect(typeAt(pathRef("box", "r"), { kind: "start", scope: s }, env(s))).toEqual(RESULT);
+  });
+
+  it("start: missing property → any", () => {
+    const s = boxScope();
+    expect(typeAt(pathRef("box", "bogus"), { kind: "start", scope: s }, env(s))).toBe("any");
+  });
+
+  it("start: non-object base → any (no primitive-member lookup)", () => {
+    const s = new Scope("p");
+    s.declare("str", STR);
+    expect(typeAt(pathRef("str", "length"), { kind: "start", scope: s }, env(s))).toBe("any");
+  });
+
+  it("start: Record<K,V> base → V", () => {
+    const s = new Scope("p");
+    s.declare("m", { type: "genericType", name: "Record", typeArgs: [STR, NUM] });
+    expect(typeAt(pathRef("m", "anyKey"), { kind: "start", scope: s }, env(s))).toEqual(NUM);
+  });
+
+  it("start: resolves through a type alias per hop", () => {
+    const s = new Scope("p");
+    s.declare("box", { type: "typeAliasVariable", aliasName: "Box" });
+    const e: FlowEnvironment = {
+      scope: s,
+      flowOf: new WeakMap(),
+      memo: new WeakMap(),
+      typeAliases: { Box: { body: boxType } },
+    };
+    expect(typeAt(pathRef("box", "r"), { kind: "start", scope: s }, e)).toEqual(RESULT);
+  });
+
+  it("narrow: applies the refine to the one-hop path (structural assertion)", () => {
+    const s = boxScope();
+    const narrow: FlowNode = {
+      kind: "narrow",
+      prev: { kind: "start", scope: s },
+      ref: pathRef("box", "r"),
+      refine: successRefine,
+    };
+    const t = typeAt(pathRef("box", "r"), narrow, env(s));
+    expect(typeof t === "object" && t.type).toBe("objectType");
+    const succ = (t as { properties: { key: string; value: VariableType }[] }).properties.find((p) => p.key === "success");
+    expect(succ?.value).toEqual({ type: "booleanLiteralType", value: "true" });
+  });
+
+  it("join: unites a narrowed-path predecessor with an un-narrowed one", () => {
+    const s = boxScope();
+    const start: FlowNode = { kind: "start", scope: s };
+    const narrowed: FlowNode = { kind: "narrow", prev: start, ref: pathRef("box", "r"), refine: successRefine };
+    const join: FlowNode = { kind: "join", prev: [narrowed, start] };
+    const t = typeAt(pathRef("box", "r"), join, env(s));
+    expect(typeof t === "object" && t.type).toBe("unionType");
+  });
+});
+
+describe("typeAt — path prefix invalidation (M1)", () => {
+  const narrowedBoxR = (s: Scope): FlowNode => ({
+    kind: "narrow",
+    prev: { kind: "start", scope: s },
+    ref: pathRef("box", "r"),
+    refine: successRefine,
+  });
+
+  it("reassigning the base var (box) drops the box.r narrowing → un-narrowed Result", () => {
+    const s = boxScope();
+    const reassigned: FlowNode = { kind: "assign", prev: narrowedBoxR(s), ref: pathRef("box"), type: boxType };
+    const after = typeAt(pathRef("box", "r"), reassigned, env(s));
+    // Pin to the SPECIFIC type: after reassigning box, box.r is the un-narrowed
+    // Result (a resultType), not the success object member. A regression to "any"
+    // would slip past a mere `!== before` check.
+    expect(typeof after === "object" && after.type).toBe("resultType");
+  });
+
+  it("reassigning the path itself (box.r) drops its narrowing (exact-key branch)", () => {
+    const s = boxScope();
+    const reassigned: FlowNode = { kind: "assign", prev: narrowedBoxR(s), ref: pathRef("box", "r"), type: RESULT };
+    expect(typeAt(pathRef("box", "r"), reassigned, env(s))).toEqual(RESULT);
+  });
+
+  it("sibling assignment (box.q) leaves box.r narrowed (the foot-gun)", () => {
+    const s = boxScope();
+    const assignSibling: FlowNode = { kind: "assign", prev: narrowedBoxR(s), ref: pathRef("box", "q"), type: NUM };
+    const t = typeAt(pathRef("box", "r"), assignSibling, env(s));
+    expect(typeof t === "object" && t.type).toBe("objectType");
+  });
+
+  it("disjoint variable assignment (other) leaves box.r narrowed", () => {
+    const s = boxScope();
+    s.declare("other", NUM);
+    const assignOther: FlowNode = { kind: "assign", prev: narrowedBoxR(s), ref: pathRef("other"), type: STR };
+    const t = typeAt(pathRef("box", "r"), assignOther, env(s));
+    expect(typeof t === "object" && t.type).toBe("objectType");
+  });
+
+  it("multi-hop (M2-ready): reassigning box.r invalidates box.r.value", () => {
+    const s = boxScope();
+    // box.r narrowed to success; then box.r reassigned to a fresh Result.
+    const reassigned: FlowNode = { kind: "assign", prev: narrowedBoxR(s), ref: pathRef("box", "r"), type: RESULT };
+    // box.r.value re-resolves from the reassigned (un-narrowed) Result → success
+    // member's `.value` is gone; structural resolve of `.value` on a resultType
+    // is "any" (diagnostic-free resolvePath).
+    expect(typeAt(pathRef("box", "r", "value"), reassigned, env(s))).toBe("any");
+  });
+
+  it("loop back-edge: a body reassign of the base re-resolves box.r from widened", () => {
+    const s = boxScope();
+    // Pre-loop narrowed; the loop body reassigned `box` (bare), so widened["box"]
+    // holds the post-body box type. box.r must re-resolve from THAT, not trust
+    // the pre-loop narrowed flow.
+    const loop: FlowNode = { kind: "loop", prev: narrowedBoxR(s), widened: { box: boxType } };
+    const after = typeAt(pathRef("box", "r"), loop, env(s));
+    expect(typeof after === "object" && after.type).toBe("resultType");
+  });
+});
+
+describe("flowHasNarrowFor (M1 strict gate)", () => {
+  it("true when a narrow for the exact path applies", () => {
+    const s = boxScope();
+    const narrow: FlowNode = { kind: "narrow", prev: { kind: "start", scope: s }, ref: pathRef("box", "r"), refine: successRefine };
+    expect(flowHasNarrowFor(pathRef("box", "r"), narrow)).toBe(true);
+  });
+
+  it("false at a plain start (no narrow on the path)", () => {
+    const s = boxScope();
+    expect(flowHasNarrowFor(pathRef("box", "r"), { kind: "start", scope: s })).toBe(false);
+  });
+
+  it("false after the base var is reassigned (prefix rebind resets it)", () => {
+    const s = boxScope();
+    const narrow: FlowNode = { kind: "narrow", prev: { kind: "start", scope: s }, ref: pathRef("box", "r"), refine: successRefine };
+    const reassigned: FlowNode = { kind: "assign", prev: narrow, ref: pathRef("box"), type: boxType };
+    expect(flowHasNarrowFor(pathRef("box", "r"), reassigned)).toBe(false);
+  });
+
+  it("true through a sibling assignment (box.q does not reset box.r)", () => {
+    const s = boxScope();
+    const narrow: FlowNode = { kind: "narrow", prev: { kind: "start", scope: s }, ref: pathRef("box", "r"), refine: successRefine };
+    const sibling: FlowNode = { kind: "assign", prev: narrow, ref: pathRef("box", "q"), type: NUM };
+    expect(flowHasNarrowFor(pathRef("box", "r"), sibling)).toBe(true);
+  });
+
+  it("requires the narrow on ALL join predecessors", () => {
+    const s = boxScope();
+    const start: FlowNode = { kind: "start", scope: s };
+    const narrowed: FlowNode = { kind: "narrow", prev: start, ref: pathRef("box", "r"), refine: successRefine };
+    expect(flowHasNarrowFor(pathRef("box", "r"), { kind: "join", prev: [narrowed, narrowed] })).toBe(true);
+    expect(flowHasNarrowFor(pathRef("box", "r"), { kind: "join", prev: [narrowed, start] })).toBe(false);
+  });
+});
+
+describe("isPrefixOf", () => {
+  it("a proper same-variable chain prefix is a prefix", () => {
+    expect(isPrefixOf(pathRef("box"), pathRef("box", "r"))).toBe(true);
+    expect(isPrefixOf(pathRef("box", "r"), pathRef("box", "r", "value"))).toBe(true);
+  });
+
+  it("equal chains are NOT a (proper) prefix", () => {
+    expect(isPrefixOf(pathRef("box", "r"), pathRef("box", "r"))).toBe(false);
+  });
+
+  it("different variables are never a prefix", () => {
+    expect(isPrefixOf(pathRef("box"), pathRef("other", "r"))).toBe(false);
+  });
+
+  it("a diverging chain segment is not a prefix", () => {
+    expect(isPrefixOf(pathRef("box", "q"), pathRef("box", "r", "value"))).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -3,7 +3,7 @@ import type { Refine, NarrowCandidate } from "./narrowing.js";
 import { narrowByRefine } from "./narrowing.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { NEVER_T } from "./primitives.js";
-import { isNever } from "./assignability.js";
+import { isNever, safeResolveType } from "./assignability.js";
 
 // NOTE: `narrowUnionByDiscriminant` and `NarrowCandidate` are added in Task 2
 // and Task 3 respectively, alongside the code that uses them. Keeping each
@@ -20,6 +20,44 @@ export type Reference = { variable: string; chain: string[] };
 /** Stable string key for a reference (map keys, equality). */
 export function referenceKey(ref: Reference): string {
   return ref.chain.length === 0 ? ref.variable : `${ref.variable}.${ref.chain.join(".")}`;
+}
+
+/**
+ * Resolve successive property hops on a type — DIAGNOSTIC-FREE (unlike
+ * `synthValueAccess`, which emits strict-member-access errors). Returns "any" on
+ * any hop that can't be resolved (missing property, non-object/Record receiver),
+ * so path narrowing stays conservative. M1: property hops only.
+ */
+function resolvePath(
+  baseType: ScopeType,
+  chain: string[],
+  aliases: Record<string, TypeAliasEntry>,
+): ScopeType {
+  let current: ScopeType = baseType;
+  for (const prop of chain) {
+    if (current === "any") return "any";
+    const resolved = safeResolveType(current, aliases);
+    if (resolved.type === "objectType") {
+      const p = resolved.properties.find((pr) => pr.key === prop);
+      current = p ? p.value : "any";
+    } else if (resolved.type === "genericType" && resolved.name === "Record") {
+      current = resolved.typeArgs[1];
+    } else {
+      return "any";
+    }
+  }
+  return current;
+}
+
+/**
+ * True if `prefix` is a proper prefix of `path` (same variable; `prefix.chain`
+ * is a leading sub-sequence of `path.chain`). Used for prefix invalidation:
+ * reassigning `box` (or `box.r`) drops a narrowing on `box.r` (or `box.r.value`).
+ */
+export function isPrefixOf(prefix: Reference, path: Reference): boolean {
+  if (prefix.variable !== path.variable) return false;
+  if (prefix.chain.length >= path.chain.length) return false;
+  return prefix.chain.every((seg, i) => seg === path.chain[i]);
 }
 
 /**
@@ -125,12 +163,22 @@ function computeTypeAt(
   env: FlowEnvironment,
 ): ScopeType {
   switch (at.kind) {
-    case "start":
-      // Non-empty chains (property-path narrowing) are a follow-on; today every
-      // reference has an empty chain, so this is a bare scope lookup.
-      return at.scope.lookup(ref.variable) ?? "any";
-    case "assign":
-      return referenceKey(at.ref) === key ? at.type : typeAt(ref, at.prev, env);
+    case "start": {
+      const base = at.scope.lookup(ref.variable) ?? "any";
+      return ref.chain.length === 0 ? base : resolvePath(base, ref.chain, env.typeAliases);
+    }
+    case "assign": {
+      // Exact match → the assigned type. A reassignment of any PREFIX of the
+      // queried path (e.g. assigning `box` invalidates `box.r`) drops the
+      // narrowing: re-resolve the path's tail from the freshly-assigned base.
+      // Disjoint refs pass through to the pre-assignment flow unchanged.
+      if (referenceKey(at.ref) === key) return at.type;
+      if (isPrefixOf(at.ref, ref)) {
+        const base = typeAt(at.ref, at, env);
+        return resolvePath(base, ref.chain.slice(at.ref.chain.length), env.typeAliases);
+      }
+      return typeAt(ref, at.prev, env);
+    }
     case "narrow": {
       if (referenceKey(at.ref) !== key) return typeAt(ref, at.prev, env);
       const base = typeAt(ref, at.prev, env);
@@ -142,9 +190,20 @@ function computeTypeAt(
     case "loop":
       // Own-property check: `at.widened` may be a plain object, so a ref named
       // "__proto__" / "toString" must not read from Object.prototype.
-      return Object.prototype.hasOwnProperty.call(at.widened, key)
-        ? at.widened[key]
-        : typeAt(ref, at.prev, env);
+      if (Object.prototype.hasOwnProperty.call(at.widened, key)) {
+        return at.widened[key];
+      }
+      // A reassigned PREFIX (the bare base var, the only shape `assignedNames`
+      // widens) invalidates this path: re-resolve from the widened base rather
+      // than trusting the (possibly narrowed) pre-loop flow. Otherwise
+      // `while (…) { box = …; box.r.value }` would trust a stale narrowing.
+      if (
+        ref.chain.length > 0 &&
+        Object.prototype.hasOwnProperty.call(at.widened, ref.variable)
+      ) {
+        return resolvePath(at.widened[ref.variable], ref.chain, env.typeAliases);
+      }
+      return typeAt(ref, at.prev, env);
     case "exit":
       throw new Error("typeAt called on an unreachable (exit) flow node");
   }
@@ -160,11 +219,45 @@ export function wrapFacts(flow: FlowNode, candidates: NarrowCandidate[]): FlowNo
     (prev, c) => ({
       kind: "narrow",
       prev,
-      ref: { variable: c.variableName, chain: [] },
+      ref: c.ref,
       refine: c.refine,
     }),
     flow,
   );
+}
+
+/**
+ * Does a `narrow` node for `ref` (exact key) apply on the flow path before any
+ * rebinding of it? Walk back until the first node that (re)establishes the ref's
+ * base — `start`/`loop`/`exit`, or an `assign` to `ref` or a prefix of it —
+ * returning true iff a `narrow` for `ref` is seen first. `synthValueAccess` uses
+ * this to route a member-path read through `typeAt` ONLY when narrowing genuinely
+ * applies, so an un-narrowed path still hits the structural walk's diagnostics
+ * (e.g. strict member access on un-guarded `b.r.value`).
+ */
+export function flowHasNarrowFor(ref: Reference, flow: FlowNode): boolean {
+  const key = referenceKey(ref);
+  let at: FlowNode = flow;
+  for (;;) {
+    switch (at.kind) {
+      case "narrow":
+        if (referenceKey(at.ref) === key) return true;
+        at = at.prev;
+        break;
+      case "assign":
+        // a rebind of the ref or any prefix resets it — no narrowing survives
+        if (referenceKey(at.ref) === key || isPrefixOf(at.ref, ref)) return false;
+        at = at.prev;
+        break;
+      case "join":
+        // sound only if narrowing holds on ALL predecessors
+        return at.prev.every((p) => flowHasNarrowFor(ref, p));
+      case "start":
+      case "loop":
+      case "exit":
+        return false;
+    }
+  }
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -100,6 +100,22 @@ describe("buildFlowGraph — linear", () => {
     }
   });
 
+  it("REGRESSION (M1): a property-access valueAccess (obj.field) gets a flowOf entry", () => {
+    // synthValueAccess's member-path narrowing gate silently degrades to "no
+    // narrowing" if a `.property` valueAccess stops being attached to the flow
+    // graph. Pin it: the `obj.field` node must have a flowOf entry.
+    const body = parseBody(`let obj = { field: 1 }\nprint(obj.field)`);
+    const scope = new Scope("t");
+    scope.declare("obj", { type: "objectType", properties: [{ key: "field", value: NUM }] });
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    const access = find(
+      body,
+      (n) => n.type === "valueAccess" && n.base.type === "variableName" && n.base.value === "obj",
+    );
+    expect(env.flowOf.get(access)).toBeDefined();
+  });
+
   it("INVARIANT holds across slice / computed-key / index positions", () => {
     // `lo`/`hi` live inside a slice; `key` inside a computed key — both were
     // missed before expressionChildren covered slice + computedKey.

--- a/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+function check(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+}
+
+const TRY = `
+def tryParse(s: string): Result<number, string> {
+  if (s == "ok") { return success(42) }
+  return failure("bad")
+}`;
+
+describe("member-path scrutinee narrowing (M1)", () => {
+  it("member-path Result guard narrows (no spurious strict-access error)", () => {
+    expect(check(`${TRY}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    let n: number = b.r.value
+  }
+}`)).toEqual([]);
+  });
+
+  it("nested object Result pattern narrows the binder (uses v in a numeric context)", () => {
+    expect(check(`${TRY}
+type Env = { result: Result<number, string> }
+def takesNumber(n: number): number { return n }
+def f(env: Env): number {
+  match (env) {
+    { result: success(v) } => takesNumber(v)
+    { result: failure(e) } => 0
+  }
+}`)).toEqual([]);
+  });
+
+  it("CRITICAL: un-narrowed member-path access STILL errors (gate doesn't over-suppress)", () => {
+    expect(check(`${TRY}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  let n: number = b.r.value
+}`).some((m) => /only available on a success Result/.test(m))).toBe(true);
+  });
+
+  it("member-path discriminant narrows — positive AND negative", () => {
+    const src = (body: string) => `
+type Ev = { payload: { kind: "click", x: number } | { kind: "scroll", d: number } }
+def takesNumber(n: number): void {}
+def takesString(s: string): void {}
+def f(e: Ev): void {
+  if (e.payload.kind == "click") { ${body} }
+}`;
+    expect(check(src("takesNumber(e.payload.x)"))).toEqual([]);
+    expect(check(src("takesString(e.payload.x)")).some((m) => /assignable/.test(m))).toBe(true);
+  });
+
+  it("member-path presence narrows", () => {
+    expect(check(`
+type Cfg = { timeout: number | null }
+def f(c: Cfg): void {
+  if (c.timeout != null) {
+    let t: number = c.timeout
+  }
+}`)).toEqual([]);
+  });
+
+  it("member-path else-branch (isFailure else → success)", () => {
+    expect(check(`${TRY}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  if (isFailure(b.r)) {
+  } else {
+    let n: number = b.r.value
+  }
+}`)).toEqual([]);
+  });
+
+  it("member-path post-guard return (the major Result idiom)", () => {
+    expect(check(`${TRY}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  if (isFailure(b.r)) { return }
+  let n: number = b.r.value
+}`)).toEqual([]);
+  });
+
+  it("SOUNDNESS: reassigning the base drops the path narrowing — exactly one error", () => {
+    const errs = check(`${TRY}
+type Box = { r: Result<number, string> }
+def other(): Box { return { r: failure("x") } }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    b = other()
+    let n: number = b.r.value
+  }
+}`);
+    expect(errs.filter((m) => /only available on a success Result/.test(m)).length).toBe(1);
+  });
+
+  it("UNTYPED let infers narrowed member-path RHS without a false positive", () => {
+    // Regression: an untyped `let` synthesizes its RHS during the pre-flow
+    // scope-building pass (no flowEnv); strict access must stay silent there so
+    // the flow-aware checkScopes pass is the single source of the diagnostic.
+    expect(check(`${TRY}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    let v = b.r.value
+  }
+}`)).toEqual([]);
+  });
+
+  it("CRITICAL: UNTYPED let with un-narrowed member-path access STILL errors", () => {
+    // The pre-flow suppression must not hide genuine errors: checkScopes
+    // re-synthesizes the access with flow and reports it.
+    expect(check(`${TRY}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  let v = b.r.value
+}`).some((m) => /only available on a success Result/.test(m))).toBe(true);
+  });
+
+  it("bare-variable narrowing is unchanged", () => {
+    expect(check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) { let n: number = r.value }
+}`)).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -27,7 +27,17 @@ describe("analyzeCondition", () => {
   // isSuccess/isFailure (and `if (r.success)`) now narrow via a discriminant on
   // the boolean `success` field (Result is consumed as a discriminated union).
   const succ = (varName: string, keep: boolean) => ({
-    variableName: varName,
+    ref: { variable: varName, chain: [] as string[] },
+    refine: {
+      kind: "discriminant",
+      prop: "success",
+      literal: { type: "booleanLiteralType", value: "true" },
+      keep,
+    },
+  });
+  // Path-aware success builder (one-hop receiver).
+  const succP = (variable: string, chain: string[], keep: boolean) => ({
+    ref: { variable, chain },
     refine: {
       kind: "discriminant",
       prop: "success",
@@ -66,10 +76,62 @@ describe("analyzeCondition", () => {
     ["unrelated function call", "foo(r)"],
     ["isSuccess with zero args", "isSuccess()"],
     ["isSuccess with too many args", "isSuccess(r, r)"],
-    ["isSuccess of a non-variable", "isSuccess(tryParse(\"x\"))"],
-    ["isSuccess of a member access", "isSuccess(o.r)"],
+    ["isSuccess of a call", 'isSuccess(tryParse("x"))'],
+    // M1 path ceiling: these scrutinees are NOT single-hop property paths.
+    ["isSuccess of an index", "isSuccess(obj[0])"],
+    ["isSuccess of a two-hop path", "isSuccess(obj.r.s)"],
+    ["isSuccess of a method call", "isSuccess(obj.method())"],
+    ["discriminant on an index receiver", 'obj[0].kind == "x"'],
+    ["discriminant on a two-hop receiver", 'a.b.c.kind == "x"'],
+    ["presence on an index", "obj[0] != null"],
   ])("produces no candidates for %s", (_label, src) => {
     expect(analyzeCondition(firstIfCondition(src))).toEqual(NO_FACTS);
+  });
+
+  // ── Single-hop member paths (M1) ──────────────────────────────────────────
+  const presP = (variable: string, chain: string[], present: boolean) => ({
+    ref: { variable, chain },
+    refine: { kind: "presence", present },
+  });
+  const discP = (variable: string, chain: string[], prop: string, value: string, keep: boolean) => ({
+    ref: { variable, chain },
+    refine: { kind: "discriminant", prop, literal: { type: "stringLiteralType", value }, keep },
+  });
+
+  it("isSuccess(obj.r): full candidate, path ref (was the old NO_FACTS member-access row)", () => {
+    expect(analyzeCondition(firstIfCondition("isSuccess(obj.r)"))).toEqual({
+      then: [succP("obj", ["r"], true)],
+      else: [succP("obj", ["r"], false)],
+    });
+  });
+  it("isFailure(obj.r): symmetric (then keep=false)", () => {
+    expect(analyzeCondition(firstIfCondition("isFailure(obj.r)")).then[0]).toEqual(
+      succP("obj", ["r"], false));
+  });
+  it('obj.kind == "x": discriminant, bare-variable receiver — full candidate', () => {
+    expect(analyzeCondition(firstIfCondition('obj.kind == "x"')).then[0]).toEqual(
+      discP("obj", [], "kind", "x", true));
+  });
+  it('obj.payload.kind == "x": receiver obj.payload (one hop), prop kind — full candidate', () => {
+    expect(analyzeCondition(firstIfCondition('obj.payload.kind == "x"')).then[0]).toEqual(
+      discP("obj", ["payload"], "kind", "x", true));
+  });
+  it("box.r != null / == null / swapped: presence on a one-hop path", () => {
+    expect(analyzeCondition(firstIfCondition("box.r != null")).then[0]).toEqual(presP("box", ["r"], true));
+    expect(analyzeCondition(firstIfCondition("box.r == null")).then[0]).toEqual(presP("box", ["r"], false));
+    expect(analyzeCondition(firstIfCondition("null != box.r")).then[0]).toEqual(presP("box", ["r"], true));
+  });
+  it("if (obj.r.success): member-access truthiness → discriminant on the one-hop receiver", () => {
+    expect(analyzeCondition(firstIfCondition("obj.r.success")).then[0]).toEqual(succP("obj", ["r"], true));
+  });
+  it("!isSuccess(obj.r): negation swaps then/else", () => {
+    expect(analyzeCondition(firstIfCondition("!isSuccess(obj.r)")).then[0]).toEqual(succP("obj", ["r"], false));
+  });
+  it("isSuccess(a.r) && isSuccess(b.r): two path facts in then", () => {
+    expect(analyzeCondition(firstIfCondition("isSuccess(a.r) && isSuccess(b.r)")).then).toEqual([
+      succP("a", ["r"], true),
+      succP("b", ["r"], true),
+    ]);
   });
 
   it("negation swaps then/else", () => {
@@ -101,7 +163,7 @@ describe("analyzeCondition", () => {
   });
 
   const disc = (keep: boolean, value = "answer", prop = "kind") => ({
-    variableName: "r",
+    ref: { variable: "r", chain: [] as string[] },
     refine: { kind: "discriminant", prop, literal: { type: "stringLiteralType", value }, keep },
   });
 
@@ -132,13 +194,17 @@ describe("analyzeCondition", () => {
   });
 
   it.each([
-    "r.kind == s.kind", // both member access
+    "r.kind == s.kind", // both member access (RHS not a literal)
     "x == 1", // no member access
-    'r.a.kind == "x"', // nested member — out of scope
     "r.kind == r.text", // same var both sides, no literal
     "r.kind == undefined", // undefined is a variableName, not a literal
   ])("produces no candidates for %s", (src) => {
     expect(analyzeCondition(firstIfCondition(src))).toEqual({ then: [], else: [] });
+  });
+
+  it('r.a.kind == "x": one-hop receiver r.a now narrows (M1; was out-of-scope)', () => {
+    expect(analyzeCondition(firstIfCondition('r.a.kind == "x"')).then[0]).toEqual(
+      discP("r", ["a"], "kind", "x", true));
   });
 
   it("composes ! with a discriminant (swaps then/else)", () => {
@@ -488,7 +554,7 @@ describe("postGuardFacts", () => {
     // isFailure → else is success==true (Result narrows via discriminant on `success`).
     expect(postGuardFacts(node, analyzeCondition(node.condition))).toEqual([
       {
-        variableName: "r",
+        ref: { variable: "r", chain: [] },
         refine: { kind: "discriminant", prop: "success", literal: { type: "booleanLiteralType", value: "true" }, keep: true },
       },
     ]);

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -10,6 +10,9 @@ import { safeResolveType } from "./assignability.js";
 import { literalToType } from "./literalType.js";
 import { resultToObjectUnion } from "./resultUnion.js";
 import { unescapeStringLiteralValue } from "../parsers/parsers.js";
+// Type-only import: `flow.ts` imports `Refine`/`NarrowCandidate` from here, so a
+// value import would cycle. `Reference` is the narrowed path (variable + chain).
+import type { Reference } from "./flow.js";
 
 /**
  * What a candidate narrows to. Tagged so a new narrowing form slots in as one
@@ -27,7 +30,7 @@ export type Refine =
       keep: boolean;
     }
   | { kind: "presence"; present: boolean };
-export type NarrowCandidate = { variableName: string; refine: Refine };
+export type NarrowCandidate = { ref: Reference; refine: Refine };
 export type ConditionFacts = { then: NarrowCandidate[]; else: NarrowCandidate[] };
 
 const NO_FACTS: ConditionFacts = { then: [], else: [] };
@@ -60,20 +63,39 @@ export function narrowByRefine(
 }
 
 /**
- * Recognize a single `v.prop` member access over a *bare variable* (exactly one
- * property hop). Returns null for anything else — nested access (`a.b.c`), a
- * non-variable base, index/call chains, etc. Variable-keyed only, so the
- * narrowed scrutinee is statically the same binding at the access site.
+ * A stable single-hop property path: a bare variable, or `variable.property`.
+ * Returns the `Reference`, or null for anything else (calls, index/computed
+ * keys, method hops, slices, or >1 property hop). M2 extends to multi-hop +
+ * index; M1 caps at one hop so the narrowed scrutinee is statically stable.
+ */
+function asPathReference(e: Expression): Reference | null {
+  if (e.type === "variableName") return { variable: e.value, chain: [] };
+  if (e.type === "valueAccess" && e.base.type === "variableName" && e.chain.length === 1) {
+    const el = e.chain[0];
+    if (el.kind === "property") return { variable: e.base.value, chain: [el.name] };
+  }
+  return null;
+}
+
+/**
+ * Recognize `V.prop` where the *receiver* `V` is a single-hop path (a bare
+ * variable, or one property hop). The discriminant is the FINAL property; the
+ * narrowed reference is the receiver. So `obj.kind` → ref `{obj,[]}`, prop
+ * `kind`; `obj.payload.kind` → ref `{obj,[payload]}`, prop `kind`. A receiver of
+ * >1 hop (`a.b.c.kind`) returns null (M2). Variable-keyed, so the narrowed
+ * scrutinee is statically the same binding at the access site.
  */
 function asDiscriminantAccess(
   e: Expression,
-): { variableName: string; prop: string } | null {
+): { ref: Reference; prop: string } | null {
   if (e.type !== "valueAccess") return null;
   if (e.base.type !== "variableName") return null;
-  if (e.chain.length !== 1) return null;
-  const el = e.chain[0];
-  if (el.kind !== "property") return null;
-  return { variableName: e.base.value, prop: el.name };
+  if (e.chain.length < 1 || e.chain.length > 2) return null;
+  if (e.chain.some((el) => el.kind !== "property")) return null;
+  const props = e.chain.map((el) => (el.kind === "property" ? el.name : ""));
+  const prop = props[props.length - 1];
+  const receiverChain = props.slice(0, -1); // [] for one hop, [p] for two hops
+  return { ref: { variable: e.base.value, chain: receiverChain }, prop };
 }
 
 /**
@@ -88,17 +110,14 @@ function isNullExpr(e: Expression): boolean {
 }
 
 /**
- * Recognize a presence test `x == null` / `x != null` over a *bare variable*
- * (either operand order). Returns the variable name, or null otherwise.
+ * Recognize a presence test `x == null` / `x != null` over a single-hop path
+ * (a bare variable or `obj.field`), either operand order. Returns the
+ * `Reference`, or null otherwise.
  */
-function asPresenceTest(left: Expression, right: Expression): string | null {
-  if (left.type === "variableName" && !isNullExpr(left) && isNullExpr(right)) {
-    return left.value;
-  }
-  if (right.type === "variableName" && !isNullExpr(right) && isNullExpr(left)) {
-    return right.value;
-  }
-  return null;
+function asPresenceTest(left: Expression, right: Expression): Reference | null {
+  const tryOne = (a: Expression, b: Expression): Reference | null =>
+    !isNullExpr(a) && isNullExpr(b) ? asPathReference(a) : null;
+  return tryOne(left, right) ?? tryOne(right, left);
 }
 
 /**
@@ -133,29 +152,28 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
       return { then: [], else: [...l.else, ...r.else] };
     }
     if (condition.operator === "==" || condition.operator === "!=") {
-      // Presence test: `x == null` / `x != null` over a bare variable (either
+      // Presence test: `x == null` / `x != null` over a single-hop path (either
       // operand order). Narrows by stripping/keeping the `null` member. Disjoint
-      // from the discriminant shape below (bare variable + `null` literal vs a
-      // `valueAccess`), so it's checked first with no precedence concern.
-      const presenceVar = asPresenceTest(condition.left, condition.right);
-      if (presenceVar) {
+      // from the discriminant shape below (path-vs-`null`-literal vs `V.prop`).
+      const presenceRef = asPresenceTest(condition.left, condition.right);
+      if (presenceRef) {
         // `x != null` → then: present (non-null); `x == null` → then: absent.
         const presentThen = condition.operator === "!=";
         const mkP = (present: boolean): NarrowCandidate => ({
-          variableName: presenceVar,
+          ref: presenceRef,
           refine: { kind: "presence", present },
         });
         return { then: [mkP(presentThen)], else: [mkP(!presentThen)] };
       }
-      // `v.prop == literal` / `!= literal` over a bare variable. Either operand
-      // order is accepted. then-branch keeps the matching member(s) for `==`
-      // (and the complement for `!=`); the else-branch is the inverse.
+      // `V.prop == literal` / `!= literal` over a single-hop receiver `V`. Either
+      // operand order. then-branch keeps the matching member(s) for `==` (and the
+      // complement for `!=`); the else-branch is the inverse.
       const acc = asDiscriminantAccess(condition.left) ?? asDiscriminantAccess(condition.right);
       const lit = literalToType(condition.right) ?? literalToType(condition.left);
       if (!acc || !lit) return NO_FACTS;
       const keepThen = condition.operator === "==";
       const mk = (keep: boolean): NarrowCandidate => ({
-        variableName: acc.variableName,
+        ref: acc.ref,
         refine: { kind: "discriminant", prop: acc.prop, literal: lit, keep },
       });
       return { then: [mk(keepThen)], else: [mk(!keepThen)] };
@@ -173,7 +191,7 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
     if (!acc) return NO_FACTS;
     const litTrue: BooleanLiteralType = { type: "booleanLiteralType", value: "true" };
     const truthy = (keep: boolean): NarrowCandidate => ({
-      variableName: acc.variableName,
+      ref: acc.ref,
       refine: { kind: "discriminant", prop: acc.prop, literal: litTrue, keep },
     });
     return { then: [truthy(true)], else: [truthy(false)] };
@@ -191,7 +209,7 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
     return {
       then: [
         {
-          variableName: condition.value,
+          ref: { variable: condition.value, chain: [] },
           refine: { kind: "presence", present: true },
         },
       ],
@@ -204,14 +222,16 @@ export function analyzeCondition(condition: Expression): ConditionFacts {
   if (fn !== "isSuccess" && fn !== "isFailure") return NO_FACTS;
   if (condition.arguments.length !== 1) return NO_FACTS;
   const arg = condition.arguments[0];
-  if (arg.type !== "variableName") return NO_FACTS;
-  const name = arg.value;
+  // Skip splat / named args (not Expressions); only a bare var or one-hop path.
+  if (arg.type !== "variableName" && arg.type !== "valueAccess") return NO_FACTS;
+  const ref = asPathReference(arg);
+  if (!ref) return NO_FACTS;
   // isSuccess(r) ⇔ r.success == true ; isFailure(r) ⇔ r.success != true.
   // Result is consumed as a discriminated union on `success` (resultUnion.ts).
   const successLit: BooleanLiteralType = { type: "booleanLiteralType", value: "true" };
   const keepThen = fn === "isSuccess";
   const onSuccess = (keep: boolean): NarrowCandidate => ({
-    variableName: name,
+    ref,
     refine: { kind: "discriminant", prop: "success", literal: successLit, keep },
   });
   return { then: [onSuccess(keepThen)], else: [onSuccess(!keepThen)] };
@@ -384,7 +404,13 @@ export function applyNarrowing(
   typeAliases: Record<string, TypeAliasEntry>,
 ): void {
   for (const cand of candidates) {
-    const current = childScope.lookup(cand.variableName);
+    // The legacy child-scope path narrows a bare variable (declareLocal by name).
+    // Member-path candidates (chain.length > 0) are handled only by the flow
+    // path (typeAt); skip them here — declaring a local named "obj.r" is
+    // meaningless. Inference is bare-variable-only; path narrowing is Phase-B.
+    if (cand.ref.chain.length !== 0) continue;
+    const name = cand.ref.variable;
+    const current = childScope.lookup(name);
     if (!current || current === "any") continue;
     // "what to narrow to" is delegated to narrowByRefine (the same dispatcher
     // the flow path uses). It resolves through type-alias variables itself
@@ -396,8 +422,8 @@ export function applyNarrowing(
     if (narrowed === null) continue;
     // Soundness gate: a branch that reassigns the variable may change its type
     // mid-branch, so don't narrow it (whole-body scan, conservative).
-    if (isReassignedIn(branchBody, cand.variableName)) continue;
-    childScope.declareLocal(cand.variableName, narrowed);
+    if (isReassignedIn(branchBody, name)) continue;
+    childScope.declareLocal(name, narrowed);
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -771,31 +771,48 @@ function validateAgencyFunctionMethod(
   }
 }
 
+/**
+ * Flow-sensitive path narrowing (M1): if `expr` is a single-hop property path
+ * `base.prop` whose flow node carries a `narrow` for that exact ref, return the
+ * narrowed type of the one-hop prefix — so `b.r.value` reads the narrowed `b.r`
+ * inside `if (isSuccess(b.r))`. `null` means no narrowing applies; the caller
+ * then resolves the base structurally and the chain walk's diagnostics (strict
+ * member access) run on the un-narrowed access. (Bare-base narrowing, `r.value`,
+ * flows through `synthType(expr.base)` and needs nothing here.)
+ *
+ * The `flowHasNarrowFor` gate is required: without it, `typeAt` would return the
+ * structural (un-narrowed) member type and short-circuiting on it would suppress
+ * the strict-member-access error that un-guarded `b.r.value` must still raise.
+ */
+function narrowedPathPrefix(
+  expr: ValueAccess,
+  ctx: TypeCheckerContext,
+): VariableType | "any" | null {
+  const first = expr.chain[0];
+  if (!ctx.flowEnv || expr.base.type !== "variableName" || first?.kind !== "property") {
+    return null;
+  }
+  const flow = ctx.flowEnv.flowOf.get(expr);
+  const ref = { variable: expr.base.value, chain: [first.name] };
+  if (!flow || !flowHasNarrowFor(ref, flow)) {
+    return null;
+  }
+  return typeAt(ref, flow, { ...ctx.flowEnv, typeAliases: ctx.getTypeAliases() });
+}
+
 export function synthValueAccess(
   expr: ValueAccess,
   scope: Scope,
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
-  let currentType = synthType(expr.base, scope, ctx);
   const typeAliases = ctx.getTypeAliases();
 
-  // Flow-sensitive path narrowing (M1): when the first hop forms a narrowed
-  // single-hop path `base.prop` (e.g. `b.r` inside `if (isSuccess(b.r))`),
-  // resolve THAT prefix through typeAt and continue the structural walk from the
-  // next hop — so `b.r.value` sees the narrowed `b.r`. (Bare-base narrowing,
-  // `r.value`, already flows through `synthType(expr.base)` above.) Gate on
-  // flowHasNarrowFor so we only short-circuit the prefix when narrowing genuinely
-  // applies; otherwise the structural walk's diagnostics (strict member access)
-  // still run on un-narrowed access.
-  let chainStart = 0;
-  if (ctx.flowEnv && expr.base.type === "variableName" && expr.chain[0]?.kind === "property") {
-    const flow = ctx.flowEnv.flowOf.get(expr);
-    const ref = { variable: expr.base.value, chain: [expr.chain[0].name] };
-    if (flow && flowHasNarrowFor(ref, flow)) {
-      currentType = typeAt(ref, flow, { ...ctx.flowEnv, typeAliases: ctx.getTypeAliases() });
-      chainStart = 1;
-    }
-  }
+  // When a narrowed single-hop prefix applies, start the structural walk from
+  // its type at the next hop; otherwise resolve the base and walk the whole chain.
+  const narrowedPrefix = narrowedPathPrefix(expr, ctx);
+  let currentType =
+    narrowedPrefix === null ? synthType(expr.base, scope, ctx) : narrowedPrefix;
+  const chainStart = narrowedPrefix === null ? 0 : 1;
 
   for (const element of expr.chain.slice(chainStart)) {
     // Validate .partial()/.describe() even when the base type is unknown,

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -9,7 +9,7 @@ import type {
 import { formatTypeHint } from "../utils/formatType.js";
 import { BUILTIN_FUNCTION_TYPES, AGENCY_FUNCTION_METHOD_TYPES } from "./builtins.js";
 import { isAssignable, isNever, safeResolveType } from "./assignability.js";
-import { typeAt } from "./flow.js";
+import { typeAt, flowHasNarrowFor } from "./flow.js";
 import { literalToType } from "./literalType.js";
 import { resultTypeForValidation } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
@@ -89,8 +89,18 @@ type StrictSeverity = "silent" | "warn" | "error";
  * un-guarded access to a branch-specific union member (notably `r.value` on an
  * un-narrowed Result) is a hard error. Set `strictMemberAccess: "silent"` to
  * opt out (restores the old lenient behavior).
+ *
+ * Strict access is FLOW-SENSITIVE: whether a member is reachable depends on
+ * narrowing (`if (isSuccess(b.r)) { b.r.value }`), which is only known once the
+ * flow graph exists. The pre-flow inference passes (return-type inference and
+ * scope-building, where an untyped `let v = b.r.value` synthesizes its RHS to
+ * declare `v`) run with `ctx.flowEnv` unset — emitting here would be a false
+ * positive on narrowed access. Suppress in that window; the flow-aware
+ * `checkScopes` pass re-synthesizes every value access and emits the genuine
+ * diagnostic.
  */
 function strictMemberAccessSeverity(ctx: TypeCheckerContext): StrictSeverity {
+  if (!ctx.flowEnv) return "silent";
   return ctx.config.typechecker?.strictMemberAccess ?? "error";
 }
 
@@ -769,7 +779,25 @@ export function synthValueAccess(
   let currentType = synthType(expr.base, scope, ctx);
   const typeAliases = ctx.getTypeAliases();
 
-  for (const element of expr.chain) {
+  // Flow-sensitive path narrowing (M1): when the first hop forms a narrowed
+  // single-hop path `base.prop` (e.g. `b.r` inside `if (isSuccess(b.r))`),
+  // resolve THAT prefix through typeAt and continue the structural walk from the
+  // next hop — so `b.r.value` sees the narrowed `b.r`. (Bare-base narrowing,
+  // `r.value`, already flows through `synthType(expr.base)` above.) Gate on
+  // flowHasNarrowFor so we only short-circuit the prefix when narrowing genuinely
+  // applies; otherwise the structural walk's diagnostics (strict member access)
+  // still run on un-narrowed access.
+  let chainStart = 0;
+  if (ctx.flowEnv && expr.base.type === "variableName" && expr.chain[0]?.kind === "property") {
+    const flow = ctx.flowEnv.flowOf.get(expr);
+    const ref = { variable: expr.base.value, chain: [expr.chain[0].name] };
+    if (flow && flowHasNarrowFor(ref, flow)) {
+      currentType = typeAt(ref, flow, { ...ctx.flowEnv, typeAliases: ctx.getTypeAliases() });
+      chainStart = 1;
+    }
+  }
+
+  for (const element of expr.chain.slice(chainStart)) {
     // Validate .partial()/.describe() even when the base type is unknown,
     // since we can check argument structure against the function definition.
     // Use continue (not return) so chained calls like fn.partial(a: 1).describe("x") are all validated.


### PR DESCRIPTION
## What

Flow narrowing for **single-hop member-path scrutinees** (M1). Before this PR, only a *bare variable* could be narrowed by a guard. Now a one-hop property path narrows too:

```agency
type Box = { r: Result<number, string> }
def f(b: Box): void {
  if (isSuccess(b.r)) {
    let n: number = b.r.value   // narrows — no strict-access error
  }
}
```

Covers all three guard families on a `base.prop` path:
- **Result** — `isSuccess(b.r)` / `isFailure(b.r)` (then-, else-, and post-guard-return)
- **Discriminant** — `e.payload.kind == "click"` filters the union member
- **Presence** — `c.timeout != null` strips the `null` member

This also makes **object-nested Result patterns** narrow, since `{ result: success(v) }` lowers to `if (isSuccess(env.result)) { const v = env.result.value }` — a member-path access that previously hit a spurious strict-access error.

## How

The flow `Reference.chain` (reserved for exactly this) is now lit up across the pipeline:
- **`typeAt`** resolves a property-path `Reference` via a new diagnostic-free `resolvePath` (objectType + `Record<K,V>`, alias-aware, `any` on any unresolvable hop).
- **Recognizers** (`asPathReference`, `asDiscriminantAccess`, `asPresenceTest`, isSuccess/isFailure) emit single-hop path `Reference`s.
- **`synthValueAccess`** resolves a narrowed one-hop prefix through `typeAt` and continues the structural walk from the next hop, behind a strict `flowHasNarrowFor` gate (only short-circuits when a `narrow` for that exact ref genuinely applies — so un-guarded access still raises strict-member-access).

## Soundness

Reassigning the path **or any prefix of it** drops the narrowing:
- `typeAt`'s `assign` case re-resolves `ref` through `resolvePath` when `isPrefixOf(at.ref, ref)` (e.g. `box = ...` invalidates `box.r`); the `loop` back-edge case does the same when the body widened the base var.
- A **sibling** assignment (`box.q = ...`) is not a prefix, so it correctly leaves `box.r` narrowed.
- `flowHasNarrowFor` applies the same prefix rule, so a re-bound `box.r.value` still hits the diagnostic.

## Latent bug fixed

Untyped member-path bindings surfaced a pre-existing flow-sensitivity bug: strict-member-access was emitted during the **pre-flow** inference passes (return-type inference; scope-building, where an untyped `let v = b.r.value` synthesizes its RHS to declare `v`) — a **false positive on narrowed access**. Strict access is flow-sensitive, so `strictMemberAccessSeverity` now returns `silent` when `ctx.flowEnv` is unset. The flow-aware `checkScopes` pass re-synthesizes every value access and is the single source of the diagnostic — verified it still fires on genuinely un-guarded access (the gate does not over-suppress).

## Scope

Multi-hop (`a.b.c`) and index (`arr[0]`) paths are a follow-on (M2) — `Reference.chain` only encodes one property hop today, and index segments aren't yet representable. Bare-variable narrowing is unchanged.

## Tests

- `memberPathNarrowing.test.ts` (new, 11 e2e) — Result/discriminant/presence narrowing, the **CRITICAL un-narrowed-still-errors** gate, soundness-on-reassign, untyped-binding regression (both directions), bare-variable unchanged.
- `flow.test.ts` — property-path `typeAt`, prefix-invalidation (exact-key/base/sibling/disjoint/multi-hop/loop), `flowHasNarrowFor`, `isPrefixOf`.
- `flowBuilder.test.ts` — `.property` valueAccess gets a `flowOf` entry (gate-degradation guard).
- `narrowing.test.ts` — path-ref recognizer positives/negatives.

Full suite green (6663 passed); `tsc`, `lint:structure` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
