### PR TITLE
feat: model-data refresh-to-stdout + opt-in std::llm.loadModelData

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -185,6 +185,7 @@ export default defineConfig({
             { text: "doc", link: "/cli/doc" },
             { text: "format", link: "/cli/format" },
             { text: "lsp / mcp", link: "/cli/editor-integration" },
+            { text: "models", link: "/cli/models" },
             { text: "optimize", link: "/cli/optimize" },
             { text: "pack", link: "/cli/pack" },
             { text: "preprocess / ast", link: "/cli/preprocess-and-ast" },

--- a/packages/agency-lang/docs/site/cli/models.md
+++ b/packages/agency-lang/docs/site/cli/models.md
@@ -15,6 +15,20 @@ agency models list --min-context 200000  # context window >= 200k tokens
 
 Columns: name, provider, open-weights, input $/1M, output $/1M, context window.
 
+To preview a saved (or hand-edited) model-data file merged with the built-in
+catalog, pass one or more files as positional arguments — handy for checking a
+file before a program loads it with `loadModelData`:
+
+```bash
+agency models refresh > my-models.json          # save + hand-edit
+agency models list my-models.json               # built-in catalog + your file
+agency models list a.json b.json --provider acme  # multiple files accumulate; filters still apply
+```
+
+Files are merged in order (later files win on provider+name collisions, like
+`loadModelData`). If a file can't be loaded, `list` prints the error and exits
+non-zero instead of showing a baked-only list.
+
 ## `agency models refresh`
 
 Fetch the latest model data and **print it as JSON to stdout**. It does not

--- a/packages/agency-lang/docs/site/cli/models.md
+++ b/packages/agency-lang/docs/site/cli/models.md
@@ -4,8 +4,7 @@ Browse the hosted model catalog and fetch fresh model data.
 
 ## `agency models list`
 
-List hosted text models from the built-in catalog (plus anything loaded this
-process). Filterable:
+List hosted text models from the built-in catalog. Filterable:
 
 ```bash
 agency models list                       # all models

--- a/packages/agency-lang/docs/site/cli/models.md
+++ b/packages/agency-lang/docs/site/cli/models.md
@@ -1,0 +1,50 @@
+# `agency models`
+
+Browse the hosted model catalog and fetch fresh model data.
+
+## `agency models list`
+
+List hosted text models from the built-in catalog (plus anything loaded this
+process). Filterable:
+
+```bash
+agency models list                       # all models
+agency models list --provider openai     # one provider
+agency models list --max-price 1         # input cost <= $1 / 1M tokens
+agency models list --min-context 200000  # context window >= 200k tokens
+```
+
+Columns: name, provider, open-weights, input $/1M, output $/1M, context window.
+
+## `agency models refresh`
+
+Fetch the latest model data and **print it as JSON to stdout**. It does not
+save or register anything — redirect it to a file you control:
+
+```bash
+agency models refresh > my-models.json
+# optionally override the source URL:
+agency models refresh https://example.com/model-data.json > my-models.json
+```
+
+Errors go to stderr with a non-zero exit code, so a failed fetch is detectable
+in a pipeline (and leaves stdout empty).
+
+## Using a saved file
+
+Load a saved model-data file in an Agency program with
+[`std::llm.loadModelData`](../stdlib/llm.md):
+
+```agency
+import { loadModelData } from "std::llm"
+
+node main() {
+  const r = loadModelData("my-models.json")
+  // r is success(count) or failure(reason)
+}
+```
+
+`loadModelData` **accumulates**: multiple calls layer over each other and over
+the built-in catalog, with the most recently loaded file winning on
+provider+name collisions. Loaded data affects `llm()` model resolution and cost
+accounting as well as `listHostedModels()` / `hostedModelInfo()`.

--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -38,7 +38,7 @@ export type LlmDefaults = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L26))
 
 ### HostedModelInfo
 
@@ -54,7 +54,7 @@ export type HostedModelInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L125))
 
 ## Functions
 
@@ -75,7 +75,7 @@ Set default options for subsequent llm() calls. Only the fields you
 |---|---|---|
 | opts | [LlmDefaults](#llmdefaults) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L35))
 
 ### setModel
 
@@ -93,7 +93,7 @@ Set the default model for subsequent llm() calls.
 |---|---|---|
 | name | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L44))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L45))
 
 ### envVarFor
 
@@ -118,7 +118,7 @@ Return the environment variable that holds the API key for a recognized
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L54))
 
 ### pickProvider
 
@@ -141,7 +141,7 @@ Return the first provider in `order` whose API-key environment variable
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L83))
 
 ### registerProviderModule
 
@@ -160,7 +160,7 @@ Load a provider module by path at runtime and register its custom provider
 |---|---|---|
 | path | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L113))
 
 ### listHostedModels
 
@@ -173,7 +173,7 @@ All known hosted text models (baked catalog plus any refreshed data), for
 
 **Returns:** `HostedModelInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L135))
 
 ### hostedModelInfo
 
@@ -194,4 +194,34 @@ Metadata for one hosted model by name, or null if the name is unknown or
 
 **Returns:** `HostedModelInfo | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L142))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L143))
+
+### loadModelData
+
+```ts
+loadModelData(path: string): Result<number>
+```
+
+Load additional model data from a JSON file (the shape printed by
+  `agency models refresh`) and register it for this program. Both the file's
+  `models` and its optional `hostedTools` are layered over any previously
+  loaded data and over the built-in catalog, with this file winning on
+  provider+name collisions; unlisted fields on an existing entry are preserved.
+  Affects llm() model resolution and cost accounting as well as
+  listHostedModels() / hostedModelInfo().
+
+  Returns the number of models in THIS file (not the running total registered),
+  or a failure describing why the file could not be loaded.
+
+  @param path - Path to a model-data JSON file (relative to the working
+    directory, or absolute)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| path | `string` |  |
+
+**Returns:** `Result<number>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L153))

--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -202,19 +202,13 @@ Metadata for one hosted model by name, or null if the name is unknown or
 loadModelData(path: string): Result<number>
 ```
 
-Load additional model data from a JSON file (the shape printed by
-  `agency models refresh`) and register it for this program. Both the file's
-  `models` and its optional `hostedTools` are layered over any previously
-  loaded data and over the built-in catalog, with this file winning on
-  provider+name collisions; unlisted fields on an existing entry are preserved.
-  Affects llm() model resolution and cost accounting as well as
-  listHostedModels() / hostedModelInfo().
+Load model data from a JSON file (the shape `agency models refresh` prints)
+  and register it for this program, so `llm()` and the model catalog
+  (`listHostedModels` / `hostedModelInfo`) recognize those models. Multiple
+  loads accumulate. Returns the number of models loaded, or a failure if the
+  file cannot be read.
 
-  Returns the number of models in THIS file (not the running total registered),
-  or a failure describing why the file could not be loaded.
-
-  @param path - Path to a model-data JSON file (relative to the working
-    directory, or absolute)
+  @param path - Path to a model-data JSON file
 
 **Parameters:**
 
@@ -224,4 +218,4 @@ Load additional model data from a JSON file (the shape printed by
 
 **Returns:** `Result<number>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L153))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L160))

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-01-model-data-refresh-and-load.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-01-model-data-refresh-and-load.md
@@ -187,7 +187,7 @@ export function _loadModelData(
     return {
       ok: false,
       count: 0,
-      error: `${path} has schemaVersion ${blob.schemaVersion} but ${prior.schemaVersion} is already loaded; load only matching-version data`,
+      error: `${path} has schemaVersion ${blob.schemaVersion} but ${prior.schemaVersion} is already loaded; re-run "agency models refresh" to regenerate the file at the current schema version`,
     };
   }
   const merged = prior
@@ -197,6 +197,9 @@ export function _loadModelData(
         // Overlay (this file) wins on provider:modelName and deep-merges, so a
         // partial hand-edited entry augments the prior one.
         models: mergeModelData(prior.models, blob.models),
+        // `?? []` on the overlay means "no new tools" (base preserved), NOT
+        // "clear" — mergeHostedTools merges overlay into base, so prior tools
+        // survive a models-only file. Do not change to pass undefined.
         hostedTools: mergeHostedTools(prior.hostedTools ?? [], blob.hostedTools ?? []),
       }
     : blob;
@@ -232,29 +235,50 @@ git commit -m "feat(stdlib): _loadModelData native (accumulate model data over s
 
 - [ ] **Step 1: Write the failing agency-js test** — create the three files under `tests/agency-js/llm-load-model-data/`.
 
+> **Note:** `env(name)` returns `string | null`, and `loadModelData(path: string)` requires a non-null `string` — passing `env(...)` directly is a hard type error (verified). The program narrows with `if (p != null)` before calling, mirroring `pickProvider` in `stdlib/llm.agency`. The test loads TWO files and checks both custom models are visible, so accumulation is proven end-to-end through the Agency layer (not just the TS native).
+
 `agent.agency`:
 ```agency
 import { loadModelData, hostedModelInfo } from "std::llm"
 import { env } from "std::system"
 
-// test.js writes a model-data file to a temp path and passes it via
-// MODELS_FIXTURE, then asserts: the load succeeds with a count, the custom
-// model becomes visible through hostedModelInfo, and a bad path fails.
+// test.js writes two model-data files to temp paths and passes them via
+// MODELS_FIXTURE_A / MODELS_FIXTURE_B. Asserts: each load succeeds with a
+// count, BOTH custom models are visible after loading both (accumulation
+// survives the Agency layer), and a bad path fails.
 node main(): any {
-  let loadedCount = -1
-  const good = loadModelData(env("MODELS_FIXTURE"))
-  if (good is success(n)) {
-    loadedCount = n
+  let countA = -1
+  const pa = env("MODELS_FIXTURE_A")
+  if (pa != null) {
+    const ra = loadModelData(pa)
+    if (ra is success(n)) {
+      countA = n
+    }
   }
-  let seen = "no"
-  const info = hostedModelInfo("custom-load-test")
-  if (info != null) {
-    seen = info.provider
+  let countB = -1
+  const pb = env("MODELS_FIXTURE_B")
+  if (pb != null) {
+    const rb = loadModelData(pb)
+    if (rb is success(n)) {
+      countB = n
+    }
+  }
+  let seenA = "no"
+  const ia = hostedModelInfo("custom-load-a")
+  if (ia != null) {
+    seenA = ia.provider
+  }
+  let seenB = "no"
+  const ib = hostedModelInfo("custom-load-b")
+  if (ib != null) {
+    seenB = ib.provider
   }
   const bad = loadModelData("/no/such/models-file.json")
   return {
-    loadedCount: loadedCount,
-    seen: seen,
+    countA: countA,
+    countB: countB,
+    seenA: seenA,
+    seenB: seenB,
     badFailed: isFailure(bad)
   }
 }
@@ -267,21 +291,25 @@ import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-// Write the model-data file to a temp path (not the test dir) and hand the
+// Write each model-data file to a temp path (not the test dir) and hand the
 // absolute path to the agency program via env — no cwd assumptions.
-const fixturePath = join(tmpdir(), `agency-models-load-${process.pid}.json`);
-writeFileSync(
-  fixturePath,
-  JSON.stringify({
-    schemaVersion: 1,
-    generatedAt: "test",
-    models: [
-      { type: "text", modelName: "custom-load-test", provider: "acme", inputTokenCost: 1, outputTokenCost: 2, maxInputTokens: 4096, family: "acme" },
-    ],
-    hostedTools: [],
-  }),
-);
-process.env.MODELS_FIXTURE = fixturePath;
+function writeModelFile(suffix, modelName) {
+  const p = join(tmpdir(), `agency-models-load-${process.pid}-${suffix}.json`);
+  writeFileSync(
+    p,
+    JSON.stringify({
+      schemaVersion: 1,
+      generatedAt: "test",
+      models: [
+        { type: "text", modelName, provider: "acme", inputTokenCost: 1, outputTokenCost: 2, maxInputTokens: 4096, family: "acme" },
+      ],
+      hostedTools: [],
+    }),
+  );
+  return p;
+}
+process.env.MODELS_FIXTURE_A = writeModelFile("a", "custom-load-a");
+process.env.MODELS_FIXTURE_B = writeModelFile("b", "custom-load-b");
 
 const result = await main({});
 writeFileSync(
@@ -293,16 +321,15 @@ writeFileSync(
 `fixture.json`:
 ```json
 {
-  "loadedCount": 1,
-  "seen": "acme",
+  "countA": 1,
+  "countB": 1,
+  "seenA": "acme",
+  "seenB": "acme",
   "badFailed": true
 }
 ```
 
-- [ ] **Step 2: Build + run, verify it fails** — `make && node ./dist/scripts/agency.js test js tests/agency-js/llm-load-model-data`
-Expected: FAIL — `loadModelData` is not exported from `std::llm` (compile/import error).
-
-- [ ] **Step 3: Add the wrapper** — in `stdlib/llm.agency`, extend the native import (currently `_setLlmOptions`, `_registerProviderModule`, `_listHostedModels`, `_hostedModelInfo`) with `_loadModelData`:
+- [ ] **Step 2: Add the wrapper** — in `stdlib/llm.agency`, extend the native import (currently `_setLlmOptions`, `_registerProviderModule`, `_listHostedModels`, `_hostedModelInfo`) with `_loadModelData`:
 
 ```agency
 import {
@@ -341,18 +368,20 @@ export def loadModelData(path: string): Result<number, string> {
 }
 ```
 
-- [ ] **Step 4: Build + run, verify it passes** — `make && node ./dist/scripts/agency.js test js tests/agency-js/llm-load-model-data`
-Expected: PASS (`__result.json` matches `fixture.json`).
-
-- [ ] **Step 5: parse + typecheck the touched Agency file** — 
+- [ ] **Step 3: parse + typecheck the touched Agency file FIRST** (faster than a full `make` for catching type errors like the `env` narrowing above) — 
 ```bash
 node ./dist/scripts/agency.js parse stdlib/llm.agency && node ./dist/scripts/agency.js typecheck stdlib/llm.agency
 ```
-Expected: parses; `No type errors found`. (Do NOT whole-file `fmt` — see Global Constraints; just confirm the new lines match the surrounding indentation.)
+Expected: parses; `No type errors found`. (Do NOT whole-file `fmt` — see Global Constraints; just confirm the new lines match the surrounding indentation.) The test's `agent.agency` is typechecked as part of the `make`/run in the next steps.
 
-- [ ] **Step 6: Commit** *(only if asked)*
+- [ ] **Step 4: Build + run, verify it PASSES** — `make && node ./dist/scripts/agency.js test js tests/agency-js/llm-load-model-data`
+Expected: PASS (`__result.json` matches `fixture.json`). `make` also regenerates `docs/site/stdlib/llm.md` from the new `loadModelData` docstring — include that regenerated file in this task's commit (the Task 4 CLI doc links to it).
+
+> If you want to see the red state first: before Step 2, run `make && node ./dist/scripts/agency.js test js tests/agency-js/llm-load-model-data` — it FAILS because `loadModelData` isn't exported from `std::llm` yet.
+
+- [ ] **Step 5: Commit** *(only if asked)*
 ```bash
-git add stdlib/llm.agency tests/agency-js/llm-load-model-data
+git add stdlib/llm.agency tests/agency-js/llm-load-model-data docs/site/stdlib/llm.md
 git commit -m "feat(stdlib): std::llm.loadModelData opt-in model-data loader"
 ```
 
@@ -383,9 +412,22 @@ Change the import `import { _refreshHostedCatalog } from "../stdlib/llm.js";` to
 ```ts
 import { _fetchModelData } from "../stdlib/llm.js";
 ```
+Also add `beforeEach`, `afterEach` to the vitest import at the top of the file (currently `import { describe, it, expect, vi } from "vitest";`):
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+```
 Replace the entire `describe("agency models refresh", …)` block with:
 ```ts
 describe("agency models refresh", () => {
+  beforeEach(() => {
+    process.exitCode = 0;
+    vi.mocked(_fetchModelData).mockReset();
+  });
+  // The failure test sets exitCode = 1; clear it so it doesn't fail the run.
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
   it("prints the fetched JSON to stdout and nothing to stderr on success", async () => {
     const blob = { schemaVersion: 1, models: [{ modelName: "x" }] };
     vi.mocked(_fetchModelData).mockResolvedValue({ ok: true, json: JSON.stringify(blob, null, 2), error: "" });
@@ -402,12 +444,10 @@ describe("agency models refresh", () => {
     vi.mocked(_fetchModelData).mockResolvedValue({ ok: false, json: "", error: "network down" });
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    process.exitCode = 0;
     await modelsRefresh();
     expect(err).toHaveBeenCalledWith(expect.stringContaining("network down"));
     expect(process.exitCode).toBe(1);
     expect(log).not.toHaveBeenCalled();
-    process.exitCode = 0; // reset so a real later failure isn't masked
     log.mockRestore();
     err.mockRestore();
   });
@@ -461,15 +501,15 @@ Expected: PASS (selection + format + both refresh tests).
 - [ ] **Step 6: Update the subcommand description** — in `scripts/agency.ts`, change the `models refresh` description line (currently `"Refresh the hosted model catalog from the remote source"`) to:
 ```ts
   modelsCmd.command("refresh").description("Fetch the latest model data and print it as JSON (redirect to a file, then load with std::llm loadModelData)")
-    .argument("[url]", "Override the catalog URL").action((url?: string) => modelsRefresh(url));
+    .argument("[url]", "Optional URL to fetch model data from (defaults to the built-in source)").action((url?: string) => modelsRefresh(url));
 ```
 
 - [ ] **Step 7: Typecheck + build + smoke** — 
 ```bash
 npx tsc --noEmit -p tsconfig.json && make
-node ./dist/scripts/agency.js models refresh 2>/dev/null | head -3
+node ./dist/scripts/agency.js models refresh > /tmp/mr.json 2>/dev/null && [ -s /tmp/mr.json ] && head -3 /tmp/mr.json && node -e "JSON.parse(require('fs').readFileSync('/tmp/mr.json','utf8')); console.log('valid JSON')" || echo "refresh failed or offline — rely on the unit test"
 ```
-Expected: tsc/build clean; the smoke prints the start of a JSON object (`{` … `"models"` …) to stdout. (Requires network; if offline, skip the smoke and rely on the unit test.)
+Expected: tsc/build clean; the smoke writes JSON to `/tmp/mr.json`, prints its first lines and `valid JSON`. The `-s` check + `JSON.parse` mean an empty/failed fetch does NOT silently look like success (it prints the offline message instead). Network-dependent; the unit test is the authoritative check.
 
 - [ ] **Step 8: Commit** *(only if asked)*
 ```bash
@@ -541,11 +581,23 @@ provider+name collisions. Loaded data affects `llm()` model resolution and cost
 accounting as well as `listHostedModels()` / `hostedModelInfo()`.
 ````
 
-- [ ] **Step 2: Verify it renders as valid Markdown** — `node ./dist/scripts/agency.js --help >/dev/null 2>&1; echo "doc is static markdown, no build step"` (the `stdlib/llm.md` page regenerates from the Agency docstring via `make`, already run in Task 2; `models.md` is hand-authored like `local.md`).
+- [ ] **Step 2: Register the page in the VitePress sidebar** — in `docs/site/.vitepress/config.mts`, add a `models` entry to the `"/cli/"` sidebar `items` array, alphabetically between `lsp / mcp` and `optimize`:
+```ts
+            { text: "lsp / mcp", link: "/cli/editor-integration" },
+            { text: "models", link: "/cli/models" },
+            { text: "optimize", link: "/cli/optimize" },
+```
+(Without this the page ships unreachable. Note: `cli/local` is also absent from this sidebar — a pre-existing gap left out of scope here; we only add `models`.)
 
-- [ ] **Step 3: Commit** *(only if asked)*
+- [ ] **Step 3: Verify the cross-link target exists** — `models.md` links `../stdlib/llm.md`. Confirm it's present and carries the new function:
 ```bash
-git add docs/site/cli/models.md
+grep -q "loadModelData" docs/site/stdlib/llm.md && echo "stdlib/llm.md has loadModelData (regenerated by make in Task 2)"
+```
+Expected: prints the confirmation. (If missing, re-run `make` — it regenerates `docs/site/stdlib/llm.md` from the `loadModelData` docstring.)
+
+- [ ] **Step 4: Commit** *(only if asked)*
+```bash
+git add docs/site/cli/models.md docs/site/.vitepress/config.mts
 git commit -m "docs(cli): document agency models list + refresh + loadModelData"
 ```
 
@@ -562,7 +614,7 @@ git commit -m "docs(cli): document agency models list + refresh + loadModelData"
 - count = this file's models → Task 1 (`blob.models.length` + explicit test + docstring). ✓
 - Errors returned not thrown, mapped to Result → Task 1 (status object) + Task 2 (`success`/`failure`). ✓
 - Tests: stderr-clean-on-success (Task 3), hostedTools accumulation + schema mismatch (Task 1), Agency wrapper end-to-end (Task 2). ✓
-- Migration: remove `_refreshHostedCatalog` (Task 3 removes it and its "does not persist" note); CLI docs `models.md` (Task 4); stdlib doc regen for `loadModelData` (`make` in Task 2). ✓
+- Migration: remove `_refreshHostedCatalog` (Task 3 removes it and its "does not persist" note); CLI docs `models.md` + VitePress sidebar entry so it's reachable (Task 4); stdlib doc regen for `loadModelData` — `make` in Task 2 Step 4 regenerates `docs/site/stdlib/llm.md` and that file is committed in Task 2 (so Task 4's `../stdlib/llm.md` cross-link resolves). ✓
 
 **Placeholder scan:** none — every step has concrete code or an exact command.
 

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-01-model-data-refresh-and-load.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-01-model-data-refresh-and-load.md
@@ -1,0 +1,571 @@
+# Model Data: Refresh-to-stdout + opt-in `loadModelData` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. (Per project preference, do NOT use subagent-driven development — implement directly in the main session.)
+
+**Goal:** Make `agency models refresh` print the fetched model-data JSON to stdout, and add an opt-in `std::llm.loadModelData(path)` that loads a model-data file and registers it (accumulating over prior loads and the baked catalog).
+
+**Architecture:** Two TS natives in `lib/stdlib/llm.ts` — `_fetchModelData` (fetch → serialized blob, no side effects) and `_loadModelData` (read file → merge over `getRegisteredModelData()` → `registerModelData`). A thin `std::llm.loadModelData` Agency wrapper turns the native's status into a `Result`. The CLI `models refresh` prints the blob to stdout. Nothing auto-loads at bootstrap — loading is entirely opt-in.
+
+**Tech Stack:** TypeScript native shims (`lib/stdlib/*.ts`, vitest), smoltalk 0.7.0 (`refreshModels` / `registerModelData` / `getRegisteredModelData` / `clearModelData` / `mergeModelData` / `mergeHostedTools`), Agency (`.agency` → TS), commander CLI (`scripts/agency.ts`), agency-js test harness.
+
+## Global Constraints
+
+- **Design spec:** `docs/superpowers/specs/2026-07-01-model-data-refresh-and-load-design.md`. Every task implicitly includes it.
+- **smoltalk is already at `^0.7.0`** (installed via the merged Phase 2). Relevant exports, all verified in `node_modules/smoltalk/dist`: `refreshModels(opts?): Promise<Result<ModelDataBlob>>`, `registerModelData(blob)` — **pure replace** (`registeredModelData = blob`), `getRegisteredModelData(): ModelDataBlob | null`, `clearModelData(): void`, `mergeModelData(base, overlay)` — overlay wins on the `provider:modelName` key and **deep-merges** fields, `mergeHostedTools(base, overlay)`. `ModelDataBlob = { schemaVersion, generatedAt, models: ModelType[], hostedTools: HostedTool[] }`.
+- **`registerModelData` replaces smoltalk's single registered slot** — the accumulate design pre-merges (`mergeModelData(prior, blob)`) and registers the whole result. `getAllModels`/`getModel` then layer the registered blob over the baked catalog (registered wins).
+- Agency rules: use `null` not `undefined`; `success(...)`/`failure(...)`/`is success(v)`/`isFailure(...)` are auto-imported (no import needed — see `stdlib/llm.agency` `pickProvider`). Record index + optional fields compare with `== null`.
+- **Do NOT whole-file `fmt` `stdlib/llm.agency`** — it is already fmt-dirty on main (`pickProvider`/`setModel` reformat even untouched). Keep only the new additions clean and consistent with the surrounding style; leave pre-existing lines alone.
+- Build with `make` before running the built CLI or any agency/agency-js test from `dist`. TS unit tests: `pnpm exec vitest run <file>`. Agency-js test: `node ./dist/scripts/agency.js test js <dir>`.
+- Do NOT commit unless the user asks.
+
+---
+
+## File Structure
+
+- `lib/stdlib/llm.ts` — **modify.** Add `fs` import; extend the smoltalk import with `getRegisteredModelData`/`mergeModelData`/`mergeHostedTools`; add `_loadModelData` (Task 1); replace `_refreshHostedCatalog` with `_fetchModelData` (Task 3).
+- `lib/stdlib/modelData.load.test.ts` — **new.** Real-smoltalk unit tests for `_loadModelData` (Task 1).
+- `stdlib/llm.agency` — **modify.** Import `_loadModelData`; add the `loadModelData` wrapper (Task 2).
+- `tests/agency-js/llm-load-model-data/` — **new** (`agent.agency` + `test.js` + `fixture.json`). End-to-end wrapper test (Task 2).
+- `lib/cli/hostedModels.ts` — **modify.** Import `_fetchModelData`; rewrite `modelsRefresh` to print JSON (Task 3).
+- `lib/cli/hostedModels.test.ts` — **modify.** Rewrite the mock + `agency models refresh` describe block (Task 3).
+- `scripts/agency.ts` — **modify.** Update the `models refresh` subcommand description (Task 3).
+- `docs/site/cli/models.md` — **new.** CLI docs for the `agency models` command (Task 4).
+
+**Task order note:** `_loadModelData` (Task 1) is added *before* `_refreshHostedCatalog` is removed (Task 3). Both use smoltalk's `registerModelData`, so keeping `_loadModelData` in place first means the import is never left unused between tasks — every intermediate state builds cleanly.
+
+---
+
+## Task 1: `_loadModelData` native (read → merge → register)
+
+**Files:**
+- Modify: `lib/stdlib/llm.ts` (imports + new function)
+- Create/Test: `lib/stdlib/modelData.load.test.ts`
+
+**Interfaces — Produces (TS):**
+- `function _loadModelData(path: string): { ok: boolean; count: number; error: string }` — reads a model-data JSON file, merges it over any currently-registered data (this file wins on `provider:modelName` collisions), calls `registerModelData`, and returns the count of models **in this file**. Never throws; failures come back as `{ ok: false, count: 0, error }`.
+
+- [ ] **Step 1: Write the failing test** — create `lib/stdlib/modelData.load.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearModelData, getModel, getRegisteredModelData } from "smoltalk";
+import { _loadModelData } from "./llm.js";
+
+function tmpFile(name: string, contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-models-"));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, contents);
+  return p;
+}
+
+const A = JSON.stringify({
+  schemaVersion: 1,
+  generatedAt: "t",
+  models: [
+    { type: "text", modelName: "custom-a", provider: "acme", inputTokenCost: 1, outputTokenCost: 2, maxInputTokens: 1000, family: "a" },
+    { type: "text", modelName: "shared", provider: "acme", inputTokenCost: 5, outputTokenCost: 5, maxInputTokens: 2000, family: "a" },
+  ],
+  hostedTools: [{ name: "tool-a" }],
+});
+// B adds custom-b, and overrides acme:shared's input price to 9. Models-only (no hostedTools).
+const B = JSON.stringify({
+  schemaVersion: 1,
+  generatedAt: "t",
+  models: [
+    { type: "text", modelName: "custom-b", provider: "acme", inputTokenCost: 2, outputTokenCost: 3, maxInputTokens: 3000, family: "b" },
+    { type: "text", modelName: "shared", provider: "acme", inputTokenCost: 9, outputTokenCost: 5, maxInputTokens: 2000, family: "a" },
+  ],
+});
+
+describe("_loadModelData", () => {
+  beforeEach(() => clearModelData());
+
+  it("registers a file's models (visible via getModel) and returns its count", () => {
+    const res = _loadModelData(tmpFile("a.json", A));
+    expect(res).toEqual({ ok: true, count: 2, error: "" });
+    expect(getModel("custom-a" as any)?.provider).toBe("acme");
+  });
+
+  it("accumulates: later load layers over earlier, overlay wins on collision", () => {
+    _loadModelData(tmpFile("a.json", A));
+    const res = _loadModelData(tmpFile("b.json", B));
+    expect(res.ok).toBe(true);
+    expect(getModel("custom-a" as any)).toBeDefined();
+    expect(getModel("custom-b" as any)).toBeDefined();
+    expect((getModel("shared" as any) as any)?.inputTokenCost).toBe(9); // B wins
+  });
+
+  it("preserves prior hostedTools when a later file omits them", () => {
+    _loadModelData(tmpFile("a.json", A)); // has hostedTools
+    _loadModelData(tmpFile("b.json", B)); // models-only
+    expect((getRegisteredModelData()?.hostedTools ?? []).some((t: any) => t.name === "tool-a")).toBe(true);
+  });
+
+  it("returns count = this file's models, not the running total", () => {
+    _loadModelData(tmpFile("a.json", A));            // 2
+    expect(_loadModelData(tmpFile("b.json", B)).count).toBe(2); // this file's 2, not 4
+  });
+
+  it("fails on missing file / invalid JSON / no models array, leaving prior registration intact", () => {
+    _loadModelData(tmpFile("a.json", A));
+    expect(_loadModelData("/no/such/file.json").ok).toBe(false);
+    expect(_loadModelData(tmpFile("bad.json", "{not json")).ok).toBe(false);
+    expect(_loadModelData(tmpFile("nomodels.json", "{}")).ok).toBe(false);
+    expect(getModel("custom-a" as any)).toBeDefined();
+  });
+
+  it("fails on schemaVersion mismatch after a prior load", () => {
+    _loadModelData(tmpFile("v1.json", A)); // schemaVersion 1
+    const v2 = JSON.stringify({
+      schemaVersion: 2,
+      models: [{ type: "text", modelName: "z", provider: "acme", inputTokenCost: 0, outputTokenCost: 0, maxInputTokens: 1 }],
+    });
+    const res = _loadModelData(tmpFile("v2.json", v2));
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("schemaVersion");
+    expect(getModel("custom-a" as any)).toBeDefined(); // v1 intact
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails** — `pnpm exec vitest run lib/stdlib/modelData.load.test.ts`
+Expected: FAIL — `_loadModelData` is not exported from `./llm.js`.
+
+- [ ] **Step 3: Add the imports** — in `lib/stdlib/llm.ts`, add an `fs` import after the existing top imports (line 3, after the `loadProviderModuleByPath` import):
+
+```ts
+import * as fs from "node:fs";
+```
+
+and extend the smoltalk import (currently `getAllModels`, `getModel`, `refreshModels`, `registerModelData`) to:
+
+```ts
+import {
+  getAllModels,
+  getModel,
+  refreshModels,
+  registerModelData,
+  getRegisteredModelData,
+  mergeModelData,
+  mergeHostedTools,
+} from "smoltalk";
+```
+
+- [ ] **Step 4: Implement `_loadModelData`** — append to `lib/stdlib/llm.ts`:
+
+```ts
+/** Read a model-data JSON file (the shape `agency models refresh` prints) and
+ *  register it, ACCUMULATING over any previously registered data (this file
+ *  wins on provider+name collisions, deep-merging fields) and over the baked
+ *  catalog. Errors are returned, never thrown, so the Agency wrapper can map
+ *  them to a Result. Returns the number of models in THIS file. */
+export function _loadModelData(
+  path: string,
+): { ok: boolean; count: number; error: string } {
+  let text: string;
+  try {
+    text = fs.readFileSync(path, "utf-8");
+  } catch (err) {
+    return { ok: false, count: 0, error: `cannot read ${path}: ${(err as Error).message}` };
+  }
+  let blob: any;
+  try {
+    blob = JSON.parse(text);
+  } catch (err) {
+    return { ok: false, count: 0, error: `${path} is not valid JSON: ${(err as Error).message}` };
+  }
+  if (!blob || !Array.isArray(blob.models)) {
+    return { ok: false, count: 0, error: `${path} is not model data (missing "models" array)` };
+  }
+  const prior = getRegisteredModelData();
+  // Refuse to stitch models of a different schema version onto the prior blob —
+  // a cross-version merge could mix incompatible field shapes. Fail loudly.
+  if (prior && blob.schemaVersion != null && prior.schemaVersion != null && blob.schemaVersion !== prior.schemaVersion) {
+    return {
+      ok: false,
+      count: 0,
+      error: `${path} has schemaVersion ${blob.schemaVersion} but ${prior.schemaVersion} is already loaded; load only matching-version data`,
+    };
+  }
+  const merged = prior
+    ? {
+        schemaVersion: blob.schemaVersion ?? prior.schemaVersion,
+        generatedAt: blob.generatedAt ?? prior.generatedAt,
+        // Overlay (this file) wins on provider:modelName and deep-merges, so a
+        // partial hand-edited entry augments the prior one.
+        models: mergeModelData(prior.models, blob.models),
+        hostedTools: mergeHostedTools(prior.hostedTools ?? [], blob.hostedTools ?? []),
+      }
+    : blob;
+  // registerModelData REPLACES smoltalk's single registered slot, so `merged`
+  // must carry everything (hence the pre-merge). No double-apply.
+  registerModelData(merged);
+  return { ok: true, count: blob.models.length, error: "" };
+}
+```
+
+- [ ] **Step 5: Run test, verify it passes** — `pnpm exec vitest run lib/stdlib/modelData.load.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Typecheck** — `npx tsc --noEmit -p tsconfig.json`
+Expected: exit 0, no errors.
+
+- [ ] **Step 7: Commit** *(only if asked)*
+```bash
+git add lib/stdlib/llm.ts lib/stdlib/modelData.load.test.ts
+git commit -m "feat(stdlib): _loadModelData native (accumulate model data over smoltalk catalog)"
+```
+
+---
+
+## Task 2: `std::llm.loadModelData` Agency wrapper + agency-js test
+
+**Files:**
+- Modify: `stdlib/llm.agency` (native import + wrapper)
+- Create: `tests/agency-js/llm-load-model-data/agent.agency`, `.../test.js`, `.../fixture.json`
+
+**Interfaces — Consumes:** `_loadModelData` (Task 1). **Produces (Agency):**
+- `def loadModelData(path: string): Result<number, string>` — `success(count)` on load, `failure(reason)` otherwise.
+
+- [ ] **Step 1: Write the failing agency-js test** — create the three files under `tests/agency-js/llm-load-model-data/`.
+
+`agent.agency`:
+```agency
+import { loadModelData, hostedModelInfo } from "std::llm"
+import { env } from "std::system"
+
+// test.js writes a model-data file to a temp path and passes it via
+// MODELS_FIXTURE, then asserts: the load succeeds with a count, the custom
+// model becomes visible through hostedModelInfo, and a bad path fails.
+node main(): any {
+  let loadedCount = -1
+  const good = loadModelData(env("MODELS_FIXTURE"))
+  if (good is success(n)) {
+    loadedCount = n
+  }
+  let seen = "no"
+  const info = hostedModelInfo("custom-load-test")
+  if (info != null) {
+    seen = info.provider
+  }
+  const bad = loadModelData("/no/such/models-file.json")
+  return {
+    loadedCount: loadedCount,
+    seen: seen,
+    badFailed: isFailure(bad)
+  }
+}
+```
+
+`test.js`:
+```js
+import { main } from "./agent.js";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Write the model-data file to a temp path (not the test dir) and hand the
+// absolute path to the agency program via env — no cwd assumptions.
+const fixturePath = join(tmpdir(), `agency-models-load-${process.pid}.json`);
+writeFileSync(
+  fixturePath,
+  JSON.stringify({
+    schemaVersion: 1,
+    generatedAt: "test",
+    models: [
+      { type: "text", modelName: "custom-load-test", provider: "acme", inputTokenCost: 1, outputTokenCost: 2, maxInputTokens: 4096, family: "acme" },
+    ],
+    hostedTools: [],
+  }),
+);
+process.env.MODELS_FIXTURE = fixturePath;
+
+const result = await main({});
+writeFileSync(
+  new URL("./__result.json", import.meta.url),
+  JSON.stringify(result.data, null, 2),
+);
+```
+
+`fixture.json`:
+```json
+{
+  "loadedCount": 1,
+  "seen": "acme",
+  "badFailed": true
+}
+```
+
+- [ ] **Step 2: Build + run, verify it fails** — `make && node ./dist/scripts/agency.js test js tests/agency-js/llm-load-model-data`
+Expected: FAIL — `loadModelData` is not exported from `std::llm` (compile/import error).
+
+- [ ] **Step 3: Add the wrapper** — in `stdlib/llm.agency`, extend the native import (currently `_setLlmOptions`, `_registerProviderModule`, `_listHostedModels`, `_hostedModelInfo`) with `_loadModelData`:
+
+```agency
+import {
+  _setLlmOptions,
+  _registerProviderModule,
+  _listHostedModels,
+  _hostedModelInfo,
+  _loadModelData,
+} from "agency-lang/stdlib-lib/llm.js"
+```
+
+Then add at the end of the file (after `hostedModelInfo`):
+
+```agency
+export def loadModelData(path: string): Result<number, string> {
+  """
+  Load additional model data from a JSON file (the shape printed by
+  `agency models refresh`) and register it for this program. Both the file's
+  `models` and its optional `hostedTools` are layered over any previously
+  loaded data and over the built-in catalog, with this file winning on
+  provider+name collisions; unlisted fields on an existing entry are preserved.
+  Affects llm() model resolution and cost accounting as well as
+  listHostedModels() / hostedModelInfo().
+
+  Returns the number of models in THIS file (not the running total registered),
+  or a failure describing why the file could not be loaded.
+
+  @param path - Path to a model-data JSON file (relative to the working
+    directory, or absolute)
+  """
+  const res = _loadModelData(path)
+  if (res.ok) {
+    return success(res.count)
+  }
+  return failure(res.error)
+}
+```
+
+- [ ] **Step 4: Build + run, verify it passes** — `make && node ./dist/scripts/agency.js test js tests/agency-js/llm-load-model-data`
+Expected: PASS (`__result.json` matches `fixture.json`).
+
+- [ ] **Step 5: parse + typecheck the touched Agency file** — 
+```bash
+node ./dist/scripts/agency.js parse stdlib/llm.agency && node ./dist/scripts/agency.js typecheck stdlib/llm.agency
+```
+Expected: parses; `No type errors found`. (Do NOT whole-file `fmt` — see Global Constraints; just confirm the new lines match the surrounding indentation.)
+
+- [ ] **Step 6: Commit** *(only if asked)*
+```bash
+git add stdlib/llm.agency tests/agency-js/llm-load-model-data
+git commit -m "feat(stdlib): std::llm.loadModelData opt-in model-data loader"
+```
+
+---
+
+## Task 3: `agency models refresh` prints JSON to stdout
+
+**Files:**
+- Modify: `lib/stdlib/llm.ts` (replace `_refreshHostedCatalog` with `_fetchModelData`)
+- Modify: `lib/cli/hostedModels.ts` (import + `modelsRefresh`)
+- Modify: `lib/cli/hostedModels.test.ts` (mock + refresh describe)
+- Modify: `scripts/agency.ts` (subcommand description)
+
+**Interfaces — Produces (TS):**
+- `function _fetchModelData(url: string): Promise<{ ok: boolean; json: string; error: string }>` — fetches the latest model-data blob and returns it pre-serialized (`JSON.stringify(blob, null, 2)`). No registration.
+- `async function modelsRefresh(url?: string): Promise<void>` — prints `json` to stdout on success; error to stderr + `process.exitCode = 1` on failure.
+
+- [ ] **Step 1: Rewrite the failing CLI test** — replace the mock and the `agency models refresh` describe block in `lib/cli/hostedModels.test.ts`.
+
+Change the mock at the top from `_refreshHostedCatalog: vi.fn()` to `_fetchModelData: vi.fn()`:
+```ts
+vi.mock("../stdlib/llm.js", () => ({
+  _listHostedModels: () => [],
+  _fetchModelData: vi.fn(),
+}));
+```
+Change the import `import { _refreshHostedCatalog } from "../stdlib/llm.js";` to:
+```ts
+import { _fetchModelData } from "../stdlib/llm.js";
+```
+Replace the entire `describe("agency models refresh", …)` block with:
+```ts
+describe("agency models refresh", () => {
+  it("prints the fetched JSON to stdout and nothing to stderr on success", async () => {
+    const blob = { schemaVersion: 1, models: [{ modelName: "x" }] };
+    vi.mocked(_fetchModelData).mockResolvedValue({ ok: true, json: JSON.stringify(blob, null, 2), error: "" });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    await modelsRefresh();
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(log.mock.calls[0][0] as string)).toHaveProperty("models");
+    expect(err).not.toHaveBeenCalled();
+    log.mockRestore();
+    err.mockRestore();
+  });
+  it("reports the error on stderr, exits non-zero, and prints nothing to stdout on failure", async () => {
+    vi.mocked(_fetchModelData).mockResolvedValue({ ok: false, json: "", error: "network down" });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = 0;
+    await modelsRefresh();
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("network down"));
+    expect(process.exitCode).toBe(1);
+    expect(log).not.toHaveBeenCalled();
+    process.exitCode = 0; // reset so a real later failure isn't masked
+    log.mockRestore();
+    err.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails** — `pnpm exec vitest run lib/cli/hostedModels.test.ts`
+Expected: FAIL — `_fetchModelData` is not exported (and `modelsRefresh` still prints a count).
+
+- [ ] **Step 3: Replace `_refreshHostedCatalog` with `_fetchModelData`** — in `lib/stdlib/llm.ts`, replace the whole `_refreshHostedCatalog` function with:
+
+```ts
+/** Fetch the latest model-data blob and return it pre-serialized. No
+ *  registration — the CLI prints this to stdout for the user to save and later
+ *  load with `std::llm.loadModelData`. */
+export async function _fetchModelData(
+  url: string,
+): Promise<{ ok: boolean; json: string; error: string }> {
+  const res = await refreshModels(url ? { url } : {});
+  if (res.success) {
+    return { ok: true, json: JSON.stringify(res.value, null, 2), error: "" };
+  }
+  return { ok: false, json: "", error: res.error };
+}
+```
+
+- [ ] **Step 4: Update the CLI** — in `lib/cli/hostedModels.ts`, change the import (line 3) from `_refreshHostedCatalog` to `_fetchModelData`:
+```ts
+import {
+  _listHostedModels,
+  _fetchModelData,
+  type HostedModelInfo,
+} from "../stdlib/llm.js";
+```
+and replace `modelsRefresh`:
+```ts
+export async function modelsRefresh(url?: string): Promise<void> {
+  const res = await _fetchModelData(url ?? "");
+  if (res.ok) {
+    console.log(res.json); // stdout only — clean JSON for redirection
+  } else {
+    console.error(`Refresh failed: ${res.error}`);
+    process.exitCode = 1;
+  }
+}
+```
+
+- [ ] **Step 5: Run test, verify it passes** — `pnpm exec vitest run lib/cli/hostedModels.test.ts`
+Expected: PASS (selection + format + both refresh tests).
+
+- [ ] **Step 6: Update the subcommand description** — in `scripts/agency.ts`, change the `models refresh` description line (currently `"Refresh the hosted model catalog from the remote source"`) to:
+```ts
+  modelsCmd.command("refresh").description("Fetch the latest model data and print it as JSON (redirect to a file, then load with std::llm loadModelData)")
+    .argument("[url]", "Override the catalog URL").action((url?: string) => modelsRefresh(url));
+```
+
+- [ ] **Step 7: Typecheck + build + smoke** — 
+```bash
+npx tsc --noEmit -p tsconfig.json && make
+node ./dist/scripts/agency.js models refresh 2>/dev/null | head -3
+```
+Expected: tsc/build clean; the smoke prints the start of a JSON object (`{` … `"models"` …) to stdout. (Requires network; if offline, skip the smoke and rely on the unit test.)
+
+- [ ] **Step 8: Commit** *(only if asked)*
+```bash
+git add lib/stdlib/llm.ts lib/cli/hostedModels.ts lib/cli/hostedModels.test.ts scripts/agency.ts
+git commit -m "feat(cli): agency models refresh prints model-data JSON to stdout"
+```
+
+---
+
+## Task 4: CLI docs — `docs/site/cli/models.md`
+
+**Files:**
+- Create: `docs/site/cli/models.md`
+
+The `agency models` command shipped in Phase 2 with no doc page (only `docs/site/cli/local.md` exists). Add one covering `list` (with filters) and the new `refresh` → save → `loadModelData` workflow.
+
+- [ ] **Step 1: Write the doc** — create `docs/site/cli/models.md`:
+
+````markdown
+# `agency models`
+
+Browse the hosted model catalog and fetch fresh model data.
+
+## `agency models list`
+
+List hosted text models from the built-in catalog (plus anything loaded this
+process). Filterable:
+
+```bash
+agency models list                       # all models
+agency models list --provider openai     # one provider
+agency models list --max-price 1         # input cost <= $1 / 1M tokens
+agency models list --min-context 200000  # context window >= 200k tokens
+```
+
+Columns: name, provider, open-weights, input $/1M, output $/1M, context window.
+
+## `agency models refresh`
+
+Fetch the latest model data and **print it as JSON to stdout**. It does not
+save or register anything — redirect it to a file you control:
+
+```bash
+agency models refresh > my-models.json
+# optionally override the source URL:
+agency models refresh https://example.com/model-data.json > my-models.json
+```
+
+Errors go to stderr with a non-zero exit code, so a failed fetch is detectable
+in a pipeline (and leaves stdout empty).
+
+## Using a saved file
+
+Load a saved model-data file in an Agency program with
+[`std::llm.loadModelData`](../stdlib/llm.md):
+
+```agency
+import { loadModelData } from "std::llm"
+
+node main() {
+  const r = loadModelData("my-models.json")
+  // r is success(count) or failure(reason)
+}
+```
+
+`loadModelData` **accumulates**: multiple calls layer over each other and over
+the built-in catalog, with the most recently loaded file winning on
+provider+name collisions. Loaded data affects `llm()` model resolution and cost
+accounting as well as `listHostedModels()` / `hostedModelInfo()`.
+````
+
+- [ ] **Step 2: Verify it renders as valid Markdown** — `node ./dist/scripts/agency.js --help >/dev/null 2>&1; echo "doc is static markdown, no build step"` (the `stdlib/llm.md` page regenerates from the Agency docstring via `make`, already run in Task 2; `models.md` is hand-authored like `local.md`).
+
+- [ ] **Step 3: Commit** *(only if asked)*
+```bash
+git add docs/site/cli/models.md
+git commit -m "docs(cli): document agency models list + refresh + loadModelData"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `agency models refresh` prints JSON to stdout, stderr+exit-1 on failure → Task 3 (`_fetchModelData` + `modelsRefresh`). ✓
+- `loadModelData(path): Result<number, string>`, accumulate, affects all catalog reads → Task 1 (`_loadModelData`) + Task 2 (wrapper). ✓
+- Precedence latest-load > earlier > baked; overlay-wins deep-merge → Task 1 (`mergeModelData(prior, blob)`) + Global Constraints. ✓
+- schemaVersion mismatch → failure → Task 1 (guard + test). ✓
+- hostedTools merged/preserved → Task 1 (`mergeHostedTools` + test). ✓
+- count = this file's models → Task 1 (`blob.models.length` + explicit test + docstring). ✓
+- Errors returned not thrown, mapped to Result → Task 1 (status object) + Task 2 (`success`/`failure`). ✓
+- Tests: stderr-clean-on-success (Task 3), hostedTools accumulation + schema mismatch (Task 1), Agency wrapper end-to-end (Task 2). ✓
+- Migration: remove `_refreshHostedCatalog` (Task 3 removes it and its "does not persist" note); CLI docs `models.md` (Task 4); stdlib doc regen for `loadModelData` (`make` in Task 2). ✓
+
+**Placeholder scan:** none — every step has concrete code or an exact command.
+
+**Type consistency:** `_loadModelData` returns `{ ok, count, error }` (Task 1), consumed by `loadModelData` (Task 2) as `res.ok`/`res.count`/`res.error`. `_fetchModelData` returns `{ ok, json, error }` (Task 3), consumed by `modelsRefresh` as `res.ok`/`res.json`/`res.error`, and mocked with the same shape in the test. `loadModelData` returns `Result<number, string>` (spec + wrapper). smoltalk helper names (`getRegisteredModelData`/`mergeModelData`/`mergeHostedTools`/`clearModelData`) match the verified 0.7.0 exports.
+
+**Ordering:** `_loadModelData` (Task 1) is added before `_refreshHostedCatalog` is removed (Task 3), so smoltalk's `registerModelData` import is always in use — no unused-import break between tasks.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-01-model-data-refresh-and-load-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-01-model-data-refresh-and-load-design.md
@@ -1,0 +1,187 @@
+# Model Data: Refresh-to-stdout + opt-in `loadModelData` — Design
+
+**Status:** Design (approved to spec)
+**Date:** 2026-07-01
+**Supersedes:** the Phase-2 (PR #379) behavior of `agency models refresh`, which registered the fetched blob into smoltalk's in-memory catalog and printed a count — a documented no-op across CLI processes. This design replaces that with an explicit, opt-in refresh→save→load flow.
+
+## Motivation
+
+`agency models refresh` (Phase 2) fetched smoltalk's model-data blob and called `registerModelData`, which writes an in-process module global that evaporates when the CLI process exits. So a later `agency models list` saw only the baked catalog — the refresh had no durable effect.
+
+Rather than invent a fixed on-disk cache that every program loads at startup (a hidden startup cost + coupling forced on programs that never touch model metadata), this design makes persistence and loading **explicit and opt-in**:
+
+- `agency models refresh` becomes a pure fetch-and-print. It writes the fetched JSON to **stdout** and does nothing else. The user decides where it goes.
+- A new `std::llm.loadModelData(path)` lets a program **explicitly** load a model-data file, layering it over smoltalk's catalog for that program only.
+
+Programs that don't call `loadModelData` pay nothing.
+
+## Goals
+
+- `agency models refresh [url]` prints a model-data JSON blob to stdout (redirectable to any file).
+- `std::llm.loadModelData(path): Result<number, string>` loads a model-data file and registers it, affecting **all** catalog reads in that program: `llm()` model resolution + cost accounting, and `listHostedModels()` / `hostedModelInfo()`.
+- Multiple `loadModelData` calls **accumulate** (later loads layer over earlier; both over baked).
+- The file is a hand-editable JSON file the user owns; its shape is exactly what `refresh` prints.
+
+## Non-goals (YAGNI)
+
+- No fixed `models.json` location, no walk-up resolution, no bootstrap auto-load.
+- No merge-policy/source-tagging file format — the file is a plain smoltalk `ModelDataBlob`; "user overrides" happen by hand-editing that file, and accumulation order (load order) resolves precedence.
+- `agency models list` stays a viewer of the **baked** catalog for the CLI process; it does not read a user file. (A `--file` preview flag is a possible future extension, not in scope.)
+
+## Data flow
+
+```
+$ agency models refresh > my-models.json     # fetch latest, save (user's choice of path)
+# (optional) hand-edit my-models.json to add/override a model
+
+# in an Agency program:
+const r = loadModelData("my-models.json")    # opt-in; registers the blob
+# from here, llm(), cost accounting, listHostedModels(), hostedModelInfo()
+# all see my-models.json's models, layered over smoltalk's baked catalog.
+```
+
+## File format
+
+The file is a smoltalk `ModelDataBlob` — exactly what `refresh` prints and what `loadModelData` reads:
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-01T...",
+  "models": [ /* ModelType[] — text/image/embeddings/etc. */ ],
+  "hostedTools": [ /* HostedTool[] */ ]
+}
+```
+
+`loadModelData` requires only that `models` is an array; `hostedTools`, `schemaVersion`, `generatedAt` are optional. A hand-editing user typically keeps a trimmed file with just the `models` they care about.
+
+## Interfaces
+
+### TS natives — `lib/stdlib/llm.ts`
+
+Replace `_refreshHostedCatalog` (register + count) with a fetch-only helper, and add the loader. Both keep smoltalk types out of their callers by returning plain status objects.
+
+```ts
+// Fetch the latest model-data blob; return it pre-serialized. No registration.
+export async function _fetchModelData(
+  url: string,
+): Promise<{ ok: boolean; json: string; error: string }> {
+  const res = await refreshModels(url ? { url } : {});
+  if (res.success) {
+    return { ok: true, json: JSON.stringify(res.value, null, 2), error: "" };
+  }
+  return { ok: false, json: "", error: res.error };
+}
+
+// Read a model-data file and register it, ACCUMULATING over any previously
+// registered data (this file wins on name collisions) and over the baked
+// catalog. Errors are returned, not thrown, so the Agency wrapper can surface
+// them as a Result.
+export function _loadModelData(
+  path: string,
+): { ok: boolean; count: number; error: string } {
+  let text: string;
+  try {
+    text = fs.readFileSync(path, "utf-8");
+  } catch (err) {
+    return { ok: false, count: 0, error: `cannot read ${path}: ${(err as Error).message}` };
+  }
+  let blob: any;
+  try {
+    blob = JSON.parse(text);
+  } catch (err) {
+    return { ok: false, count: 0, error: `${path} is not valid JSON: ${(err as Error).message}` };
+  }
+  if (!blob || !Array.isArray(blob.models)) {
+    return { ok: false, count: 0, error: `${path} is not model data (missing "models" array)` };
+  }
+  const prior = getRegisteredModelData();
+  const merged = prior
+    ? {
+        schemaVersion: blob.schemaVersion ?? prior.schemaVersion,
+        generatedAt: blob.generatedAt ?? prior.generatedAt,
+        models: mergeModelData(prior.models, blob.models), // overlay (new file) wins
+        hostedTools: mergeHostedTools(prior.hostedTools ?? [], blob.hostedTools ?? []),
+      }
+    : blob;
+  registerModelData(merged);
+  return { ok: true, count: blob.models.length, error: "" };
+}
+```
+
+Smoltalk helpers used (all already exported by smoltalk 0.7.0): `refreshModels`, `registerModelData`, `getRegisteredModelData`, `mergeModelData`, `mergeHostedTools`.
+
+> The try/catch blocks are not swallowing errors — each returns the error text in the status object, which the Agency wrapper turns into a `failure(...)`.
+
+### Agency wrapper — `stdlib/llm.agency`
+
+Extend the native import with `_loadModelData` (the Agency layer does not need `_fetchModelData` — that is CLI-only) and add:
+
+```agency
+export def loadModelData(path: string): Result<number, string> {
+  """
+  Load additional model data from a JSON file (the shape printed by
+  `agency models refresh`) and register it for this program. The data is
+  layered over any previously loaded data and over the built-in catalog, with
+  this file winning on name collisions. Affects llm() model resolution and
+  cost accounting as well as listHostedModels() / hostedModelInfo(). Returns
+  the number of models loaded, or a failure describing why the file could not
+  be read.
+
+  @param path - Path to a model-data JSON file (relative to the working
+    directory, or absolute)
+  """
+  const res = _loadModelData(path)
+  if (res.ok) {
+    return success(res.count)
+  }
+  return failure(res.error)
+}
+```
+
+`_fetchModelData` is consumed only by the CLI (below), so it is not re-exported through `std::llm`.
+
+### CLI — `lib/cli/hostedModels.ts` + `scripts/agency.ts`
+
+`modelsRefresh` prints the JSON to stdout; errors go to stderr with a non-zero exit code (so `agency models refresh > f.json` yields a clean file, and a failed run is detectable in a pipeline):
+
+```ts
+export async function modelsRefresh(url?: string): Promise<void> {
+  const res = await _fetchModelData(url ?? "");
+  if (res.ok) {
+    console.log(res.json); // stdout only — clean JSON for redirection
+  } else {
+    console.error(`Refresh failed: ${res.error}`);
+    process.exitCode = 1;
+  }
+}
+```
+
+Update the `models refresh` subcommand description in `scripts/agency.ts` to:
+> "Fetch the latest model data and print it as JSON (redirect to a file, then load it with `std::llm` `loadModelData`)."
+
+`selectHostedModels` / `formatHostedCatalog` / `modelsList` are unchanged.
+
+## Precedence
+
+After N `loadModelData` calls: **latest-loaded file > earlier-loaded files > smoltalk baked catalog.** `mergeModelData(base, overlay)` (overlay wins) is applied with `base = getRegisteredModelData()` and `overlay = the new file`, and smoltalk's own `getModel`/`getAllModels` then layer the single registered blob over the baked catalog.
+
+## Error handling
+
+- **refresh:** network / parse failure → `Refresh failed: <error>` on stderr, `process.exitCode = 1`, nothing on stdout. Caveat: the shell truncates the redirect target before the command runs, so a failed `agency models refresh > f.json` leaves `f.json` empty; the user re-runs. We do not try to work around shell redirection.
+- **loadModelData:** missing file, invalid JSON, or a payload with no `models` array → `failure("<reason>")`. The `models` array is the only structural requirement; individual malformed model entries are smoltalk's concern at use time, not validated here.
+
+## Testing
+
+- **CLI (`lib/cli/hostedModels.test.ts`)** — mock the native: `modelsRefresh` on success writes a single `console.log` whose argument is valid JSON parseable back into an object with a `models` array; on failure writes to `console.error` and sets `process.exitCode = 1` with nothing on `console.log`.
+- **`_loadModelData` (`lib/stdlib/llm.test.ts`)** — using temp fixture files (or a mocked `fs` + real smoltalk merge):
+  - loading file A then file B → `getAllModels()` (or `_listHostedModels`) contains models from both; on a name collision, B's version wins (accumulate + overlay-wins).
+  - returns `{ ok: true, count }` equal to the file's `models` length.
+  - missing file / invalid JSON / no `models` array → `{ ok: false, error }` (non-empty message), and the registered data is unchanged.
+- **Agency (`tests/` under stdlib or agency-agent)** — `loadModelData(fixture)` returns `success(n)`, and a subsequent `listHostedModels()` includes the fixture's model; `loadModelData("nope.json")` returns a `failure`.
+
+## Migration notes
+
+- `_refreshHostedCatalog` is removed; `_fetchModelData` replaces it. Update `lib/cli/hostedModels.test.ts` (the current success/failure refresh tests assert a printed count; they change to assert printed JSON).
+- Remove the "KNOWN LIMITATION — refresh does not persist" note from the Phase-2 plan/code; this design resolves it by making persistence explicit.
+- The `std::llm` stdlib docs regenerate (`make`) to include `loadModelData`.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-01-model-data-refresh-and-load-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-01-model-data-refresh-and-load-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Design (approved to spec)
 **Date:** 2026-07-01
-**Supersedes:** the Phase-2 (PR #379) behavior of `agency models refresh`, which registered the fetched blob into smoltalk's in-memory catalog and printed a count — a documented no-op across CLI processes. This design replaces that with an explicit, opt-in refresh→save→load flow.
+**Supersedes:** the Phase-2 (PR #379) behavior of `agency models refresh`, which registered the fetched blob into smoltalk's in-memory catalog and printed a count — which is a documented no-op across CLI processes because the registration does not persist. This design replaces that with an explicit, opt-in refresh→save→load flow.
 
 ## Motivation
 
@@ -96,22 +96,38 @@ export function _loadModelData(
     return { ok: false, count: 0, error: `${path} is not model data (missing "models" array)` };
   }
   const prior = getRegisteredModelData();
+  // Refuse to stitch models of a different schema version onto the prior blob —
+  // a cross-version merge could mix incompatible field shapes. Fail loudly
+  // instead of silently producing a corrupt blob. (Same-version accumulation is
+  // the normal path; this only trips if two files from different smoltalk
+  // versions are loaded in one process.)
+  if (prior && blob.schemaVersion != null && prior.schemaVersion != null && blob.schemaVersion !== prior.schemaVersion) {
+    return {
+      ok: false,
+      count: 0,
+      error: `${path} has schemaVersion ${blob.schemaVersion} but ${prior.schemaVersion} is already loaded; load only matching-version data`,
+    };
+  }
   const merged = prior
     ? {
         schemaVersion: blob.schemaVersion ?? prior.schemaVersion,
         generatedAt: blob.generatedAt ?? prior.generatedAt,
-        models: mergeModelData(prior.models, blob.models), // overlay (new file) wins
+        // Overlay (this file) wins on the `provider:modelName` key and
+        // deep-merges fields, so a partial hand-edited entry augments the prior
+        // one rather than clobbering unlisted fields.
+        models: mergeModelData(prior.models, blob.models),
         hostedTools: mergeHostedTools(prior.hostedTools ?? [], blob.hostedTools ?? []),
       }
     : blob;
+  // registerModelData REPLACES smoltalk's single registered slot (verified:
+  // `registeredModelData = blob` in smoltalk/dist/models.js), so `merged` must
+  // carry everything — hence the pre-merge above. No double-apply.
   registerModelData(merged);
   return { ok: true, count: blob.models.length, error: "" };
 }
 ```
 
-Smoltalk helpers used (all already exported by smoltalk 0.7.0): `refreshModels`, `registerModelData`, `getRegisteredModelData`, `mergeModelData`, `mergeHostedTools`.
-
-> The try/catch blocks are not swallowing errors — each returns the error text in the status object, which the Agency wrapper turns into a `failure(...)`.
+Smoltalk helpers used (all already exported by smoltalk 0.7.0, verified in `dist/models.js` / `dist/modelData.js`): `refreshModels`, `registerModelData` (pure replace), `getRegisteredModelData`, `mergeModelData` (overlay-wins on `provider:modelName`, deep-merges fields), `mergeHostedTools`. The `catch` blocks return the error text in the status object (the Agency wrapper turns it into `failure(...)`) — they do not swallow it.
 
 ### Agency wrapper — `stdlib/llm.agency`
 
@@ -121,12 +137,15 @@ Extend the native import with `_loadModelData` (the Agency layer does not need `
 export def loadModelData(path: string): Result<number, string> {
   """
   Load additional model data from a JSON file (the shape printed by
-  `agency models refresh`) and register it for this program. The data is
-  layered over any previously loaded data and over the built-in catalog, with
-  this file winning on name collisions. Affects llm() model resolution and
-  cost accounting as well as listHostedModels() / hostedModelInfo(). Returns
-  the number of models loaded, or a failure describing why the file could not
-  be read.
+  `agency models refresh`) and register it for this program. Both the file's
+  `models` and its (optional) `hostedTools` are layered over any previously
+  loaded data and over the built-in catalog, with this file winning on
+  provider+name collisions; unlisted fields on an existing entry are preserved.
+  Affects llm() model resolution and cost accounting as well as
+  listHostedModels() / hostedModelInfo().
+
+  Returns the number of models in THIS file (not the running total registered),
+  or a failure describing why the file could not be loaded.
 
   @param path - Path to a model-data JSON file (relative to the working
     directory, or absolute)
@@ -158,7 +177,7 @@ export async function modelsRefresh(url?: string): Promise<void> {
 ```
 
 Update the `models refresh` subcommand description in `scripts/agency.ts` to:
-> "Fetch the latest model data and print it as JSON (redirect to a file, then load it with `std::llm` `loadModelData`)."
+> "Fetch the latest model data and print it as JSON (redirect to a file, then load it with `std::llm.loadModelData`)."
 
 `selectHostedModels` / `formatHostedCatalog` / `modelsList` are unchanged.
 
@@ -170,14 +189,19 @@ After N `loadModelData` calls: **latest-loaded file > earlier-loaded files > smo
 
 - **refresh:** network / parse failure → `Refresh failed: <error>` on stderr, `process.exitCode = 1`, nothing on stdout. Caveat: the shell truncates the redirect target before the command runs, so a failed `agency models refresh > f.json` leaves `f.json` empty; the user re-runs. We do not try to work around shell redirection.
 - **loadModelData:** missing file, invalid JSON, or a payload with no `models` array → `failure("<reason>")`. The `models` array is the only structural requirement; individual malformed model entries are smoltalk's concern at use time, not validated here.
+- **loadModelData schema-version guard:** if a file's `schemaVersion` is present and differs from the version already registered by a prior load, the call returns a `failure` rather than stitching different-shape models together. Same-version accumulation is the normal path; this only trips when two files produced by different smoltalk versions are loaded in one process. (A first load, or a file without `schemaVersion`, is never blocked.)
 
 ## Testing
 
-- **CLI (`lib/cli/hostedModels.test.ts`)** — mock the native: `modelsRefresh` on success writes a single `console.log` whose argument is valid JSON parseable back into an object with a `models` array; on failure writes to `console.error` and sets `process.exitCode = 1` with nothing on `console.log`.
+- **CLI (`lib/cli/hostedModels.test.ts`)** — mock the native:
+  - `modelsRefresh` on success writes a single `console.log` whose argument is valid JSON parseable back into an object with a `models` array — **and writes nothing to `console.error`** (a script parsing stdout must not get stderr contamination on the happy path).
+  - on failure writes to `console.error`, sets `process.exitCode = 1`, and writes nothing to `console.log`.
 - **`_loadModelData` (`lib/stdlib/llm.test.ts`)** — using temp fixture files (or a mocked `fs` + real smoltalk merge):
-  - loading file A then file B → `getAllModels()` (or `_listHostedModels`) contains models from both; on a name collision, B's version wins (accumulate + overlay-wins).
-  - returns `{ ok: true, count }` equal to the file's `models` length.
+  - loading file A then file B → `getAllModels()` (or `_listHostedModels`) contains models from both; on a `provider:modelName` collision, B's version wins and B's fields deep-merge over A's (accumulate + overlay-wins).
+  - **`hostedTools` accumulation:** file A carries `hostedTools`, file B carries only `models` → after both loads, A's hosted tools survive and B's models are present (the models-only overlay doesn't wipe prior hosted tools); and two files each carrying a hosted tool → both present.
+  - returns `{ ok: true, count }` equal to **the file's** `models` length (not the running total).
   - missing file / invalid JSON / no `models` array → `{ ok: false, error }` (non-empty message), and the registered data is unchanged.
+  - schema-version mismatch: load a v1 file, then a v2 file → second call returns `{ ok: false }` and leaves the v1 registration intact.
 - **Agency (`tests/` under stdlib or agency-agent)** — `loadModelData(fixture)` returns `success(n)`, and a subsequent `listHostedModels()` includes the fixture's model; `loadModelData("nope.json")` returns a `failure`.
 
 ## Migration notes
@@ -185,3 +209,4 @@ After N `loadModelData` calls: **latest-loaded file > earlier-loaded files > smo
 - `_refreshHostedCatalog` is removed; `_fetchModelData` replaces it. Update `lib/cli/hostedModels.test.ts` (the current success/failure refresh tests assert a printed count; they change to assert printed JSON).
 - Remove the "KNOWN LIMITATION — refresh does not persist" note from the Phase-2 plan/code; this design resolves it by making persistence explicit.
 - The `std::llm` stdlib docs regenerate (`make`) to include `loadModelData`.
+- **CLI docs:** the `agency models` command currently has **no** doc page (only `docs/site/cli/local.md` exists). Add `docs/site/cli/models.md` documenting `models list` (with filters) and the new `models refresh` → stdout + `loadModelData` workflow, including an `agency models refresh > my-models.json` example.

--- a/packages/agency-lang/lib/cli/hostedModels.test.ts
+++ b/packages/agency-lang/lib/cli/hostedModels.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the native shim so modelsRefresh's success/failure branches are
 // exercised without a real network fetch. The pure functions under test
@@ -6,7 +6,7 @@ import { describe, it, expect, vi } from "vitest";
 // the mocked natives, so this mock doesn't affect them.
 vi.mock("../stdlib/llm.js", () => ({
   _listHostedModels: () => [],
-  _refreshHostedCatalog: vi.fn(),
+  _fetchModelData: vi.fn(),
 }));
 
 import {
@@ -14,7 +14,7 @@ import {
   formatHostedCatalog,
   modelsRefresh,
 } from "./hostedModels.js";
-import { _refreshHostedCatalog } from "../stdlib/llm.js";
+import { _fetchModelData } from "../stdlib/llm.js";
 import type { HostedModelInfo } from "../stdlib/llm.js";
 
 const catalog: HostedModelInfo[] = [
@@ -45,21 +45,36 @@ describe("agency models selection", () => {
 });
 
 describe("agency models refresh", () => {
-  it("prints the model count on success", async () => {
-    vi.mocked(_refreshHostedCatalog).mockResolvedValue({ ok: true, count: 42, error: "" });
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    await modelsRefresh();
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("42"));
-    log.mockRestore();
-  });
-  it("reports the error and sets a non-zero exit code on failure", async () => {
-    vi.mocked(_refreshHostedCatalog).mockResolvedValue({ ok: false, count: 0, error: "network down" });
-    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+  beforeEach(() => {
     process.exitCode = 0;
+    vi.mocked(_fetchModelData).mockReset();
+  });
+  // The failure test sets exitCode = 1; clear it so it doesn't fail the run.
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  it("prints the fetched JSON to stdout and nothing to stderr on success", async () => {
+    const blob = { schemaVersion: 1, models: [{ modelName: "x" }] };
+    vi.mocked(_fetchModelData).mockResolvedValue({ ok: true, json: JSON.stringify(blob, null, 2), error: "" });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     await modelsRefresh();
-    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("network down"));
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(log.mock.calls[0][0] as string)).toHaveProperty("models");
+    expect(err).not.toHaveBeenCalled();
+    log.mockRestore();
+    err.mockRestore();
+  });
+  it("reports the error on stderr, exits non-zero, and prints nothing to stdout on failure", async () => {
+    vi.mocked(_fetchModelData).mockResolvedValue({ ok: false, json: "", error: "network down" });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    await modelsRefresh();
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("network down"));
     expect(process.exitCode).toBe(1);
-    process.exitCode = 0; // reset so a real later failure isn't masked
-    errorLog.mockRestore();
+    expect(log).not.toHaveBeenCalled();
+    log.mockRestore();
+    err.mockRestore();
   });
 });

--- a/packages/agency-lang/lib/cli/hostedModels.test.ts
+++ b/packages/agency-lang/lib/cli/hostedModels.test.ts
@@ -7,14 +7,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 vi.mock("../stdlib/llm.js", () => ({
   _listHostedModels: () => [],
   _fetchModelData: vi.fn(),
+  _loadModelData: vi.fn(),
 }));
 
 import {
   selectHostedModels,
   formatHostedCatalog,
   modelsRefresh,
+  modelsList,
 } from "./hostedModels.js";
-import { _fetchModelData } from "../stdlib/llm.js";
+import { _fetchModelData, _loadModelData } from "../stdlib/llm.js";
 import type { HostedModelInfo } from "../stdlib/llm.js";
 
 const catalog: HostedModelInfo[] = [
@@ -41,6 +43,45 @@ describe("agency models selection", () => {
     expect(out).toContain("yes"); // open-weights shown as a column
     expect(out).toContain("0.1");
     expect(out).toContain("32000");
+  });
+});
+
+describe("agency models list with files", () => {
+  beforeEach(() => {
+    process.exitCode = 0;
+    vi.mocked(_loadModelData).mockReset();
+    vi.mocked(_loadModelData).mockReturnValue({ ok: true, count: 1, error: "" });
+  });
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  it("loads each positional file (in order) before listing", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await modelsList({}, ["a.json", "b.json"]);
+    expect(vi.mocked(_loadModelData).mock.calls.map((c) => c[0])).toEqual(["a.json", "b.json"]);
+    expect(log).toHaveBeenCalled(); // the table is printed after loading
+    log.mockRestore();
+  });
+
+  it("errors and exits non-zero WITHOUT listing if a file fails to load", async () => {
+    vi.mocked(_loadModelData).mockReturnValue({ ok: false, count: 0, error: "bad file" });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    await modelsList({}, ["nope.json"]);
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("bad file"));
+    expect(process.exitCode).toBe(1);
+    expect(log).not.toHaveBeenCalled();
+    log.mockRestore();
+    err.mockRestore();
+  });
+
+  it("lists normally when no files are passed", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await modelsList({});
+    expect(_loadModelData).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
   });
 });
 

--- a/packages/agency-lang/lib/cli/hostedModels.ts
+++ b/packages/agency-lang/lib/cli/hostedModels.ts
@@ -1,6 +1,7 @@
 import {
   _listHostedModels,
   _fetchModelData,
+  _loadModelData,
   type HostedModelInfo,
 } from "../stdlib/llm.js";
 
@@ -50,7 +51,20 @@ export function formatHostedCatalog(models: HostedModelInfo[]): string {
   return [header, ...rows].join("\n");
 }
 
-export async function modelsList(opts: ModelsListOpts): Promise<void> {
+// Optional `files` are model-data JSON files (as printed by `agency models
+// refresh`) to load into this process before listing, so the table previews
+// the baked catalog merged with those files (later files win, like
+// std::llm.loadModelData). A load failure aborts before printing so the user
+// doesn't mistake a baked-only list for the merged one.
+export async function modelsList(opts: ModelsListOpts, files: string[] = []): Promise<void> {
+  for (const file of files) {
+    const res = _loadModelData(file);
+    if (!res.ok) {
+      console.error(`Cannot load ${file}: ${res.error}`);
+      process.exitCode = 1;
+      return;
+    }
+  }
   console.log(formatHostedCatalog(selectHostedModels(_listHostedModels(), opts)));
 }
 

--- a/packages/agency-lang/lib/cli/hostedModels.ts
+++ b/packages/agency-lang/lib/cli/hostedModels.ts
@@ -1,6 +1,6 @@
 import {
   _listHostedModels,
-  _refreshHostedCatalog,
+  _fetchModelData,
   type HostedModelInfo,
 } from "../stdlib/llm.js";
 
@@ -55,9 +55,9 @@ export async function modelsList(opts: ModelsListOpts): Promise<void> {
 }
 
 export async function modelsRefresh(url?: string): Promise<void> {
-  const res = await _refreshHostedCatalog(url ?? "");
+  const res = await _fetchModelData(url ?? "");
   if (res.ok) {
-    console.log(`Refreshed hosted model catalog (${res.count} models).`);
+    console.log(res.json); // stdout only — clean JSON for redirection
   } else {
     console.error(`Refresh failed: ${res.error}`);
     process.exitCode = 1;

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -110,18 +110,17 @@ export function _hostedModelInfo(name: string): HostedModelInfo | null {
   return model && model.type === "text" ? toHostedInfo(model) : null;
 }
 
-/** Fetch a fresh model-data blob and register it into smoltalk's in-memory
- *  catalog for this process. Returns a plain status (no smoltalk types leak
- *  out). NOTE: registration is process-local — it does not persist to disk. */
-export async function _refreshHostedCatalog(
+/** Fetch the latest model-data blob and return it pre-serialized. No
+ *  registration — the CLI prints this to stdout for the user to save and later
+ *  load with `std::llm.loadModelData`. */
+export async function _fetchModelData(
   url: string,
-): Promise<{ ok: boolean; count: number; error: string }> {
+): Promise<{ ok: boolean; json: string; error: string }> {
   const res = await refreshModels(url ? { url } : {});
   if (res.success) {
-    registerModelData(res.value);
-    return { ok: true, count: res.value.models.length, error: "" };
+    return { ok: true, json: JSON.stringify(res.value, null, 2), error: "" };
   }
-  return { ok: false, count: 0, error: res.error };
+  return { ok: false, json: "", error: res.error };
 }
 
 /** Read a model-data JSON file (the shape `agency models refresh` prints) and

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import type { RetryConfig } from "../runtime/llmRetry.js";
 import { loadProviderModuleByPath } from "../runtime/providerModules.js";
@@ -6,6 +7,9 @@ import {
   getModel,
   refreshModels,
   registerModelData,
+  getRegisteredModelData,
+  mergeModelData,
+  mergeHostedTools,
 } from "smoltalk";
 
 /**
@@ -118,4 +122,56 @@ export async function _refreshHostedCatalog(
     return { ok: true, count: res.value.models.length, error: "" };
   }
   return { ok: false, count: 0, error: res.error };
+}
+
+/** Read a model-data JSON file (the shape `agency models refresh` prints) and
+ *  register it, ACCUMULATING over any previously registered data (this file
+ *  wins on provider+name collisions, deep-merging fields) and over the baked
+ *  catalog. Errors are returned, never thrown, so the Agency wrapper can map
+ *  them to a Result. Returns the number of models in THIS file. */
+export function _loadModelData(
+  path: string,
+): { ok: boolean; count: number; error: string } {
+  let text: string;
+  try {
+    text = fs.readFileSync(path, "utf-8");
+  } catch (err) {
+    return { ok: false, count: 0, error: `cannot read ${path}: ${(err as Error).message}` };
+  }
+  let blob: any;
+  try {
+    blob = JSON.parse(text);
+  } catch (err) {
+    return { ok: false, count: 0, error: `${path} is not valid JSON: ${(err as Error).message}` };
+  }
+  if (!blob || !Array.isArray(blob.models)) {
+    return { ok: false, count: 0, error: `${path} is not model data (missing "models" array)` };
+  }
+  const prior = getRegisteredModelData();
+  // Refuse to stitch models of a different schema version onto the prior blob —
+  // a cross-version merge could mix incompatible field shapes. Fail loudly.
+  if (prior && blob.schemaVersion != null && prior.schemaVersion != null && blob.schemaVersion !== prior.schemaVersion) {
+    return {
+      ok: false,
+      count: 0,
+      error: `${path} has schemaVersion ${blob.schemaVersion} but ${prior.schemaVersion} is already loaded; re-run "agency models refresh" to regenerate the file at the current schema version`,
+    };
+  }
+  const merged = prior
+    ? {
+        schemaVersion: blob.schemaVersion ?? prior.schemaVersion,
+        generatedAt: blob.generatedAt ?? prior.generatedAt,
+        // Overlay (this file) wins on provider:modelName and deep-merges, so a
+        // partial hand-edited entry augments the prior one.
+        models: mergeModelData(prior.models, blob.models),
+        // `?? []` on the overlay means "no new tools" (base preserved), NOT
+        // "clear" — mergeHostedTools merges overlay into base, so prior tools
+        // survive a models-only file. Do not change to pass undefined.
+        hostedTools: mergeHostedTools(prior.hostedTools ?? [], blob.hostedTools ?? []),
+      }
+    : blob;
+  // registerModelData REPLACES smoltalk's single registered slot, so `merged`
+  // must carry everything (hence the pre-merge). No double-apply.
+  registerModelData(merged);
+  return { ok: true, count: blob.models.length, error: "" };
 }

--- a/packages/agency-lang/lib/stdlib/modelData.load.test.ts
+++ b/packages/agency-lang/lib/stdlib/modelData.load.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearModelData, getModel, getRegisteredModelData } from "smoltalk";
+import { _loadModelData } from "./llm.js";
+
+function tmpFile(name: string, contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-models-"));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, contents);
+  return p;
+}
+
+const A = JSON.stringify({
+  schemaVersion: 1,
+  generatedAt: "t",
+  models: [
+    { type: "text", modelName: "custom-a", provider: "acme", inputTokenCost: 1, outputTokenCost: 2, maxInputTokens: 1000, family: "a" },
+    { type: "text", modelName: "shared", provider: "acme", inputTokenCost: 5, outputTokenCost: 5, maxInputTokens: 2000, family: "a" },
+  ],
+  hostedTools: [{ name: "tool-a" }],
+});
+// B adds custom-b, and overrides acme:shared's input price to 9. Models-only (no hostedTools).
+const B = JSON.stringify({
+  schemaVersion: 1,
+  generatedAt: "t",
+  models: [
+    { type: "text", modelName: "custom-b", provider: "acme", inputTokenCost: 2, outputTokenCost: 3, maxInputTokens: 3000, family: "b" },
+    { type: "text", modelName: "shared", provider: "acme", inputTokenCost: 9, outputTokenCost: 5, maxInputTokens: 2000, family: "a" },
+  ],
+});
+
+describe("_loadModelData", () => {
+  beforeEach(() => clearModelData());
+
+  it("registers a file's models (visible via getModel) and returns its count", () => {
+    const res = _loadModelData(tmpFile("a.json", A));
+    expect(res).toEqual({ ok: true, count: 2, error: "" });
+    expect(getModel("custom-a" as any)?.provider).toBe("acme");
+  });
+
+  it("accumulates: later load layers over earlier, overlay wins on collision", () => {
+    _loadModelData(tmpFile("a.json", A));
+    const res = _loadModelData(tmpFile("b.json", B));
+    expect(res.ok).toBe(true);
+    expect(getModel("custom-a" as any)).toBeDefined();
+    expect(getModel("custom-b" as any)).toBeDefined();
+    expect((getModel("shared" as any) as any)?.inputTokenCost).toBe(9); // B wins
+  });
+
+  it("preserves prior hostedTools when a later file omits them", () => {
+    _loadModelData(tmpFile("a.json", A)); // has hostedTools
+    _loadModelData(tmpFile("b.json", B)); // models-only
+    expect((getRegisteredModelData()?.hostedTools ?? []).some((t: any) => t.name === "tool-a")).toBe(true);
+  });
+
+  it("returns count = this file's models, not the running total", () => {
+    _loadModelData(tmpFile("a.json", A));            // 2
+    expect(_loadModelData(tmpFile("b.json", B)).count).toBe(2); // this file's 2, not 4
+  });
+
+  it("fails on missing file / invalid JSON / no models array, leaving prior registration intact", () => {
+    _loadModelData(tmpFile("a.json", A));
+    expect(_loadModelData("/no/such/file.json").ok).toBe(false);
+    expect(_loadModelData(tmpFile("bad.json", "{not json")).ok).toBe(false);
+    expect(_loadModelData(tmpFile("nomodels.json", "{}")).ok).toBe(false);
+    expect(getModel("custom-a" as any)).toBeDefined();
+  });
+
+  it("fails on schemaVersion mismatch after a prior load", () => {
+    _loadModelData(tmpFile("v1.json", A)); // schemaVersion 1
+    const v2 = JSON.stringify({
+      schemaVersion: 2,
+      models: [{ type: "text", modelName: "z", provider: "acme", inputTokenCost: 0, outputTokenCost: 0, maxInputTokens: 1 }],
+    });
+    const res = _loadModelData(tmpFile("v2.json", v2));
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("schemaVersion");
+    expect(getModel("custom-a" as any)).toBeDefined(); // v1 intact
+  });
+});

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -890,10 +890,11 @@ export function createProgram(deps: CliDependencies = {}): Command {
 
   const modelsCmd = program.command("models").description("Browse the hosted model catalog");
   modelsCmd.command("list").description("List hosted models (filterable)")
+    .argument("[files...]", "Model-data JSON files to also load and include (as printed by `agency models refresh`)")
     .option("--provider <name>", "Only this provider")
     .option("--max-price <usd>", "Max input $/1M tokens", parseFloat)
     .option("--min-context <tokens>", "Min context window", parseInt)
-    .action((opts: { provider?: string; maxPrice?: number; minContext?: number }) => modelsList(opts));
+    .action((files: string[], opts: { provider?: string; maxPrice?: number; minContext?: number }) => modelsList(opts, files));
   modelsCmd.command("refresh").description("Fetch the latest model data and print it as JSON (redirect to a file, then load with std::llm.loadModelData)")
     .argument("[url]", "Optional URL to fetch model data from (defaults to the built-in source)").action((url?: string) => modelsRefresh(url));
 

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -894,8 +894,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option("--max-price <usd>", "Max input $/1M tokens", parseFloat)
     .option("--min-context <tokens>", "Min context window", parseInt)
     .action((opts: { provider?: string; maxPrice?: number; minContext?: number }) => modelsList(opts));
-  modelsCmd.command("refresh").description("Refresh the hosted model catalog from the remote source")
-    .argument("[url]", "Override the catalog URL").action((url?: string) => modelsRefresh(url));
+  modelsCmd.command("refresh").description("Fetch the latest model data and print it as JSON (redirect to a file, then load with std::llm loadModelData)")
+    .argument("[url]", "Optional URL to fetch model data from (defaults to the built-in source)").action((url?: string) => modelsRefresh(url));
 
   program
     .command("agent")

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -894,7 +894,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option("--max-price <usd>", "Max input $/1M tokens", parseFloat)
     .option("--min-context <tokens>", "Min context window", parseInt)
     .action((opts: { provider?: string; maxPrice?: number; minContext?: number }) => modelsList(opts));
-  modelsCmd.command("refresh").description("Fetch the latest model data and print it as JSON (redirect to a file, then load with std::llm loadModelData)")
+  modelsCmd.command("refresh").description("Fetch the latest model data and print it as JSON (redirect to a file, then load with std::llm.loadModelData)")
     .argument("[url]", "Optional URL to fetch model data from (defaults to the built-in source)").action((url?: string) => modelsRefresh(url));
 
   program

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -150,21 +150,22 @@ export def hostedModelInfo(name: string): HostedModelInfo | null {
   return _hostedModelInfo(name)
 }
 
+// Accumulation details (kept out of the docstring, which is also the LLM tool
+// description): when called more than once, the newly loaded file wins over
+// previously loaded files and over the built-in catalog on provider+name
+// collisions, deep-merging fields so a partial entry augments an existing one
+// instead of replacing it; `hostedTools` are merged too. The returned count is
+// the number of models in this file, not the running total registered. `path`
+// is resolved relative to the working directory, or used as-is if absolute.
 export def loadModelData(path: string): Result<number, string> {
   """
-  Load additional model data from a JSON file (the shape printed by
-  `agency models refresh`) and register it for this program. Both the file's
-  `models` and its optional `hostedTools` are layered over any previously
-  loaded data and over the built-in catalog, with this file winning on
-  provider+name collisions; unlisted fields on an existing entry are preserved.
-  Affects llm() model resolution and cost accounting as well as
-  listHostedModels() / hostedModelInfo().
+  Load model data from a JSON file (the shape `agency models refresh` prints)
+  and register it for this program, so `llm()` and the model catalog
+  (`listHostedModels` / `hostedModelInfo`) recognize those models. Multiple
+  loads accumulate. Returns the number of models loaded, or a failure if the
+  file cannot be read.
 
-  Returns the number of models in THIS file (not the running total registered),
-  or a failure describing why the file could not be loaded.
-
-  @param path - Path to a model-data JSON file (relative to the working
-    directory, or absolute)
+  @param path - Path to a model-data JSON file
   """
   const res = _loadModelData(path)
   if (res.ok) {

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -3,6 +3,7 @@ import {
   _registerProviderModule,
   _listHostedModels,
   _hostedModelInfo,
+  _loadModelData,
 } from "agency-lang/stdlib-lib/llm.js"
 import { env } from "std::system"
 
@@ -147,4 +148,27 @@ export def hostedModelInfo(name: string): HostedModelInfo | null {
   @param name - The hosted model name (e.g. "gpt-4o-mini")
   """
   return _hostedModelInfo(name)
+}
+
+export def loadModelData(path: string): Result<number, string> {
+  """
+  Load additional model data from a JSON file (the shape printed by
+  `agency models refresh`) and register it for this program. Both the file's
+  `models` and its optional `hostedTools` are layered over any previously
+  loaded data and over the built-in catalog, with this file winning on
+  provider+name collisions; unlisted fields on an existing entry are preserved.
+  Affects llm() model resolution and cost accounting as well as
+  listHostedModels() / hostedModelInfo().
+
+  Returns the number of models in THIS file (not the running total registered),
+  or a failure describing why the file could not be loaded.
+
+  @param path - Path to a model-data JSON file (relative to the working
+    directory, or absolute)
+  """
+  const res = _loadModelData(path)
+  if (res.ok) {
+    return success(res.count)
+  }
+  return failure(res.error)
 }

--- a/packages/agency-lang/tests/agency-js/llm-load-model-data/agent.agency
+++ b/packages/agency-lang/tests/agency-js/llm-load-model-data/agent.agency
@@ -1,0 +1,43 @@
+import { loadModelData, hostedModelInfo } from "std::llm"
+import { env } from "std::system"
+
+// test.js writes two model-data files to temp paths and passes them via
+// MODELS_FIXTURE_A / MODELS_FIXTURE_B. Asserts: each load succeeds with a
+// count, BOTH custom models are visible after loading both (accumulation
+// survives the Agency layer), and a bad path fails.
+node main(): any {
+  let countA = -1
+  const pa = env("MODELS_FIXTURE_A")
+  if (pa != null) {
+    const ra = loadModelData(pa)
+    if (ra is success(n)) {
+      countA = n
+    }
+  }
+  let countB = -1
+  const pb = env("MODELS_FIXTURE_B")
+  if (pb != null) {
+    const rb = loadModelData(pb)
+    if (rb is success(n)) {
+      countB = n
+    }
+  }
+  let seenA = "no"
+  const ia = hostedModelInfo("custom-load-a")
+  if (ia != null) {
+    seenA = ia.provider
+  }
+  let seenB = "no"
+  const ib = hostedModelInfo("custom-load-b")
+  if (ib != null) {
+    seenB = ib.provider
+  }
+  const bad = loadModelData("/no/such/models-file.json")
+  return {
+    countA: countA,
+    countB: countB,
+    seenA: seenA,
+    seenB: seenB,
+    badFailed: isFailure(bad)
+  }
+}

--- a/packages/agency-lang/tests/agency-js/llm-load-model-data/fixture.json
+++ b/packages/agency-lang/tests/agency-js/llm-load-model-data/fixture.json
@@ -1,0 +1,7 @@
+{
+  "countA": 1,
+  "countB": 1,
+  "seenA": "acme",
+  "seenB": "acme",
+  "badFailed": true
+}

--- a/packages/agency-lang/tests/agency-js/llm-load-model-data/test.js
+++ b/packages/agency-lang/tests/agency-js/llm-load-model-data/test.js
@@ -1,0 +1,30 @@
+import { main } from "./agent.js";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Write each model-data file to a temp path (not the test dir) and hand the
+// absolute path to the agency program via env — no cwd assumptions.
+function writeModelFile(suffix, modelName) {
+  const p = join(tmpdir(), `agency-models-load-${process.pid}-${suffix}.json`);
+  writeFileSync(
+    p,
+    JSON.stringify({
+      schemaVersion: 1,
+      generatedAt: "test",
+      models: [
+        { type: "text", modelName, provider: "acme", inputTokenCost: 1, outputTokenCost: 2, maxInputTokens: 4096, family: "acme" },
+      ],
+      hostedTools: [],
+    }),
+  );
+  return p;
+}
+process.env.MODELS_FIXTURE_A = writeModelFile("a", "custom-load-a");
+process.env.MODELS_FIXTURE_B = writeModelFile("b", "custom-load-b");
+
+const result = await main({});
+writeFileSync(
+  new URL("./__result.json", import.meta.url),
+  JSON.stringify(result.data, null, 2),
+);


### PR DESCRIPTION
## Model Data: refresh-to-stdout + opt-in `loadModelData`

Retires the Phase-2 (#379) `agency models refresh` no-op (it registered into smoltalk's in-memory catalog, which evaporates when the CLI process exits) and replaces it with an explicit, opt-in refresh→save→load flow. No fixed location, no bootstrap auto-load — programs that never touch model metadata pay nothing.

Design spec + implementation plan are included in the first commits (`docs/superpowers/specs` + `docs/superpowers/plans`), both reviewed.

### What's included
- **`agency models refresh [url]`** → pure fetch-and-print. Writes smoltalk's `ModelDataBlob` JSON to **stdout** (errors to stderr + exit 1). Redirect it wherever you want:
  ```
  agency models refresh > my-models.json
  ```
- **`std::llm.loadModelData(path): Result<number, string>`** → opt-in loader. Reads the file, **accumulates** over previously-registered data (latest load wins on `provider:modelName`, deep-merge) and over the baked catalog via smoltalk's `mergeModelData`/`mergeHostedTools`, then `registerModelData`. Reaches everything downstream of `getAllModels`/`getModel`: `llm()` model resolution + cost accounting, and `listHostedModels`/`hostedModelInfo`. Returns this file's model count, or `failure(reason)`.
- **Schema-version guard:** loading a file whose `schemaVersion` differs from what's already registered fails loudly instead of stitching different-shape models together.
- **CLI docs:** new `docs/site/cli/models.md` (the `models` command shipped without docs), registered in the VitePress sidebar.

### Native design
`_fetchModelData` (fetch → serialized blob, no side effects) replaces `_refreshHostedCatalog`. `_loadModelData` returns a plain status object; the Agency wrapper maps it to a `Result` (mirrors `pickProvider`). smoltalk types never leak into Agency callers.

### Testing
- `_loadModelData` unit tests (`lib/stdlib/modelData.load.test.ts`, real smoltalk + `clearModelData` isolation): field mapping, accumulate + overlay-wins, `hostedTools` preservation across a models-only load, count = this-file-not-total, error paths, schema-version mismatch.
- CLI (`lib/cli/hostedModels.test.ts`): refresh prints valid JSON to stdout with **nothing on stderr** on success; error + exit-1 + no stdout on failure (`beforeEach`/`afterEach` reset `process.exitCode`).
- Agency-js (`tests/agency-js/llm-load-model-data`): loads **two** files and confirms both custom models are visible (accumulation through the Agency layer) and a bad path fails.
- Full suite green locally: **vitest 6798 passed**, `tsc` 0 errors, structural linter clean, agency-js test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
