### PR TITLE
feat(typechecker): narrow multi-hop + literal-index member paths (M2)

### DIFF
--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -28,11 +28,11 @@ flow-typed checker work and the four narrowing specs at the repo root.
 |---|---|---|
 | `isSuccess(r)` / `isFailure(r)` on a bare variable | ✅ | then- and else-branch; `r.value` / `r.error` type precisely |
 | `r.prop == literal` / `!= literal` on a bare variable | ✅ | discriminated-union member filter (either operand order; string/number/boolean literals) |
-| Same guards on a **single-hop member-path** scrutinee (`b.r`, `e.payload`) | ✅ | M1 — `isSuccess(b.r)`, `b.r.kind == "x"`, `b.r != null` narrow the path; `b.r.value` then types precisely. One hop only (`base.prop`); see the nested-access row for multi-hop |
+| Same guards on a **member-path** scrutinee (`b.r`, `o.inner.r`, `arr[0]`) | ✅ | M1 (single-hop) + M2 (multi-hop + literal-index) — `isSuccess(arr[0])`, `o.inner.r.kind == "x"`, `b.r != null` narrow the path; `arr[0].value` then types precisely |
 | `match` arm **bound fields** | ✅ | free via lowering to a `__s` temp — no match-specific code |
 | `!c`, `a && b`, `a || b` combinators | ✅ | `!` swaps then/else; `&&` unions then-facts; `\|\|` unions else-facts |
 | Post-guard / early-return (`if (isFailure(r)) { return }` ⇒ `r` is Success after) | ✅ | `alwaysExits` counts only `return` (conservative) |
-| Multi-hop / index nested scrutinee (`a.b.c`, `arr[0]`) | ❌ | M2 follow-on — `Reference.chain` only encodes one property hop today (`asPathReference`'s one-hop ceiling); index segments aren't yet representable |
+| Multi-hop + literal-index member paths (`a.b.c`, `arr[0]`) | ✅ | M2 — `Reference.chain` is `PathSegment[]` (property + literal-index hops); `arr[0]` narrows per-index (does not leak to `arr[1]`). Covers **array-nested patterns** (`[success(v), _]`). Computed/dynamic index (`arr[i]`), slices, and method hops stay un-narrowable |
 | The scrutinee *variable* in a `match` arm (vs a bound field) | ❌ | only bound fields narrow; the source var isn't re-typed |
 | Mixed union with a non-literal discriminant member | ❌ | by design — the `string` member can't be proven disjoint |
 | Narrowing to `never` (dead-branch detection) | ❌ | suppressed today; **planned** with the flow model + `never` |
@@ -159,16 +159,23 @@ since its type could change. The `narrowedBranch` marker on `ResultType` is set 
 by this layer and is stripped by `widenType`, so it never leaks through `declare()`
 into a function's inferred return type.
 
-**Member-path prefix invalidation (M1).** A narrowing of `box.r` is keyed on the
-whole path. Reassigning the path *or any prefix of it* drops the narrowing: after
-`box = …` (or `box.r = …`), `box.r` re-resolves from the reassigned base, not the
-stale narrowed flow. `typeAt`'s `assign` case detects this via `isPrefixOf(at.ref,
-ref)` and re-resolves through `resolvePath`; the `loop` back-edge case does the same
-when the body widened the base var. A *sibling* assignment (`box.q = …`) is **not** a
-prefix, so it correctly leaves `box.r` narrowed. `flowHasNarrowFor` — the gate
-`synthValueAccess` uses before short-circuiting a path read through `typeAt` — applies
-the same prefix rule, so an un-guarded (or re-bound) `box.r.value` still hits the
-structural walk's strict-member-access diagnostic.
+**Member-path prefix invalidation.** A narrowing of `box.r` (or `arr[0]`) is keyed
+on the whole path — `Reference.chain` is a `PathSegment[]` of `prop`/`index` hops,
+so `box.r` and `arr[0]` (and a numeric property `obj["0"]` vs `arr[0]`) never alias
+in `referenceKey`/`isPrefixOf`. Reassigning the path *or any prefix of it* drops the
+narrowing: after `box = …`, `box.r = …`, `b.inner = …`, or `arr[0] = …`, the path
+re-resolves from the reassigned base, not the stale narrowed flow. `typeAt`'s
+`assign` case detects this via `isPrefixOf(at.ref, ref)` and re-resolves through
+`resolvePath`; the `loop` back-edge case does the same when the body widened the
+base var; and the flow builder now emits a path-keyed `assign` node for stable
+access-chain WRITES (`obj.field = x`, `arr[0] = x`) so a mutation invalidates too
+(an unstable target like `obj[i()] = x` can't be keyed and passes through — no
+aliasing analysis). A *sibling* assignment (`box.q = …`) is **not** a prefix, so it
+correctly leaves `box.r` narrowed. At the access site `synthValueAccess` consults
+the LONGEST narrowed stable prefix via `stablePrefix` (so `o.inner.r.value` reads the
+more precise `o.inner.r` narrowing, and a later unstable hop — `a.b[i()].x` — doesn't
+block narrowing the stable `a.b` prefix), behind the `flowHasNarrowFor` gate so an
+un-guarded (or re-bound) access still hits the strict-member-access diagnostic.
 
 Strict member access is itself flow-sensitive, so `strictMemberAccessSeverity`
 returns `silent` whenever `ctx.flowEnv` is unset — i.e. during the pre-flow inference

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -166,6 +166,10 @@ match (pair) {
 }
 ```
 
+The bound value (`v` above) is narrowed precisely — it has the success
+value's type, so it can be used wherever that type is required (e.g. passed
+to a function expecting a `number`), with no extra guard.
+
 Note: `failure(e)` binds only the error string. For checkpoint,
 functionName, or args, use the traditional `if (isFailure(result))`
 form and access fields on the result variable directly.

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -408,6 +408,15 @@ describe("typeAt — path prefix invalidation (M1)", () => {
     const after = typeAt(pathRef("box", "r"), loop, env(s));
     expect(typeof after === "object" && after.type).toBe("resultType");
   });
+
+  it("an access-chain write (path-keyed assign) drops flowHasNarrowFor AND re-resolves typeAt", () => {
+    // The flow LAYER already handles a path-keyed assign (referenceKey + isPrefixOf
+    // are generic); Task 4 only makes flowBuilder EMIT this node for `box.r = …`.
+    const s = boxScope();
+    const write: FlowNode = { kind: "assign", prev: narrowedBoxR(s), ref: pathRef("box", "r"), type: RESULT };
+    expect(flowHasNarrowFor(pathRef("box", "r"), write)).toBe(false);
+    expect(typeAt(pathRef("box", "r"), write, env(s))).toEqual(RESULT);
+  });
 });
 
 describe("flowHasNarrowFor (M1 strict gate)", () => {

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -9,22 +9,29 @@ import {
   widenAtLoopBackEdge,
   flowHasNarrowFor,
   isPrefixOf,
+  segKey,
   type FlowNode,
   type FlowEnvironment,
 } from "./flow.js";
 import { Scope } from "./scope.js";
 import { NEVER_T } from "./primitives.js";
 import type { VariableType } from "../types.js";
+import type { PathSegment } from "./flow.js";
 
 const STR: VariableType = { type: "primitiveType", value: "string" };
 const NUM: VariableType = { type: "primitiveType", value: "number" };
+const NUMA: VariableType = { type: "arrayType", elementType: NUM };
+
+// Path-segment constructors (PathSegment[] replaced string[] chains in M2).
+const prop = (name: string): PathSegment => ({ kind: "prop", name });
+const idx = (index: number): PathSegment => ({ kind: "index", index });
 
 describe("referenceKey", () => {
   it("is the bare variable for an empty chain", () => {
     expect(referenceKey({ variable: "x", chain: [] })).toBe("x");
   });
   it("dotted-joins a non-empty chain", () => {
-    expect(referenceKey({ variable: "u", chain: ["profile", "email"] })).toBe("u.profile.email");
+    expect(referenceKey({ variable: "u", chain: [prop("profile"), prop("email")] })).toBe("u.profile.email");
   });
 });
 
@@ -58,7 +65,7 @@ describe("uniteTypes", () => {
 function env(scope: Scope): FlowEnvironment {
   return { scope, flowOf: new WeakMap(), typeAliases: {}, memo: new WeakMap() };
 }
-const ref = (variable: string) => ({ variable, chain: [] as string[] });
+const ref = (variable: string) => ({ variable, chain: [] as PathSegment[] });
 
 // A discriminated union: { kind: "a", v: string } | { kind: "b", v: number }
 const memberA: VariableType = {
@@ -271,7 +278,7 @@ describe("widenAtLoopBackEdge", () => {
 const RESULT: VariableType = { type: "resultType", successType: NUM, failureType: STR };
 // box : { r: Result<number, string> }
 const boxType: VariableType = { type: "objectType", properties: [{ key: "r", value: RESULT }] };
-const pathRef = (variable: string, ...chain: string[]) => ({ variable, chain });
+const pathRef = (variable: string, ...names: string[]) => ({ variable, chain: names.map(prop) });
 const successRefine = {
   kind: "discriminant" as const,
   prop: "success",
@@ -454,5 +461,71 @@ describe("isPrefixOf", () => {
 
   it("a diverging chain segment is not a prefix", () => {
     expect(isPrefixOf(pathRef("box", "q"), pathRef("box", "r", "value"))).toBe(false);
+  });
+});
+
+describe("PathSegment helpers + index resolution (M2)", () => {
+  it("referenceKey encodes property and index segments distinctly", () => {
+    expect(referenceKey({ variable: "box", chain: [prop("r")] })).toBe("box.r");
+    expect(referenceKey({ variable: "arr", chain: [idx(0)] })).toBe("arr.[0]");
+    expect(referenceKey({ variable: "x", chain: [] })).toBe("x");
+    expect(referenceKey({ variable: "m", chain: [prop("a"), idx(2), prop("b")] })).toBe("m.a.[2].b");
+  });
+
+  it("segKey distinguishes a numeric property from an index", () => {
+    expect(segKey(prop("0"))).toBe("0");
+    expect(segKey(idx(0))).toBe("[0]");
+    expect(segKey(prop("0"))).not.toBe(segKey(idx(0)));
+  });
+
+  it("isPrefixOf compares segments structurally (prop vs index do not alias)", () => {
+    expect(isPrefixOf({ variable: "arr", chain: [] }, { variable: "arr", chain: [idx(0)] })).toBe(true);
+    expect(isPrefixOf({ variable: "arr", chain: [idx(0)] }, { variable: "arr", chain: [idx(0), prop("value")] })).toBe(true);
+    expect(isPrefixOf({ variable: "arr", chain: [idx(0)] }, { variable: "arr", chain: [idx(1), prop("value")] })).toBe(false);
+    expect(isPrefixOf({ variable: "arr", chain: [prop("0")] }, { variable: "arr", chain: [idx(0), prop("v")] })).toBe(false);
+  });
+
+  // resolvePath is module-private (declaredPathType is the public seam); exercise
+  // it through typeAt's `start` case, which calls it for a non-empty chain.
+  const startWith = (name: string, t: VariableType): FlowNode => {
+    const s = new Scope("t");
+    s.declare(name, t);
+    return { kind: "start", scope: s };
+  };
+  const at = (variable: string, chain: PathSegment[], t: VariableType) =>
+    typeAt({ variable, chain }, startWith(variable, t), env(startWithScope(variable, t)));
+  const startWithScope = (name: string, t: VariableType): Scope => {
+    const s = new Scope("t");
+    s.declare(name, t);
+    return s;
+  };
+
+  it("resolves an index segment into the array element type", () => {
+    expect(at("arr", [idx(0)], NUMA)).toEqual(NUM);
+    expect(at("arr", [idx(5)], NUMA)).toEqual(NUM); // any literal index → elementType
+  });
+
+  it("returns any for an index on a non-array, non-Record receiver", () => {
+    expect(at("n", [idx(0)], NUM)).toBe("any");
+  });
+
+  it("resolves an index segment into a Record<K,V> value type", () => {
+    const REC: VariableType = { type: "genericType", name: "Record", typeArgs: [STR, NUM] };
+    expect(at("m", [idx(0)], REC)).toEqual(NUM);
+  });
+
+  it("returns any for an index hop into an objectType", () => {
+    const OBJ: VariableType = { type: "objectType", properties: [{ key: "a", value: NUM }] };
+    expect(at("o", [idx(0)], OBJ)).toBe("any");
+  });
+
+  it("assigning arr[0] invalidates arr[0] (index exact-key + element re-resolve)", () => {
+    const s = new Scope("t");
+    s.declare("arr", { type: "arrayType", elementType: RESULT });
+    const start: FlowNode = { kind: "start", scope: s };
+    const narrowed: FlowNode = { kind: "narrow", prev: start, ref: { variable: "arr", chain: [idx(0)] }, refine: successRefine };
+    const reassigned: FlowNode = { kind: "assign", prev: narrowed, ref: { variable: "arr", chain: [idx(0)] }, type: RESULT };
+    const after = typeAt({ variable: "arr", chain: [idx(0)] }, reassigned, env(s));
+    expect(typeof after === "object" && after.type).toBe("resultType");
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -141,6 +141,15 @@ export function stablePrefix(elements: AccessChainElement[]): PathSegment[] {
   return segs;
 }
 
+/** The DECLARED (un-narrowed) type of a path, from the base var's scope type. */
+export function declaredPathType(
+  scope: Scope,
+  ref: Reference,
+  aliases: Record<string, TypeAliasEntry>,
+): ScopeType {
+  return resolvePath(scope.lookup(ref.variable) ?? "any", ref.chain, aliases);
+}
+
 /**
  * A program point. Type checking builds and discards this graph per check; it
  * NEVER appears in AST output, so it cannot affect lowering, codegen, or

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -1,4 +1,5 @@
 import type { AgencyNode, TypeAliasEntry, VariableType } from "../types.js";
+import type { AccessChainElement } from "../types/access.js";
 import type { Refine, NarrowCandidate } from "./narrowing.js";
 import { narrowByRefine } from "./narrowing.js";
 import { Scope, type ScopeType } from "./scope.js";
@@ -10,43 +11,81 @@ import { isNever, safeResolveType } from "./assignability.js";
 // commit's imports tight to its surface area.
 
 /**
- * A normalized reference path — the bound thing being narrowed. Today the
- * builder only emits empty chains (bare variables); the `chain` is reserved so
- * property-path narrowing (`if (user.profile != null) { user.profile.email }`)
- * can be added without revisiting `FlowNode` or `typeAt`'s signature.
+ * One hop of a narrowed access path. A `prop` is a static property name; an
+ * `index` is a LITERAL array index. They are kept distinct so `box.r` (property
+ * "r") and `arr[0]` (index 0) — and a numeric property `obj["0"]` vs `arr[0]` —
+ * never alias in `referenceKey`/`isPrefixOf`. The chain is reserved for stable
+ * paths only: calls, computed keys, slices, and method hops never appear here
+ * (the recognizers reject them).
  */
-export type Reference = { variable: string; chain: string[] };
+export type PathSegment =
+  | { kind: "prop"; name: string }
+  | { kind: "index"; index: number };
+
+/**
+ * A normalized reference path — the bound thing being narrowed. A bare variable
+ * is the empty-chain case; member paths (`box.r`, `arr[0]`, `a.b.c`) carry their
+ * hops as `PathSegment`s.
+ */
+export type Reference = { variable: string; chain: PathSegment[] };
+
+/** Stable string key for one path hop. `prop` → its name; `index` → `[N]`. */
+export function segKey(seg: PathSegment): string {
+  return seg.kind === "prop" ? seg.name : `[${seg.index}]`;
+}
 
 /** Stable string key for a reference (map keys, equality). */
 export function referenceKey(ref: Reference): string {
-  return ref.chain.length === 0 ? ref.variable : `${ref.variable}.${ref.chain.join(".")}`;
+  return ref.chain.length === 0
+    ? ref.variable
+    : `${ref.variable}.${ref.chain.map(segKey).join(".")}`;
 }
 
 /**
- * Resolve successive property hops on a type — DIAGNOSTIC-FREE (unlike
+ * Resolve successive path hops on a type — DIAGNOSTIC-FREE (unlike
  * `synthValueAccess`, which emits strict-member-access errors). Returns "any" on
- * any hop that can't be resolved (missing property, non-object/Record receiver),
- * so path narrowing stays conservative. M1: property hops only.
+ * any hop that can't be resolved (missing property, non-object/Record/array
+ * receiver), so path narrowing stays conservative. Handles property and
+ * literal-index hops (no tuple types exist, so an index resolves to the array
+ * element type regardless of the index value).
  */
 function resolvePath(
   baseType: ScopeType,
-  chain: string[],
+  chain: PathSegment[],
   aliases: Record<string, TypeAliasEntry>,
 ): ScopeType {
   let current: ScopeType = baseType;
-  for (const prop of chain) {
+  for (const seg of chain) {
     if (current === "any") return "any";
     const resolved = safeResolveType(current, aliases);
-    if (resolved.type === "objectType") {
-      const p = resolved.properties.find((pr) => pr.key === prop);
-      current = p ? p.value : "any";
-    } else if (resolved.type === "genericType" && resolved.name === "Record") {
-      current = resolved.typeArgs[1];
+    if (seg.kind === "prop") {
+      if (resolved.type === "objectType") {
+        const p = resolved.properties.find((pr) => pr.key === seg.name);
+        current = p ? p.value : "any";
+      } else if (resolved.type === "genericType" && resolved.name === "Record") {
+        current = resolved.typeArgs[1];
+      } else {
+        return "any";
+      }
     } else {
-      return "any";
+      // index segment: array element, or Record value (Record<K,V>[i] → V)
+      if (resolved.type === "arrayType") {
+        current = resolved.elementType;
+      } else if (resolved.type === "genericType" && resolved.name === "Record") {
+        current = resolved.typeArgs[1];
+      } else {
+        return "any";
+      }
     }
   }
   return current;
+}
+
+function segEq(a: PathSegment, b: PathSegment): boolean {
+  // Discriminated compare — no nested ternary (docs/dev/anti-patterns.md).
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "prop") return a.name === (b as { name: string }).name;
+  return a.index === (b as { index: number }).index;
 }
 
 /**
@@ -57,7 +96,49 @@ function resolvePath(
 export function isPrefixOf(prefix: Reference, path: Reference): boolean {
   if (prefix.variable !== path.variable) return false;
   if (prefix.chain.length >= path.chain.length) return false;
-  return prefix.chain.every((seg, i) => seg === path.chain[i]);
+  return prefix.chain.every((seg, i) => segEq(seg, path.chain[i]));
+}
+
+/**
+ * One access-chain hop → a path segment, or null if the hop is UNSTABLE (a
+ * computed/non-literal-integer index, a slice, or a method call). Stable hops:
+ * a property, or a literal non-negative-integer index. THE single source of the
+ * stability rule — `chainToSegments` and `stablePrefix` both build on it.
+ */
+export function toSegment(el: AccessChainElement): PathSegment | null {
+  if (el.kind === "property") return { kind: "prop", name: el.name };
+  if (el.kind === "index" && el.index.type === "number") {
+    const n = Number(el.index.value); // NumberLiteral.value is a string
+    if (!Number.isInteger(n) || n < 0) return null;
+    return { kind: "index", index: n };
+  }
+  return null; // computed index, slice, methodCall
+}
+
+/** Whole chain → segments, or null if ANY hop is unstable. */
+export function chainToSegments(elements: AccessChainElement[]): PathSegment[] | null {
+  const segs: PathSegment[] = [];
+  for (const el of elements) {
+    const seg = toSegment(el);
+    if (seg === null) return null;
+    segs.push(seg);
+  }
+  return segs;
+}
+
+/**
+ * The maximal STABLE prefix — stops at the first unstable hop instead of
+ * nulling the whole chain. A later unstable hop must NOT block narrowing an
+ * earlier stable prefix (`a.b[i()].x` can still use a narrowed `a.b`).
+ */
+export function stablePrefix(elements: AccessChainElement[]): PathSegment[] {
+  const segs: PathSegment[] = [];
+  for (const el of elements) {
+    const seg = toSegment(el);
+    if (seg === null) break;
+    segs.push(seg);
+  }
+  return segs;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -1,45 +1,25 @@
 import type { AgencyNode, TypeAliasEntry, VariableType } from "../types.js";
-import type { AccessChainElement } from "../types/access.js";
 import type { Refine, NarrowCandidate } from "./narrowing.js";
 import { narrowByRefine } from "./narrowing.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { NEVER_T } from "./primitives.js";
 import { isNever, safeResolveType } from "./assignability.js";
-
-// NOTE: `narrowUnionByDiscriminant` and `NarrowCandidate` are added in Task 2
-// and Task 3 respectively, alongside the code that uses them. Keeping each
-// commit's imports tight to its surface area.
-
-/**
- * One hop of a narrowed access path. A `prop` is a static property name; an
- * `index` is a LITERAL array index. They are kept distinct so `box.r` (property
- * "r") and `arr[0]` (index 0) — and a numeric property `obj["0"]` vs `arr[0]` —
- * never alias in `referenceKey`/`isPrefixOf`. The chain is reserved for stable
- * paths only: calls, computed keys, slices, and method hops never appear here
- * (the recognizers reject them).
- */
-export type PathSegment =
-  | { kind: "prop"; name: string }
-  | { kind: "index"; index: number };
-
-/**
- * A normalized reference path — the bound thing being narrowed. A bare variable
- * is the empty-chain case; member paths (`box.r`, `arr[0]`, `a.b.c`) carry their
- * hops as `PathSegment`s.
- */
-export type Reference = { variable: string; chain: PathSegment[] };
-
-/** Stable string key for one path hop. `prop` → its name; `index` → `[N]`. */
-export function segKey(seg: PathSegment): string {
-  return seg.kind === "prop" ? seg.name : `[${seg.index}]`;
-}
-
-/** Stable string key for a reference (map keys, equality). */
-export function referenceKey(ref: Reference): string {
-  return ref.chain.length === 0
-    ? ref.variable
-    : `${ref.variable}.${ref.chain.map(segKey).join(".")}`;
-}
+// The pure path-segment core lives in its own module so `narrowing.ts` can
+// value-import it (chainToSegments) without a runtime cycle back through
+// `flow.ts` (which value-imports `narrowByRefine` from `narrowing.ts`). Re-export
+// it here so existing importers of `flow.js` are unaffected.
+import type { PathSegment, Reference } from "./pathSegments.js";
+import { referenceKey, isPrefixOf } from "./pathSegments.js";
+export {
+  type PathSegment,
+  type Reference,
+  segKey,
+  referenceKey,
+  isPrefixOf,
+  toSegment,
+  chainToSegments,
+  stablePrefix,
+} from "./pathSegments.js";
 
 /**
  * Resolve successive path hops on a type — DIAGNOSTIC-FREE (unlike
@@ -79,66 +59,6 @@ function resolvePath(
     }
   }
   return current;
-}
-
-function segEq(a: PathSegment, b: PathSegment): boolean {
-  // Discriminated compare — no nested ternary (docs/dev/anti-patterns.md).
-  if (a.kind !== b.kind) return false;
-  if (a.kind === "prop") return a.name === (b as { name: string }).name;
-  return a.index === (b as { index: number }).index;
-}
-
-/**
- * True if `prefix` is a proper prefix of `path` (same variable; `prefix.chain`
- * is a leading sub-sequence of `path.chain`). Used for prefix invalidation:
- * reassigning `box` (or `box.r`) drops a narrowing on `box.r` (or `box.r.value`).
- */
-export function isPrefixOf(prefix: Reference, path: Reference): boolean {
-  if (prefix.variable !== path.variable) return false;
-  if (prefix.chain.length >= path.chain.length) return false;
-  return prefix.chain.every((seg, i) => segEq(seg, path.chain[i]));
-}
-
-/**
- * One access-chain hop → a path segment, or null if the hop is UNSTABLE (a
- * computed/non-literal-integer index, a slice, or a method call). Stable hops:
- * a property, or a literal non-negative-integer index. THE single source of the
- * stability rule — `chainToSegments` and `stablePrefix` both build on it.
- */
-export function toSegment(el: AccessChainElement): PathSegment | null {
-  if (el.kind === "property") return { kind: "prop", name: el.name };
-  if (el.kind === "index" && el.index.type === "number") {
-    const n = Number(el.index.value); // NumberLiteral.value is a string
-    if (!Number.isInteger(n) || n < 0) return null;
-    return { kind: "index", index: n };
-  }
-  return null; // computed index, slice, methodCall
-}
-
-/** Whole chain → segments, or null if ANY hop is unstable. */
-export function chainToSegments(elements: AccessChainElement[]): PathSegment[] | null {
-  const segs: PathSegment[] = [];
-  for (const el of elements) {
-    const seg = toSegment(el);
-    if (seg === null) return null;
-    segs.push(seg);
-  }
-  return segs;
-}
-
-/**
- * The maximal STABLE prefix — stops at the first unstable hop instead of
- * nulling the whole chain. A later unstable hop must NOT block narrowing an
- * earlier stable prefix (`a.b[i()].x` can still use a narrowed `a.b`).
- */
-export function stablePrefix(elements: AccessChainElement[]): PathSegment[] {
-  const segs: PathSegment[] = [];
-  for (const el of elements) {
-    const seg = toSegment(el);
-    if (seg === null) break;
-    segs.push(seg);
-  }
-  return segs;
 }
 
 /** The DECLARED (un-narrowed) type of a path, from the base var's scope type. */

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parseAgency } from "../parser.js";
 import { Scope } from "./scope.js";
-import { typeAt, type FlowEnvironment, type FlowNode } from "./flow.js";
+import { typeAt, type FlowEnvironment, type FlowNode, type PathSegment } from "./flow.js";
 import { buildFlowGraph } from "./flowBuilder.js";
 import { walkNodes } from "../utils/node.js";
 import type { AgencyNode, VariableType } from "../types.js";
@@ -32,7 +32,7 @@ function freshEnv(
   return { scope, flowOf: new WeakMap(), typeAliases, memo: new WeakMap() };
 }
 
-const ref = (variable: string) => ({ variable, chain: [] as string[] });
+const ref = (variable: string) => ({ variable, chain: [] as PathSegment[] });
 
 function find(body: AgencyNode[], pred: (n: AgencyNode) => boolean): AgencyNode {
   for (const { node } of walkNodes(body)) {

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -133,6 +133,19 @@ describe("buildFlowGraph — linear", () => {
     expect(env.flowOf.get(access)).toBeDefined();
   });
 
+  it("REGRESSION (M2): an index valueAccess (arr[0]) gets a flowOf entry", () => {
+    const body = parseBody(`let arr = [1, 2]\nprint(arr[0])`);
+    const scope = new Scope("t");
+    scope.declare("arr", { type: "arrayType", elementType: NUM });
+    const env = freshEnv(scope);
+    buildFlowGraph(body, { kind: "start", scope }, env);
+    const access = find(
+      body,
+      (n) => n.type === "valueAccess" && n.base.type === "variableName" && n.base.value === "arr",
+    );
+    expect(env.flowOf.get(access)).toBeDefined();
+  });
+
   it("INVARIANT holds across slice / computed-key / index positions", () => {
     // `lo`/`hi` live inside a slice; `key` inside a computed key — both were
     // missed before expressionChildren covered slice + computedKey.

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -1,4 +1,5 @@
 import type { AgencyNode } from "../types.js";
+import type { AccessChainElement } from "../types/access.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { expressionChildren, walkNodes } from "../utils/node.js";
 import type { ScopeInfo, TypeCheckerContext } from "./types.js";
@@ -9,7 +10,29 @@ import {
   wrapFacts,
   mergeFlows,
   widenAtLoopBackEdge,
+  chainToSegments,
+  declaredPathType,
 } from "./flow.js";
+
+/**
+ * The flow node after an access-chain write (`obj.field = x`, `arr[0] = x`): a
+ * path-keyed `assign` so the path's narrowing is dropped (the field/element was
+ * rebound). Returns `null` for an UNSTABLE target (`obj[i()] = x`) — it can't be
+ * keyed, so it passes through (a known soundness gap; no aliasing analysis). The
+ * assigned type is the path's DECLARED (un-narrowed) type, matching the
+ * bare-rebind case.
+ */
+function assignNodeForAccessChainWrite(
+  variableName: string,
+  accessChain: AccessChainElement[],
+  flow: FlowNode,
+  env: FlowEnvironment,
+): FlowNode | null {
+  const chain = chainToSegments(accessChain);
+  if (chain === null) return null;
+  const ref = { variable: variableName, chain };
+  return { kind: "assign", prev: flow, ref, type: declaredPathType(env.scope, ref, env.typeAliases) };
+}
 
 /**
  * Attach `flow` to every variable-referencing node inside an expression. The
@@ -111,13 +134,18 @@ const statementRules: StatementRuleTable = {
     // node has no flowOf entry of its own, so without this the base would resolve
     // to its flat (un-narrowed) scope type. The check reads this entry to narrow
     // the base via typeAt.
+    // env.flowOf.set(node, flow) above records the PRE-write flow on the node
+    // for the Phase-B access-chain target check — DO NOT reorder it below the
+    // branches.
     env.flowOf.set(node, flow);
-    // Only a bare `x = …` / `let x = …` rebinds the variable. Skip access-chain
-    // writes (`obj.x = 5` — a mutation, not a rebind; matches walkScopeBody)
-    // and destructuring patterns (`node.variableName` not meaningful). The RHS
-    // is still attached above; PR 2 must not trust assign nodes for these.
-    if (node.accessChain || node.pattern) {
-      return flow;
+    if (node.pattern) {
+      return flow; // destructuring — variableName not meaningful
+    }
+    if (node.accessChain) {
+      // A write to a STABLE path (`obj.field = x`, `arr[0] = x`) emits a
+      // path-keyed assign so the path's narrowing drops. Unstable targets
+      // (`obj[i()] = x`) can't be keyed → pass through unchanged.
+      return assignNodeForAccessChainWrite(node.variableName, node.accessChain, flow, env) ?? flow;
     }
     return {
       kind: "assign",

--- a/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
@@ -395,3 +395,65 @@ def f(rs: Result<number, string>[]): void {
 }`)).toEqual([]);
   });
 });
+
+describe("member-path scrutinee narrowing — write invalidation (M2 soundness)", () => {
+  it("SOUNDNESS: mutating the path (b.r = …) drops the narrowing — exactly one error", () => {
+    const errs = check(`${TRY}
+type Box = { r: Result<number, string> }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    b.r = failure("x")
+    let n: number = b.r.value
+  }
+}`);
+    expect(errs.filter((m) => /only available on a success Result/.test(m)).length).toBe(1);
+  });
+
+  it("SOUNDNESS: writing rs[0] = failure(…) drops rs[0] narrowing — exactly one error", () => {
+    const errs = check(`${TRY}
+def f(rs: Result<number, string>[]): void {
+  if (isSuccess(rs[0])) {
+    rs[0] = failure("x")
+    let n: number = rs[0].value
+  }
+}`);
+    expect(errs.filter((m) => /only available on a success Result/.test(m)).length).toBe(1);
+  });
+
+  it("SOUNDNESS: writing b.other = … keeps b.r narrowed (no spurious error)", () => {
+    expect(check(`${TRY}
+type Box = { r: Result<number, string>, other: number }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    b.other = 5
+    let n: number = b.r.value
+  }
+}`)).toEqual([]);
+  });
+
+  it("SOUNDNESS: writing b.inner = … drops the b.inner.r narrowing — exactly one error", () => {
+    const errs = check(`${TRY}
+type In = { r: Result<number, string> }
+type Box = { inner: In }
+def otherIn(): In { return { r: failure("x") } }
+def f(b: Box): void {
+  if (isSuccess(b.inner.r)) {
+    b.inner = otherIn()
+    let n: number = b.inner.r.value
+  }
+}`);
+    expect(errs.filter((m) => /only available on a success Result/.test(m)).length).toBe(1);
+  });
+
+  it("SOUNDNESS: an unstable write target neither errors nor drops unrelated narrowing", () => {
+    expect(check(`${TRY}
+type Box = { r: Result<number, string>, xs: number[] }
+def idx(): number { return 0 }
+def f(b: Box): void {
+  if (isSuccess(b.r)) {
+    b.xs[idx()] = 9
+    let n: number = b.r.value
+  }
+}`)).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
@@ -250,3 +250,148 @@ node main() {
 }`).some((m) => /only available on a success Result/.test(m))).toBe(true);
   });
 });
+
+describe("member-path scrutinee narrowing — multi-hop + index (M2)", () => {
+  it("literal-index Result guard narrows (rs[0].value)", () => {
+    expect(check(`${TRY}
+def f(rs: Result<number, string>[]): void {
+  if (isSuccess(rs[0])) {
+    let n: number = rs[0].value
+  }
+}`)).toEqual([]);
+  });
+
+  it("HEADLINE: array-nested Result pattern narrows the binder", () => {
+    expect(check(`${TRY}
+def takesNumber(n: number): number { return n }
+def f(pair: Result<number, string>[]): number {
+  match (pair) {
+    [success(v), _] => takesNumber(v)
+    _ => 0
+  }
+}`)).toEqual([]);
+  });
+
+  it("multi-hop property guard narrows (o.inner.r)", () => {
+    expect(check(`${TRY}
+type Inner = { r: Result<number, string> }
+type Outer = { inner: Inner }
+def f(o: Outer): void {
+  if (isSuccess(o.inner.r)) {
+    let n: number = o.inner.r.value
+  }
+}`)).toEqual([]);
+  });
+
+  it("CRITICAL: un-narrowed index access STILL errors", () => {
+    expect(check(`${TRY}
+def f(rs: Result<number, string>[]): void {
+  let n: number = rs[0].value
+}`).some((m) => /only available on a success Result/.test(m))).toBe(true);
+  });
+
+  it("index narrowing does not leak across indices (rs[0] guarded, rs[1] not)", () => {
+    expect(check(`${TRY}
+def f(rs: Result<number, string>[]): void {
+  if (isSuccess(rs[0])) {
+    let n: number = rs[1].value
+  }
+}`).some((m) => /only available on a success Result/.test(m))).toBe(true);
+  });
+
+  it("narrowing flows through a pipe operand (rs[0].value |> double)", () => {
+    // `|>` yields a Result (auto-unwrap semantics), so we don't pin the binding
+    // type — assert ONLY that the narrowed operand `rs[0].value` raised no
+    // strict-access error (i.e. narrowing reached the pipe operand).
+    expect(check(`${TRY}
+def double(x: number): number { return x * 2 }
+def f(rs: Result<number, string>[]): void {
+  if (isSuccess(rs[0])) {
+    let n = rs[0].value |> double
+  }
+}`).some((m) => /only available on a success Result/.test(m))).toBe(false);
+  });
+
+  it("narrowing flows into a trailing block body (… as value { rs[0].value })", () => {
+    expect(check(`${TRY}
+def wrap(value: number, block: (number) => number): number { return block(value) }
+def f(rs: Result<number, string>[]): void {
+  if (isSuccess(rs[0])) {
+    let n: number = wrap(3) as value {
+      let inner: number = rs[0].value
+      return inner
+    }
+  }
+}`)).toEqual([]);
+  });
+
+  it("LONGEST PREFIX: o.inner.r.value reads the longer (more precise) narrowing", () => {
+    expect(check(`${TRY}
+type In = { r: Result<number, string> }
+type Out = { inner: In | null }
+def f(o: Out): void {
+  if (o.inner != null) {
+    if (isSuccess(o.inner.r)) {
+      let n: number = o.inner.r.value
+    }
+  }
+}`)).toEqual([]);
+  });
+
+  it("BREAK-vs-NULL: a stable (multi-hop) prefix narrows under an unstable later hop", () => {
+    // t.mid.item is narrowed (2-hop receiver discriminant); the access
+    // t.mid.item.data[pick()] has an UNSTABLE trailing index. stablePrefix must
+    // still yield [mid,item,data] (not null) so the narrowed t.mid.item prefix is
+    // consulted and `.data` resolves on the ok member. Requires longest-prefix +
+    // break-vs-null together.
+    expect(check(`
+type Item = { kind: "ok", data: number[] } | { kind: "err", msg: string }
+type Mid = { item: Item }
+type Top = { mid: Mid }
+def pick(): number { return 0 }
+def f(t: Top): void {
+  if (t.mid.item.kind == "ok") {
+    let n: number = t.mid.item.data[pick()]
+  }
+}`)).toEqual([]);
+  });
+
+  it("deeper multi-hop: isSuccess(x.a.b.c) narrows x.a.b.c.value", () => {
+    expect(check(`${TRY}
+type C = { c: Result<number, string> }
+type B = { b: C }
+type A = { a: B }
+def f(x: A): void {
+  if (isSuccess(x.a.b.c)) {
+    let n: number = x.a.b.c.value
+  }
+}`)).toEqual([]);
+  });
+
+  it("discriminant on an index path: if (rs[0].kind == \"click\") narrows rs[0].x", () => {
+    expect(check(`
+type Ev = { kind: "click", x: number } | { kind: "scroll", d: number }
+def takesNumber(n: number): void {}
+def f(rs: Ev[]): void {
+  if (rs[0].kind == "click") { takesNumber(rs[0].x) }
+}`)).toEqual([]);
+  });
+
+  it("index else-branch (isFailure(rs[0]) else → success)", () => {
+    expect(check(`${TRY}
+def f(rs: Result<number, string>[]): void {
+  if (isFailure(rs[0])) {
+  } else {
+    let n: number = rs[0].value
+  }
+}`)).toEqual([]);
+  });
+
+  it("index post-guard return (the major Result idiom)", () => {
+    expect(check(`${TRY}
+def f(rs: Result<number, string>[]): void {
+  if (isFailure(rs[0])) { return }
+  let n: number = rs[0].value
+}`)).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -82,13 +82,12 @@ describe("analyzeCondition", () => {
     ["isSuccess with zero args", "isSuccess()"],
     ["isSuccess with too many args", "isSuccess(r, r)"],
     ["isSuccess of a call", 'isSuccess(tryParse("x"))'],
-    // M1 path ceiling: these scrutinees are NOT single-hop property paths.
-    ["isSuccess of an index", "isSuccess(obj[0])"],
-    ["isSuccess of a two-hop path", "isSuccess(obj.r.s)"],
+    // Unstable scrutinees stay NO_FACTS even under M2 (calls/slices can't be
+    // statically pinned). Multi-hop + literal-index are now POSITIVE — see the
+    // M2 recognizer block below.
     ["isSuccess of a method call", "isSuccess(obj.method())"],
-    ["discriminant on an index receiver", 'obj[0].kind == "x"'],
-    ["discriminant on a two-hop receiver", 'a.b.c.kind == "x"'],
-    ["presence on an index", "obj[0] != null"],
+    ["isSuccess of a computed index", "isSuccess(obj[i])"],
+    ["isSuccess of a slice", "isSuccess(obj[0:2])"],
   ])("produces no candidates for %s", (_label, src) => {
     expect(analyzeCondition(firstIfCondition(src))).toEqual(NO_FACTS);
   });
@@ -137,6 +136,48 @@ describe("analyzeCondition", () => {
       succP("a", ["r"], true),
       succP("b", ["r"], true),
     ]);
+  });
+
+  // ── Multi-hop + literal-index member paths (M2) ───────────────────────────
+  it("isSuccess(o.inner.r) narrows a two-hop property path", () => {
+    expect(analyzeCondition(firstIfCondition("isSuccess(o.inner.r)")).then[0]).toEqual(
+      succP("o", ["inner", "r"], true));
+  });
+
+  it('a.b.c == "x" splits to receiver a.b and discriminant c', () => {
+    expect(analyzeCondition(firstIfCondition('a.b.c == "x"')).then[0]).toEqual(
+      discP("a", ["b"], "c", "x", true));
+  });
+
+  it("isSuccess(arr[0]) narrows the index path", () => {
+    expect(analyzeCondition(firstIfCondition("isSuccess(arr[0])")).then[0].ref).toEqual(
+      { variable: "arr", chain: [{ kind: "index", index: 0 }] });
+  });
+
+  it('arr[0].kind == "x" splits to receiver arr[0] and discriminant kind', () => {
+    expect(analyzeCondition(firstIfCondition('arr[0].kind == "x"')).then[0].ref).toEqual(
+      { variable: "arr", chain: [{ kind: "index", index: 0 }] });
+  });
+
+  it('"click" == arr[0].kind narrows the same as the other operand order', () => {
+    expect(analyzeCondition(firstIfCondition('"click" == arr[0].kind')).then[0].ref).toEqual(
+      { variable: "arr", chain: [{ kind: "index", index: 0 }] });
+  });
+
+  it("arr[0] != null narrows the index path (presence)", () => {
+    expect(analyzeCondition(firstIfCondition("arr[0] != null")).then[0]).toEqual({
+      ref: { variable: "arr", chain: [{ kind: "index", index: 0 }] },
+      refine: { kind: "presence", present: true },
+    });
+  });
+
+  it.each([
+    ["non-integer index", "isSuccess(arr[0.5])"],
+    ["negative index", "isSuccess(arr[-1])"],
+    ["unstable receiver before discriminant", 'arr[f()].kind == "x"'],
+    ["last hop is an index (not a property)", "arr[0] == 5"],
+  ])("M2 recognizer rejects %s → NO_FACTS", (_label, src) => {
+    expect(analyzeCondition(firstIfCondition(src))).toEqual(NO_FACTS);
   });
 
   it("negation swaps then/else", () => {

--- a/packages/agency-lang/lib/typeChecker/narrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.test.ts
@@ -6,6 +6,11 @@ import { analyzeCondition, alwaysExits, postGuardFacts } from "./narrowing.js";
 import { walkNodes } from "../utils/node.js";
 import type { Expression, IfElse } from "../types.js";
 import type { ResultType } from "../types/typeHints.js";
+import type { PathSegment } from "./flow.js";
+
+// Path-segment constructor — builders take string[] chains and map to `prop`
+// segments so existing property-path callers stay unchanged (M2 representation).
+const prop = (name: string): PathSegment => ({ kind: "prop", name });
 
 // Parse a snippet and return the first ifElse node in main. Uses the shared
 // walkNodes traversal (lib/utils/node.ts) rather than a hand-rolled walker —
@@ -27,7 +32,7 @@ describe("analyzeCondition", () => {
   // isSuccess/isFailure (and `if (r.success)`) now narrow via a discriminant on
   // the boolean `success` field (Result is consumed as a discriminated union).
   const succ = (varName: string, keep: boolean) => ({
-    ref: { variable: varName, chain: [] as string[] },
+    ref: { variable: varName, chain: [] as PathSegment[] },
     refine: {
       kind: "discriminant",
       prop: "success",
@@ -35,9 +40,9 @@ describe("analyzeCondition", () => {
       keep,
     },
   });
-  // Path-aware success builder (one-hop receiver).
+  // Path-aware success builder — string chain mapped to `prop` segments.
   const succP = (variable: string, chain: string[], keep: boolean) => ({
-    ref: { variable, chain },
+    ref: { variable, chain: chain.map(prop) },
     refine: {
       kind: "discriminant",
       prop: "success",
@@ -90,12 +95,12 @@ describe("analyzeCondition", () => {
 
   // ── Single-hop member paths (M1) ──────────────────────────────────────────
   const presP = (variable: string, chain: string[], present: boolean) => ({
-    ref: { variable, chain },
+    ref: { variable, chain: chain.map(prop) },
     refine: { kind: "presence", present },
   });
-  const discP = (variable: string, chain: string[], prop: string, value: string, keep: boolean) => ({
-    ref: { variable, chain },
-    refine: { kind: "discriminant", prop, literal: { type: "stringLiteralType", value }, keep },
+  const discP = (variable: string, chain: string[], propName: string, value: string, keep: boolean) => ({
+    ref: { variable, chain: chain.map(prop) },
+    refine: { kind: "discriminant", prop: propName, literal: { type: "stringLiteralType", value }, keep },
   });
 
   it("isSuccess(obj.r): full candidate, path ref (was the old NO_FACTS member-access row)", () => {
@@ -163,7 +168,7 @@ describe("analyzeCondition", () => {
   });
 
   const disc = (keep: boolean, value = "answer", prop = "kind") => ({
-    ref: { variable: "r", chain: [] as string[] },
+    ref: { variable: "r", chain: [] as PathSegment[] },
     refine: { kind: "discriminant", prop, literal: { type: "stringLiteralType", value }, keep },
   });
 

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -12,7 +12,8 @@ import { resultToObjectUnion } from "./resultUnion.js";
 import { unescapeStringLiteralValue } from "../parsers/parsers.js";
 // Type-only import: `flow.ts` imports `Refine`/`NarrowCandidate` from here, so a
 // value import would cycle. `Reference` is the narrowed path (variable + chain).
-import type { PathSegment, Reference } from "./flow.js";
+import { chainToSegments } from "./flow.js";
+import type { Reference } from "./flow.js";
 
 /**
  * What a candidate narrows to. Tagged so a new narrowing form slots in as one
@@ -65,41 +66,38 @@ export function narrowByRefine(
 /**
  * A stable single-hop property path: a bare variable, or `variable.property`.
  * Returns the `Reference`, or null for anything else (calls, index/computed
- * keys, method hops, slices, or >1 property hop). M2 extends to multi-hop +
- * index; M1 caps at one hop so the narrowed scrutinee is statically stable.
+ * keys, method hops, slices). A stable path is a bare variable or any chain of
+ * property + literal-non-negative-integer-index hops over one (M2). The shared
+ * `chainToSegments` (flow.ts) is the single source of the stability rule.
  */
 function asPathReference(e: Expression): Reference | null {
   if (e.type === "variableName") return { variable: e.value, chain: [] };
-  if (e.type === "valueAccess" && e.base.type === "variableName" && e.chain.length === 1) {
-    const el = e.chain[0];
-    if (el.kind === "property") return { variable: e.base.value, chain: [{ kind: "prop", name: el.name }] };
+  if (e.type === "valueAccess" && e.base.type === "variableName") {
+    const chain = chainToSegments(e.chain);
+    return chain === null ? null : { variable: e.base.value, chain };
   }
   return null;
 }
 
 /**
- * Recognize `V.prop` where the *receiver* `V` is a single-hop path (a bare
- * variable, or one property hop). The discriminant is the FINAL property; the
- * narrowed reference is the receiver. So `obj.kind` → ref `{obj,[]}`, prop
- * `kind`; `obj.payload.kind` → ref `{obj,[payload]}`, prop `kind`. A receiver of
- * >1 hop (`a.b.c.kind`) returns null (M2). Variable-keyed, so the narrowed
- * scrutinee is statically the same binding at the access site.
+ * Recognize `V.prop` where the *receiver* `V` is any stable path. The
+ * discriminant is the FINAL hop (must be a property); the narrowed reference is
+ * the receiver prefix. So `obj.kind` → ref `{obj,[]}`, prop `kind`;
+ * `obj.payload.kind` → ref `{obj,[payload]}`; `arr[0].kind` → ref `{arr,[[0]]}`,
+ * prop `kind`. An unstable hop before the discriminant (`arr[i()].kind`) → null.
+ * Variable-keyed, so the narrowed scrutinee is statically the same binding at
+ * the access site.
  */
 function asDiscriminantAccess(
   e: Expression,
 ): { ref: Reference; prop: string } | null {
-  if (e.type !== "valueAccess") return null;
-  if (e.base.type !== "variableName") return null;
-  if (e.chain.length < 1 || e.chain.length > 2) return null;
-  if (e.chain.some((el) => el.kind !== "property")) return null;
-  const props = e.chain.map((el) => (el.kind === "property" ? el.name : ""));
-  const prop = props[props.length - 1];
-  // [] for one hop, [p] for two hops — all property segments (Task 1 keeps the
-  // 1-2 property-hop ceiling; Task 2 generalizes via chainToSegments).
-  const receiverChain: PathSegment[] = props
-    .slice(0, -1)
-    .map((name) => ({ kind: "prop", name }));
-  return { ref: { variable: e.base.value, chain: receiverChain }, prop };
+  if (e.type !== "valueAccess" || e.base.type !== "variableName") return null;
+  if (e.chain.length < 1) return null;
+  const last = e.chain[e.chain.length - 1];
+  if (last.kind !== "property") return null; // discriminant must be a static prop
+  const receiver = chainToSegments(e.chain.slice(0, -1));
+  if (receiver === null) return null; // an unstable hop before the discriminant
+  return { ref: { variable: e.base.value, chain: receiver }, prop: last.name };
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -12,8 +12,11 @@ import { resultToObjectUnion } from "./resultUnion.js";
 import { unescapeStringLiteralValue } from "../parsers/parsers.js";
 // Type-only import: `flow.ts` imports `Refine`/`NarrowCandidate` from here, so a
 // value import would cycle. `Reference` is the narrowed path (variable + chain).
-import { chainToSegments } from "./flow.js";
-import type { Reference } from "./flow.js";
+// Import the path-segment core from its own module (NOT flow.ts) — flow.ts
+// value-imports narrowByRefine from here, so a value import back from flow.ts
+// would form a runtime cycle. See pathSegments.ts.
+import { chainToSegments } from "./pathSegments.js";
+import type { Reference } from "./pathSegments.js";
 
 /**
  * What a candidate narrows to. Tagged so a new narrowing form slots in as one

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -12,7 +12,7 @@ import { resultToObjectUnion } from "./resultUnion.js";
 import { unescapeStringLiteralValue } from "../parsers/parsers.js";
 // Type-only import: `flow.ts` imports `Refine`/`NarrowCandidate` from here, so a
 // value import would cycle. `Reference` is the narrowed path (variable + chain).
-import type { Reference } from "./flow.js";
+import type { PathSegment, Reference } from "./flow.js";
 
 /**
  * What a candidate narrows to. Tagged so a new narrowing form slots in as one
@@ -72,7 +72,7 @@ function asPathReference(e: Expression): Reference | null {
   if (e.type === "variableName") return { variable: e.value, chain: [] };
   if (e.type === "valueAccess" && e.base.type === "variableName" && e.chain.length === 1) {
     const el = e.chain[0];
-    if (el.kind === "property") return { variable: e.base.value, chain: [el.name] };
+    if (el.kind === "property") return { variable: e.base.value, chain: [{ kind: "prop", name: el.name }] };
   }
   return null;
 }
@@ -94,7 +94,11 @@ function asDiscriminantAccess(
   if (e.chain.some((el) => el.kind !== "property")) return null;
   const props = e.chain.map((el) => (el.kind === "property" ? el.name : ""));
   const prop = props[props.length - 1];
-  const receiverChain = props.slice(0, -1); // [] for one hop, [p] for two hops
+  // [] for one hop, [p] for two hops — all property segments (Task 1 keeps the
+  // 1-2 property-hop ceiling; Task 2 generalizes via chainToSegments).
+  const receiverChain: PathSegment[] = props
+    .slice(0, -1)
+    .map((name) => ({ kind: "prop", name }));
   return { ref: { variable: e.base.value, chain: receiverChain }, prop };
 }
 

--- a/packages/agency-lang/lib/typeChecker/pathSegments.ts
+++ b/packages/agency-lang/lib/typeChecker/pathSegments.ts
@@ -1,0 +1,99 @@
+import type { AccessChainElement } from "../types/access.js";
+
+/**
+ * Pure path-segment core, split out of `flow.ts` so both `flow.ts` and
+ * `narrowing.ts` can VALUE-import it without forming a runtime cycle (`flow.ts`
+ * value-imports `narrowByRefine` from `narrowing.ts`; `narrowing.ts` needs
+ * `chainToSegments`). No dependency on the flow graph, scopes, or narrowing.
+ */
+
+/**
+ * One hop of a narrowed access path. A `prop` is a static property name; an
+ * `index` is a LITERAL array index. They are kept distinct so `box.r` (property
+ * "r") and `arr[0]` (index 0) — and a numeric property `obj["0"]` vs `arr[0]` —
+ * never alias in `referenceKey`/`isPrefixOf`. The chain is reserved for stable
+ * paths only: calls, computed keys, slices, and method hops never appear here
+ * (the recognizers reject them).
+ */
+export type PathSegment =
+  | { kind: "prop"; name: string }
+  | { kind: "index"; index: number };
+
+/**
+ * A normalized reference path — the bound thing being narrowed. A bare variable
+ * is the empty-chain case; member paths (`box.r`, `arr[0]`, `a.b.c`) carry their
+ * hops as `PathSegment`s.
+ */
+export type Reference = { variable: string; chain: PathSegment[] };
+
+/** Stable string key for one path hop. `prop` → its name; `index` → `[N]`. */
+export function segKey(seg: PathSegment): string {
+  return seg.kind === "prop" ? seg.name : `[${seg.index}]`;
+}
+
+/** Stable string key for a reference (map keys, equality). */
+export function referenceKey(ref: Reference): string {
+  return ref.chain.length === 0
+    ? ref.variable
+    : `${ref.variable}.${ref.chain.map(segKey).join(".")}`;
+}
+
+function segEq(a: PathSegment, b: PathSegment): boolean {
+  // Discriminated compare — no nested ternary (docs/dev/anti-patterns.md).
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "prop") return a.name === (b as { name: string }).name;
+  return a.index === (b as { index: number }).index;
+}
+
+/**
+ * True if `prefix` is a proper prefix of `path` (same variable; `prefix.chain`
+ * is a leading sub-sequence of `path.chain`). Used for prefix invalidation:
+ * reassigning `box` (or `box.r`) drops a narrowing on `box.r` (or `box.r.value`).
+ */
+export function isPrefixOf(prefix: Reference, path: Reference): boolean {
+  if (prefix.variable !== path.variable) return false;
+  if (prefix.chain.length >= path.chain.length) return false;
+  return prefix.chain.every((seg, i) => segEq(seg, path.chain[i]));
+}
+
+/**
+ * One access-chain hop → a path segment, or null if the hop is UNSTABLE (a
+ * computed/non-literal-integer index, a slice, or a method call). Stable hops:
+ * a property, or a literal non-negative-integer index. THE single source of the
+ * stability rule — `chainToSegments` and `stablePrefix` both build on it.
+ */
+export function toSegment(el: AccessChainElement): PathSegment | null {
+  if (el.kind === "property") return { kind: "prop", name: el.name };
+  if (el.kind === "index" && el.index.type === "number") {
+    const n = Number(el.index.value); // NumberLiteral.value is a string
+    if (!Number.isInteger(n) || n < 0) return null;
+    return { kind: "index", index: n };
+  }
+  return null; // computed index, slice, methodCall
+}
+
+/** Whole chain → segments, or null if ANY hop is unstable. */
+export function chainToSegments(elements: AccessChainElement[]): PathSegment[] | null {
+  const segs: PathSegment[] = [];
+  for (const el of elements) {
+    const seg = toSegment(el);
+    if (seg === null) return null;
+    segs.push(seg);
+  }
+  return segs;
+}
+
+/**
+ * The maximal STABLE prefix — stops at the first unstable hop instead of
+ * nulling the whole chain. A later unstable hop must NOT block narrowing an
+ * earlier stable prefix (`a.b[i()].x` can still use a narrowed `a.b`).
+ */
+export function stablePrefix(elements: AccessChainElement[]): PathSegment[] {
+  const segs: PathSegment[] = [];
+  for (const el of elements) {
+    const seg = toSegment(el);
+    if (seg === null) break;
+    segs.push(seg);
+  }
+  return segs;
+}

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -9,7 +9,7 @@ import type {
 import { formatTypeHint } from "../utils/formatType.js";
 import { BUILTIN_FUNCTION_TYPES, AGENCY_FUNCTION_METHOD_TYPES } from "./builtins.js";
 import { isAssignable, isNever, safeResolveType } from "./assignability.js";
-import { typeAt, flowHasNarrowFor } from "./flow.js";
+import { typeAt, flowHasNarrowFor, stablePrefix } from "./flow.js";
 import { literalToType } from "./literalType.js";
 import { resultTypeForValidation } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
@@ -772,32 +772,39 @@ function validateAgencyFunctionMethod(
 }
 
 /**
- * Flow-sensitive path narrowing (M1): if `expr` is a single-hop property path
- * `base.prop` whose flow node carries a `narrow` for that exact ref, return the
- * narrowed type of the one-hop prefix — so `b.r.value` reads the narrowed `b.r`
- * inside `if (isSuccess(b.r))`. `null` means no narrowing applies; the caller
- * then resolves the base structurally and the chain walk's diagnostics (strict
- * member access) run on the un-narrowed access. (Bare-base narrowing, `r.value`,
- * flows through `synthType(expr.base)` and needs nothing here.)
+ * Flow-sensitive path narrowing (M2): if a stable prefix of `expr` carries a
+ * `narrow` for that exact ref, return its narrowed type and how many chain
+ * elements it consumes — so `arr[0].value` reads the narrowed `arr[0]` and
+ * `o.inner.r.value` reads the narrowed `o.inner.r`. Searches the LONGEST prefix
+ * first (so the most precise narrowing wins). `null` = no narrowing → the caller
+ * resolves the base structurally and the chain walk's diagnostics (strict member
+ * access) run on the un-narrowed access. (Bare-base narrowing, `r.value`, flows
+ * through `synthType(expr.base)` and needs nothing here.)
+ *
+ * `stablePrefix` (not `chainToSegments`) is used so a later UNSTABLE hop doesn't
+ * block narrowing an earlier stable prefix (`a.b[i()].x` can still use a narrowed
+ * `a.b`).
  *
  * The `flowHasNarrowFor` gate is required: without it, `typeAt` would return the
  * structural (un-narrowed) member type and short-circuiting on it would suppress
- * the strict-member-access error that un-guarded `b.r.value` must still raise.
+ * the strict-member-access error that un-guarded access must still raise.
  */
 function narrowedPathPrefix(
   expr: ValueAccess,
   ctx: TypeCheckerContext,
-): VariableType | "any" | null {
-  const first = expr.chain[0];
-  if (!ctx.flowEnv || expr.base.type !== "variableName" || first?.kind !== "property") {
-    return null;
-  }
+): { type: VariableType | "any"; consumed: number } | null {
+  if (!ctx.flowEnv || expr.base.type !== "variableName") return null;
   const flow = ctx.flowEnv.flowOf.get(expr);
-  const ref = { variable: expr.base.value, chain: [{ kind: "prop" as const, name: first.name }] };
-  if (!flow || !flowHasNarrowFor(ref, flow)) {
-    return null;
+  if (!flow) return null;
+  const stable = stablePrefix(expr.chain);
+  const env = { ...ctx.flowEnv, typeAliases: ctx.getTypeAliases() };
+  for (let len = stable.length; len >= 1; len--) {
+    const ref = { variable: expr.base.value, chain: stable.slice(0, len) };
+    if (flowHasNarrowFor(ref, flow)) {
+      return { type: typeAt(ref, flow, env), consumed: len };
+    }
   }
-  return typeAt(ref, flow, { ...ctx.flowEnv, typeAliases: ctx.getTypeAliases() });
+  return null;
 }
 
 export function synthValueAccess(
@@ -807,12 +814,12 @@ export function synthValueAccess(
 ): VariableType | "any" {
   const typeAliases = ctx.getTypeAliases();
 
-  // When a narrowed single-hop prefix applies, start the structural walk from
-  // its type at the next hop; otherwise resolve the base and walk the whole chain.
+  // When a narrowed stable prefix applies, start the structural walk from its
+  // type at the next hop; otherwise resolve the base and walk the whole chain.
   const narrowedPrefix = narrowedPathPrefix(expr, ctx);
   let currentType =
-    narrowedPrefix === null ? synthType(expr.base, scope, ctx) : narrowedPrefix;
-  const chainStart = narrowedPrefix === null ? 0 : 1;
+    narrowedPrefix === null ? synthType(expr.base, scope, ctx) : narrowedPrefix.type;
+  const chainStart = narrowedPrefix === null ? 0 : narrowedPrefix.consumed;
 
   for (const element of expr.chain.slice(chainStart)) {
     // Validate .partial()/.describe() even when the base type is unknown,

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -793,7 +793,7 @@ function narrowedPathPrefix(
     return null;
   }
   const flow = ctx.flowEnv.flowOf.get(expr);
-  const ref = { variable: expr.base.value, chain: [first.name] };
+  const ref = { variable: expr.base.value, chain: [{ kind: "prop" as const, name: first.name }] };
   if (!flow || !flowHasNarrowFor(ref, flow)) {
     return null;
   }


### PR DESCRIPTION
## What

Extends member-path flow narrowing from M1's single-hop property paths to **multi-hop** (`a.b.c`) and **literal-index** (`arr[0]`) paths. The headline: **array-nested match patterns** like `[success(v), _]` now narrow the binder instead of hard-erroring under enforced Result safety.

```agency
def f(rs: Result<number, string>[]): number {
  match (rs) {
    [success(v), _] => takesNumber(v)   // before: strict-access error on the lowered __s[0].value; now: ok
    _ => 0
  }
}
```

Also narrows: `isSuccess(arr[0])` → `arr[0].value`; `isSuccess(o.inner.r)` → `o.inner.r.value`; `arr[0].kind == "click"`; `arr[0] != null`; and the else-branch / post-guard-return idioms on index paths.

## How (5 commits, one per task)

1. **`Reference.chain` → `PathSegment[]`** (`{kind:"prop"}` | `{kind:"index"}`) so `box.r` and `arr[0]` (and `obj["0"]` vs `arr[0]`) never alias in `referenceKey`/`isPrefixOf`. `resolvePath` walks index hops into the array element type. A single shared stability predicate — `toSegment`/`chainToSegments`/`stablePrefix` — lives in `flow.ts` (one home, no drift). Behavior-preserving for property paths.
2. **Recognizers** accept any stable path (`asPathReference`, `asDiscriminantAccess` via `chainToSegments`); unstable hops (computed index, slice, method, negative/non-integer index) → no facts.
3. **`synthValueAccess`** consults `typeAt` for the **longest narrowed stable prefix** (`stablePrefix`), so a later unstable hop doesn't block narrowing an earlier stable prefix (`a.b[i()].x` still uses a narrowed `a.b`).
4. **Access-chain-write invalidation** — `obj.field = x` / `arr[0] = x` now emit a path-keyed `assign` node, closing a latent soundness hole shared with M1.
5. Docs.

## Soundness

- **Per-index**: `isSuccess(arr[0])` does NOT narrow `arr[1]`.
- **Writes**: mutating the path or any prefix (`b.r = …`, `rs[0] = …`, `b.inner = …`) drops the narrowing; a **disjoint** write (`b.other = …`) does not; an **unstable** write target (`obj[i()] = x`) passes through (no aliasing analysis).
- **Longest-prefix-first** and **break-vs-null** each have a dedicated e2e that fails if the rule regresses.
- Un-guarded access still errors (the `flowHasNarrowFor` gate doesn't over-suppress).

## Pipes & blocks

Verified narrowing flows through a `|>` operand and into block bodies (lock-in e2e). Block-body narrowing depends on PR #372 (merged), which this builds on.

## Tests

35 new tests across `flow.test.ts` (PathSegment/index units, prefix invalidation), `narrowing.test.ts` (multi-hop/index recognizers + negatives; 5 former negative-table rows flipped to positive), `memberPathNarrowing.test.ts` (headline + index/multi-hop + soundness + write-invalidation e2e), `flowBuilder.test.ts` (index flowOf attachment).

Full gate green: `make`, `tsc`, `lint:structure` clean; full vitest suite **6708 passed**.

## Scope

Computed/dynamic index (`arr[i]`), slices, and method hops stay un-narrowable (conservative). No tuple types exist, so `arr[0]` resolves to the array element type. Type-checker only — no codegen change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
