### PR TITLE
Fix type-checker warnings in the built-in agents (groups C & D)

### DIFF
--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -242,7 +242,7 @@ def renderLLMCallResponse(data: LLMResponse): string {
   if (data.output != "" && data.output != null && data.output != undefined) {
     response.push(data.output)
   }
-  if (data.toolCalls && data.toolCalls.length > 0) {
+  if (data.toolCalls.length > 0) {
     for (toolCall in data.toolCalls) {
       response.push(`${toolCall.name}(${formatArgs(toolCall.arguments)})`)
     }
@@ -814,7 +814,7 @@ def mainAgent(prompt: string): string {
       // `_context` carries the per-run grounding (date, cwd, AGENTS.md),
       // set by `setupSession`. Appending it to the system prompt is what
       // actually gets that context to the LLM.
-      systemMessage(mainAgentSystemPrompt + _context)
+      systemMessage("${mainAgentSystemPrompt}${_context}")
       first = false
     }
     const result = llm(prompt, {

--- a/packages/agency-lang/lib/agents/agency-agent/lib/search.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/search.agency
@@ -100,7 +100,7 @@ export type LlmOpts = {
   model?: string;
   provider?: string;
   memory?: boolean;
-  reasoningEffort?: string;
+  reasoningEffort?: "low" | "medium" | "high";
   thinking?: ThinkingConfig;
 }
 

--- a/packages/agency-lang/lib/agents/agency-agent/tests/search.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/search.agency
@@ -8,6 +8,16 @@
  */
 import { planSearchSetup, withWebSearch, setActiveBackend } from "../lib/search.agency"
 
+// `tools` is optional on the opts returned by withWebSearch, so reading
+// `.length` directly trips the checker (`any[] | null`). Narrow it here;
+// withWebSearch always sets tools in these tests, so the null branch is
+// defensive and never taken.
+def toolCount(opts: { tools?: any[] }): number {
+  const t = opts.tools
+  if (t == null) { return 0 }
+  return t.length
+}
+
 def ctx(isLocal: boolean, isTty: boolean, tav: boolean, brave: boolean, saved: string): any {
   return { isLocal: isLocal, isTty: isTty, hasTavily: tav, hasBrave: brave, savedBackend: saved }
 }
@@ -66,21 +76,21 @@ node hostedBackendSetsHostedToolsAndLeavesTools(): string {
   setActiveBackend("hosted", false)
   const opts = withWebSearch({ memory: true, tools: [] })
   // Pipe-delimited: "<first hostedTool>|<tools length>"
-  return "${opts.hostedTools[0]}|${opts.tools.length}"
+  return "${opts.hostedTools[0]}|${toolCount(opts)}"
 }
 
 node tavilyBackendAppendsOneSearchTool(): string {
   setActiveBackend("tavily", false)
   const opts = withWebSearch({ memory: true, tools: [] })
   const hostedSet = opts.hostedTools != null && opts.hostedTools != undefined
-  return "${opts.tools.length}|${hostedSet}"
+  return "${toolCount(opts)}|${hostedSet}"
 }
 
 node offBackendLeavesOptsUnchanged(): string {
   setActiveBackend("off", false)
   const opts = withWebSearch({ memory: true, tools: [] })
   const hostedSet = opts.hostedTools != null && opts.hostedTools != undefined
-  return "${opts.tools.length}|${hostedSet}"
+  return "${toolCount(opts)}|${hostedSet}"
 }
 
 node tavilyDoesNotMutateTheCallersSharedToolsArray(): string {


### PR DESCRIPTION
## Fix type-checker warnings in the built-in agents (groups C & D)

Resolves the type-checker warnings groups **C** and **D** from the `make` build investigation. All are in the bundled agency-agent (not the stdlib).

### C — `LlmOpts` not assignable to `llm()` (4 warnings: oracle / code / explorer)
`LlmOpts.reasoningEffort` was typed `string`, but `llm()`'s option shape requires the union `"low" | "medium" | "high"` — `string` is wider, so it wasn't assignable. Tightened the field to the union. The call sites already pass `"high"`, so object construction is unaffected.

### D — real type mismatches in agency-agent code (5 warnings)
- **`agent.agency` (condition):** `if (data.toolCalls && data.toolCalls.length > 0)` gave the condition type `ToolCallData[] | boolean`. Since `toolCalls` is a required field on `LLMResponse`, the `&&` guard is redundant → `if (data.toolCalls.length > 0)`.
- **`agent.agency` (systemMessage):** `systemMessage(mainAgentSystemPrompt + _context)` typed the argument as `number`. Root cause: the checker doesn't track the types of module-level `static const` / `let` inside a function body, so `+` fell back to numeric. Switched to string interpolation (`"${mainAgentSystemPrompt}${_context}"`), which is unambiguously string-typed.
- **`tests/search.agency` (`.length`):** `opts.tools.length` on the optional `tools?: any[]` field flagged `.length` on `any[] | null`. Added a small null-narrowing `toolCount` helper (optional chaining did **not** suppress this check). Runtime behavior is unchanged — `withWebSearch` always sets `tools` in these tests.

### Verification
`agency typecheck` (the authoritative checker) reports **no type errors** on all five affected files after the change; each showed the corresponding error before. Only 3 source files changed (generated `.js` are gitignored).

### Out of scope (flagged, not fixed here)
- A full `make` currently fails on `main` for an **unrelated** reason: the Makefile still runs `cp -r docs/site/appendix …`, but `docs/site/appendix/` was removed by the recent docs-sidebar reorg (commit `0f77c823`). Worth a small follow-up.
- Groups **A** (`std::index` reserved-`callback` / `_emit` intrinsic — checker false positives) and **B** (host-handled agents' "may throw interrupts" lint) were intentionally left; they're checker-gaps / by-design lints, not code bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
