### PR TITLE
feat(typechecker): matchExhaustiveness defaults to error

### DIFF
--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -69,7 +69,7 @@ branch a compiler-enforced guarantee rather than a convention.
 A `match` over a **closed** value type — a `Result`, or a closed literal/value
 union (`"a" | "b"`) — that doesn't cover every case and has no `_` arm is a
 diagnostic, governed by `typechecker.matchExhaustiveness: "silent" | "warn" |
-"error"` (default `"silent"`; see [config](../../../misc/config.md)).
+"error"` (default `"error"`; see [config](../../../misc/config.md)).
 
 - A shared `decomposeCases(type)` (`typeCases.ts`) enumerates a value type's
   cases; `checkMatchExhaustiveness` (`matchExhaustiveness.ts`) reports the cases

--- a/packages/agency-lang/docs/misc/config.md
+++ b/packages/agency-lang/docs/misc/config.md
@@ -71,7 +71,7 @@ This lets you prevent specific built-in functions from being generated in the ou
   - **`matchExhaustiveness`** (`"silent" | "warn" | "error"`): What to do when a
     `match` over a closed value type (a `Result`, or a closed literal/value union
     like `"a" | "b"`) doesn't cover every case and has no `_` arm. Default:
-    `"silent"`. Conservative: open types (`string`/`number`/`any`, effect sets)
+    `"error"`. Conservative: open types (`string`/`number`/`any`, effect sets)
     are never required to be exhaustive; a guarded arm doesn't count toward
     coverage; a `_` arm always satisfies it.
 

--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -303,7 +303,7 @@ handle {
 } with (e) {
   match (e.effect) {
     "app::confirm" => approve()
-    // warning: match is not exhaustive: missing "app::rateLimited"
+    // error: match is not exhaustive: missing "app::rateLimited"
   }
 }
 ```

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -211,7 +211,7 @@ The type checker reports (by default, a **warning**) when a `match` over a
 type Ev = { kind: "click", x: number } | { kind: "scroll", d: number }
 match (e) {
     { kind: "click" } => handleClick(e)
-    // warning: match is not exhaustive: missing `{ kind: "scroll" }`
+    // error: match is not exhaustive: missing `{ kind: "scroll" }`
 }
 ```
 
@@ -220,7 +220,7 @@ Adding the missing arm — or a `_` catch-all — clears it. A guarded arm
 `number`, arbitrary object unions) and the `match(x is …)` form are never
 required to be exhaustive. Control the severity with
 `typechecker.matchExhaustiveness` in `agency.json` (`"silent"` / `"warn"` /
-`"error"`; default `"warn"`).
+`"error"`; default `"error"`).
 
 ## Narrowing on a field-path scrutinee
 

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -25,10 +25,15 @@ function allErrors(source: string): TypeCheckError[] {
 
 const warningsFrom = (source: string) => allErrors(source).filter((e) => e.severity === "warning");
 const errorsFrom = (source: string) => allErrors(source);
+// A non-exhaustive `match` is a hard error by default now
+// (typechecker.matchExhaustiveness default = "error"). These tests assert the
+// missing case is DETECTED, independent of severity, so they match the message.
+const exhaustivenessDiagsFrom = (source: string) =>
+  allErrors(source).filter((e) => /not exhaustive/i.test(e.message));
 
 describe("handler param .effect typing (H1)", () => {
-  it("types e.effect so a non-exhaustive match(e.effect) warns", () => {
-    const warnings = warningsFrom(`
+  it("types e.effect so a non-exhaustive match(e.effect) is flagged", () => {
+    const diags = exhaustivenessDiagsFrom(`
 effect mytest::alpha { }
 effect mytest::beta { }
 def risky() {
@@ -44,7 +49,7 @@ node main() {
     }
   }
 }`);
-    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /beta/.test(w.message))).toBe(true);
+    expect(diags.some((d) => /beta/.test(d.message))).toBe(true);
   });
 
   it("an explicit param annotation is not overridden", () => {
@@ -158,7 +163,7 @@ node main() {
   });
 
   it("transitive raise (effect raised inside a called function) reaches the match", () => {
-    const warnings = warningsFrom(`
+    const diags = exhaustivenessDiagsFrom(`
 effect mytest::alpha { }
 effect mytest::beta { }
 def inner() { raise mytest::beta("b", {}) }
@@ -168,11 +173,11 @@ node main() {
     match (e.effect) { "mytest::alpha" => 1 }
   }
 }`);
-    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /beta/.test(w.message))).toBe(true);
+    expect(diags.some((d) => /beta/.test(d.message))).toBe(true);
   });
 
   it("effect name with :: is handled verbatim as the literal", () => {
-    const warnings = warningsFrom(`
+    const diags = exhaustivenessDiagsFrom(`
 effect ns::sub::alpha { }
 effect ns::sub::beta { }
 def risky() { raise ns::sub::alpha("a", {})\n raise ns::sub::beta("b", {}) }
@@ -181,7 +186,7 @@ node main() {
     match (e.effect) { "ns::sub::alpha" => 1 }
   }
 }`);
-    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /beta/.test(w.message))).toBe(true);
+    expect(diags.some((d) => /beta/.test(d.message))).toBe(true);
   });
 
   it("SOUNDNESS: an outer handle with a NESTED handle is not typed (no false positive)", () => {
@@ -203,8 +208,8 @@ node main() {
 });
 
 describe("handler effect exhaustiveness (H2)", () => {
-  it("no double-report: the handle catches everything; only the inner match warns", () => {
-    const warnings = warningsFrom(`
+  it("no double-report: the handle catches everything; only the inner match is flagged", () => {
+    const diags = allErrors(`
 effect mytest::alpha { }
 effect mytest::beta { }
 def risky() { raise mytest::alpha("a", {})\n raise mytest::beta("b", {}) }
@@ -213,10 +218,10 @@ node main() {
     match (e.effect) { "mytest::alpha" => 1 }
   }
 }`);
-    // Exactly one warning — the exhaustiveness one. The handle block is a
-    // catch-all, so the unhandled-interrupt check is satisfied (no extra warning).
-    expect(warnings.filter((w) => /not exhaustive/i.test(w.message))).toHaveLength(1);
-    expect(warnings).toHaveLength(1);
+    // Exactly one diagnostic — the exhaustiveness one. The handle block is a
+    // catch-all, so the unhandled-interrupt check is satisfied (no extra diagnostic).
+    expect(diags).toHaveLength(1);
+    expect(/not exhaustive/i.test(diags[0].message)).toBe(true);
   });
 
   it("a `_` arm in match(e.effect) clears the diagnostic", () => {
@@ -240,7 +245,7 @@ const hardErrorsFrom = (source: string) =>
 
 describe("handler param payload typing (H3)", () => {
   it("types e as a discriminated union so match(e) checks B2 exhaustiveness", () => {
-    const warnings = warningsFrom(`
+    const diags = exhaustivenessDiagsFrom(`
 effect payl::a { x: number }
 effect payl::b { y: string }
 def risky() { raise payl::a("a", { x: 1 })\n raise payl::b("b", { y: "s" }) }
@@ -252,7 +257,7 @@ node main() {
   }
 }`);
     // match(e) over the 2-member discriminated union is non-exhaustive: missing payl::b.
-    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /payl::b/.test(w.message))).toBe(true);
+    expect(diags.some((d) => /payl::b/.test(d.message))).toBe(true);
   });
 
   it("errors on a payload-shape mismatch after narrowing on e.effect", () => {
@@ -282,7 +287,7 @@ node main() {
   });
 
   it("still refines e.effect for exhaustiveness (H1 regression)", () => {
-    const warnings = warningsFrom(`
+    const diags = exhaustivenessDiagsFrom(`
 effect h3::a { }
 effect h3::b { }
 def risky() { raise h3::a("a", {})\n raise h3::b("b", {}) }
@@ -291,7 +296,7 @@ node main() {
     match (e.effect) { "h3::a" => 1 }
   }
 }`);
-    expect(warnings.some((w) => /not exhaustive/i.test(w.message) && /h3::b/.test(w.message))).toBe(true);
+    expect(diags.some((d) => /h3::b/.test(d.message))).toBe(true);
   });
 });
 

--- a/packages/agency-lang/lib/typeChecker/matchArmNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchArmNarrowing.test.ts
@@ -113,9 +113,10 @@ node main() {
     }
   }
 }`);
-    // Missing "app::rateLimited" is a warn (default), not a hard error; this only
-    // confirms narrowing didn't suppress or crash the exhaustiveness pass.
-    expect(errs).toEqual([]);
+    // Missing "app::rateLimited" is now a hard error (matchExhaustiveness default
+    // = "error"). Confirms narrowing didn't suppress or crash the exhaustiveness
+    // pass — the missing-case diagnostic still fires.
+    expect(errs.some((m) => /not exhaustive/i.test(m) && /app::rateLimited/.test(m))).toBe(true);
   });
 });
 

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -235,14 +235,15 @@ function normalizeSite(
 /**
  * Diagnostic: a `match` over a closed value type (Result or a closed
  * literal/value union) that doesn't cover every case and has no `_` arm.
- * Opt-in via `typechecker.matchExhaustiveness` (default `silent`). Conservative:
+ * Enabled by default at `error`; configurable via
+ * `typechecker.matchExhaustiveness` (`silent` / `warn` / `error`). Conservative:
  * open types and non-discriminated object unions are never reported (B1).
  */
 export function checkMatchExhaustiveness(
   scopes: ScopeInfo[],
   ctx: TypeCheckerContext,
 ): void {
-  const severity = (ctx.config.typechecker?.matchExhaustiveness ?? "warn") as Severity;
+  const severity = (ctx.config.typechecker?.matchExhaustiveness ?? "error") as Severity;
   if (severity === "silent") {
     return;
   }


### PR DESCRIPTION
## matchExhaustiveness defaults to `error`

Promotes the match-exhaustiveness diagnostic from **warn** to **error** by default. A `match` over a closed type (a `Result`, or a closed literal/discriminated union) that misses a case and has no `_` arm is now a hard compile error:

```
match (e.effect) {
  "app::confirm" => approve()
  // error: match is not exhaustive: missing "app::rateLimited"
}
```

Still fully configurable via `typechecker.matchExhaustiveness` (`"silent"` / `"warn"` / `"error"`). Conservative as before: open types (`string`/`number`/`any`, effect sets) are never required to be exhaustive; a guarded arm doesn't count; a `_` arm always satisfies it.

This is the enforcement payoff for the B1/B2 exhaustiveness work, mirroring the `strictMemberAccess` silent→error flip that landed enforced Result safety. B2 shipped as `warn` (#375) and has baked.

### Measured blast radius: zero

Before flipping, measured with the default temporarily at `error`:
- stdlib + all 121 typechecker fixtures — clean
- full typeChecker unit suite (1220) — clean after test updates
- **841 execution-test `.agency` programs** (tests/agency, tests/agency-js, tests/integration) scanned — 0 parse failures, 0 non-exhaustive matches

There are no non-exhaustive matches anywhere in the codebase, so nothing needed fixing.

### Changes

- `matchExhaustiveness.ts`: default `?? "warn"` → `?? "error"` + docstring (which still said the stale `silent`).
- 7 handler/narrowing detection tests made severity-agnostic (they assert the missing case is *detected*, not its severity).
- Docs: `config.md` and the narrowing `README.md` still stated the doubly-stale `"silent"` default; `pattern-matching.md`/`handlers.md` example comments updated `warning:` → `error:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
