### PR TITLE
feat: multimodal image/file attachments for llm() and userMessage()

### DIFF
--- a/packages/agency-lang/docs/site/guide/llm.md
+++ b/packages/agency-lang/docs/site/guide/llm.md
@@ -52,7 +52,8 @@ Both builders take optional arguments:
 - `mimeType` — set an explicit MIME type (overrides inference).
 - `base64: true` — treat `source` as raw base64 data. A `mimeType` is then
   required, e.g. `image(data, mimeType: "image/png", base64: true)`. This is
-  handy with `readImage()`, which returns raw base64.
+  handy when you already hold base64 in memory — for example the base64 string
+  inside the `Result` that `readImage()` returns.
 - `file(source, filename)` — the filename shown to the model; it defaults to the
   source's basename.
 

--- a/packages/agency-lang/docs/site/guide/llm.md
+++ b/packages/agency-lang/docs/site/guide/llm.md
@@ -22,6 +22,49 @@ const response: Response = llm("What is the capital of France?")
 print(response)
 ```
 
+## Attachments (images & files)
+
+`llm()`'s first argument can also be an **array** that mixes text with image and
+file attachments. Bare strings in the array are text; use the `image()` and
+`file()` builders from `std::thread` for attachments:
+
+```ts
+import { image, file } from "std::thread"
+
+node main() {
+  const answer = llm([
+    "What's in this image, and how does it relate to the report?",
+    image("./diagram.png"),               // local path
+    image("https://example.com/a.jpg"),   // remote URL (auto-detected)
+    file("./report.pdf"),                 // local PDF / file
+  ])
+  print(answer)
+}
+```
+
+`image(source)` and `file(source)` accept a local path, an `http(s)` URL, or a
+`data:` URI, and figure out which it is. Smoltalk reads the file, fetches the
+URL, infers the MIME type, and enforces size limits when the call is sent — you
+don't do any file I/O yourself.
+
+Both builders take optional arguments:
+
+- `mimeType` — set an explicit MIME type (overrides inference).
+- `base64: true` — treat `source` as raw base64 data. A `mimeType` is then
+  required, e.g. `image(data, mimeType: "image/png", base64: true)`. This is
+  handy with `readImage()`, which returns raw base64.
+- `file(source, filename)` — the filename shown to the model; it defaults to the
+  source's basename.
+
+The same array form works with `userMessage()` from `std::thread`, so you can
+seed a multimodal user turn into the conversation history:
+
+```ts
+import { userMessage, image } from "std::thread"
+
+userMessage(["Here's the screenshot I mentioned", image("./screenshot.png")])
+```
+
 ### Limitation: structured output inside block bodies
 
 Any `return llm(...)` inside a block body — anywhere in the block,

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -17,7 +17,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L27))
 
 ### Attachment
 
@@ -28,7 +28,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L32))
 
 ### ModelCost
 
@@ -41,7 +41,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L135))
 
 ### GuardFailureData
 
@@ -55,7 +55,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L158))
 
 ## Functions
 
@@ -77,12 +77,12 @@ Add a system message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L36))
 
 ### userMessage
 
 ```ts
-userMessage(msg: string | string | Attachment[])
+userMessage(msg: string | (string | Attachment)[])
 ```
 
 Add a user message to the current thread's message history. Accepts a
@@ -96,9 +96,9 @@ Add a user message to the current thread's message history. Accepts a
 
 | Name | Type | Default |
 |---|---|---|
-| msg | `string \| string \| Attachment[]` |  |
+| msg | `string \| (string \| Attachment)[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L47))
 
 ### image
 
@@ -125,7 +125,7 @@ Build an image attachment for a multimodal llm() call or userMessage().
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L59))
 
 ### file
 
@@ -154,7 +154,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call or
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L77))
 
 ### assistantMessage
 
@@ -174,7 +174,7 @@ Add an assistant message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L97))
 
 ### getCost
 
@@ -198,7 +198,7 @@ Get the cumulative cost (USD, floating point) of all LLM calls
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L108))
 
 ### getTokens
 
@@ -211,7 +211,7 @@ Get the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L127))
 
 ### getModelCosts
 
@@ -232,7 +232,7 @@ Get a per-model breakdown of cumulative LLM usage, one entry per
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L140))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L142))
 
 ### guard
 
@@ -306,4 +306,4 @@ Run a block under a cost limit, a time limit, or both. The block
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L168))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L170))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -6,6 +6,30 @@ name: "thread"
 
 ## Types
 
+### AttachmentSource
+
+```ts
+export type AttachmentSource =
+  | { kind: "path"; path: string; mimeType: string
+  | null }
+  | { kind: "url"; url: string; mimeType: string
+  | null }
+  | { kind: "base64"; base64: string; mimeType: string }
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L25))
+
+### Attachment
+
+```ts
+export type Attachment =
+  | { type: "image"; source: AttachmentSource }
+  | { type: "file"; source: AttachmentSource; filename: string
+  | null }
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L30))
+
 ### ModelCost
 
 ```ts
@@ -17,7 +41,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L133))
 
 ### GuardFailureData
 
@@ -31,7 +55,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
 
 ## Functions
 
@@ -53,27 +77,84 @@ Add a system message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L19))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L34))
 
 ### userMessage
 
 ```ts
-userMessage(msg: string)
+userMessage(msg: string | string | Attachment[])
 ```
 
-Add a user message to the current thread's message history.
-  Use this when you want to seed the conversation with prior user
-  context that wasn't actually typed by the user this turn.
+Add a user message to the current thread's message history. Accepts a
+  plain string, or an array mixing text strings and image()/file()
+  attachments. Use this when you want to seed the conversation with prior
+  user context that wasn't actually typed by the user this turn.
 
-  @param msg - The user message content
+  @param msg - The user message content: a string, or an array of strings and attachments.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| msg | `string` |  |
+| msg | `string \| string \| Attachment[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L45))
+
+### image
+
+```ts
+image(source: string, mimeType: string, base64: boolean): Attachment
+```
+
+Build an image attachment for a multimodal llm() call or userMessage().
+  `source` is a local path, an http(s) URL, or a data: URI. Pass base64: true
+  to treat `source` as raw base64 data (a mimeType is then required).
+  smoltalk reads/fetches and MIME-infers the source at send time.
+
+  @param source - Path, http(s) URL, data: URI, or raw base64 (with base64: true)
+  @param mimeType - Explicit MIME type; overrides inference. Required for raw base64.
+  @param base64 - When true, treat `source` as raw base64 data.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+| mimeType | `string` | "" |
+| base64 | `boolean` | false |
+
+**Returns:** [Attachment](#attachment)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L57))
+
+### file
+
+```ts
+file(source: string, filename: string, mimeType: string, base64: boolean): Attachment
+```
+
+Build a file (e.g. PDF) attachment for a multimodal llm() call or
+  userMessage(). `source` is a local path, an http(s) URL, or a data: URI.
+  Pass base64: true to treat `source` as raw base64 data (mimeType required).
+  `filename` defaults to the source's basename.
+
+  @param source - Path, http(s) URL, data: URI, or raw base64 (with base64: true)
+  @param filename - Name shown to the model; defaults to the source basename.
+  @param mimeType - Explicit MIME type; overrides inference. Required for raw base64.
+  @param base64 - When true, treat `source` as raw base64 data.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+| filename | `string` | "" |
+| mimeType | `string` | "" |
+| base64 | `boolean` | false |
+
+**Returns:** [Attachment](#attachment)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
 
 ### assistantMessage
 
@@ -93,7 +174,7 @@ Add an assistant message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L95))
 
 ### getCost
 
@@ -117,7 +198,7 @@ Get the cumulative cost (USD, floating point) of all LLM calls
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L106))
 
 ### getTokens
 
@@ -130,7 +211,7 @@ Get the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L71))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L125))
 
 ### getModelCosts
 
@@ -151,7 +232,7 @@ Get a per-model breakdown of cumulative LLM usage, one entry per
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L140))
 
 ### guard
 
@@ -225,4 +306,4 @@ Run a block under a cost limit, a time limit, or both. The block
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L114))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L168))

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-01-multimodal-llm-attachments.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-01-multimodal-llm-attachments.md
@@ -1,0 +1,919 @@
+# Multimodal LLM Attachments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (the user's standing preference is to do implementation directly in the main session, not via dispatched subagents). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Agency's `llm()` and `std::thread.userMessage()` accept image/file attachments alongside text, via two smart builders (`image`, `file`), backed by smoltalk 0.7.1's multimodal user-message content — with statelog kept attachment-safe.
+
+**Architecture:** Two Agency `def`s in `std::thread` wrap `_`-prefixed TS helpers that classify a source string (path / URL / `data:` URI / raw base64) into a plain attachment object matching smoltalk's `UserContentPart`. Those objects flow — unchanged — through the existing `llm()` codegen and the single `smoltalk.userMessage(prompt)` runtime push site (smoltalk does all file I/O). The `llm()` first-param type is tightened from `any` to `string | (string | Attachment)[]`, the runtime is audited for string-only `prompt` consumers, and every statelog site that carries messages/prompt is wrapped in smoltalk's `redactAttachments`.
+
+**Tech Stack:** TypeScript (runtime + typechecker + codegen), Agency stdlib (`.agency`), smoltalk `0.7.1`, vitest, the agency-js fixture-diff test harness.
+
+**Spec:** `docs/superpowers/specs/2026-07-01-multimodal-llm-attachments-design.md`
+
+## Global Constraints
+
+- **smoltalk `>= 0.7.1`** — already installed. `redactAttachments` and `UserContentInput` are imported from the top-level `"smoltalk"` package (both are re-exported there).
+- **Run `make`** after editing any `stdlib/*.agency` file (rebuilds stdlib artifacts the compiler/typechecker read). Do NOT rely on `pnpm run build` for stdlib.
+- **TS unit tests:** `pnpm test:run <path>`. **Agency-js tests:** `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js <dir>`; **save the output to a file** (agency tests are slow/expensive to rerun). Do NOT run the full agency suite locally — CI runs it.
+- **Coding standards:** no dynamic imports; objects not maps; arrays not sets; `type` not `interface`.
+- **Git:** branch off `main` before the first commit; never force-push or amend. Commit messages / PR bodies go in a file (apostrophes on the CLI break). End commit messages with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- **Agency syntax:** `def name(params): Ret { ... }`, union types with `|`, array types with `T[]`, docstrings in `"""..."""`.
+
+## File Structure
+
+- `lib/stdlib/thread.ts` — **modify.** Add `AttachmentSource` / `ImageAttachment` / `FileAttachment` TS types, `classifySource` (private), and exported `_imageAttachment` / `_fileAttachment`. Widen `_userMessage` param to `smoltalk.UserContentInput`.
+- `lib/stdlib/thread.attachments.test.ts` — **create.** Unit tests for the two helpers.
+- `stdlib/thread.agency` — **modify.** Add `AttachmentSource` / `Attachment` Agency types; add `image` / `file` builder defs (with docstrings); widen `userMessage` param; import the two new TS helpers.
+- `lib/typeChecker/builtins.ts` — **modify.** Add the structural `attachment` mirror; tighten `llm` first param to `string | (string | Attachment)[]`.
+- `lib/typeChecker/attachments.test.ts` — **create.** Accept/reject + inference tests (doubles as the mirror-drift guard).
+- `lib/backends/llmAttachmentCodegen.test.ts` — **create.** Assert `llm([...])` compiles to an array argument.
+- `lib/runtime/prompt.ts` — **modify.** Add `promptText` + `redactMessagesForLog`; widen `prompt: string` types; route the memory-recall call through `promptText`; wrap the three message statelog sites in redaction.
+- `lib/runtime/streaming.ts` — **modify.** Widen `prompt: string`; redact `prompt` in the `debug` statelog call.
+- `lib/runtime/agencyLlm.ts` — **modify.** Widen the TS-facade `llm` prompt param (3 signatures) + JSDoc.
+- `lib/runtime/prompt.attachments.test.ts` — **create.** Unit tests for `promptText` and `redactMessagesForLog`.
+- `tests/agency-js/multimodal-attachments/` — **create.** End-to-end integration fixture (`agent.agency`, `test.js`, `llmMocks.json`, `useTestLLMProvider`, generated `fixture.json`).
+- `docs/site/guide/llm.md` — **modify.** Add a "Attachments (images & files)" section.
+
+---
+
+### Task 1: TS attachment builders (`lib/stdlib/thread.ts`)
+
+Pure, dependency-free classification + construction. This is the foundation; nothing else needs to exist yet.
+
+**Files:**
+- Modify: `lib/stdlib/thread.ts`
+- Test: `lib/stdlib/thread.attachments.test.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `type AttachmentSource = { kind: "path"; path: string; mimeType?: string } | { kind: "url"; url: string; mimeType?: string } | { kind: "base64"; base64: string; mimeType: string }`
+  - `type ImageAttachment = { type: "image"; source: AttachmentSource }`
+  - `type FileAttachment = { type: "file"; source: AttachmentSource; filename?: string }`
+  - `_imageAttachment(source: string, mimeType: string, base64: boolean): ImageAttachment`
+  - `_fileAttachment(source: string, filename: string, mimeType: string, base64: boolean): FileAttachment`
+
+- [ ] **Step 1: Write the failing test** — create `lib/stdlib/thread.attachments.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { _imageAttachment, _fileAttachment } from "./thread.js";
+
+describe("_imageAttachment", () => {
+  it("classifies a plain path", () => {
+    expect(_imageAttachment("./cat.png", "", false)).toEqual({
+      type: "image",
+      source: { kind: "path", path: "./cat.png" },
+    });
+  });
+
+  it("auto-detects an http(s) URL", () => {
+    expect(_imageAttachment("https://x.com/a.jpg", "", false)).toEqual({
+      type: "image",
+      source: { kind: "url", url: "https://x.com/a.jpg" },
+    });
+  });
+
+  it("parses a data: URI into a base64 source (mime from the URI)", () => {
+    expect(_imageAttachment("data:image/png;base64,AAAB", "", false)).toEqual({
+      type: "image",
+      source: { kind: "base64", base64: "AAAB", mimeType: "image/png" },
+    });
+  });
+
+  it("treats a data: URI as base64 even when base64:true is passed", () => {
+    expect(_imageAttachment("data:image/png;base64,AAAB", "", true)).toEqual({
+      type: "image",
+      source: { kind: "base64", base64: "AAAB", mimeType: "image/png" },
+    });
+  });
+
+  it("uses base64:true with an explicit mimeType", () => {
+    expect(_imageAttachment("AAAB", "image/png", true)).toEqual({
+      type: "image",
+      source: { kind: "base64", base64: "AAAB", mimeType: "image/png" },
+    });
+  });
+
+  it("lets mimeType override inference on a path", () => {
+    expect(_imageAttachment("./blob", "image/webp", false)).toEqual({
+      type: "image",
+      source: { kind: "path", path: "./blob", mimeType: "image/webp" },
+    });
+  });
+
+  it("throws on base64 with no mimeType", () => {
+    expect(() => _imageAttachment("AAAB", "", true)).toThrow(/mimeType/i);
+  });
+});
+
+describe("_fileAttachment", () => {
+  it("derives filename from a path basename", () => {
+    expect(_fileAttachment("./docs/report.pdf", "", "", false)).toEqual({
+      type: "file",
+      source: { kind: "path", path: "./docs/report.pdf" },
+      filename: "report.pdf",
+    });
+  });
+
+  it("derives filename from a URL, stripping query/hash", () => {
+    expect(_fileAttachment("https://x.com/a/report.pdf?v=2", "", "", false)).toEqual({
+      type: "file",
+      source: { kind: "url", url: "https://x.com/a/report.pdf?v=2" },
+      filename: "report.pdf",
+    });
+  });
+
+  it("respects an explicit filename", () => {
+    expect(_fileAttachment("./r.pdf", "custom.pdf", "", false)).toEqual({
+      type: "file",
+      source: { kind: "path", path: "./r.pdf" },
+      filename: "custom.pdf",
+    });
+  });
+
+  it("does NOT derive a filename from a base64 source", () => {
+    expect(_fileAttachment("AAAB", "", "application/pdf", true)).toEqual({
+      type: "file",
+      source: { kind: "base64", base64: "AAAB", mimeType: "application/pdf" },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:run lib/stdlib/thread.attachments.test.ts`
+Expected: FAIL — `_imageAttachment` / `_fileAttachment` are not exported.
+
+- [ ] **Step 3: Implement the helpers** — add to `lib/stdlib/thread.ts` (near the message helpers). `classifySource` is module-private; the three `type` aliases are exported:
+
+```ts
+export type AttachmentSource =
+  | { kind: "path"; path: string; mimeType?: string }
+  | { kind: "url"; url: string; mimeType?: string }
+  | { kind: "base64"; base64: string; mimeType: string };
+
+export type ImageAttachment = { type: "image"; source: AttachmentSource };
+export type FileAttachment = {
+  type: "file";
+  source: AttachmentSource;
+  filename?: string;
+};
+
+function classifySource(
+  source: string,
+  mimeType: string,
+  base64: boolean,
+): AttachmentSource {
+  // A data: URI is authoritative regardless of the base64 flag.
+  if (source.startsWith("data:")) {
+    const marker = ";base64,";
+    const idx = source.indexOf(marker);
+    if (idx === -1) {
+      throw new Error(
+        "image()/file(): a data: URI must be base64-encoded (data:<mime>;base64,<data>)",
+      );
+    }
+    const uriMime = source.slice("data:".length, idx);
+    const data = source.slice(idx + marker.length);
+    return { kind: "base64", base64: data, mimeType: mimeType || uriMime };
+  }
+  if (base64) {
+    if (!mimeType) {
+      throw new Error(
+        "image()/file(): base64 sources require an explicit mimeType",
+      );
+    }
+    return { kind: "base64", base64: source, mimeType };
+  }
+  if (source.startsWith("http://") || source.startsWith("https://")) {
+    return mimeType
+      ? { kind: "url", url: source, mimeType }
+      : { kind: "url", url: source };
+  }
+  return mimeType
+    ? { kind: "path", path: source, mimeType }
+    : { kind: "path", path: source };
+}
+
+export function _imageAttachment(
+  source: string,
+  mimeType: string,
+  base64: boolean,
+): ImageAttachment {
+  return { type: "image", source: classifySource(source, mimeType, base64) };
+}
+
+function basename(source: string): string {
+  const clean = source.split(/[?#]/)[0];
+  const segments = clean.split("/");
+  return segments[segments.length - 1] || "";
+}
+
+export function _fileAttachment(
+  source: string,
+  filename: string,
+  mimeType: string,
+  base64: boolean,
+): FileAttachment {
+  const src = classifySource(source, mimeType, base64);
+  let name = filename;
+  if (!name && (src.kind === "path" || src.kind === "url")) {
+    name = basename(source);
+  }
+  return name
+    ? { type: "file", source: src, filename: name }
+    : { type: "file", source: src };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:run lib/stdlib/thread.attachments.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stdlib/thread.ts lib/stdlib/thread.attachments.test.ts
+git commit -F .git/COMMIT_EDITMSG_multimodal_1
+```
+(Write the message to a file first, e.g. `feat(stdlib): attachment source classifiers for multimodal messages`, ending with the Co-Authored-By trailer.)
+
+---
+
+### Task 2: Agency builders, types, and `userMessage` widening (`stdlib/thread.agency`)
+
+Expose the TS helpers as Agency `image`/`file`, declare the Agency `Attachment` types, and widen `userMessage` (plus its `_userMessage` runtime helper) to accept attachments.
+
+**Files:**
+- Modify: `lib/stdlib/thread.ts` (widen `_userMessage`)
+- Modify: `stdlib/thread.agency`
+- Test: covered by Task 7 (integration) + a parse check here.
+
+**Interfaces:**
+- Consumes: `_imageAttachment`, `_fileAttachment` (Task 1).
+- Produces (Agency): `type Attachment`, `type AttachmentSource`, `def image(source, mimeType?, base64?): Attachment`, `def file(source, filename?, mimeType?, base64?): Attachment`, widened `def userMessage(msg: string | (string | Attachment)[])`.
+
+- [ ] **Step 1: Widen `_userMessage` in `lib/stdlib/thread.ts`** — change its signature from `string` to smoltalk's input union (add `UserContentInput` to the existing `import * as smoltalk`):
+
+```ts
+// was: export async function _userMessage(msg: string): Promise<void> {
+export async function _userMessage(
+  msg: smoltalk.UserContentInput,
+): Promise<void> {
+  const threads = getRuntimeContext().threads;
+  threads.getOrCreateActive().push(smoltalk.userMessage(msg));
+}
+```
+
+Also widen `__internal_userMessage` the same way for consistency (the migration-window twin at ~line 48).
+
+- [ ] **Step 2: Add types + builders to `stdlib/thread.agency`** — add the new import symbols and, after the `assistantMessage` def, the types and builders:
+
+Import (extend the existing `from "agency-lang/stdlib-lib/thread.js"` block):
+
+```ts
+import {
+  _systemMessage,
+  _userMessage,
+  _assistantMessage,
+  _imageAttachment,
+  _fileAttachment,
+  _getCost,
+  _getTokens,
+  _getModelCosts,
+  _pushGuard,
+  _popGuard,
+  _runGuarded,
+ } from "agency-lang/stdlib-lib/thread.js"
+```
+
+Types + builders:
+
+```ts
+// KEEP IN SYNC with the structural `attachment` mirror in
+// lib/typeChecker/builtins.ts (the `llm()` first-param type). A drift is
+// caught by lib/typeChecker/attachments.test.ts.
+export type AttachmentSource =
+  | { kind: "path", path: string, mimeType?: string }
+  | { kind: "url", url: string, mimeType?: string }
+  | { kind: "base64", base64: string, mimeType: string }
+
+export type Attachment =
+  | { type: "image", source: AttachmentSource }
+  | { type: "file", source: AttachmentSource, filename?: string }
+
+export safe def image(
+  source: string,
+  mimeType: string = "",
+  base64: boolean = false,
+): Attachment {
+  """
+  Build an image attachment for a multimodal llm() call or userMessage().
+  `source` is a local path, an http(s) URL, or a data: URI. Pass base64: true
+  to treat `source` as raw base64 data (a mimeType is then required).
+  smoltalk reads/fetches and MIME-infers the source at send time.
+
+  @param source - Path, http(s) URL, data: URI, or raw base64 (with base64: true)
+  @param mimeType - Explicit MIME type; overrides inference. Required for raw base64.
+  @param base64 - When true, treat `source` as raw base64 data.
+  """
+  return _imageAttachment(source, mimeType, base64)
+}
+
+export safe def file(
+  source: string,
+  filename: string = "",
+  mimeType: string = "",
+  base64: boolean = false,
+): Attachment {
+  """
+  Build a file (e.g. PDF) attachment for a multimodal llm() call or
+  userMessage(). `source` is a local path, an http(s) URL, or a data: URI.
+  Pass base64: true to treat `source` as raw base64 data (mimeType required).
+  `filename` defaults to the source's basename.
+
+  @param source - Path, http(s) URL, data: URI, or raw base64 (with base64: true)
+  @param filename - Name shown to the model; defaults to the source basename.
+  @param mimeType - Explicit MIME type; overrides inference. Required for raw base64.
+  @param base64 - When true, treat `source` as raw base64 data.
+  """
+  return _fileAttachment(source, filename, mimeType, base64)
+}
+```
+
+- [ ] **Step 3: Widen `userMessage` in `stdlib/thread.agency`**:
+
+```ts
+export def userMessage(msg: string | (string | Attachment)[]) {
+  """
+  Add a user message to the current thread's message history. Accepts a plain
+  string, or an array mixing text strings and image()/file() attachments.
+  Use this when you want to seed the conversation with prior user context that
+  wasn't actually typed by the user this turn.
+
+  @param msg - The user message content: a string, or an array of strings and attachments.
+  """
+  _userMessage(msg)
+}
+```
+
+- [ ] **Step 4: Rebuild stdlib and verify it parses**
+
+Run: `make 2>&1 | tee /private/tmp/claude-501/-Users-adityabhargava-agency-lang-packages-agency-lang/ad319109-1b8d-4e42-8e2a-b10ad1b47931/scratchpad/make-task2.log`
+Then: `pnpm run ast stdlib/thread.agency > /private/tmp/claude-501/-Users-adityabhargava-agency-lang-packages-agency-lang/ad319109-1b8d-4e42-8e2a-b10ad1b47931/scratchpad/thread-ast.json`
+Expected: `make` succeeds; `ast` emits JSON with no parse error.
+
+**If `(string | Attachment)[]` fails to parse** (parenthesized union array), fall back to a named alias declared above the builders and use it in both `userMessage` and (later) the doc:
+
+```ts
+export type AttachmentContent = string | (string | Attachment)[]
+```
+
+If even the alias body fails, use `string | Attachment[]` and document that mixing bare text strings and attachments in one array still works at runtime (smoltalk normalizes bare strings) — but prefer the parenthesized union; confirm which parses before moving on.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stdlib/thread.ts stdlib/thread.agency
+git commit -F <message-file>
+```
+Message: `feat(stdlib): std::thread image()/file() builders + multimodal userMessage`.
+
+---
+
+### Task 3: Tighten `llm()` first param (`lib/typeChecker/builtins.ts`)
+
+Replace the `"any"` prompt param with the structural union, and lock it with accept/reject/inference tests that double as the mirror-drift guard.
+
+**Files:**
+- Modify: `lib/typeChecker/builtins.ts`
+- Test: `lib/typeChecker/attachments.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `image`/`file` from `std::thread` (Task 2), `optional()` + `string` primitives already in `builtins.ts`.
+- Produces: `BUILTIN_FUNCTION_TYPES.llm.params[0]` is now `string | (string | Attachment)[]`.
+
+- [ ] **Step 1: Write the failing tests** — create `lib/typeChecker/attachments.test.ts` (reuse the `errorsFrom` harness from `lib/typeChecker/builtinNamedArgs.test.ts`):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+
+function errorsFrom(source: string): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-attach-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath, {});
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) throw new Error("Parse failed");
+    const info = buildCompilationUnit(parseResult.result, symbolTable, absPath, source);
+    return typeCheck(parseResult.result, {}, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+const IMPORT = `import { image, file } from "std::thread"\n`;
+
+describe("llm() multimodal first-arg typing", () => {
+  it("accepts a plain string", () => {
+    expect(errorsFrom(`node main() { let r: string = llm("hi")\n print(r) }`)).toHaveLength(0);
+  });
+
+  it("accepts a mixed text + attachment array", () => {
+    expect(
+      errorsFrom(`${IMPORT}node main() { let r: string = llm(["hi", image("x"), file("y")])\n print(r) }`),
+    ).toHaveLength(0);
+  });
+
+  it("accepts an array bound to a local first (inference path)", () => {
+    expect(
+      errorsFrom(`${IMPORT}node main() { let arr = ["hi", image("x")]\n let r: string = llm(arr)\n print(r) }`),
+    ).toHaveLength(0);
+  });
+
+  it("rejects a number element in the array", () => {
+    expect(
+      errorsFrom(`node main() { let r: string = llm([42])\n print(r) }`).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("accepts a mixed array on userMessage()", () => {
+    expect(
+      errorsFrom(`import { userMessage, image } from "std::thread"\nnode main() { userMessage(["hi", image("x")]) }`),
+    ).toHaveLength(0);
+  });
+
+  it("rejects a number element on userMessage()", () => {
+    expect(
+      errorsFrom(`import { userMessage } from "std::thread"\nnode main() { userMessage([42]) }`).length,
+    ).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test:run lib/typeChecker/attachments.test.ts`
+Expected: the two "rejects" tests FAIL (param is still `"any"`, so `[42]` is accepted). The "accepts" tests may already pass.
+
+- [ ] **Step 3: Add the structural mirror and tighten the param** — in `lib/typeChecker/builtins.ts`, above `BUILTIN_FUNCTION_TYPES`, after `llmNamedOptions`:
+
+```ts
+// KEEP IN SYNC with the `Attachment` / `AttachmentSource` types in
+// stdlib/thread.agency. This is the structural mirror the `llm()` signature
+// needs (builtin types live in TS, not the .agency universe). Drift is caught
+// by lib/typeChecker/attachments.test.ts.
+const attachmentSource: VariableType = {
+  type: "unionType",
+  types: [
+    { type: "objectType", properties: [
+      { key: "kind", value: { type: "stringLiteralType", value: "path" } },
+      { key: "path", value: string },
+      { key: "mimeType", value: optional(string) },
+    ] },
+    { type: "objectType", properties: [
+      { key: "kind", value: { type: "stringLiteralType", value: "url" } },
+      { key: "url", value: string },
+      { key: "mimeType", value: optional(string) },
+    ] },
+    { type: "objectType", properties: [
+      { key: "kind", value: { type: "stringLiteralType", value: "base64" } },
+      { key: "base64", value: string },
+      { key: "mimeType", value: string },
+    ] },
+  ],
+};
+
+const attachment: VariableType = {
+  type: "unionType",
+  types: [
+    { type: "objectType", properties: [
+      { key: "type", value: { type: "stringLiteralType", value: "image" } },
+      { key: "source", value: attachmentSource },
+    ] },
+    { type: "objectType", properties: [
+      { key: "type", value: { type: "stringLiteralType", value: "file" } },
+      { key: "source", value: attachmentSource },
+      { key: "filename", value: optional(string) },
+    ] },
+  ],
+};
+
+const llmContent: VariableType = {
+  type: "unionType",
+  types: [
+    string,
+    { type: "arrayType", elementType: { type: "unionType", types: [string, attachment] } },
+  ],
+};
+```
+
+Then change the `llm` signature:
+
+```ts
+  llm: {
+    params: [llmContent, llmOptions],   // was: ["any", llmOptions]
+    minParams: 1,
+    returnType: string,
+    acceptsNamedArgs: llmNamedOptions,
+    description:
+      "Send a prompt to an LLM and return its response. The prompt is a string, or an array of text strings and image()/file() attachments. The return type is inferred from the call-site annotation and compiled to a JSON schema for structured output.",
+  },
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm test:run lib/typeChecker/attachments.test.ts`
+Expected: PASS.
+
+**If an "accepts" test fails** (heterogeneous-array inference weaker than assumed), that is the feasibility finding from the spec: loosen `llmContent`'s array arm to `{ type: "arrayType", elementType: ANY_T }` while keeping the `string` arm, so misuse of a *non-array* first arg is still typed but element checking relaxes. Note the outcome in the commit body.
+
+- [ ] **Step 5: Run the existing builtin/typechecker tests for regressions**
+
+Run: `pnpm test:run lib/typeChecker/ 2>&1 | tee /private/tmp/claude-501/-Users-adityabhargava-agency-lang-packages-agency-lang/ad319109-1b8d-4e42-8e2a-b10ad1b47931/scratchpad/tc-suite.log`
+Expected: no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/typeChecker/builtins.ts lib/typeChecker/attachments.test.ts
+git commit -F <message-file>
+```
+Message: `feat(typechecker): type llm()/userMessage() first arg as string | (string | Attachment)[]`.
+
+---
+
+### Task 4: Codegen array-argument test (`lib/backends`)
+
+Confirm (and lock) that `llm([...])` compiles the array through to `runPrompt`'s `prompt` field. Expected: no production change — this is a guard test.
+
+**Files:**
+- Test: `lib/backends/llmAttachmentCodegen.test.ts` (create)
+
+- [ ] **Step 1: Write the test** — mirror the structure of `lib/backends/llmNamedArgsCodegen.test.ts` (open it to copy the exact compile-helper imports). Assert the generated TS contains a `runPrompt` call whose `prompt` is an array literal including an `_imageAttachment`/`image(` call:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { compileAgencyToTs } from "./testHelpers.js"; // use the same helper llmNamedArgsCodegen.test.ts uses
+
+describe("llm() multimodal codegen", () => {
+  it("passes an array first-arg through to runPrompt as an array", () => {
+    const ts = compileAgencyToTs(
+      `import { image } from "std::thread"\n` +
+      `node main() { let r: string = llm(["hi", image("x")])\n print(r) }`,
+    );
+    expect(ts).toContain("runPrompt");
+    // the prompt arg is an array literal, not a bare string
+    expect(ts).toMatch(/prompt:\s*\[/);
+    expect(ts).toContain("image");
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pnpm test:run lib/backends/llmAttachmentCodegen.test.ts`
+Expected: PASS with no `processLlmCall` change. **If it fails**, inspect the emitted TS (log `ts`) and adjust `processLlmCall` only as needed so `arguments[0]`'s array literal reaches `prompt`; add the fix as its own step here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/backends/llmAttachmentCodegen.test.ts
+git commit -F <message-file>
+```
+Message: `test(codegen): lock llm([...]) array-argument compilation`.
+
+---
+
+### Task 5: Runtime `prompt` audit — flatten helper + type widening (`prompt.ts`, `streaming.ts`, `agencyLlm.ts`)
+
+Make the runtime accept an array `prompt` end-to-end and route every string-only consumer through one text-flattening helper.
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts`, `lib/runtime/streaming.ts`, `lib/runtime/agencyLlm.ts`
+- Test: `lib/runtime/prompt.attachments.test.ts` (create — `promptText` portion)
+
+**Interfaces:**
+- Produces: `export function promptText(p: string | UserContentInput): string`.
+
+- [ ] **Step 1: Write the failing test** — create `lib/runtime/prompt.attachments.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { promptText } from "./prompt.js";
+
+describe("promptText", () => {
+  it("returns a plain string unchanged", () => {
+    expect(promptText("hello")).toBe("hello");
+  });
+
+  it("joins text parts and bare strings, dropping attachments", () => {
+    const p = [
+      "describe this",
+      { type: "image", source: { kind: "path", path: "./cat.png" } },
+      { type: "text", text: "and this" },
+    ] as any;
+    expect(promptText(p)).toBe("describe this and this");
+  });
+});
+```
+
+- [ ] **Step 2: Run it** — Run: `pnpm test:run lib/runtime/prompt.attachments.test.ts` — Expected: FAIL (`promptText` not exported).
+
+- [ ] **Step 3: Implement + widen types in `lib/runtime/prompt.ts`.**
+
+  (a) Extend the smoltalk import (line ~2) to bring in the content-input type:
+  ```ts
+  import { PromptResult, ToolCallJSON, UserContentInput } from "smoltalk";
+  ```
+
+  (b) Add the helper (top-level, exported):
+  ```ts
+  /** Flatten a prompt (string, or array of text/attachment parts) to plain
+   *  text for consumers that require a string (memory recall, previews).
+   *  Logging does NOT use this — it keeps the structured prompt (redacted). */
+  export function promptText(p: string | UserContentInput): string {
+    if (typeof p === "string") return p;
+    return p
+      .map((x) => (typeof x === "string" ? x : x.type === "text" ? x.text : ""))
+      .join(" ");
+  }
+  ```
+
+  (c) Widen every `prompt: string;` arg-type declaration to `prompt: string | UserContentInput;` at lines ~60, ~301, ~369, ~583.
+
+  (d) Route the memory-recall consumer (line ~801):
+  ```ts
+  const facts = await recallManager.recallForInjection(promptText(prompt));
+  ```
+
+- [ ] **Step 4: Widen `lib/runtime/streaming.ts`** — extend its `"smoltalk"` import with `UserContentInput` and change `prompt: string;` (line ~17) to `prompt: string | UserContentInput;`.
+
+- [ ] **Step 5: Widen `lib/runtime/agencyLlm.ts`** — import `UserContentInput` from smoltalk and change all three `prompt: string` occurrences (lines ~69, ~72, ~73) to `prompt: string | UserContentInput`. Update the JSDoc above the overloads to note "prompt is a string, or an array of text strings and image()/file() attachments."
+
+- [ ] **Step 6: Run the unit test + a typecheck of the runtime**
+
+Run: `pnpm test:run lib/runtime/prompt.attachments.test.ts`
+Expected: PASS.
+Run: `pnpm exec tsc --noEmit 2>&1 | tee /private/tmp/claude-501/-Users-adityabhargava-agency-lang-packages-agency-lang/ad319109-1b8d-4e42-8e2a-b10ad1b47931/scratchpad/tsc-task5.log`
+Expected: no new type errors from the widened signatures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/runtime/prompt.ts lib/runtime/streaming.ts lib/runtime/agencyLlm.ts lib/runtime/prompt.attachments.test.ts
+git commit -F <message-file>
+```
+Message: `feat(runtime): accept array prompts; flatten to text for string-only consumers`.
+
+---
+
+### Task 6: Statelog redaction (`prompt.ts`, `streaming.ts`)
+
+Wrap every message/prompt statelog payload in smoltalk's `redactAttachments` so base64 blobs never reach the log. DRY: one shared `redactMessagesForLog` for the three message sites.
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts`, `lib/runtime/streaming.ts`
+- Test: `lib/runtime/prompt.attachments.test.ts` (extend — redaction portion)
+
+**Interfaces:**
+- Produces: `export function redactMessagesForLog(messages: MessageThread): unknown`.
+
+- [ ] **Step 1: Extend the test** — append to `lib/runtime/prompt.attachments.test.ts`:
+
+```ts
+import { redactMessagesForLog } from "./prompt.js";
+import { MessageThread } from "./state/messageThread.js";
+import * as smoltalk from "smoltalk";
+
+describe("redactMessagesForLog", () => {
+  it("redacts base64 attachment payloads but keeps structure", () => {
+    const thread = new MessageThread();
+    thread.push(
+      smoltalk.userMessage([
+        "look",
+        { type: "image", source: { kind: "base64", base64: "A".repeat(5000), mimeType: "image/png" } } as any,
+      ]),
+    );
+    const redacted = JSON.stringify(redactMessagesForLog(thread));
+    expect(redacted).not.toContain("A".repeat(5000)); // blob gone
+    expect(redacted).toContain("image/png");           // structure kept
+  });
+
+  it("leaves a plain string message intact", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.userMessage("just text"));
+    expect(JSON.stringify(redactMessagesForLog(thread))).toContain("just text");
+  });
+});
+```
+
+Confirm the `MessageThread` constructor/`push` API against `lib/runtime/state/messageThread.ts` before running; adjust the construction line to match (e.g. a factory) if the bare constructor differs.
+
+- [ ] **Step 2: Run it** — Run: `pnpm test:run lib/runtime/prompt.attachments.test.ts` — Expected: FAIL (`redactMessagesForLog` not exported).
+
+- [ ] **Step 3: Implement in `lib/runtime/prompt.ts`.**
+
+  (a) Add `redactAttachments` to the smoltalk import:
+  ```ts
+  import { PromptResult, ToolCallJSON, UserContentInput, redactAttachments } from "smoltalk";
+  ```
+
+  (b) Add the helper near `promptText`:
+  ```ts
+  /** Deep-copy of a thread's messages with attachment payloads redacted, for
+   *  statelog. Uses toJSON() (the same plain shape JSON.stringify would emit)
+   *  so wire consumers like wireAccessors.userMessageOf keep working. */
+  export function redactMessagesForLog(messages: MessageThread): unknown {
+    return redactAttachments(messages.toJSON().messages);
+  }
+  ```
+
+  (c) Redact the three message sites and the `onLLMCallStart` prompt field:
+  - Line ~406 (`onLLMCallStart` hook `data`): `prompt: redactAttachments(prompt),` and `messages: redactMessagesForLog(messages),`.
+  - Line ~485 (`promptCompletion`): `messages: redactMessagesForLog(messages),` (this replaces `messages.getMessages()`).
+  - Line ~574 (`onLLMCallEnd` hook `data`): `messages: redactMessagesForLog(messages),`.
+
+- [ ] **Step 4: Redact the streaming site in `lib/runtime/streaming.ts`** — add `redactAttachments` to its smoltalk import and wrap the `debug` payload's prompt (line ~31):
+```ts
+      {
+        prompt: redactAttachments(prompt),
+        callbacks: Object.keys(ctx.callbacks),
+      },
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `pnpm test:run lib/runtime/prompt.attachments.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/runtime/prompt.ts lib/runtime/streaming.ts lib/runtime/prompt.attachments.test.ts
+git commit -F <message-file>
+```
+Message: `fix(statelog): redact attachment payloads from logged messages/prompt`.
+
+---
+
+### Task 7: End-to-end integration test (agency-js)
+
+Prove the whole path: `image`/`file` builders → array `llm(...)` and `userMessage(...)` → the smoltalk user message lands on the thread with the right parts, under the deterministic LLM provider (no real call).
+
+**Files:**
+- Create: `tests/agency-js/multimodal-attachments/agent.agency`
+- Create: `tests/agency-js/multimodal-attachments/test.js`
+- Create: `tests/agency-js/multimodal-attachments/llmMocks.json`
+- Create: `tests/agency-js/multimodal-attachments/useTestLLMProvider` (empty)
+- Generate: `tests/agency-js/multimodal-attachments/fixture.json`
+
+- [ ] **Step 1: Write `agent.agency`** (path-based attachments only — deterministic, fully serializable, no file I/O since we never actually send to a provider):
+
+```ts
+import { image, file, userMessage } from "std::thread"
+
+node main() {
+  // A multimodal user turn seeded directly into history.
+  userMessage(["seed-user", image("./cat.png")])
+
+  // A multimodal llm() call. Under the deterministic provider the content is
+  // still pushed onto the thread verbatim before the mock reply.
+  let _r: string = llm(["describe", image("./cat.png"), file("./report.pdf")])
+
+  return "done"
+}
+```
+
+- [ ] **Step 2: Write `test.js`** (copy the stdlib-thread-messages driver):
+
+```js
+import { main } from "./agent.js";
+import { writeFileSync } from "fs";
+
+const result = await main();
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ data: result.data, messages: result.messages }, null, 2),
+);
+```
+
+- [ ] **Step 3: Write `llmMocks.json`** (one entry for the single `llm()` call):
+
+```json
+[
+  { "return": "described" }
+]
+```
+
+- [ ] **Step 4: Create the marker file**
+
+Run: `touch tests/agency-js/multimodal-attachments/useTestLLMProvider`
+
+- [ ] **Step 5: Generate the fixture and inspect it**
+
+Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/multimodal-attachments 2>&1 | tee /private/tmp/claude-501/-Users-adityabhargava-agency-lang-packages-agency-lang/ad319109-1b8d-4e42-8e2a-b10ad1b47931/scratchpad/agencyjs-multimodal.log`
+Expected: first run has no `fixture.json`, so it writes `__result.json` and offers to save it as the fixture. **Read `__result.json`** and verify thread 0's messages include:
+- a `user` message whose `content` is an array with a `text` part `"seed-user"` and an `image` part with `source.kind === "path"`, `path === "./cat.png"`;
+- a `user` message with `text` `"describe"`, an `image` path part, and a `file` part with `source.path === "./report.pdf"` and `filename === "report.pdf"`.
+
+If correct, save it as `fixture.json` (accept the prompt, or copy `__result.json` → `fixture.json`).
+
+- [ ] **Step 6: Re-run to confirm the fixture matches**
+
+Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/multimodal-attachments 2>&1 | tee /private/tmp/claude-501/-Users-adityabhargava-agency-lang-packages-agency-lang/ad319109-1b8d-4e42-8e2a-b10ad1b47931/scratchpad/agencyjs-multimodal-2.log`
+Expected: PASS (diff clean).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/agency-js/multimodal-attachments/
+git commit -F <message-file>
+```
+Message: `test(agency-js): end-to-end multimodal llm()/userMessage() attachments`.
+
+---
+
+### Task 8: Documentation (`docs/site/guide/llm.md`)
+
+**Files:**
+- Modify: `docs/site/guide/llm.md`
+
+- [ ] **Step 1: Add an "Attachments (images & files)" section** after the intro `llm()` examples (around line 24), documenting: importing `image`/`file` from `std::thread`; the array form of `llm(...)`; path/URL/data-URI/base64 sources; the optional `mimeType` / `base64` / `filename` args; that smoltalk reads/fetches/sizes attachments; and that `userMessage(...)` accepts the same array form. Use only verified syntax:
+
+```ts
+import { image, file } from "std::thread"
+
+node main() {
+  const answer = llm([
+    "What's in this image, and how does it relate to the report?",
+    image("./diagram.png"),          // local path
+    image("https://example.com/a.jpg"),  // remote URL
+    file("./report.pdf"),            // local PDF
+  ])
+  print(answer)
+}
+```
+
+Do NOT hand-edit generated stdlib reference pages — the `image`/`file`/`userMessage` docstrings from Task 2 feed `agency doc`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/site/guide/llm.md
+git commit -F <message-file>
+```
+Message: `docs(guide): document multimodal llm() attachments`.
+
+---
+
+## Final verification (before opening a PR)
+
+- [ ] Targeted TS suites green: `pnpm test:run lib/stdlib/thread.attachments.test.ts lib/typeChecker/attachments.test.ts lib/backends/llmAttachmentCodegen.test.ts lib/runtime/prompt.attachments.test.ts` — save to a log file.
+- [ ] `pnpm exec tsc --noEmit` clean.
+- [ ] `pnpm run lint:structure` clean.
+- [ ] The agency-js multimodal test passes (Task 7, Step 6).
+- [ ] Do NOT run the full agency suite locally — let CI run it. Open the PR with the spec + this plan linked in the description (write the body to a file).
+
+## Self-Review notes (traceability to the spec)
+
+- Builders + optional args + normalization rules → Task 1 (TS) + Task 2 (Agency surface + docstrings).
+- `Attachment`/`AttachmentSource` Agency types + subset-of-smoltalk documentation → Task 2.
+- `llm()` param tightening + mirror-drift guard + inference feasibility check → Task 3.
+- Codegen "no change" verification → Task 4.
+- `prompt` string-assumption audit + `promptText` + memory-recall routing + type widening (incl. `streaming.ts`, `agencyLlm.ts`) → Task 5.
+- Four statelog redaction sites + `toJSON` swap → Task 6.
+- End-to-end + parts-on-thread assertion → Task 7. `promptText`/redaction units → Tasks 5/6.
+- Guide + stdlib docstrings → Tasks 8 + 2.
+- Prerequisite (smoltalk 0.7.1 + `redactAttachments` export) → Global Constraints (already satisfied).
+
+### Lighter coverage than the spec's test list — deliberate tradeoffs
+
+- **Memory-injection with an array prompt** (spec's "highest-value regression"). The
+  actual defect is `recallForInjection` receiving a non-string; that fix is guarded
+  directly by the `promptText` unit test (Task 5) plus the routed call site. A full
+  `llm([...], memory: true)` agency-js test additionally needs the memory manager +
+  embedding path wired under the deterministic provider, which may pull in real embed
+  calls. **If** the memory harness runs offline (check an existing `memory` agency /
+  agency-js test), add a `memory: true` array-prompt variant to Task 7; otherwise the
+  unit-level guard stands as the honest coverage. Do not claim the integration test
+  exists unless it was actually added.
+- **Fork/race statelog under attachments** (spec item). Redaction sits on shared log
+  helpers (`redactMessagesForLog`), unit-tested in Task 6; the fork/race interaction is
+  not separately exercised. Add a `fork([...]) as _ { llm([..., image(...)]) }` case to
+  Task 7's `agent.agency` only if it can assert something the single-branch test
+  cannot; otherwise leave it out rather than add a test that asserts nothing new.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-01-multimodal-llm-attachments-design-review.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-01-multimodal-llm-attachments-design-review.md
@@ -1,0 +1,199 @@
+---
+name: Multimodal LLM Attachments — Design Review
+description: Review of docs/superpowers/specs/2026-07-01-multimodal-llm-attachments-design.md
+status: review
+date: 2026-07-01
+reviews: docs/superpowers/specs/2026-07-01-multimodal-llm-attachments-design.md
+---
+
+# Multimodal LLM Attachments — Design Review
+
+## Overall
+
+Strong spec. The scope is well-drawn (additive, no breaking changes), the
+boundary with smoltalk is clean (Agency constructs plain objects; smoltalk
+does I/O), and the risk list at the bottom names the real hazards. A few
+claims are inaccurate against the code, and a few concrete gaps deserve to
+be pinned before "design → plan".
+
+## Correctness of claims
+
+### Verified
+
+- `lib/runtime/prompt.ts:815` is the sole `smoltalk.userMessage(prompt)` push site. ✅
+- Statelog message-carrying sites at `prompt.ts:406` and `prompt.ts:485`. ✅
+- `redactAttachments` exists in `smoltalk/dist/util/redact.d.ts` but is
+  **not** re-exported from `smoltalk/dist/index.d.ts` (only
+  `normalizeImageRef` and `loadBlob` are). ✅
+- `llm`'s first param is `"any"` in `lib/typeChecker/builtins.ts:166`. ✅
+- `stdlib/thread.agency` has no `image` / `file` today; adding them there
+  is the right home. ✅
+- smoltalk 0.7.0 exports `UserContentInput = string | Array<string | UserContentPart>`
+  and `userMessage(content: UserContentInput, options?)` — the widened
+  contract matches. ✅
+
+### Wrong or imprecise
+
+1. **The "streaming completion" line-574 site is mislabeled.** Lines
+   565–576 in `prompt.ts` are the `onLLMCallEnd` hook, not a streaming
+   event. Real streaming-side logging lives in
+   `lib/runtime/streaming.ts` (`handleStreamingResponse`). Grep that
+   file for statelog emits carrying `messages` / `prompt` and add each
+   to the redaction list. Missing a site re-introduces the base64 blow-up.
+
+2. **The `prompt` string-assumption audit is not thorough enough.** The
+   spec calls the audit out as Risk #1 but does not enumerate the sites
+   that will break. At minimum:
+
+   - `recallManager.recallForInjection(prompt)` at `prompt.ts:801` —
+     param is typed `string`.
+   - The template literal at `prompt.ts:803`:
+     `\`Relevant context from memory:\n${facts}\`` uses `prompt`
+     indirectly via `facts`, but the wider audit must include the
+     surrounding branch where `prompt` is used in `${...}` expansion.
+     If `prompt` becomes `string | UserContentInput`, any raw `${prompt}`
+     emits `[object Object]` when the caller passed an array.
+   - `dispatchLLMRequest`'s param at `prompt.ts:60` types `prompt: string`.
+   - Any `.length` / `.substring` / `.slice` reads for statelog previews.
+
+   The design should specify **one** text-preview helper (e.g.,
+   `promptText(p) = typeof p === 'string' ? p : p.map(x => typeof x === 'string' ? x : x.type === 'text' ? x.text : '').join(' ')`)
+   and require every string-only consumer to route through it. This is
+   the single most valuable clarification the spec needs.
+
+3. **Codegen "expected no change" — mostly right, but non-obvious.**
+   `processLlmCall` compiles `arguments[0]` as an expression, so an
+   Agency array literal produces a JS array. But the array literal
+   must also **typecheck** against the tightened param, which requires
+   three type-checker capabilities in one line:
+   1. heterogeneous-array-literal inference,
+   2. function-call return types (`image(...) : Attachment`) flowing
+      into the array element union,
+   3. the union `string | Attachment` accepting either.
+
+   The spec's feasibility test is correct in spirit; make it exercise
+   all three explicitly — e.g. bind the literal to a name first:
+
+   ```ts
+   let arr = ["hi", image("x"), file("y")]  // arr : (string | Attachment)[]
+   llm(arr)
+   ```
+
+4. **`Attachment` naming collides with itself and with smoltalk.** The
+   spec exports an Agency type `Attachment` whose variants are
+   `type: "image" | "file"`, but smoltalk's `UserContentPart` also
+   allows `type: "text"`. Two consequences:
+
+   - Agency's `Attachment` is a strict subset of `UserContentPart`.
+     The `llm` element union `string | Attachment` is slightly narrower
+     than smoltalk accepts. That's probably fine — Agency users express
+     text via raw strings — but the design should **say so** rather
+     than leave it implicit.
+   - Rename or document. Either widen to `AttachmentPart` (includes
+     text) or add: "text is expressed as a plain string in the array;
+     `Attachment` deliberately omits `text`."
+
+5. **`AttachmentSource` is a subset of smoltalk's.** smoltalk's
+   `AttachmentSource` also has `providerFile` and `bytes` kinds.
+   Agency's mirror deliberately omits them (correct for v1). Say so
+   explicitly: "future smoltalk source kinds are not automatically
+   accepted by Agency's `image` / `file` builders."
+
+6. **`std::readImage()` motivation is unverified.** The spec cites
+   `readImage()` as motivation for the `base64: true` escape hatch.
+   Grep the stdlib and confirm the actual return shape before
+   promising this pattern works end-to-end.
+
+## Design gaps to close
+
+1. **`file()` with a URL and no extension.** A URL like
+   `https://example.com/download?id=42` yields `download` as the last
+   path segment — no extension. Does that break smoltalk MIME inference?
+   Two viable rules: (a) delegate everything to smoltalk (it defaults
+   to `attachment.pdf`), or (b) require `mimeType` for extensionless
+   URL sources. Pick one and write it into the semantics table.
+
+2. **`base64: true` + a data-URI `source`.** The table says
+   `data:<mime>;base64,<data>` → `base64` and separately
+   `base64: true` → `base64`. What happens for
+   `image("data:image/png;base64,...", base64: true)`? Should the
+   builder strip the data-URI prefix, reject it, or blindly forward as
+   raw base64 (which would produce garbage on the wire)? Add a
+   normalization rule.
+
+3. **`base64: true` without `mimeType` — "throws" where?** In Agency,
+   "throws" inside a `safe` pure constructor is unusual. Confirm:
+   does `throw` in a `safe def` work, or should it return a `Result` /
+   call `error(...)`? Match the pattern other `safe` stdlib
+   constructors already use.
+
+4. **`redactAttachments` shape at line 485 — verify the swap.** Spec
+   says switching from `messages.getMessages()` to
+   `messages.toJSON().messages` is behavior-preserving because
+   `JSON.stringify` calls `toJSON()`. Check what
+   `statelogClient.promptCompletion` **does** with `messages` besides
+   serialize — if it inspects `Message` instances (`.role`, class
+   methods, `Symbol.for(...)`) the swap breaks it. Confirm before
+   writing it in as a done deal. Same check applies wherever the
+   redacted plain form flows into `wireAccessors.userMessageOf`.
+
+5. **`agencyLlm.ts` widening.** Widening `prompt: string` at
+   `lib/runtime/agencyLlm.ts:68` is called out, but check the whole
+   surface: JSDoc, examples, and any Zod / runtime validation of the
+   arg. TS callers should get the same type experience Agency callers do.
+
+6. **Streaming preview.** As per correctness #1: audit
+   `handleStreamingResponse` for statelog emits carrying `messages` /
+   `prompt`. Widening the type is not enough if a streaming path
+   formats the prompt as a preview string.
+
+7. **The `.agency` ⇄ `builtins.ts` mirror is fragile.** Instead of
+   "add a KEEP IN SYNC comment," look at how `LlmDefaults` ⇄
+   `RetryConfig` are actually kept in sync. If it's manual, at least
+   add a small unit test that structurally compares the two — a
+   comment drifts silently, a test doesn't.
+
+## Testing coverage gaps
+
+- **Memory-injection interaction:** `llm([...], memory: true)` — the
+  recall/injection path currently assumes `prompt` is a string. Add a
+  test that exercises it with an array prompt. This is the highest-
+  value regression test given audit gap #2.
+- **Fork/branch statelog under attachments:** the redaction change
+  touches shared log paths; ensure `fork` / `race` with attachment-
+  carrying `llm(...)` calls don't double-log or dedup incorrectly.
+- **`toJSON` swap invariance** at `prompt.ts:485` (see design gap #4).
+
+## Nits
+
+- "smoltalk hardcodes `detail: 'auto'`" — cite the smoltalk file/line
+  or drop the parenthetical (it's advisory context, not design).
+- "Confirm Agency string methods (`startsWith`) are available" belongs
+  in the feasibility checklist, not the middle of the design. If
+  unavailable, the design changes (needs a helper). Resolve before
+  the doc is called "design".
+- Agency's `url` source in the type table lacks `timeoutMs`, but
+  smoltalk's `ImageRef` has it. If `timeoutMs` is out of scope for
+  v1 (as stated), pin it on the type: "Agency's `url` source
+  deliberately omits `timeoutMs`; smoltalk's 60s default applies."
+- Consider renaming the `source` parameter on `image` / `file`.
+  `source` reads as "sender / origin"; `input` or `from` is clearer
+  for a string that might be a path, URL, base64, or data URI.
+
+## Summary verdict
+
+Design is ~80% there. Before "design → plan":
+
+1. Do the concrete `prompt` grep in `prompt.ts` **now** and fold the
+   enumerated string-only sites into the spec (Risk #1 → hard
+   requirements). The memory-injection path is the smoking gun.
+2. Fix the mislabel at `prompt.ts:574` and audit `streaming.ts` for a
+   fourth statelog site.
+3. Pin the `Attachment` vs. `UserContentPart` naming — either widen
+   to include text parts or explicitly document the "strings-for-text"
+   convention.
+4. Resolve the two `base64: true` normalization ambiguities.
+5. Verify `messages.toJSON().messages` is a safe swap for
+   `messages.getMessages()` at line 485.
+
+Nothing above is a design killer — all are edits, not rewrites.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-01-multimodal-llm-attachments-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-01-multimodal-llm-attachments-design.md
@@ -1,0 +1,353 @@
+---
+name: Multimodal LLM Attachments
+description: Let Agency's llm() and std::thread.userMessage() accept image and file attachments alongside text, via two smart builder functions, backed by smoltalk 0.7.1's multimodal user-message content.
+status: design
+date: 2026-07-01
+---
+
+# Multimodal LLM Attachments
+
+## Summary
+
+smoltalk 0.7.x (commit `0badbb2`) changed a user message's content from a plain
+`string` to `string | Array<string | UserContentPart>`, where a part is a typed
+`text` / `image` / `file` object. This lets a user turn carry image and PDF/file
+attachments. This spec brings that capability into Agency.
+
+The user-facing change is small and additive:
+
+1. `llm()`'s first argument accepts an **array** of text strings and attachments,
+   in addition to a plain string.
+2. Two **smart builder** functions — `image(...)` and `file(...)` — construct
+   attachments from a path, URL, data URI, or raw base64.
+3. `std::thread.userMessage()` is widened the same way, so multimodal user turns
+   can be seeded into history.
+4. Statelog logging is made attachment-safe: base64 payloads are redacted so a
+   logged message never carries a large media blob.
+
+```ts
+import { image, file } from "std::thread"
+
+node main() {
+  // Unchanged: a plain string still works exactly as today.
+  llm("What is the capital of France?")
+
+  // New: an array of text + attachments. Plain strings ARE the text; there is
+  // no text() builder — Agency expresses text as a bare string element.
+  const answer = llm([
+    "What's in this image, and how does it relate to the attached report?",
+    image("./diagram.png"),         // local path
+    image("https://x.com/a.jpg"),   // auto-detected URL
+    file("./report.pdf"),           // local PDF/file
+  ])
+}
+```
+
+## Background: how this works end-to-end today
+
+- **`llm()` is a compiler primitive**, not a stdlib wrapper. Its signature lives in
+  `lib/typeChecker/builtins.ts` (`BUILTIN_FUNCTION_TYPES.llm`); its codegen lives in
+  `processLlmCall` (`lib/backends/typescriptBuilder.ts:2981`). The first argument is
+  extracted as `node.arguments[0]`, compiled as an ordinary expression, and passed
+  as `prompt` to the runtime's `runPrompt`.
+- **The runtime constructs the user message at one line:** `lib/runtime/prompt.ts:815`
+  — `messages.push(smoltalk.userMessage(prompt))`.
+- **smoltalk 0.7.x already does all attachment resolution** inside its client:
+  reading files from a `path`, fetching a `url`, MIME inference (by extension /
+  Content-Type), a 20 MB default size cap, and per-provider remote-URL passthrough.
+  Agency performs **no** file I/O — it only constructs the part objects.
+- **The builders return plain data objects** matching smoltalk's `UserContentPart`
+  / `ImageRef` shapes, so they flow straight into `smoltalk.userMessage(...)` with
+  no adapter layer.
+
+## Design
+
+### 1. Builder functions (`stdlib/thread.agency` + `lib/stdlib/thread.ts`)
+
+The builders live in `std::thread`, next to `userMessage` / `assistantMessage` /
+`systemMessage`, and are imported explicitly:
+
+```ts
+import { image, file } from "std::thread"
+```
+
+Each Agency `def` is a thin wrapper over a `_`-prefixed TS helper in
+`lib/stdlib/thread.ts` — the same pattern `userMessage`/`systemMessage` already use.
+**Why TS-backed rather than pure-Agency object literals:** Agency user code has no
+general `throw` (only `raise`, which is interrupt/effect machinery), so the
+validation error for `base64: true` with no `mimeType` cannot be raised from Agency.
+The TS helper also centralizes the source-string classification (path / URL /
+data-URI / raw-base64) where it is easy to unit-test.
+
+Signatures (Agency side):
+
+```ts
+export safe def image(
+  source: string,
+  mimeType: string = "",      // explicit MIME; overrides inference
+  base64: boolean = false,    // treat `source` as raw base64 data
+): Attachment {
+  return _imageAttachment(source, mimeType, base64)
+}
+
+export safe def file(
+  source: string,
+  filename: string = "",      // shown to the model; defaults to the basename
+  mimeType: string = "",
+  base64: boolean = false,
+): Attachment {
+  return _fileAttachment(source, filename, mimeType, base64)
+}
+```
+
+`_imageAttachment` / `_fileAttachment` (TS) return the plain part object and own all
+classification and validation.
+
+**Source-string classification** (single string, in the TS helper):
+
+| `source` looks like             | Resolved `kind` | Notes                                                   |
+|---------------------------------|-----------------|---------------------------------------------------------|
+| `http://…` / `https://…`        | `url`           | smoltalk fetches it                                     |
+| `data:<mime>;base64,<data>`     | `base64`        | MIME parsed from the data URI (overrides `mimeType`)    |
+| anything else                   | `path`          | local file; smoltalk reads it                           |
+| (path/URL string) + `base64: true` | `base64`     | raw base64 — **requires `mimeType`** (else throws)      |
+
+**Normalization rules (resolve the review's ambiguities):**
+
+- **`base64: true` + a `data:` source.** The helper detects the `data:` prefix first
+  and treats the value as a data URI regardless of the `base64` flag: it strips the
+  `data:<mime>;base64,` prefix, uses the URI's MIME (unless `mimeType` overrides), and
+  uses the trailing base64. This prevents the "raw-forward a full data URI as base64"
+  garbage-on-the-wire case.
+- **`base64: true` without `mimeType`.** The TS helper throws a clear `Error`
+  ("image()/file(): base64 sources require an explicit mimeType"). Because `image`/
+  `file` are pure constructors that return `Attachment` (not `Result`), a thrown
+  Error — surfaced as a normal Agency runtime error — is the right signal for a
+  programming mistake; returning a `Result` would force every inline
+  `llm([image(...)])` to unwrap.
+- **Extensionless URL / path for `file()`.** The helper does **not** try to infer a
+  filename or MIME for these; it delegates entirely to smoltalk, which defaults the
+  filename to `attachment.pdf` and infers MIME from the Content-Type. If the caller
+  needs control, they pass `filename` and/or `mimeType`. (Chosen rule: delegate to
+  smoltalk, do not require `mimeType` for extensionless sources.)
+- **`filename` derivation.** When `filename` is empty, the helper derives it from the
+  last path segment of the path/URL; if that is empty it leaves `filename` unset and
+  lets smoltalk default it.
+
+**`mimeType`** is emitted onto the `source` object only when non-empty, so smoltalk's
+inference still runs by default for path/URL sources.
+
+**Deliberate subset of smoltalk (v1 scope — state explicitly):**
+
+- Agency's `image`/`file` cover only smoltalk source kinds `path` / `url` / `base64`.
+  smoltalk also has `bytes` and `providerFile` kinds; Agency omits them (no
+  first-class bytes type; provider-file uploads deserve their own builder later).
+  Future smoltalk source kinds are **not** automatically reachable through these
+  builders.
+- Agency's `url` source deliberately omits smoltalk's `timeoutMs`; smoltalk's 60s
+  fetch default applies. Non-breaking to add later.
+- No `detail` / resolution hint. smoltalk currently emits a fixed `detail: "auto"`
+  for images (in `UserMessage.toOpenAIResponseInputItem`) and does not carry `detail`
+  on the part, so exposing it needs a smoltalk change first.
+
+### 2. Type model (`stdlib/thread.agency` + `lib/typeChecker/builtins.ts`)
+
+New Agency types, co-located with the builders:
+
+```ts
+export type AttachmentSource =
+  | { kind: "path", path: string, mimeType?: string }
+  | { kind: "url", url: string, mimeType?: string }
+  | { kind: "base64", base64: string, mimeType: string }
+
+export type Attachment =
+  | { type: "image", source: AttachmentSource }
+  | { type: "file", source: AttachmentSource, filename?: string }
+```
+
+`Attachment` is a **strict subset** of smoltalk's `UserContentPart`: smoltalk also
+allows `{ type: "text", text }`, but Agency expresses text as a bare string element
+in the array, so `Attachment` intentionally omits the text variant. The `llm`
+element union `string | Attachment` is therefore slightly narrower than what smoltalk
+would accept — which is correct, and is called out here so it is not a surprise.
+
+**`llm()` first-param tightening** (`builtins.ts`): today it is `"any"`. Tighten to:
+
+```
+string | (string | Attachment)[]
+```
+
+expressed structurally with the existing type primitives (`unionType`, `arrayType`,
+`objectType`, `stringLiteralType`, `optional()`). The `llm()` **return** type is
+unchanged (`string`, overridden by the call-site annotation → Zod structured-output
+schema).
+
+**Mirror is guarded by a test, not just a comment.** `Attachment` is declared in two
+universes — the `.agency` type (for builder return types + docs) and the TS
+structural mirror in `builtins.ts` (for the `llm` signature). Following the existing
+`LlmDefaults`⇄`RetryConfig` precedent (which is comment-only and has *no* test), we
+improve on it: add a typechecker test that compiles representative programs and
+asserts accept/reject, so drift between the two definitions fails CI rather than
+rotting silently:
+
+```ts
+llm("s")                          // ok
+llm(["s", image("x")])            // ok
+llm([42])                         // rejected
+userMessage(["s", image("x")])    // ok
+userMessage([42])                 // rejected
+```
+
+**Feasibility check to run FIRST (before any impl)** — the tightened param requires
+three checker capabilities in one expression; exercise all three explicitly by
+binding the literal to a name first (so inference, not just call-arg checking, is
+tested):
+
+```ts
+let arr = ["hi", image("x"), file("y")]   // must infer (string | Attachment)[]
+llm(arr)                                   // must accept
+```
+
+1. heterogeneous-array-literal element-union inference,
+2. function-call return types (`image(...) : Attachment`) flowing into the element
+   union,
+3. the union `string | Attachment` accepting either arm.
+
+Prove it with `pnpm run ast` / typecheck before committing to the strict signature.
+Tightening never *breaks* valid code — the element type stays assignable in every
+case — so the worst outcome of weak inference is that it catches *less*, in which
+case fall back to a looser param.
+
+### 3. Runtime & codegen
+
+- **Codegen — expected no change.** `processLlmCall` compiles `arguments[0]` as an
+  expression; an Agency array literal produces a JS array of the builders' object
+  literals. Add a codegen test to lock this in.
+- **Runtime user-message construction — no change at the push site.**
+  `prompt.ts:815` already calls `smoltalk.userMessage(prompt)`, and smoltalk accepts
+  `string | array`.
+- **`std::thread.userMessage()` widening.** Widen `userMessage(msg: string)` to
+  `string | (string | Attachment)[]` and forward to `smoltalk.userMessage` via
+  `_userMessage` (`lib/stdlib/thread.ts`), whose param widens to smoltalk's
+  `UserContentInput`.
+- **TS facade parity.** `lib/runtime/agencyLlm.ts` (lines ~68–73) types the prompt
+  param as `string`. Widen it to the same `string | (string | Attachment)[]` union,
+  **and** update its JSDoc, the doc examples, and any Zod/runtime validation of the
+  arg, so TS callers get the same type experience as Agency callers.
+
+#### 3a. The `prompt` string-assumption audit (Risk #1 — now a hard requirement)
+
+Between `runPrompt`'s entry and line 815, `prompt` is threaded through several
+functions typed `prompt: string`. Once it can be an array, two classes of site break:
+type declarations, and string-only *consumers*.
+
+**One shared text-flattening helper.** Add `promptText(p)` to `lib/runtime/prompt.ts`
+(or a small util) and route every consumer that needs a plain string through it:
+
+```ts
+function promptText(p: string | UserContentInput): string {
+  if (typeof p === "string") return p;
+  return p
+    .map((x) => (typeof x === "string" ? x : x.type === "text" ? x.text : ""))
+    .join(" ");
+}
+```
+
+Enumerated sites (from a grep of `prompt.ts` + `streaming.ts`):
+
+- **Type declarations to widen** `string → string | UserContentInput`:
+  `prompt.ts:60` (`dispatchLLMRequest`), `:301` (`dispatchWithRetry`), `:369`
+  (`_runPrompt`), `:583` (`runPrompt` inner), and `streaming.ts:17`
+  (`handleStreamingResponse`).
+- **String consumer that MUST flatten:** `recallManager.recallForInjection(prompt)`
+  at `prompt.ts:801` → `recallForInjection(promptText(prompt))`. This is the memory
+  path and the single highest-risk site — an array prompt would otherwise recall
+  against `[object Object]`.
+- **Any `.length` / `.substring` / `.slice` preview reads** of `prompt` → route
+  through `promptText(prompt)`. (Current grep shows none other than the memory path,
+  but the rule stands so future previews are safe.)
+- Note the distinction from logging: statelog keeps the *structured* prompt (redacted;
+  see §4), it does NOT flatten to text — `promptText` is only for consumers that
+  genuinely need a `string`.
+
+### 4. Statelog redaction
+
+Statelog serializes the whole event with `JSON.stringify` at POST time
+(`statelogClient.ts:1059`), invoking each `Message.toJSON()`; a base64 attachment
+payload would be encoded into the wire body — the blow-up. Make every statelog site
+that carries messages or the prompt attachment-safe using smoltalk's
+`redactAttachments` (now re-exported from smoltalk's top-level index in 0.7.1):
+
+```
+messages: redactAttachments(messages.toJSON().messages)
+prompt:   redactAttachments(prompt)
+```
+
+**All four sites (verified against the code):**
+
+1. `lib/runtime/prompt.ts:406` — `onLLMCallStart` hook data (`messages` + `prompt`).
+2. `lib/runtime/prompt.ts:485` — `promptCompletion` (`messages`). Switch from
+   `messages.getMessages()` to `messages.toJSON().messages`. **Verified safe:**
+   `statelogClient.promptCompletion` only stores `messages` and serializes later; it
+   never inspects `Message` instance methods, and `wireAccessors.userMessageOf` reads
+   `.role`/`.content` off the plain JSON form (identical shape either way, since
+   `JSON.stringify` already calls `toJSON()`).
+3. `lib/runtime/prompt.ts:574` — this is the **`onLLMCallEnd` hook** (the spec's
+   earlier "streaming completion" label was wrong), carrying `messages`.
+4. `lib/runtime/streaming.ts:~28` — `ctx.statelogClient.debug("…", { prompt })` in
+   the no-`onStream` branch. Redact `prompt` here. (This is the fourth site the
+   original spec missed.)
+
+`redactAttachments` deep-copies and replaces only base64 / data-URI blobs with
+`[redacted N base64 chars]`, keeping structure (`kind`, `mimeType`, `filename`, path,
+URL). Observability still shows *what* was attached, just not the bytes.
+
+## Non-goals
+
+- `assistantMessage` / `systemMessage` stay string-only. Providers do not accept
+  image/file parts on those roles, and smoltalk types them `string | TextPart[]`.
+- No new attachment source kinds beyond path / url / base64 (no `bytes`,
+  `providerFile`).
+- No `timeoutMs`, no `detail` (blocked on smoltalk).
+- No `text()` builder — text is a bare string element in the array.
+
+## Testing
+
+- **Builder units** (TS `_imageAttachment` / `_fileAttachment`): path vs. url vs.
+  data-URI vs. `base64: true`; `data:` + `base64:true` normalization; `mimeType`
+  override; filename derivation from basename; extensionless URL delegated to
+  smoltalk; `base64: true` without `mimeType` throws.
+- **Typechecker** (accept/reject, doubling as the mirror-drift guard): the five
+  `llm(...)` / `userMessage(...)` cases in §2, plus the `let arr = [...]` inference
+  check.
+- **Codegen:** `llm([...])` emits an array argument to `runPrompt`.
+- **Agency-js execution test (no real LLM call):** compile a program calling
+  `llm([...])` / `userMessage([...])`; assert the constructed smoltalk user message
+  has the expected parts (via statelog, per the deterministic-mock testing pattern);
+  assert statelog output is redacted (no base64 blob in any logged event).
+- **Memory-injection interaction (highest-value regression):** `llm([...], memory:
+  true)` — exercises the `recallForInjection(promptText(...))` path with an array
+  prompt; guards audit §3a.
+- **Fork/branch statelog under attachments:** `fork` / `race` with attachment-carrying
+  `llm(...)` — ensure the redaction change on shared log paths doesn't double-log or
+  dedup incorrectly.
+- **`toJSON` swap invariance** at `prompt.ts:485` — assert the wire shape is unchanged
+  by the `getMessages()` → `toJSON().messages` swap.
+- **Docs:** `docs/site/guide/llm.md` (a multimodal section) and stdlib doc comments on
+  `image` / `file` / the widened `userMessage` (these become tool descriptions).
+
+## Dependencies & prerequisites
+
+1. smoltalk `0.7.1` installed. ✅ Done.
+2. smoltalk re-exports `redactAttachments` from its top-level index. ✅ Done (0.7.1).
+3. `make` after editing any `.agency` stdlib file (per project convention).
+
+## Open implementation risks (ranked)
+
+1. **`prompt` string-assumption audit** (§3a) — now enumerated; the memory-injection
+   path is the smoking gun. Route all string consumers through `promptText`.
+2. **Heterogeneous array-literal inference** against the tightened `llm` param —
+   validate empirically with the `let arr = [...]` check before committing to the
+   strict signature.
+3. **Redaction completeness** — all four sites (§4) plus the `prompt` field must be
+   covered; a missed site re-introduces the blow-up.

--- a/packages/agency-lang/lib/backends/llmAttachmentCodegen.test.ts
+++ b/packages/agency-lang/lib/backends/llmAttachmentCodegen.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+function gen(src: string): string {
+  const r = parseAgency(src, {}, false);
+  if (!r.success) throw new Error("parse failed: " + r.message);
+  return generateTypeScript(r.result, undefined, undefined, "test.agency");
+}
+
+describe("llm() multimodal codegen", () => {
+  it("passes an array first-arg through to runPrompt as an array literal", () => {
+    const out = gen(
+      `import { image, file } from "std::thread"\n` +
+        `node main() {\n const r = llm(["hi", image("x"), file("y")])\n print(r)\n}`,
+    );
+    // The prompt argument is compiled to an array literal, not a bare string.
+    expect(out).toMatch(/prompt:\s*\[/);
+    // The image()/file() builder calls survive inside the array.
+    expect(out).toContain("__call(image");
+    expect(out).toContain("__call(file");
+  });
+
+  it("still compiles a plain-string prompt unchanged", () => {
+    const out = gen(`node main() {\n const r = llm("hi")\n print(r)\n}`);
+    expect(out).toMatch(/prompt:\s*`hi`/);
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
@@ -128,8 +128,18 @@ export function variableTypeToString(
     }
     return variableType.value;
   } else if (variableType.type === "arrayType") {
-    // Recursively build array type string
-    return `${variableTypeToString(variableType.elementType, typeAliases, forFormatting)}[]`;
+    // Recursively build array type string. Parenthesize a union element so
+    // `(a | b)[]` does not render as the ambiguous `a | b[]` (which reads as
+    // `a | (b[])`).
+    const inner = variableTypeToString(
+      variableType.elementType,
+      typeAliases,
+      forFormatting,
+    );
+    if (variableType.elementType.type === "unionType") {
+      return `(${inner})[]`;
+    }
+    return `${inner}[]`;
   } else if (variableType.type === "stringLiteralType") {
     return `"${variableType.value}"`;
   } else if (variableType.type === "numberLiteralType") {

--- a/packages/agency-lang/lib/runtime/agencyLlm.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.ts
@@ -32,6 +32,7 @@
  * wrapped explicitly with `agency.withTestContext` in unit tests).
  */
 import type { z } from "zod";
+import type { UserContentInput } from "smoltalk";
 import { agencyStore } from "./asyncContext.js";
 import { runPrompt } from "./prompt.js";
 import type { RetryConfig } from "./llmRetry.js";
@@ -61,16 +62,25 @@ export type LlmOpts<S extends z.ZodSchema = z.ZodSchema> = RetryConfig & {
 
 /** Module-private. Re-exposed only via `agency.llm`.
  *
+ *  `prompt` is a string, or an array of text strings and image()/file()
+ *  attachments (see `std::thread`), matching smoltalk's user-message content.
+ *
  *  Overloads: when `opts.schema` is provided the return type is
  *  `z.infer<S>`; otherwise it's `string`. Order matters — the
  *  schema-bearing overload must come first so TS picks it over the
  *  string-returning fallback. */
 export function llm<S extends z.ZodSchema>(
-  prompt: string,
+  prompt: string | UserContentInput,
   opts: LlmOpts<S> & { schema: S },
 ): Promise<z.infer<S>>;
-export function llm(prompt: string, opts?: LlmOpts): Promise<string>;
-export async function llm(prompt: string, opts: LlmOpts = {}): Promise<any> {
+export function llm(
+  prompt: string | UserContentInput,
+  opts?: LlmOpts,
+): Promise<string>;
+export async function llm(
+  prompt: string | UserContentInput,
+  opts: LlmOpts = {},
+): Promise<any> {
   const thread = opts.thread ?? getRuntimeContext().threads.getOrCreateActive();
   // Build clientConfig with `model` only when explicitly overridden.
   // Passing `{ model: undefined }` would still let `runPrompt`'s merge

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -6,6 +6,7 @@ import type {
   PromptResult,
   TokenUsage,
   ToolCallJSON,
+  UserContentInput,
 } from "smoltalk";
 import type { CallbackName } from "../types/function.js";
 import type { LLMRetryReason } from "./llmRetry.js";
@@ -28,7 +29,8 @@ export type CallbackMap = {
   onNodeStart: { nodeName: string };
   onNodeEnd: { nodeName: string; data: any };
   onLLMCallStart: {
-    prompt: string;
+    // A string, or an array of text/attachment parts (redacted for logging).
+    prompt: string | UserContentInput;
     tools: { name: string; description?: string; schema: any }[];
     model: ModelName | undefined;
     messages: MessageJSON[];

--- a/packages/agency-lang/lib/runtime/prompt.attachments.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.attachments.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import * as smoltalk from "smoltalk";
+import { promptText, redactMessagesForLog } from "./prompt.js";
+import { MessageThread } from "./state/messageThread.js";
+
+describe("promptText", () => {
+  it("returns a plain string unchanged", () => {
+    expect(promptText("hello")).toBe("hello");
+  });
+
+  it("joins text parts and bare strings, dropping attachments", () => {
+    const p = [
+      "describe this",
+      { type: "image", source: { kind: "path", path: "./cat.png" } },
+      { type: "text", text: "and this" },
+    ] as smoltalk.UserContentInput;
+    expect(promptText(p)).toBe("describe this and this");
+  });
+});
+
+describe("redactMessagesForLog", () => {
+  it("redacts base64 attachment payloads but keeps structure", () => {
+    const thread = new MessageThread();
+    thread.push(
+      smoltalk.userMessage([
+        "look",
+        {
+          type: "image",
+          source: {
+            kind: "base64",
+            base64: "A".repeat(5000),
+            mimeType: "image/png",
+          },
+        },
+      ] as smoltalk.UserContentInput),
+    );
+    const redacted = JSON.stringify(redactMessagesForLog(thread));
+    expect(redacted).not.toContain("A".repeat(5000)); // the blob is gone
+    expect(redacted).toContain("image/png"); // structure is kept
+  });
+
+  it("leaves a plain string message intact", () => {
+    const thread = new MessageThread();
+    thread.push(smoltalk.userMessage("just text"));
+    expect(JSON.stringify(redactMessagesForLog(thread))).toContain("just text");
+  });
+});

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1,5 +1,10 @@
 import * as smoltalk from "smoltalk";
-import { PromptResult, ToolCallJSON } from "smoltalk";
+import {
+  PromptResult,
+  ToolCallJSON,
+  UserContentInput,
+  redactAttachments,
+} from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { agencyStore, getRuntimeContext, __threads } from "./asyncContext.js";
@@ -45,6 +50,37 @@ export type RunPromptResult = {
   toolCalls: smoltalk.ToolCallJSON[];
 };
 
+/** Flatten a prompt (a string, or an array of text/attachment parts) to plain
+ *  text for consumers that require a string — e.g. memory recall and log
+ *  previews. Attachments are dropped. Statelog does NOT use this: it keeps the
+ *  structured prompt, redacted (see `redactMessagesForLog`). */
+export function promptText(p: string | UserContentInput): string {
+  if (typeof p === "string") return p;
+  return p
+    .map((x) => (typeof x === "string" ? x : x.type === "text" ? x.text : null))
+    .filter((s): s is string => s !== null)
+    .join(" ");
+}
+
+/** Deep copy of a thread's messages with attachment payloads (base64 / data
+ *  URIs) redacted, for statelog. Uses `toJSON()` — the same plain shape
+ *  `JSON.stringify` would emit — so wire consumers like
+ *  `wireAccessors.userMessageOf` keep working. Redaction only shortens base64
+ *  string values, so the result is still structurally `MessageJSON[]`. */
+export function redactMessagesForLog(
+  messages: MessageThread,
+): smoltalk.MessageJSON[] {
+  return redactAttachments(messages.toJSON().messages) as smoltalk.MessageJSON[];
+}
+
+/** A prompt with attachment payloads redacted, preserving its string-or-array
+ *  shape, for statelog / hook data. */
+export function redactPromptForLog(
+  p: string | UserContentInput,
+): string | UserContentInput {
+  return redactAttachments(p) as string | UserContentInput;
+}
+
 /** Dispatch the LLM request and extract `{completion, toolCalls}`,
  *  branching on the `stream` flag. Streaming uses `handleStreamingResponse`
  *  to accumulate chunks; non-streaming awaits the single response Promise.
@@ -57,7 +93,7 @@ async function dispatchLLMRequest({
 }: {
   ctx: RuntimeContext<GraphState>;
   promptConfig: PromptConfig;
-  prompt: string;
+  prompt: string | UserContentInput;
   stream: boolean;
 }): Promise<{ completion: PromptResult; toolCalls: ToolCallJSON[] }> {
   if (stream) {
@@ -298,7 +334,7 @@ async function runWithRetry<T>(
 async function dispatchWithRetry(args: {
   ctx: RuntimeContext<GraphState>;
   promptConfig: PromptConfig;
-  prompt: string;
+  prompt: string | UserContentInput;
   stream: boolean;
   retryPolicy: RetryPolicy;
   parentSignal: AbortSignal | undefined;
@@ -366,7 +402,7 @@ async function _runPrompt({
   ctx: RuntimeContext<GraphState>;
   messages: MessageThread;
   tools: Tool[];
-  prompt: string;
+  prompt: string | UserContentInput;
   responseFormat?: any;
   clientConfig: Partial<smoltalk.SmolConfig>;
   /** The branch-local stack, if this _runPrompt call is running inside a
@@ -400,10 +436,10 @@ async function _runPrompt({
     ctx,
     name: "onLLMCallStart",
     data: {
-      prompt,
+      prompt: redactPromptForLog(prompt),
       tools,
       model: clientConfig.model,
-      messages: messages.toJSON().messages,
+      messages: redactMessagesForLog(messages),
     },
   });
 
@@ -482,7 +518,7 @@ async function _runPrompt({
   const modelName = completion.model || clientConfig.model || "unknown model";
 
   ctx.statelogClient.promptCompletion({
-    messages: messages.getMessages(),
+    messages: redactMessagesForLog(messages),
     completion,
     model: JSON.stringify(modelName),
     timeTaken: endTime - startTime,
@@ -571,7 +607,7 @@ async function _runPrompt({
       usage: completion.usage,
       cost: completion.cost,
       timeTaken: endTime - startTime,
-      messages: messages.toJSON().messages,
+      messages: redactMessagesForLog(messages),
     },
   });
 
@@ -580,7 +616,7 @@ async function _runPrompt({
 
 // eslint-disable-next-line max-lines-per-function -- core prompt execution loop; refactor tracked separately
 export async function runPrompt(args: {
-  prompt: string;
+  prompt: string | UserContentInput;
   messages: MessageThread;
   responseFormat?: any;
   /** Provider-shaped config (model/temperature/...). Retry fields may also
@@ -798,7 +834,9 @@ export async function runPrompt(args: {
       const recallManager = ctx.getActiveMemoryManager();
       if (memoryOption && recallManager) {
         try {
-          const facts = await recallManager.recallForInjection(prompt);
+          const facts = await recallManager.recallForInjection(
+            promptText(prompt),
+          );
           if (facts) {
             injectedFactsContent = `Relevant context from memory:\n${facts}`;
             messages.push(smoltalk.systemMessage(injectedFactsContent));

--- a/packages/agency-lang/lib/runtime/streaming.ts
+++ b/packages/agency-lang/lib/runtime/streaming.ts
@@ -1,4 +1,11 @@
-import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
+import {
+  PromptResult,
+  Result,
+  StreamChunk,
+  ToolCallJSON,
+  UserContentInput,
+  redactAttachments,
+} from "smoltalk";
 import { builtinSleep } from "./builtins.js";
 import type { RuntimeContext } from "./state/context.js";
 import { GraphState } from "./types.js";
@@ -14,7 +21,7 @@ export function isGenerator(variable: any): boolean {
 export async function handleStreamingResponse(args: {
   ctx: RuntimeContext<GraphState>;
   completion: AsyncGenerator<StreamChunk>;
-  prompt: string;
+  prompt: string | UserContentInput;
 }): Promise<
   Result<{ completion: PromptResult; toolCalls: ToolCallJSON[] }> | undefined
 > {
@@ -28,7 +35,7 @@ export async function handleStreamingResponse(args: {
     ctx.statelogClient.debug(
       "Got streaming response but no onStream callback provided, returning response synchronously",
       {
-        prompt,
+        prompt: redactAttachments(prompt),
         callbacks: Object.keys(ctx.callbacks),
       },
     );

--- a/packages/agency-lang/lib/stdlib/thread.attachments.test.ts
+++ b/packages/agency-lang/lib/stdlib/thread.attachments.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { _imageAttachment, _fileAttachment } from "./thread.js";
+
+describe("_imageAttachment", () => {
+  it("classifies a plain path", () => {
+    expect(_imageAttachment("./cat.png", "", false)).toEqual({
+      type: "image",
+      source: { kind: "path", path: "./cat.png" },
+    });
+  });
+
+  it("auto-detects an http(s) URL", () => {
+    expect(_imageAttachment("https://x.com/a.jpg", "", false)).toEqual({
+      type: "image",
+      source: { kind: "url", url: "https://x.com/a.jpg" },
+    });
+  });
+
+  it("parses a data: URI into a base64 source (mime from the URI)", () => {
+    expect(_imageAttachment("data:image/png;base64,AAAB", "", false)).toEqual({
+      type: "image",
+      source: { kind: "base64", base64: "AAAB", mimeType: "image/png" },
+    });
+  });
+
+  it("treats a data: URI as base64 even when base64:true is passed", () => {
+    expect(_imageAttachment("data:image/png;base64,AAAB", "", true)).toEqual({
+      type: "image",
+      source: { kind: "base64", base64: "AAAB", mimeType: "image/png" },
+    });
+  });
+
+  it("uses base64:true with an explicit mimeType", () => {
+    expect(_imageAttachment("AAAB", "image/png", true)).toEqual({
+      type: "image",
+      source: { kind: "base64", base64: "AAAB", mimeType: "image/png" },
+    });
+  });
+
+  it("lets mimeType override inference on a path", () => {
+    expect(_imageAttachment("./blob", "image/webp", false)).toEqual({
+      type: "image",
+      source: { kind: "path", path: "./blob", mimeType: "image/webp" },
+    });
+  });
+
+  it("throws on base64 with no mimeType", () => {
+    expect(() => _imageAttachment("AAAB", "", true)).toThrow(/mimeType/i);
+  });
+
+  it("throws on a data: URI that is not base64-encoded", () => {
+    expect(() => _imageAttachment("data:text/plain,hello", "", false)).toThrow(
+      /base64/i,
+    );
+  });
+});
+
+describe("_fileAttachment", () => {
+  it("derives filename from a path basename", () => {
+    expect(_fileAttachment("./docs/report.pdf", "", "", false)).toEqual({
+      type: "file",
+      source: { kind: "path", path: "./docs/report.pdf" },
+      filename: "report.pdf",
+    });
+  });
+
+  it("derives filename from a URL, stripping query/hash", () => {
+    expect(
+      _fileAttachment("https://x.com/a/report.pdf?v=2", "", "", false),
+    ).toEqual({
+      type: "file",
+      source: { kind: "url", url: "https://x.com/a/report.pdf?v=2" },
+      filename: "report.pdf",
+    });
+  });
+
+  it("respects an explicit filename", () => {
+    expect(_fileAttachment("./r.pdf", "custom.pdf", "", false)).toEqual({
+      type: "file",
+      source: { kind: "path", path: "./r.pdf" },
+      filename: "custom.pdf",
+    });
+  });
+
+  it("does NOT derive a filename from a base64 source", () => {
+    expect(_fileAttachment("AAAB", "", "application/pdf", true)).toEqual({
+      type: "file",
+      source: { kind: "base64", base64: "AAAB", mimeType: "application/pdf" },
+    });
+  });
+});

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -49,13 +49,16 @@ export async function __internal_userMessage(
   _ctx: RuntimeContext<any>,
   _stack: StateStack,
   threads: ThreadStore,
-  msg: string,
+  msg: smoltalk.UserContentInput,
 ): Promise<void> {
   threads.getOrCreateActive().push(smoltalk.userMessage(msg));
 }
 
-/** ALS-reading replacement for `__internal_userMessage`. */
-export async function _userMessage(msg: string): Promise<void> {
+/** ALS-reading replacement for `__internal_userMessage`. Accepts a plain
+ *  string or an array of text strings and image()/file() attachments. */
+export async function _userMessage(
+  msg: smoltalk.UserContentInput,
+): Promise<void> {
   const { threads } = getRuntimeContext();
   threads.getOrCreateActive().push(smoltalk.userMessage(msg));
 }
@@ -73,6 +76,97 @@ export async function __internal_assistantMessage(
 export async function _assistantMessage(msg: string): Promise<void> {
   const { threads } = getRuntimeContext();
   threads.getOrCreateActive().push(smoltalk.assistantMessage(msg));
+}
+
+// --- Multimodal attachment builders -------------------------------------
+//
+// Backing implementations for `std::thread`'s `image()` / `file()`. They
+// return plain data objects matching smoltalk's `UserContentPart` /
+// `ImageRef` shapes, so the result flows straight into
+// `smoltalk.userMessage([...])`. smoltalk does all the I/O (reading paths,
+// fetching URLs, MIME inference, size caps) at send time — these builders
+// only describe the attachment.
+//
+// KEEP IN SYNC with the `Attachment` / `AttachmentSource` types in
+// stdlib/thread.agency and the structural mirror in
+// lib/typeChecker/builtins.ts (guarded by lib/typeChecker/attachments.test.ts).
+
+export type AttachmentSource =
+  | { kind: "path"; path: string; mimeType?: string }
+  | { kind: "url"; url: string; mimeType?: string }
+  | { kind: "base64"; base64: string; mimeType: string };
+
+export type ImageAttachment = { type: "image"; source: AttachmentSource };
+export type FileAttachment = {
+  type: "file";
+  source: AttachmentSource;
+  filename?: string;
+};
+
+function classifySource(
+  source: string,
+  mimeType: string,
+  base64: boolean,
+): AttachmentSource {
+  // A data: URI is authoritative regardless of the base64 flag.
+  if (source.startsWith("data:")) {
+    const marker = ";base64,";
+    const idx = source.indexOf(marker);
+    if (idx === -1) {
+      throw new Error(
+        "image()/file(): a data: URI must be base64-encoded (data:<mime>;base64,<data>)",
+      );
+    }
+    const uriMime = source.slice("data:".length, idx);
+    const data = source.slice(idx + marker.length);
+    return { kind: "base64", base64: data, mimeType: mimeType || uriMime };
+  }
+  if (base64) {
+    if (!mimeType) {
+      throw new Error(
+        "image()/file(): base64 sources require an explicit mimeType",
+      );
+    }
+    return { kind: "base64", base64: source, mimeType };
+  }
+  if (source.startsWith("http://") || source.startsWith("https://")) {
+    return mimeType
+      ? { kind: "url", url: source, mimeType }
+      : { kind: "url", url: source };
+  }
+  return mimeType
+    ? { kind: "path", path: source, mimeType }
+    : { kind: "path", path: source };
+}
+
+export function _imageAttachment(
+  source: string,
+  mimeType: string,
+  base64: boolean,
+): ImageAttachment {
+  return { type: "image", source: classifySource(source, mimeType, base64) };
+}
+
+function basename(source: string): string {
+  const clean = source.split(/[?#]/)[0];
+  const segments = clean.split("/");
+  return segments[segments.length - 1] || "";
+}
+
+export function _fileAttachment(
+  source: string,
+  filename: string,
+  mimeType: string,
+  base64: boolean,
+): FileAttachment {
+  const src = classifySource(source, mimeType, base64);
+  let name = filename;
+  if (!name && (src.kind === "path" || src.kind === "url")) {
+    name = basename(source);
+  }
+  return name
+    ? { type: "file", source: src, filename: name }
+    : { type: "file", source: src };
 }
 
 export async function __internal_getCost(

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -87,9 +87,10 @@ export async function _assistantMessage(msg: string): Promise<void> {
 // fetching URLs, MIME inference, size caps) at send time — these builders
 // only describe the attachment.
 //
-// KEEP IN SYNC with the `Attachment` / `AttachmentSource` types in
-// stdlib/thread.agency and the structural mirror in
-// lib/typeChecker/builtins.ts (guarded by lib/typeChecker/attachments.test.ts).
+// These return-type shapes must stay structurally compatible with the
+// `Attachment` / `AttachmentSource` types in stdlib/thread.agency (the single
+// source of truth that `llm()`'s typechecker signature references by name).
+// The end-to-end fixture in tests/agency-js/multimodal-attachments guards it.
 
 export type AttachmentSource =
   | { kind: "path"; path: string; mimeType?: string }

--- a/packages/agency-lang/lib/typeChecker/attachments.test.ts
+++ b/packages/agency-lang/lib/typeChecker/attachments.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+
+function errorsFrom(source: string): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-attach-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath, {});
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) throw new Error("Parse failed");
+    const info = buildCompilationUnit(
+      parseResult.result,
+      symbolTable,
+      absPath,
+      source,
+    );
+    return typeCheck(parseResult.result, {}, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+const IMPORT = `import { image, file } from "std::thread"\n`;
+
+describe("llm() multimodal first-arg typing", () => {
+  it("accepts a plain string", () => {
+    expect(
+      errorsFrom(`node main() { let r: string = llm("hi")\n print(r) }`),
+    ).toHaveLength(0);
+  });
+
+  it("accepts a mixed text + attachment array", () => {
+    expect(
+      errorsFrom(
+        `${IMPORT}node main() { let r: string = llm(["hi", image("x"), file("y")])\n print(r) }`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("accepts an array bound to a local first (inference path)", () => {
+    expect(
+      errorsFrom(
+        `${IMPORT}node main() { let arr = ["hi", image("x")]\n let r: string = llm(arr)\n print(r) }`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("rejects a number element in the array", () => {
+    expect(
+      errorsFrom(`node main() { let r: string = llm([42])\n print(r) }`).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("accepts a mixed array on userMessage()", () => {
+    expect(
+      errorsFrom(
+        `import { userMessage, image } from "std::thread"\nnode main() { userMessage(["hi", image("x")]) }`,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("rejects a number element on userMessage()", () => {
+    expect(
+      errorsFrom(
+        `import { userMessage } from "std::thread"\nnode main() { userMessage([42]) }`,
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -110,73 +110,26 @@ const llmNamedOptions: Record<string, VariableType> = Object.assign(
   Object.fromEntries(llmOptionProperties.map((p) => [p.key, p.value])),
 );
 
-/**
- * Structural mirror of the `Attachment` / `AttachmentSource` types declared
- * in `stdlib/thread.agency` (and the TS builders in `lib/stdlib/thread.ts`).
- * The `llm()` first-arg type lives here in the TS type universe, so it cannot
- * reference the `.agency` type by name — the shapes must be kept in sync by
- * hand. Drift is caught by `lib/typeChecker/attachments.test.ts`.
- */
-const attachmentSource: VariableType = {
-  type: "unionType",
-  types: [
-    {
-      type: "objectType",
-      properties: [
-        { key: "kind", value: { type: "stringLiteralType", value: "path" } },
-        { key: "path", value: string },
-        { key: "mimeType", value: optional(string) },
-      ],
-    },
-    {
-      type: "objectType",
-      properties: [
-        { key: "kind", value: { type: "stringLiteralType", value: "url" } },
-        { key: "url", value: string },
-        { key: "mimeType", value: optional(string) },
-      ],
-    },
-    {
-      type: "objectType",
-      properties: [
-        { key: "kind", value: { type: "stringLiteralType", value: "base64" } },
-        { key: "base64", value: string },
-        { key: "mimeType", value: string },
-      ],
-    },
-  ],
-};
-
-const attachment: VariableType = {
-  type: "unionType",
-  types: [
-    {
-      type: "objectType",
-      properties: [
-        { key: "type", value: { type: "stringLiteralType", value: "image" } },
-        { key: "source", value: attachmentSource },
-      ],
-    },
-    {
-      type: "objectType",
-      properties: [
-        { key: "type", value: { type: "stringLiteralType", value: "file" } },
-        { key: "source", value: attachmentSource },
-        { key: "filename", value: optional(string) },
-      ],
-    },
-  ],
-};
-
 /** `llm()`'s first argument: a plain string, or an array mixing text strings
- *  and `image()` / `file()` attachments. */
+ *  and `image()` / `file()` attachments.
+ *
+ *  The attachment element references the `Attachment` type alias defined in
+ *  `stdlib/thread.agency` (the single source of truth) rather than restating
+ *  its shape here — it resolves against the type-alias table the same way any
+ *  user type does. `image()` / `file()` return `Attachment`, so a call like
+ *  `llm(["hi", image("x")])` type-checks; `llm([42])` does not. */
+const attachmentRef: VariableType = {
+  type: "typeAliasVariable",
+  aliasName: "Attachment",
+};
+
 const llmContent: VariableType = {
   type: "unionType",
   types: [
     string,
     {
       type: "arrayType",
-      elementType: { type: "unionType", types: [string, attachment] },
+      elementType: { type: "unionType", types: [string, attachmentRef] },
     },
   ],
 };

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -111,6 +111,77 @@ const llmNamedOptions: Record<string, VariableType> = Object.assign(
 );
 
 /**
+ * Structural mirror of the `Attachment` / `AttachmentSource` types declared
+ * in `stdlib/thread.agency` (and the TS builders in `lib/stdlib/thread.ts`).
+ * The `llm()` first-arg type lives here in the TS type universe, so it cannot
+ * reference the `.agency` type by name — the shapes must be kept in sync by
+ * hand. Drift is caught by `lib/typeChecker/attachments.test.ts`.
+ */
+const attachmentSource: VariableType = {
+  type: "unionType",
+  types: [
+    {
+      type: "objectType",
+      properties: [
+        { key: "kind", value: { type: "stringLiteralType", value: "path" } },
+        { key: "path", value: string },
+        { key: "mimeType", value: optional(string) },
+      ],
+    },
+    {
+      type: "objectType",
+      properties: [
+        { key: "kind", value: { type: "stringLiteralType", value: "url" } },
+        { key: "url", value: string },
+        { key: "mimeType", value: optional(string) },
+      ],
+    },
+    {
+      type: "objectType",
+      properties: [
+        { key: "kind", value: { type: "stringLiteralType", value: "base64" } },
+        { key: "base64", value: string },
+        { key: "mimeType", value: string },
+      ],
+    },
+  ],
+};
+
+const attachment: VariableType = {
+  type: "unionType",
+  types: [
+    {
+      type: "objectType",
+      properties: [
+        { key: "type", value: { type: "stringLiteralType", value: "image" } },
+        { key: "source", value: attachmentSource },
+      ],
+    },
+    {
+      type: "objectType",
+      properties: [
+        { key: "type", value: { type: "stringLiteralType", value: "file" } },
+        { key: "source", value: attachmentSource },
+        { key: "filename", value: optional(string) },
+      ],
+    },
+  ],
+};
+
+/** `llm()`'s first argument: a plain string, or an array mixing text strings
+ *  and `image()` / `file()` attachments. */
+const llmContent: VariableType = {
+  type: "unionType",
+  types: [
+    string,
+    {
+      type: "arrayType",
+      elementType: { type: "unionType", types: [string, attachment] },
+    },
+  ],
+};
+
+/**
  * Signatures for builtin / auto-imported functions that the typechecker
  * needs to know about.
  *
@@ -163,12 +234,12 @@ export const AGENCY_FUNCTION_METHOD_TYPES: Record<string, BuiltinSignature> = {
 export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
   // --- LLM primitive ---
   llm: {
-    params: ["any", llmOptions],
+    params: [llmContent, llmOptions],
     minParams: 1,
     returnType: string,
     acceptsNamedArgs: llmNamedOptions,
     description:
-      "Send a prompt to an LLM and return its response. The return type is inferred from the call-site annotation and compiled to a JSON schema for structured output.",
+      "Send a prompt to an LLM and return its response. The prompt is a string, or an array of text strings and image()/file() attachments. The return type is inferred from the call-site annotation and compiled to a JSON schema for structured output.",
   },
 
   // --- Result type (lib/runtime/result.ts) ---

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -8,6 +8,8 @@ import {
   _systemMessage,
   _userMessage,
   _assistantMessage,
+  _imageAttachment,
+  _fileAttachment,
   _getCost,
   _getTokens,
   _getModelCosts,
@@ -15,6 +17,19 @@ import {
   _popGuard,
   _runGuarded,
  } from "agency-lang/stdlib-lib/thread.js"
+
+// KEEP IN SYNC with the structural `attachment` mirror in
+// lib/typeChecker/builtins.ts (the `llm()` first-param type) and the TS
+// `AttachmentSource` type in lib/stdlib/thread.ts. Drift is caught by
+// lib/typeChecker/attachments.test.ts.
+export type AttachmentSource =
+  | { kind: "path", path: string, mimeType?: string }
+  | { kind: "url", url: string, mimeType?: string }
+  | { kind: "base64", base64: string, mimeType: string }
+
+export type Attachment =
+  | { type: "image", source: AttachmentSource }
+  | { type: "file", source: AttachmentSource, filename?: string }
 
 export def systemMessage(msg: string) {
   """
@@ -27,15 +42,54 @@ export def systemMessage(msg: string) {
   _systemMessage(msg)
 }
 
-export def userMessage(msg: string) {
+export def userMessage(msg: string | (string | Attachment)[]) {
   """
-  Add a user message to the current thread's message history.
-  Use this when you want to seed the conversation with prior user
-  context that wasn't actually typed by the user this turn.
+  Add a user message to the current thread's message history. Accepts a
+  plain string, or an array mixing text strings and image()/file()
+  attachments. Use this when you want to seed the conversation with prior
+  user context that wasn't actually typed by the user this turn.
 
-  @param msg - The user message content
+  @param msg - The user message content: a string, or an array of strings and attachments.
   """
   _userMessage(msg)
+}
+
+export safe def image(
+  source: string,
+  mimeType: string = "",
+  base64: boolean = false,
+): Attachment {
+  """
+  Build an image attachment for a multimodal llm() call or userMessage().
+  `source` is a local path, an http(s) URL, or a data: URI. Pass base64: true
+  to treat `source` as raw base64 data (a mimeType is then required).
+  smoltalk reads/fetches and MIME-infers the source at send time.
+
+  @param source - Path, http(s) URL, data: URI, or raw base64 (with base64: true)
+  @param mimeType - Explicit MIME type; overrides inference. Required for raw base64.
+  @param base64 - When true, treat `source` as raw base64 data.
+  """
+  return _imageAttachment(source, mimeType, base64)
+}
+
+export safe def file(
+  source: string,
+  filename: string = "",
+  mimeType: string = "",
+  base64: boolean = false,
+): Attachment {
+  """
+  Build a file (e.g. PDF) attachment for a multimodal llm() call or
+  userMessage(). `source` is a local path, an http(s) URL, or a data: URI.
+  Pass base64: true to treat `source` as raw base64 data (mimeType required).
+  `filename` defaults to the source's basename.
+
+  @param source - Path, http(s) URL, data: URI, or raw base64 (with base64: true)
+  @param filename - Name shown to the model; defaults to the source basename.
+  @param mimeType - Explicit MIME type; overrides inference. Required for raw base64.
+  @param base64 - When true, treat `source` as raw base64 data.
+  """
+  return _fileAttachment(source, filename, mimeType, base64)
 }
 
 export def assistantMessage(msg: string) {

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -18,10 +18,12 @@ import {
   _runGuarded,
  } from "agency-lang/stdlib-lib/thread.js"
 
-// KEEP IN SYNC with the structural `attachment` mirror in
-// lib/typeChecker/builtins.ts (the `llm()` first-param type) and the TS
-// `AttachmentSource` type in lib/stdlib/thread.ts. Drift is caught by
-// lib/typeChecker/attachments.test.ts.
+// The single source of truth for the attachment shape. `llm()`'s first-param
+// type in lib/typeChecker/builtins.ts references this `Attachment` alias by
+// name (no duplicated structure). The TS builders in lib/stdlib/thread.ts
+// (`_imageAttachment` / `_fileAttachment`) construct values of this shape at
+// runtime, so their return types must stay structurally compatible; the
+// end-to-end fixture in tests/agency-js/multimodal-attachments guards that.
 export type AttachmentSource =
   | { kind: "path", path: string, mimeType?: string }
   | { kind: "url", url: string, mimeType?: string }

--- a/packages/agency-lang/tests/agency-js/multimodal-attachments/agent.agency
+++ b/packages/agency-lang/tests/agency-js/multimodal-attachments/agent.agency
@@ -1,0 +1,16 @@
+// Verifies multimodal attachments end-to-end: the image()/file() builders
+// from std::thread produce attachment parts that land on the active thread
+// as real message content — both when seeded via userMessage() and when
+// passed as the array first-arg to llm(). Runs under the deterministic LLM
+// provider (no real API call, no file I/O), so path-based sources are safe.
+import { image, file, userMessage } from "std::thread"
+
+node main() {
+  // A multimodal user turn seeded directly into history (before any llm()).
+  userMessage(["seed-user", image("./cat.png")])
+
+  // A multimodal llm() call: text + an image + a file, in one array.
+  let _r: string = llm(["describe", image("./cat.png"), file("./report.pdf")])
+
+  return "done"
+}

--- a/packages/agency-lang/tests/agency-js/multimodal-attachments/fixture.json
+++ b/packages/agency-lang/tests/agency-js/multimodal-attachments/fixture.json
@@ -1,0 +1,64 @@
+{
+  "data": "done",
+  "messages": {
+    "threads": {
+      "0": {
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "seed-user"
+              },
+              {
+                "type": "image",
+                "source": {
+                  "kind": "path",
+                  "path": "./cat.png"
+                }
+              }
+            ]
+          },
+          {
+            "role": "user",
+            "content": [
+              {
+                "type": "text",
+                "text": "describe"
+              },
+              {
+                "type": "image",
+                "source": {
+                  "kind": "path",
+                  "path": "./cat.png"
+                }
+              },
+              {
+                "type": "file",
+                "source": {
+                  "kind": "path",
+                  "path": "./report.pdf"
+                },
+                "filename": "report.pdf"
+              }
+            ]
+          },
+          {
+            "role": "assistant",
+            "content": "described"
+          }
+        ],
+        "parentId": null,
+        "hidden": false,
+        "label": null,
+        "summary": null
+      }
+    },
+    "counter": 1,
+    "activeStack": [
+      "0"
+    ],
+    "sessions": {}
+  }
+}

--- a/packages/agency-lang/tests/agency-js/multimodal-attachments/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/multimodal-attachments/llmMocks.json
@@ -1,0 +1,3 @@
+[
+  { "return": "described" }
+]

--- a/packages/agency-lang/tests/agency-js/multimodal-attachments/test.js
+++ b/packages/agency-lang/tests/agency-js/multimodal-attachments/test.js
@@ -1,0 +1,8 @@
+import { main } from "./agent.js";
+import { writeFileSync } from "fs";
+
+const result = await main();
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ data: result.data, messages: result.messages }, null, 2),
+);


### PR DESCRIPTION
## What

Adds multimodal **image/file attachments** to Agency, backed by smoltalk 0.7.1's multimodal user-message content. `llm()`'s first argument and `std::thread.userMessage()` now accept an array mixing text strings with attachments; smoltalk does all the I/O (reading paths, fetching URLs, MIME inference, size caps) at send time — Agency only constructs the plain attachment objects.

```ts
import { image, file } from "std::thread"

node main() {
  const answer = llm([
    "What's in this image, and how does it relate to the report?",
    image("./diagram.png"),               // local path
    image("https://example.com/a.jpg"),   // remote URL (auto-detected)
    file("./report.pdf"),                 // local PDF / file
  ])
  print(answer)
}
```

`image(source, mimeType?, base64?)` / `file(source, filename?, mimeType?, base64?)` classify `source` as a local path, `http(s)` URL, `data:` URI, or raw base64 (`base64: true`, which requires a `mimeType`).

## How

- **`std::thread`** — new `image()` / `file()` builders (TS-backed `_imageAttachment` / `_fileAttachment` that own classification + validation, since Agency has no user-level `throw`). New `Attachment` / `AttachmentSource` types; `userMessage()` widened to the same array form.
- **Typechecker** — `llm()` first param tightened from `any` to `string | (string | Attachment)[]` via a structural mirror of the `.agency` types. A new accept/reject/inference test guards the mirror against drift **and** proves heterogeneous-array-literal inference works.
- **Runtime** — `prompt` now threads `string | UserContentInput`; a single `promptText()` flattener feeds string-only consumers (memory recall). Statelog is made attachment-safe: `redactAttachments` at all four message/prompt sites (`onLLMCallStart`, `promptCompletion`, `onLLMCallEnd`, streaming `debug`) so base64 blobs never reach the log.
- **Codegen** — unchanged (an array literal already flows to `runPrompt.prompt`); locked by a guard test.
- **Docs** — new guide section; regenerated stdlib reference from the builder docstrings.

## Scope / non-goals

- `assistantMessage` / `systemMessage` stay string-only (providers don't take attachments on those roles).
- Source kinds limited to path / url / base64 (no `bytes` / `providerFile`); no `timeoutMs` / `detail` knobs in v1.

## Testing

- New: builder units (12), typechecker accept/reject/inference (6), codegen guard (2), runtime `promptText`/redaction units (4), and an end-to-end agency-js fixture asserting attachment parts land on the thread.
- Regression sweep green (llm named-args codegen, builtin named-args, agencyLlm, deterministic client, existing `stdlib-thread-messages` agency-js test).
- `tsc --noEmit` clean · `lint:structure` clean.
- Full agency suite left to CI per repo convention.

Design spec, review, and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
