### PR TITLE
feat(typechecker): match exhaustiveness for discriminated unions + boolean (B2)

### DIFF
--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -193,5 +193,31 @@ for ({ name, age } in users) {
 Destructuring relies on the underlying JavaScript runtime: reading a
 property of `null` or `undefined` (e.g. `let { name } = null`) throws a
 `TypeError`, which Agency captures and surfaces as a `failure` Result.
-No exhaustiveness check is performed on match blocks — a match without
-a `_` arm that matches no other arm silently does nothing.
+At runtime, a match without a `_` arm that matches no other arm does
+nothing and returns `null`.
+
+## Exhaustiveness checking
+
+The type checker reports (by default, a **warning**) when a `match` over a
+*closed* type doesn't cover every case and has no `_` arm:
+
+- a **Result** (`success` / `failure`),
+- a **closed literal or value union** (`"a" | "b"`, `1 | 2`),
+- a **discriminated object union** (`{ kind: "a" } | { kind: "b" }` — a common
+  property typed as a distinct literal in each member),
+- a bare **`boolean`** (`true` / `false`).
+
+```agency
+type Ev = { kind: "click", x: number } | { kind: "scroll", d: number }
+match (e) {
+    { kind: "click" } => handleClick(e)
+    // warning: match is not exhaustive: missing `{ kind: "scroll" }`
+}
+```
+
+Adding the missing arm — or a `_` catch-all — clears it. A guarded arm
+(`… if (…) => …`) never counts toward coverage. Open types (`string`,
+`number`, arbitrary object unions) and the `match(x is …)` form are never
+required to be exhaustive. Control the severity with
+`typechecker.matchExhaustiveness` in `agency.json` (`"silent"` / `"warn"` /
+`"error"`; default `"warn"`).

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -193,8 +193,8 @@ for ({ name, age } in users) {
 Destructuring relies on the underlying JavaScript runtime: reading a
 property of `null` or `undefined` (e.g. `let { name } = null`) throws a
 `TypeError`, which Agency captures and surfaces as a `failure` Result.
-At runtime, a match without a `_` arm that matches no other arm does
-nothing and returns `null`.
+At runtime, a match without a `_` arm that matches no other arm is a
+no-op — no branch runs.
 
 ## Exhaustiveness checking
 

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -285,3 +285,140 @@ node main() {
     expect(run({})).toBe(run({ typechecker: { matchExhaustiveness: "silent" } }));
   });
 });
+
+const EV = `type Ev = { kind: "click", x: number } | { kind: "scroll", d: number }`;
+
+describe("match exhaustiveness — discriminated object union (B2)", () => {
+  it("missing a discriminant member is non-exhaustive", () => {
+    const errs = check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click" } => 1 }
+}`, ERROR);
+    expect(errs.some((m) => /not exhaustive/i.test(m) && /scroll/.test(m))).toBe(true);
+  });
+
+  it("all members covered → clean", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click" } => 1  { kind: "scroll" } => 2 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("a `_` arm clears it", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click" } => 1  _ => 0 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("a guarded arm does not count as coverage", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click" } => 1  { kind: "scroll" } if (e.d > 0) => 2 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m) && /scroll/.test(m))).toBe(true);
+  });
+
+  it("an ambiguous objectPattern arm (no discriminant literal) → no diagnostic (bail)", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { x } => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("a non-discriminated object union is not checked", () => {
+    expect(check(`
+type U = { a: number } | { b: string }
+def f(u: U): number {
+  match (u) { { a } => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("number discriminant works", () => {
+    expect(check(`
+type T = { tag: 1, x: number } | { tag: 2, y: number }
+def f(t: T): number {
+  match (t) { { tag: 1 } => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(true);
+  });
+
+  it("boolean discriminant works", () => {
+    expect(check(`
+type T = { open: true, x: number } | { open: false, y: number }
+def f(t: T): number {
+  match (t) { { open: true } => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(true);
+  });
+
+  it("multiple missing members are all named", () => {
+    const errs = check(`
+type T = { kind: "a" } | { kind: "b" } | { kind: "c" }
+def f(t: T): number {
+  match (t) { { kind: "a" } => 1 }
+}`, ERROR);
+    expect(errs.some((m) => /not exhaustive/i.test(m) && /b/.test(m) && /c/.test(m))).toBe(true);
+  });
+
+  it("a rest binding still covers the member", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click", ...rest } => 1  { kind: "scroll" } => 2 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("a shorthand discriminant property (`{ kind }`) does not pin → bail", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind } => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("an interpolated-string discriminant does not pin → bail", () => {
+    expect(check(`${EV}
+def f(e: Ev, s: string): number {
+  match (e) { { kind: "cl${"$"}{s}" } => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("a guarded arm alongside `_` is clean", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click" } => 1  { kind: "scroll" } if (e.d > 0) => 2  _ => 0 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+
+  it("discriminates through a type alias of the union", () => {
+    expect(check(`${EV}
+type Wrap = Ev
+def f(w: Wrap): number {
+  match (w) { { kind: "click" } => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m) && /scroll/.test(m))).toBe(true);
+  });
+
+  it("default silent: no diagnostic without the knob", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click" } => 1 }
+}`).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+});
+
+describe("match exhaustiveness — boolean scrutinee (B2)", () => {
+  it("both true and false arms → exhaustive", () => {
+    expect(check(`
+def f(b: boolean): number {
+  match (b) { true => 1  false => 0 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+  it("missing the false arm is non-exhaustive", () => {
+    expect(check(`
+def f(b: boolean): number {
+  match (b) { true => 1 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m) && /false/.test(m))).toBe(true);
+  });
+  it("a `_` arm clears it", () => {
+    expect(check(`
+def f(b: boolean): number {
+  match (b) { true => 1  _ => 0 }
+}`, ERROR).some((m) => /not exhaustive/i.test(m))).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -66,7 +66,18 @@ node main() {
     expect(errs.some((e) => /not exhaustive/i.test(e) && /failure/.test(e))).toBe(true);
   });
 
-  it("silent (default): never reported", () => {
+  it("silent config: never reported", () => {
+    const errs = check(`${TRY}
+node main() {
+  let r = tryParse("ok")
+  match (r) {
+    success(v) => v
+  }
+}`, { typechecker: { matchExhaustiveness: "silent" } });
+    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+  });
+
+  it("warn is now the DEFAULT: a missing case is reported without the knob", () => {
     const errs = check(`${TRY}
 node main() {
   let r = tryParse("ok")
@@ -74,7 +85,7 @@ node main() {
     success(v) => v
   }
 }`);
-    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /failure/.test(e))).toBe(true);
   });
 
   it("warn: emitted as a warning, not an error", () => {
@@ -268,7 +279,7 @@ def f(x: "a" | "b", y: "p" | "q"): number {
     expect(reported[0]).toMatch(/missing\b.*"q"/);
   });
 
-  it("behavior-preserving: silent default adds zero errors vs. the no-knob baseline", () => {
+  it("the no-knob default resolves to warn (same count as explicit warn, one more than silent)", () => {
     const src = `${TRY}
 node main() {
   let r = tryParse("ok")
@@ -282,7 +293,10 @@ node main() {
       const info = buildCompilationUnit(p.result, undefined, undefined, src);
       return typeCheck(p.result, config, info).errors.length;
     };
-    expect(run({})).toBe(run({ typechecker: { matchExhaustiveness: "silent" } }));
+    const silent = run({ typechecker: { matchExhaustiveness: "silent" } });
+    // No-knob default now behaves like explicit `warn` (the B2b flip).
+    expect(run({})).toBe(run({ typechecker: { matchExhaustiveness: "warn" } }));
+    expect(run({})).toBe(silent + 1);
   });
 });
 
@@ -394,11 +408,18 @@ def f(w: Wrap): number {
 }`, ERROR).some((m) => /not exhaustive/i.test(m) && /scroll/.test(m))).toBe(true);
   });
 
-  it("default silent: no diagnostic without the knob", () => {
+  it("default (warn): a missing discriminant member is reported without the knob", () => {
     expect(check(`${EV}
 def f(e: Ev): number {
   match (e) { { kind: "click" } => 1 }
-}`).some((m) => /not exhaustive/i.test(m))).toBe(false);
+}`).some((m) => /not exhaustive/i.test(m) && /scroll/.test(m))).toBe(true);
+  });
+
+  it("silent config still suppresses the discriminated-union diagnostic", () => {
+    expect(check(`${EV}
+def f(e: Ev): number {
+  match (e) { { kind: "click" } => 1 }
+}`, { typechecker: { matchExhaustiveness: "silent" } }).some((m) => /not exhaustive/i.test(m))).toBe(false);
   });
 });
 

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.test.ts
@@ -196,14 +196,14 @@ def f(u: U): number {
     expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
   });
 
-  it("error config: match over a plain boolean is open (not enumerated as true|false)", () => {
+  it("error config: match over a plain boolean IS checked (B2 enumerates true|false)", () => {
     const errs = check(`
 def f(x: boolean): number {
   match (x) {
     true => 1
   }
 }`, ERROR);
-    expect(errs.some((e) => /not exhaustive/i.test(e))).toBe(false);
+    expect(errs.some((e) => /not exhaustive/i.test(e) && /false/.test(e))).toBe(true);
   });
 });
 

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -81,10 +81,30 @@ function coveredCases(arms: NormalizedArm[]): TypeCase[] {
   return covered;
 }
 
+type LiteralValue = string | number | boolean;
+
+// Case identity keys. A value is tagged with its `typeof` so a numeric `1` and a
+// string "1" never collide. An arm and a decomposed case are the "same case"
+// iff their keys are equal.
+function literalKey(value: LiteralValue): string {
+  return `literal:${typeof value}:${String(value)}`;
+}
+function discriminatedMemberKey(prop: string, value: LiteralValue): string {
+  return `member:${prop}:${typeof value}:${String(value)}`;
+}
+
 function caseKey(c: TypeCase): string {
-  if (c.kind === "literal") return `literal:${typeof c.value}:${String(c.value)}`;
-  if (c.kind === "member" && c.disc) return `member:${c.disc.prop}:${typeof c.disc.value}:${String(c.disc.value)}`;
-  return c.kind; // resultSuccess/resultFailure, or an opaque member (no disc)
+  switch (c.kind) {
+    case "resultSuccess":
+    case "resultFailure":
+      return c.kind;
+    case "literal":
+      return literalKey(c.value);
+    case "member":
+      // A discriminated member keys on its tag; an opaque member has no key an
+      // arm can match (its coverage is never computed — the union bails).
+      return c.disc ? discriminatedMemberKey(c.disc.prop, c.disc.value) : "member";
+  }
 }
 
 function describeCase(c: TypeCase): string {
@@ -104,15 +124,53 @@ function describeCase(c: TypeCase): string {
 }
 
 /**
+ * The single discriminant property shared by every member case, or null if the
+ * members aren't a uniformly-discriminated set (an object union with no common
+ * tag → un-checkable, B1 behavior).
+ */
+function sharedDiscriminant(memberCases: TypeCase[]): string | null {
+  const first = memberCases[0];
+  const prop = first.kind === "member" ? first.disc?.prop : undefined;
+  if (prop === undefined) return null;
+  const everyMemberSharesIt = memberCases.every(
+    (c) => c.kind === "member" && c.disc?.prop === prop,
+  );
+  return everyMemberSharesIt ? prop : null;
+}
+
+/**
+ * True if some un-guarded arm is an objectPattern that does NOT pin the
+ * discriminant to a literal (e.g. `{ x }`, shorthand `{ kind }`, interpolated
+ * `{ kind: "x${y}" }`). Such an arm could match several members, so we can't
+ * prove any member is uncovered → the whole match must bail.
+ */
+function hasArmWithUnpinnedDiscriminant(arms: NormalizedArm[], prop: string): boolean {
+  return arms.some(
+    (arm) =>
+      !arm.guarded &&
+      !isCatchAll(arm) &&
+      arm.caseValue !== "_" &&
+      arm.caseValue.type === "objectPattern" &&
+      objectPatternDiscriminantValue(arm.caseValue, prop) === null,
+  );
+}
+
+/** The member keys covered by the un-guarded objectPattern arms (a guarded arm
+ *  may not run, so it never counts toward coverage). */
+function coveredMemberKeys(arms: NormalizedArm[], prop: string): Set<string> {
+  const covered = new Set<string>();
+  for (const arm of arms) {
+    if (arm.guarded) continue;
+    const pinnedValue = objectPatternDiscriminantValue(arm.caseValue, prop);
+    if (pinnedValue !== null) covered.add(discriminatedMemberKey(prop, pinnedValue));
+  }
+  return covered;
+}
+
+/**
  * The cases a closed-type match leaves uncovered, or [] when no requirement
- * applies (open type, non-discriminated object union, or a catch-all arm).
- *
- * Object-union path (B2): if every `member` case carries the SAME discriminant
- * prop, an un-guarded `objectPattern` arm that pins that prop to a literal
- * covers the matching member. Bail (no diagnostic) if the union isn't
- * discriminated, or if any un-guarded, non-catch-all arm is an `objectPattern`
- * that does NOT pin the discriminant (it could match several members → we can't
- * prove non-coverage). Guarded arms never cover.
+ * applies (open type or a catch-all arm). Object unions take the discriminated
+ * path; Result / literal / boolean take the B1 path.
  */
 function missingCases(arms: NormalizedArm[], caseSet: CaseSet): TypeCase[] {
   if (!caseSet.closed) return [];
@@ -120,27 +178,10 @@ function missingCases(arms: NormalizedArm[], caseSet: CaseSet): TypeCase[] {
 
   const memberCases = caseSet.cases.filter((c) => c.kind === "member");
   if (memberCases.length > 0) {
-    const disc = memberCases[0].kind === "member" ? memberCases[0].disc : undefined;
-    const allDisc =
-      disc !== undefined &&
-      memberCases.every((c) => c.kind === "member" && c.disc !== undefined && c.disc.prop === disc.prop);
-    if (!allDisc) return []; // non-discriminated object union → un-checkable (B1)
-    const ambiguous = arms.some(
-      (a) =>
-        !a.guarded &&
-        !isCatchAll(a) &&
-        a.caseValue !== "_" &&
-        a.caseValue.type === "objectPattern" &&
-        objectPatternDiscriminantValue(a.caseValue, disc.prop) === null,
-    );
-    if (ambiguous) return [];
-    const covered = new Set(
-      arms
-        .filter((a) => !a.guarded)
-        .map((a) => objectPatternDiscriminantValue(a.caseValue, disc.prop))
-        .filter((v): v is string | number | boolean => v !== null)
-        .map((v) => `member:${disc.prop}:${typeof v}:${String(v)}`),
-    );
+    const discriminant = sharedDiscriminant(memberCases);
+    if (discriminant === null) return []; // non-discriminated object union
+    if (hasArmWithUnpinnedDiscriminant(arms, discriminant)) return [];
+    const covered = coveredMemberKeys(arms, discriminant);
     return caseSet.cases.filter((c) => !covered.has(caseKey(c)));
   }
 

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -17,15 +17,38 @@ type MatchSite = {
   loc: SourceLocation | undefined;
 };
 
-/** A literal match arm's static value, or null if the arm isn't a static literal. */
-function armLiteral(cv: CaseValue): string | number | boolean | null {
-  if (cv === "_") return null;
-  if (cv.type === "number") return Number(cv.value);
-  if (cv.type === "boolean") return cv.value;
-  if (cv.type === "string") {
-    const segs = cv.segments;
+/**
+ * A static literal value from a pattern's `Literal` node, or null (interpolated
+ * string, or a non-value literal / binding / nested pattern). THE single
+ * expression-side literal extractor — used by both `armLiteral` and
+ * `objectPatternDiscriminantValue`.
+ */
+function asStaticLiteral(v: Exclude<CaseValue, "_">): string | number | boolean | null {
+  if (v.type === "number") return Number(v.value);
+  if (v.type === "boolean") return v.value;
+  if (v.type === "string") {
+    const segs = v.segments;
     if (segs.length === 1 && segs[0].type === "text") return segs[0].value;
     return null; // interpolated → not a static literal case
+  }
+  return null;
+}
+
+/** A literal match arm's static value, or null if the arm isn't a static literal. */
+function armLiteral(cv: CaseValue): string | number | boolean | null {
+  return cv === "_" ? null : asStaticLiteral(cv);
+}
+
+/** The literal value an objectPattern arm pins property `prop` to, or null. */
+function objectPatternDiscriminantValue(
+  cv: CaseValue,
+  prop: string,
+): string | number | boolean | null {
+  if (cv === "_" || cv.type !== "objectPattern") return null;
+  for (const p of cv.properties) {
+    if (p.type !== "objectPatternProperty" || p.key !== prop) continue;
+    // value is BindingPattern | Literal | ResultPattern; only a Literal pins it.
+    return asStaticLiteral(p.value);
   }
   return null;
 }
@@ -59,7 +82,9 @@ function coveredCases(arms: NormalizedArm[]): TypeCase[] {
 }
 
 function caseKey(c: TypeCase): string {
-  return c.kind === "literal" ? `literal:${typeof c.value}:${String(c.value)}` : c.kind;
+  if (c.kind === "literal") return `literal:${typeof c.value}:${String(c.value)}`;
+  if (c.kind === "member" && c.disc) return `member:${c.disc.prop}:${typeof c.disc.value}:${String(c.disc.value)}`;
+  return c.kind; // resultSuccess/resultFailure, or an opaque member (no disc)
 }
 
 function describeCase(c: TypeCase): string {
@@ -69,7 +94,7 @@ function describeCase(c: TypeCase): string {
     case "resultFailure":
       return "`failure`";
     case "member":
-      return "an object case";
+      return c.disc ? `\`{ ${c.disc.prop}: ${JSON.stringify(c.disc.value)} }\`` : "an object case";
     case "literal":
       // JSON-encode so a string value renders quoted-and-escaped (a newline/quote
       // can't make the diagnostic multi-line or ambiguous); numbers/booleans print
@@ -80,13 +105,45 @@ function describeCase(c: TypeCase): string {
 
 /**
  * The cases a closed-type match leaves uncovered, or [] when no requirement
- * applies: an open type, a union with any `member` case (B2 territory — no
- * covering-arm rule yet), or a catch-all arm all yield [].
+ * applies (open type, non-discriminated object union, or a catch-all arm).
+ *
+ * Object-union path (B2): if every `member` case carries the SAME discriminant
+ * prop, an un-guarded `objectPattern` arm that pins that prop to a literal
+ * covers the matching member. Bail (no diagnostic) if the union isn't
+ * discriminated, or if any un-guarded, non-catch-all arm is an `objectPattern`
+ * that does NOT pin the discriminant (it could match several members → we can't
+ * prove non-coverage). Guarded arms never cover.
  */
 function missingCases(arms: NormalizedArm[], caseSet: CaseSet): TypeCase[] {
   if (!caseSet.closed) return [];
-  if (caseSet.cases.some((c) => c.kind === "member")) return [];
   if (arms.some(isCatchAll)) return [];
+
+  const memberCases = caseSet.cases.filter((c) => c.kind === "member");
+  if (memberCases.length > 0) {
+    const disc = memberCases[0].kind === "member" ? memberCases[0].disc : undefined;
+    const allDisc =
+      disc !== undefined &&
+      memberCases.every((c) => c.kind === "member" && c.disc !== undefined && c.disc.prop === disc.prop);
+    if (!allDisc) return []; // non-discriminated object union → un-checkable (B1)
+    const ambiguous = arms.some(
+      (a) =>
+        !a.guarded &&
+        !isCatchAll(a) &&
+        a.caseValue !== "_" &&
+        a.caseValue.type === "objectPattern" &&
+        objectPatternDiscriminantValue(a.caseValue, disc.prop) === null,
+    );
+    if (ambiguous) return [];
+    const covered = new Set(
+      arms
+        .filter((a) => !a.guarded)
+        .map((a) => objectPatternDiscriminantValue(a.caseValue, disc.prop))
+        .filter((v): v is string | number | boolean => v !== null)
+        .map((v) => `member:${disc.prop}:${typeof v}:${String(v)}`),
+    );
+    return caseSet.cases.filter((c) => !covered.has(caseKey(c)));
+  }
+
   const covered = new Set(coveredCases(arms).map(caseKey));
   return caseSet.cases.filter((c) => !covered.has(caseKey(c)));
 }

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -201,7 +201,7 @@ export function checkMatchExhaustiveness(
   scopes: ScopeInfo[],
   ctx: TypeCheckerContext,
 ): void {
-  const severity = (ctx.config.typechecker?.matchExhaustiveness ?? "silent") as Severity;
+  const severity = (ctx.config.typechecker?.matchExhaustiveness ?? "warn") as Severity;
   if (severity === "silent") {
     return;
   }

--- a/packages/agency-lang/lib/typeChecker/typeCases.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.test.ts
@@ -13,6 +13,10 @@ const lit = (value: string): VariableType => ({ type: "stringLiteralType", value
 const numLit = (value: string): VariableType => ({ type: "numberLiteralType", value });
 const boolLit = (value: "true" | "false"): VariableType => ({ type: "booleanLiteralType", value });
 const union = (...types: VariableType[]): VariableType => ({ type: "unionType", types });
+const obj = (props: Record<string, VariableType>): VariableType => ({
+  type: "objectType",
+  properties: Object.entries(props).map(([key, value]) => ({ key, value })),
+});
 
 describe("decomposeCases", () => {
   it("Result → resultSuccess + resultFailure, closed", () => {
@@ -100,12 +104,76 @@ describe("decomposeCases", () => {
     expect(decomposeCases(obj, {})).toEqual({ cases: [], closed: false });
   });
 
-  it("boolean primitive → open (NOT enumerated as true|false)", () => {
-    expect(decomposeCases({ type: "primitiveType", value: "boolean" }, {})).toEqual({ cases: [], closed: false });
+  it("boolean primitive → true | false, closed (B2 enumerates it)", () => {
+    expect(decomposeCases({ type: "primitiveType", value: "boolean" }, {})).toEqual({
+      cases: [{ kind: "literal", value: true }, { kind: "literal", value: false }],
+      closed: true,
+    });
   });
 
   it("generic/parameterized type → open (conservative)", () => {
     const g: VariableType = { type: "genericType", name: "Box", typeArgs: [STRING_T] };
     expect(decomposeCases(g, {})).toEqual({ cases: [], closed: false });
+  });
+});
+
+describe("decomposeCases — discriminated object unions (B2)", () => {
+  it("tags a discriminated object union by its discriminant", () => {
+    const ev = union(obj({ kind: lit("click"), x: NUMBER_T }), obj({ kind: lit("scroll"), d: NUMBER_T }));
+    const cs = decomposeCases(ev, {});
+    expect(cs.closed).toBe(true);
+    expect(cs.cases).toEqual([
+      { kind: "member", type: expect.anything(), disc: { prop: "kind", value: "click" } },
+      { kind: "member", type: expect.anything(), disc: { prop: "kind", value: "scroll" } },
+    ]);
+  });
+
+  it("leaves a non-discriminated object union as opaque members", () => {
+    const u = union(obj({ a: NUMBER_T }), obj({ b: STRING_T }));
+    expect(decomposeCases(u, {}).cases.every((c) => c.kind === "member" && c.disc === undefined)).toBe(true);
+  });
+
+  it("does not discriminate a union with a shared tag value", () => {
+    const u = union(obj({ kind: lit("a"), x: NUMBER_T }), obj({ kind: lit("a"), y: STRING_T }));
+    expect(decomposeCases(u, {}).cases.every((c) => c.kind === "member" && c.disc === undefined)).toBe(true);
+  });
+
+  it("does not discriminate when a member is not an object", () => {
+    const u = union(obj({ kind: lit("a") }), STRING_T);
+    expect(decomposeCases(u, {}).cases.some((c) => c.kind === "member" && c.disc)).toBe(false);
+  });
+
+  it("discriminates a 3-member union", () => {
+    const u = union(obj({ kind: lit("a") }), obj({ kind: lit("b") }), obj({ kind: lit("c") }));
+    const disc = decomposeCases(u, {}).cases.map((c) => (c.kind === "member" ? c.disc?.value : null));
+    expect(disc).toEqual(["a", "b", "c"]);
+  });
+
+  it("discriminates a boolean-tagged union", () => {
+    const u = union(obj({ open: boolLit("true"), x: NUMBER_T }), obj({ open: boolLit("false"), y: STRING_T }));
+    const disc = decomposeCases(u, {}).cases.map((c) => (c.kind === "member" ? c.disc : null));
+    expect(disc).toEqual([{ prop: "open", value: true }, { prop: "open", value: false }]);
+  });
+
+  it("advances past a shared-value literal prop to a later discriminating one", () => {
+    const u = union(
+      obj({ version: numLit("1"), kind: lit("a") }),
+      obj({ version: numLit("1"), kind: lit("b") }),
+    );
+    const disc = decomposeCases(u, {}).cases.map((c) => (c.kind === "member" ? c.disc : null));
+    expect(disc).toEqual([{ prop: "kind", value: "a" }, { prop: "kind", value: "b" }]);
+  });
+
+  it("does not discriminate when a member is itself a nested union", () => {
+    const u = union(obj({ kind: lit("a") }), union(obj({ kind: lit("b") }), STRING_T));
+    expect(decomposeCases(u, {}).cases.some((c) => c.kind === "member" && c.disc)).toBe(false);
+  });
+
+  it("discriminates through a type alias of the union", () => {
+    const ev = union(obj({ kind: lit("a") }), obj({ kind: lit("b") }));
+    const aliases: Record<string, TypeAliasEntry> = { Ev: { body: ev } };
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "Ev" };
+    const disc = decomposeCases(ref, aliases).cases.map((c) => (c.kind === "member" ? c.disc?.value : null));
+    expect(disc).toEqual(["a", "b"]);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/typeCases.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.ts
@@ -5,20 +5,64 @@ import { unescapeStringLiteralValue } from "../parsers/parsers.js";
 export type TypeCase =
   | { kind: "resultSuccess" }
   | { kind: "resultFailure" }
-  | { kind: "member"; type: VariableType }
+  | { kind: "member"; type: VariableType; disc?: { prop: string; value: string | number | boolean } }
   | { kind: "literal"; value: string | number | boolean };
 
 export type CaseSet = { cases: TypeCase[]; closed: boolean };
 
 const OPEN: CaseSet = { cases: [], closed: false };
 
+/**
+ * The literal value of a `*LiteralType`, or null for a non-literal type. THE
+ * single type-side literal extractor (used by `literalCase` and
+ * `findDiscriminant`). Unescape so a string-literal TYPE value (stored escaped,
+ * e.g. `a\nb`) keys identically to a match arm's text value (a real newline) —
+ * see matchExhaustiveness.armLiteral / asStaticLiteral.
+ */
+function literalValue(t: VariableType): string | number | boolean | null {
+  if (t.type === "stringLiteralType") return unescapeStringLiteralValue(t.value);
+  if (t.type === "numberLiteralType") return Number(t.value);
+  if (t.type === "booleanLiteralType") return t.value === "true";
+  return null;
+}
+
 function literalCase(t: VariableType): TypeCase | null {
-  // Unescape so a string-literal TYPE value (stored escaped, e.g. `a\nb`) keys
-  // identically to a match arm's text value (already unescaped, a real newline)
-  // — see matchExhaustiveness.armLiteral.
-  if (t.type === "stringLiteralType") return { kind: "literal", value: unescapeStringLiteralValue(t.value) };
-  if (t.type === "numberLiteralType") return { kind: "literal", value: Number(t.value) };
-  if (t.type === "booleanLiteralType") return { kind: "literal", value: t.value === "true" };
+  const v = literalValue(t);
+  return v === null ? null : { kind: "literal", value: v };
+}
+
+type Discriminant = { prop: string; values: (string | number | boolean)[] };
+
+/**
+ * A union is DISCRIMINATED on property `p` iff every member resolves to an
+ * objectType with `p` typed as a string/number/boolean LITERAL, and those
+ * literals are pairwise DISTINCT (a value uniquely selects a member). Returns
+ * the first such property in member-0's declaration order (advancing past
+ * candidates whose values collide), or null. Exhaustiveness must DETECT the
+ * discriminant (narrowing is told it by the condition).
+ */
+function findDiscriminant(
+  members: VariableType[],
+  aliases: Record<string, TypeAliasEntry>,
+): Discriminant | null {
+  const first = safeResolveType(members[0], aliases);
+  if (first.type !== "objectType") return null;
+  for (const cand of first.properties) {
+    if (literalValue(safeResolveType(cand.value, aliases)) === null) continue;
+    const values: (string | number | boolean)[] = [];
+    let ok = true;
+    for (const m of members) {
+      const rm = safeResolveType(m, aliases);
+      if (rm.type !== "objectType") { ok = false; break; }
+      const pv = rm.properties.find((p) => p.key === cand.key)?.value;
+      const lv = pv ? literalValue(safeResolveType(pv, aliases)) : null;
+      if (lv === null) { ok = false; break; }
+      values.push(lv);
+    }
+    if (ok && new Set(values.map((v) => `${typeof v}:${String(v)}`)).size === members.length) {
+      return { prop: cand.key, values };
+    }
+  }
   return null;
 }
 
@@ -47,24 +91,33 @@ export function decomposeCases(
 
   if (resolved.type === "unionType") {
     if (resolved.isEffectSet) return OPEN; // owned by resolveEffectSet, never re-walked
-    const cases: TypeCase[] = [];
-    for (const member of resolved.types) {
-      const rm = safeResolveType(member, aliases);
-      if (rm.type === "primitiveType" && rm.value === "any") {
-        return OPEN; // a union with an open member can't be required to be exhaustive
-      }
-      // A nested unionType member is deliberately pushed as a single `member`
-      // case (not flattened): checkSite then skips the whole match (member ⇒ no
-      // diagnostic), which is sound. Don't "fix" this by recursing without
-      // re-checking the coverage implications.
-      const litC = literalCase(rm);
-      cases.push(litC ?? { kind: "member", type: rm });
+    const members = resolved.types.map((m) => safeResolveType(m, aliases));
+    if (members.some((rm) => rm.type === "primitiveType" && rm.value === "any")) {
+      return OPEN; // a union with an open member can't be required to be exhaustive
     }
+    // B2: a union whose members are all literal-tagged, distinct-valued objects
+    // is discriminated — tag each member case so `matchExhaustiveness` can map
+    // `{ tag: literal }` arms. Otherwise members stay opaque (B1). A nested
+    // unionType member isn't an objectType, so `findDiscriminant` returns null
+    // and it stays a single opaque `member` case (sound; don't flatten).
+    const disc = findDiscriminant(members, aliases);
+    const cases: TypeCase[] = members.map((rm, i) => {
+      const litC = literalCase(rm);
+      if (litC) return litC;
+      // Destructure after the null-check — no `disc!` non-null assertion.
+      return disc === null
+        ? { kind: "member", type: rm }
+        : { kind: "member", type: rm, disc: { prop: disc.prop, value: disc.values[i] } };
+    });
     return { cases, closed: true };
   }
 
-  // primitives (string/number/boolean/…), objectType, generics, etc. → open.
-  // NOTE: `boolean` is open here — it is NOT enumerated as `true | false`. Only
-  // a literal union (`true | false` written explicitly) decomposes to literals.
+  // A bare `boolean` is a closed two-case type. Coverage rides B1's literal-arm
+  // path (a `true`/`false` arm → a `literal` case).
+  if (resolved.type === "primitiveType" && resolved.value === "boolean") {
+    return { cases: [{ kind: "literal", value: true }, { kind: "literal", value: false }], closed: true };
+  }
+
+  // Other primitives (string/number/…), objectType, generics, etc. → open.
   return OPEN;
 }

--- a/packages/agency-lang/lib/typeChecker/typeCases.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.ts
@@ -45,25 +45,49 @@ function findDiscriminant(
   members: VariableType[],
   aliases: Record<string, TypeAliasEntry>,
 ): Discriminant | null {
-  const first = safeResolveType(members[0], aliases);
-  if (first.type !== "objectType") return null;
-  for (const cand of first.properties) {
-    if (literalValue(safeResolveType(cand.value, aliases)) === null) continue;
-    const values: (string | number | boolean)[] = [];
-    let ok = true;
-    for (const m of members) {
-      const rm = safeResolveType(m, aliases);
-      if (rm.type !== "objectType") { ok = false; break; }
-      const pv = rm.properties.find((p) => p.key === cand.key)?.value;
-      const lv = pv ? literalValue(safeResolveType(pv, aliases)) : null;
-      if (lv === null) { ok = false; break; }
-      values.push(lv);
-    }
-    if (ok && new Set(values.map((v) => `${typeof v}:${String(v)}`)).size === members.length) {
-      return { prop: cand.key, values };
+  const firstMember = safeResolveType(members[0], aliases);
+  if (firstMember.type !== "objectType") return null;
+
+  // Only properties that are literal-typed on the first member could be a tag.
+  const candidateProps = firstMember.properties
+    .filter((p) => literalValue(safeResolveType(p.value, aliases)) !== null)
+    .map((p) => p.key);
+
+  for (const prop of candidateProps) {
+    const values = memberLiteralValues(members, prop, aliases);
+    if (values !== null && allDistinct(values)) {
+      return { prop, values };
     }
   }
   return null;
+}
+
+/**
+ * Each member's literal value for property `prop`, in member order — or null if
+ * ANY member is not an object, lacks `prop`, or types it as a non-literal (so
+ * `prop` can't be a discriminant).
+ */
+function memberLiteralValues(
+  members: VariableType[],
+  prop: string,
+  aliases: Record<string, TypeAliasEntry>,
+): (string | number | boolean)[] | null {
+  const values: (string | number | boolean)[] = [];
+  for (const member of members) {
+    const resolved = safeResolveType(member, aliases);
+    if (resolved.type !== "objectType") return null;
+    const propType = resolved.properties.find((p) => p.key === prop)?.value;
+    const value = propType ? literalValue(safeResolveType(propType, aliases)) : null;
+    if (value === null) return null;
+    values.push(value);
+  }
+  return values;
+}
+
+/** True if every value is distinct (type-aware, so `1` and "1" don't collide). */
+function allDistinct(values: (string | number | boolean)[]): boolean {
+  const keys = values.map((v) => `${typeof v}:${String(v)}`);
+  return new Set(keys).size === keys.length;
 }
 
 /**


### PR DESCRIPTION
## What

Extends the compile-time **"match is not exhaustive"** diagnostic (B1 shipped Result + closed literal/value unions) to:

- **Discriminated object/tagged unions** — `{ kind: "a" } | { kind: "b" }`, where a common property is typed as a distinct literal in each member. A `{ kind: "a" }` arm covers that member; an uncovered member is reported.
- **Bare `boolean` scrutinees** — `match(b) { true => …; false => … }` (previously hard-coded open).

And **flips the default `silent → warn`** so it actually fires.

```agency
type Ev = { kind: "click", x: number } | { kind: "scroll", d: number }
match (e) {
    { kind: "click" } => handleClick(e)
    // warning: match is not exhaustive: missing `{ kind: "scroll" }`
}
```

## How (4 commits)

1. **`decomposeCases`** — new `findDiscriminant` detects a common literal-typed, distinct-valued tag across all object members and tags each member case with `{ prop, value }`; a bare `boolean` enumerates as `true | false`. `literalCase` refactored onto a shared `literalValue`.
2. **`matchExhaustiveness`** — an `objectPattern` arm that pins the discriminant to a literal covers that member; `missingCases` reports the uncovered ones. `armLiteral` + `objectPatternDiscriminantValue` share a single `asStaticLiteral`.
3. **B2b flip** — default `silent → warn` (a single read-site `??`; the zod schema is `.partial()` with no default, so there's one place, not two).
4. **Docs** — replace the guide's stale *"No exhaustiveness check is performed"* line with the current behavior.

## Soundness — every uncertainty path bails (no false positives)

Non-discriminated union · shared tag value · non-object member · nested-union member → not discriminated → no diagnostic. An un-guarded `objectPattern` arm that doesn't pin the discriminant (`{ x }`, shorthand `{ kind }`, interpolated `{ kind: "x${y}" }`) → could match several members → bail. Guarded arms never cover; `_`/bare-binding is a catch-all. `match(x is …)` is never checked (no `matchSource`).

## The B2b sweep

Measured at `warn` across the full suite + `agency doc stdlib`: **zero** genuine non-exhaustive matches in stdlib or fixtures — no source changes needed. The only tests touched were the three that asserted the *silent default* (now assert `warn`).

## Boolean scrutinees came free

Boolean coverage rides B1's existing `armLiteral` (a `true`/`false` arm is already a literal case), so Task 1's `decomposeCases` enumeration was sufficient — no `matchExhaustiveness.ts` change for it.

## Tests

- `typeCases.test.ts` — `findDiscriminant`/`decomposeCases` units: string/number/boolean tags, 3-member, **candidate-loop-advances** (shared `version:1` then discriminating `kind`), non-object/shared-value/nested-union negatives, type-alias unwrap, boolean enumeration.
- `matchExhaustiveness.test.ts` — discriminated e2e: missing member, multiple-missing (names all), covered/`_`/guarded, ambiguous/shorthand/interpolated bail, rest-binding covers, alias; boolean-scrutinee e2e; the flipped default tests.

Full gate green: `make`, `tsc`, `lint:structure` clean; full vitest **6737 passed**.

## Scope

`error` default, multi-field/nested discriminants, and non-discriminated object unions remain out of scope (documented follow-ons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
