### PR TITLE
Type the standard library's interrupts

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -14,7 +14,46 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L16))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L30))
+
+## Effects
+
+### std::read
+
+```ts
+effect std::read {
+  dir: string;
+  filename: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L19))
+
+### std::write
+
+```ts
+effect std::write {
+  dir: string;
+  filename: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L20))
+
+### std::run
+
+```ts
+effect std::run {
+  moduleId: string;
+  node: string;
+  args: Record<string, any>;
+  limits: { wallClock: number; memory: number; ipcPayload: number; stdout: number };
+  cwd: string;
+  logFile: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L21))
 
 ## Functions
 
@@ -35,7 +74,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L55))
 
 ### run
 
@@ -75,7 +114,7 @@ Execute a compiled Agency program in a subprocess. The parent's handler chain ex
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L63))
 
 ### runFile
 
@@ -117,7 +156,7 @@ Compile and execute an Agency file in a subprocess. The file is read from dir/fi
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L115))
 
 ### typecheck
 
@@ -139,7 +178,7 @@ Type-check Agency source code without compiling or running it. Returns a TypeChe
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L158))
 
 ### parseAST
 
@@ -161,7 +200,7 @@ Parse Agency source code into an abstract syntax tree. Returns the raw AST as a 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L174))
 
 ### writeAST
 
@@ -193,7 +232,7 @@ Format an AST as Agency source and write it to dir/filename. The AST is typicall
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L171))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L185))
 
 ### format
 
@@ -215,7 +254,7 @@ Format Agency source code using the standard Agency formatter (the same one used
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L197))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L211))
 
 ### formatFile
 
@@ -243,7 +282,7 @@ Format an Agency file in place. Reads dir/filename, formats it with the standard
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L208))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L222))
 
 ### walkAST
 
@@ -269,7 +308,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor with each
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L226))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L240))
 
 ### getNodesOfType
 
@@ -293,7 +332,7 @@ Parse Agency source code and return all AST nodes whose `type` field matches any
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L244))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L258))
 
 ### getImports
 
@@ -313,7 +352,7 @@ Return all import statements in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L256))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L270))
 
 ### getFunctions
 
@@ -333,7 +372,7 @@ Return all function definitions (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L265))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L279))
 
 ### getGraphNodes
 
@@ -353,7 +392,7 @@ Return all graph node definitions (`node main() { ... }`) in the source. Note: "
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L288))
 
 ### filterImports
 
@@ -396,7 +435,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L283))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L297))
 
 ### typecheckFile
 
@@ -426,7 +465,7 @@ Type-check an Agency file on disk. The file is read from dir/filename, and relat
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L323))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L337))
 
 ### getVersion
 
@@ -438,4 +477,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L343))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L357))

--- a/packages/agency-lang/docs/site/stdlib/agent.md
+++ b/packages/agency-lang/docs/site/stdlib/agent.md
@@ -119,7 +119,7 @@ export type PromptSpec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L132))
 
 ### AgentSpec
 
@@ -131,7 +131,7 @@ export type AgentSpec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L137))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L139))
 
 ### RouterConfig
 
@@ -175,7 +175,19 @@ export type RouterConfig = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L159))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L161))
+
+## Effects
+
+### std::question
+
+```ts
+effect std::question {
+  prompt: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L89))
 
 ## Functions
 
@@ -195,7 +207,7 @@ Replace the current todo list. Each todo has an id, text, and status (one of 'pe
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L91))
 
 ### todoList
 
@@ -207,7 +219,7 @@ Return the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L99))
 
 ### question
 
@@ -227,7 +239,7 @@ Ask the user a question and wait for their reply. Unlike input(), this raises an
 
 **Throws:** `std::question`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L106))
 
 ### handoff
 
@@ -271,7 +283,7 @@ Re-route the user's current message to a different specialist.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L191))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L193))
 
 ### consumeHandoff
 
@@ -290,7 +302,7 @@ Read and clear the pending handoff target. Returns "" when no
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L224))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L226))
 
 ### route
 
@@ -343,4 +355,4 @@ Run one user turn through a multi-specialist agent. Owns the hop
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L347))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L349))

--- a/packages/agency-lang/docs/site/stdlib/auth/keyring.md
+++ b/packages/agency-lang/docs/site/stdlib/auth/keyring.md
@@ -28,6 +28,41 @@ name: "keyring"
   Pass a custom `service` parameter to use a different namespace.
   No external dependencies required.
 
+## Effects
+
+### std::setSecret
+
+```ts
+effect std::setSecret {
+  key: string;
+  service: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L29))
+
+### std::getSecret
+
+```ts
+effect std::getSecret {
+  key: string;
+  service: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L30))
+
+### std::deleteSecret
+
+```ts
+effect std::deleteSecret {
+  key: string;
+  service: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L31))
+
 ## Functions
 
 ### setSecret
@@ -54,7 +89,7 @@ Store a secret in the system keyring (macOS Keychain or Linux Secret Service). T
 
 **Throws:** `std::setSecret`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L33))
 
 ### getSecret
 
@@ -78,7 +113,7 @@ Retrieve a secret from the system keyring by key. Returns the secret value as a 
 
 **Throws:** `std::getSecret`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L49))
 
 ### deleteSecret
 
@@ -102,7 +137,7 @@ Delete a secret from the system keyring. Returns true if deleted, false if the k
 
 **Throws:** `std::deleteSecret`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L64))
 
 ### isKeyringAvailable
 
@@ -114,4 +149,4 @@ Check if the system keyring is available on this platform. Returns true on macOS
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L79))

--- a/packages/agency-lang/docs/site/stdlib/auth/oauth.md
+++ b/packages/agency-lang/docs/site/stdlib/auth/oauth.md
@@ -47,6 +47,40 @@ name: "oauth"
   2. System keyring (macOS Keychain / Linux Secret Service) — key is auto-generated on first use
   3. If neither is available, tokens are stored unencrypted
 
+## Effects
+
+### std::authorize
+
+```ts
+effect std::authorize {
+  name: string;
+  authUrl: string;
+  scopes: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L49))
+
+### std::getAccessToken
+
+```ts
+effect std::getAccessToken {
+  name: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L50))
+
+### std::revokeAuth
+
+```ts
+effect std::revokeAuth {
+  name: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L51))
+
 ## Functions
 
 ### authorize
@@ -83,7 +117,7 @@ Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, cap
 
 **Throws:** `std::authorize`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L53))
 
 ### getAccessToken
 
@@ -105,7 +139,7 @@ Get a valid OAuth access token for a previously authorized provider. Automatical
 
 **Throws:** `std::getAccessToken`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L83))
 
 ### isAuthorized
 
@@ -123,7 +157,7 @@ Check if OAuth tokens exist for a given provider name. Returns true if tokens ar
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L92))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L96))
 
 ### revokeAuth
 
@@ -143,4 +177,4 @@ Delete stored OAuth tokens for a provider. The user will need to run authorize a
 
 **Throws:** `std::revokeAuth`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L103))

--- a/packages/agency-lang/docs/site/stdlib/calendar.md
+++ b/packages/agency-lang/docs/site/stdlib/calendar.md
@@ -108,6 +108,68 @@ name: "calendar"
 
 ## Types
 
+## Effects
+
+### std::authorizeCalendar
+
+```ts
+effect std::authorizeCalendar {
+  clientId: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L117))
+
+### std::listEvents
+
+```ts
+effect std::listEvents {
+  maxResults: number;
+  calendarId: string;
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L118))
+
+### std::createEvent
+
+```ts
+effect std::createEvent {
+  summary: string;
+  start: string;
+  end: string;
+  description: string;
+  location: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L119))
+
+### std::updateEvent
+
+```ts
+effect std::updateEvent {
+  eventId: string;
+  summary: string;
+  start: string;
+  end: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L120))
+
+### std::deleteEvent
+
+```ts
+effect std::deleteEvent {
+  eventId: string;
+  calendarId: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L121))
+
 ## Functions
 
 ### authorizeCalendar
@@ -132,7 +194,7 @@ Authorize access to Google Calendar. Opens a browser for the user to sign in and
 
 **Throws:** `std::authorizeCalendar`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L123))
 
 ### isCalendarAuthorized
 
@@ -144,7 +206,7 @@ Check if Google Calendar has been authorized. Returns true if OAuth tokens exist
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L137))
 
 ### listEvents
 
@@ -174,7 +236,7 @@ List upcoming events from Google Calendar. Returns an array of events with id, s
 
 **Throws:** `std::listEvents`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L138))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L144))
 
 ### createEvent
 
@@ -206,7 +268,7 @@ Create a new event on Google Calendar. Parameters: summary (title), start (ISO 8
 
 **Throws:** `std::createEvent`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L169))
 
 ### updateEvent
 
@@ -240,7 +302,7 @@ Update an existing event on Google Calendar. Pass the eventId and any fields to 
 
 **Throws:** `std::updateEvent`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L198))
 
 ### deleteEvent
 
@@ -264,4 +326,4 @@ Delete an event from Google Calendar by its event ID. Returns { deleted: true } 
 
 **Throws:** `std::deleteEvent`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L222))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L228))

--- a/packages/agency-lang/docs/site/stdlib/capabilities.md
+++ b/packages/agency-lang/docs/site/stdlib/capabilities.md
@@ -85,7 +85,7 @@ Anything that talks to the outside world over the network.
 
 ```ts
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary>
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L45))

--- a/packages/agency-lang/docs/site/stdlib/clipboard.md
+++ b/packages/agency-lang/docs/site/stdlib/clipboard.md
@@ -4,6 +4,24 @@ name: "clipboard"
 
 # clipboard
 
+## Effects
+
+### std::clipboardCopy
+
+```ts
+effect std::clipboardCopy {}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L3))
+
+### std::clipboardPaste
+
+```ts
+effect std::clipboardPaste {}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L4))
+
 ## Functions
 
 ### copy
@@ -22,7 +40,7 @@ A tool for copying text to the system clipboard.
 
 **Throws:** `std::clipboardCopy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L3))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L6))
 
 ### paste
 
@@ -36,4 +54,4 @@ A tool for reading text from the system clipboard.
 
 **Throws:** `std::clipboardPaste`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L12))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L15))

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -6,6 +6,74 @@ name: "fs"
 
 ## Types
 
+## Effects
+
+### std::edit
+
+```ts
+effect std::edit {
+  dir: string;
+  filename: string;
+  edits: Edit[];
+  before: string;
+  after: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L17))
+
+### std::applyPatch
+
+```ts
+effect std::applyPatch {
+  patch: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L18))
+
+### std::mkdir
+
+```ts
+effect std::mkdir {
+  dir: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L19))
+
+### std::copy
+
+```ts
+effect std::copy {
+  src: string;
+  dest: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L20))
+
+### std::move
+
+```ts
+effect std::move {
+  src: string;
+  dest: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L21))
+
+### std::remove
+
+```ts
+effect std::remove {
+  target: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L22))
+
 ## Functions
 
 ### edit
@@ -38,7 +106,7 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 
 **Throws:** `std::edit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L17))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L24))
 
 ### applyPatch
 
@@ -62,7 +130,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L50))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L57))
 
 ### mkdir
 
@@ -88,7 +156,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L71))
 
 ### copy
 
@@ -116,7 +184,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L89))
 
 ### move
 
@@ -144,7 +212,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L110))
 
 ### remove
 
@@ -170,4 +238,4 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L131))

--- a/packages/agency-lang/docs/site/stdlib/http.md
+++ b/packages/agency-lang/docs/site/stdlib/http.md
@@ -4,6 +4,41 @@ name: "http"
 
 # http
 
+## Effects
+
+### std::http::fetch
+
+```ts
+effect std::http::fetch {
+  baseUrl: string;
+  path: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L12))
+
+### std::http::fetchJSON
+
+```ts
+effect std::http::fetchJSON {
+  baseUrl: string;
+  path: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L13))
+
+### std::http::fetchMarkdown
+
+```ts
+effect std::http::fetchMarkdown {
+  baseUrl: string;
+  path: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L14))
+
 ## Functions
 
 ### fetch
@@ -34,7 +69,7 @@ A tool for fetching a URL and returning the response as text. Provide baseUrl an
 
 **Throws:** `std::http::fetch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L12))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L16))
 
 ### fetchJSON
 
@@ -64,7 +99,7 @@ A tool for fetching a URL and returning the response as parsed JSON. Provide bas
 
 **Throws:** `std::http::fetchJSON`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L39))
 
 ### fetchMarkdown
 
@@ -94,4 +129,4 @@ Fetch a URL and return the body as readable markdown when the response is HTML, 
 
 **Throws:** `std::http::fetchMarkdown`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L62))

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -4,6 +4,52 @@ name: "index"
 
 # index
 
+## Effects
+
+### std::read
+
+```ts
+effect std::read {
+  dir: string;
+  filename: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L51))
+
+### std::write
+
+```ts
+effect std::write {
+  dir: string;
+  filename: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L52))
+
+### std::readImage
+
+```ts
+effect std::readImage {
+  dir: string;
+  filename: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L53))
+
+### std::notify
+
+```ts
+effect std::notify {
+  title: string;
+  body: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L54))
+
 ## Functions
 
 ### print
@@ -20,7 +66,7 @@ A tool for printing a message to the console.
 |---|---|---|
 | messages |  |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L56))
 
 ### setAgentCwd
 
@@ -41,7 +87,7 @@ Set the agent working directory. Path-taking tools (read, write, edit,
 |---|---|---|
 | dir | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L75))
 
 ### getAgentCwd
 
@@ -54,7 +100,7 @@ Return the agent working directory, or an empty string when none is
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L87))
 
 ### applyAgentCwd
 
@@ -78,7 +124,7 @@ Resolve `dir` against the agent working directory when one is set;
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L95))
 
 ### printJSON
 
@@ -95,7 +141,7 @@ A tool for printing an object as formatted JSON to the console.
 | obj | `any` |  |
 | highlight | `boolean` | false |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L112))
 
 ### parseJSON
 
@@ -113,7 +159,7 @@ Parse a JSON string and return the corresponding value (object, array, string, n
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L114))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L124))
 
 ### input
 
@@ -133,7 +179,7 @@ A tool for prompting the user for input and returning their response.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L131))
 
 ### sleep
 
@@ -151,7 +197,7 @@ Pause execution for the given duration in milliseconds. Use with unit literals f
 |---|---|---|
 | ms | `number` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L140))
 
 ### round
 
@@ -170,7 +216,7 @@ A tool for rounding a number to a specified number of decimal places.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L149))
 
 ### read
 
@@ -206,7 +252,7 @@ A tool for reading the contents of a file and returning it as a string. The file
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L156))
 
 ### write
 
@@ -241,7 +287,7 @@ A tool for writing content to a file. The filename is resolved relative to dir.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L180))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L190))
 
 ### readImage
 
@@ -267,7 +313,7 @@ A tool for reading an image file and returning its contents as a Base64-encoded 
 
 **Throws:** `std::readImage`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L213))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L223))
 
 ### notify
 
@@ -288,7 +334,7 @@ A tool for showing a native OS notification with a title and message. Returns tr
 
 **Throws:** `std::notify`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L235))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L245))
 
 ### range
 
@@ -307,7 +353,7 @@ Generate an array of numbers. With one argument, generates from 0 to start-1. Wi
 
 **Returns:** `number[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L246))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L256))
 
 ### mostCommon
 
@@ -325,7 +371,7 @@ Return the most common element in an array. Uses JSON serialization for comparis
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L256))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L266))
 
 ### keys
 
@@ -343,7 +389,7 @@ Return an array of an object's own enumerable property names.
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L263))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L273))
 
 ### values
 
@@ -361,7 +407,7 @@ Return an array of an object's own enumerable property values.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L270))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L280))
 
 ### entries
 
@@ -379,7 +425,7 @@ Return an array of an object's own enumerable entries, each as { key, value }.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L277))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L287))
 
 ### emit
 
@@ -395,7 +441,7 @@ Emit a custom event to the calling TypeScript code via the onEmit callback.
 |---|---|---|
 | data |  |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L284))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L294))
 
 ### callback
 
@@ -417,4 +463,4 @@ Register a scoped callback for the dynamic extent of the calling function or nod
 | name | `string` |  |
 | fn | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L291))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L301))

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -20,6 +20,56 @@ export type MemoryConfig = {
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L40))
 
+## Effects
+
+### std::memory::enableMemory
+
+```ts
+effect std::memory::enableMemory {
+  dir: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L48))
+
+### std::memory::disableMemory
+
+```ts
+effect std::memory::disableMemory {}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L49))
+
+### std::memory::remember
+
+```ts
+effect std::memory::remember {
+  contentLength: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L50))
+
+### std::memory::recall
+
+```ts
+effect std::memory::recall {
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L51))
+
+### std::memory::forget
+
+```ts
+effect std::memory::forget {
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L52))
+
 ## Functions
 
 ### isMemoryActive
@@ -40,7 +90,7 @@ Return `true` iff there is an active memory frame on the current
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L54))
 
 ### setMemoryId
 
@@ -72,7 +122,7 @@ Set the memory scope for this agent run. Call this before other
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L69))
 
 ### getMemoryId
 
@@ -88,7 +138,7 @@ Return the current memory scope id (the value last passed to
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L92))
 
 ### enableMemory
 
@@ -128,7 +178,7 @@ Turn memory on for the current execution branch using `config`.
 
 **Throws:** `std::memory::enableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L103))
 
 ### disableMemory
 
@@ -149,7 +199,7 @@ Pop the top memory frame from the current branch's stateStack.
 
 **Throws:** `std::memory::disableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L136))
 
 ### memory
 
@@ -189,7 +239,7 @@ Run `block` with `config` pushed as the active memory frame; pop
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L154))
 
 ### remember
 
@@ -216,7 +266,7 @@ Extract and store structured facts from the given text into the
 
 **Throws:** `std::memory::remember`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L181))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L187))
 
 ### recall
 
@@ -243,7 +293,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Throws:** `std::memory::recall`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L207))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L213))
 
 ### forget
 
@@ -269,4 +319,4 @@ Soft-delete facts matching the query from the knowledge graph.
 
 **Throws:** `std::memory::forget`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L225))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L231))

--- a/packages/agency-lang/docs/site/stdlib/messaging/email.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/email.md
@@ -40,6 +40,20 @@ name: "email"
 
 ## Types
 
+## Effects
+
+### std::sendEmail
+
+```ts
+effect std::sendEmail {
+  from: string;
+  to: string;
+  subject: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L44))
+
 ## Functions
 
 ### sendWithResend
@@ -84,7 +98,7 @@ Send an email using the Resend API. Requires `RESEND_API_KEY` env var or pass ap
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L47))
 
 ### sendWithSendGrid
 
@@ -128,7 +142,7 @@ Send an email using the SendGrid API. Requires `SENDGRID_API_KEY` env var or pas
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L84))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L86))
 
 ### sendWithMailgun
 
@@ -176,4 +190,4 @@ Send an email using the Mailgun API. Requires `MAILGUN_API_KEY` and `MAILGUN_DOM
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L125))

--- a/packages/agency-lang/docs/site/stdlib/messaging/imessage.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/imessage.md
@@ -22,6 +22,18 @@ name: "imessage"
 
 ## Types
 
+## Effects
+
+### std::sendIMessage
+
+```ts
+effect std::sendIMessage {
+  to: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/imessage.agency#L25))
+
 ## Functions
 
 ### sendIMessage
@@ -50,4 +62,4 @@ Send an iMessage via the macOS Messages app. Only works on macOS with Messages.a
 
 **Throws:** `std::sendIMessage`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/imessage.agency#L25))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/imessage.agency#L27))

--- a/packages/agency-lang/docs/site/stdlib/messaging/sms.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/sms.md
@@ -22,6 +22,18 @@ name: "sms"
 
 ## Types
 
+## Effects
+
+### std::sendSms
+
+```ts
+effect std::sendSms {
+  to: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/sms.agency#L26))
+
 ## Functions
 
 ### sendSms
@@ -56,4 +68,4 @@ Send an SMS text message via the Twilio API. Requires TWILIO_ACCOUNT_SID, TWILIO
 
 **Throws:** `std::sendSms`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/sms.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/sms.agency#L28))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -6,6 +6,73 @@ name: "shell"
 
 ## Types
 
+## Effects
+
+### std::exec
+
+```ts
+effect std::exec {
+  command: string;
+  args: string[];
+  subcommand: string;
+  cwd: string;
+  timeout: number;
+  stdin: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L20))
+
+### std::bash
+
+```ts
+effect std::bash {
+  command: string;
+  cwd: string;
+  timeout: number;
+  stdin: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L21))
+
+### std::ls
+
+```ts
+effect std::ls {
+  dir: string;
+  recursive: boolean;
+  maxResults: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L22))
+
+### std::grep
+
+```ts
+effect std::grep {
+  pattern: string;
+  dir: string;
+  flags: string;
+  maxResults: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L23))
+
+### std::glob
+
+```ts
+effect std::glob {
+  pattern: string;
+  dir: string;
+  maxResults: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L24))
+
 ## Functions
 
 ### exec
@@ -44,7 +111,7 @@ Run an executable directly with an array of arguments, bypassing the shell. This
 
 **Throws:** `std::exec`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L20))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L26))
 
 ### bash
 
@@ -78,7 +145,7 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L85))
 
 ### ls
 
@@ -110,7 +177,7 @@ List entries in a directory. Each entry includes name, path, type ("file", "dir"
 
 **Throws:** `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L128))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L134))
 
 ### grep
 
@@ -146,7 +213,7 @@ Search for a regex pattern in files under a directory. Returns matches with file
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L170))
 
 ### glob
 
@@ -176,7 +243,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Stops at maxRe
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L199))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L205))
 
 ### stat
 
@@ -204,7 +271,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L234))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L240))
 
 ### exists
 
@@ -232,7 +299,7 @@ Return true if a file or directory exists at the given path. Set allowedPaths to
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L256))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L262))
 
 ### which
 
@@ -250,4 +317,4 @@ Locate an executable in PATH and return its absolute path. Returns an empty stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L278))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L284))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -6,18 +6,9 @@ name: "skills"
 
 ## Types
 
-## Functions
+## Effects
 
-### skillsDir
-
-```ts
-skillsDir(dir: string, layout: "flat" | "standard")
-```
-
-Build a skills tool for an LLM over a directory of skills.
-
-  @param dir - Directory containing the skills.
-  @param layout - "standard" (default) for subdirectory-per-skill with SKILL.md, "flat" for a directory of loose Markdown files.
+### std::skills::skillsDir
 
 * Build a tool that lets an LLM read skill files in `dir`. Supports two
  * layouts:
@@ -31,6 +22,51 @@ Build a skills tool for an LLM over a directory of skills.
  * description lists every available skill so the LLM knows which
  * `location` to pass back as `filename`.
 
+```ts
+/**
+ * Build a tool that lets an LLM read skill files in `dir`. Supports two
+ * layouts:
+ *   - "standard" (default): each subdirectory of `dir` is one skill
+ *     with a `SKILL.md` entrypoint. Frontmatter `name` / `description`
+ *     are read; `name` defaults to the subdirectory name.
+ *   - "flat": each `.md` / `.markdown` file directly under `dir` is one
+ *     skill. Frontmatter `name` (or `title`) and `description` are read.
+ *
+ * The returned tool is `read` partially applied with `dir: dir`. Its
+ * description lists every available skill so the LLM knows which
+ * `location` to pass back as `filename`.
+ */
+effect std::skills::skillsDir {
+  dir: string;
+  layout: "flat" | "standard"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L136))
+
+### std::skills::commandsDir
+
+```ts
+effect std::skills::commandsDir {
+  dir: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L137))
+
+## Functions
+
+### skillsDir
+
+```ts
+skillsDir(dir: string, layout: "flat" | "standard")
+```
+
+Build a skills tool for an LLM over a directory of skills.
+
+  @param dir - Directory containing the skills.
+  @param layout - "standard" (default) for subdirectory-per-skill with SKILL.md, "flat" for a directory of loose Markdown files.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -40,7 +76,7 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L136))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L139))
 
 ### commandsDir
 
@@ -93,7 +129,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L240))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L243))
 
 ### expandSlash
 
@@ -133,4 +169,4 @@ Expand a /command in `msg` using a `commandsDir(...)` result.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L297))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L300))

--- a/packages/agency-lang/docs/site/stdlib/speech.md
+++ b/packages/agency-lang/docs/site/stdlib/speech.md
@@ -4,6 +4,36 @@ name: "speech"
 
 # speech
 
+## Effects
+
+### std::speak
+
+```ts
+effect std::speak {
+  textLength: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L14))
+
+### std::record
+
+```ts
+effect std::record {}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L15))
+
+### std::transcribe
+
+```ts
+effect std::transcribe {
+  filepath: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L16))
+
 ## Functions
 
 ### speak
@@ -34,7 +64,7 @@ A tool for speaking text aloud using text-to-speech. Optionally specify a voice 
 
 **Throws:** `std::speak`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L14))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L18))
 
 ### record
 
@@ -70,7 +100,7 @@ Record audio from the microphone. Stops when the user presses Enter,
 
 **Throws:** `std::record`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L33))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L37))
 
 ### transcribe
 
@@ -98,4 +128,4 @@ A tool for transcribing an audio file to text using OpenAI's Whisper API. Option
 
 **Throws:** `std::transcribe`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/speech.agency#L60))

--- a/packages/agency-lang/docs/site/stdlib/system.md
+++ b/packages/agency-lang/docs/site/stdlib/system.md
@@ -4,6 +4,49 @@ name: "system"
 
 # system
 
+## Effects
+
+### std::screenshot
+
+```ts
+effect std::screenshot {
+  filepath: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L15))
+
+### std::exit
+
+```ts
+effect std::exit {
+  code: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L16))
+
+### std::setEnv
+
+```ts
+effect std::setEnv {
+  name: string;
+  value: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L17))
+
+### std::openUrl
+
+```ts
+effect std::openUrl {
+  url: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L18))
+
 ## Functions
 
 ### screenshot
@@ -36,7 +79,7 @@ A tool for taking a screenshot and saving it to a file. Optionally specify x, y,
 
 **Throws:** `std::screenshot`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L15))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L20))
 
 ### exit
 
@@ -55,7 +98,7 @@ Terminate the process immediately with the given exit code. Use with caution —
 
 **Throws:** `std::exit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L47))
 
 ### args
 
@@ -67,7 +110,7 @@ Return the command-line arguments passed to the Agency program (excluding the no
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L58))
 
 ### cwd
 
@@ -79,7 +122,7 @@ Return the absolute path of the current working directory of the Agency process.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L65))
 
 ### dirname
 
@@ -102,7 +145,7 @@ Return the absolute path of the directory containing the *compiled
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L72))
 
 ### env
 
@@ -120,7 +163,7 @@ Read an environment variable. Returns null if the variable is not set.
 
 **Returns:** `string | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L90))
 
 ### setEnv
 
@@ -144,7 +187,7 @@ Set an environment variable in the current process. Fails if the name is empty o
 
 **Throws:** `std::setEnv`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L92))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L97))
 
 ### isTTY
 
@@ -156,7 +199,7 @@ Return true if standard input is connected to a terminal. Returns false when std
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L111))
 
 ### readStdin
 
@@ -168,7 +211,7 @@ Read all of standard input until EOF and return it as a string. Blocks until the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L118))
 
 ### openUrl
 
@@ -190,7 +233,7 @@ Open a URL in the user's default browser. Currently macOS-only.
 
 **Throws:** `std::openUrl`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L125))
 
 ### setTitle
 
@@ -210,4 +253,4 @@ Set the process title (as shown in system monitors, `ps` output, and the termina
 
 **Returns:** `void`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/system.agency#L138))

--- a/packages/agency-lang/docs/site/stdlib/weather.md
+++ b/packages/agency-lang/docs/site/stdlib/weather.md
@@ -6,6 +6,19 @@ name: "weather"
 
 ## Types
 
+## Effects
+
+### std::weather
+
+```ts
+effect std::weather {
+  location: string;
+  units: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L3))
+
 ## Functions
 
 ### weather
@@ -30,7 +43,7 @@ Get current weather for a city name or zip code. Returns temperature, feels-like
 
 **Throws:** `std::weather`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L30))
 
 ### celsiusToFahrenheit
 
@@ -46,7 +59,7 @@ celsiusToFahrenheit(celsius: number): number
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L45))
 
 ### fahrenheitToCelsius
 
@@ -62,4 +75,4 @@ fahrenheitToCelsius(fahrenheit: number): number
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/weather.agency#L49))

--- a/packages/agency-lang/docs/site/stdlib/web/browser.md
+++ b/packages/agency-lang/docs/site/stdlib/web/browser.md
@@ -21,6 +21,19 @@ Usage from Agency code:
 
 ## Types
 
+## Effects
+
+### std::browserUse
+
+```ts
+effect std::browserUse {
+  task: string;
+  model: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/browser.agency#L23))
+
 ## Functions
 
 ### browserUse
@@ -55,4 +68,4 @@ Run a browser automation task using natural language via the Browser Use cloud A
 
 **Throws:** `std::browserUse`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/browser.agency#L23))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/browser.agency#L25))

--- a/packages/agency-lang/docs/site/stdlib/web/search.md
+++ b/packages/agency-lang/docs/site/stdlib/web/search.md
@@ -6,6 +6,36 @@ name: "search"
 
 ## Types
 
+## Effects
+
+### std::search
+
+```ts
+effect std::search {
+  query: string;
+  count: number;
+  country: string;
+  searchLang: string;
+  safesearch: string;
+  freshness: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/search.agency#L9))
+
+### std::tavilySearch
+
+```ts
+effect std::tavilySearch {
+  query: string;
+  count: number;
+  searchDepth: string;
+  topic: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/search.agency#L10))
+
 ## Functions
 
 ### search
@@ -40,7 +70,7 @@ Search the web. Returns a list of results with title, url, and description. Set 
 
 **Throws:** `std::search`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/search.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/search.agency#L21))
 
 ### tavilySearch
 
@@ -68,6 +98,6 @@ Search the web with Tavily, a search API built for AI agents. Returns a list of 
 
 **Returns:** `SearchResult[]`
 
-**Throws:** `std::search`
+**Throws:** `std::tavilySearch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/search.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/web/search.agency#L62))

--- a/packages/agency-lang/docs/site/stdlib/wikipedia.md
+++ b/packages/agency-lang/docs/site/stdlib/wikipedia.md
@@ -6,6 +6,39 @@ name: "wikipedia"
 
 ## Types
 
+## Effects
+
+### std::wikipedia::search
+
+```ts
+effect std::wikipedia::search {
+  query: string;
+  limit: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L22))
+
+### std::wikipedia::summary
+
+```ts
+effect std::wikipedia::summary {
+  title: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L23))
+
+### std::wikipedia::article
+
+```ts
+effect std::wikipedia::article {
+  title: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L24))
+
 ## Functions
 
 ### search
@@ -27,7 +60,7 @@ Search Wikipedia for articles matching the given query. Returns up to limit resu
 
 **Throws:** `std::wikipedia::search`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L22))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L26))
 
 ### summary
 
@@ -47,7 +80,7 @@ Get a summary of a Wikipedia article by its title. Returns the title, descriptio
 
 **Throws:** `std::wikipedia::summary`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L38))
 
 ### article
 
@@ -67,4 +100,4 @@ Get the full text of a Wikipedia article by its title. Returns the title, full p
 
 **Throws:** `std::wikipedia::article`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/wikipedia.agency#L49))

--- a/packages/agency-lang/lib/agents/agency-agent/lib/defaultPolicy.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/defaultPolicy.agency
@@ -80,6 +80,9 @@ export static const recommendedAutoApprovePolicy = {
   "std::search": [{
     action: "approve"
   }],
+  "std::tavilySearch": [{
+    action: "approve"
+  }],
   "std::skills::skillsDir": [{
     action: "approve"
   }],

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -13,6 +13,20 @@ import {
  } from "agency-lang/stdlib-lib/agency.js"
 import { VERSION } from "agency-lang/stdlib-lib/version.js"
 
+// `std::read`/`std::write` are the shared file-access effects (also raised by
+// `std::read`/`std::write` in `std::index`), so their reads/writes here stay
+// governed by the same file policy; the canonical payload is `{ dir, filename }`.
+effect std::read { dir: string, filename: string }
+effect std::write { dir: string, filename: string }
+effect std::run {
+  moduleId: string,
+  node: string,
+  args: Record<string, any>,
+  limits: { wallClock: number, memory: number, ipcPayload: number, stdout: number },
+  cwd: string,
+  logFile: string,
+}
+
 export type CompiledProgram = {
   moduleId: string
 }

--- a/packages/agency-lang/stdlib/agent.agency
+++ b/packages/agency-lang/stdlib/agent.agency
@@ -86,6 +86,8 @@ type Todo = {
 
 let _todos: Todo[] = []
 
+effect std::question { prompt: string }
+
 export safe def todoWrite(todos: Todo[]): Todo[] {
   """
   Replace the current todo list. Each todo has an id, text, and status (one of 'pending', 'in_progress', 'completed'). Use this to track multi-step work as you go: mark a todo 'in_progress' before starting it and 'completed' when done. Returns the new list.

--- a/packages/agency-lang/stdlib/auth/keyring.agency
+++ b/packages/agency-lang/stdlib/auth/keyring.agency
@@ -26,6 +26,10 @@ import { _setSecret, _getSecret, _deleteSecret, _isKeyringAvailable } from "agen
   No external dependencies required.
 */
 
+effect std::setSecret { key: string, service: string }
+effect std::getSecret { key: string, service: string }
+effect std::deleteSecret { key: string, service: string }
+
 export def setSecret(key: string, value: string, service: string = "agency-lang"): Result {
   """
   Store a secret in the system keyring (macOS Keychain or Linux Secret Service). The secret is stored under the given service name (default "agency-lang") with the given key. Overwrites any existing value for the same key.

--- a/packages/agency-lang/stdlib/auth/oauth.agency
+++ b/packages/agency-lang/stdlib/auth/oauth.agency
@@ -46,6 +46,10 @@ import { fetchJSON } from "std::http"
   3. If neither is available, tokens are stored unencrypted
 */
 
+effect std::authorize { name: string, authUrl: string, scopes: string }
+effect std::getAccessToken { name: string }
+effect std::revokeAuth { name: string }
+
 export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string, port: number = 8914, extraAuthParams: string = ""): Result {
   """
   Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, captures the callback, exchanges the code for tokens, and saves them locally. Only needs to be run once per provider. Parameters: name (identifier like "google-calendar"), authUrl (authorization endpoint), tokenUrl (token endpoint), clientId, clientSecret, scopes (space-separated), port (callback port, default 8914), extraAuthParams (space-separated key=value pairs for provider-specific params like "access_type=offline prompt=consent").

--- a/packages/agency-lang/stdlib/calendar.agency
+++ b/packages/agency-lang/stdlib/calendar.agency
@@ -114,6 +114,12 @@ type CalendarEvent = {
   htmlLink: string
 }
 
+effect std::authorizeCalendar { clientId: string }
+effect std::listEvents { maxResults: number, calendarId: string, query: string }
+effect std::createEvent { summary: string, start: string, end: string, description: string, location: string }
+effect std::updateEvent { eventId: string, summary: string, start: string, end: string }
+effect std::deleteEvent { eventId: string, calendarId: string }
+
 export def authorizeCalendar(clientId: string, clientSecret: string): Result {
   """
   Authorize access to Google Calendar. Opens a browser for the user to sign in and grant permission. Only needs to be run once — tokens are stored locally and refreshed automatically.

--- a/packages/agency-lang/stdlib/capabilities.agency
+++ b/packages/agency-lang/stdlib/capabilities.agency
@@ -42,7 +42,7 @@ export effectSet FileSystem = <FileRead, FileWrite>
 export effectSet Shell = <std::bash, std::exec, std::run>
 
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary>
 
 /** Sending messages to people: email, SMS, and iMessage. */
 export effectSet Messaging = <std::sendEmail, std::sendSms, std::sendIMessage>

--- a/packages/agency-lang/stdlib/clipboard.agency
+++ b/packages/agency-lang/stdlib/clipboard.agency
@@ -1,5 +1,8 @@
 import { _copy, _paste } from "agency-lang/stdlib-lib/clipboard.js"
 
+effect std::clipboardCopy {}
+effect std::clipboardPaste {}
+
 export def copy(text: string) {
   """
   A tool for copying text to the system clipboard.

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -14,6 +14,13 @@ type EditResult = {
   edits: number
 }
 
+effect std::edit { dir: string, filename: string, edits: Edit[], before: string, after: string }
+effect std::applyPatch { patch: string }
+effect std::mkdir { dir: string }
+effect std::copy { src: string, dest: string }
+effect std::move { src: string, dest: string }
+effect std::remove { target: string }
+
 export def edit(filename: string, edits: Edit[], dir: string = ".", useAgentCwd: boolean = false): Result {
   """
   Edit a single file by applying one or more text replacements atomically. Each edit has `oldText`, `newText`, and `replaceAll`. Every edit's `oldText` must match a unique, non-overlapping region of the original file (matches are looked up against the file as it stands when the edit runs, after earlier edits). Set `replaceAll: true` on an edit to replace every occurrence. When any edit fails, nothing is written.

--- a/packages/agency-lang/stdlib/http.agency
+++ b/packages/agency-lang/stdlib/http.agency
@@ -9,6 +9,10 @@ import {
   _fetchMarkdown,
 } from "agency-lang/stdlib-lib/http.js"
 
+effect std::http::fetch { baseUrl: string, path: string }
+effect std::http::fetchJSON { baseUrl: string, path: string }
+effect std::http::fetchMarkdown { baseUrl: string, path: string }
+
 export safe def fetch(
   baseUrl: string,
   path: string = "",

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -43,6 +43,16 @@ import {
   syntaxHighlight as _syntaxHighlight,
  } from "agency-lang/stdlib-lib/syntax.js"
 
+// Payload types for the interrupt effects raised by this module.
+// `std::read`/`std::write` are shared file-access effects (also raised by
+// `std::agency`); their canonical payload is the file identity a policy
+// keys on — `{ dir, filename }` — while per-call extras (content, mode,
+// offset, ...) are permitted at individual raise sites.
+effect std::read { dir: string, filename: string }
+effect std::write { dir: string, filename: string }
+effect std::readImage { dir: string, filename: string }
+effect std::notify { title: string, body: string }
+
 export safe def print(...messages) {
   """
   A tool for printing a message to the console.

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -45,6 +45,12 @@ export type MemoryConfig = {
   embeddings?: { model: string | undefined }
 }
 
+effect std::memory::enableMemory { dir: string }
+effect std::memory::disableMemory {}
+effect std::memory::remember { contentLength: number }
+effect std::memory::recall { query: string }
+effect std::memory::forget { query: string }
+
 export safe def isMemoryActive(): boolean {
   """
   Return `true` iff there is an active memory frame on the current

--- a/packages/agency-lang/stdlib/messaging/email.agency
+++ b/packages/agency-lang/stdlib/messaging/email.agency
@@ -41,6 +41,8 @@ type EmailResult = {
   provider: string
 }
 
+effect std::sendEmail { from: string, to: string, subject: string }
+
 /** Send an email using the Resend API. Requires `RESEND_API_KEY` env var or pass apiKey directly. */
 export def sendWithResend(from: string, to: string, subject: string, html: string = "", text: string = "", cc: string = "", bcc: string = "", replyTo: string = "", apiKey: string = "", allowList: string[] = [], blockList: string[] = []): Result {
   """

--- a/packages/agency-lang/stdlib/messaging/imessage.agency
+++ b/packages/agency-lang/stdlib/messaging/imessage.agency
@@ -22,6 +22,8 @@ type IMessageResult = {
   sent: boolean
 }
 
+effect std::sendIMessage { to: string }
+
 export def sendIMessage(to: string, message: string, allowList: string[] = [], blockList: string[] = []): Result {
   """
   Send an iMessage via the macOS Messages app. Only works on macOS with Messages.app signed in. Set allowList to restrict recipients to specific addresses/numbers. Set blockList to reject specific addresses/numbers.

--- a/packages/agency-lang/stdlib/messaging/sms.agency
+++ b/packages/agency-lang/stdlib/messaging/sms.agency
@@ -23,6 +23,8 @@ type SmsResult = {
   status: string
 }
 
+effect std::sendSms { to: string }
+
 export def sendSms(to: string, body: string, from: string = "", accountSid: string = "", authToken: string = "", allowList: string[] = [], blockList: string[] = []): Result {
   """
   Send an SMS text message via the Twilio API. Requires TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_FROM_NUMBER env vars, or pass them directly. Set allowList to restrict recipients to specific numbers. Set blockList to reject specific numbers.

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -17,6 +17,12 @@ type ExecResult = {
   exitCode: number
 }
 
+effect std::exec { command: string, args: string[], subcommand: string, cwd: string, timeout: number, stdin: string }
+effect std::bash { command: string, cwd: string, timeout: number, stdin: string }
+effect std::ls { dir: string, recursive: boolean, maxResults: number }
+effect std::grep { pattern: string, dir: string, flags: string, maxResults: number }
+effect std::glob { pattern: string, dir: string, maxResults: number }
+
 export def exec(
   command: string,
   args: string[] = [],

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -133,6 +133,9 @@ def standardEntry(skillPath: string, parsedFrontmatter: any): SkillEntry {
  * description lists every available skill so the LLM knows which
  * `location` to pass back as `filename`.
  */
+effect std::skills::skillsDir { dir: string, layout: "flat" | "standard" }
+effect std::skills::commandsDir { dir: string }
+
 export def skillsDir(dir: string, layout: "flat" | "standard" = "standard") {
   """
   Build a skills tool for an LLM over a directory of skills.

--- a/packages/agency-lang/stdlib/speech.agency
+++ b/packages/agency-lang/stdlib/speech.agency
@@ -11,6 +11,10 @@ import {
   _transcribe,
 } from "agency-lang/stdlib-lib/speech.js"
 
+effect std::speak { textLength: number }
+effect std::record {}
+effect std::transcribe { filepath: string }
+
 export def speak(text: string, voice: string = "", rate: number = 0, outputFile: string = "", allowedPaths: string[] = []) {
   """
   A tool for speaking text aloud using text-to-speech. Optionally specify a voice name, rate in words per minute, and an output file to save the audio to instead of playing it. Set allowedPaths to restrict where the output file may be written.

--- a/packages/agency-lang/stdlib/system.agency
+++ b/packages/agency-lang/stdlib/system.agency
@@ -12,6 +12,11 @@ import {
   _setTitle,
  } from "agency-lang/stdlib-lib/system.js"
 
+effect std::screenshot { filepath: string }
+effect std::exit { code: number }
+effect std::setEnv { name: string, value: string }
+effect std::openUrl { url: string }
+
 export def screenshot(
   filepath: string,
   x: number = -1,

--- a/packages/agency-lang/stdlib/weather.agency
+++ b/packages/agency-lang/stdlib/weather.agency
@@ -1,4 +1,7 @@
 import { _weather } from "agency-lang/stdlib-lib/weather.js"
+
+effect std::weather { location: string, units: string }
+
 type WeatherResult = {
   location: string;
   country: string;

--- a/packages/agency-lang/stdlib/web/browser.agency
+++ b/packages/agency-lang/stdlib/web/browser.agency
@@ -20,6 +20,8 @@ type BrowserUseResult = {
   sessionId: string
 }
 
+effect std::browserUse { task: string, model: string }
+
 export def browserUse(task: string, model: string = "", maxCostUsd: number = 0, proxyCountryCode: string = "", timeout: number = 0, apiKey: string = "", allowedDomains: string[] = []): Result {
   """
   Run a browser automation task using natural language via the Browser Use cloud API. Sends the task to a managed browser with stealth capabilities, CAPTCHA solving, and residential proxies. Returns the task output, status, and session ID. Requires a BROWSER_USE_API_KEY environment variable or pass apiKey directly. Available models: "bu-mini" (default), "bu-max", "bu-ultra". Set maxCostUsd to limit spending. Set proxyCountryCode (e.g. "US", "DE") to control geographic routing. Set timeout to control how long to wait for completion (default: 120000ms / 2 minutes). Set allowedDomains to instruct the browser to only visit specific domains.

--- a/packages/agency-lang/stdlib/web/search.agency
+++ b/packages/agency-lang/stdlib/web/search.agency
@@ -6,6 +6,9 @@ type SearchResult = {
   description: string
 }
 
+effect std::search { query: string, count: number, country: string, searchLang: string, safesearch: string, freshness: string }
+effect std::tavilySearch { query: string, count: number, searchDepth: string, topic: string }
+
 /*
   Usage from Agency code:
   import { search } from "std::web/search"
@@ -72,7 +75,7 @@ export safe def tavilySearch(
   @param searchDepth - Depth of the search ("basic" for fast results, "advanced" for deeper retrieval)
   @param topic - Category of the search ("general" or "news")
   """
-  return interrupt std::search("Are you sure you want to perform this web search?", {
+  return interrupt std::tavilySearch("Are you sure you want to perform this web search?", {
     query: query,
     count: count,
     searchDepth: searchDepth,

--- a/packages/agency-lang/stdlib/wikipedia.agency
+++ b/packages/agency-lang/stdlib/wikipedia.agency
@@ -19,6 +19,10 @@ type WikiArticle = {
   url: string
 }
 
+effect std::wikipedia::search { query: string, limit: number }
+effect std::wikipedia::summary { title: string }
+effect std::wikipedia::article { title: string }
+
 export safe def search(query: string, limit: number = 5): WikiSearchResult[] {
   """
   Search Wikipedia for articles matching the given query. Returns up to limit results (default 5).

--- a/packages/agency-lang/tests/integration/stdlib-sandbox/credential/tavily.agency
+++ b/packages/agency-lang/tests/integration/stdlib-sandbox/credential/tavily.agency
@@ -2,8 +2,8 @@ import { tavilySearch } from "std::web/search"
 
 node main() {
   // Live Tavily search. Runs only in the integration-credentials CI job,
-  // which provides TAVILY_API_KEY. The `with approve` auto-approves the
-  // std::search interrupt so the request actually goes out.
+  // which provides TAVILY_API_KEY. The catch-all handler auto-approves the
+  // std::tavilySearch interrupt so the request actually goes out.
   handle {
     const results = tavilySearch("TypeScript programming language", count: 3)
     if (results.length == 0) {


### PR DESCRIPTION
## Type the standard library's interrupts

Every interrupt raised by the stdlib was untyped. This adds an `effect <name> { field: type, ... }` payload-type declaration for each one, using the typed-effect-declarations feature (raise-site typing). The typechecker now validates each `interrupt <name>("msg", { ... })` data object against its declared payload.

Declarations are co-located in the module that raises the effect and rendered in the generated stdlib docs (each module page gains an **Effects** section).

### Coverage
All ~50 stdlib interrupt effects are now declared — verified by a declared-vs-raised sweep (zero raised effects without a declaration) and a per-file `agency typecheck` sweep across all 21 files with declarations (zero payload errors, zero cross-file conflicts).

### The non-obvious decisions
The checker requires each *declared* field at every raise site but allows *extra* fields, so single-site effects are typed exactly. Three cases needed judgment:

- **`std::read` / `std::write` — kept shared, typed `{ dir, filename }`.** These are raised by both `std::index` (the primary `read`/`write`) and `std::agency` (`writeAST`/`formatFile`/`typecheckFile`), which deliberately reuse them so their file I/O stays governed by the same file-access policy. `{ dir, filename }` is the canonical file identity a policy keys on; per-call extras (`content`, `mode`, `offset`, `overwrite`) remain allowed at each site. Splitting them out would have let those operations escape the `std::read`/`std::write` policy — a security regression.
- **`std::search` — split.** `search()` (Brave) keeps `std::search`, fully typed; `tavilySearch()` (Tavily) now raises a distinct **`std::tavilySearch`** effect. The `Network` effect set in `std::capabilities` and the agency-agent's default policy are updated to include `std::tavilySearch`. (Existing Tavily tests use a catch-all approval handler, so they're unaffected; a stale comment was corrected.)
- **Empty payloads.** Effects that carry no data (`std::record`, `std::clipboardCopy`/`Paste`, `std::memory::disableMemory`) get empty payload types `{}`.

### Verification
- `make` (build → stdlib → agents → doc) clean.
- Full effect-payload typecheck sweep clean; complete declared-vs-raised coverage.
- The feature's own `effectDeclaration` test passes; a stdlib typed-interrupt runtime smoke runs.
- Generated `.js` are gitignored build artifacts (not committed), per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
