### PR TITLE
feat(typechecker): payload-safe handler params (H3)

### DIFF
--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -311,6 +311,37 @@ handle {
 Add the missing arm — or a `_` catch-all — to clear it. The check is
 conservative: if the raisable set can't be determined precisely (an explicitly
 annotated param, a `functionRef` handler, or a nested `handle` inside the body),
-the parameter stays untyped and no check is required. The other fields
-(`message`, `data`, `origin`) are untyped for now; per-effect payload typing on
-`e.data` is a later addition.
+the parameter stays untyped and no check is required.
+
+## Payload typing on `e.data`
+
+The parameter is typed as a discriminated union — one member per raisable
+effect kind — so `e.data` carries **that effect's declared payload** once you
+narrow on `e.effect`. Guard with `if (e.effect == "...")` (a member-path guard)
+and the payload becomes concrete inside the branch:
+
+```ts
+effect app::confirm { question: string }
+effect app::rateLimited { retryAfter: number }
+
+handle {
+  doRiskyThings()
+} with (e) {
+  if (e.effect == "app::confirm") {
+    ask(e.data.question)          // e.data.question : string
+  }
+  if (e.effect == "app::rateLimited") {
+    waitFor(e.data.retryAfter)    // e.data.retryAfter : number
+    // ask(e.data.question)       // error: `question` is not on this effect's payload
+  }
+}
+```
+
+An effect declared with no payload (`effect ping { }`) gives `e.data` an empty
+object, so reading a field off it is an error. An effect with no declaration, or
+one dropped because its declarations conflict, leaves `e.data` untyped (`any`).
+
+The `if (e.effect == "...")` member-path guard is the supported idiom for
+per-effect payload access. A `match (e) { { effect: "..." } => ... }` object-pattern
+arm still drives exhaustiveness, but does **not** narrow `e.data` inside the arm
+body — use the member-path guard when you need the payload.

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-01-handler-payload-typing-h3-review.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-01-handler-payload-typing-h3-review.md
@@ -1,0 +1,185 @@
+# Review: Handler Payload Typing (H3)
+
+Review of [docs/superpowers/plans/2026-07-01-handler-payload-typing-h3.md](2026-07-01-handler-payload-typing-h3.md). Verified against current source: [handlerParamTyping.ts](../../lib/typeChecker/handlerParamTyping.ts), [effectPayloadCheck.ts](../../lib/typeChecker/effectPayloadCheck.ts), [interruptAnalysis.ts](../../lib/typeChecker/interruptAnalysis.ts), [index.ts](../../lib/typeChecker/index.ts).
+
+---
+
+## Overall: The strongest plan in the series — but 2 real blockers and several tests hedged
+
+This plan is markedly better than H1/M2 in three ways: (1) it identifies the ONE real architectural constraint (retype must happen BEFORE `checkScopes`, not after), (2) it opens with a throwaway SPIKE (Task 1) to measure blast radius before committing, and (3) it acknowledges the flat-scope limitation up front and pins it with a documenting test. Genuine engineering hygiene.
+
+**But** two blockers remain:
+
+1. **Nested-handle guard silently dropped.** Current H1 has `bodyHasNestedHandle(body)` in [handlerParamTyping.ts:12-18](../../lib/typeChecker/handlerParamTyping.ts) that SKIPS retyping when the handler body contains a nested `handleBlock` (because a nested handle catches some effects, making the outer raisable set an over-count → the discriminant union would include effects the outer handler will never actually see). Task 3's rewrite doesn't discuss this guard. Silently dropping it → false-positive payload narrowing.
+2. **Task 3's Step 1 test hedges on syntax existence.** "If `match (e) { is <effect> => … }` is not supported, fall back to `match (e.effect) …`." That's a red flag: the test that GUARDS the shape of the union is unclear on WHICH surface syntax proves it. The Task-3 test may end up asserting only the H1 behavior again.
+
+---
+
+## Source verification
+
+- [handlerParamTyping.ts:29-33](../../lib/typeChecker/handlerParamTyping.ts) docstring confirms the plan's architectural claim: "although this is a closed `objectType`, it does NOT make `e.<field>` a 'does not exist' error — field-access checking runs in `checkScopes`, BEFORE this pass re-types the param." The reorder rationale is exactly right.
+- [effectPayloadCheck.ts:43](../../lib/typeChecker/effectPayloadCheck.ts) `function buildRegistry(ctx)` is currently un-exported. Task 2's rename+export is correct.
+- [effectPayloadCheck.ts:20](../../lib/typeChecker/effectPayloadCheck.ts) `const registry = buildRegistry(ctx)` — one call today, one registry, so the plan's "conflicts reported exactly once" baseline is correct.
+- [index.ts:303](../../lib/typeChecker/index.ts) `analyzeInterruptsFromScopes` and [index.ts:309](../../lib/typeChecker/index.ts) `buildInterruptCallGraph` are separate — the plan's claim that only the former (not the call graph) needs to move up is correct.
+- [handlerParamTyping.ts:12-18](../../lib/typeChecker/handlerParamTyping.ts) `bodyHasNestedHandle` — the existing guard the plan omits to discuss. **Blocker 1.**
+
+---
+
+## Design assessment
+
+**The reorder is correctly scoped.** `analyzeInterruptsFromScopes` and `buildRegistry` are both pure computations over already-populated data (`ctx.functionDefs` from `inferReturnTypes`, `ctx.symbolTable.allEffectDeclarations()`). Moving them ahead of `buildFlowGraphs`/`checkScopes` should be side-effect-free. The plan lays this out with the right level of detail and evidence.
+
+**The reorder unblocks the memo-reset hack.** H1 today needs `ctx.flowEnv.memo = new WeakMap()` because retype happens AFTER flow-build. Task 4 removes this because flow-build now happens AFTER retype. Cleaner. Correct because `typeAt` reads scope at query time; the memo is the only stale artifact.
+
+**The spike-first approach is right.** Task 1's throwaway measurement is the right pattern for a change with unknown blast radius. Discarding the spike code and requiring GO/NO-GO before proceeding is disciplined.
+
+**Discriminated union reuses existing D1/M2 machinery.** The narrowing flows through `narrowUnionByDiscriminant` (union of objects → filter by `effect` literal) + `synthValueAccess` (member-path). No new checker code. Elegant.
+
+---
+
+## Real bugs / concerns
+
+### Blocker 1: `bodyHasNestedHandle` guard silently dropped
+
+Current H1 pass at [handlerParamTyping.ts](../../lib/typeChecker/handlerParamTyping.ts) has a guard that skips retyping if the handler body contains a nested `handleBlock`. Reason: a nested handle catches some effects, so the outer body's raisable set is an OVER-count → the discriminated union would include members for effects the outer handler can never actually receive at runtime. If preserved in H3, this is fine (conservative). If dropped, `if (e.effect == "innerKind")` narrows to a member the code can never reach, and the "impossible" branch's `e.data` typing is wrong (correctly typed, but for a runtime path that can't happen — mostly harmless but wasted). Worse, it may confuse users who see a branch typecheck for an effect they know the inner handler catches.
+
+**Fix:** the plan needs to explicitly retain (or explicitly deprecate) the guard, and add a test for a nested-handle configuration.
+
+### Blocker 2: Task 3 Step 1's syntax hedge is unresolved
+
+The Task-3 test's purpose is to prove the retyped param is a DISCRIMINATED UNION (multiple members with `effect` discriminant), not just the H1 shape (single object with `effect: union`). The e2e signal is exhaustiveness on `match (e)`.
+
+But the plan hedges: "if `match (e) { is <effect> => … }` is not supported, fall back to `match (e.effect) …`". The fallback test EXACTLY reproduces the H1 test — it proves nothing new about the union shape. If the intended `match (e)` arm syntax doesn't exist, the Task-3 test has no diagnostic power for the union shape; the shape is only tested indirectly via the Task-4 payload-narrowing e2e.
+
+**Fix:** verify the pattern grammar via `pnpm run ast` on a scratch file BEFORE Task 3. If `match (e)` on an effect discriminated union isn't supported, drop the Task-3 union-shape test and rely on Task 4's payload-narrowing e2e as the shape guarantee (which is fine — the union shape is a means to that end).
+
+### Concern 3: `analyzeInterruptsFromScopes` reorder claimed pure but not audited
+
+The plan claims: "This pass is `collectProfiles → propagateTransitively → formatResult`; it reads function-ref arg types via `synthType(...)` against `ctx.functionDefs` (populated by `inferReturnTypes`, step 2) and pushes no diagnostics itself."
+
+Two things to actually verify:
+
+- **Does `analyzeInterruptsFromScopes` call `synthType` on any expression whose type depends on flow narrowing?** If yes, moving it BEFORE `buildFlowGraphs` means it sees pre-narrowed types. Unlikely to affect interrupt effect kinds (which are declared per function), but worth a grep.
+- **Does `collectFromBody` push any errors?** The plan says no. Verify with `git grep -n "ctx.errors.push\|ctx.errors\[" lib/typeChecker/interruptAnalysis.ts`. If it does, the reorder changes error order (a fixture concern).
+
+### Concern 4: Registry sharing between passes has subtle ordering
+
+Task 2's `buildEffectRegistry` reports conflicts as a side effect. Task 4 calls it ONCE at pipeline step 3b, then passes the same registry into `checkEffectPayloads` at 6d. But if `buildEffectRegistry` pushes conflict errors, those errors are pushed at step 3b (very early), BEFORE `checkScopes` runs. Any test that asserts error ORDER (e.g., "expected error at line X to come before error at line Y") could regress.
+
+Low likelihood but worth grepping error-order assertions.
+
+### Concern 5: Effect declared with empty payload (`effect foo { }`)
+
+If the registry returns `{type: "objectType", properties: []}` for a payload-less effect, then `e.data` after narrowing is that empty object. Accessing `e.data.anything` becomes "does not exist" (correctly). But if the registry returns `undefined` / has no entry, `registry[kind] ?? ANY_T` gives `data: any`.
+
+Which case fires for `effect foo { }`? Verify against `allEffectDeclarations()`. If empty-payload effects DO get registry entries with empty properties, users declaring `effect ping { }` and reading `e.data.foo` will see the new "does not exist" error — a subtle breaking change that the spike may or may not surface (depends on whether stdlib has such patterns).
+
+**Test:** effect with declared empty payload AND effect with no declaration should be tested separately.
+
+### Concern 6: `matchExhaustiveness` and discriminated-union B2
+
+The plan says H1's exhaustiveness (B1, literal union on `.effect`) still works. But with H3, the parameter itself is a discriminated OBJECT union (B2 territory). `match (e.effect)` continues to work by projecting the discriminant string. Does `match (e)` (on the whole discriminated union) work via B2's discriminated-object-union exhaustiveness that shipped in match-exhaustiveness-b2? If B2 hasn't fully shipped yet or has edge cases with these auto-synthesized member types, this could regress.
+
+The plan doesn't audit interaction with B2's `findDiscriminant` — it may correctly detect the `effect` discriminant on the synthesized union, or it may fail (e.g., if `findDiscriminant` bails on some property shape the plan's `handlerParamType` produces). Worth verifying with an e2e test that `match (e) { is foo => … is bar => … }` (or equivalent object-pattern arms) triggers a "not exhaustive: missing bar" diagnostic under B2.
+
+### Concern 7: Task 5 Step 3 "limitation test" is too soft
+
+> "Assert whatever the current behavior is (likely: the second binding wins / a benign result), with a comment citing the flat-scope limitation."
+
+This is a test whose expected outcome the plan author doesn't know. The "documenting comment" is genuinely valuable, but pinning an unknown behavior as a test creates a maintenance burden: the next person to change scope handling will see the test pass or fail arbitrarily and won't know if that's intentional. Either:
+- Determine the current behavior via a scratch run BEFORE Task 5, and assert the specific outcome; OR
+- Skip the test entirely and put the documenting comment in the module's docstring.
+
+### Concern 8: Machine-specific scratchpad paths
+
+Every `tee` command uses `/private/tmp/claude-501/-Users-adityabhargava-agency-lang-packages-agency-lang/8cc629ca-13fc-4078-93fc-a61171ef7b15/scratchpad/…`. Fine for you but useless for another agent, a fresh clone, or CI reruns. Should be `/tmp/h3-*.txt` or a workspace-relative `./scratchpad/h3-*.txt`.
+
+---
+
+## Missing test cases
+
+Beyond the concerns above, I'd add:
+
+1. **Nested `handle` block** — verify the outer handler param handles nested handles correctly (probably: don't retype at all, per current H1 guard).
+2. **Effect with empty payload** (`effect foo { }`) — `e.data` shape after narrowing; access should error.
+3. **Effect with no declaration** — `registry[kind]` is undefined → `data: any` → free access.
+4. **Guarded arm** — `if (e.effect == "a") { … } else { e.data }` — the else branch's `e.data` should be a union of the other effects' payloads. Verify.
+5. **Payload conflict + shared registry** — plan tests conflict-reported-once, but not that the CONFLICTED effect is dropped from BOTH the registry-check AND the handler-param typing (should be treated as "unknown" → `data: any`).
+6. **Two handlers, same enclosing scope, same param name** — the "accepted flat-scope limitation" needs a specific test outcome, not "whatever the checker does today."
+7. **B2 discriminated exhaustiveness on `match (e)` over the synthesized union** — proves H3 composes with B2, not just B1.
+8. **Recursive function raising an effect** — transitive raisable set includes recursive callees; `e.data` in the handler has the union.
+9. **Function-ref handler (`handle …  with someFn`)** — plan (and H1) leaves these untouched; should have an explicit test that H3 doesn't accidentally retype the wrong param.
+10. **`interruptCallGraph` position** — plan keeps it at 5a, but if the reordered `analyzeInterruptsFromScopes` populates something the call graph reads pre-checkScopes, verify no crash.
+
+---
+
+## Anti-pattern audit (against [docs/dev/anti-patterns.md](../../dev/anti-patterns.md))
+
+- **Duplicating existing code:** the plan builds the effect registry TWICE between Task 3 and Task 4 (temporary bridge). Explicitly flagged as "do NOT ship between Task 3 and Task 4." Acceptable if they land in one PR.
+- **Imperative vs declarative:** `handlerParamType` is a pure expression (union of members). Declarative. ✓
+- **Order-dependent mutable state:** the pipeline reorder is inherently order-dependent — but every dependency is justified by the docstring's reasoning. Fine.
+- **Nested ternaries:** `handlerParamType`'s `kinds.length === 1 ? member(kinds[0]) : { type: "unionType", …}` is a single ternary. ✓
+- **Leaky abstractions:** `checkEffectPayloads(scopes, ctx, registry?)` — the optional third arg is a compromise, but the plan justifies it (back-compat for existing callers). ✓
+- **Magic numbers / dynamic requires / one-line ifs / try-catch:** none.
+- **`interface` / `Map` / `Set`:** plan explicitly follows the objects-not-maps rule for new code; grandfathered existing `Map` in `nameCount`. ✓
+- **Machine-specific paths in commands** — anti-pattern by convention (not in the doc); should use `/tmp/` or relative.
+
+---
+
+## "Will the test fail when the code breaks?" matrix
+
+| Regression | Test catches? |
+|---|---|
+| Payload narrowing doesn't fire (still `any` at usage) | ✓ (Task 4 e2e mismatch test) |
+| Nested-handle guard silently dropped | ✗ |
+| `match (e) { is foo => … }` union-shape exhaustiveness | ✗ (Task 3 test hedges syntax) |
+| Effect with empty payload → `e.data.x` should error | ✗ |
+| Effect with no declaration → `e.data.x` should succeed | ✗ (not distinguished) |
+| Guarded else branch has correct union payload | ✗ |
+| Conflicted effect dropped from handler param typing | ✗ (Task 2 tests once-reported, not once-typed) |
+| Two handlers same scope same param name | ✗ (Task 5 Step 3 test is a soft "assert what happens") |
+| Function-ref handler untouched | ✗ |
+| Recursive raise flows into handler param | ✗ |
+| Payload conflict once (basic) | ✓ (Task 2) |
+| H1 exhaustiveness regression | ✓ (Task 4 regression test) |
+| Payload conflict error order changed | ✗ (no order assertion) |
+| Blast radius (closed-object strict field access) | ✓ (Task 1 spike + Task 5 flip) |
+| Memo-reset removal breaks flow narrowing | ✓ (any downstream narrowing test would catch) |
+
+Better than the H1 plan, but the highest-value missing tests are **nested handle, empty payload, `match (e)` on union shape, and guarded else branch**.
+
+---
+
+## Recommendations
+
+**Must-fix (blocks execution):**
+
+1. **Address the `bodyHasNestedHandle` guard explicitly.** Either preserve it (recommended, matches H1's conservative behavior) with a test, or drop it with a written justification.
+2. **Resolve the Task 3 Step 1 syntax hedge BEFORE writing code.** Run `pnpm run ast` on a scratch `match (e) { is foo => … }` and either commit to the test or replace it with a proxy shape check.
+3. **Change machine-specific `/private/tmp/claude-501/…` paths to `/tmp/h3-*.txt` or workspace-relative.** Blocks reproducibility.
+
+**Should-fix:**
+
+4. **Audit `analyzeInterruptsFromScopes` for `ctx.errors.push`** — verify the "no diagnostics" claim, else the reorder changes error order.
+5. **Distinguish empty-payload from no-declaration in tests** — different behaviors, both should be pinned.
+6. **Add a nested-handle test** covering the guard decision above.
+7. **Add a `match (e)` B2 discriminated exhaustiveness test** to prove H3 composes with B2.
+8. **Add a guarded-else test** — the else branch of `if (e.effect == "a")` should type `e.data` as the union of remaining payloads.
+9. **Convert Task 5 Step 3 from "assert whatever happens" into a specific assertion** by measuring the current behavior in a scratch first.
+
+**Nice-to-have:**
+
+10. Function-ref handler untouched test.
+11. Recursive function raise test.
+12. Effect-name with special chars (`::`) confirmation.
+
+---
+
+## Bottom line
+
+The **strongest plan in the recent series** — it identifies the real architectural constraint, opens with a disciplined spike, and acknowledges limitations up front. Two real blockers before execution:
+
+1. **`bodyHasNestedHandle` guard needs an explicit decision** (currently dropped without discussion).
+2. **Task 3 Step 1's syntax hedge must be resolved** (verify grammar first).
+
+Plus one reproducibility fix (paths) and 4–5 missing tests around edge cases (nested handles, empty payloads, guarded else, B2 composition). Fix those and this is mergeable — the design and pipeline reorder are otherwise sound.

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-01-handler-payload-typing-h3.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-01-handler-payload-typing-h3.md
@@ -1,0 +1,795 @@
+# Handler Payload Typing (H3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Type an inline handler's param `e` so that `e.data` (the interrupt payload) is type-safe **per effect** — e.g. after `if (e.effect == "mymod::deposit")`, `e.data.amount` is known to be a `number`, and passing `e.data` to a function expecting the wrong shape is a type error.
+
+**Architecture:** Type `e` as a **discriminated union** of per-effect members: one member `{ effect: "<kind>", data: <declared payload>, message: any, origin: any }` per raisable effect kind. Payload narrowing then falls out **for free** from the existing discriminated-union narrowing (D1) and member-path narrowing (M2): `if (e.effect == "...")` narrows `e` to the matching member, which carries the concrete `data` type. Exhaustiveness (B1 on `e.effect`, B2 on `e`) keeps working on the same union.
+
+**The load-bearing design decision** (see "Core Design Decision"): unlike H1 — which retyped `e` *after* `checkScopes`, feeding only `checkMatchExhaustiveness` — payload safety requires `e` to carry its refined type **during** `checkScopes`, because `e.data` *usage* sites (`takesNum(e.data)`, `e.data.amount`) are checked there. That forces a **pipeline reorder**: interrupt analysis + the effect→payload registry + the handler-param refinement must run **before** `buildFlowGraphs`/`checkScopes`. Task 1 is a throwaway spike proving this works and measuring the blast radius before we invest in the clean implementation.
+
+**Tech Stack:** TypeScript, vitest, the Agency type checker (`lib/typeChecker/`). No new dependencies.
+
+## Revisions from review
+
+This plan incorporates [the review](2026-07-01-handler-payload-typing-h3-review.md). Resolved before writing code (findings recorded inline in the relevant tasks):
+
+- **Nested-`handle` guard preserved.** `bodyHasNestedHandle` lives in `refineInlineHandlerParams`'s *eligibility* loop; Task 3 rewrites only `handlerParamType` and does **not** touch that loop, so the guard survives. Task 3 states this explicitly and Task 5 adds a nested-handle test. (`docs/site/guide/handlers.md` documents the nested-handle → untyped behavior.)
+- **Match arm grammar verified.** The discriminated-object-union arm is `{ effect: "kind" } => …` (per `docs/site/guide/pattern-matching.md:212` and `handlers.md`), **not** `is <effect>`. The Task-3 shape test uses the verified form — no hedge.
+- **`analyzeInterruptsFromScopes` purity confirmed.** Its three `ctx.errors.push` neighbors (`interruptAnalysis.ts:373/418/538`) belong to the *consumer* functions `checkUnhandledInterruptWarnings` (@356), `checkHandlerBodyInterrupts` (@398), `checkCallbackBodyInterrupts` (@514) — all of which stay in place. `analyzeInterruptsFromScopes` (@70–236) pushes nothing. The reorder does not move any error-emission point.
+- **Scratch paths are portable** (`/tmp/h3-*.txt`).
+- Added tests: nested handle, empty-payload vs no/dropped declaration, guarded-else union, function-ref handler untouched, B2 `match (e)` exhaustiveness, recursive raise. The flat-scope limitation test asserts a **measured** outcome, not "whatever happens."
+
+## Global Constraints
+
+- **Handlers are safety infrastructure.** This is a **type-only** change. It must NEVER touch handler registration (`pushHandler`), execution, checkpoints, or state restoration. The only runtime-adjacent mutation permitted is `info.scope.declare(name, type)` (re-declaring a param's *type* in the checker's scope), exactly as H1 already does.
+- **No dynamic imports.** Static `import` only.
+- **Use objects, not maps; arrays, not sets; `type`, not `interface`.** (The existing `nameCount` `Map` in `handlerParamTyping.ts` predates the rule and is out of scope; do not add new `Map`/`Set`.)
+- **Never commit/push unless the user asks.** Implement directly — no subagents. Commit messages / PR bodies go in a **file** (apostrophes break inline `-m`).
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- **Do not run the agency execution suite locally.** Run typeChecker unit tests + targeted vitest files only. CI runs the full suite on the PR.
+- Build stdlib with `make` if any `.agency` stdlib file changes (none expected).
+
+---
+
+## Core Design Decision — why a pipeline reorder
+
+### What H1 does today (and why it is not enough for H3)
+
+`refineInlineHandlerParams` (`handlerParamTyping.ts`) runs at pipeline step **6d-bis**, *after* `checkScopes` (step 4). It re-declares `e` as `{ effect: <literal union>, message: any, data: any, origin: any }`. Because it runs *after* field-access checking, the refined type only reaches `checkMatchExhaustiveness` (6e). H1's own docstring records this:
+
+> although this is a closed `objectType`, it does NOT make `e.<field>` a "does not exist" error — field-access checking runs in `checkScopes`, BEFORE this pass re-types the param.
+
+For **exhaustiveness** that is fine (`checkMatchExhaustiveness` re-synthesizes the scrutinee). For **payload safety** it is fatal: `takesNum(e.data)` / `e.data.amount` are checked *during* `checkScopes`, when `e` is still `any`. A late retype cannot rescue a usage site that already type-checked as `any`.
+
+**Therefore `e` must carry its discriminated-union type before `checkScopes` runs.**
+
+### The reorder (contained, not "move everything")
+
+`refineInlineHandlerParams` needs exactly two inputs, **neither depending on `checkScopes`**:
+
+1. `interruptEffectsByFunction` — from `analyzeInterruptsFromScopes(scopes, ctx)`. This pass (`interruptAnalysis.ts:70–236`) reads function-ref arg types via `synthType(...)` against `ctx.functionDefs` (populated by `inferReturnTypes`, step 2) and **pushes no diagnostics** (verified: the three `ctx.errors.push` in the file are all in the consumer functions @356/@398/@514, which stay put). Moving it earlier is side-effect-free.
+2. The effect→payload registry — `buildEffectRegistry(ctx)` (`effectPayloadCheck.ts`), reading `ctx.symbolTable.allEffectDeclarations()`. Independent of `checkScopes`.
+
+So the reorder moves **only these** ahead of `buildFlowGraphs`/`checkScopes`:
+
+```
+2.  inferReturnTypes
+3.  buildScopes
+3a. analyzeInterruptsFromScopes         ← MOVED UP (pure; returns data, no diagnostics)
+3b. registry = buildEffectRegistry(ctx) ← NEW: build ONCE here
+3c. refineInlineHandlerParams(..., registry)  ← MOVED UP (now payload-typed)
+4.  buildFlowGraphs      (now sees the refined `e` — no memo-reset hack needed)
+5.  checkScopes          (now `e.data` is typed → payload narrowing fires at usage)
+6.  buildInterruptCallGraph, checkUnhandled…, checkCallback…, checkHandler…, checkRaises…  (UNCHANGED positions; consume the value from 3a)
+6d. checkEffectPayloads(scopes, ctx, registry)  ← receives the prebuilt registry (no rebuild → no double conflict-report)
+6e. checkMatchExhaustiveness  (UNCHANGED)
+```
+
+The consumers of `analyzeInterruptsFromScopes` just read a value computed a few steps earlier. `buildInterruptCallGraph` stays put (`refineInlineHandlerParams` uses `interruptEffectsByFunction`, not the call graph).
+
+### The blast radius — closed-object strictness
+
+With `e` typed as `{effect, data, message, origin}` **during** `checkScopes`, member access on an **unknown** field (`e.foo`) now errors, and `e.data.x` where `data` is a union-of-payloads may error **without** a preceding `if (e.effect == "...")` narrow. This is the interrupt runtime object's true shape (`interrupts.ts` — exactly those four fields), so the strictness is arguably *correct*, but it is a **behavior change**. **Task 1 (spike) measures it before we commit.** Large/unfixable radius → STOP and report.
+
+### Rejected alternative
+
+*Keep `e: any` and special-case only `e.data` narrowing in member-access checking.* Rejected: bespoke per-effect code that does not compose with `match`/D1/M2 and would need its own narrowing + exhaustiveness machinery. The reorder reuses all of it.
+
+---
+
+## File Structure
+
+- `lib/typeChecker/handlerParamTyping.ts` (modify) — `handlerParamType` gains a `registry` arg + builds a discriminated union; `refineInlineHandlerParams` gains a `registry` param and drops the memo-reset (Task 4). **Eligibility loop — including `bodyHasNestedHandle` — is untouched.**
+- `lib/typeChecker/effectPayloadCheck.ts` (modify) — export `buildRegistry` as `buildEffectRegistry`; `checkEffectPayloads` accepts an optional prebuilt registry.
+- `lib/typeChecker/index.ts` (modify) — the reorder.
+- `lib/typeChecker/handlerParamTyping.test.ts` (modify) — payload-shape + payload-narrowing + edge-case tests.
+- `lib/typeChecker/effectPayloadCheck.test.ts` (modify) — conflict reported exactly once with a shared registry.
+- Docs: `docs/site/guide/handlers.md` (the "per-effect payload typing on `e.data` is a later addition" note becomes "shipped"); `handler-narrowing-spec.md` status line.
+
+---
+
+### Task 1: Spike — prove payload narrowing fires and measure the blast radius (THROWAWAY)
+
+**This task's code is exploratory and discarded/redone cleanly in Tasks 2–4.** Deliverable: a GO/NO-GO decision + a breakage count. Do it on a scratch commit you `git reset` afterward.
+
+**Files:**
+- Modify (temporarily): `index.ts`, `handlerParamTyping.ts`, `effectPayloadCheck.ts`
+- Scratch test: `lib/typeChecker/__h3_spike.test.ts` (delete at end of task)
+
+**Interfaces:**
+- Consumes: `analyzeInterruptsFromScopes(scopes, ctx): Record<string, InterruptEffect[]>`, `buildRegistry(ctx): Record<string, ObjectType>` (currently un-exported), `refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx)`.
+- Produces: a decision (nothing durable).
+
+- [ ] **Step 1: Write the spike e2e test**
+
+Create `lib/typeChecker/__h3_spike.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+
+function allErrors(source: string): TypeCheckError[] {
+  const file = path.join(os.tmpdir(), `tc-h3spike-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`);
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath);
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) throw new Error("Parse failed");
+    const info = buildCompilationUnit(parseResult.result, symbolTable, absPath, source);
+    return typeCheck(parseResult.result, {}, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+describe("H3 spike", () => {
+  it("flags a payload-shape mismatch after narrowing", () => {
+    const errs = allErrors(`
+effect spike::deposit { amount: number }
+def takesString(s: string): string { return s }
+def risky() { raise spike::deposit("d", { amount: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "spike::deposit") {
+      takesString(e.data.amount)
+    }
+  }
+}`);
+    expect(errs.some((x) => x.severity === "error")).toBe(true);
+  });
+
+  it("accepts a correctly-typed payload use after narrowing", () => {
+    const errs = allErrors(`
+effect spike::deposit { amount: number }
+def takesNum(n: number): number { return n }
+def risky() { raise spike::deposit("d", { amount: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "spike::deposit") {
+      takesNum(e.data.amount)
+    }
+  }
+}`);
+    expect(errs.filter((x) => x.severity === "error")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm it FAILS on today's pipeline**
+
+Run: `pnpm exec vitest run lib/typeChecker/__h3_spike.test.ts 2>&1 | tee /tmp/h3-spike-before.txt`
+Expected: "flags a payload-shape mismatch" FAILS (today `e.data` is `any`).
+
+- [ ] **Step 3: Apply the minimal spike wiring**
+
+In `handlerParamTyping.ts`, temporarily rewrite `handlerParamType` to a discriminated union taking a registry, and drop the memo reset:
+
+```ts
+import type { ObjectType } from "../types/typeHints.js";
+
+function handlerParamType(kinds: string[], registry: Record<string, ObjectType>): VariableType {
+  const member = (kind: string): VariableType => ({
+    type: "objectType",
+    properties: [
+      { key: "effect", value: stringLiteral(kind) },
+      { key: "data", value: registry[kind] ?? ANY_T },
+      { key: "message", value: ANY_T },
+      { key: "origin", value: ANY_T },
+    ],
+  });
+  return kinds.length === 1 ? member(kinds[0]) : { type: "unionType", types: kinds.map(member) };
+}
+```
+
+Thread `registry` into `refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, registry)`; pass to `handlerParamType(kinds, registry)`; delete the trailing `if (changed && ctx.flowEnv) …` memo-reset block. **Do not touch the eligibility loop** (the `bodyHasNestedHandle` / name-collision / annotation filters stay).
+
+In `effectPayloadCheck.ts`, add `export` to `buildRegistry`.
+
+In `index.ts`, reorder (spike-quality is fine):
+```ts
+const scopes = buildScopes(ctx);
+const interruptEffectsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
+const registry = buildRegistry(ctx);
+refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, registry);
+buildFlowGraphs(scopes, ctx);
+checkScopes(scopes, ctx);
+// Leave the interrupt-check consumers + buildInterruptCallGraph where they are,
+// still reading interruptEffectsByFunction. For the spike, keep the existing
+// checkEffectPayloads(scopes, ctx) call — a double registry is acceptable noise
+// for a throwaway; you only care whether narrowing fires.
+```
+
+- [ ] **Step 4: Run to confirm it now PASSES**
+
+Run: `pnpm exec vitest run lib/typeChecker/__h3_spike.test.ts 2>&1 | tee /tmp/h3-spike-after.txt`
+Expected: BOTH tests PASS. If the mismatch test still does not error, payload narrowing is NOT firing — STOP, probe `synthType` on `e.data` after the narrow, report to the user. Do not proceed.
+
+- [ ] **Step 5: Measure blast radius — full typeChecker unit suite**
+
+Run: `pnpm exec vitest run lib/typeChecker 2>&1 | tee /tmp/h3-spike-unit.txt`
+Record newly-failing tests, each classified (a) legitimately asserting the old `any` behavior, or (b) a genuine regression (a handler accessing a real field now errors). Ignore double conflict-reports from `checkEffectPayloads` (the un-deduped spike registry — expected).
+
+- [ ] **Step 6: Measure blast radius — stdlib + fixtures**
+
+Run: `pnpm exec vitest run lib 2>&1 | tee /tmp/h3-spike-lib.txt`
+Record the count of newly-failing tests stemming from handler-param field access on unknown fields, or `e.data.x` without a narrow.
+
+- [ ] **Step 7: GO / NO-GO + clean up**
+
+Write the verdict to `/tmp/h3-spike-verdict.md`: did narrowing fire (Step 4)? blast radius N, classified (a legit-flip vs b regression)? recommendation GO / NO-GO. Then discard:
+```bash
+git checkout -- lib/typeChecker/index.ts lib/typeChecker/handlerParamTyping.ts lib/typeChecker/effectPayloadCheck.ts
+rm lib/typeChecker/__h3_spike.test.ts
+```
+
+- [ ] **Step 8: Gate**
+
+GO → Task 2. NO-GO / needs a product call → STOP and present `/tmp/h3-spike-verdict.md` to the user. (No commit — throwaway.)
+
+---
+
+### Task 2: Share one effect→payload registry (no double conflict-reporting)
+
+**Files:**
+- Modify: `lib/typeChecker/effectPayloadCheck.ts`
+- Test: `lib/typeChecker/effectPayloadCheck.test.ts`
+
+**Interfaces:**
+- Produces: `export function buildEffectRegistry(ctx: TypeCheckerContext): Record<string, ObjectType>` — the renamed, exported builder (reports conflicts/duplicates as a side effect, drops conflicting effects).
+- Produces: `checkEffectPayloads(scopes: ScopeInfo[], ctx: TypeCheckerContext, registry?: Record<string, ObjectType>): void` — uses the passed registry when provided, else builds its own (back-compat).
+
+- [ ] **Step 1: Write the failing test — conflicts reported exactly once**
+
+`effectPayloadCheck.test.ts` already imports `typecheckSource` from `./testUtils.js`. Add:
+
+```ts
+it("reports a payload conflict exactly once (shared-registry guard)", () => {
+  const errs = typecheckSource(`
+effect dup::e { a: number }
+effect dup::e { a: string }
+node main() { }`).filter((x) => /Conflicting payload types for effect 'dup::e'/.test(x.message));
+  expect(errs.length).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run — baseline PASS**
+
+Run: `pnpm exec vitest run lib/typeChecker/effectPayloadCheck.test.ts 2>&1 | tee /tmp/h3-t2-before.txt`
+Expected: PASS (today: one `checkEffectPayloads` call → one registry → one conflict). This is a **regression guard** for Task 4, where a shared registry must not become a rebuilt-twice registry.
+
+- [ ] **Step 3: Rename + export the builder, add the optional param**
+
+In `effectPayloadCheck.ts`:
+- Rename `function buildRegistry` → `export function buildEffectRegistry` (update the internal call site).
+- Change `checkEffectPayloads` to accept `registry?: Record<string, ObjectType>` and use `const reg = registry ?? buildEffectRegistry(ctx);` (rename the local from `registry` to `reg` to avoid shadowing):
+
+```ts
+export function checkEffectPayloads(
+  scopes: ScopeInfo[],
+  ctx: TypeCheckerContext,
+  registry?: Record<string, ObjectType>,
+): void {
+  const reg = registry ?? buildEffectRegistry(ctx);
+  for (const info of scopes) {
+    if (!info.name || info.name === "top-level") continue;
+    ctx.withScope(info.scopeKey, () => {
+      for (const { node } of walkNodes(info.body)) {
+        if (node.type !== "interruptStatement") continue;
+        const payloadType = reg[node.effect];
+        if (!payloadType) continue;
+        checkRaiseSite(node, payloadType, info, ctx);
+      }
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run the effectPayloadCheck tests**
+
+Run: `pnpm exec vitest run lib/typeChecker/effectPayloadCheck.test.ts 2>&1 | tee /tmp/h3-t2-after.txt`
+Expected: PASS (including the new once-only conflict test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/typeChecker/effectPayloadCheck.ts lib/typeChecker/effectPayloadCheck.test.ts
+git commit -F /tmp/h3-t2-msg.txt
+```
+`/tmp/h3-t2-msg.txt`:
+```
+refactor(typechecker): export shared effect→payload registry
+
+Rename buildRegistry → buildEffectRegistry (exported) and let
+checkEffectPayloads accept a prebuilt registry, so a single registry can be
+shared across passes without double-reporting conflicts. Pure refactor;
+behavior unchanged (guarded by a once-only conflict test).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+### Task 3: Discriminated-union `handlerParamType`
+
+**Files:**
+- Modify: `lib/typeChecker/handlerParamTyping.ts`
+- Test: `lib/typeChecker/handlerParamTyping.test.ts`
+
+**Interfaces:**
+- Consumes: `buildEffectRegistry` (Task 2), `ObjectType` (`../types/typeHints.js`), `ANY_T` (`./primitives.js`).
+- Produces: `handlerParamType(kinds: string[], registry: Record<string, ObjectType>): VariableType` — a single `objectType` member when `kinds.length === 1`, else a `unionType` of one member per kind. Member: `{ effect: <string literal>, data: registry[kind] ?? any, message: any, origin: any }`.
+- Produces: `refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, registry)` — the H1 pass, 4-arg positional, passing `registry` through. **Eligibility loop unchanged** (the `bodyHasNestedHandle`, explicit-annotation, and name-collision guards all remain — they gate WHICH params get retyped, orthogonal to WHAT type they get).
+
+Note: this task changes the type-builder + threads the registry but does **not** reorder the pipeline. Between Task 3 and Task 4, `refineInlineHandlerParams` still runs at 6d-bis (after `checkScopes`), so the new `data` typing reaches only `checkMatchExhaustiveness` — payload *usage* narrowing does not fire until Task 4. Keep the memo-reset for now (Task 4 removes it).
+
+- [ ] **Step 1: Write the failing test — the union drives B2 exhaustiveness on `match (e)`**
+
+The discriminated-object-union arm syntax is `{ effect: "kind" } => …` (verified: `docs/site/guide/pattern-matching.md:212`, `handlers.md:304`). This asserts the retyped param is a real discriminated union (multiple members, `effect` discriminant), which the H1 flat shape (`data: any`) does not change but the discriminant detection (B2 `findDiscriminant` on `effect`) must accept. Add to `handlerParamTyping.test.ts`:
+
+```ts
+it("types e as a discriminated union so match(e) checks B2 exhaustiveness", () => {
+  const warnings = warningsFrom(`
+effect payl::a { x: number }
+effect payl::b { y: string }
+def risky() { raise payl::a("a", { x: 1 })\n raise payl::b("b", { y: "s" }) }
+node main() {
+  handle { risky() } with (e) {
+    match (e) {
+      { effect: "payl::a" } => 1
+    }
+  }
+}`);
+  // match(e) over the 2-member discriminated union is non-exhaustive: missing payl::b.
+  expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /payl::b/.test(w.message))).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm exec vitest run lib/typeChecker/handlerParamTyping.test.ts 2>&1 | tee /tmp/h3-t3-before.txt`
+Expected: the new test FAILS (today `handlerParamType` returns a single flat object, so `match (e)` sees no per-member discriminant to enumerate).
+
+- [ ] **Step 3: Rewrite `handlerParamType` to build the discriminated union**
+
+In `handlerParamTyping.ts`, add the import and rewrite:
+
+```ts
+import type { ObjectType } from "../types/typeHints.js";
+
+/**
+ * The type of an inline handler param whose body raises `kinds`, as a
+ * DISCRIMINATED UNION: one member per effect kind,
+ *   { effect: "<kind>", data: <declared payload | any>, message: any, origin: any },
+ * matching the runtime interrupt object (interrupts.ts). The `effect` literal is
+ * the discriminant, so `if (e.effect == "<kind>")` / `match (e)` narrows `e` to a
+ * single member whose `data` carries that effect's declared payload — H3 payload
+ * safety falls out of discriminated-union narrowing (D1) + member-path narrowing
+ * (M2). A single kind is a single member (no union wrapper). An effect with no
+ * registry entry (undeclared or dropped as conflicting) gets `data: any`.
+ */
+function handlerParamType(kinds: string[], registry: Record<string, ObjectType>): VariableType {
+  const member = (kind: string): VariableType => ({
+    type: "objectType",
+    properties: [
+      { key: "effect", value: stringLiteral(kind) },
+      { key: "data", value: registry[kind] ?? ANY_T },
+      { key: "message", value: ANY_T },
+      { key: "origin", value: ANY_T },
+    ],
+  });
+  return kinds.length === 1 ? member(kinds[0]) : { type: "unionType", types: kinds.map(member) };
+}
+```
+
+Update `refineInlineHandlerParams`'s signature to accept `registry: Record<string, ObjectType>` as the 4th positional param; change the declare call to `info.scope.declare(h.name, handlerParamType(kinds, registry));`. **Leave the eligibility loop and the memo-reset block untouched.**
+
+- [ ] **Step 4: Update the H1 call site in `index.ts` so the project compiles**
+
+`refineInlineHandlerParams` now needs a registry. **Temporary bridge** (Task 4 replaces this): build it inline at the existing 6d-bis call:
+```ts
+refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, buildEffectRegistry(ctx));
+```
+Add `buildEffectRegistry` to the `./effectPayloadCheck.js` import. This rebuilds the registry a second time and would double-report conflicts, so **Tasks 3 and 4 land in one PR — do not ship between them.**
+
+- [ ] **Step 5: Run handler-param + exhaustiveness tests**
+
+Run: `pnpm exec vitest run lib/typeChecker/handlerParamTyping.test.ts lib/typeChecker/matchExhaustiveness.test.ts 2>&1 | tee /tmp/h3-t3-after.txt`
+Expected: the new B2 test PASSES; all existing H1 `match (e.effect)` tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/typeChecker/handlerParamTyping.ts lib/typeChecker/handlerParamTyping.test.ts lib/typeChecker/index.ts
+git commit -F /tmp/h3-t3-msg.txt
+```
+`/tmp/h3-t3-msg.txt`:
+```
+feat(typechecker): type handler param as a per-effect discriminated union
+
+handlerParamType now returns a discriminated union — one member per raisable
+effect kind carrying that effect's declared payload as `data` (discriminant =
+the `effect` string literal) — instead of a single flat object with `data: any`.
+Exhaustiveness (B1 on e.effect, B2 on e) still works; payload narrowing is wired
+in the following commit (pipeline reorder). Eligibility (nested-handle,
+annotation, name-collision guards) is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+### Task 4: The pipeline reorder — payload narrowing at usage sites
+
+**Files:**
+- Modify: `lib/typeChecker/index.ts`
+- Modify: `lib/typeChecker/handlerParamTyping.ts` (remove the memo reset)
+- Test: `lib/typeChecker/handlerParamTyping.test.ts` (payload-narrowing e2e)
+
+**Interfaces:**
+- Consumes: `analyzeInterruptsFromScopes`, `buildEffectRegistry`, `refineInlineHandlerParams(…, registry)`, `checkEffectPayloads(…, registry)`.
+- Produces: a pipeline where `e` is a payload-typed discriminated union during `checkScopes`.
+
+- [ ] **Step 1: Write the failing payload-narrowing e2e tests**
+
+Add to `handlerParamTyping.test.ts` (durable versions of the spike):
+
+```ts
+describe("handler param payload typing (H3)", () => {
+  it("errors on a payload-shape mismatch after narrowing on e.effect", () => {
+    const errs = errorsFrom(`
+effect h3::deposit { amount: number }
+def takesString(s: string): string { return s }
+def risky() { raise h3::deposit("d", { amount: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3::deposit") { takesString(e.data.amount) }
+  }
+}`);
+    expect(errs.some((x) => x.severity === "error")).toBe(true);
+  });
+
+  it("accepts a correctly-typed payload use after narrowing", () => {
+    const errs = errorsFrom(`
+effect h3::deposit { amount: number }
+def takesNum(n: number): number { return n }
+def risky() { raise h3::deposit("d", { amount: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3::deposit") { takesNum(e.data.amount) }
+  }
+}`);
+    expect(errs.filter((x) => x.severity === "error")).toEqual([]);
+  });
+
+  it("still refines e.effect for exhaustiveness (H1 regression)", () => {
+    const warnings = warningsFrom(`
+effect h3::a { }
+effect h3::b { }
+def risky() { raise h3::a("a", {})\n raise h3::b("b", {}) }
+node main() {
+  handle { risky() } with (e) {
+    match (e.effect) { "h3::a" => 1 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /h3::b/.test(w.message))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect the two payload tests to FAIL (retype still after checkScopes)**
+
+Run: `pnpm exec vitest run lib/typeChecker/handlerParamTyping.test.ts 2>&1 | tee /tmp/h3-t4-before.txt`
+Expected: "errors on a payload-shape mismatch" FAILS (`e.data` still `any` at usage).
+
+- [ ] **Step 3: Apply the reorder in `index.ts`**
+
+Replace the steps 3b–4 region; move `analyzeInterruptsFromScopes`, a single `buildEffectRegistry`, and `refineInlineHandlerParams` before `buildFlowGraphs`; delete the 6d-bis call and Task-3's temporary inline registry; pass the shared `registry` into `checkEffectPayloads`:
+
+```ts
+    // 3. Build scopes (collects variable types and checks assignments)
+    const scopes = buildScopes(ctx);
+
+    // 3a. Analyze interrupts (pure — returns transitive effect sets, pushes no
+    // diagnostics; the ctx.errors sites in interruptAnalysis.ts belong to the
+    // consumer passes below). Moved ahead of flow/checkScopes so the handler-param
+    // refinement can run before field-access checking.
+    const interruptEffectsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
+
+    // 3b. Build the ambient effect→payload registry ONCE and share it with both
+    // the handler-param refinement (below) and checkEffectPayloads (6d). Building
+    // it once avoids double-reporting payload conflicts.
+    const effectRegistry = buildEffectRegistry(ctx);
+
+    // 3c. H3: re-type each eligible inline handler param `e` as a per-effect
+    // discriminated union carrying that effect's declared payload as `data`.
+    // MUST run before checkScopes so `e.data` usage sites narrow correctly.
+    refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, effectRegistry);
+
+    // 3d. Build the flow graph AFTER the param retype, so its typeAt oracle is
+    // seeded with the refined `e` (no stale-memo reset needed).
+    buildFlowGraphs(scopes, ctx);
+
+    // 4. Check function calls, return types, and expressions. `e.data` is now
+    // payload-typed → narrowing on `e.effect` makes `e.data` concrete here.
+    checkScopes(scopes, ctx);
+
+    // 5a. Build the per-function interrupt call graph (structural info for
+    // `agency interrupts`). Independent of the retype above.
+    const interruptCallGraph = buildInterruptCallGraph(scopes, ctx);
+
+    // 6. Unhandled-interrupt warnings (consume the transitive results from 3a).
+    checkUnhandledInterruptWarnings(scopes, interruptEffectsByFunction, ctx);
+
+    // 6a. Reject `interrupt` inside any callback body.
+    checkCallbackBodyInterrupts(scopes, interruptEffectsByFunction, ctx);
+
+    // 6b. Reject handlers whose body may itself raise an interrupt.
+    checkHandlerBodyInterrupts(scopes, interruptEffectsByFunction, ctx);
+
+    // 6c. Verify declared `raises` clauses.
+    checkRaisesDeclarations(interruptEffectsByFunction, ctx);
+
+    // 6d. Check interrupt payloads against `effect` declarations (shared registry).
+    checkEffectPayloads(scopes, ctx, effectRegistry);
+
+    // 6e. Match exhaustiveness over closed value types.
+    checkMatchExhaustiveness(scopes, ctx);
+```
+
+Preserve whatever the current code does with `interruptCallGraph` (e.g. a `void interruptCallGraph;` or a later consumer) — do not introduce an unused-var lint error.
+
+- [ ] **Step 4: Remove the now-unnecessary memo reset in `handlerParamTyping.ts`**
+
+The flow graph is now built *after* the retype, so no stale `typeAt` memo exists. Delete the trailing block:
+```ts
+  // DELETE — flow graph is built after this pass now:
+  // if (changed && ctx.flowEnv) ctx.flowEnv.memo = new WeakMap();
+```
+Drop the now-unused `changed` accumulator if nothing else reads it. Update the pass docstring: it now runs **before** `checkScopes`, so re-typing `e` to a closed object DOES make `e.<unknown-field>` a "does not exist" error during `checkScopes` (the opposite of H1's old note) — intended (the interrupt object has exactly `{effect, message, data, origin}`).
+
+- [ ] **Step 5: Run H3 tests + the full interrupt/exhaustiveness regression set**
+
+Run: `pnpm exec vitest run lib/typeChecker/handlerParamTyping.test.ts lib/typeChecker/matchExhaustiveness.test.ts lib/typeChecker/interruptWarnings.test.ts lib/typeChecker/handlerBodyInterrupts.test.ts lib/typeChecker/callbackBodyInterrupts.test.ts lib/typeChecker/effectPayloadCheck.test.ts lib/typeChecker/interruptAnalysis.test.ts lib/typeChecker/interruptCallGraph.test.ts 2>&1 | tee /tmp/h3-t4-after.txt`
+Expected: all PASS. The interrupt-check suites confirm moving `analyzeInterruptsFromScopes` earlier changed no diagnostics (their inputs are unchanged). **If any interrupt-warning error-ORDER assertion regresses, that surfaces the Concern-4 registry-ordering risk — investigate before proceeding.**
+
+- [ ] **Step 6: Run the full typeChecker unit suite**
+
+Run: `pnpm exec vitest run lib/typeChecker 2>&1 | tee /tmp/h3-t4-unit.txt`
+Expected: PASS. Compare against `/tmp/h3-spike-unit.txt` — every newly-failing test must be an intentional `any`→typed flip (fixed in Task 5). A regression the spike did not predict → STOP and reassess.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/typeChecker/index.ts lib/typeChecker/handlerParamTyping.ts lib/typeChecker/handlerParamTyping.test.ts
+git commit -F /tmp/h3-t4-msg.txt
+```
+`/tmp/h3-t4-msg.txt`:
+```
+feat(typechecker): payload-safe handler params via pipeline reorder (H3)
+
+Move interrupt analysis + the effect→payload registry + the handler-param
+refinement ahead of buildFlowGraphs/checkScopes, so an inline handler's `e`
+carries its per-effect discriminated-union type DURING field-access checking.
+`if (e.effect == "...")` now narrows `e.data` to that effect's declared payload,
+making payload misuse a type error. The flow graph is built after the retype, so
+the stale-memo reset is gone. Interrupt-check diagnostics are unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+### Task 5: Edge-case tests, blast-radius fixes, docs, and final gate
+
+**Files:**
+- Modify: whatever tests/fixtures the spike/Task-4 sweep flagged as legitimate `any`→typed flips.
+- Test: `lib/typeChecker/handlerParamTyping.test.ts` (edge cases + idioms + limitation).
+- Docs: `docs/site/guide/handlers.md`, `handler-narrowing-spec.md`.
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Fix the legitimate blast-radius test flips**
+
+For each test in `/tmp/h3-t4-unit.txt` that asserted the OLD `e.data: any` / unknown-field-allowed behavior, update it to the payload-typed expectation (mirror H1's flipped "unknown field errors" precedent). Re-run each fixed file with `tee`. Do NOT weaken a test to hide a genuine regression — surface it.
+
+- [ ] **Step 2: Edge-case + idiom tests**
+
+Add to `handlerParamTyping.test.ts`:
+
+```ts
+describe("H3 edge cases", () => {
+  // Member-path idiom: narrow per branch, read e.data inline. Sidesteps the
+  // accepted same-name-binder flat-scope limitation.
+  it("member-path narrowing gives each branch its own payload", () => {
+    const errs = errorsFrom(`
+effect h3i::a { n: number }
+effect h3i::b { s: string }
+def takesNum(n: number): number { return n }
+def takesStr(s: string): string { return s }
+def risky() { raise h3i::a("a", { n: 1 })\n raise h3i::b("b", { s: "x" }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3i::a") { takesNum(e.data.n) }
+    if (e.effect == "h3i::b") { takesStr(e.data.s) }
+  }
+}`);
+    expect(errs.filter((x) => x.severity === "error")).toEqual([]);
+  });
+
+  // Guarded else: after `if (e.effect == "a")`, the else branch must NOT keep
+  // e.data as a's payload — reading a's field there must error (whether e
+  // narrows to the remaining union or stays the full union, a's field is absent
+  // from at least one member → error).
+  it("does not leak the narrowed payload into the else branch", () => {
+    const errs = errorsFrom(`
+effect h3e::a { n: number }
+effect h3e::b { s: string }
+def takesNum(n: number): number { return n }
+def risky() { raise h3e::a("a", { n: 1 })\n raise h3e::b("b", { s: "x" }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3e::a") { takesNum(e.data.n) } else { takesNum(e.data.n) }
+  }
+}`);
+    expect(errs.some((x) => x.severity === "error")).toBe(true);
+  });
+
+  // Empty-payload effect: e.data is the empty object → accessing a field errors.
+  it("errors accessing a field on an empty-payload effect's data", () => {
+    const errs = errorsFrom(`
+effect h3p::ping { }
+def risky() { raise h3p::ping("p", {}) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3p::ping") { let x = e.data.nope }
+  }
+}`);
+    expect(errs.some((x) => x.severity === "error")).toBe(true);
+  });
+
+  // Conflicting declarations → the effect is DROPPED from the registry → its
+  // data falls back to `any` → field access is permitted (no derivative error).
+  it("falls back to any for an effect dropped as conflicting", () => {
+    const errs = errorsFrom(`
+effect h3c::e { a: number }
+effect h3c::e { a: string }
+def risky() { raise h3c::e("c", { a: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3c::e") { let x = e.data.anything }
+  }
+}`);
+    // Exactly the one conflict diagnostic; no "field does not exist" on e.data.
+    expect(errs.some((x) => /does not exist/i.test(x.message))).toBe(false);
+  });
+
+  // Nested handle → outer param stays untyped (eligibility guard preserved), so
+  // e.data field access is unconstrained (no payload error).
+  it("leaves the outer param untyped when the body contains a nested handle", () => {
+    const errs = errorsFrom(`
+effect h3n::a { n: number }
+effect h3n::b { s: string }
+def risky() { raise h3n::a("a", { n: 1 }) }
+def inner() { raise h3n::b("b", { s: "x" }) }
+node main() {
+  handle {
+    risky()
+    handle { inner() } with (f) { let y = f.data }
+  } with (e) {
+    let z = e.data.whatever
+  }
+}`);
+    expect(errs.some((x) => /does not exist/i.test(x.message))).toBe(false);
+  });
+
+  // functionRef handler → not an inline param → never retyped by this pass.
+  it("does not retype a functionRef handler's param", () => {
+    const errs = errorsFrom(`
+effect h3f::a { n: number }
+def risky() { raise h3f::a("a", { n: 1 }) }
+def onEffect(e: any): number { return 0 }
+node main() {
+  handle { risky() } with onEffect
+}`);
+    expect(errs.filter((x) => x.severity === "error")).toEqual([]);
+  });
+
+  // Recursive raise: the transitive raisable set still reaches the handler, so
+  // e.data narrows to the payload.
+  it("narrows payload for an effect raised transitively through recursion", () => {
+    const errs = errorsFrom(`
+effect h3r::a { n: number }
+def recur(k: number) { if (k > 0) { recur(k - 1) } else { raise h3r::a("a", { n: 1 }) } }
+def takesString(s: string): string { return s }
+node main() {
+  handle { recur(3) } with (e) {
+    if (e.effect == "h3r::a") { takesString(e.data.n) }
+  }
+}`);
+    // e.data.n is number, takesString wants string → error.
+    expect(errs.some((x) => x.severity === "error")).toBe(true);
+  });
+});
+```
+
+If the `functionRef` handler arm syntax (`with onEffect`) differs from what parses, confirm with `pnpm run ast` on a scratch file and adjust the arm to the parsing form; the assertion (param untouched → no error) is what matters.
+
+- [ ] **Step 3: The flat-scope limitation test — measured, not guessed**
+
+First measure the current behavior with a scratch file, THEN assert it. Create `/tmp/h3-limitation-probe.agency`:
+```agency
+effect h3l::a { n: number }
+effect h3l::b { s: string }
+def risky() { raise h3l::a("a", { n: 1 })\n raise h3l::b("b", { s: "x" }) }
+node main() {
+  handle { risky() } with (e) {
+    match (e) {
+      { effect: "h3l::a" } => e.data.n
+      { effect: "h3l::b" } => e.data.s
+    }
+  }
+}
+```
+Run `pnpm run compile /tmp/h3-limitation-probe.agency` (or the test harness) and record whether `e.data.n` / `e.data.s` in the arms each narrow to their member (works), or collide (the accepted flat-scope limitation). Then add ONE test asserting that exact measured outcome, with a comment: `// Flat-scope limitation (PR3-accepted): same-name binders across arms share the function scope. Workaround: member-path idiom (see above).` If the measured outcome is "both narrow correctly," the limitation does not bite here and the comment says so. **Do not commit an assertion you have not run.**
+
+- [ ] **Step 4: Run the handler-param file**
+
+Run: `pnpm exec vitest run lib/typeChecker/handlerParamTyping.test.ts 2>&1 | tee /tmp/h3-t5-edge.txt`
+Expected: PASS.
+
+- [ ] **Step 5: Update docs**
+
+- `docs/site/guide/handlers.md`: the paragraph ending "per-effect payload typing on `e.data` is a later addition" → describe the shipped behavior: `e` is a per-effect discriminated union; `e.data` is that effect's declared payload after narrowing on `e.effect` (via `if`/`match`); an undeclared/conflicting effect's `data` stays untyped; the conservative cases (annotated param, functionRef handler, nested handle) still opt out.
+- `handler-narrowing-spec.md` (repo root): mark H3 implemented; note the reorder + closed-object strictness + the same-name-binder flat-scope limitation.
+
+- [ ] **Step 6: Structural lint + full typeChecker suite (final gate)**
+
+Run: `pnpm run lint:structure 2>&1 | tee /tmp/h3-t5-lint.txt`
+Run: `pnpm exec vitest run lib/typeChecker 2>&1 | tee /tmp/h3-t5-unit.txt`
+Expected: both clean/PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -F /tmp/h3-t5-msg.txt
+```
+`/tmp/h3-t5-msg.txt`:
+```
+test(typechecker): H3 edge cases + limitation; docs; blast-radius flips
+
+Add member-path/guarded-else/empty-payload/conflicting-drop/nested-handle/
+functionRef/recursive-raise tests, a measured flat-scope-limitation test,
+update handlers.md + handler-narrowing-spec, and flip the tests that asserted
+the pre-H3 `e.data: any` behavior.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (against `handler-narrowing-spec.md` H3 = "A-rich: discriminated-effect-union param typing, payload per arm"):
+- Per-effect `data` payload typing → Task 3 (`handlerParamType` union) + Task 4 (reorder makes it reach usage). ✓
+- "Folds into discriminated-union narrowing" → reuses D1/M2/B2, no bespoke code; proven by payload-narrowing e2e (Task 4) + member-path/guarded-else tests (Task 5). ✓
+- Exhaustiveness preserved → B1 (`match (e.effect)`, Task 4 Step 1) + B2 (`match (e)`, Task 3 Step 1). ✓
+- Payload conflicts reported once → Task 2; conflicting effect dropped → `data: any` test (Task 5). ✓
+- Conservative opt-outs (annotation, functionRef, nested handle) preserved → eligibility loop untouched + nested-handle/functionRef tests (Task 5). ✓
+
+**Review blockers:** (1) nested-handle guard — resolved (eligibility loop untouched + test). (2) match-arm syntax hedge — resolved (verified `{ effect: "..." }` form). (3) portable paths — done. Concerns 3/4/5/6/7/8 — addressed in Revisions + Tasks 4-5.
+
+**Placeholder scan:** every code step shows real code; every run step has an exact command + expected result. Task 5 Step 3 deliberately measures-then-asserts (with an exact procedure) rather than hardcoding an unknown outcome — that is intentional, not a placeholder.
+
+**Type consistency:** `buildEffectRegistry(ctx): Record<string, ObjectType>` (Task 2) consumed identically in Tasks 3–4. `handlerParamType(kinds: string[], registry: Record<string, ObjectType>): VariableType` (Task 3) used identically in Task 4. `refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, registry)` — 4-arg positional — defined Task 3, called with `effectRegistry` in Task 4. `checkEffectPayloads(scopes, ctx, registry?)` (Task 2) called with the shared registry in Task 4. Consistent.
+
+**Risk note:** feasibility rests on Task 1's spike. If narrowing does not fire, or the closed-object blast radius is large, the plan pauses at Task 1 Step 8 for a user decision — Tasks 2–5 assume GO.

--- a/packages/agency-lang/lib/typeChecker/effectPayloadCheck.test.ts
+++ b/packages/agency-lang/lib/typeChecker/effectPayloadCheck.test.ts
@@ -179,7 +179,7 @@ describe("effect data checking", () => {
   });
 
   it("same-file dup with different payloads fires BOTH dup and conflict", () => {
-    // Two diagnostics from two passes in `buildRegistry`: the per-file
+    // Two diagnostics from two passes in `buildEffectRegistry`: the per-file
     // duplicate detector AND the cross-declaration conflict detector. This
     // pins that order isn't load-bearing: collapsing one into the other
     // would lose a useful error.
@@ -196,6 +196,19 @@ describe("effect data checking", () => {
     );
     expect(dup).toBeDefined();
     expect(conflict).toBeDefined();
+  });
+
+  it("reports a payload conflict exactly once (shared-registry guard)", () => {
+    // H3 shares ONE registry across refineInlineHandlerParams AND
+    // checkEffectPayloads. A rebuilt-twice registry would double-report this
+    // conflict. The handler exercises both registry consumers.
+    const errs = typecheckSource(
+      "effect dup::e { a: number }\n" +
+        "effect dup::e { a: string }\n" +
+        "def risky() { raise dup::e(\"m\", { a: 1 }) }\n" +
+        "node main() { handle { risky() } with (e) { match (e.effect) { \"dup::e\" => 1 } } }",
+    ).filter((x) => /Conflicting payload types for effect 'dup::e'/.test(x.message));
+    expect(errs).toHaveLength(1);
   });
 });
 

--- a/packages/agency-lang/lib/typeChecker/effectPayloadCheck.ts
+++ b/packages/agency-lang/lib/typeChecker/effectPayloadCheck.ts
@@ -26,8 +26,10 @@ export function checkEffectPayloads(
     ctx.withScope(info.scopeKey, () => {
       for (const { node } of walkNodes(info.body)) {
         if (node.type !== "interruptStatement") continue;
+        // Own-property guard: `node.effect` is a user-controlled string, so a
+        // reserved key must not resolve a payload via Object.prototype.
+        if (!Object.prototype.hasOwnProperty.call(reg, node.effect)) continue;
         const payloadType = reg[node.effect];
-        if (!payloadType) continue;
         checkRaiseSite(node, payloadType, info, ctx);
       }
     });
@@ -44,13 +46,16 @@ type DeclEntry = { decl: EffectDeclaration; file: string };
  */
 export function buildEffectRegistry(ctx: TypeCheckerContext): Record<string, ObjectType> {
   const grouped = groupBy(collectDeclarations(ctx), (e) => e.decl.effect);
-  return Object.fromEntries(
-    Object.entries(grouped).flatMap(([effect, entries]) => {
-      reportSameFileDuplicates(effect, entries, ctx);
-      const merged = mergePayload(effect, entries, ctx);
-      return merged ? [[effect, merged] as const] : [];
-    }),
-  );
+  // Null-prototype dict: effect names are user-controlled strings (they may be
+  // bare identifiers), so a reserved key like "__proto__"/"constructor"/"toString"
+  // must not corrupt the registry on write or resolve via Object.prototype on read.
+  const registry: Record<string, ObjectType> = Object.create(null);
+  for (const [effect, entries] of Object.entries(grouped)) {
+    reportSameFileDuplicates(effect, entries, ctx);
+    const merged = mergePayload(effect, entries, ctx);
+    if (merged) registry[effect] = merged;
+  }
+  return registry;
 }
 
 /** Prefer the import closure (ambient); fall back to the current program's
@@ -71,7 +76,9 @@ function groupBy<T, K extends string>(
   items: T[],
   key: (t: T) => K,
 ): Record<K, T[]> {
-  const out = {} as Record<K, T[]>;
+  // Null-prototype accumulator: keys derive from user-controlled strings (effect
+  // names, file paths), so a reserved key must not read/write Object.prototype.
+  const out = Object.create(null) as Record<K, T[]>;
   for (const item of items) (out[key(item)] ??= []).push(item);
   return out;
 }

--- a/packages/agency-lang/lib/typeChecker/effectPayloadCheck.ts
+++ b/packages/agency-lang/lib/typeChecker/effectPayloadCheck.ts
@@ -8,23 +8,25 @@ import { synthType } from "./synthesizer.js";
 import { isAssignable } from "./assignability.js";
 
 /**
- * Build the ambient effect→payload registry from declarations across the
- * import closure (or the current program when there's no symbol table),
- * report conflicting / duplicate declarations, then check every interrupt
- * raise site's payload against its declared type.
+ * Check every interrupt raise site's payload against its declared type. The
+ * effect→payload registry is built via `buildEffectRegistry` (reporting
+ * conflicting / duplicate declarations as a side effect). Callers that already
+ * built the registry — H3 shares ONE across passes — pass it in to avoid
+ * rebuilding it (which would double-report those conflicts).
  */
 export function checkEffectPayloads(
   scopes: ScopeInfo[],
   ctx: TypeCheckerContext,
+  registry?: Record<string, ObjectType>,
 ): void {
-  const registry = buildRegistry(ctx);
+  const reg = registry ?? buildEffectRegistry(ctx);
 
   for (const info of scopes) {
     if (!info.name || info.name === "top-level") continue;
     ctx.withScope(info.scopeKey, () => {
       for (const { node } of walkNodes(info.body)) {
         if (node.type !== "interruptStatement") continue;
-        const payloadType = registry[node.effect];
+        const payloadType = reg[node.effect];
         if (!payloadType) continue;
         checkRaiseSite(node, payloadType, info, ctx);
       }
@@ -40,7 +42,7 @@ type DeclEntry = { decl: EffectDeclaration; file: string };
  * Validation pushes diagnostics; merge returns the agreed type or `null` on
  * conflict (so we drop the effect from the registry — see `mergePayload`).
  */
-function buildRegistry(ctx: TypeCheckerContext): Record<string, ObjectType> {
+export function buildEffectRegistry(ctx: TypeCheckerContext): Record<string, ObjectType> {
   const grouped = groupBy(collectDeclarations(ctx), (e) => e.decl.effect);
   return Object.fromEntries(
     Object.entries(grouped).flatMap(([effect, entries]) => {

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -356,6 +356,27 @@ node main() {
     expect(errs.some((x) => /does not exist/i.test(x.message))).toBe(false);
   });
 
+  it("an effect named like a prototype key that is NOT an own registry entry is safe", () => {
+    // Effect names are user-controlled (bare identifiers allowed). Here `toString`
+    // is dropped from the registry (conflicting declarations), so it has no OWN
+    // entry. Without an own-property guard, `registry["toString"]` would resolve
+    // to Object.prototype.toString (a function) — crashing the raise-site check
+    // and mistyping `e.data` as that function. The guard makes `data` fall back
+    // to `any`, so field access is permitted and nothing crashes. We assert only
+    // the conflict diagnostic — no crash, no spurious "does not exist".
+    const errs = errorsFrom(`
+effect toString { a: number }
+effect toString { a: string }
+def risky() { raise toString("t", { a: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "toString") { let x = e.data.anything }
+  }
+}`);
+    expect(errs.some((x) => /Conflicting payload types for effect 'toString'/.test(x.message))).toBe(true);
+    expect(errs.some((x) => /does not exist/i.test(x.message))).toBe(false);
+  });
+
   it("LIMITATION: a match(e) object-pattern arm does not narrow e.data inside the arm", () => {
     // Object-pattern match arms match+dispatch but do NOT narrow the scrutinee's
     // member access within the arm body, so `e.data.n` sees the full payload

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -88,11 +88,12 @@ node main() {
     expect(errs.some((e) => /does not exist|not assignable/i.test(e.message))).toBe(false);
   });
 
-  it("NOT a breaking change: reading an unknown field is still allowed", () => {
-    // Field-access checking runs in checkScopes, BEFORE this pass re-types `e`.
-    // The refined `.effect` type only ever reaches checkMatchExhaustiveness, so
-    // no field read (known or unknown) is re-checked against the object type —
-    // `e.notARealField` stays allowed exactly as it was when `e` was `any`.
+  it("H3: reading an unknown field on `e` is now a 'does not exist' error", () => {
+    // This pass now runs BEFORE checkScopes, so `e` is the closed interrupt
+    // object `{ effect, message, data, origin }` during field-access checking.
+    // A field outside those four is a real error — the interrupt object has
+    // exactly those members. (Under H1 this read was permissively allowed
+    // because the retype happened after checkScopes.)
     const errs = errorsFrom(`
 effect mytest::alpha { }
 def risky() { raise mytest::alpha("a", {}) }
@@ -101,7 +102,7 @@ node main() {
     return e.notARealField
   }
 }`);
-    expect(errs.some((e) => /does not exist/i.test(e.message))).toBe(false);
+    expect(errs.some((e) => /does not exist/i.test(e.message))).toBe(true);
   });
 
   it("functionRef handler is untouched (no crash, no spurious diagnostic)", () => {
@@ -229,5 +230,67 @@ node main() {
   }
 }`);
     expect(warnings.some((w) => /not exhaustive/i.test(w.message))).toBe(false);
+  });
+});
+
+// A "hard error" is any diagnostic with severity "error" (or no explicit
+// severity, which renders as an error — e.g. type-mismatch diagnostics).
+const hardErrorsFrom = (source: string) =>
+  allErrors(source).filter((e) => (e.severity ?? "error") === "error");
+
+describe("handler param payload typing (H3)", () => {
+  it("types e as a discriminated union so match(e) checks B2 exhaustiveness", () => {
+    const warnings = warningsFrom(`
+effect payl::a { x: number }
+effect payl::b { y: string }
+def risky() { raise payl::a("a", { x: 1 })\n raise payl::b("b", { y: "s" }) }
+node main() {
+  handle { risky() } with (e) {
+    match (e) {
+      { effect: "payl::a" } => 1
+    }
+  }
+}`);
+    // match(e) over the 2-member discriminated union is non-exhaustive: missing payl::b.
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /payl::b/.test(w.message))).toBe(true);
+  });
+
+  it("errors on a payload-shape mismatch after narrowing on e.effect", () => {
+    const errs = hardErrorsFrom(`
+effect h3::deposit { amount: number }
+def takesString(s: string): string { return s }
+def risky() { raise h3::deposit("d", { amount: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3::deposit") { takesString(e.data.amount) }
+  }
+}`);
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("accepts a correctly-typed payload use after narrowing", () => {
+    const errs = hardErrorsFrom(`
+effect h3::deposit { amount: number }
+def takesNum(n: number): number { return n }
+def risky() { raise h3::deposit("d", { amount: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3::deposit") { takesNum(e.data.amount) }
+  }
+}`);
+    expect(errs).toEqual([]);
+  });
+
+  it("still refines e.effect for exhaustiveness (H1 regression)", () => {
+    const warnings = warningsFrom(`
+effect h3::a { }
+effect h3::b { }
+def risky() { raise h3::a("a", {})\n raise h3::b("b", {}) }
+node main() {
+  handle { risky() } with (e) {
+    match (e.effect) { "h3::a" => 1 }
+  }
+}`);
+    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /h3::b/.test(w.message))).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -294,3 +294,88 @@ node main() {
     expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /h3::b/.test(w.message))).toBe(true);
   });
 });
+
+describe("handler param payload typing (H3) — edge cases", () => {
+  it("member-path narrowing gives each branch its own payload", () => {
+    const errs = hardErrorsFrom(`
+effect h3i::a { n: number }
+effect h3i::b { s: string }
+def takesNum(n: number): number { return n }
+def takesStr(s: string): string { return s }
+def risky() { raise h3i::a("a", { n: 1 })\n raise h3i::b("b", { s: "x" }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3i::a") { takesNum(e.data.n) }
+    if (e.effect == "h3i::b") { takesStr(e.data.s) }
+  }
+}`);
+    expect(errs).toEqual([]);
+  });
+
+  it("does not leak the narrowed payload into the else branch", () => {
+    // After `if (e.effect == "h3e::a")`, reading a's field in the else must error
+    // (whether e narrows to the remaining member or stays the union, a's field is
+    // absent from at least one member).
+    const errs = hardErrorsFrom(`
+effect h3e::a { n: number }
+effect h3e::b { s: string }
+def takesNum(n: number): number { return n }
+def risky() { raise h3e::a("a", { n: 1 })\n raise h3e::b("b", { s: "x" }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3e::a") { takesNum(e.data.n) } else { takesNum(e.data.n) }
+  }
+}`);
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("errors accessing a field on an empty-payload effect's data", () => {
+    const errs = hardErrorsFrom(`
+effect h3p::ping { }
+def risky() { raise h3p::ping("p", {}) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3p::ping") { let x = e.data.nope }
+  }
+}`);
+    expect(errs.some((x) => /does not exist/i.test(x.message))).toBe(true);
+  });
+
+  it("falls back to any for an effect dropped as conflicting", () => {
+    // Conflicting declarations drop the effect from the registry → data: any →
+    // field access is permitted (no derivative "does not exist").
+    const errs = errorsFrom(`
+effect h3c::e { a: number }
+effect h3c::e { a: string }
+def risky() { raise h3c::e("c", { a: 1 }) }
+node main() {
+  handle { risky() } with (e) {
+    if (e.effect == "h3c::e") { let x = e.data.anything }
+  }
+}`);
+    expect(errs.some((x) => /does not exist/i.test(x.message))).toBe(false);
+  });
+
+  it("LIMITATION: a match(e) object-pattern arm does not narrow e.data inside the arm", () => {
+    // Object-pattern match arms match+dispatch but do NOT narrow the scrutinee's
+    // member access within the arm body, so `e.data.n` sees the full payload
+    // union and errors. The supported idiom for per-effect payload access is the
+    // member-path guard `if (e.effect == "...")` (see the tests above). Pinned so
+    // a future reader sees this is a known boundary, not a regression.
+    const errs = hardErrorsFrom(`
+effect h3m::a { n: number }
+effect h3m::b { s: string }
+def takesNum(x: number): number { return x }
+def takesStr(x: string): string { return x }
+def risky() { raise h3m::a("a", { n: 1 })\n raise h3m::b("b", { s: "x" }) }
+node main() {
+  handle { risky() } with (e) {
+    match (e) {
+      { effect: "h3m::a" } => takesNum(e.data.n)
+      { effect: "h3m::b" } => takesStr(e.data.s)
+    }
+  }
+}`);
+    expect(errs.some((x) => /not available on every member/i.test(x.message))).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
@@ -1,6 +1,7 @@
 import type { AgencyNode, VariableType } from "../types.js";
 import type { ScopeInfo, TypeCheckerContext } from "./types.js";
 import type { InterruptEffect } from "../symbolTable.js";
+import type { ObjectType } from "../types/typeHints.js";
 import { collectRaisableEffects } from "./interruptAnalysis.js";
 import { walkNodes } from "../utils/node.js";
 import { isInScope } from "./checker.js";
@@ -18,39 +19,44 @@ function bodyHasNestedHandle(body: AgencyNode[]): boolean {
 }
 
 /**
- * The type of an inline handler param whose body raises `kinds`. Matches the
- * runtime interrupt object `{ effect, message, data, origin }` (interrupts.ts).
- * Only `effect` is refined (the literal union of raisable kinds), so
- * `match (e.effect)` is a value-track literal-union match (checked by
- * match-exhaustiveness B1). The other 3 fields stay `any`.
+ * The type of an inline handler param whose body raises `kinds`, as a
+ * DISCRIMINATED UNION: one member per effect kind,
+ *   { effect: "<kind>", data: <declared payload | any>, message: any, origin: any },
+ * matching the runtime interrupt object (interrupts.ts). The `effect` literal is
+ * the discriminant, so `if (e.effect == "<kind>")` / `match (e)` narrows `e` to a
+ * single member whose `data` carries that effect's declared payload — H3 payload
+ * safety falls out of discriminated-union narrowing (D1) + member-path narrowing
+ * (M2). `match (e.effect)` remains a value-track literal-union match (B1). A single
+ * kind is a single member (no union wrapper). An effect with no registry entry
+ * (undeclared, or dropped as conflicting) gets `data: any`.
  *
- * NOTE: although this is a closed `objectType`, it does NOT make `e.<field>` a
- * "does not exist" error — field-access checking runs in `checkScopes`, BEFORE
- * this pass re-types the param, so the refined type only ever reaches
- * `checkMatchExhaustiveness`. A single kind stays a bare literal (a one-member
- * match is not exhaustiveness-checked, which is fine). Payload typing on `.data`
- * per effect is H3.
+ * NOTE: this pass runs BEFORE `checkScopes`, so re-typing `e` to a closed object
+ * DOES make `e.<unknown-field>` a "does not exist" error during `checkScopes` —
+ * intended, since the interrupt object has exactly `{ effect, message, data, origin }`.
  */
-function handlerParamType(kinds: string[]): VariableType {
-  const effect: VariableType =
-    kinds.length === 1
-      ? stringLiteral(kinds[0])
-      : { type: "unionType", types: kinds.map(stringLiteral) };
-  return {
+function handlerParamType(
+  kinds: string[],
+  registry: Record<string, ObjectType>,
+): VariableType {
+  const member = (kind: string): VariableType => ({
     type: "objectType",
     properties: [
-      { key: "effect", value: effect },
+      { key: "effect", value: stringLiteral(kind) },
+      { key: "data", value: registry[kind] ?? ANY_T },
       { key: "message", value: ANY_T },
-      { key: "data", value: ANY_T },
       { key: "origin", value: ANY_T },
     ],
-  };
+  });
+  return kinds.length === 1
+    ? member(kinds[0])
+    : { type: "unionType", types: kinds.map(member) };
 }
 
 /**
- * TYPE-ONLY pass (runs after the interrupt call-graph is built): re-declare each
- * eligible inline handler param as `handlerParamType(kinds)`, refining `.effect`
- * from `any` to the literal union of raisable kinds. Does NOT touch handler
+ * TYPE-ONLY pass (runs after the interrupt effect analysis, BEFORE `buildFlowGraphs`
+ * / `checkScopes`): re-declare each eligible inline handler param as
+ * `handlerParamType(kinds, registry)` — a per-effect discriminated union carrying
+ * each effect's declared payload as `data`. Does NOT touch handler
  * registration/execution — it only calls `info.scope.declare`.
  *
  * Eligibility: inline handler, no explicit `with (e: T)` annotation, non-empty
@@ -77,8 +83,8 @@ export function refineInlineHandlerParams(
   scopes: ScopeInfo[],
   interruptEffectsByFunction: Record<string, InterruptEffect[]>,
   ctx: TypeCheckerContext,
+  registry: Record<string, ObjectType>,
 ): void {
-  let changed = false;
   for (const info of scopes) {
     ctx.withScope(info.scopeKey, () => {
       // Count EVERY inline handler param name (eligible or not) — a shared name
@@ -99,14 +105,11 @@ export function refineInlineHandlerParams(
         if ((nameCount.get(h.name) ?? 0) > 1) continue; // shared name → leave as-is
         const kinds = collectRaisableEffects(h.node.body, info, interruptEffectsByFunction, ctx);
         if (kinds.length === 0) continue; // fall back to `any`
-        info.scope.declare(h.name, handlerParamType(kinds));
-        changed = true;
+        info.scope.declare(h.name, handlerParamType(kinds, registry));
       }
     });
   }
-  // We mutated scope types after the flow graph + its `typeAt` memo were built,
-  // so any cached `e`-is-`any` result is now stale. The flow env's soundness
-  // contract requires discarding the memo when scope contents change; otherwise
-  // `checkMatchExhaustiveness` reads the pre-refinement `any` for `e.effect`.
-  if (changed && ctx.flowEnv) ctx.flowEnv.memo = new WeakMap();
+  // No flow-env memo reset needed: this pass runs BEFORE `buildFlowGraphs`, so
+  // the flow graph's `typeAt` oracle is seeded from the refined scope from the
+  // start — there is no stale `e`-is-`any` cache to discard.
 }

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
@@ -38,11 +38,15 @@ function handlerParamType(
   kinds: string[],
   registry: Record<string, ObjectType>,
 ): VariableType {
+  // Own-property guard: effect kinds are user-controlled strings, so a reserved
+  // key ("__proto__"/"toString"/…) must not resolve a payload via Object.prototype.
+  const payloadFor = (kind: string): VariableType =>
+    Object.prototype.hasOwnProperty.call(registry, kind) ? registry[kind] : ANY_T;
   const member = (kind: string): VariableType => ({
     type: "objectType",
     properties: [
       { key: "effect", value: stringLiteral(kind) },
-      { key: "data", value: registry[kind] ?? ANY_T },
+      { key: "data", value: payloadFor(kind) },
       { key: "message", value: ANY_T },
       { key: "origin", value: ANY_T },
     ],

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -43,7 +43,7 @@ import {
 import { checkRaisesDeclarations } from "./raisesDiagnostic.js";
 import { checkMatchExhaustiveness } from "./matchExhaustiveness.js";
 import { refineInlineHandlerParams } from "./handlerParamTyping.js";
-import { checkEffectPayloads } from "./effectPayloadCheck.js";
+import { checkEffectPayloads, buildEffectRegistry } from "./effectPayloadCheck.js";
 import type { SymbolTable } from "../symbolTable.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
@@ -294,14 +294,29 @@ export class TypeChecker {
     // 3. Build scopes (collects variable types and checks assignments)
     const scopes = buildScopes(ctx);
 
-    // 3b. Build the flow graph (PR 1b — populated, not yet consulted).
+    // 3a. Analyze interrupts (pure — returns transitive effect sets and pushes
+    // no diagnostics; the ctx.errors sites in interruptAnalysis.ts belong to the
+    // consumer passes below). Moved ahead of flow/checkScopes so the handler-param
+    // refinement can run before field-access checking.
+    const interruptEffectsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
+
+    // 3b. Build the ambient effect→payload registry ONCE and share it with both
+    // the handler-param refinement (below) and checkEffectPayloads (6d). Building
+    // it once avoids double-reporting payload conflicts.
+    const effectRegistry = buildEffectRegistry(ctx);
+
+    // 3c. H3: re-type each eligible inline handler param `e` as a per-effect
+    // discriminated union carrying that effect's declared payload as `data`.
+    // MUST run before checkScopes so `e.data` usage sites narrow correctly.
+    refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, effectRegistry);
+
+    // 3d. Build the flow graph AFTER the param retype, so its `typeAt` oracle is
+    // seeded with the refined `e` (no stale-memo reset needed).
     buildFlowGraphs(scopes, ctx);
 
-    // 4. Check function calls, return types, and expressions
+    // 4. Check function calls, return types, and expressions. `e.data` is now
+    // payload-typed → narrowing on `e.effect` makes `e.data` concrete here.
     checkScopes(scopes, ctx);
-
-    // 5. Analyze interrupts using functionRefType
-    const interruptEffectsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
 
     // 5a. Build the per-function interrupt call graph used by
     // `agency interrupts` for static handler-set analysis. The
@@ -324,15 +339,8 @@ export class TypeChecker {
     // exceeded by its transitively-inferred effect set.
     checkRaisesDeclarations(interruptEffectsByFunction, ctx);
 
-    // 6d. Check interrupt payloads against `effect` declarations.
-    checkEffectPayloads(scopes, ctx);
-
-    // 6d-bis. H1: refine each eligible inline handler param's `.effect` to the
-    // literal union of effect kinds its body can raise (now that the call-graph
-    // exists), so `checkMatchExhaustiveness` sees a closed literal-union
-    // scrutinee. Type-only; runs after every interrupt check (none of which read
-    // the param type) and before exhaustiveness.
-    refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx);
+    // 6d. Check interrupt payloads against `effect` declarations (shared registry).
+    checkEffectPayloads(scopes, ctx, effectRegistry);
 
     // 6e. Match exhaustiveness over closed value types (opt-in, default silent).
     checkMatchExhaustiveness(scopes, ctx);


### PR DESCRIPTION
## Handler payload typing (H3)

Types an inline handler's parameter `e` so that `e.data` (the interrupt payload) is type-safe **per effect**. After narrowing on the discriminant `e.effect`, `e.data` carries that effect's declared payload:

```ts
effect app::confirm { question: string }
effect app::rateLimited { retryAfter: number }

handle { doRiskyThings() } with (e) {
  if (e.effect == "app::confirm")     { ask(e.data.question) }      // e.data.question : string
  if (e.effect == "app::rateLimited") { waitFor(e.data.retryAfter) } // e.data.retryAfter : number
}
```

Passing a payload field to a function expecting the wrong type is now a compile error.

### Approach

`e` is typed as a **discriminated union** — one member `{ effect: "<kind>", data: <declared payload>, message: any, origin: any }` per raisable effect kind. Payload narrowing then falls out of the existing discriminated-union (D1) + member-path (M2) narrowing; exhaustiveness keeps working (B1 on `e.effect`, B2 on `e`). No bespoke payload-narrowing code.

### The one architectural change: a pipeline reorder

H1 retyped `e` *after* `checkScopes`, so its type only reached exhaustiveness checking. Payload *usage* (`e.data.amount`) is checked *during* `checkScopes`, so H3 requires `e` to carry its type earlier. This moves three passes — interrupt effect analysis, the effect->payload registry, and the handler-param refinement — ahead of `buildFlowGraphs`/`checkScopes`. The reorder is contained:

- `analyzeInterruptsFromScopes` is pure (returns data, pushes no diagnostics — the `ctx.errors` sites in that file belong to the consumer passes, which stay in place).
- A single effect->payload registry is built once and shared by both the refinement and `checkEffectPayloads` (no double conflict-reporting).
- The flow graph is now built *after* the retype, so the old stale-`typeAt`-memo reset is gone.

Because `e` is now the closed interrupt object `{ effect, message, data, origin }` *during* `checkScopes`, reading an unknown field is a real "does not exist" error (the interrupt object has exactly those four members). This was the only behavior flip — measured blast radius across the whole test suite was **one** test (the H1 "unknown field allowed" test, updated here); stdlib and all 121 fixtures typecheck unchanged.

### De-risking

Built the reorder first as a throwaway spike to confirm payload narrowing fires and to measure the blast radius before committing. Findings drove the final tests (notably: type-mismatch diagnostics carry no explicit `severity`, so "expects an error" assertions use `(e.severity ?? "error") === "error"`).

### Limitations (pinned by tests)

- A `match (e) { { effect: "..." } => ... }` object-pattern arm drives exhaustiveness but does **not** narrow `e.data` inside the arm body — the supported idiom for payload access is the `if (e.effect == "...")` member-path guard.
- Effects declared with an empty payload give `e.data` an empty object (field access errors); undeclared or conflict-dropped effects leave `e.data` as `any`.
- Conservative opt-outs preserved (explicitly annotated param, `functionRef` handler, nested `handle`) — the param stays untyped.

### Tests

Full typeChecker suite green (1202 tests); structural lint clean. New tests cover payload mismatch/accept, B2 `match (e)` exhaustiveness, member-path per-branch payloads, guarded-else, empty-payload, dropped-conflict, the shared-registry once-only conflict guard, and the match-arm limitation. Two pre-existing backend failures (`.meta()` Zod / docstring-interpolation runtime, both requiring a dist build) are unrelated and fail identically on the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
