### PR TITLE
feat(typechecker): handler effect-set exhaustiveness via match(e.effect) (H1/H2)

### DIFF
--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -237,3 +237,36 @@ content splits into focused pages (each owned by the PR that builds it):
 
 Until a page exists, its topic is covered above. Keep this list in sync when adding
 a page so the directory stays discoverable.
+
+## Handler param `.effect` typing (H1)
+
+`lib/typeChecker/handlerParamTyping.ts` (`refineInlineHandlerParams`) is a
+type-only pass that types an inline `handle … with (e)` param's `.effect` field
+as the literal union of effect kinds the handled body can raise, so
+`match (e.effect)` is a plain literal-union match checked by the value-track
+exhaustiveness diagnostic — no handler-specific check.
+
+Pipeline position: **after** `buildInterruptCallGraph` (the transitive raisable
+set needs the graph) and after the interrupt checks, **before**
+`checkMatchExhaustiveness` (index.ts). It re-declares the param
+(`buildScopes` declared it `any`) as a closed object
+`{ effect: <union>, message: any, data: any, origin: any }` matching the runtime
+interrupt object. The raisable set is computed by `collectRaisableEffects`
+(shared with `collectHandlerOffenderKinds`), so the exhaustiveness check and the
+unhandled-interrupt check agree on "what can be raised."
+
+Two subtleties:
+- **Memo reset.** The pass mutates scope types after the flow graph + its
+  `typeAt` memo were built, so it discards `ctx.flowEnv.memo` (the flow env's
+  documented soundness contract) — otherwise `synthType(e.effect)` returns the
+  stale pre-refinement `any`.
+- **Not a breaking change.** Field-access checking runs in `checkScopes`, before
+  this pass, so the refined object type only reaches `checkMatchExhaustiveness`;
+  no `e.<field>` read is re-checked against the closed object.
+
+Conservative fall-backs to `any` (a missed warning, never a wrong one): explicit
+annotation, `functionRef` handler, empty/unknown kinds, a param name shared by
+two inline handlers in one scope (they'd clobber the flat function scope), and a
+body containing a nested `handle` (the walker would over-count inner-caught
+effects). Per-effect payload typing on `e.data` is a follow-on (H3, via
+discriminated-union narrowing).

--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -290,3 +290,27 @@ node main() {
 ```
 
 This shorthand can make code more readable. It still follows the rules of handlers, so you can still wrap this code in a handler and reject the interrupt.
+## Matching on the effect (exhaustiveness)
+
+An inline handler's parameter carries the interrupt that fired:
+`{ effect, message, data, origin }`. Its `effect` field is typed as the union
+of the effect kinds the handled body can actually raise, so you can branch on it
+with `match` and get an exhaustiveness check:
+
+```ts
+handle {
+  doRiskyThings()                 // can raise app::confirm or app::rateLimited
+} with (e) {
+  match (e.effect) {
+    "app::confirm" => approve()
+    // warning: match is not exhaustive: missing "app::rateLimited"
+  }
+}
+```
+
+Add the missing arm — or a `_` catch-all — to clear it. The check is
+conservative: if the raisable set can't be determined precisely (an explicitly
+annotated param, a `functionRef` handler, or a nested `handle` inside the body),
+the parameter stays untyped and no check is required. The other fields
+(`message`, `data`, `origin`) are untyped for now; per-effect payload typing on
+`e.data` is a later addition.

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+
+function allErrors(source: string): TypeCheckError[] {
+  const file = path.join(os.tmpdir(), `tc-h1-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`);
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath);
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) throw new Error("Parse failed");
+    const info = buildCompilationUnit(parseResult.result, symbolTable, absPath, source);
+    return typeCheck(parseResult.result, {}, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+const warningsFrom = (source: string) => allErrors(source).filter((e) => e.severity === "warning");
+const errorsFrom = (source: string) => allErrors(source);
+
+describe("handler param .effect typing (H1)", () => {
+  it("types e.effect so a non-exhaustive match(e.effect) warns", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def risky() {
+  raise mytest::alpha("a", {})
+  raise mytest::beta("b", {})
+}
+node main() {
+  handle {
+    risky()
+  } with (e) {
+    match (e.effect) {
+      "mytest::alpha" => 1
+    }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /beta/.test(w.message))).toBe(true);
+  });
+
+  it("an explicit param annotation is not overridden", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def risky() { raise mytest::alpha("a", {})\n raise mytest::beta("b", {}) }
+node main() {
+  handle { risky() } with (e: any) {
+    match (e.effect) { "mytest::alpha" => 1 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+
+  it("a covered match(e.effect) is clean", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def risky() { raise mytest::alpha("a", {})\n raise mytest::beta("b", {}) }
+node main() {
+  handle { risky() } with (e) {
+    match (e.effect) { "mytest::alpha" => 1  "mytest::beta" => 2 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+
+  it("reading the 4 runtime fields (effect/message/data/origin) still type-checks", () => {
+    const errs = errorsFrom(`
+effect mytest::alpha { }
+def risky() { raise mytest::alpha("a", {}) }
+node main() {
+  handle { risky() } with (e) {
+    print(e.message)
+    print(e.origin)
+    let d = e.data
+    return 0
+  }
+}`);
+    expect(errs.some((e) => /does not exist|not assignable/i.test(e.message))).toBe(false);
+  });
+
+  it("NOT a breaking change: reading an unknown field is still allowed", () => {
+    // Field-access checking runs in checkScopes, BEFORE this pass re-types `e`.
+    // The refined `.effect` type only ever reaches checkMatchExhaustiveness, so
+    // no field read (known or unknown) is re-checked against the object type —
+    // `e.notARealField` stays allowed exactly as it was when `e` was `any`.
+    const errs = errorsFrom(`
+effect mytest::alpha { }
+def risky() { raise mytest::alpha("a", {}) }
+node main() {
+  handle { risky() } with (e) {
+    return e.notARealField
+  }
+}`);
+    expect(errs.some((e) => /does not exist/i.test(e.message))).toBe(false);
+  });
+
+  it("functionRef handler is untouched (no crash, no spurious diagnostic)", () => {
+    const errs = errorsFrom(`
+effect mytest::alpha { }
+def risky() { raise mytest::alpha("a", {}) }
+def onErr(e: any): number { return 0 }
+node main() {
+  handle { risky() } with onErr
+}`);
+    expect(errs.some((e) => /not exhaustive/i.test(e.message))).toBe(false);
+  });
+
+  it("empty raisable set → param stays any → no diagnostic", () => {
+    const warnings = warningsFrom(`
+node main() {
+  handle { let x = 1 } with (e) {
+    match (e.effect) { "anything" => 1 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+
+  it("SOUNDNESS: two same-named inline handler params in one scope both stay any", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def raiseA() { raise mytest::alpha("a", {}) }
+def raiseB() { raise mytest::beta("b", {}) }
+node main() {
+  handle { raiseA() } with (e) { match (e.effect) { "mytest::alpha" => 1 } }
+  handle { raiseB() } with (e) { match (e.effect) { "mytest::beta" => 2 } }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+
+  it("transitive raise (effect raised inside a called function) reaches the match", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def inner() { raise mytest::beta("b", {}) }
+def risky() { raise mytest::alpha("a", {})\n inner() }
+node main() {
+  handle { risky() } with (e) {
+    match (e.effect) { "mytest::alpha" => 1 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /beta/.test(w.message))).toBe(true);
+  });
+
+  it("effect name with :: is handled verbatim as the literal", () => {
+    const warnings = warningsFrom(`
+effect ns::sub::alpha { }
+effect ns::sub::beta { }
+def risky() { raise ns::sub::alpha("a", {})\n raise ns::sub::beta("b", {}) }
+node main() {
+  handle { risky() } with (e) {
+    match (e.effect) { "ns::sub::alpha" => 1 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /beta/.test(w.message))).toBe(true);
+  });
+
+  it("SOUNDNESS: an outer handle with a NESTED handle is not typed (no false positive)", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def raiseA() { raise mytest::alpha("a", {}) }
+def raiseB() { raise mytest::beta("b", {}) }
+node main() {
+  handle {
+    handle { raiseA() } with (inner) { return 0 }
+    raiseB()
+  } with (e) {
+    match (e.effect) { "mytest::beta" => 1 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -182,3 +182,34 @@ node main() {
     expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
   });
 });
+
+describe("handler effect exhaustiveness (H2)", () => {
+  it("no double-report: the handle catches everything; only the inner match warns", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def risky() { raise mytest::alpha("a", {})\n raise mytest::beta("b", {}) }
+node main() {
+  handle { risky() } with (e) {
+    match (e.effect) { "mytest::alpha" => 1 }
+  }
+}`);
+    // Exactly one warning — the exhaustiveness one. The handle block is a
+    // catch-all, so the unhandled-interrupt check is satisfied (no extra warning).
+    expect(warnings.filter((w) => /not exhaustive/i.test(w.message))).toHaveLength(1);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("a `_` arm in match(e.effect) clears the diagnostic", () => {
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def risky() { raise mytest::alpha("a", {})\n raise mytest::beta("b", {}) }
+node main() {
+  handle { risky() } with (e) {
+    match (e.effect) { "mytest::alpha" => 1  _ => 0 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -138,6 +138,24 @@ node main() {
     expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
   });
 
+  it("SOUNDNESS: a param name shared with an ANNOTATED handler is not clobbered", () => {
+    // The first handler is annotated `e: any`; the second is eligible with the
+    // SAME name. Typing the second would clobber the first's binding → the first
+    // match(e.effect) would see the second's effect union and be wrongly flagged.
+    // The name-count includes the annotated handler, so the eligible one is
+    // skipped → neither is flagged.
+    const warnings = warningsFrom(`
+effect mytest::alpha { }
+effect mytest::beta { }
+def raiseA() { raise mytest::alpha("a", {}) }
+def raiseB() { raise mytest::beta("b", {}) }
+node main() {
+  handle { raiseA() } with (e: any) { match (e.effect) { "mytest::alpha" => 1 } }
+  handle { raiseB() } with (e) { match (e.effect) { "mytest::beta" => 2 } }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+
   it("transitive raise (effect raised inside a called function) reaches the match", () => {
     const warnings = warningsFrom(`
 effect mytest::alpha { }

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
@@ -19,14 +19,17 @@ function bodyHasNestedHandle(body: AgencyNode[]): boolean {
 
 /**
  * The type of an inline handler param whose body raises `kinds`. Matches the
- * runtime interrupt object `{ effect, message, data, origin }` (interrupts.ts) —
- * ALL FOUR fields, so the common `e.message`/`e.data`/`e.origin` reads still
- * type-check. Only `effect` is refined (the literal union of raisable kinds), so
+ * runtime interrupt object `{ effect, message, data, origin }` (interrupts.ts).
+ * Only `effect` is refined (the literal union of raisable kinds), so
  * `match (e.effect)` is a value-track literal-union match (checked by
- * match-exhaustiveness B1). This is a closed object, so reading any OTHER field
- * is now a "does not exist" error (intended). A single kind stays a bare literal
- * (a one-member match is not exhaustiveness-checked, which is fine). Payload
- * safety on `.data` is H3.
+ * match-exhaustiveness B1). The other 3 fields stay `any`.
+ *
+ * NOTE: although this is a closed `objectType`, it does NOT make `e.<field>` a
+ * "does not exist" error — field-access checking runs in `checkScopes`, BEFORE
+ * this pass re-types the param, so the refined type only ever reaches
+ * `checkMatchExhaustiveness`. A single kind stays a bare literal (a one-member
+ * match is not exhaustiveness-checked, which is fine). Payload typing on `.data`
+ * per effect is H3.
  */
 function handlerParamType(kinds: string[]): VariableType {
   const effect: VariableType =
@@ -55,15 +58,20 @@ function handlerParamType(kinds: string[]): VariableType {
  * param stays `any` (already declared by buildScopes) → conservative.
  *
  * SOUNDNESS — colliding param names. `Scope.declare` writes to the FUNCTION scope
- * and overwrites, so two inline handlers in the same function that share a param
- * name would clobber each other (the later type would win for the earlier
- * handler's `match (e.effect)`). We SKIP any param name used by >1 eligible
- * handler in the same scope → those stay `any` (a missed warning, never wrong).
+ * and overwrites, so an inline handler param clobbers ANY same-named inline
+ * handler param in the same function scope (including one with an explicit
+ * annotation or one skipped for a nested handle). We count EVERY inline handler
+ * param name in the scope and skip any name used more than once → those stay as
+ * declared by buildScopes (a missed warning, never a wrong one).
  *
  * SOUNDNESS — nested handles. `collectRaisableEffects` walks the whole body,
  * including inside a nested `handle`, so it counts effects the inner handler
  * already catches → over-reporting → a false "missing case". Handlers whose body
- * contains a nested handle are skipped above (fall back to `any`).
+ * contains a nested handle are not eligible (fall back to `any`).
+ *
+ * Runs each scope under `ctx.withScope(info.scopeKey, …)` so `collectRaisableEffects`
+ * → `synthType` resolves scope-local type aliases against the right scope (mirrors
+ * `checkHandlerBodyInterrupts`).
  */
 export function refineInlineHandlerParams(
   scopes: ScopeInfo[],
@@ -72,24 +80,29 @@ export function refineInlineHandlerParams(
 ): void {
   let changed = false;
   for (const info of scopes) {
-    const eligible: { node: Extract<AgencyNode, { type: "handleBlock" }>; name: string }[] = [];
-    for (const { node, scopes: nodeScopes } of walkNodes(info.body)) {
-      if (!isInScope(nodeScopes, info)) continue;
-      if (node.type !== "handleBlock" || node.handler.kind !== "inline") continue;
-      if (node.handler.param.typeHint) continue; // explicit annotation wins
-      if (bodyHasNestedHandle(node.body)) continue; // nested handle → over-count
-      eligible.push({ node, name: node.handler.param.name });
-    }
-    const nameCount = new Map<string, number>();
-    for (const h of eligible) nameCount.set(h.name, (nameCount.get(h.name) ?? 0) + 1);
+    ctx.withScope(info.scopeKey, () => {
+      // Count EVERY inline handler param name (eligible or not) — a shared name
+      // means typing one would clobber the other's function-scoped binding.
+      const nameCount = new Map<string, number>();
+      const eligible: { node: Extract<AgencyNode, { type: "handleBlock" }>; name: string }[] = [];
+      for (const { node, scopes: nodeScopes } of walkNodes(info.body)) {
+        if (!isInScope(nodeScopes, info)) continue;
+        if (node.type !== "handleBlock" || node.handler.kind !== "inline") continue;
+        const name = node.handler.param.name;
+        nameCount.set(name, (nameCount.get(name) ?? 0) + 1);
+        if (node.handler.param.typeHint) continue; // explicit annotation wins
+        if (bodyHasNestedHandle(node.body)) continue; // nested handle → over-count
+        eligible.push({ node, name });
+      }
 
-    for (const h of eligible) {
-      if ((nameCount.get(h.name) ?? 0) > 1) continue; // colliding name → leave `any`
-      const kinds = collectRaisableEffects(h.node.body, info, interruptEffectsByFunction, ctx);
-      if (kinds.length === 0) continue; // fall back to `any`
-      info.scope.declare(h.name, handlerParamType(kinds));
-      changed = true;
-    }
+      for (const h of eligible) {
+        if ((nameCount.get(h.name) ?? 0) > 1) continue; // shared name → leave as-is
+        const kinds = collectRaisableEffects(h.node.body, info, interruptEffectsByFunction, ctx);
+        if (kinds.length === 0) continue; // fall back to `any`
+        info.scope.declare(h.name, handlerParamType(kinds));
+        changed = true;
+      }
+    });
   }
   // We mutated scope types after the flow graph + its `typeAt` memo were built,
   // so any cached `e`-is-`any` result is now stale. The flow env's soundness

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
@@ -1,0 +1,99 @@
+import type { AgencyNode, VariableType } from "../types.js";
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import type { InterruptEffect } from "../symbolTable.js";
+import { collectRaisableEffects } from "./interruptAnalysis.js";
+import { walkNodes } from "../utils/node.js";
+import { isInScope } from "./checker.js";
+import { ANY_T } from "./primitives.js";
+
+const stringLiteral = (value: string): VariableType => ({ type: "stringLiteralType", value });
+
+/** True if `body` contains a nested `handle` block (whose handler would catch
+ *  some of the effects, making the outer raisable set an over-count). */
+function bodyHasNestedHandle(body: AgencyNode[]): boolean {
+  for (const { node } of walkNodes(body)) {
+    if (node.type === "handleBlock") return true;
+  }
+  return false;
+}
+
+/**
+ * The type of an inline handler param whose body raises `kinds`. Matches the
+ * runtime interrupt object `{ effect, message, data, origin }` (interrupts.ts) —
+ * ALL FOUR fields, so the common `e.message`/`e.data`/`e.origin` reads still
+ * type-check. Only `effect` is refined (the literal union of raisable kinds), so
+ * `match (e.effect)` is a value-track literal-union match (checked by
+ * match-exhaustiveness B1). This is a closed object, so reading any OTHER field
+ * is now a "does not exist" error (intended). A single kind stays a bare literal
+ * (a one-member match is not exhaustiveness-checked, which is fine). Payload
+ * safety on `.data` is H3.
+ */
+function handlerParamType(kinds: string[]): VariableType {
+  const effect: VariableType =
+    kinds.length === 1
+      ? stringLiteral(kinds[0])
+      : { type: "unionType", types: kinds.map(stringLiteral) };
+  return {
+    type: "objectType",
+    properties: [
+      { key: "effect", value: effect },
+      { key: "message", value: ANY_T },
+      { key: "data", value: ANY_T },
+      { key: "origin", value: ANY_T },
+    ],
+  };
+}
+
+/**
+ * TYPE-ONLY pass (runs after the interrupt call-graph is built): re-declare each
+ * eligible inline handler param as `handlerParamType(kinds)`, refining `.effect`
+ * from `any` to the literal union of raisable kinds. Does NOT touch handler
+ * registration/execution — it only calls `info.scope.declare`.
+ *
+ * Eligibility: inline handler, no explicit `with (e: T)` annotation, non-empty
+ * known raisable-effect set, and no nested `handle` in the body. Otherwise the
+ * param stays `any` (already declared by buildScopes) → conservative.
+ *
+ * SOUNDNESS — colliding param names. `Scope.declare` writes to the FUNCTION scope
+ * and overwrites, so two inline handlers in the same function that share a param
+ * name would clobber each other (the later type would win for the earlier
+ * handler's `match (e.effect)`). We SKIP any param name used by >1 eligible
+ * handler in the same scope → those stay `any` (a missed warning, never wrong).
+ *
+ * SOUNDNESS — nested handles. `collectRaisableEffects` walks the whole body,
+ * including inside a nested `handle`, so it counts effects the inner handler
+ * already catches → over-reporting → a false "missing case". Handlers whose body
+ * contains a nested handle are skipped above (fall back to `any`).
+ */
+export function refineInlineHandlerParams(
+  scopes: ScopeInfo[],
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
+  ctx: TypeCheckerContext,
+): void {
+  let changed = false;
+  for (const info of scopes) {
+    const eligible: { node: Extract<AgencyNode, { type: "handleBlock" }>; name: string }[] = [];
+    for (const { node, scopes: nodeScopes } of walkNodes(info.body)) {
+      if (!isInScope(nodeScopes, info)) continue;
+      if (node.type !== "handleBlock" || node.handler.kind !== "inline") continue;
+      if (node.handler.param.typeHint) continue; // explicit annotation wins
+      if (bodyHasNestedHandle(node.body)) continue; // nested handle → over-count
+      eligible.push({ node, name: node.handler.param.name });
+    }
+    const nameCount = new Map<string, number>();
+    for (const h of eligible) nameCount.set(h.name, (nameCount.get(h.name) ?? 0) + 1);
+
+    for (const h of eligible) {
+      if ((nameCount.get(h.name) ?? 0) > 1) continue; // colliding name → leave `any`
+      const kinds = collectRaisableEffects(h.node.body, info, interruptEffectsByFunction, ctx);
+      if (kinds.length === 0) continue; // fall back to `any`
+      info.scope.declare(h.name, handlerParamType(kinds));
+      changed = true;
+    }
+  }
+  // We mutated scope types after the flow graph + its `typeAt` memo were built,
+  // so any cached `e`-is-`any` result is now stale. The flow env's soundness
+  // contract requires discarding the memo when scope contents change; otherwise
+  // `checkMatchExhaustiveness` reads the pre-refinement `any` for `e.effect`.
+  if (changed && ctx.flowEnv) ctx.flowEnv.memo = new WeakMap();
+}

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -42,6 +42,7 @@ import {
 } from "./interruptAnalysis.js";
 import { checkRaisesDeclarations } from "./raisesDiagnostic.js";
 import { checkMatchExhaustiveness } from "./matchExhaustiveness.js";
+import { refineInlineHandlerParams } from "./handlerParamTyping.js";
 import { checkEffectPayloads } from "./effectPayloadCheck.js";
 import type { SymbolTable } from "../symbolTable.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
@@ -325,6 +326,13 @@ export class TypeChecker {
 
     // 6d. Check interrupt payloads against `effect` declarations.
     checkEffectPayloads(scopes, ctx);
+
+    // 6d-bis. H1: refine each eligible inline handler param's `.effect` to the
+    // literal union of effect kinds its body can raise (now that the call-graph
+    // exists), so `checkMatchExhaustiveness` sees a closed literal-union
+    // scrutinee. Type-only; runs after every interrupt check (none of which read
+    // the param type) and before exhaustiveness.
+    refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx);
 
     // 6e. Match exhaustiveness over closed value types (opt-in, default silent).
     checkMatchExhaustiveness(scopes, ctx);

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -433,18 +433,12 @@ export function checkHandlerBodyInterrupts(
   }
 }
 
-/** Collect every interrupt effect a handle block's handler may raise,
- *  transitively. For a `functionRef` handler we read the already-propagated
- *  kinds directly. For an inline handler we reuse `collectFromBody` (the
- *  same walker Phase 1 uses for every scope) and then resolve its callees
- *  through `interruptEffectsByFunction`, so transitive interrupts via tool
- *  calls, function refs in args, or `goto` targets are caught with no
- *  duplicated walker logic. */
 /**
- * Every interrupt effect kind `body` can raise, transitively — direct raises
- * plus the propagated kinds of everything it calls. The single source of the
- * "what can this body raise" computation, shared by handler-offender detection
- * and handler-param typing (H1).
+ * Every interrupt effect kind an (inline handler / handle) `body` can raise,
+ * transitively — direct raises plus the propagated kinds of everything it calls
+ * (via `collectFromBody` + `interruptEffectsByFunction`). The single source of
+ * the "what can this body raise" computation, shared by handler-offender
+ * detection and handler-param typing (H1).
  */
 export function collectRaisableEffects(
   body: AgencyNode[],
@@ -462,6 +456,11 @@ export function collectRaisableEffects(
   return kinds;
 }
 
+/** Collect every interrupt effect a handle block's handler may raise,
+ *  transitively. For a `functionRef` handler we read the already-propagated
+ *  kinds directly; for an inline handler we delegate to `collectRaisableEffects`
+ *  on the handler body — so transitive interrupts via tool calls, function refs
+ *  in args, or `goto` targets are caught with no duplicated walker logic. */
 function collectHandlerOffenderKinds(
   node: { handler: { kind: string; functionName?: string; body?: any[] } },
   info: ScopeInfo,

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -440,6 +440,28 @@ export function checkHandlerBodyInterrupts(
  *  through `interruptEffectsByFunction`, so transitive interrupts via tool
  *  calls, function refs in args, or `goto` targets are caught with no
  *  duplicated walker logic. */
+/**
+ * Every interrupt effect kind `body` can raise, transitively — direct raises
+ * plus the propagated kinds of everything it calls. The single source of the
+ * "what can this body raise" computation, shared by handler-offender detection
+ * and handler-param typing (H1).
+ */
+export function collectRaisableEffects(
+  body: AgencyNode[],
+  info: ScopeInfo,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
+  ctx: TypeCheckerContext,
+): string[] {
+  const profile = collectFromBody(body, info.scope, ctx);
+  const kinds = [...profile.kinds];
+  for (const callee of profile.callees) {
+    for (const k of interruptEffectsByFunction[callee] ?? []) {
+      addUnique(kinds, k.effect);
+    }
+  }
+  return kinds;
+}
+
 function collectHandlerOffenderKinds(
   node: { handler: { kind: string; functionName?: string; body?: any[] } },
   info: ScopeInfo,
@@ -450,14 +472,7 @@ function collectHandlerOffenderKinds(
     const ks = interruptEffectsByFunction[node.handler.functionName!] ?? [];
     return ks.map((k) => k.effect);
   }
-  const profile = collectFromBody(node.handler.body ?? [], info.scope, ctx);
-  const kinds = [...profile.kinds];
-  for (const callee of profile.callees) {
-    for (const k of interruptEffectsByFunction[callee] ?? []) {
-      addUnique(kinds, k.effect);
-    }
-  }
-  return kinds;
+  return collectRaisableEffects(node.handler.body ?? [], info, interruptEffectsByFunction, ctx);
 }
 
 /** Narrow a call-argument slot (which may be a positional Expression,


### PR DESCRIPTION
## What

An inline `handle … with (e)` handler's param `.effect` is now typed as the **literal union of effect kinds the handled body can raise**, so `match (e.effect) { … }` gets an exhaustiveness check for free from the value-track diagnostic (B1/B2). Forgetting to handle a possible effect is now a warning:

```ts
handle {
  doRiskyThings()                 // can raise app::confirm or app::rateLimited
} with (e) {
  match (e.effect) {
    "app::confirm" => approve()
    // warning: match is not exhaustive: missing "app::rateLimited"
  }
}
```

## How (3 commits)

1. **Factor `collectRaisableEffects`** out of the existing `collectHandlerOffenderKinds` — the transitive raisable-effect computation is reused verbatim (same source of truth as the unhandled-interrupt check), not reinvented.
2. **H1** — a new type-only pass `refineInlineHandlerParams` (`handlerParamTyping.ts`), run after the interrupt call-graph is built and before match-exhaustiveness, re-declares each eligible inline handler param as `{ effect: <union>, message: any, data: any, origin: any }` (matching the runtime interrupt object). `match (e.effect)` is then a plain literal-union match — **no new diagnostic code**.
3. **H2** — e2e confirming exhaustiveness fires + no double-report; docs.

## Type-only / handler-safety (CLAUDE.md)

The pass only calls `info.scope.declare` — nothing touches `pushHandler`, handler registration, execution, or checkpoints.

## Soundness — every uncertainty path falls back to `any`

A missed warning is always preferred over a wrong one. The param stays `any` (no check) for: an explicit `with (e: T)` annotation, a `functionRef` handler, an empty/unknown raisable set, a **param name shared by two inline handlers in one scope** (they'd clobber the flat function scope), and a **body containing a nested `handle`** (the walker would over-count effects the inner handler catches → a false "missing case"). All are tested.

## Two findings during execution

- **Not a breaking change (contrary to the plan/review's concern).** The plan worried that typing the param as a closed object would make `e.<otherField>` a hard error. It doesn't: field-access checking runs in `checkScopes`, *before* this pass re-types `e`, so the refined type only ever reaches `checkMatchExhaustiveness`. No `e.<field>` read is re-checked. A test pins this.
- **Flow-env memo reset required.** `synthType(e.effect)` routes through the flow oracle `typeAt`, whose memo had cached `e`-is-`any` during `checkScopes`. Mutating scope types after the flow graph is built requires discarding `ctx.flowEnv.memo` (the flow env's own documented soundness contract) — otherwise exhaustiveness reads the stale `any`.

## Tests

13 e2e in `handlerParamTyping.test.ts`: `.effect` typed → non-exhaustive match warns (direct + transitive + `::`-qualified names); covered / `_`-arm / explicit-annotation / functionRef / empty-set / two-handlers-collision / nested-handle all clean; unknown-field read still allowed (no breaking change); no double-report against the unhandled-interrupt check.

Full gate green: `make`, `tsc`, `lint:structure` clean; full vitest **6750 passed**; the Task 1 refactor is behavior-preserving (49 interrupt tests).

## Scope

Only `.effect` is refined; `e.data` payload typing per effect is a follow-on (H3, folds into discriminated-union narrowing). `functionRef` handlers + effect-name arm patterns are H4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
