### PR TITLE
fix(tests): refresh stale provider fixtures (post-merge Real-LLM CI)

### DIFF
--- a/packages/agency-lang/tests/agency-js/llm-pick-provider/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-pick-provider/fixture.json
@@ -2,5 +2,5 @@
   "defaultOrder": "google",
   "openaiFirst": "openai",
   "noneAvailable": "FAIL:No LLM API key found. Set one of: ANTHROPIC_API_KEY",
-  "emptyOrder": "FAIL:pickProvider: no recognized providers given (expected anthropic, google, or openai)"
+  "emptyOrder": "FAIL:pickProvider: no recognized providers given (expected one of anthropic, google, openai, openrouter, litellm)"
 }

--- a/packages/agency-lang/tests/agency-js/llm-provider-defaults/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-provider-defaults/fixture.json
@@ -2,7 +2,7 @@
   "providerOpenai": "openai",
   "providerGoogleNoKey": "FAIL:No API key for provider 'google'. Set GEMINI_API_KEY.",
   "autoDetect": "anthropic",
-  "customNoModel": "FAIL:--provider ollama has no built-in defaults; also pass --model (or --fastmodel/--slowmodel). Providers with defaults: openai, anthropic, google.",
+  "customNoModel": "FAIL:--provider ollama has no built-in defaults; also pass --model (or --fastmodel/--slowmodel). Providers with defaults: openai, anthropic, google, openrouter.",
   "customWithModel": "ollama",
   "planOpenai": {
     "fastModel": "gpt-4o-mini",


### PR DESCRIPTION
## Problem

Post-merge **Real-LLM tests** are red on `main` ([run 28492832272](https://github.com/egonSchiele/agency-lang/actions/runs/28492832272/job/84452925500)) — the "Agency-JS integration tests (real LLM)" step fails on two fixtures:

- `tests/agency-js/llm-pick-provider` — `emptyOrder`
- `tests/agency-js/llm-provider-defaults` — `customNoModel`

## Cause

When `openrouter`/`litellm` were added to the provider set, two user-facing strings grew but the fixtures were never regenerated:

- `pickProvider`'s failure: `…(expected anthropic, google, or openai)` → `…(expected one of anthropic, google, openai, openrouter, litellm)`
- `resolveDetected`'s "providers with defaults": `…openai, anthropic, google.` → `…openai, anthropic, google, openrouter.`

Both are intended behavior; only the fixtures were stale (not a code regression).

## Fix

Update the two fixture strings to match current output. Both changed fields are deterministic error messages (env-independent). Verified: `llm-pick-provider` and `llm-provider-defaults` both pass locally (1/1 each).
