### PR TITLE
fix(runtime): key parallel tool branches by position, not tool-call id

### DIFF
--- a/packages/agency-lang/lib/runtime/deterministicClient.test.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.test.ts
@@ -59,6 +59,37 @@ describe("DeterministicClient", () => {
     }
   });
 
+  it("returns multiple tool calls with synthetic ids by default", async () => {
+    const client = new DeterministicClient([
+      { toolCalls: [{ name: "a" }, { name: "b" }] },
+    ]);
+    const result = await client.text(baseConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.toolCalls).toHaveLength(2);
+      // Distinct, non-empty synthetic ids so branch keying never collides.
+      expect(result.value.toolCalls[0].id).toBe("mock-tool-1-0");
+      expect(result.value.toolCalls[1].id).toBe("mock-tool-1-1");
+    }
+  });
+
+  it("honors an explicit empty tool-call id (id-less provider like Gemini)", async () => {
+    // Google Gemini returns no tool-call id; smoltalk defaults the missing
+    // id to "". Reproducing that requires the mock to emit "" verbatim
+    // (nullish default, not `||`), which is what the agency-js
+    // parallel-tools-no-ids regression relies on.
+    const client = new DeterministicClient([
+      { toolCalls: [{ name: "a", id: "" }, { name: "b", id: "" }] },
+    ]);
+    const result = await client.text(baseConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.toolCalls).toHaveLength(2);
+      expect(result.value.toolCalls[0].id).toBe("");
+      expect(result.value.toolCalls[1].id).toBe("");
+    }
+  });
+
   it("consumes mocks in order", async () => {
     const client = new DeterministicClient([
       { return: "first" },

--- a/packages/agency-lang/lib/runtime/deterministicClient.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.ts
@@ -20,9 +20,14 @@ export type ToolCallMock = {
 };
 
 /** Multi-tool variant: simulate the LLM returning multiple tool calls in
- *  one round (used to test concurrent tool execution in `runPrompt`). */
+ *  one round (used to test concurrent tool execution in `runPrompt`).
+ *
+ *  `id` is optional: when omitted a synthetic `mock-tool-*` id is used.
+ *  Pass `id: ""` to reproduce providers (notably Google Gemini) whose
+ *  function-calling protocol returns no tool-call id — smoltalk defaults
+ *  the missing id to "". */
 export type MultiToolCallMock = {
-  toolCalls: Array<{ name: string; args?: Record<string, any> }>;
+  toolCalls: Array<{ name: string; args?: Record<string, any>; id?: string }>;
 };
 
 export type LLMMock = ReturnMock | ToolCallMock | MultiToolCallMock;
@@ -151,7 +156,13 @@ export class DeterministicClient implements LLMClient {
       // mocks for tools that take no arguments can omit it cleanly.
       const calls = mock.toolCalls.map(
         (tc, i) =>
-          new ToolCall(`mock-tool-${callIndex}-${i}`, tc.name, tc.args ?? {}),
+          // `tc.id ?? ...` (nullish, not `||`) so an explicit "" survives —
+          // that's how a test simulates an id-less provider like Gemini.
+          new ToolCall(
+            tc.id ?? `mock-tool-${callIndex}-${i}`,
+            tc.name,
+            tc.args ?? {},
+          ),
       );
       return {
         success: true,

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1096,17 +1096,32 @@ export async function runPrompt(args: {
         toolCalls,
         // keyFor: MUST match the branchKey the body uses below
         // (`stack.getOrCreateBranch(branchKey)`) so runBatch and the body
-        // operate on the same branch.
-        (toolCall) => `tool_${toolCall.id}`,
-        async (toolCall, b) => {
+        // operate on the same branch. Keyed by the tool call's POSITION in
+        // the round, not its id: some providers (notably Google Gemini)
+        // return tool calls with no id — Gemini matches responses to calls
+        // by function name + position, so smoltalk defaults the missing id
+        // to "". Two id-less parallel calls would otherwise collide on the
+        // branch key ("tool_") and trip `runBatch: duplicate child key`.
+        // The id is folded in after the index only for readability; the
+        // index alone guarantees uniqueness within the round.
+        (toolCall, i) => `tool_${i}_${toolCall.id}`,
+        async (toolCall, b, index) => {
           if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
+
+          // Per-call slug used for the branch key, every resume-idempotency
+          // step path, and the per-tool timing key below. Position-based so
+          // it stays unique even when `toolCall.id` is "" (see keyFor). Must
+          // NOT leak into message `tool_call_id` fields — those keep the
+          // real (possibly empty) id so provider pairing / threadRepair are
+          // byte-for-byte unchanged.
+          const callSlug = `${index}_${toolCall.id}`;
 
           const handler = toolFunctions.find(
             (fn) => fn.name === toolCall.name,
           );
           if (!handler) {
             await b.step(
-              `round.${round}.tool.${toolCall.id}.unhandled`,
+              `round.${round}.tool.${callSlug}.unhandled`,
               async () => {
                 console.error(
                   `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
@@ -1124,7 +1139,7 @@ export async function runPrompt(args: {
 
           if (self.toolCallRound >= maxToolCallRounds) {
             await b.step(
-              `round.${round}.tool.${toolCall.id}.tooManyRounds`,
+              `round.${round}.tool.${callSlug}.tooManyRounds`,
               async () => {
                 messages.push(
                   smoltalk.toolMessage(
@@ -1144,7 +1159,7 @@ export async function runPrompt(args: {
           // notice toolMessage.
           if (removedTools.includes(handler.name)) {
             await b.step(
-              `round.${round}.tool.${toolCall.id}.removed`,
+              `round.${round}.tool.${callSlug}.removed`,
               async () => {
                 messages.push(
                   smoltalk.toolMessage(
@@ -1157,7 +1172,7 @@ export async function runPrompt(args: {
             return;
           }
 
-          const branchKey = `tool_${toolCall.id}`;
+          const branchKey = `tool_${callSlug}`;
           // Note: a "cached result" short-circuit used to live here for
           // resume after a sibling interrupt; idempotency is now handled
           // uniformly by completedSteps inside b.step (start/invoke/end
@@ -1166,7 +1181,7 @@ export async function runPrompt(args: {
           const namedArgs = { ...toolCall.arguments };
 
           await b.step(
-            `round.${round}.tool.${toolCall.id}.start`,
+            `round.${round}.tool.${callSlug}.start`,
             async () => {
               // Pass `branchStack` so scoped callbacks registered inside
               // the branch's frame chain are discovered by
@@ -1212,7 +1227,7 @@ export async function runPrompt(args: {
             // tool that began even when the run is killed before it
             // completes (the matching toolCall event won't fire).
             await b.step(
-              `round.${round}.tool.${toolCall.id}.logStart`,
+              `round.${round}.tool.${callSlug}.logStart`,
               async () => {
                 ctx.statelogClient.toolCallStart({
                   toolName: handler.name,
@@ -1229,7 +1244,7 @@ export async function runPrompt(args: {
             // (returns void unless interrupted) and is marked done so
             // resume skips this whole block.
             await b.step(
-              `round.${round}.tool.${toolCall.id}.invoke`,
+              `round.${round}.tool.${callSlug}.invoke`,
               async () => {
                 const outcome = await runInvokeStep({
                   handler,
@@ -1241,7 +1256,7 @@ export async function runPrompt(args: {
                 toolResult = outcome.toolResult;
                 invokeOutcome = outcome.invokeOutcome;
                 if (outcome.invokeOutcome === "success") {
-                  self.runnerState.toolTimings[toolCall.id] =
+                  self.runnerState.toolTimings[callSlug] =
                     performance.now() - toolCallStartTime;
                 }
                 return outcome.interrupts;
@@ -1262,9 +1277,9 @@ export async function runPrompt(args: {
             // statelogClient.toolCall always report the real exec time,
             // not the resume pass's overhead.
             const timeTaken: number =
-              self.runnerState.toolTimings[toolCall.id] ?? 0;
+              self.runnerState.toolTimings[callSlug] ?? 0;
             await b.step(
-              `round.${round}.tool.${toolCall.id}.end`,
+              `round.${round}.tool.${callSlug}.end`,
               async () => {
                 // Same scope-discovery rationale as the .start hook.
                 await invokeCallbacks({
@@ -1284,7 +1299,7 @@ export async function runPrompt(args: {
             // (e.g. after a later `nextLlmCall` step bails). Without this
             // guard, every re-entry would emit a duplicate toolCall event.
             await b.step(
-              `round.${round}.tool.${toolCall.id}.log`,
+              `round.${round}.tool.${callSlug}.log`,
               async () => {
                 ctx.statelogClient.toolCall({
                   toolName: handler.name,

--- a/packages/agency-lang/lib/runtime/promptRunner.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.ts
@@ -165,7 +165,7 @@ export class PromptRunner {
     keyPrefix: string,
     items: T[],
     keyFor: (item: T, index: number) => string,
-    branchFn: (item: T, b: BranchRunner) => Promise<void>,
+    branchFn: (item: T, b: BranchRunner, index: number) => Promise<void>,
   ): Promise<RunBatchResult<void>> {
     const branches = items.map(() => new BranchRunner(this.opts.self));
     const parentFrame = this.opts.parentFrame ?? this.opts.stateStack.lastFrame();
@@ -202,7 +202,7 @@ export class PromptRunner {
       children: items.map((item, i) => ({
         key: keyFor(item, i),
         invoke: async () => {
-          await branchFn(item, branches[i]);
+          await branchFn(item, branches[i], i);
           // Surface the branch's collected interrupts (if any) as the
           // invoke's return value. runBatch will batch them with sibling
           // interrupts and stamp the shared checkpoint.

--- a/packages/agency-lang/tests/agency-js/parallel-tools-no-ids-resume/agent.agency
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-no-ids-resume/agent.agency
@@ -1,0 +1,12 @@
+def succeedTool(): string {
+  return "SUCCEED_RESULT"
+}
+
+def interruptTool(): string {
+  interrupt("approve interrupt-tool")
+  return "INTERRUPT_RESULT"
+}
+
+node main() {
+  return llm("call both tools in parallel", { tools: [succeedTool, interruptTool] })
+}

--- a/packages/agency-lang/tests/agency-js/parallel-tools-no-ids-resume/fixture.json
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-no-ids-resume/fixture.json
@@ -1,0 +1,8 @@
+{
+  "finalData": "all done",
+  "llmCallCount": 2,
+  "toolResponseContents": [
+    "INTERRUPT_RESULT",
+    "SUCCEED_RESULT"
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/parallel-tools-no-ids-resume/test.js
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-no-ids-resume/test.js
@@ -1,0 +1,137 @@
+import {
+  main,
+  hasInterrupts,
+  approve,
+  respondToInterrupts,
+  __setLLMClient,
+} from "./agent.js";
+import { writeFileSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+// Interrupt/resume regression for id-less tool calls (e.g. Google Gemini,
+// whose function-calling protocol returns NO tool-call id — smoltalk
+// defaults the missing id to ""). A single parallel-tool round has one
+// tool succeed and a sibling interrupt. This exercises BOTH halves of the
+// id-less fix in prompt.ts:
+//
+//   1. Branch key: `tool_${index}_${id}` — without the index, both id-less
+//      branches key on "tool_" and runBatch throws `duplicate child key`,
+//      so `main()` would never surface interrupts at all.
+//
+//   2. Per-tool resume step paths (`completedSteps`): keyed by the same
+//      index-based slug. If they instead collided on the empty id,
+//      succeedTool completing on the FIRST pass would mark the shared
+//      `round.0.tool..invoke` step done, so on RESUME interruptTool's
+//      invoke step is skipped — interruptTool never returns and its
+//      tool_response is dropped. The post-resume LLM call would then see
+//      only ONE tool response instead of two.
+//
+// The assertion that the SECOND (post-resume) llm call carries exactly two
+// tool responses — one per tool, each invoked exactly once — is what pins
+// down the step-path half of the fix.
+
+const captured = [];
+let callIndex = 0;
+
+const SYNTHETIC_USAGE = {
+  inputTokens: 1,
+  outputTokens: 1,
+  cachedInputTokens: 0,
+  totalTokens: 2,
+};
+const SYNTHETIC_COST = {
+  inputCost: 0,
+  outputCost: 0,
+  totalCost: 0,
+  currency: "USD",
+};
+
+const captureClient = {
+  async text(config) {
+    captured.push({
+      messages: config.messages.map((m) => {
+        const json = typeof m.toJSON === "function" ? m.toJSON() : m;
+        return {
+          role: json.role,
+          tool_call_id: json.tool_call_id ?? null,
+          content: json.content ?? null,
+        };
+      }),
+    });
+    const idx = callIndex++;
+    if (idx === 0) {
+      // First call: two parallel tool calls, BOTH with an empty id — the
+      // exact shape smoltalk produces for a Gemini parallel-tool round.
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [
+            new ToolCall("", "succeedTool", {}),
+            new ToolCall("", "interruptTool", {}),
+          ],
+          model: "test",
+          usage: SYNTHETIC_USAGE,
+          cost: SYNTHETIC_COST,
+        },
+      };
+    }
+    // After both tool responses are pushed back, wrap up.
+    return {
+      success: true,
+      value: {
+        output: "all done",
+        toolCalls: [],
+        model: "test",
+        usage: SYNTHETIC_USAGE,
+        cost: SYNTHETIC_COST,
+      },
+    };
+  },
+  async *textStream(config) {
+    const result = await this.text(config);
+    if (result.success) {
+      yield { type: "done", result: result.value };
+    } else {
+      yield { type: "error", error: result.error };
+    }
+  },
+  async embed() {
+    return { success: false, error: "captureClient does not implement embed" };
+  },
+};
+
+__setLLMClient(captureClient);
+
+const initial = await main();
+if (!hasInterrupts(initial.data)) {
+  // Would trip if the id-less branch keys collided (runBatch crash) — the
+  // round never runs, so interruptTool never interrupts.
+  throw new Error(
+    `Expected interrupts from interruptTool, got: ${JSON.stringify(initial.data)}`,
+  );
+}
+
+const final = await respondToInterrupts(initial.data, [approve()]);
+
+// The post-resume llm call must carry BOTH tool responses, each exactly
+// once. Sorting by content makes the fixture stable regardless of branch
+// completion order.
+const secondCall = captured[captured.length - 1];
+const toolContents = secondCall.messages
+  .filter((m) => m.role === "tool")
+  .map((m) => m.content)
+  .sort();
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      finalData: final.data,
+      llmCallCount: captured.length,
+      toolResponseContents: toolContents,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/agent.agency
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/agent.agency
@@ -1,0 +1,13 @@
+def slowTool1(): string {
+  sleep(50)
+  return "tool1 done"
+}
+
+def slowTool2(): string {
+  sleep(50)
+  return "tool2 done"
+}
+
+node main() {
+  return llm("call both slowTool1 and slowTool2", { tools: [slowTool1, slowTool2] })
+}

--- a/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/fixture.json
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/fixture.json
@@ -1,0 +1,3 @@
+{
+  "data": "both done"
+}

--- a/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/llmMocks.json
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/llmMocks.json
@@ -1,0 +1,9 @@
+[
+  {
+    "toolCalls": [
+      { "name": "slowTool1", "args": {}, "id": "" },
+      { "name": "slowTool2", "args": {}, "id": "" }
+    ]
+  },
+  { "return": "both done" }
+]

--- a/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/test.js
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-no-ids/test.js
@@ -1,0 +1,15 @@
+import { main } from "./agent.js";
+import { writeFileSync } from "fs";
+
+// Two tools are called in one LLM round, but the mocked provider returns
+// BOTH tool calls with an empty id ("") — exactly what Google Gemini's
+// function-calling protocol does (it matches responses to calls by name +
+// position, not by id, so smoltalk defaults the missing id to ""). The
+// tool-dispatch loop must NOT collide on a shared "tool_" branch key; the
+// regression this guards against is `runBatch: duplicate child key "tool_"`.
+const result = await main();
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ data: result.data }, null, 2),
+);


### PR DESCRIPTION
## Summary

Fixes `runBatch: duplicate child key "tool_"` when running on **Google Gemini** with parallel tool calls.

Gemini's function-calling protocol returns **no tool-call id** — it matches responses to calls by function name + position, not by id — so smoltalk's Google client defaults the missing id to `""` (`clients/google.js`, `id: z.string().default("")`). runPrompt's parallel tool-dispatch loop keyed each concurrent branch off `tool_${toolCall.id}`, so when Gemini emitted **two tool calls in one round** (parallel function calling), both keys became `"tool_"` and `runBatch` threw:

```
ERROR Function codeAgent threw an exception (converted to Failure): runBatch: duplicate child key "tool_"
    at runBatch (.../runBatch.js:243)
    at PromptRunner.parallel (.../promptRunner.js:125)
    at runPrompt (.../prompt.js:825)
```

The `No handler found for tool call: codeAgent` line was a secondary symptom after the round was abandoned.

## Fix

Derive the branch key, **every per-tool resume step path, and the per-tool timing key** from the tool call's **position index** in the round (`${index}_${toolCall.id}`) instead of the id alone — exactly how Gemini itself disambiguates parallel calls. This also closes a latent second bug: the id-less step paths were colliding too, which would silently break interrupt/resume idempotency (`completedSteps`) for id-less providers.

The real (possibly empty) `toolCall.id` is left **untouched** in message `tool_call_id` fields, so provider pairing and `threadRepair` are byte-for-byte unchanged.

Not done by mutating the id: at runtime the tool calls are `ToolCall` instances (getter, **no setter**) on a fresh run but plain JSON on resume, so mutation is unreliable and would also touch message content.

## Changes

- `lib/runtime/prompt.ts` — branch key / step paths / timing key use a position-based slug (`callSlug`)
- `lib/runtime/promptRunner.ts` — `pr.parallel` threads the item index into the branch body
- `lib/runtime/deterministicClient.ts` — `MultiToolCallMock` accepts an optional per-call `id` so tests can simulate an id-less provider (pass `id: ""`)
- `tests/agency-js/parallel-tools-no-ids/` — regression test: two id-less parallel tool calls in one round must not collide

## Testing

- New regression test reproduces the exact error without the fix and passes with it.
- Unit tests pass: `promptRunner`, `deterministicClient`, `prompt`, `agencyLlm`, `agencyLlm.checkpointInfo`, `agencyInterrupt`, `interrupts` (94 tests).
- Structural lint clean.
- The pre-existing `parallel-tools` timing assertion (`ranInParallel`) is unaffected by this change — its `data` result stays `"both done"`; only its wall-clock threshold is machine-load sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
