### PR TITLE
test(router-handoff): mock the eager-summarize llm() calls

### DIFF
--- a/packages/agency-lang/tests/agency/router-handoff/main.test.json
+++ b/packages/agency-lang/tests/agency/router-handoff/main.test.json
@@ -6,11 +6,13 @@
       "expectedOutput": "\"final research answer\"",
       "evaluationCriteria": [{ "type": "exact" }],
       "useTestLLMProvider": true,
-      "description": "Two-agent run: code agent hands off to research, research replies. Pinned to the deterministic LLM provider (even on the post-merge real-LLM CI run) because this test verifies router dispatch wiring — handoff tool detection, consumeHandoff signal handling, per-category thread(session:) switching, and reply propagation — none of which a real LLM would reliably reproduce (it might not call handoff at all, or call it with different args). The exact-match on 'final research answer' is what proves the second specialist actually ran.",
+      "description": "Two-agent run: code agent hands off to research, research replies. Pinned to the deterministic LLM provider (even on the post-merge real-LLM CI run) because this test verifies router dispatch wiring — handoff tool detection, consumeHandoff signal handling, per-category thread(session:) switching, and reply propagation — none of which a real LLM would reliably reproduce (it might not call handoff at all, or call it with different args). The exact-match on 'final research answer' is what proves the second specialist actually ran. NOTE: the router opens each specialist turn in a `thread(summarize: true)` block, so each thread close fires an eager-summarize llm() call — hence the two `{summary: ...}` mocks interleaved between the turn responses (positions 3 and 5). Do not remove them or the mock queue shifts and the research reply lands on an unmocked call.",
       "llmMocks": [
         { "toolCall": { "name": "handoff", "args": { "category": "research", "reason": "needs lookup" } } },
         { "return": "ok handing off" },
-        { "return": "final research answer" }
+        { "return": { "summary": "code turn summary" } },
+        { "return": "final research answer" },
+        { "return": { "summary": "research turn summary" } }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Fixes the failing CI on `main` — `tests/agency/router-handoff/main.test.json` (the only failing test in the deterministic Agency suite; the Real-LLM workflow pins this test to the deterministic provider, so it fails there too):

```
DeterministicClient: no mock provided for llm() call #4
```

## Root cause

The router drives each specialist turn through a `thread(label: category, summarize: true, session: category)` block. On block close, `summarize: true` fires a **one-shot summarization `llm()` call** via the global `onThreadEnd` hook (`lib/stdlib/threads.ts` → `registerGlobalHook("onThreadEnd", _eagerSummarizeIfNeeded)`).

The test mocked only the three *turn* responses, but the real call sequence is **five** (traced by instrumenting the deterministic client):

| # | call | 
|---|---|
| 1 | code agent → `handoff` tool call |
| 2 | code continuation → "ok handing off" |
| **3** | **code-thread summarize** ← consumed the research reply's mock |
| 4 | research agent → real reply (no mock left → **error**) |
| 5 | research-thread summarize |

So the code-thread's summarize call stole mock #3 and pushed the research reply to an unmocked slot.

## Why it started at the stdlib-reorg commit

The reorg (`f3aad6ea`) didn't change the router, thread, or runtime code — it renamed/moved stdlib modules, which changed the module-load graph so the global eager-summarize hook is now active for this test's run. It previously no-op'd, so the incomplete 3-mock test passed by accident. The eager-summarize behavior itself is **intended** (`summarize: true` is explicitly requested and documented to summarize at close), so the correct fix is to complete the mocks.

## Fix

Add the two `{summary: ...}` responses in the observed positions (3 and 5) — matching how every other `thread(summarize: true)` test under `tests/agency/threads-registry` is written — plus a note in the test description so they aren't removed again.

## Testing

Verified the fixed test passes **5/5** runs locally under the deterministic provider. This is a test-only, single-file change.

Note: not caused by the recent tool-call-id or handler-recursion PRs — those merely inherited this failure from the reorg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
