### PR TITLE
feat(llm): accept named option arguments on llm(...)

### DIFF
--- a/packages/agency-lang/lib/backends/llmNamedArgsCodegen.test.ts
+++ b/packages/agency-lang/lib/backends/llmNamedArgsCodegen.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+function gen(src: string): string {
+  const r = parseAgency(src, {}, false);
+  if (!r.success) throw new Error("parse failed: " + r.message);
+  return generateTypeScript(r.result, undefined, undefined, "test.agency");
+}
+
+describe("llm named-arg option folding", () => {
+  it("folds named options into the clientConfig object", () => {
+    const out = gen(
+      `node main() {\n const r = llm("hi", model: "gpt-4o-mini", maxTokens: 5)\n print(r)\n}`,
+    );
+    // Named args must fold into a clientConfig OBJECT.
+    expect(out).toMatch(/clientConfig:\s*\{/);
+    expect(out).toContain('"model":');
+    expect(out).toContain('"maxTokens":');
+    // Regression: the first named arg's value must not become the whole
+    // clientConfig (the pre-fix miscompile produced `clientConfig: `gpt-4o-mini``).
+    expect(out).not.toMatch(/clientConfig:\s*`gpt-4o-mini`/);
+  });
+
+  it("preserves the positional options-object form", () => {
+    const out = gen(
+      `node main() {\n const r = llm("hi", { model: "gpt-4o-mini" })\n print(r)\n}`,
+    );
+    expect(out).toMatch(/clientConfig:\s*\{/);
+    expect(out).toContain('"model":');
+  });
+});

--- a/packages/agency-lang/lib/backends/llmNamedArgsCodegen.test.ts
+++ b/packages/agency-lang/lib/backends/llmNamedArgsCodegen.test.ts
@@ -29,4 +29,26 @@ describe("llm named-arg option folding", () => {
     expect(out).toMatch(/clientConfig:\s*\{/);
     expect(out).toContain('"model":');
   });
+
+  it("spreads a positional options object first, with named args winning", () => {
+    const out = gen(
+      `node main() {\n const o = { model: "a" }\n const r = llm("hi", o, temperature: 0.5)\n print(r)\n}`,
+    );
+    expect(out).toMatch(/clientConfig:\s*\{/);
+    expect(out).toContain("...__stack.locals.o");
+    expect(out).toContain('"temperature":');
+    // Spread must come before the named key so named args override.
+    expect(out.indexOf("...__stack.locals.o")).toBeLessThan(
+      out.indexOf('"temperature":'),
+    );
+  });
+
+  it("spreads a splat option argument without double-spreading", () => {
+    const out = gen(
+      `node main() {\n const o = { model: "a" }\n const r = llm("hi", ...o, temperature: 0.5)\n print(r)\n}`,
+    );
+    expect(out).toContain("...__stack.locals.o");
+    // The pre-fix bug wrapped an already-spread node, emitting invalid `......`.
+    expect(out).not.toContain("......");
+  });
 });

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2983,16 +2983,35 @@ export class TypeScriptBuilder {
       ? this.processCallArg(promptArg)
       : ts.raw("``");
 
-    // Config is the second argument — passed straight through to runPrompt.
-    // Tools (AgencyFunction instances, MCP tools) live in config.tools and
-    // are handled entirely by runPrompt at runtime.
-    const configArg = node.arguments[1];
+    // Everything after the prompt becomes the clientConfig, passed straight
+    // through to runPrompt. Tools (AgencyFunction instances, MCP tools) live
+    // in config.tools and are handled entirely by runPrompt at runtime.
+    const argsAfterPrompt = node.arguments.slice(1);
+    const hasNamedOptions = argsAfterPrompt.some(
+      (a) => a.type === "namedArgument",
+    );
     let clientConfig: TsNode;
-
-    if (configArg) {
-      clientConfig = this.processCallArg(configArg);
+    if (!hasNamedOptions) {
+      // Back-compat: a lone positional options object (or nothing) passes
+      // through unchanged, keeping generated output byte-identical.
+      const configArg = argsAfterPrompt[0];
+      clientConfig = configArg ? this.processCallArg(configArg) : ts.obj({});
     } else {
-      clientConfig = ts.obj({});
+      // Named option args (`llm(prompt, model: "x", tools: [t])`) fold into a
+      // single object; a positional options object, if also present, is
+      // spread in first so named args win on conflict.
+      const configEntries: TsObjectEntry[] = [];
+      for (const arg of argsAfterPrompt) {
+        if (arg.type === "namedArgument") {
+          const keyCode = arg.name.replace(/"/g, '\\"');
+          configEntries.push(
+            ts.set(`"${keyCode}"`, this.processNode(arg.value)),
+          );
+        } else {
+          configEntries.push(ts.setSpread(this.processCallArg(arg)));
+        }
+      }
+      clientConfig = ts.obj(configEntries);
     }
 
     // Thread expression — always use the shared active thread.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3007,6 +3007,10 @@ export class TypeScriptBuilder {
           configEntries.push(
             ts.set(`"${keyCode}"`, this.processNode(arg.value)),
           );
+        } else if (arg.type === "splat") {
+          // `processCallArg` already lowers a splat to a spread node; spread
+          // the underlying expression once to avoid emitting `......expr`.
+          configEntries.push(ts.setSpread(this.processNode(arg.value)));
         } else {
           configEntries.push(ts.setSpread(this.processCallArg(arg)));
         }

--- a/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
@@ -118,4 +118,20 @@ describe("builtin named-arg validation (llm options)", () => {
     expect(errors.length).toBeGreaterThan(0);
     expect(errors.some((e) => /number/i.test(e.message))).toBe(true);
   });
+
+  it("rejects prototype-chain names as options (no prototype pollution)", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", __proto__: "x")\n print(r) }`,
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => /__proto__/.test(e.message))).toBe(true);
+  });
+
+  it("rejects 'constructor' as an option (no prototype-chain match)", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", constructor: "x")\n print(r) }`,
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => /constructor/.test(e.message))).toBe(true);
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
@@ -87,3 +87,35 @@ describe("builtin named-arg validation (fork/race shared:)", () => {
     expect(errors.some((e) => /boolean/i.test(e.message))).toBe(true);
   });
 });
+
+describe("builtin named-arg validation (llm options)", () => {
+  it("accepts a known option as a named arg", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", model: "gpt-4o-mini")\n print(r) }`,
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("accepts several known options as named args", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", model: "gpt-4o-mini", maxTokens: 50, memory: true)\n print(r) }`,
+    );
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects an unknown option named arg", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", modle: "gpt-4o-mini")\n print(r) }`,
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => /modle/.test(e.message))).toBe(true);
+  });
+
+  it("rejects a wrongly-typed option named arg", () => {
+    const errors = errorsFrom(
+      `node main() { let r = llm("hi", maxTokens: "big")\n print(r) }`,
+    );
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => /number/i.test(e.message))).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -24,9 +24,7 @@ const optional = (t: VariableType): VariableType => ({
  * forwards everything to smoltalk. `metadata` accepts arbitrary shape, so
  * we type it as optional `any` and skip structural checking.
  */
-const llmOptions: VariableType = {
-  type: "objectType",
-  properties: [
+const llmOptionProperties: { key: string; value: VariableType }[] = [
     { key: "model", value: optional(string) },
     { key: "provider", value: optional(string) },
     { key: "apiKey", value: optional(string) },
@@ -90,8 +88,22 @@ const llmOptions: VariableType = {
     },
     // `any` already accepts undefined, so no need to wrap in optional.
     { key: "metadata", value: ANY_T },
-  ],
+];
+
+const llmOptions: VariableType = {
+  type: "objectType",
+  properties: llmOptionProperties,
 };
+
+/**
+ * The same option fields exposed as named arguments, so callers may write
+ * `llm(prompt, model: "…", tools: [...])` instead of passing an options
+ * object. Derived from {@link llmOptionProperties} so the two forms never
+ * drift. Codegen folds these named args back into the options object.
+ */
+const llmNamedOptions: Record<string, VariableType> = Object.fromEntries(
+  llmOptionProperties.map((p) => [p.key, p.value]),
+);
 
 /**
  * Signatures for builtin / auto-imported functions that the typechecker
@@ -149,6 +161,7 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
     params: ["any", llmOptions],
     minParams: 1,
     returnType: string,
+    acceptsNamedArgs: llmNamedOptions,
     description:
       "Send a prompt to an LLM and return its response. The return type is inferred from the call-site annotation and compiled to a JSON schema for structured output.",
   },

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -101,8 +101,13 @@ const llmOptions: VariableType = {
  * object. Derived from {@link llmOptionProperties} so the two forms never
  * drift. Codegen folds these named args back into the options object.
  */
-const llmNamedOptions: Record<string, VariableType> = Object.fromEntries(
-  llmOptionProperties.map((p) => [p.key, p.value]),
+const llmNamedOptions: Record<string, VariableType> = Object.assign(
+  // Null-prototype: the checker tests membership with `in`, so a normal
+  // prototype would make user-controlled names like `__proto__` /
+  // `constructor` appear "allowed" via the prototype chain (and codegen
+  // would then emit `{ "__proto__": ... }`, mutating the object prototype).
+  Object.create(null),
+  Object.fromEntries(llmOptionProperties.map((p) => [p.key, p.value])),
 );
 
 /**

--- a/packages/agency-lang/tests/agency/llm-named-args.agency
+++ b/packages/agency-lang/tests/agency/llm-named-args.agency
@@ -1,0 +1,4 @@
+node main(): number {
+  const result: number = llm("What is 2 + 2? Return just the number.", model: "gpt-4o-mini", maxTokens: 50)
+  return result
+}

--- a/packages/agency-lang/tests/agency/llm-named-args.test.json
+++ b/packages/agency-lang/tests/agency/llm-named-args.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "4",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "llmMocks": [
+        { "return": 4 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Allow named option arguments on `llm(...)`:

```agency
llm("Summarize this", model: "gpt-4o-mini", maxTokens: 200)
llm("Do the math", tools: [add])
```

as an ergonomic alternative to the options-object form. The object form
still works unchanged:

```agency
llm("Summarize this", { model: "gpt-4o-mini", maxTokens: 200 })
```

## Why

Named args are nicer to write and read than a nested object, and they're
already the norm for other Agency functions. Previously `llm("hi", model: "x")`
emitted a warning (`Named arguments can only be used with Agency-defined
functions, not 'llm'`) **and miscompiled** — the first named arg's value became
the entire client config (`clientConfig: \`x\``), silently dropping everything
else.

## How

`llm` stays a compiler primitive; no wrapper, stdlib function, or new
machinery. Two small changes:

1. **Checker** (`builtins.ts`): the `llm` builtin gets an `acceptsNamedArgs`
   allowlist derived from the existing `llmOptions` field set (one source of
   truth, so the two never drift). Named option args are now validated
   per-field — unknown keys and wrong value types are errors, e.g.
   `llm("hi", modle: "x")` → `'llm' does not accept the named argument 'modle'`,
   and `llm("hi", maxTokens: "big")` → type error. This reuses the existing
   `acceptsNamedArgs` mechanism already used by `fork`/`race`.

2. **Codegen** (`processLlmCall`): folds named option args into the
   `clientConfig` object. If a positional options object is also present it's
   spread in first, so named args win on conflict. The no-named-args path is
   byte-identical to before (verified against the golden fixtures).

## Testing

- Checker: `lib/typeChecker/builtinNamedArgs.test.ts` — accepts known options,
  rejects unknown names and wrong types.
- Codegen: `lib/backends/llmNamedArgsCodegen.test.ts` — named args fold into a
  `clientConfig` object; positional object form preserved.
- Execution: `tests/agency/llm-named-args.agency` — a named-arg call runs
  end-to-end (deterministic mock).
- Full `lib/typeChecker/` + `lib/backends/` sweep (1308 tests) green;
  `typecheck` and `lint:structure` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
