### PR TITLE
fix(typechecker): narrow inside block bodies in any call position

### DIFF
--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -177,6 +177,17 @@ synthesizes its RHS to declare `v`). Emitting there would be a false positive on
 narrowed access; the flow-aware `checkScopes` pass re-synthesizes every value access
 and is the single source of the diagnostic.
 
+**Block bodies narrow.** Trailing `as` blocks and inline `\… -> …` blocks narrow
+with the enclosing flow wherever the block-bearing call appears (statement,
+assignment value, pipe operand, argument). `attachExpressionsToFlow` walks the
+block body (`functionCall.block.body` / `blockArgument.body`) as statements with
+the live flow, so a guarded `r.value` / `b.r.value` inside a block resolves, and a
+guard nested in the block builds its own `narrow` nodes. CAVEAT: this narrows as
+if the block runs in the enclosing flow; a deferred callback that executes after a
+later reassignment is the classic closure-staleness limitation (mainstream
+checkers narrow `const` but not reassigned `let` across closures) and is not
+specially handled.
+
 Un-narrowed `Result` field access still synthesizes to `any` (the legacy escape
 hatch in `synthValueAccess`); tightening that into a hard error is a later increment
 (the enforced-Result-safety flip, which the flow-typed model unblocks).

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -116,6 +116,23 @@ describe("buildFlowGraph — linear", () => {
     expect(env.flowOf.get(access)).toBeDefined();
   });
 
+  it("REGRESSION: a valueAccess inside an expression-position block body gets a flowOf entry", () => {
+    // A block on a call used as an EXPRESSION (assignment value) must have its
+    // body flow-walked, so a `.property` access inside it narrows. Pins the
+    // mechanism (flowOf attached), not just the outcome.
+    const body = parseBody(`let n = wrap(3) as value {\n  let inner = obj.field\n  return inner\n}`);
+    const scope = new Scope("t");
+    scope.declare("obj", { type: "objectType", properties: [{ key: "field", value: NUM }] });
+    scope.declare("wrap", { type: "primitiveType", value: "any" });
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    const access = find(
+      body,
+      (n) => n.type === "valueAccess" && n.base.type === "variableName" && n.base.value === "obj",
+    );
+    expect(env.flowOf.get(access)).toBeDefined();
+  });
+
   it("INVARIANT holds across slice / computed-key / index positions", () => {
     // `lo`/`hi` live inside a slice; `key` inside a computed key — both were
     // missed before expressionChildren covered slice + computedKey.

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -45,6 +45,24 @@ export function attachExpressionsToFlow(
   if (node.type === "variableName" || node.type === "valueAccess") {
     env.flowOf.set(node, flow);
   }
+  // Block bodies narrow with the enclosing flow, regardless of where the
+  // block-bearing call sits (statement, assignment value, pipe operand,
+  // argument). A trailing block is `functionCall.block`; an inline `\… -> …`
+  // block is a `blockArgument` reached via the call's arguments. Walk the body
+  // as statements (buildFlowGraph) so declarations + nested guards inside the
+  // block get flow nodes. The statement-level `functionCall` rule relies on this
+  // (it no longer walks the block itself), so the body is walked exactly once.
+  // CAVEAT: this narrows as if the block runs in the enclosing flow — a deferred
+  // callback that runs after a later reassignment is the classic closure-
+  // staleness limitation (pre-existing for statement-position blocks; not
+  // addressed here).
+  if (node.type === "functionCall" && node.block) {
+    buildFlowGraph(node.block.body, flow, env);
+  }
+  if (node.type === "blockArgument") {
+    buildFlowGraph(node.body, flow, env);
+    return; // body walked as statements; no expression children to attach
+  }
   for (const child of expressionChildren(node)) {
     attachExpressionsToFlow(child, flow, env);
   }
@@ -171,10 +189,11 @@ const statementRules: StatementRuleTable = {
   },
 
   functionCall: (node, flow, env) => {
+    // attachExpressionsToFlow now descends into node.block / blockArgument
+    // bodies itself, so the block body is walked exactly once here. Do NOT
+    // re-add an explicit `buildFlowGraph(node.block.body, …)` — that would
+    // double-walk the body.
     attachExpressionsToFlow(node, flow, env);
-    if (node.block) {
-      buildFlowGraph(node.block.body, flow, env);
-    }
     return flow;
   },
 

--- a/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
@@ -133,3 +133,120 @@ node main() {
 }`)).toEqual([]);
   });
 });
+
+describe("narrowing inside block bodies", () => {
+  const BLOCKDEFS = `
+def wrap(value: number, block: (number) => number): number { return block(value) }
+def applyN(n: number, block: (number) => number): number { return block(n) }`;
+
+  it("bare var narrows inside an expression-position trailing block", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) {
+    let n: number = wrap(3) as value {
+      let inner: number = r.value
+      return inner
+    }
+  }
+}`)).toEqual([]);
+  });
+
+  it("bare var narrows inside an inline block", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) {
+    let n: number = applyN(3, \\x -> r.value)
+  }
+}`)).toEqual([]);
+  });
+
+  it("member path narrows inside an expression-position trailing block", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    let n: number = wrap(3) as value {
+      let inner: number = b.r.value
+      return inner
+    }
+  }
+}`)).toEqual([]);
+  });
+
+  it("member path narrows inside an inline block", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    let n: number = applyN(3, \\x -> b.r.value)
+  }
+}`)).toEqual([]);
+  });
+
+  it("narrows inside an inline block passed as a named argument", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) {
+    let n: number = applyN(n: 3, block: \\x -> r.value)
+  }
+}`)).toEqual([]);
+  });
+
+  it("a guard nested inside a block body narrows within the block", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+node main() {
+  let r = tryParse("ok")
+  let m: number = wrap(3) as value {
+    if (isFailure(r)) {
+      return 0
+    } else {
+      let inner: number = r.value
+      return inner
+    }
+  }
+}`)).toEqual([]);
+  });
+
+  it("statement-position block still narrows (no regression)", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+node main() {
+  let r = tryParse("ok")
+  if (isSuccess(r)) {
+    wrap(3) as value {
+      let inner: number = r.value
+      return inner
+    }
+  }
+}`)).toEqual([]);
+  });
+
+  it("reassignment inside a block body drops the narrowing (exactly one error)", () => {
+    const errs = check(`${TRY}${BLOCKDEFS}
+node main() {
+  let r = tryParse("ok")
+  let m: number = wrap(3) as value {
+    if (isSuccess(r)) {
+      r = failure("x")
+      let inner: number = r.value
+      return inner
+    }
+    return 0
+  }
+}`);
+    expect(errs.filter((m) => /only available on a success Result/.test(m)).length).toBe(1);
+  });
+
+  it("CONTROL: un-guarded access inside a block still errors", () => {
+    expect(check(`${TRY}${BLOCKDEFS}
+node main() {
+  let r = tryParse("ok")
+  let n: number = wrap(3) as value {
+    let inner: number = r.value
+    return inner
+  }
+}`).some((m) => /only available on a success Result/.test(m))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Flow-sensitive narrowing now reaches inside Agency **block bodies** — trailing `as` blocks and inline `\… -> …` blocks — regardless of where the block-bearing call sits. Before, a guarded member/Result access inside a block spuriously errored under enforced Result safety:

```agency
if (isSuccess(b.r)) {
  let n: number = wrap(3) as value {
    let inner: number = b.r.value   // before: "'.value' only available on a success Result"; now: ok
    return inner
  }
}
```

This is a **pre-existing gap in the M1 flow checker** (it affects bare variables too, e.g. `\x -> r.value` inside a guard), surfaced while reviewing member-path M2.

## Root cause

The flowBuilder's `functionCall` *statement* rule walked `node.block.body` with the live (narrowed) flow — so a block in **statement position** narrowed. But when the call is nested in an **expression** (assignment value, pipe operand, argument), it's reached through the *expression* walk (`attachExpressionsToFlow`), which never descended into `node.block`; and `blockArgument` (inline `\` blocks) had no `expressionChildren` case at all. So those block bodies got no flow attachment, and `synthValueAccess` saw no narrowing.

Empirically confirmed before the fix (bare-var `r.value` under `if (isSuccess(r))`): statement-position block ✅, expression-position block ❌, inline block ❌.

## Fix

`attachExpressionsToFlow` now drives `buildFlowGraph(body, flow, env)` into both block forms (`functionCall.block.body` and `blockArgument.body`) wherever a call appears; the statement `functionCall` rule drops its now-redundant block walk, so the body is walked exactly once. ~12 lines.

**Type-checker only** — the flow graph is built and discarded per check, never serialized, so there is no codegen or interrupt-resume impact.

## Scope / caveat

Consistency, not new soundness: statement-position blocks already narrowed this way; this extends it to expression-position and inline blocks. A block that runs *after* a later reassignment it can't see is narrowed optimistically — the classic closure-staleness limitation (mainstream checkers narrow `const` but not reassigned `let` across closures), shared with statement-position blocks and documented, not solved here.

## Tests

Added to `memberPathNarrowing.test.ts` (e2e): bare-var and member-path × expression-position trailing block and inline block; inline block in **named-argument** position; a **guard nested inside** a block (builds fresh `narrow` nodes in the body); **reassignment inside** a block invalidates narrowing; statement-position **no-regression**; and an un-guarded **control** that must still error. Plus a `flowBuilder.test.ts` unit pinning the **mechanism** (a `valueAccess` inside an expression-position block body gets a `flowOf` entry).

Full gate green: `make`, `tsc`, `lint:structure` clean; full vitest suite **6673 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
