### PR TITLE
fix(parser): stop unbounded debugMessages growth that OOMs the agency test runner

### DIFF
--- a/packages/agency-lang/lib/parsers/debugMessagesLeak.test.ts
+++ b/packages/agency-lang/lib/parsers/debugMessagesLeak.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getDebugMessages } from "tarsec";
+import { parseAgency } from "../parser.js";
+
+/**
+ * Regression test for the `agency test` OOM (parent process grew to ~4GB).
+ *
+ * Root cause: `_bodyNodeParser` wrapped `typeAliasParser` in tarsec's
+ * `debug(...)`, which appends a source-capturing record to tarsec's
+ * module-global `debugMessages` array on every FAILED parse. That array is
+ * never cleared, and `typeAliasParser` fails constantly during normal
+ * backtracking, so a long-lived compiling process (the `agency test`
+ * runner compiles every fixture in one process) accumulated the array
+ * without bound until it exhausted the heap.
+ *
+ * The parser must not append to that global buffer during normal parsing.
+ */
+describe("parser does not accumulate tarsec debugMessages (OOM regression)", () => {
+  it("repeated parses do not grow the global debugMessages buffer", () => {
+    // A program that exercises the body-node alternatives (so the removed
+    // `debug(typeAliasParser)` alternative would have fired on failure).
+    const src = `node main() {\n  const x = 1\n  print(x)\n}\n`;
+
+    // Prime once so any one-time module setup is already accounted for.
+    parseAgency(src, {}, false);
+    const before = getDebugMessages().length;
+
+    for (let i = 0; i < 25; i++) {
+      parseAgency(src, {}, false);
+    }
+
+    const after = getDebugMessages().length;
+    expect(after).toBe(before);
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -13,7 +13,6 @@ import {
   captureCaptures,
   char,
   count,
-  debug,
   digit,
   fail,
   failure,
@@ -3624,7 +3623,7 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
   keywordParser,
   effectSetDeclParser,
   effectDeclParser,
-  debug(typeAliasParser, "error in typeAliasParser"),
+  typeAliasParser,
   tagParser,
   bodyReservedModifierParser,
   // withModifierParser must be tried before returnStatementParser/


### PR DESCRIPTION
## Summary

Fixes the `JavaScript heap out of memory` (exit 134) that has been failing the **Node.js CI `build` job** on `main` and every PR.

The OOM was **not** in `pnpm test:run` (vitest) — that step passes. It was in the later **"Agency execution tests"** and **"Built-in agent tests"** steps, which run `agency test … -p 12`.

## Root cause

`_bodyNodeParser` wrapped `typeAliasParser` in tarsec's `debug(...)` combinator:

```ts
debug(typeAliasParser, "error in typeAliasParser"),
```

`debug()` appends a source-capturing record to tarsec's **module-global `debugMessages` array on every failed parse**, and that array is never cleared. `typeAliasParser` fails constantly during normal parser backtracking (~2,468 records per compile).

The `agency test` runner **compiles every fixture in one long-lived parent process**, so `debugMessages` grew without bound (~48 MB per compiled file) until the parent hit V8's ~4 GB heap limit and died. This is why the heap was dominated by duplicate `std::…` source strings.

## Fix

Drop the leftover `debug()` wrapper (a development aid). `typeAliasParser` stays in the same alternative, unwrapped, so **parsing behavior is identical** — the only change is that parsing no longer writes to the global buffer.

## Verification

- New regression test (`lib/parsers/debugMessagesLeak.test.ts`): repeated parses no longer grow `getDebugMessages()`. Watched it fail first (grew 3 → 78 over 25 parses), pass after the fix.
- Repeated-compile repro: heap now **flat at ~33 MB** across 30 compiles (was 32 → 1507 MB before).
- **`test:agents` passes (exit 0)** under a 4 GB cap where it previously OOM'd (exit 134) in ~52 s.
- `lib/parsers/` + `lib/typeChecker.test.ts` suites green (1683 tests); `tsc --noEmit` clean.

## Follow-up (not in this PR)

tarsec doesn't currently expose a way to clear/bound `debugMessages`. A future guardrail would be to add one (e.g. `resetDebugMessages()`) and call it per-parse in `parse()` alongside the existing `resetMemos()`, so a stray `debug()` wrap can't reintroduce this class of leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
