### PR TITLE
feat: model selection DX Phase 2 — hosted catalog, agency models CLI, /model & /models pickers

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -38,7 +38,23 @@ export type LlmDefaults = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L20))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L25))
+
+### HostedModelInfo
+
+```ts
+export type HostedModelInfo = {
+  name: string;
+  provider: string;
+  openWeights: boolean;
+  inputCost: number;
+  outputCost: number;
+  contextWindow: number;
+  family: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L124))
 
 ## Functions
 
@@ -59,7 +75,7 @@ Set default options for subsequent llm() calls. Only the fields you
 |---|---|---|
 | opts | [LlmDefaults](#llmdefaults) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L34))
 
 ### setModel
 
@@ -77,7 +93,7 @@ Set the default model for subsequent llm() calls.
 |---|---|---|
 | name | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L44))
 
 ### envVarFor
 
@@ -102,7 +118,7 @@ Return the environment variable that holds the API key for a recognized
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L53))
 
 ### pickProvider
 
@@ -125,7 +141,7 @@ Return the first provider in `order` whose API-key environment variable
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L82))
 
 ### registerProviderModule
 
@@ -144,4 +160,38 @@ Load a provider module by path at runtime and register its custom provider
 |---|---|---|
 | path | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L112))
+
+### listHostedModels
+
+```ts
+listHostedModels(): HostedModelInfo[]
+```
+
+All known hosted text models (baked catalog plus any refreshed data), for
+  discovery and model pickers. Backed by smoltalk's getAllModels.
+
+**Returns:** `HostedModelInfo[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L134))
+
+### hostedModelInfo
+
+```ts
+hostedModelInfo(name: string): HostedModelInfo | null
+```
+
+Metadata for one hosted model by name, or null if the name is unknown or
+  is not a text model.
+
+  @param name - The hosted model name (e.g. "gpt-4o-mini")
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+
+**Returns:** `HostedModelInfo | null`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L142))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -415,12 +415,11 @@ export def reactToSlotChange(change: SlotChange): boolean {
 export def modelChoiceItems(filters: ModelFilters): ChoiceItem[] {
   let items: ChoiceItem[] = []
   for (model in filterHostedModels(listHostedModels(), filters)) {
-    items.push(
-      {
+    const label = "${model.name}  (${model.provider}, $${model.inputCost}/1M in)"
+    items.push({
       key: model.name,
-      label: "${model.name}  (${model.provider}, $${model.inputCost}/1M in)"
-    },
-    )
+      label: label
+    })
   }
   return items
 }

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -15,6 +15,7 @@ import {
 import { today } from "std::date"
 import { setAgentCwd } from "std::index"
 import { box, render } from "std::layout"
+import { listHostedModels, hostedModelInfo } from "std::llm"
 import { setMemoryId, disableMemory } from "std::memory"
 import {
   ScopedRuleFields,
@@ -35,6 +36,7 @@ import {
   minimalAutoApprovePolicy,
   recommendedAutoApprovePolicy,
  } from "./lib/defaultPolicy.agency"
+import { filterHostedModels, ModelFilters } from "./lib/modelFilters.agency"
 import { parseModelFlag, knownProviders, Resolved } from "./lib/models.agency"
 import {
   buildLayers,
@@ -283,6 +285,7 @@ def builtinPalette(): Record<string, string> {
     "/clear-history": "Clear the input history (recall + saved file)",
     "/cost": "Show cumulative LLM cost and tokens",
     "/model": "Switch the model (bare to pick, or slot=model)",
+    "/models": "List / filter the hosted model catalog",
     "/local": "Switch to a local model",
     "/search": "Choose the web search backend (hosted / Tavily / Brave / off)",
     "/paste": "Multi-line paste mode (Ctrl+D submits, Ctrl+C cancels)",
@@ -407,6 +410,38 @@ export def reactToSlotChange(change: SlotChange): boolean {
   return false
 }
 
+// ChoiceItem list for the model pickers: the hosted catalog, filtered, each
+// labeled with provider + input price for an informed pick.
+export def modelChoiceItems(filters: ModelFilters): ChoiceItem[] {
+  let items: ChoiceItem[] = []
+  for (model in filterHostedModels(listHostedModels(), filters)) {
+    items.push(
+      {
+      key: model.name,
+      label: "${model.name}  (${model.provider}, $${model.inputCost}/1M in)"
+    },
+    )
+  }
+  return items
+}
+
+// Parse a `/models [provider]` command line into filters. Bare `/models` (or a
+// trailing-space-only arg) yields no filters; `/models <provider>` narrows to
+// one provider. Extracted from the handler so it is unit-testable.
+export def parseModelsFilters(cmd: string): ModelFilters {
+  const prefix = "/models "
+  if (!cmd.startsWith(prefix)) {
+    return {}
+  }
+  const arg = cmd.substring(prefix.length).trim()
+  if (arg == "") {
+    return {}
+  }
+  return {
+    provider: arg
+  }
+}
+
 // Slash-command + user-message dispatcher invoked by `repl()` for
 // every Enter keystroke. Return `false` to terminate the loop.
 def _runTurn(msg: string): boolean {
@@ -433,7 +468,7 @@ def _runTurn(msg: string): boolean {
   }
   if (trimmed == "/help") {
     pushMessage(
-      "Commands: /exit, /clear, /clear-history, /cost, /model, /local, /search, /paste, /help",
+      "Commands: /exit, /clear, /clear-history, /cost, /model, /models, /local, /search, /paste, /help",
     )
     return true
   }
@@ -494,11 +529,11 @@ def _runTurn(msg: string): boolean {
           pushMessage("  ${slot}: ${resolved.model} (${resolved.via})")
         }
       }
-      let noItems: ChoiceItem[] = []
+      const items = modelChoiceItems({})
       const choice = chooseOption(
         "Model",
-        "Type a model, or slot=model (e.g. reasoning=claude-opus-4-8). Empty to cancel.",
-        noItems,
+        "Pick a model, or type one (or slot=model, e.g. reasoning=claude-opus-4-8). Empty to cancel.",
+        items,
         allowFreeText: true,
         allowCancel: true,
       )
@@ -522,6 +557,20 @@ def _runTurn(msg: string): boolean {
       if (resolved != null) {
         pushMessage(color.dim("  ${slot}: ${resolved.model} (${resolved.via})"))
       }
+    }
+    return true
+  }
+  if (trimmed == "/models" || trimmed.startsWith("/models ")) {
+    const filters = parseModelsFilters(trimmed)
+    const models = filterHostedModels(listHostedModels(), filters)
+    if (models.length == 0) {
+      pushMessage("No models match.")
+      return true
+    }
+    for (model in models) {
+      pushMessage(
+        "  ${model.name}  (${model.provider}, $${model.inputCost}/1M in, ${model.contextWindow} ctx)",
+      )
     }
     return true
   }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/modelFilters.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/modelFilters.agency
@@ -1,0 +1,29 @@
+/** @module Pure filtering of the hosted model catalog for the agent's
+  /model and /models pickers. No I/O.
+
+  Mirrors the TS predicate in lib/cli/hostedModels.ts (selectHostedModels) —
+  keep the two in sync; both are unit-tested so drift shows up as a failure. */
+import { HostedModelInfo } from "std::llm"
+
+export type ModelFilters = {
+  provider?: string;
+  maxPrice?: number
+}
+
+export def filterHostedModels(
+  models: HostedModelInfo[],
+  filters: ModelFilters,
+): HostedModelInfo[] {
+  let out: HostedModelInfo[] = []
+  for (model in models) {
+    if (filters.provider != null && filters.provider != "" && model.provider != filters.provider) {
+      continue
+    }
+    if (filters.maxPrice != null && model.inputCost > filters.maxPrice) {
+      continue
+    }
+    out.push(model)
+  }
+  return out
+}
+

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
@@ -179,3 +179,58 @@ node reactSilentOnSameProvider(): boolean {
   return reactToSlotChange(change)
 }
 
+
+import { modelChoiceItems, parseModelsFilters } from "../agent.agency"
+import { hostedModelInfo } from "std::llm"
+
+// Built from the real baked catalog, so a bare filter yields items.
+node modelItemsNonEmpty(): boolean {
+  return modelChoiceItems({}).length > 0
+}
+
+// The provider filter must ACTUALLY narrow: every returned item resolves to an
+// anthropic model (via hostedModelInfo on the item key). If modelChoiceItems
+// ignored the filter, a non-anthropic item would appear and this returns false
+// — the thing a plain length>0 check cannot catch.
+node modelItemsFilterOnlyAnthropic(): boolean {
+  const items = modelChoiceItems({ provider: "anthropic" })
+  if (items.length == 0) {
+    return false
+  }
+  for (item in items) {
+    const info = hostedModelInfo(item.key)
+    if (info == null) {
+      return false
+    }
+    if (info.provider != "anthropic") {
+      return false
+    }
+  }
+  return true
+}
+
+// ...and the filtered set is a strict subset of the whole catalog.
+node modelItemsFilterNarrows(): boolean {
+  return modelChoiceItems({ provider: "anthropic" }).length < modelChoiceItems({}).length
+}
+
+// The item key is the model name (what switchModel receives); guards a
+// key/label swap. hostedModelInfo resolving it confirms it is a real name.
+node modelItemKeyIsModelName(): boolean {
+  const items = modelChoiceItems({ provider: "anthropic" })
+  return hostedModelInfo(items[0].key) != null
+}
+
+// `/models` arg parsing (extracted so it is unit-testable, no magic offset).
+node parseModelsBareIsEmpty(): boolean {
+  const filters = parseModelsFilters("/models")
+  return filters.provider == null
+}
+node parseModelsProviderArg(): boolean {
+  const filters = parseModelsFilters("/models anthropic")
+  return filters.provider == "anthropic"
+}
+node parseModelsTrailingSpaceIsEmpty(): boolean {
+  const filters = parseModelsFilters("/models   ")
+  return filters.provider == null
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
@@ -16,6 +16,13 @@
     { "nodeName": "switchDoesNotMutatePrior", "input": "", "expectedOutput": "\"\"", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "switchRejectsUnknownSlot", "input": "", "expectedOutput": "\"claude-sonnet-4-6|0\"", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "reactNotifiesOnMainProviderChange", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "reactSilentOnSameProvider", "input": "", "expectedOutput": "false", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "reactSilentOnSameProvider", "input": "", "expectedOutput": "false", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "modelItemsNonEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "modelItemsFilterOnlyAnthropic", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "modelItemsFilterNarrows", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "modelItemKeyIsModelName", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "parseModelsBareIsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "parseModelsProviderArg", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "parseModelsTrailingSpaceIsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/modelFilters.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/modelFilters.agency
@@ -1,0 +1,32 @@
+import { filterHostedModels } from "../lib/modelFilters.agency"
+import { HostedModelInfo } from "std::llm"
+
+static const CATALOG: HostedModelInfo[] = [
+  { name: "cheap-oss", provider: "openrouter", openWeights: true, inputCost: 0.1, outputCost: 0.2, contextWindow: 32000, family: "x" },
+  { name: "pricey-closed", provider: "anthropic", openWeights: false, inputCost: 15.0, outputCost: 75.0, contextWindow: 200000, family: "y" }
+]
+
+node filterByProvider(): string {
+  const out = filterHostedModels(CATALOG, { provider: "anthropic" })
+  return "${out.length}:${out[0].name}"
+}
+
+node filterMaxPrice(): string {
+  const out = filterHostedModels(CATALOG, { maxPrice: 1.0 })
+  return "${out.length}:${out[0].name}"
+}
+
+node providerAndPriceCombine(): number {
+  // anthropic model is $15 in, so provider=anthropic + maxPrice=1 yields none.
+  return filterHostedModels(CATALOG, { provider: "anthropic", maxPrice: 1.0 }).length
+}
+
+node emptyProviderPassesAll(): number {
+  // provider "" is treated as "no provider filter" (the != "" guard). If that
+  // guard regressed, nothing matches provider "" and this would be 0, not 2.
+  return filterHostedModels(CATALOG, { provider: "" }).length
+}
+
+node noFiltersPassesAll(): number {
+  return filterHostedModels(CATALOG, {}).length
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/modelFilters.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/modelFilters.test.json
@@ -1,0 +1,7 @@
+{ "sourceFile": "modelFilters.agency", "tests": [
+  { "nodeName": "filterByProvider", "input": "", "expectedOutput": "\"1:pricey-closed\"", "evaluationCriteria": [{ "type": "exact" }] },
+  { "nodeName": "filterMaxPrice", "input": "", "expectedOutput": "\"1:cheap-oss\"", "evaluationCriteria": [{ "type": "exact" }] },
+  { "nodeName": "providerAndPriceCombine", "input": "", "expectedOutput": "0", "evaluationCriteria": [{ "type": "exact" }] },
+  { "nodeName": "emptyProviderPassesAll", "input": "", "expectedOutput": "2", "evaluationCriteria": [{ "type": "exact" }] },
+  { "nodeName": "noFiltersPassesAll", "input": "", "expectedOutput": "2", "evaluationCriteria": [{ "type": "exact" }] }
+]}

--- a/packages/agency-lang/lib/cli/hostedModels.test.ts
+++ b/packages/agency-lang/lib/cli/hostedModels.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Mock the native shim so modelsRefresh's success/failure branches are
+// exercised without a real network fetch. The pure functions under test
+// (selectHostedModels/formatHostedCatalog) take explicit args and don't touch
+// the mocked natives, so this mock doesn't affect them.
+vi.mock("../stdlib/llm.js", () => ({
+  _listHostedModels: () => [],
+  _refreshHostedCatalog: vi.fn(),
+}));
+
+import {
+  selectHostedModels,
+  formatHostedCatalog,
+  modelsRefresh,
+} from "./hostedModels.js";
+import { _refreshHostedCatalog } from "../stdlib/llm.js";
+import type { HostedModelInfo } from "../stdlib/llm.js";
+
+const catalog: HostedModelInfo[] = [
+  { name: "cheap-oss", provider: "openrouter", openWeights: true, inputCost: 0.1, outputCost: 0.2, contextWindow: 32000, family: "x" },
+  { name: "pricey", provider: "anthropic", openWeights: false, inputCost: 15, outputCost: 75, contextWindow: 200000, family: "y" },
+];
+
+describe("agency models selection", () => {
+  it("filters by provider, price, and minContext", () => {
+    expect(selectHostedModels(catalog, { provider: "anthropic" }).map((model) => model.name)).toEqual(["pricey"]);
+    expect(selectHostedModels(catalog, { maxPrice: 1 }).map((model) => model.name)).toEqual(["cheap-oss"]);
+    expect(selectHostedModels(catalog, { minContext: 100000 }).map((model) => model.name)).toEqual(["pricey"]);
+    expect(selectHostedModels(catalog, {}).length).toBe(2);
+    // maxPrice/minContext must use `!== undefined`, NOT a truthy check: 0 is a
+    // real bound (excludes everything here), not "no filter". Guards against a
+    // regression to `if (opts.maxPrice && …)`.
+    expect(selectHostedModels(catalog, { maxPrice: 0 }).length).toBe(0);
+    expect(selectHostedModels(catalog, { minContext: 0 }).length).toBe(2);
+  });
+  it("formats a table with name, provider, open-weights column, price, context", () => {
+    const out = formatHostedCatalog(catalog);
+    expect(out).toContain("cheap-oss");
+    expect(out).toContain("openrouter");
+    expect(out).toContain("yes"); // open-weights shown as a column
+    expect(out).toContain("0.1");
+    expect(out).toContain("32000");
+  });
+});
+
+describe("agency models refresh", () => {
+  it("prints the model count on success", async () => {
+    vi.mocked(_refreshHostedCatalog).mockResolvedValue({ ok: true, count: 42, error: "" });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await modelsRefresh();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("42"));
+    log.mockRestore();
+  });
+  it("reports the error and sets a non-zero exit code on failure", async () => {
+    vi.mocked(_refreshHostedCatalog).mockResolvedValue({ ok: false, count: 0, error: "network down" });
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = 0;
+    await modelsRefresh();
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("network down"));
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0; // reset so a real later failure isn't masked
+    errorLog.mockRestore();
+  });
+});

--- a/packages/agency-lang/lib/cli/hostedModels.ts
+++ b/packages/agency-lang/lib/cli/hostedModels.ts
@@ -1,0 +1,65 @@
+import {
+  _listHostedModels,
+  _refreshHostedCatalog,
+  type HostedModelInfo,
+} from "../stdlib/llm.js";
+
+export type ModelsListOpts = {
+  provider?: string;
+  maxPrice?: number;
+  minContext?: number;
+};
+
+// Filter predicate mirrors the Agency `filterHostedModels` in
+// lib/agents/agency-agent/lib/modelFilters.agency (the agent can't call this TS
+// and vice-versa) — keep the two in sync; both are unit-tested.
+export function selectHostedModels(
+  all: HostedModelInfo[],
+  opts: ModelsListOpts,
+): HostedModelInfo[] {
+  return all.filter((model) => {
+    if (opts.provider && model.provider !== opts.provider) {
+      return false;
+    }
+    if (opts.maxPrice !== undefined && model.inputCost > opts.maxPrice) {
+      return false;
+    }
+    if (opts.minContext !== undefined && model.contextWindow < opts.minContext) {
+      return false;
+    }
+    return true;
+  });
+}
+
+// Fixed-width columns. NOTE: names longer than NAME_WIDTH are truncated in the
+// table (display only — the agent picker uses the full untruncated name).
+const NAME_WIDTH = 29;
+const PROVIDER_WIDTH = 12;
+
+export function formatHostedCatalog(models: HostedModelInfo[]): string {
+  const header = "NAME                          PROVIDER     OPEN   $IN/1M   $OUT/1M    CTX";
+  const rows = models.map((model) => {
+    const name = model.name.padEnd(NAME_WIDTH).slice(0, NAME_WIDTH);
+    const provider = model.provider.padEnd(PROVIDER_WIDTH).slice(0, PROVIDER_WIDTH);
+    const open = (model.openWeights ? "yes" : "no").padEnd(6);
+    const inCost = String(model.inputCost).padStart(7);
+    const outCost = String(model.outputCost).padStart(8);
+    const context = String(model.contextWindow).padStart(8);
+    return `${name} ${provider} ${open} ${inCost} ${outCost} ${context}`;
+  });
+  return [header, ...rows].join("\n");
+}
+
+export async function modelsList(opts: ModelsListOpts): Promise<void> {
+  console.log(formatHostedCatalog(selectHostedModels(_listHostedModels(), opts)));
+}
+
+export async function modelsRefresh(url?: string): Promise<void> {
+  const res = await _refreshHostedCatalog(url ?? "");
+  if (res.ok) {
+    console.log(`Refreshed hosted model catalog (${res.count} models).`);
+  } else {
+    console.error(`Refresh failed: ${res.error}`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/agency-lang/lib/stdlib/llm.hostedCatalog.integration.test.ts
+++ b/packages/agency-lang/lib/stdlib/llm.hostedCatalog.integration.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { _listHostedModels } from "./llm.js";
+
+// No mock: exercises the REAL smoltalk catalog end-to-end, so a smoltalk
+// upgrade that changes getAllModels' shape or stops returning text models is
+// caught here (this is the automated counterpart to the Task 0 upgrade check).
+// Name-agnostic on purpose — no pinned model names — so ordinary catalog/price
+// churn on a dependency bump does NOT break it.
+describe("hosted catalog — real smoltalk integration", () => {
+  it("returns mapped text models with sane fields", () => {
+    const all = _listHostedModels();
+    expect(all.length).toBeGreaterThan(0);
+    expect(all.every((model) => model.name.length > 0)).toBe(true);
+    expect(all.every((model) => model.contextWindow > 0)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/llm.test.ts
+++ b/packages/agency-lang/lib/stdlib/llm.test.ts
@@ -41,3 +41,42 @@ describe("_setLlmOptions", () => {
     expect(stack.other.llmDefaults.temperature).toBe(0.5);
   });
 });
+
+import { _listHostedModels, _hostedModelInfo } from "./llm.js";
+
+describe("hosted catalog accessor", () => {
+  it("_listHostedModels maps text models to HostedModelInfo (structural)", () => {
+    const all = _listHostedModels();
+    expect(all.length).toBeGreaterThan(0);
+    const mini = all.find((model) => model.name === "gpt-4o-mini");
+    expect(mini).toBeDefined();
+    // Stable identity/metadata:
+    expect(mini!.provider).toBe("openai");
+    expect(mini!.openWeights).toBe(false);
+    // `family` must actually be mapped (guards a wrong-source-field bug) —
+    // assert presence, not the exact string:
+    expect(typeof mini!.family).toBe("string");
+    expect(mini!.family.length).toBeGreaterThan(0);
+    // Numeric fields mapped + sane — NOT exact, so a smoltalk price bump can't
+    // break this:
+    expect(mini!.inputCost).toBeGreaterThan(0);
+    expect(mini!.outputCost).toBeGreaterThan(0);
+    expect(mini!.contextWindow).toBeGreaterThan(0);
+  });
+  it("_listHostedModels excludes non-text models", () => {
+    const all = _listHostedModels();
+    // Every text model has a real context window; embeddings/image models map
+    // to contextWindow 0. If the `type === "text"` filter regressed, one would
+    // leak in with contextWindow 0 and this fails.
+    expect(all.every((model) => model.contextWindow > 0)).toBe(true);
+    // And a known embeddings model must not appear in the text-only list:
+    expect(all.find((model) => model.name === "text-embedding-3-small")).toBeUndefined();
+  });
+  it("_hostedModelInfo returns one text model, or null for unknown/non-text", () => {
+    expect(_hostedModelInfo("gpt-4o-mini")?.provider).toBe("openai");
+    expect(_hostedModelInfo("no-such-model-xyz")).toBeNull();
+    // Non-text name → null (the `&& model.type === "text"` guard). Drop the
+    // guard and this returns a malformed HostedModelInfo instead of null:
+    expect(_hostedModelInfo("text-embedding-3-small")).toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/stdlib/llm.test.ts
+++ b/packages/agency-lang/lib/stdlib/llm.test.ts
@@ -1,6 +1,25 @@
-import { describe, it, expect } from "vitest";
-import { _setLlmOptions } from "./llm.js";
+import { describe, it, expect, vi } from "vitest";
+import { _setLlmOptions, _listHostedModels, _hostedModelInfo } from "./llm.js";
 import { agencyStore } from "../runtime/asyncContext.js";
+
+// Deterministic smoltalk catalog so the shim's mapping/filtering is tested
+// against a small fixture, not smoltalk's baked (external, version-churning)
+// data. The real-catalog wiring is covered separately (name-agnostically) in
+// llm.hostedCatalog.integration.test.ts.
+const { FIXTURE_MODELS } = vi.hoisted(() => ({
+  FIXTURE_MODELS: [
+    { type: "text", modelName: "fixture-text", provider: "openai", openWeights: false, inputTokenCost: 0.15, outputTokenCost: 0.6, maxInputTokens: 128000, family: "gpt-mini" },
+    // A text model with every optional field absent → exercises the ?? defaults.
+    { type: "text", modelName: "fixture-bare" },
+    { type: "embeddings", modelName: "fixture-embed", provider: "openai" },
+  ],
+}));
+vi.mock("smoltalk", () => ({
+  getAllModels: () => FIXTURE_MODELS,
+  getModel: (name: string) => FIXTURE_MODELS.find((model) => model.modelName === name),
+  refreshModels: vi.fn(),
+  registerModelData: vi.fn(),
+}));
 
 // _setLlmOptions writes the ACTIVE stack's `other.llmDefaults`. A bare
 // `{ other: {} }` stand-in stack is enough to exercise the merge.
@@ -42,41 +61,40 @@ describe("_setLlmOptions", () => {
   });
 });
 
-import { _listHostedModels, _hostedModelInfo } from "./llm.js";
-
-describe("hosted catalog accessor", () => {
-  it("_listHostedModels maps text models to HostedModelInfo (structural)", () => {
+describe("hosted catalog accessor (over a fixture)", () => {
+  it("maps every field incl. family, and applies ?? defaults for absent ones", () => {
     const all = _listHostedModels();
-    expect(all.length).toBeGreaterThan(0);
-    const mini = all.find((model) => model.name === "gpt-4o-mini");
-    expect(mini).toBeDefined();
-    // Stable identity/metadata:
-    expect(mini!.provider).toBe("openai");
-    expect(mini!.openWeights).toBe(false);
-    // `family` must actually be mapped (guards a wrong-source-field bug) —
-    // assert presence, not the exact string:
-    expect(typeof mini!.family).toBe("string");
-    expect(mini!.family.length).toBeGreaterThan(0);
-    // Numeric fields mapped + sane — NOT exact, so a smoltalk price bump can't
-    // break this:
-    expect(mini!.inputCost).toBeGreaterThan(0);
-    expect(mini!.outputCost).toBeGreaterThan(0);
-    expect(mini!.contextWindow).toBeGreaterThan(0);
+    expect(all.find((model) => model.name === "fixture-text")).toEqual({
+      name: "fixture-text",
+      provider: "openai",
+      openWeights: false,
+      inputCost: 0.15,
+      outputCost: 0.6,
+      contextWindow: 128000,
+      family: "gpt-mini",
+    });
+    // A text model missing every optional field falls back to sane defaults —
+    // guards the `?? ""` / `?? 0` / `?? false` mapping.
+    expect(all.find((model) => model.name === "fixture-bare")).toEqual({
+      name: "fixture-bare",
+      provider: "",
+      openWeights: false,
+      inputCost: 0,
+      outputCost: 0,
+      contextWindow: 0,
+      family: "",
+    });
   });
-  it("_listHostedModels excludes non-text models", () => {
-    const all = _listHostedModels();
-    // Every text model has a real context window; embeddings/image models map
-    // to contextWindow 0. If the `type === "text"` filter regressed, one would
-    // leak in with contextWindow 0 and this fails.
-    expect(all.every((model) => model.contextWindow > 0)).toBe(true);
-    // And a known embeddings model must not appear in the text-only list:
-    expect(all.find((model) => model.name === "text-embedding-3-small")).toBeUndefined();
+  it("excludes non-text models", () => {
+    // fixture-embed (embeddings) must not appear; if the `type === "text"`
+    // filter regressed it would leak in here.
+    expect(_listHostedModels().map((model) => model.name)).toEqual(["fixture-text", "fixture-bare"]);
   });
-  it("_hostedModelInfo returns one text model, or null for unknown/non-text", () => {
-    expect(_hostedModelInfo("gpt-4o-mini")?.provider).toBe("openai");
-    expect(_hostedModelInfo("no-such-model-xyz")).toBeNull();
+  it("_hostedModelInfo returns a text model, or null for unknown/non-text", () => {
+    expect(_hostedModelInfo("fixture-text")?.provider).toBe("openai");
+    expect(_hostedModelInfo("no-such-model")).toBeNull();
     // Non-text name → null (the `&& model.type === "text"` guard). Drop the
     // guard and this returns a malformed HostedModelInfo instead of null:
-    expect(_hostedModelInfo("text-embedding-3-small")).toBeNull();
+    expect(_hostedModelInfo("fixture-embed")).toBeNull();
   });
 });

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -1,6 +1,12 @@
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import type { RetryConfig } from "../runtime/llmRetry.js";
 import { loadProviderModuleByPath } from "../runtime/providerModules.js";
+import {
+  getAllModels,
+  getModel,
+  refreshModels,
+  registerModelData,
+} from "smoltalk";
 
 /**
  * Fields that may be set as LLM defaults via `setLlmOptions`. A
@@ -56,4 +62,60 @@ export function _setLlmOptions(opts: LlmDefaults): void {
  *  demand. */
 export async function _registerProviderModule(modulePath: string): Promise<void> {
   await loadProviderModuleByPath(modulePath);
+}
+
+/**
+ * Stable, flat view of one hosted model for discovery/pickers. Maps smoltalk's
+ * `ModelType` (union, optional-heavy fields) into a fixed shape the CLI, the
+ * agent, and `std::llm` all share. Field order is mirrored by the Agency-side
+ * `HostedModelInfo` in `stdlib/llm.agency` — keep the two in sync.
+ */
+export type HostedModelInfo = {
+  name: string;
+  provider: string;
+  openWeights: boolean;
+  inputCost: number;
+  outputCost: number;
+  contextWindow: number;
+  family: string;
+};
+
+function toHostedInfo(model: any): HostedModelInfo {
+  return {
+    name: model.modelName,
+    provider: model.provider ?? "",
+    openWeights: model.openWeights ?? false,
+    inputCost: model.inputTokenCost ?? 0,
+    outputCost: model.outputTokenCost ?? 0,
+    contextWindow: model.maxInputTokens ?? 0,
+    family: model.family ?? "",
+  };
+}
+
+/** All known hosted TEXT models (baked catalog + any refreshed data). Non-text
+ *  members of the `ModelType` union lack pricing/context and are excluded. */
+export function _listHostedModels(): HostedModelInfo[] {
+  return getAllModels()
+    .filter((model) => model.type === "text")
+    .map(toHostedInfo);
+}
+
+/** Metadata for one hosted text model by name, or null if unknown/non-text. */
+export function _hostedModelInfo(name: string): HostedModelInfo | null {
+  const model = getModel(name as any);
+  return model && model.type === "text" ? toHostedInfo(model) : null;
+}
+
+/** Fetch a fresh model-data blob and register it into smoltalk's in-memory
+ *  catalog for this process. Returns a plain status (no smoltalk types leak
+ *  out). NOTE: registration is process-local — it does not persist to disk. */
+export async function _refreshHostedCatalog(
+  url: string,
+): Promise<{ ok: boolean; count: number; error: string }> {
+  const res = await refreshModels(url ? { url } : {});
+  if (res.success) {
+    registerModelData(res.value);
+    return { ok: true, count: res.value.models.length, error: "" };
+  }
+  return { ok: false, count: 0, error: res.error };
 }

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -98,7 +98,7 @@
     "nanoid": "^5.1.6",
     "picomatch": "^4.0.4",
     "prompts": "^2.4.2",
-    "smoltalk": "^0.6.0",
+    "smoltalk": "^0.7.0",
     "tarsec": "0.4.7",
     "typestache": "^0.5.0",
     "vscode-languageserver": "^9.0.1",

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -47,6 +47,7 @@ import {
   runAliasAdd as localAliasAdd,
   runAliasRemove as localAliasRemove,
 } from "@/cli/local.js";
+import { modelsList, modelsRefresh } from "@/cli/hostedModels.js";
 import { doctor } from "@/cli/doctor.js";
 import { review } from "@/cli/review.js";
 import { policyGen } from "@/cli/policy.js";
@@ -886,6 +887,15 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(localAliasAdd);
   aliasCmd.command("remove").description("Remove a short-name alias").argument("<name>")
     .action(localAliasRemove);
+
+  const modelsCmd = program.command("models").description("Browse the hosted model catalog");
+  modelsCmd.command("list").description("List hosted models (filterable)")
+    .option("--provider <name>", "Only this provider")
+    .option("--max-price <usd>", "Max input $/1M tokens", parseFloat)
+    .option("--min-context <tokens>", "Min context window", parseInt)
+    .action((opts: { provider?: string; maxPrice?: number; minContext?: number }) => modelsList(opts));
+  modelsCmd.command("refresh").description("Refresh the hosted model catalog from the remote source")
+    .argument("[url]", "Override the catalog URL").action((url?: string) => modelsRefresh(url));
 
   program
     .command("agent")

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -1,4 +1,9 @@
-import { _setLlmOptions, _registerProviderModule } from "agency-lang/stdlib-lib/llm.js"
+import {
+  _setLlmOptions,
+  _registerProviderModule,
+  _listHostedModels,
+  _hostedModelInfo,
+} from "agency-lang/stdlib-lib/llm.js"
 import { env } from "std::system"
 
 /** @module
@@ -112,4 +117,34 @@ export def registerProviderModule(path: string) {
   @param path - Path to the provider module (.mjs/.js)
   """
   _registerProviderModule(path)
+}
+
+// Field order is mirrored by the TS HostedModelInfo in lib/stdlib/llm.ts and is
+// JSON-compared by callers in tests; do not reorder.
+export type HostedModelInfo = {
+  name: string;
+  provider: string;
+  openWeights: boolean;
+  inputCost: number;
+  outputCost: number;
+  contextWindow: number;
+  family: string
+}
+
+export def listHostedModels(): HostedModelInfo[] {
+  """
+  All known hosted text models (baked catalog plus any refreshed data), for
+  discovery and model pickers. Backed by smoltalk's getAllModels.
+  """
+  return _listHostedModels()
+}
+
+export def hostedModelInfo(name: string): HostedModelInfo | null {
+  """
+  Metadata for one hosted model by name, or null if the name is unknown or
+  is not a text model.
+
+  @param name - The hosted model name (e.g. "gpt-4o-mini")
+  """
+  return _hostedModelInfo(name)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       smoltalk:
-        specifier: ^0.6.0
-        version: 0.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)
+        specifier: ^0.7.0
+        version: 0.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)
       tarsec:
         specifier: 0.4.7
         version: 0.4.7
@@ -2578,8 +2578,8 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  smoltalk@0.6.0:
-    resolution: {integrity: sha512-6Wq/IAcHfiX0sfkgmnrNixLkNHHnatN5u/NwCJe5COZJyuzQUITbGT6OOCfQhQ48MNVBQEd81pRIqqrIN72ctA==}
+  smoltalk@0.7.0:
+    resolution: {integrity: sha512-p5dVFfgVowCYwuu0MgpBOXmIgXYkdwbJQSOG8eaDgpeoQzTLWVIYbHS/nb6Coe9S0odg0WEDmC+WYll5jqmRqQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5443,7 +5443,7 @@ snapshots:
 
   slash@3.0.0: {}
 
-  smoltalk@0.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0):
+  smoltalk@0.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0):
     dependencies:
       '@anthropic-ai/sdk': 0.78.0(zod@4.3.6)
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))


### PR DESCRIPTION
## Model Selection DX — Phase 2 (Catalog & Discovery)

Surfaces smoltalk's hosted model catalog in Agency so users can discover and filter models. Builds on Phase 1 (#374).

### What's included
- **smoltalk `^0.7.0`** — upgraded from `^0.6.0` to get `getAllModels()`. Verified the smoltalk-touching test slice is green (no `0.6→0.7` breakage).
- **Native shim** (`lib/stdlib/llm.ts`) — `_listHostedModels` / `_hostedModelInfo` / `_refreshHostedCatalog` map smoltalk's `ModelType` into a stable flat `HostedModelInfo` (text models only).
- **`std::llm` accessors** (`stdlib/llm.agency`) — `listHostedModels()` / `hostedModelInfo(name)`.
- **Pure filtering** (`lib/agents/agency-agent/lib/modelFilters.agency`) — `ModelFilters {provider?, maxPrice?}` + `filterHostedModels`.
- **`agency models` CLI** — `list` (`--provider` / `--max-price` / `--min-context`, with an open-weights display column) + `refresh`.
- **Agent pickers** — `/model` picker now lists the catalog (keeping free-text so `slot=model` / off-catalog names still work); new `/models` command lists/filters by provider; added to the palette + `/help`.

### Filter surfaces (corrected)
- **Interactive `/models`:** filters by **provider** (`/models <provider>`); bare `/models` lists all. Parsed by the extracted `parseModelsFilters`.
- **Interactive `/model` picker:** shows the **full** catalog (`modelChoiceItems({})`) and relies on `chooseOption`'s built-in substring filter for ad-hoc narrowing (plus free-text entry).
- **CLI `agency models list`:** `--provider`, `--max-price`, `--min-context`.
- `maxPrice` lives in the shared `ModelFilters`/`filterHostedModels` predicate but is currently surfaced only as a **CLI flag**, not as `/models` syntax. Open-weights is a display column, not a filter. Param-size is N/A for hosted models.

### Testing
- Full TS unit suite green (6758 passed). Shim tests (`lib/stdlib/llm.test.ts`) now mock smoltalk with a small fixture — assert field mapping incl. `family`, the `?? ` fallback defaults, non-text exclusion, and the non-text→null guard — so a smoltalk catalog/price change on a dep bump can't make them brittle. A separate name-agnostic `llm.hostedCatalog.integration.test.ts` exercises the real smoltalk catalog (length > 0, all context windows sane). CLI tests (`lib/cli/hostedModels.test.ts`) cover the filters incl. the `maxPrice`/`minContext` `0` edge (`!== undefined`, not truthy) and both refresh branches (mocked native).
- Agency execution tests: `modelFilters.agency` (5/5) and `agentTurn.agency` (+7 — the filter is verified to **actually narrow**: every item resolves to anthropic + strict subset — plus key-is-model-name and `parseModelsFilters` cases).
- `tsc` clean; structural linter clean; `agent.agency` typecheck shows only the 2 pre-existing errors (unchanged from Phase 1).

### Known limitation (follow-up)
`agency models refresh` registers into smoltalk's **in-memory** catalog only — it does not persist across separate CLI processes, so a later `agency models list` sees only the baked catalog. Decision needed before relying on it: persist the blob to disk (mirror `agency local refresh`) or scope refresh to the long-running agent session. Flagged inline in the code and the plan.

### Not in this PR (by design)
`/price` + curated economy/premium bands (needs a curation decision), interactive `maxPrice` filtering syntax for `/models`, provider constraint `allowedProviders` (Phase 3), session forking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
