### PR TITLE
Agent image generation + auto-attached user images/PDFs

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -38,7 +38,7 @@ export type LlmDefaults = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L27))
 
 ### HostedModelInfo
 
@@ -54,7 +54,7 @@ export type HostedModelInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L126))
 
 ## Functions
 
@@ -75,7 +75,7 @@ Set default options for subsequent llm() calls. Only the fields you
 |---|---|---|
 | opts | [LlmDefaults](#llmdefaults) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L36))
 
 ### setModel
 
@@ -93,7 +93,7 @@ Set the default model for subsequent llm() calls.
 |---|---|---|
 | name | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L46))
 
 ### envVarFor
 
@@ -118,7 +118,7 @@ Return the environment variable that holds the API key for a recognized
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L55))
 
 ### pickProvider
 
@@ -141,7 +141,7 @@ Return the first provider in `order` whose API-key environment variable
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L84))
 
 ### registerProviderModule
 
@@ -160,7 +160,7 @@ Load a provider module by path at runtime and register its custom provider
 |---|---|---|
 | path | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L114))
 
 ### listHostedModels
 
@@ -173,7 +173,7 @@ All known hosted text models (baked catalog plus any refreshed data), for
 
 **Returns:** `HostedModelInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L136))
 
 ### hostedModelInfo
 
@@ -194,7 +194,32 @@ Metadata for one hosted model by name, or null if the name is unknown or
 
 **Returns:** `HostedModelInfo | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L143))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L144))
+
+### modelSupportsInput
+
+```ts
+modelSupportsInput(model: string, modality: string): boolean | null
+```
+
+Whether a model accepts a given input modality ("image" or "pdf").
+  Tri-state: true / false when the model catalog says so, null when the
+  model or its modality data is unknown. Treat null as "do not gate" —
+  that is the same rule llm() applies at send time.
+
+  @param model - The model name (e.g. "gpt-4o-mini")
+  @param modality - "image" or "pdf"
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| model | `string` |  |
+| modality | `string` |  |
+
+**Returns:** `boolean | null`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L154))
 
 ### loadModelData
 
@@ -218,4 +243,4 @@ Load model data from a JSON file (the shape `agency models refresh` prints)
 
 **Returns:** `Result<number>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L174))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -248,7 +248,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Stops at maxRe
 ### stat
 
 ```ts
-stat(filename: string, dir: string, allowedPaths: string[], useAgentCwd: boolean): StatInfo
+stat(filename: string, dir: string, allowedPaths: string[], useAgentCwd: boolean, followSymlinks: boolean): StatInfo
 ```
 
 Return metadata about a filesystem entry: whether it exists, its type ("file", "dir", "symlink", "other", or "missing" if absent), size in bytes, and mtime in ms. Set allowedPaths to restrict which paths may be stat-ed.
@@ -259,6 +259,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
   @param dir - Optional directory to resolve `filename` against (default: process cwd, absolute paths allowed)
   @param allowedPaths - Only allow paths under these prefixes
   @param useAgentCwd - When true, resolve a relative filename against the agent working directory (see setAgentCwd) if one is set. Absolute filenames are unaffected. Defaults to false.
+  @param followSymlinks - When true, report the symlink TARGET's type and size (a broken link reports "missing"). Defaults to false: the link itself is reported with type "symlink".
 
 **Parameters:**
 
@@ -268,6 +269,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 | dir | `string` | "" |
 | allowedPaths | `string[]` | [] |
 | useAgentCwd | `boolean` | false |
+| followSymlinks | `boolean` | false |
 
 **Returns:** [StatInfo](#statinfo)
 
@@ -299,7 +301,7 @@ Return true if a file or directory exists at the given path. Set allowedPaths to
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L262))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L264))
 
 ### which
 
@@ -317,4 +319,4 @@ Locate an executable in PATH and return its absolute path. Returns an empty stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L284))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L286))

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-02-agent-images-and-attachments-review.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-02-agent-images-and-attachments-review.md
@@ -1,0 +1,424 @@
+# Review: Agent Images and Attachments Plan
+
+**Reviewed:** `docs/superpowers/plans/2026-07-02-agent-images-and-attachments.md`
+**Against spec:** `docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md`
+**Reviewer:** Amp (Claude)
+**Date:** 2026-07-02
+
+---
+
+## Summary
+
+Overall a **solid, executable plan**. Task ordering is correct (both prerequisites — placeholder rendering and the modality probe — come before the feature tasks that depend on them). TDD steps are concrete, commits are scoped to their tasks, and the "Spec-coverage map" at the end honestly ties every spec item to a task, including a named "known limitation" for the un-exercisable generation-failure branch. Verified: `mainAgentTools` layout, `Resolved.model`, `stat` shape, `Attachment` shape, `_contentToString` current behavior, `smoltalk.modelSupportsInputModality` signature and `undefined` return for unknown models — all match the plan's assumptions.
+
+Nonetheless there are a handful of correctness bugs, test-fragility issues, and one small style deviation that should be addressed before execution.
+
+---
+
+## Blocking issues
+
+### B1. `modalityFilter` mutates its input's `skipped` array (Task 5, Step 1)
+
+```
+let skipped: string[] = detected.skipped
+...
+skipped.push("${label} (model ${main.model} has no image input)")
+```
+
+Agency arrays are reference-typed. `let skipped = detected.skipped` aliases the caller's array, and `skipped.push(...)` mutates it. The wrapping call site (`modalityFilter(detectAttachments(expanded))`) does not reuse `detected`, so the observable behavior is correct today — but this is a landmine for the next caller who does. Also inconsistent with the fresh `attachments`/`labels` arrays right next to it.
+
+**Fix:** `let skipped: string[] = [...detected.skipped]` (array spread is called out as proven in "Global Constraints"). Same pattern the plan already uses to build `parts` in the wiring.
+
+### B2. `modalityFilterPassthroughWhenNoSlots` relies on execution-test process state
+
+The test asserts `main == null` in `getResolvedSlots()` to exercise the passthrough branch, but a single Agency execution-test process runs many nodes. If any earlier node in `attachments.agency` (or a test the runner batches with it) has called `applyResolved(...)`, `main` will be non-null and this node's `.attachments.length` result depends on whether the leftover model happens to accept images. The other two `modalityFilter*` nodes in this same file **do** call `applyResolved(...)`, and node execution order within a `.agency` file is not documented to be top-to-bottom.
+
+**Fix:** Either (a) explicitly reset with `applyResolved({})` at the top of the passthrough test, or (b) drop the "no slots" node and only test the two positive cases where the model is explicitly set. Option (a) is preferable if `applyResolved({})` clears the "main" slot cleanly — worth a quick check against `shared.agency:121`.
+
+### B3. `attachmentsTurn.agency` thread-slug probe is silently fragile
+
+`threadHasImagePlaceholder()` probes `["t0", "t1", "t2", "t3"]`. The `main` thread's assigned slug is a function of every `thread(...)` block opened earlier in the run, not a stable constant. The plan itself flags this ("do not widen the slug probe list silently without understanding why") but that's a guardrail, not a fix — if slug allocation changes for any reason, all three tests silently return `…|false` and the human has to debug the fixture.
+
+**Fix (pick one):**
+- Grab the current thread id explicitly: replace the slug loop with `getThread(currentThreadId(), 0, 200)` after the reply returns. `currentThreadId()` is exported from `std::thread` (line 409). This is exact — no guessing.
+- Or use `listThreads(lazySummarize: false)` and filter to `label == "main"`, then read that id. Passing `false` avoids the "burns mocks via summarization" concern the plan calls out.
+
+Either replaces four brittle string constants with the real id and eliminates the "which slug did I get today" failure mode.
+
+---
+
+## Non-blocking correctness/robustness issues
+
+### N1. `normalizeToken` doesn't handle empty `HOME`
+
+```
+if (t.startsWith("~/")) {
+  const home = env("HOME")
+  if (home != null) {
+    t = home + t.slice(1)
+  }
+}
+```
+
+`env` returns `string | null` but nothing prevents a `HOME=""` (rare but real in containers/CI). An empty `home` would rewrite `~/foo.png` to `/foo.png` and then fail the stat silently. Cheap guard: `if (home != null && home != "")`.
+
+### N2. `tildeExpansion` test permanently mutates process-wide `HOME`
+
+`setEnv("HOME", "/tmp")` in the test leaks to every subsequent node in the same execution-test process. Any later test that legitimately depends on the real `HOME` will observe `/tmp`. Test parallelism in `test:agents -p 12` is per-file subprocess, so the leak stays within the file, but future tests appended to `attachments.agency` are still affected.
+
+**Fix:** Snapshot and restore:
+```
+const savedHome = env("HOME")
+setEnv("HOME", "/tmp")
+const d = detectAttachments("see ~/da-tilde.png") with approve
+if (savedHome != null) { setEnv("HOME", savedHome) }
+return "${d.attachments.length}"
+```
+
+### N3. `directoryIgnored` uses `exec("mkdir", ...)` without checking it succeeded
+
+If `/tmp/da-dir.png` already exists as a regular file (leftover from a prior `da-a.png`-style test run — nothing cleans `/tmp`), `mkdir` fails, `stat.type == "file"`, and the test wrongly reports `1`. Two ways to be safe:
+
+- Use `mkdir -p /tmp/da-dir-$$.png` (unique) — but Agency has no `$$` shell expansion here.
+- Prefer a unique fixed name that no other node writes to: `da-uniq-dir.png` (already unlikely to collide) and add `exec("rm", ["-rf", "/tmp/da-uniq-dir.png"]) with approve` before `mkdir` to guarantee a clean starting state.
+
+Same "leftover fixture" concern applies more broadly — several nodes reuse the same `/tmp/da-*.png` names across runs, but for those the write always overwrites, so no drift.
+
+### N4. `modalityFilter` uses a while-loop where `for (i in range(...))` would be idiomatic
+
+Micro-nit. The two parallel arrays (`attachments[i]`, `labels[i]`) argue for index iteration, and Agency's `range()` is used elsewhere in the same test file (`capsAtTen`). This is style, not correctness.
+
+### N5. `MIME_TYPES: Record<string, string>` used with `MIME_TYPES[ext]` and compared `== null`
+
+Fine given how Agency codegens `Record` index access, but double-check the type checker allows `MIME_TYPES[ext]` to narrow to `string | null` rather than raising an "index may not exist" error. If it does raise, the plan should switch to a small `if/else if` chain or an `includes()` guard on a keys array. Not a huge risk — `Record<string,string>` index access is used all over the stdlib — but worth confirming during Task 3 Step 2 (`pnpm run ast`).
+
+### N6. `reportsWriteFailure` assumes `writeBinary` returns a `Failure` for a nonexistent directory
+
+Not verified in this review. If `writeBinary` instead auto-creates the missing directory (mkdir -p behavior), the test flips green for the wrong reason. Suggest a quick smoke: `pnpm test:run lib/stdlib/write*.test.ts` (or equivalent) before assuming the failure shape. If the current behavior is auto-create, use a truly-unwritable directory (`/` on macOS, `/proc` on Linux) or set an interrupt-denying handler and use `with reject` instead of `with approve`.
+
+### N7. The `10` cap constant is spec'd but the test proves it "at 10 or fewer", not "exactly 10"
+
+`capsAtTen` writes 11 files, expects the return to be `10`. Good. But there's no test that at 9 attachments all 9 come through — trivial to add and would catch an accidental off-by-one that clamps at 9.
+
+Not a blocker; consider adding.
+
+---
+
+## Spec vs. plan alignment
+
+| Spec item | Plan task | Status |
+|---|---|---|
+| Part A tool: generate + edit, agent-cwd, dirname split, Result-checked write | Task 4 Step 3 | ✅ Exact match |
+| Part A registration + system-prompt bullet | Task 4 (c)/(d) | ✅ Includes the "5 subagent tools + one direct tool" copy fix |
+| Part B algorithm steps 1–9 | Task 3 | ✅ All present, incl. tilde, quoted, escaped-space, dedupe, cap, size-skip, inline base64 |
+| Attachment lifetime (inline at attach) | Task 3 Step 1 | ✅ Comment even cites the poison-thread / policy-gate reasons |
+| Wiring (visible 📎 lines, `mainAgent` widening) | Task 5 Step 3 | ✅ |
+| Risk 4: modality (`modelSupportsInput`, tri-state, skip-on-false) | Task 2 + Task 5 | ✅ Correct tri-state semantics — only `== false` drops |
+| Risk 5 prerequisite (placeholders in `_contentToString`) | Task 1 | ✅ Also exports the symbol so tests can import it |
+| Testing: detectAttachments units | Task 3 | ✅ Covers all 13 spec cases |
+| Testing: generateImageFile | Task 4 | ✅ + honest note about the un-exercisable failure branch |
+| Testing: turn integration | Task 5 | ✅ (see B3) |
+
+**No spec drift.** Every decision in the spec's "Decisions" and "Non-goals" sections is respected — the plan does not extend scope to subagent attachments, view-back loop, or eviction tooling.
+
+---
+
+## Small factual/style notes
+
+- **`color` is used in `agent.agency` (line 135 etc.) without an import.** The plan says "(`pushMessage` and `color` are already imported in `agent.agency`.)". `pushMessage` is imported from `std::ui/cli` (line 10), but `color` is auto-imported / global. That's fine, but the parenthetical is slightly inaccurate — worth removing to avoid confusion.
+- **Task 2 Step 1 probe** — the `modelSupportsInputModality` check confirmed that `gpt-3.5-turbo` returns `false` (verified while reviewing). The substitution instructions are still valuable as future-proofing.
+- **Task 6 Step 2** — running `pnpm run test:agents` locally is called out as safe (no LLM). Good; that's consistent with the AGENTS.md guidance about `.agency` execution tests being LLM-free by default.
+- **Task 1 test file `describe` name.** Appending a bare `describe("_contentToString", ...)` at the end is fine, but if `threads.test.ts` currently wraps everything in a top-level `describe`, indent it accordingly. Nit.
+- The `Attachment[]` and `type: "image" | "file"` shape used by `modalityFilter` matches `stdlib/thread.agency:75-77` exactly — good.
+
+---
+
+## Recommendations before starting execution
+
+1. **Must fix (blocking):** B1 (`skipped` aliasing), B3 (fragile slug probe).
+2. **Should fix:** B2 (test state contamination), N2 (`HOME` restore), N3 (directory-fixture cleanup).
+3. **Nice to have:** N1 (empty-`HOME` guard), N6 (verify `writeBinary` failure shape ahead of Task 4), N7 (positive-cap test at N=9).
+4. **Cosmetic:** N4 (`for … in range`), the "`color` already imported" wording.
+
+With B1–B3 addressed, this plan is ready to execute. The overall design is coherent, the TDD flow is real (each task's Step 2 verifies failure before Step 3–4 implements + verifies success), and the commit boundaries mean any single revert is safe.
+
+---
+
+## Anti-pattern audit (against `docs/dev/anti-patterns.md`)
+
+Focused pass on whether the plan's *generated code* (not the plan document itself) exhibits any of the catalog's anti-patterns. The most important question you asked — **does the plan write declarative interfaces that neatly encapsulate complexity, or is it imperative code all the way down?** — has a mixed answer: the *outer* interfaces are well shaped (`DetectedContent`, `modalityFilter(detectAttachments(...))` composes as a pipeline, `generateImageFile` does one thing), but the *innards* of the two new helpers lean heavily imperative in ways the anti-patterns doc explicitly calls out.
+
+### AP1. Order-dependent mutable state — `modalityFilter` (Task 5, Step 1). Real hit.
+
+```
+let ok = true
+if (a.type == "image" && imageOk == false) {
+  ok = false
+  skipped.push(...)
+}
+if (a.type == "file" && pdfOk == false) {
+  ok = false
+  skipped.push(...)
+}
+if (ok) {
+  attachments.push(a)
+  labels.push(label)
+}
+```
+
+Textbook example of the anti-pattern's "Bad" — `ok` is declared, mutated in two guarded blocks, then read below. The two branches happen to be mutually exclusive (an Attachment can't be both `image` and `file`), so the code works, but the intent gets lost in a mutable flag.
+
+**Declarative rewrite:**
+```
+const drop =
+  (a.type == "image" && imageOk == false) ||
+  (a.type == "file" && pdfOk == false)
+if (drop) {
+  const reason = a.type == "image" ? "image" : "PDF"
+  skipped.push("${label} (model ${main.model} has no ${reason} input)")
+} else {
+  attachments.push(a)
+  labels.push(label)
+}
+```
+
+`drop` is a `const` derived from the inputs — no reordering can break it.
+
+### AP2. Imperative parallel arrays leaking through the interface — `DetectedContent` (Task 3). Design smell.
+
+`DetectedContent` returns three same-length, index-coupled arrays: `attachments: Attachment[]`, `labels: string[]`, plus `skipped: string[]` (which is not index-coupled but still a bare array). `modalityFilter` then walks two of them by shared index (`detected.attachments[i]` + `detected.labels[i]`), and the wiring iterates each separately for its print loop. This is exactly the "imperative code everywhere" case the anti-patterns doc warns about: consumers must know *how* the arrays are aligned rather than being handed a shape that expresses *what* they are.
+
+**Declarative rewrite:**
+```
+type DetectedAttachment = { attachment: Attachment, label: string }
+type SkippedAttachment = { label: string, reason: string }
+
+export type DetectedContent = {
+  text: string,
+  attached: DetectedAttachment[],
+  skipped: SkippedAttachment[]
+}
+```
+
+Then `modalityFilter` is a single `filter`/`map`, wiring prints via `for (s in detected.skipped) { pushMessage(color.yellow("📎 skipped ${s.label} — ${s.reason}")) }`, and consumers can't accidentally desynchronize the arrays. The plan already imports `map` from `std::array` for Task 4 — the same primitive would make Task 3's main loop declarative.
+
+Bonus: this also unpicks AP1's `ok` flag naturally, because filtering *is* the declarative form of "keep if …".
+
+### AP3. Manual imperative accumulator loops in `detectAttachments` (Task 3). Encapsulation is fine at the seams, imperative in the middle.
+
+The main loop:
+```
+for (t in tokens) {
+  if (attachments.length >= MAX_ATTACHMENTS) { continue }
+  const norm = normalizeToken(t)
+  const ext = extname(norm).toLowerCase()
+  const mime = MIME_TYPES[ext]
+  if (mime == null) { continue }
+  ...
+  seen.push(abs)
+  ...
+  if (info.size > maxBytes) { skipped.push(...); continue }
+  const bytes = readBinary(name, dirname(abs))
+  if (isFailure(bytes)) { skipped.push(...); continue }
+  if (mime == "application/pdf") { attachments.push(...) } else { attachments.push(...) }
+  labels.push(name)
+}
+```
+
+Every step of the algorithm — tokenize, normalize, extension filter, resolve, dedupe, stat, size gate, read, attachment shape — is inlined into one loop with 4 mutating accumulators. Anti-patterns doc §"Imperative code everywhere" specifically calls out `for + if + push + dedupe` chains and prescribes a `filter`/`map` pipeline instead. A more declarative shape:
+
+```
+def tokenToCandidate(token: string): Candidate | null { ... }   // normalize, ext, resolve, mime
+def readCandidate(cand: Candidate): Attempt                     // stat, size, read → attached or skipped
+```
+
+then
+
+```
+const candidates = tokenize(msg).map(tokenToCandidate).filter(c => c != null)
+const unique = dedupeByPath(candidates)
+const attempts = unique.slice(0, MAX_ATTACHMENTS).map(readCandidate)
+```
+
+Not obligatory — the plan's shape is testable and correct — but the current form buries the algorithm's 9 spec steps inside one imperative loop, so future edits (e.g. adding SVG, changing the dedupe key to content hash) touch the whole loop instead of one small function. Worth pulling apart at least `tokenToCandidate` (steps 1–5) from `readCandidate` (steps 6–8).
+
+**`tokenize` itself is fine** — it's a hand-written scanner, and the doc explicitly exempts parsers from the order-dependent-state rule.
+
+### AP4. One-line `if` statements — Task 1 (`_contentToString`) and Task 2 (`_modelSupportsInput`). Direct hit.
+
+```ts
+// Task 1
+if (typeof content === "string") return content;
+if (content == null) return "";
+...
+
+// Task 2
+if (modality !== "image" && modality !== "pdf") return null;
+return modelSupportsInputModality(model, modality) ?? null;
+```
+
+Both violate the "One-line if statements" entry. The bodies should be braced. Purely cosmetic; the structural linter (`pnpm run lint:structure`, called in Task 6) may or may not flag these — worth checking. If the linter is silent, still fix, because the plan explicitly says "Task 6 Step 1: linter clean" and other stdlib TS files (e.g. `lib/stdlib/threads.ts:41`) already use single-line-return style. If the codebase precedent overrides the doc here, note that in the review of Task 6.
+
+### AP5. Single-character variable names — pervasive. Direct hit.
+
+The plan's Agency code repeatedly uses single-char loop and helper vars: `for (t in tokens)`, `let t = token`, `const a = detected.attachments[i]`, `const p = part`, `for (s in detected.skipped)`, `for (l in detected.labels)`, `map(images) as p { ... }`, `const w = writeBinary(...)`, `const r = generateImage(...)`, `const d = detectAttachments(...)`, `const f = modalityFilter(d)`. The anti-patterns doc explicitly forbids these and asks for descriptive names.
+
+Renames worth making mechanically:
+- `t` → `token`, `p` → `part` / `path`, `a` → `att` / `attachment`, `s` → `skipReason`, `l` → `label`, `d` → `detected`, `f` → `filtered`, `r` → `result`, `w` → `writeResult`.
+
+Test-node bodies (e.g. `const d = detectAttachments(...)`) are less critical because they're throwaway assertions, but the production code (`attachments.agency`, `modalityFilter`, `generateImageFile`) should follow the rule.
+
+### AP6. Useless special case — arguable, Task 5 wiring.
+
+```
+if (detected.attachments.length == 0) {
+  return mainAgent(expanded)
+}
+...
+const parts: (string | Attachment)[] = [expanded, ...detected.attachments]
+return mainAgent(parts)
+```
+
+If `mainAgent` widens to `string | (string | Attachment)[]`, passing `[expanded]` (a one-element array) should be semantically identical to passing `expanded` (a bare string) — smoltalk's `userMessage` accepts both. If so, this is the anti-patterns doc's "useless special case" — drop it and always take the array path. **Worth actively verifying** rather than assuming, because there may be a subtle downstream difference (e.g. summarization, thread persistence, provider serialization) that treats the two shapes differently, and if there is, the early return is documenting that difference (and should have a comment saying so).
+
+### AP7. Magic number — `20971520` (Task 3).
+
+`export def detectAttachments(msg: string, maxBytes: number = 20971520)` uses the raw byte count. Bind it: `static const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024` (matches smoltalk's 20 MB cap the comment already cites), then default to `MAX_ATTACHMENT_BYTES`. The plan already binds `MAX_ATTACHMENTS = 10` right above — do the same for the byte cap for consistency.
+
+### Not violated
+
+- **Duplicating existing code.** The plan explicitly reuses `applyAgentCwd`, `readBinary`, `writeBinary`, `stat`, `basename`/`dirname`/`extname`, `env`, `map`, `modelSupportsInputModality`, `getResolvedSlots`, `_contentToString`. No reinvention.
+- **Leaky abstractions.** `DetectedContent` hides the tokenizer/normalizer/reader entirely — callers only see `{ text, attachments, labels, skipped }`. `modalityFilter` composes on the same type. Same story for `generateImageFile`: caller sees `(prompt, path, size, images) → string`, not `generateImage` + `writeBinary` + `dirname`. The outer seams are clean; the internals (see AP2, AP3) are the imperative part.
+- **Inconsistent patterns.** Follows the surrounding agent code (`shared.agency`, `resolution.agency`) idioms.
+- **Nested ternaries / try-catch without logging / dynamic requires / nested type objects.** None present.
+
+### Verdict on the "declarative interfaces + imperative internals" question
+
+The **interface layer is well-designed** — you can read `modalityFilter(detectAttachments(expanded))` and immediately understand the pipeline. The **implementation layer regresses to imperative style** in three places (AP1, AP2, AP3), most sharply in `modalityFilter`'s `ok` flag and in the parallel `attachments` / `labels` arrays that leak through `DetectedContent` itself. AP1 and AP2 are worth fixing because they compound: refactor `DetectedContent` to carry `DetectedAttachment[]`, and `modalityFilter` collapses to a single `filter`+`map` with no flags. AP3 is a "should", AP4/AP5/AP6/AP7 are "cheap wins while you're in the file."
+
+None of these promote to blocking — the code works — but the anti-patterns doc's tone is prescriptive ("read this before starting a task"), so a review that ignores them would be doing the plan a disservice.
+
+---
+
+## Test-plan audit: do the tests actually test what they claim?
+
+The tests as a set cover the happy paths honestly, but there are several tests that would still pass if the code they claim to test were broken, and several code paths with no test at all. Grouped by severity.
+
+### T-BLOCK. Tests that pass even when the code is broken
+
+**T-B1. `editInputsPassThrough` (Task 4) doesn't test what its name says.**
+
+```
+node editInputsPassThrough(): string {
+  setAgentCwd("/tmp")
+  generateImageFile("seed", "it-seed.png") with approve
+  return generateImageFile("restyle it", "it-edit.png", images: ["it-seed.png"]) with approve
+}
+```
+
+The deterministic image client (`useTestLLMProvider: true`) returns the same fixed 1×1 PNG regardless of the `images` argument. So this test only proves that passing a non-empty `images` list doesn't crash — the entire `const inputs = map(images) as p { return applyAgentCwd(p) }` line could be deleted (or replaced with `const inputs = []`) and the test would still pass green.
+
+**Consequence:** the "LLM-supplied paths resolve against the agent cwd" invariant for edit inputs — one of the spec's explicit requirements ("Both paths resolve against the agent cwd") — has **no test coverage**. If someone accidentally removes `applyAgentCwd`, no test catches it.
+
+**Fix:** either (a) have the deterministic image client capture and expose the last-received `images` argument so the test can assert `it-seed.png` was resolved to `/tmp/it-seed.png`, or (b) add a unit that reads the underlying `generateImage` call args via a spy/mock, or (c) at minimum, exercise with a bogus relative input path and confirm the read-input step reaches the correct place (harder — the deterministic client doesn't read inputs at all).
+
+**T-B2. `modalityFilterDropsForTextOnlyModel` doesn't cover the PDF branch.**
+
+The implementation has two independent drops:
+```
+if (a.type == "image" && imageOk == false) { ... }
+if (a.type == "file" && pdfOk == false) { ... }
+```
+
+Only the `image` drop is tested. Delete the `pdfOk` check entirely and every test still passes. Also, `pdfOk` computed from `modelSupportsInput(main.model, "pdf")` (Task 2) — nothing tests the "pdf" modality end-to-end.
+
+**Fix:** add a `modalityFilterDropsPdfForNoPdfModel` node with a `.pdf` attachment and a text-only model. Requires a model in the catalog with `pdf: false` — the same probe pattern from Task 2 Step 1 will find one.
+
+**T-B3. `_modelSupportsInput` tests never exercise `"pdf"`.**
+
+All four `describe("_modelSupportsInput")` cases pass `"image"` or `"audio"`. The whitelist `if (modality !== "image" && modality !== "pdf") return null` could be tightened to `if (modality !== "image") return null` and the tests would still pass, silently breaking the entire PDF-attachment code path in Task 5.
+
+**Fix:** add `expect(_modelSupportsInput("<pdf-capable-model>", "pdf")).toBe(true)` and one for `false`.
+
+**T-B4. `savesToAgentCwd` doesn't distinguish agent-cwd from process-cwd resolution.**
+
+```
+setAgentCwd("/tmp")
+const msg = generateImageFile("a red bicycle", "it-gen.png") with approve
+const back = readBinary("it-gen.png", "/tmp") with approve
+```
+
+The Agency test process's own cwd is almost certainly `packages/agency-lang/`, and `writeBinary("it-gen.png", ..., "")` (the "no agent cwd" fallback) would land at `packages/agency-lang/it-gen.png`. So the test *does* meaningfully assert that the agent cwd was consulted — but only if the process cwd is guaranteed *not* to be `/tmp` when the test runs. Fragile if someone runs the test suite from `/tmp` for any reason (e.g. a hermetic-CI change). Micro-risk, but worth using a distinctive path like `/tmp/agency-imgtest-<pid>/` if the fixture directory can be made unique.
+
+More concretely: **there's no negative assertion** that `it-gen.png` was NOT written under process cwd. A truly diagnostic version would `setAgentCwd("/tmp")`, call `generateImageFile(..., "it-gen.png")`, then assert both `readBinary("it-gen.png", "/tmp").isSuccess()` AND `readBinary("it-gen.png", cwd()).isFailure()`.
+
+### T-COVERAGE. Missing tests for real code paths
+
+**T-C1. Only two of six MIME types are exercised.** `MIME_TYPES` has entries for `.png .jpg .jpeg .gif .webp .pdf`. Tests hit `.png` and `.pdf`. Someone accidentally deleting `.gif` or `.webp` from the table (a real-world drift risk when someone adds `.svg` or `.heic` later) would not fail any test. **Add:** one parameterized-style test per remaining extension, or one aggregate test that writes a `.jpg`, `.jpeg`, `.gif`, `.webp` fixture and asserts `attachments.length == 4`.
+
+**T-C2. Case-insensitive extension (`.toLowerCase()`) is untested.** A user drag-dropping `Screenshot.PNG` (macOS default caps) or a `Report.PDF`. Delete `.toLowerCase()` in the implementation and the tests still pass.
+
+**T-C3. `readBinary` failure branch is untested.** `if (isFailure(bytes)) { skipped.push("${name} (could not read)") }` — no test constructs a file that stat sees as a file but readBinary rejects. Hard to build portably (a chmod 000 file needs a `chmod` call; a symlink-loop needs `ln -s`), and the branch is two lines, so this is an acceptable known gap — but the plan doesn't call it out the way it calls out the generation-failure gap in Task 4.
+
+**T-C4. Multiple attachments in one message.** No test asserts that `see /tmp/a.png and /tmp/b.png` returns two attachments in the given order. If a bug reordered or dropped subsequent attachments (e.g. an off-by-one in the cap check firing at 0 instead of `MAX_ATTACHMENTS`), only the `capsAtTen` corner case would catch it, and even that only tells you "≥10 became 10", not "the first N are preserved."
+
+**T-C5. Mixed attachment types in one message.** `.png + .pdf` in one call — untested. Would exercise the `if (mime == "application/pdf") { file(...) } else { image(...) }` branch selection in a single loop, and would also catch a bug where the `if` predicate is inverted.
+
+**T-C6. Subagent route stays text-only** (spec decision #3). The spec explicitly reserves subagent direct-routing (`agentReplyVia("code", "look at /tmp/x.png")`) as text-only. **No test verifies this.** If a future refactor accidentally routed `agentReplyVia("code", ...)` through the same `detectAttachments` path, this decision would silently regress. Add a `subagentRouteIgnoresImagePath` node.
+
+**T-C7. Visible print lines (`📎 attached`, `📎 skipped`) are untested.** Task 5 Step 3 adds `pushMessage(color.yellow("📎 skipped ${s}"))` and `pushMessage(color.dim("📎 attached ${l}"))`. Delete either line and no test fails. The spec's "**never silent**" invariant is unenforced. Capturing REPL output in `.agency` tests is possible via the `clearMessages`/`pushMessage` module or by structuring `agentReply` to return the message trail — worth at least one test that captures and asserts on the emitted string.
+
+**T-C8. Cost tracking on generation.** Spec: "generation cost flows into the agent's existing cost tracking / `guard(cost:)`". No test does `const before = getCost(); generateImageFile(...); const after = getCost(); assert(after > before)`. If `generateImageFile` accidentally used a code path that bypassed cost accrual, `guard(cost:)` would silently fail to budget for it.
+
+**T-C9. Attachment order preservation.** The pipeline is `tokenize → filter → attachments.push(...)` — insertion order should match message order. Untested. `dedupes` uses only one path, so it can't distinguish "the second mention was dropped" from "the second mention was reordered."
+
+**T-C10. Empty message.** `detectAttachments("")` — untested. Should return `{ text: "", attachments: [], labels: [], skipped: [] }`.
+
+**T-C11. `_contentToString` corner cases.** The implementation has code paths for: `null` content, `type: "text"` with nullish `text` field, unknown part `type` (falls through to `JSON.stringify`), empty array. None are tested. The `"never leaks base64"` test is largely redundant with the placeholder-rendering test (the exact-match assertion already implies the base64 is absent).
+
+**T-C12. Double-quoted path in tokenizer.** Tokenizer handles both `'` and `"`. Only `'` is tested (`quotedPathWithSpaces`). A refactor that broke double-quote handling wouldn't fail.
+
+### T-FRAGILE. Tests whose green result depends on test-order/environment
+
+**T-F1. `applyResolved` state leakage across nodes** — already covered as B2, but broader than the passthrough test. `attachesImageToTurn` (turn integration) doesn't call `applyResolved`, so it inherits whatever main-slot model is set from the framework's default. If the default were ever changed to a text-only model, or if a previously-run node in the same process left one behind, the modality filter would drop the image and `threadHasImagePlaceholder()` would return `false` → test fails for a reason unrelated to the code under test.
+
+**T-F2. `/tmp` fixture-file collisions across the suite.** Multiple test nodes write to `/tmp/da-*.png` and `/tmp/at-*.png` with fixed names. Under `-p 12` parallel-file execution the *files* are per-process, but if two nodes within the same file happen to race (Agency test runner may run nodes serially within a file — worth checking), the last writer wins and read-back can flap. Suggest: prefix fixtures with the node name (`/tmp/at-x-attachesImageToTurn.png`) or a shared `testFixturePath("at-x.png")` helper.
+
+**T-F3. `tildeExpansion` mutates `HOME` process-wide** — already covered as N2 in the correctness section. Repeating here for completeness: if a future test appended below reads `env("HOME")`, it sees `/tmp`.
+
+**T-F4. `directoryIgnored` assumes `mkdir` won.** If `/tmp/da-dir.png` already exists as a file from a stale prior run, `mkdir` fails silently, stat sees the file, and the test wrongly reports `1` (a false negative on "we ignore directories") — but the expected output is `"0"`, so the test would loudly fail with a mismatch. Wait — that means the test *would* fail, just with a confusing diagnostic. Still worth a `rm -rf` prefix to make the message clearer when it fires.
+
+### T-GOOD. Tests that hold up under scrutiny
+
+- **`_contentToString` "renders text parts and attachment placeholders"** — exact-match string assertion covers ordering, spacing, and label formatting all at once. Nice.
+- **`overLimitSkipped`** — asserts both count and the exact `skipped[0]` string. If the skip label wording changes, the test fails loudly.
+- **`relativeResolvesAgainstAgentCwd`** — actually distinguishes agent-cwd resolution from other resolutions, because the token has no `/`, the file is at `/tmp/da-rel.png`, and `setAgentCwd("/tmp")` is the only way it can be found.
+- **`quotedPathWithSpaces` and `escapedSpacePath`** — the `da b.png` filename cannot be produced by any tokenization other than the intended one, so a broken tokenizer would give a `"0"` count.
+- **`capsAtTen`** — returning a number (not a string) sidesteps the JSON-encoding quirk and exercises the cap boundary properly.
+- **`reportsWriteFailure`** — uses `startsWith(...)`, which is robust against writeBinary appending errno details but strict enough to fail if the "Generated the image, but saving" branch is replaced with the wrong string. (Modulo the N6 concern that writeBinary might auto-create the dir.)
+
+### Prioritized test additions
+
+If the plan is executed as written, these are the additions that would catch the most real regressions per line of test code:
+
+| # | Test | Catches |
+|---|---|---|
+| 1 | `_modelSupportsInput("<pdf-model>", "pdf") == true` and `false` | T-B3 — silent PDF path removal |
+| 2 | `modalityFilterDropsPdfForNoPdfModel` | T-B2 — silent `pdfOk` removal |
+| 3 | `subagentRouteIgnoresImagePath` (`agentReplyVia("code", ...)`) | T-C6 — spec decision #3 regression |
+| 4 | Aggregate multi-extension test (`.jpg .jpeg .gif .webp` fixtures, expect 4) | T-C1 — MIME table drift |
+| 5 | `editInputsResolveAgainstAgentCwd` — needs image-client spy | T-B1 — silent removal of `applyAgentCwd` on edit inputs |
+| 6 | `mixedImageAndPdfInOneMessage` — expect one image + one file | T-C5 — branch coverage |
+| 7 | `printsVisibleAttachedLine` — capture pushMessage output | T-C7 — silent-attach regression |
+| 8 | `costRecordedForGeneration` — `getCost()` delta | T-C8 — guard(cost:) budgeting |
+
+Add the top 3 minimum, all 8 for defense in depth.
+
+### Summary of the test-plan audit
+
+- **False greens (4):** `editInputsPassThrough`, `modalityFilterDropsForTextOnlyModel` (missing PDF twin), `_modelSupportsInput` (missing PDF), `savesToAgentCwd` (weak agent-cwd vs process-cwd distinction).
+- **Missing coverage (12):** MIME extensions, case-insensitive ext, readBinary failure, multi-attachment, mixed types, subagent route, `📎` print lines, cost tracking, order preservation, empty message, `_contentToString` corner cases, double-quoted paths.
+- **Test-isolation fragility (4):** `applyResolved` leak, `/tmp` fixture collision, `HOME` leak, `mkdir` assumption.
+- **Honest green (6):** the tests listed under T-GOOD really do fail when their subjects break.
+
+Net: **the test suite as written proves the happy path works, but under-defends against regressions.** The single most valuable additions are T-B3 (pdf whitelist) and T-B1 (edit-inputs agent-cwd) — both are one-liners in the production code, both are called out in the spec, and neither would fail a single test if removed.

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-02-agent-images-and-attachments.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-02-agent-images-and-attachments.md
@@ -1,0 +1,1259 @@
+# Agent Image Generation + Attachments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the merged multimodal capability into the built-in agent: a `generateImageFile` tool that generates/edits images and saves them to disk, and auto-detection of image/PDF paths in user messages that inlines them as base64 attachments on the coordinator LLM turn.
+
+**Architecture:** Two prerequisite stdlib changes (attachment-placeholder rendering in the thread reader/summarizer; a tri-state `std::llm.modelSupportsInput` bridge), then a pure detection helper module (`attachments.agency`), the image tool, and the `agentReplyVia`/`mainAgent` wiring. Attachments are inlined as base64 at attach time (never stored as paths in the persistent thread). Detection returns `DetectedAttachment[]` records (attachment + label together) — no index-coupled parallel arrays.
+
+**Tech Stack:** Agency language (agent + stdlib), TypeScript stdlib bridges (`lib/stdlib/`), vitest for TS units, the Agency execution-test runner (`.agency` + `.test.json`) with the deterministic LLM/image provider for agent tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md` — read it first.
+**Review applied:** `docs/superpowers/plans/2026-07-02-agent-images-and-attachments-review.md` (B1/B3, N1/N3, AP1–AP5/AP7, T-B1–T-B4, T-C1/C2/C4–C6/C8/C10–C12 addressed; B2/N2/T-F1/T-F3 rejected — each test node runs in its own subprocess via `executeNode`'s `execFileSync`, so no state leaks between nodes; AP6 rejected — see Task 5 Step 3 comment).
+
+## Global Constraints
+
+- All paths below are relative to `packages/agency-lang/` unless they start with `docs/superpowers`.
+- Agency syntax: `def name(params): Type { ... }`, `if (cond) { ... }`, `let`/`const` before use, `for (x in items) { ... }`. NO Python-style blocks, NO bare assignment. Verify new `.agency` files parse with `pnpm run ast <file>` before running tests.
+- Agency has `null`, never `undefined`. Tri-state values are `boolean | null`.
+- `break` is NOT used anywhere in the Agency codebase — use `continue` with a guard instead. `continue`, ternary `cond ? a : b` (no nesting), `.includes()`, `.slice()`, `.split()`, `.startsWith()`, `.endsWith()`, `.toLowerCase()`, `.push()`, string interpolation `"${x}"`, and array spread `[a, ...b]` are all proven in existing code.
+- Follow `docs/dev/anti-patterns.md`: braces on every `if` (no one-liners), descriptive variable names (no single-char), no order-dependent mutable flags, prefer `const`-derived conditions.
+- `writeBinary`/`readBinary`/`write` REJECT an absolute filename whenever `dir` is set (which is always — `dir` defaults to `"."`). Always pass `(basename, dir)` pairs: `readBinary("x.png", "/tmp")`, never `readBinary("/tmp/x.png")`. `_writeBytes` does NOT create missing directories (verified) — a write into a nonexistent dir returns a Failure.
+- Each Agency test node runs in its OWN subprocess (`executeNode` → `execFileSync("node", [evaluateFile])`), serially within a file. Nodes cannot leak `applyResolved`/`setEnv`/`setAgentCwd` state into each other. `/tmp` fixture files DO persist across runs — clean or overwrite them at the top of the node that uses them.
+- Run `make` after ANY change to `stdlib/*.agency` or `lib/agents/**` before running Agency tests (the test runner uses `dist/`).
+- Save every test run's output to a file (e.g. `> /tmp/t1.log 2>&1`) so failures can be inspected without rerunning. Never run the full `tests/agency` suite locally — CI does that.
+- Agency execution tests need no LLM calls: the deterministic provider (`"useTestLLMProvider": true` in the `.test.json`) serves both `llm()` (via `llmMocks`) and `generateImage()` (fixed 1×1 PNG, $0.04 cost, `images:` argument ignored).
+- Interrupts in tests are answered inline with `with approve` / `with reject` on the call.
+- Commit messages contain apostrophes → always write the message to a file and use `git commit -F <file>`. End every commit message with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Work on a branch: before Task 1, run `git checkout -b agent-images-attachments`.
+- The deterministic 1×1 PNG used throughout (89 bytes decoded, valid base64):
+  `iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC`
+
+### Known coverage gaps (named, accepted)
+
+1. `generateImageFile`'s generation-failure branch — the deterministic image client never fails; the write-failure test proves the "never report success on failure" contract instead.
+2. `detectAttachments`' read-failure branch (`could not read` skip) — building a stat-succeeds/read-fails file portably needs `chmod 000` machinery; the branch is two lines.
+3. The `📎 attached` / `📎 skipped` `pushMessage` lines — `std::ui` exposes no message-buffer reader (only `clearMessages`), so the "never silent" invariant has no assertion. Do not build capture machinery for it in this plan.
+4. That `generateImageFile` actually CALLS `resolveEditInputs` (the composition seam) — the resolution logic itself is unit-tested (Task 4), but the deterministic client ignores `images:`, so wiring-level removal would only be caught by review.
+
+---
+
+### Task 1: Attachment placeholders in the thread reader/summarizer (`_contentToString`)
+
+The summarizer transcript and the `getThread` reader currently `JSON.stringify` non-string message content (`lib/stdlib/threads.ts:40`), which would dump base64 attachment payloads into the summarize prompt. Render parts as placeholders instead. This is a prerequisite: Task 5's turn-integration test asserts on the `[image attachment]` placeholder.
+
+**Files:**
+- Modify: `lib/stdlib/threads.ts:40-44` (`_contentToString` — also export it)
+- Test: `lib/stdlib/threads.test.ts` (append a new top-level `describe`, matching the existing top-level `describe("_eagerSummarizeIfNeeded", ...)` at line 41)
+
+**Interfaces:**
+- Produces: `export function _contentToString(content: smoltalk.MessageJSON["content"]): string` — text parts pass through, image parts → `"[image attachment]"`, file parts → `"[file attachment: <filename>]"` (or `"[file attachment]"` with no filename), parts joined with a single space. Task 5's test relies on the exact string `[image attachment]` appearing in `getThread` content.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/stdlib/threads.test.ts` (add `_contentToString` to its import from `./threads.js`):
+
+```ts
+describe("_contentToString", () => {
+  it("passes plain strings through", () => {
+    expect(_contentToString("hello")).toBe("hello");
+  });
+
+  it("renders text parts and attachment placeholders", () => {
+    const content = [
+      { type: "text", text: "look at this" },
+      { type: "image", source: { kind: "base64", base64: "AAAA", mimeType: "image/png" } },
+      { type: "file", filename: "report.pdf", source: { kind: "base64", base64: "BBBB", mimeType: "application/pdf" } },
+    ];
+    expect(_contentToString(content as any)).toBe(
+      "look at this [image attachment] [file attachment: report.pdf]",
+    );
+  });
+
+  it("never leaks base64 payloads into the transcript", () => {
+    const content = [
+      { type: "image", source: { kind: "base64", base64: "SECRETPAYLOAD", mimeType: "image/png" } },
+    ];
+    expect(_contentToString(content as any)).not.toContain("SECRETPAYLOAD");
+  });
+
+  it("handles null content and empty part arrays", () => {
+    expect(_contentToString(null as any)).toBe("");
+    expect(_contentToString([] as any)).toBe("");
+  });
+
+  it("renders a file part without filename generically", () => {
+    const content = [{ type: "file", source: { kind: "base64", base64: "CCCC", mimeType: "application/pdf" } }];
+    expect(_contentToString(content as any)).toBe("[file attachment]");
+  });
+
+  it("renders a text part with a missing text field as empty", () => {
+    expect(_contentToString([{ type: "text" }] as any)).toBe("");
+  });
+
+  it("falls back to JSON for unknown part types", () => {
+    expect(_contentToString([{ type: "mystery", x: 1 }] as any)).toBe('{"type":"mystery","x":1}');
+  });
+
+  it("keeps JSON fallback for unknown non-string content", () => {
+    expect(_contentToString({ weird: true } as any)).toBe('{"weird":true}');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test:run lib/stdlib/threads.test.ts > /tmp/task1-fail.log 2>&1; tail -30 /tmp/task1-fail.log`
+Expected: FAIL — `_contentToString` is not exported (import error), or once exported, the placeholder assertions fail against the `JSON.stringify` behavior.
+
+- [ ] **Step 3: Implement placeholder rendering**
+
+Replace `_contentToString` in `lib/stdlib/threads.ts` (keep the doc comment above it, extend it with one line about attachment placeholders) and add `export`. Braces on every branch per `docs/dev/anti-patterns.md` "One-line if statements":
+
+```ts
+export function _contentToString(content: smoltalk.MessageJSON["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (content == null) {
+    return "";
+  }
+  if (Array.isArray(content)) {
+    const rendered = content.map((part) => {
+      if (part && typeof part === "object" && "type" in part) {
+        const typedPart = part as { type?: string; text?: unknown; filename?: string };
+        if (typedPart.type === "text") {
+          return String(typedPart.text ?? "");
+        }
+        if (typedPart.type === "image") {
+          return "[image attachment]";
+        }
+        if (typedPart.type === "file") {
+          return typedPart.filename ? `[file attachment: ${typedPart.filename}]` : "[file attachment]";
+        }
+      }
+      return JSON.stringify(part);
+    });
+    return rendered.join(" ");
+  }
+  return JSON.stringify(content);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test:run lib/stdlib/threads.test.ts > /tmp/task1-pass.log 2>&1; tail -10 /tmp/task1-pass.log`
+Expected: PASS (all pre-existing `_eagerSummarizeIfNeeded` tests in the file must also still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cat > /tmp/commit-msg.txt <<'EOF'
+Render attachment parts as placeholders in thread transcripts
+
+_contentToString backs both the summarizer transcript and the getThread
+reader; it used to JSON.stringify multimodal content, which would dump
+base64 attachment payloads into the summarize prompt. Attachment parts
+now render as "[image attachment]" / "[file attachment: name]".
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+git add lib/stdlib/threads.ts lib/stdlib/threads.test.ts
+git commit -F /tmp/commit-msg.txt
+```
+
+---
+
+### Task 2: `std::llm.modelSupportsInput` tri-state modality probe
+
+Expose smoltalk's `modelSupportsInputModality` so the agent can check ahead of send whether the resolved model accepts image/PDF input. It is the exact predicate smoltalk's send-time gate uses.
+
+**Files:**
+- Modify: `lib/stdlib/llm.ts` (add `modelSupportsInputModality` to the existing `from "smoltalk"` import at the top; add `_modelSupportsInput`)
+- Modify: `stdlib/llm.agency` (add `_modelSupportsInput` to the existing `from "agency-lang/stdlib-lib/llm.js"` import block at line 1; add the `modelSupportsInput` def)
+- Test: `lib/stdlib/llm.test.ts` (append a `describe`)
+
+**Interfaces:**
+- Produces (TS): `export function _modelSupportsInput(model: string, modality: string): boolean | null`
+- Produces (Agency): `export safe def modelSupportsInput(model: string, modality: string): boolean | null` in `std::llm` — `true`/`false` from the catalog, `null` = unknown ("don't gate"). Task 5's `modalityFilter` consumes this with BOTH `"image"` and `"pdf"`.
+
+- [ ] **Step 1: Verify the catalog fixtures the tests depend on**
+
+CAUTION: iterating `getAllModels()` and calling `modelSupportsInputModality(m.name, ...)` returns `undefined` for every entry (name-form mismatch) — do NOT probe that way. Probe direct names (run from `packages/agency-lang`):
+
+```bash
+node --input-type=module -e "
+const s = await import('smoltalk');
+for (const name of ['gpt-4o', 'gpt-3.5-turbo', 'claude-opus-4-8']) {
+  console.log(name, 'image:', s.modelSupportsInputModality(name, 'image'), 'pdf:', s.modelSupportsInputModality(name, 'pdf'));
+}"
+```
+
+Expected (verified 2026-07-02): `gpt-4o` → image `true`, pdf `true`; `gpt-3.5-turbo` → image `false`, pdf `false`. If the catalog has drifted, substitute models with the same true/false shape **everywhere this plan uses `gpt-4o` / `gpt-3.5-turbo` in modality tests** (Task 2 and Task 5).
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `lib/stdlib/llm.test.ts` (add `_modelSupportsInput` to its import from `./llm.js`):
+
+```ts
+describe("_modelSupportsInput", () => {
+  it("returns true for a vision model", () => {
+    expect(_modelSupportsInput("gpt-4o", "image")).toBe(true);
+  });
+
+  it("returns false for a text-only model", () => {
+    expect(_modelSupportsInput("gpt-3.5-turbo", "image")).toBe(false);
+  });
+
+  it("returns true for a pdf-capable model", () => {
+    expect(_modelSupportsInput("gpt-4o", "pdf")).toBe(true);
+  });
+
+  it("returns false for a model without pdf input", () => {
+    expect(_modelSupportsInput("gpt-3.5-turbo", "pdf")).toBe(false);
+  });
+
+  it("returns null for an unknown model", () => {
+    expect(_modelSupportsInput("no-such-model-xyz", "image")).toBe(null);
+  });
+
+  it("returns null for an unsupported modality string", () => {
+    expect(_modelSupportsInput("gpt-4o", "audio")).toBe(null);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm test:run lib/stdlib/llm.test.ts > /tmp/task2-fail.log 2>&1; tail -20 /tmp/task2-fail.log`
+Expected: FAIL — `_modelSupportsInput` is not exported.
+
+- [ ] **Step 4: Implement the TS bridge**
+
+In `lib/stdlib/llm.ts`, add `modelSupportsInputModality` to the existing smoltalk import list, then add near `_hostedModelInfo`:
+
+```ts
+/** Tri-state modality probe backing `std::llm.modelSupportsInput`. Returns
+ *  null (not undefined — Agency has no undefined) when the model is unknown
+ *  or carries no modality data; that matches smoltalk's send-time gate,
+ *  which only blocks on an explicit false. */
+export function _modelSupportsInput(model: string, modality: string): boolean | null {
+  if (modality !== "image" && modality !== "pdf") {
+    return null;
+  }
+  return modelSupportsInputModality(model, modality) ?? null;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm test:run lib/stdlib/llm.test.ts > /tmp/task2-pass.log 2>&1; tail -10 /tmp/task2-pass.log`
+Expected: PASS.
+
+- [ ] **Step 6: Add the Agency-level def**
+
+In `stdlib/llm.agency`: add `_modelSupportsInput,` to the import block from `"agency-lang/stdlib-lib/llm.js"` (lines 1–7). Then add after the `hostedModelInfo` def:
+
+```
+export safe def modelSupportsInput(model: string, modality: string): boolean | null {
+  """
+  Whether a model accepts a given input modality ("image" or "pdf").
+  Tri-state: true / false when the model catalog says so, null when the
+  model or its modality data is unknown. Treat null as "do not gate" —
+  that is the same rule llm() applies at send time.
+
+  @param model - The model name (e.g. "gpt-4o-mini")
+  @param modality - "image" or "pdf"
+  """
+  return _modelSupportsInput(model, modality)
+}
+```
+
+- [ ] **Step 7: Build and smoke-test the Agency surface**
+
+```bash
+make > /tmp/task2-make.log 2>&1; tail -5 /tmp/task2-make.log
+```
+Expected: build succeeds. (`make` is REQUIRED after stdlib changes.)
+
+`.agency` files cannot run from `/tmp` (missing node_modules) — smoke-test from the repo instead. Create a throwaway file `smoke-modality.agency` in the repo root of `packages/agency-lang`:
+
+```
+import { modelSupportsInput } from "std::llm"
+
+node main() {
+  print("${modelSupportsInput("gpt-4o", "image")}|${modelSupportsInput("nope-xyz", "image")}")
+}
+```
+
+Run: `pnpm run agency smoke-modality.agency > /tmp/task2-smoke.log 2>&1; cat /tmp/task2-smoke.log`
+Expected output contains: `true|null`
+Then delete the file: `rm smoke-modality.agency`
+
+- [ ] **Step 8: Commit**
+
+```bash
+cat > /tmp/commit-msg.txt <<'EOF'
+Add std::llm.modelSupportsInput tri-state modality probe
+
+Exposes smoltalk modelSupportsInputModality — the exact predicate the
+send-time modality gate uses — so callers can check ahead of a call
+whether a model accepts image/pdf input. null = unknown = do not gate.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+git add lib/stdlib/llm.ts lib/stdlib/llm.test.ts stdlib/llm.agency
+git commit -F /tmp/commit-msg.txt
+```
+
+---
+
+### Task 3: `detectAttachments` helper module
+
+A pure, unit-testable helper that scans a user message for image/PDF paths (drag-dropped or typed), and returns inline-base64 attachments with display labels. Spec section "Part B — Attachment detection" defines the algorithm; follow it exactly. Structure per the anti-patterns doc: candidate extraction (pure) is separated from the I/O stage (stat/read), and attachments carry their labels in one record — no index-coupled parallel arrays.
+
+**Files:**
+- Create: `lib/agents/agency-agent/lib/attachments.agency`
+- Test: `lib/agents/agency-agent/tests/attachments.agency`
+- Test: `lib/agents/agency-agent/tests/attachments.test.json`
+
+**Interfaces:**
+- Consumes: `stat` (`std::shell`), `env`/`setEnv` (`std::system`), `basename`/`dirname`/`extname`/`isAbsolute` (`std::path`), `Attachment`/`image`/`file` (`std::thread`), auto-imported `readBinary`/`applyAgentCwd`.
+- Produces:
+  - `export type DetectedAttachment = { attachment: Attachment, label: string }`
+  - `export type SkippedFile = { label: string, reason: string }`
+  - `export type DetectedContent = { text: string, attached: DetectedAttachment[], skipped: SkippedFile[] }`
+  - `export def detectAttachments(msg: string, maxBytes: number = 20971520): DetectedContent` — raises `std::readBinary` interrupts (one per attached file); callers must have a read-approving handler or use `with approve`.
+  - Task 5 adds `modalityFilter` to this same file.
+
+- [ ] **Step 1: Write the module**
+
+Create `lib/agents/agency-agent/lib/attachments.agency`:
+
+```
+import { stat } from "std::shell"
+import { env } from "std::system"
+import { basename, extname, dirname, isAbsolute } from "std::path"
+import { Attachment, image, file } from "std::thread"
+
+// Detects image/PDF file paths in a user message (terminal drag-drop
+// inserts a quoted/escaped path; typed mentions are plain tokens) and
+// returns them as inline-base64 attachments for the coordinator turn.
+// Media-only by design: code/text paths stay with the read tool.
+
+export type DetectedAttachment = { attachment: Attachment, label: string }
+export type SkippedFile = { label: string, reason: string }
+
+export type DetectedContent = {
+  text: string,
+  attached: DetectedAttachment[],
+  skipped: SkippedFile[]
+}
+
+// A token that survived the pure (no-I/O) gates: normalized, media
+// extension, resolved to an absolute path.
+type Candidate = { abs: string, mime: string }
+
+// extension (lowercase, with dot) -> MIME type. Media-only by design.
+static const MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".pdf": "application/pdf"
+}
+
+static const MAX_ATTACHMENTS = 10
+
+// Split msg into candidate tokens. Shell-quoted spans ('…' / "…")
+// become single tokens (drag-drop quotes paths with spaces), and a
+// backslash-escaped space is unescaped into the current token.
+// Hand-written scanner — order-dependent state is fine here (parsers
+// are exempt per docs/dev/anti-patterns.md).
+def tokenize(msg: string): string[] {
+  let tokens: string[] = []
+  let current = ""
+  let quote = ""
+  let index = 0
+  while (index < msg.length) {
+    const ch = msg.slice(index, index + 1)
+    if (quote != "") {
+      if (ch == quote) {
+        quote = ""
+      } else {
+        current = current + ch
+      }
+    } else if (ch == "'" || ch == "\"") {
+      quote = ch
+    } else if (ch == "\\" && index + 1 < msg.length && msg.slice(index + 1, index + 2) == " ") {
+      current = current + " "
+      index = index + 1
+    } else if (ch == " " || ch == "\t" || ch == "\n") {
+      if (current != "") {
+        tokens.push(current)
+        current = ""
+      }
+    } else {
+      current = current + ch
+    }
+    index = index + 1
+  }
+  if (current != "") {
+    tokens.push(current)
+  }
+  return tokens
+}
+
+// Trim trailing punctuation typed after a path, and expand a leading ~/
+// (drag-drop inserts absolute paths, but typed mentions are often ~/…).
+def normalizeToken(token: string): string {
+  let normalized = token
+  while (normalized.length > 0 && (normalized.endsWith(",") || normalized.endsWith(".") || normalized.endsWith("?") || normalized.endsWith(":"))) {
+    normalized = normalized.slice(0, normalized.length - 1)
+  }
+  if (normalized.startsWith("~/")) {
+    const home = env("HOME")
+    if (home != null && home != "") {
+      normalized = home + normalized.slice(1)
+    }
+  }
+  return normalized
+}
+
+// Pure stage (spec steps 2-3 + extension gate): normalize, keep only
+// media extensions, resolve to an absolute path. Returns null for
+// tokens that are not candidate media paths. No filesystem access.
+def tokenToCandidate(token: string): Candidate | null {
+  const normalized = normalizeToken(token)
+  const ext = extname(normalized).toLowerCase()
+  const mime = MIME_TYPES[ext]
+  if (mime == null) {
+    return null
+  }
+  if (isAbsolute(normalized)) {
+    return { abs: normalized, mime: mime }
+  }
+  return { abs: applyAgentCwd(normalized), mime: mime }
+}
+
+export def detectAttachments(msg: string, maxBytes: number = 20971520): DetectedContent {
+  """
+  Scan a user message for image/PDF file paths and return them as
+  inline-base64 attachments with display labels. Non-existent paths,
+  directories, non-media extensions, unreadable files, and files over
+  maxBytes (default 20971520 = smoltalk's 20 MB per-file cap) are not
+  attached; size/read skips are reported in `skipped`. Caps at 10
+  attachments per message.
+  """
+  let attached: DetectedAttachment[] = []
+  let skipped: SkippedFile[] = []
+  let seen: string[] = []
+  for (token in tokenize(msg)) {
+    if (attached.length >= MAX_ATTACHMENTS) {
+      continue
+    }
+    const candidate = tokenToCandidate(token)
+    if (candidate == null) {
+      continue
+    }
+    if (seen.includes(candidate.abs)) {
+      continue
+    }
+    seen.push(candidate.abs)
+    const info = stat(candidate.abs)
+    if (info.type != "file") {
+      continue
+    }
+    const label = basename(candidate.abs)
+    if (info.size > maxBytes) {
+      skipped.push({ label: label, reason: "too large to attach" })
+      continue
+    }
+    // readBinary rejects an absolute filename when dir is set, so pass
+    // the (basename, dirname) split. Inlining the bytes here (instead of
+    // letting smoltalk read the path at every send) keeps the persistent
+    // thread immune to later file deletion/edits and keeps the read
+    // inside the std::readBinary policy gate.
+    const bytes = readBinary(label, dirname(candidate.abs))
+    if (isFailure(bytes)) {
+      skipped.push({ label: label, reason: "could not read" })
+      continue
+    }
+    if (candidate.mime == "application/pdf") {
+      attached.push({ attachment: file(bytes.value, filename: label, mimeType: candidate.mime, base64: true), label: label })
+    } else {
+      attached.push({ attachment: image(bytes.value, candidate.mime, base64: true), label: label })
+    }
+  }
+  return { text: msg, attached: attached, skipped: skipped }
+}
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `pnpm run ast lib/agents/agency-agent/lib/attachments.agency > /tmp/task3-ast.log 2>&1; echo "exit=$?"`
+Expected: `exit=0`. If it fails, debug with `DEBUG=1 pnpm run ast lib/agents/agency-agent/lib/attachments.agency > /tmp/task3-ast-debug.log 2>&1` and inspect the log. Likely culprit: the `"\\"` / `"\""` escapes (backslash codegen was fixed in PR #315 and should work) — if an escape form fails to parse, check how `stdlib/skills.agency` writes escaped literals and mirror it.
+
+- [ ] **Step 3: Write the failing tests**
+
+Create `lib/agents/agency-agent/tests/attachments.agency`. Reminder: every node is its own subprocess — no state leaks between nodes, so no env/slot restore is needed; but `/tmp` files persist across RUNS, so nodes (re)create their own fixtures.
+
+```
+import { detectAttachments } from "../lib/attachments.agency"
+import { setAgentCwd } from "std::index"
+import { exec } from "std::shell"
+import { setEnv } from "std::system"
+
+// 1x1 PNG, 89 bytes decoded. Content is irrelevant to detection (the
+// gate is extension + stat), but a real PNG keeps fixtures honest.
+static const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+node detectsPngPath(): string {
+  writeBinary("da-a.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("look at /tmp/da-a.png please") with approve
+  if (detected.attached.length != 1) {
+    return "count=${detected.attached.length}"
+  }
+  const item = detected.attached[0]
+  return "1|${item.label}|${item.attachment.type}|${item.attachment.source.kind}"
+}
+
+node detectsPdfPath(): string {
+  writeBinary("da-doc.pdf", "JVBERi0xLjQK", "/tmp") with approve
+  const detected = detectAttachments("summarize /tmp/da-doc.pdf") with approve
+  if (detected.attached.length != 1) {
+    return "count=${detected.attached.length}"
+  }
+  return "1|${detected.attached[0].label}|${detected.attached[0].attachment.type}"
+}
+
+node quotedPathWithSpaces(): string {
+  writeBinary("da b.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see '/tmp/da b.png' now") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node doubleQuotedPath(): string {
+  writeBinary("da b.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see \"/tmp/da b.png\" now") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node escapedSpacePath(): string {
+  writeBinary("da b.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da\\ b.png now") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node tildeExpansion(): string {
+  writeBinary("da-tilde.png", PNG, "/tmp") with approve
+  setEnv("HOME", "/tmp")
+  const detected = detectAttachments("see ~/da-tilde.png") with approve
+  return "${detected.attached.length}"
+}
+
+node trailingPunctuation(): string {
+  writeBinary("da-p.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("is it /tmp/da-p.png?") with approve
+  return "${detected.attached.length}"
+}
+
+node nonexistentIgnored(): string {
+  const detected = detectAttachments("see /tmp/da-not-there-xyz.png") with approve
+  return "${detected.attached.length}"
+}
+
+node codePathIgnored(): string {
+  writeBinary("da-code.ts", "AQID", "/tmp") with approve
+  const detected = detectAttachments("read /tmp/da-code.ts") with approve
+  return "${detected.attached.length}"
+}
+
+node directoryIgnored(): string {
+  exec("rm", ["-rf", "/tmp/da-dir.png"]) with approve
+  exec("mkdir", ["-p", "/tmp/da-dir.png"]) with approve
+  const detected = detectAttachments("see /tmp/da-dir.png") with approve
+  return "${detected.attached.length}"
+}
+
+node overLimitSkipped(): string {
+  writeBinary("da-big.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-big.png", maxBytes: 4) with approve
+  return "${detected.attached.length}|${detected.skipped[0].label}|${detected.skipped[0].reason}"
+}
+
+node dedupes(): string {
+  writeBinary("da-dup.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("/tmp/da-dup.png and again /tmp/da-dup.png") with approve
+  return "${detected.attached.length}"
+}
+
+node capsAtTen(): number {
+  let msg = "look at"
+  for (i in range(11)) {
+    writeBinary("da-cap-${i}.png", PNG, "/tmp") with approve
+    msg = msg + " /tmp/da-cap-${i}.png"
+  }
+  const detected = detectAttachments(msg) with approve
+  return detected.attached.length
+}
+
+node allImageExtensions(): number {
+  writeBinary("da-e1.jpg", PNG, "/tmp") with approve
+  writeBinary("da-e2.jpeg", PNG, "/tmp") with approve
+  writeBinary("da-e3.gif", PNG, "/tmp") with approve
+  writeBinary("da-e4.webp", PNG, "/tmp") with approve
+  writeBinary("da-e5.PNG", PNG, "/tmp") with approve
+  const detected = detectAttachments("/tmp/da-e1.jpg /tmp/da-e2.jpeg /tmp/da-e3.gif /tmp/da-e4.webp /tmp/da-e5.PNG") with approve
+  return detected.attached.length
+}
+
+node mixedTypesPreserveOrder(): string {
+  writeBinary("da-m1.png", PNG, "/tmp") with approve
+  writeBinary("da-m2.pdf", "JVBERi0xLjQK", "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-m1.png then /tmp/da-m2.pdf") with approve
+  if (detected.attached.length != 2) {
+    return "count=${detected.attached.length}"
+  }
+  return "2|${detected.attached[0].label}|${detected.attached[0].attachment.type}|${detected.attached[1].label}|${detected.attached[1].attachment.type}"
+}
+
+node relativeResolvesAgainstAgentCwd(): string {
+  writeBinary("da-rel.png", PNG, "/tmp") with approve
+  setAgentCwd("/tmp")
+  const detected = detectAttachments("see da-rel.png") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node bareTextNoAttachments(): string {
+  const detected = detectAttachments("please draw me a diagram") with approve
+  return "${detected.attached.length}|${detected.text}"
+}
+
+node emptyMessage(): string {
+  const detected = detectAttachments("") with approve
+  return "${detected.attached.length}|${detected.skipped.length}|${detected.text}"
+}
+```
+
+Create `lib/agents/agency-agent/tests/attachments.test.json`:
+
+```json
+{
+  "tests": [
+    { "nodeName": "detectsPngPath", "input": "", "expectedOutput": "\"1|da-a.png|image|base64\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "detectsPdfPath", "input": "", "expectedOutput": "\"1|da-doc.pdf|file\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "quotedPathWithSpaces", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "doubleQuotedPath", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "escapedSpacePath", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "tildeExpansion", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "trailingPunctuation", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "nonexistentIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "codePathIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "directoryIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "overLimitSkipped", "input": "", "expectedOutput": "\"0|da-big.png|too large to attach\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "dedupes", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "capsAtTen", "input": "", "expectedOutput": "10", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "allImageExtensions", "input": "", "expectedOutput": "5", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "mixedTypesPreserveOrder", "input": "", "expectedOutput": "\"2|da-m1.png|image|da-m2.pdf|file\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "relativeResolvesAgainstAgentCwd", "input": "", "expectedOutput": "\"1|da-rel.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "bareTextNoAttachments", "input": "", "expectedOutput": "\"0|please draw me a diagram\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "emptyMessage", "input": "", "expectedOutput": "\"0|0|\"", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}
+```
+
+- [ ] **Step 4: Build and run the tests**
+
+```bash
+make > /tmp/task3-make.log 2>&1; tail -3 /tmp/task3-make.log
+pnpm run agency test lib/agents/agency-agent/tests/attachments.agency > /tmp/task3-test.log 2>&1; tail -30 /tmp/task3-test.log
+```
+Expected: all 18 tests pass. If a node fails, read `/tmp/task3-test.log` — do NOT rerun blindly. Common failure: `expectedOutput` quoting (string returns are JSON-encoded — `"\"1\""` not `"1"`; number returns are bare — `"10"`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cat > /tmp/commit-msg.txt <<'EOF'
+Add detectAttachments helper for the built-in agent
+
+Scans a user message for image/PDF paths (drag-drop quoting, escaped
+spaces, tilde, trailing punctuation), resolves them against the agent
+cwd, and inlines the bytes as base64 attachments carried in
+DetectedAttachment records (attachment + label together). Media-only,
+deduped, capped at 10; over-limit files are skipped with a visible
+reason so an oversized mention can never fail the turn at the smoltalk
+gate.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+git add lib/agents/agency-agent/lib/attachments.agency lib/agents/agency-agent/tests/attachments.agency lib/agents/agency-agent/tests/attachments.test.json
+git commit -F /tmp/commit-msg.txt
+```
+
+---
+
+### Task 4: `generateImageFile` agent tool
+
+The coordinator gets a direct tool to generate (or edit — non-empty `images`) an image and save it to disk, returning the path. Never returns base64 to the LLM.
+
+**Files:**
+- Modify: `lib/agents/agency-agent/agent.agency` — imports (top of file), new defs placed immediately ABOVE `static const mainAgentTools` (~line 802), the tools list, and `mainAgentSystemPrompt` (~line 638)
+- Test: `lib/agents/agency-agent/tests/imageTool.agency`
+- Test: `lib/agents/agency-agent/tests/imageTool.test.json`
+
+**Interfaces:**
+- Consumes: `generateImage` (`std::image`, returns `Result` of `{ base64, mimeType }`), auto-imported `writeBinary`/`applyAgentCwd`, `map` (`std::array`), `basename`/`dirname`/`isAbsolute` (`std::path`), `getCost` (`std::thread`, already imported).
+- Produces: `export def resolveEditInputs(images: string[]): string[]` and `export def generateImageFile(prompt: string, path: string, size: string = "", images: string[] = []): string` — the latter registered in `mainAgentTools`. Its docstring is the LLM-facing tool description.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/agents/agency-agent/tests/imageTool.agency`:
+
+```
+import { generateImageFile, resolveEditInputs } from "../agent.agency"
+import { setAgentCwd } from "std::index"
+import { cwd } from "std::system"
+import { getCost } from "std::thread"
+
+node savesToAgentCwd(): string {
+  setAgentCwd("/tmp")
+  const msg = generateImageFile("a red bicycle", "it-gencwd.png") with approve
+  const inAgentCwd = readBinary("it-gencwd.png", "/tmp") with approve
+  const inProcessCwd = readBinary("it-gencwd.png", cwd()) with approve
+  return "${msg}|${isSuccess(inAgentCwd)}|${isFailure(inProcessCwd)}"
+}
+
+node savesToAbsolutePath(): string {
+  const msg = generateImageFile("a red bicycle", "/tmp/it-abs.png") with approve
+  const back = readBinary("it-abs.png", "/tmp") with approve
+  return "${msg}|${isSuccess(back)}"
+}
+
+node reportsWriteFailure(): boolean {
+  const msg = generateImageFile("x", "/nonexistent-dir-e51b/x.png") with approve
+  return msg.startsWith("Generated the image, but saving to /nonexistent-dir-e51b/x.png failed")
+}
+
+node editInputsResolveAgainstAgentCwd(): string {
+  setAgentCwd("/tmp")
+  const resolved = resolveEditInputs(["a.png", "/abs/b.png"])
+  return "${resolved[0]}|${resolved[1]}"
+}
+
+node editInputsPassThrough(): string {
+  setAgentCwd("/tmp")
+  generateImageFile("seed", "it-seed.png") with approve
+  return generateImageFile("restyle it", "it-edit.png", images: ["it-seed.png"]) with approve
+}
+
+node costRecordedForGeneration(): string {
+  setAgentCwd("/tmp")
+  const before = getCost()
+  generateImageFile("a red bicycle", "it-cost.png") with approve
+  const after = getCost()
+  return "${(after - before).toFixed(2)}"
+}
+```
+
+Create `lib/agents/agency-agent/tests/imageTool.test.json`:
+
+```json
+{
+  "tests": [
+    { "nodeName": "savesToAgentCwd", "input": "", "expectedOutput": "\"Saved image to it-gencwd.png|true|true\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "savesToAbsolutePath", "input": "", "expectedOutput": "\"Saved image to /tmp/it-abs.png|true\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "reportsWriteFailure", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "editInputsResolveAgainstAgentCwd", "input": "", "expectedOutput": "\"/tmp/a.png|/abs/b.png\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "editInputsPassThrough", "input": "", "expectedOutput": "\"Saved image to it-edit.png\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "costRecordedForGeneration", "input": "", "expectedOutput": "\"0.04\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true }
+  ]
+}
+```
+
+Test-design notes:
+- `savesToAgentCwd` asserts BOTH that the file landed under the agent cwd AND that it did NOT land under the process cwd — distinguishing agent-cwd from process-cwd resolution.
+- `editInputsResolveAgainstAgentCwd` unit-tests the edit-input resolution invariant directly, because the deterministic image client ignores its `images:` argument (`editInputsPassThrough` only proves plumb-through doesn't crash — see Known coverage gaps #4).
+- `costRecordedForGeneration` pins the deterministic client's fixed $0.04 per generation flowing into `getCost()` (the spec's cost/`guard(cost:)` claim).
+- The generation-failure branch is not exercisable — Known coverage gaps #1.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+make > /tmp/task4-make.log 2>&1; tail -3 /tmp/task4-make.log
+pnpm run agency test lib/agents/agency-agent/tests/imageTool.agency > /tmp/task4-fail.log 2>&1; tail -10 /tmp/task4-fail.log
+```
+Expected: FAIL — `generateImageFile` is not exported from `../agent.agency`.
+
+- [ ] **Step 3: Implement the tool**
+
+In `lib/agents/agency-agent/agent.agency`:
+
+(a) Add imports near the other stdlib imports (keep the existing grouping style):
+
+```
+import { map } from "std::array"
+import { generateImage } from "std::image"
+import { basename, dirname, isAbsolute } from "std::path"
+```
+
+(b) Immediately ABOVE `static const mainAgentTools` add:
+
+```
+// Exported for tests: agent-cwd resolution of edit inputs is a spec
+// invariant with no other observable (the deterministic image client
+// ignores its images argument).
+export def resolveEditInputs(images: string[]): string[] {
+  return map(images) as inputPath {
+    return applyAgentCwd(inputPath)
+  }
+}
+
+// Direct image generation for the coordinator. Saves to disk and
+// returns the path — never base64, which would flood the LLM context.
+// The write rides the std::writeBinary interrupt gate (writes are not
+// auto-approved by policy) and generation cost accrues to the agent's
+// cost tracking like any llm() call.
+export def generateImageFile(
+  prompt: string,
+  path: string,
+  size: string = "",
+  images: string[] = [],
+): string {
+  """
+  Generate an image from a text prompt and save it to `path`. To MODIFY
+  existing images (edit / variation), pass their paths in `images`.
+  Returns the saved path on success. Use this when the user asks to
+  create, draw, edit, or restyle an image.
+
+  @param prompt - What to generate, or how to modify the input images.
+  @param path - Where to save the resulting image (e.g. "diagram.png").
+  @param size - Optional size like "1024x1024".
+  @param images - Optional input image paths to edit / vary.
+  """
+  // LLM-supplied paths resolve against the agent cwd, like every other
+  // agent file tool.
+  const inputs = resolveEditInputs(images)
+  const generated = generateImage(prompt, size: size, images: inputs)
+  if (isFailure(generated)) {
+    return "Image generation failed: ${generated.error}"
+  }
+  // writeBinary rejects an absolute filename when dir is set, so split
+  // path into (dir, name) and resolve the dir against the agent cwd.
+  let dir = dirname(path)
+  if (!isAbsolute(dir)) {
+    dir = applyAgentCwd(dir)
+  }
+  const written = writeBinary(basename(path), generated.value.base64, dir)
+  if (isFailure(written)) {
+    return "Generated the image, but saving to ${path} failed: ${written.error}"
+  }
+  return "Saved image to ${path}"
+}
+```
+
+(c) Register it — `mainAgentTools` becomes:
+
+```
+static const mainAgentTools = [
+  researchAgent.partial(allowHandoff: false),
+  codeAgent.partial(allowHandoff: false),
+  reviewAgent.partial(allowHandoff: false),
+  oracleAgent.partial(allowHandoff: false),
+  explorerAgent.partial(allowHandoff: false),
+  generateImageFile,
+]
+```
+
+(d) In `mainAgentSystemPrompt`, after the `explorerAgent` bullet, add:
+
+```
+- `generateImageFile(prompt, path, size, images)` — generate an image
+  from a text prompt (or modify existing images by passing their paths
+  in `images`) and save it to `path`. Call it directly whenever the
+  user asks you to create, draw, edit, or restyle an image — do NOT
+  route image generation to `codeAgent`.
+```
+
+Also update the sentence `You have five subagent tools, each running in its own isolated context:` to `You have five subagent tools (each running in its own isolated context) and one direct tool:`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+make > /tmp/task4-make2.log 2>&1; tail -3 /tmp/task4-make2.log
+pnpm run agency test lib/agents/agency-agent/tests/imageTool.agency > /tmp/task4-pass.log 2>&1; tail -12 /tmp/task4-pass.log
+```
+Expected: 6/6 pass.
+
+- [ ] **Step 5: Regression — existing agent turn tests still pass**
+
+Run: `pnpm run agency test lib/agents/agency-agent/tests/agentTurn.agency > /tmp/task4-regress.log 2>&1; tail -10 /tmp/task4-regress.log`
+Expected: all pass (the tools-list change must not break the seed turn).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cat > /tmp/commit-msg.txt <<'EOF'
+Add generateImageFile tool to the agent coordinator
+
+Generates (or, with input images, edits) an image via std::image and
+saves it to disk through the writeBinary interrupt gate, resolving
+paths against the agent cwd. Returns the saved path to the LLM, and a
+failure message when generation or the write fails — never a false
+success. Registered in mainAgentTools with a system-prompt bullet so
+the coordinator does not route image requests to codeAgent.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+git add lib/agents/agency-agent/agent.agency lib/agents/agency-agent/tests/imageTool.agency lib/agents/agency-agent/tests/imageTool.test.json
+git commit -F /tmp/commit-msg.txt
+```
+
+---
+
+### Task 5: Wire attachments into the coordinator turn
+
+`agentReplyVia` detects attachments (modality-filtered), prints visible `📎` lines, and passes a multimodal array to a widened `mainAgent`. Subagent routes stay text-only (spec decision 3) — and now have a regression test.
+
+**Files:**
+- Modify: `lib/agents/agency-agent/lib/attachments.agency` (add `modalityFilter`)
+- Modify: `lib/agents/agency-agent/agent.agency` (imports; `mainAgent` ~line 810; `agentReplyVia` ~line 833)
+- Test: `lib/agents/agency-agent/tests/attachmentsTurn.agency`
+- Test: `lib/agents/agency-agent/tests/attachmentsTurn.test.json`
+- Test (extend): `lib/agents/agency-agent/tests/attachments.agency` + `.test.json` (modalityFilter units)
+
+**Interfaces:**
+- Consumes: `detectAttachments`/`DetectedContent`/`DetectedAttachment`/`SkippedFile` (Task 3), `modelSupportsInput` (`std::llm`, Task 2), `getResolvedSlots`/`applyResolved` (`../shared.agency`, existing), `_contentToString` placeholders (Task 1, asserted via `getThread`).
+- Produces: `export def modalityFilter(detected: DetectedContent): DetectedContent` in `attachments.agency`; `mainAgent` widened to `prompt: string | (string | Attachment)[]`.
+
+- [ ] **Step 1: Add `modalityFilter` to `attachments.agency`**
+
+Add imports at the top of `lib/agents/agency-agent/lib/attachments.agency`:
+
+```
+import { modelSupportsInput } from "std::llm"
+import { getResolvedSlots } from "../shared.agency"
+```
+
+Append the def. Note the `const drop` derivation (no mutable `ok` flag — anti-patterns "Order-dependent mutable state") and the spread copy of `skipped` (never mutate the caller's array):
+
+```
+// Drop attachments the resolved main model explicitly cannot accept.
+// Tri-state on purpose: only a catalog `false` drops a part. Unknown
+// models (null) attach optimistically — smoltalk's send-time gate does
+// not fire for them either, so this can never be stricter than send.
+export def modalityFilter(detected: DetectedContent): DetectedContent {
+  const slots = getResolvedSlots()
+  const main = slots["main"]
+  if (main == null) {
+    return detected
+  }
+  const imageOk = modelSupportsInput(main.model, "image")
+  const pdfOk = modelSupportsInput(main.model, "pdf")
+  let attached: DetectedAttachment[] = []
+  let skipped: SkippedFile[] = [...detected.skipped]
+  for (item in detected.attached) {
+    const drop =
+      (item.attachment.type == "image" && imageOk == false) ||
+      (item.attachment.type == "file" && pdfOk == false)
+    if (drop) {
+      const modality = item.attachment.type == "image" ? "image" : "PDF"
+      skipped.push({ label: item.label, reason: "model ${main.model} has no ${modality} input" })
+    } else {
+      attached.push(item)
+    }
+  }
+  return { text: detected.text, attached: attached, skipped: skipped }
+}
+```
+
+- [ ] **Step 2: Write failing modalityFilter units**
+
+Append to `lib/agents/agency-agent/tests/attachments.agency` (add `modalityFilter` to the import from `../lib/attachments.agency`, and add `import { applyResolved } from "../shared.agency"`). Each node is a fresh subprocess, so `getResolvedSlots()` starts empty unless the node itself calls `applyResolved` — the passthrough test is deterministic without any reset:
+
+```
+node modalityFilterPassthroughWhenNoSlots(): string {
+  writeBinary("da-mf.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mf.png") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}"
+}
+
+node modalityFilterDropsForTextOnlyModel(): string {
+  applyResolved({ main: { model: "gpt-3.5-turbo", provider: "openai", via: "test" } })
+  writeBinary("da-mf2.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mf2.png") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}|${filtered.skipped[0].label}|${filtered.skipped[0].reason}"
+}
+
+node modalityFilterDropsPdfForNoPdfModel(): string {
+  applyResolved({ main: { model: "gpt-3.5-turbo", provider: "openai", via: "test" } })
+  writeBinary("da-mfp.pdf", "JVBERi0xLjQK", "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mfp.pdf") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}|${filtered.skipped[0].label}|${filtered.skipped[0].reason}"
+}
+
+node modalityFilterKeepsForVisionModel(): string {
+  applyResolved({ main: { model: "gpt-4o", provider: "openai", via: "test" } })
+  writeBinary("da-mf3.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mf3.png") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}"
+}
+```
+
+(`gpt-3.5-turbo` is `false` for BOTH image and pdf; `gpt-4o` is `true` for both — verified in Task 2 Step 1. Substitute consistently if the catalog drifted.)
+
+Append to `lib/agents/agency-agent/tests/attachments.test.json` `tests` array:
+
+```json
+    { "nodeName": "modalityFilterPassthroughWhenNoSlots", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "modalityFilterDropsForTextOnlyModel", "input": "", "expectedOutput": "\"0|da-mf2.png|model gpt-3.5-turbo has no image input\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "modalityFilterDropsPdfForNoPdfModel", "input": "", "expectedOutput": "\"0|da-mfp.pdf|model gpt-3.5-turbo has no PDF input\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "modalityFilterKeepsForVisionModel", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] }
+```
+
+Run (expect the new nodes to FAIL until Step 1 is implemented + `make`):
+
+```bash
+make > /tmp/task5-make.log 2>&1; tail -3 /tmp/task5-make.log
+pnpm run agency test lib/agents/agency-agent/tests/attachments.agency > /tmp/task5-units.log 2>&1; tail -12 /tmp/task5-units.log
+```
+Expected after implementing Step 1 + `make`: all 22 nodes pass.
+
+- [ ] **Step 3: Wire `agent.agency`**
+
+(a) Imports: add `Attachment` to the existing `std::thread` import (line ~30: `import { getCost, getModelCosts, systemMessage } from "std::thread"` → add `Attachment`). Add with the other `./lib/` imports:
+
+```
+import { detectAttachments, modalityFilter } from "./lib/attachments.agency"
+```
+
+(b) Widen `mainAgent` (body unchanged):
+
+```
+def mainAgent(prompt: string | (string | Attachment)[]): string {
+```
+
+(c) Replace the tail of `agentReplyVia` — the line `return mainAgent(expanded)` becomes:
+
+```
+  // Auto-attach image/PDF files the user referenced (drag-drop or typed
+  // path), filtered to what the resolved model accepts. Never silent:
+  // every attach and every skip prints a visible line.
+  const detected = modalityFilter(detectAttachments(expanded))
+  for (skippedFile in detected.skipped) {
+    pushMessage(color.yellow("📎 skipped ${skippedFile.label} (${skippedFile.reason})"))
+  }
+  if (detected.attached.length == 0) {
+    // Deliberate special case: a text-only turn stays a bare string. A
+    // one-element array is API-equivalent, but the stored thread message
+    // shape (string vs parts array) — and with it every serialized
+    // session and message fixture — would change for EVERY turn.
+    return mainAgent(expanded)
+  }
+  for (item in detected.attached) {
+    pushMessage(color.dim("📎 attached ${item.label}"))
+  }
+  const attachments = map(detected.attached) as item {
+    return item.attachment
+  }
+  const parts: (string | Attachment)[] = [expanded, ...attachments]
+  return mainAgent(parts)
+```
+
+(`pushMessage` is already imported in `agent.agency`; `color` is available there without an import — it is used throughout the file, e.g. line 135. `map` was imported in Task 4.)
+
+- [ ] **Step 4: Write the turn-integration tests**
+
+Create `lib/agents/agency-agent/tests/attachmentsTurn.agency`:
+
+```
+import { agentReply, agentReplyVia } from "../agent.agency"
+import { applyResolved } from "../shared.agency"
+import { getThread, listThreads } from "std::thread"
+
+static const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+// The thread reader renders attachment parts as "[image attachment]"
+// (see _contentToString), so finding that placeholder in a user message
+// proves the multimodal array reached the llm() turn. listThreads with
+// lazySummarize: false enumerates real thread ids without triggering
+// the on-demand LLM summarization of closed threads (which would burn
+// mocks). currentThreadId() would NOT work here: after agentReply
+// returns, the active thread is the node root, not the main thread.
+def threadHasImagePlaceholder(): boolean {
+  const threads = listThreads(lazySummarize: false)
+  if (isFailure(threads)) {
+    return false
+  }
+  for (info in threads.value) {
+    const messages = getThread(info.id, 0, 200)
+    if (isFailure(messages)) {
+      continue
+    }
+    for (message in messages.value) {
+      if (message.role == "user" && message.content.includes("[image attachment]")) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+node attachesImageToTurn(): string {
+  writeBinary("at-x.png", PNG, "/tmp") with approve
+  const reply = agentReply("look at /tmp/at-x.png") with approve
+  return "${reply}|${threadHasImagePlaceholder()}"
+}
+
+node plainMessageStaysString(): string {
+  const reply = agentReply("hello there") with approve
+  return "${reply}|${threadHasImagePlaceholder()}"
+}
+
+node modalitySkipsTextOnlyModel(): string {
+  applyResolved({ main: { model: "gpt-3.5-turbo", provider: "openai", via: "test" } })
+  writeBinary("at-y.png", PNG, "/tmp") with approve
+  const reply = agentReply("look at /tmp/at-y.png") with approve
+  return "${reply}|${threadHasImagePlaceholder()}"
+}
+
+node subagentRouteIgnoresImagePath(): string {
+  writeBinary("at-z.png", PNG, "/tmp") with approve
+  const reply = agentReplyVia("code", "look at /tmp/at-z.png") with approve
+  return "${reply}|${threadHasImagePlaceholder()}"
+}
+```
+
+Create `lib/agents/agency-agent/tests/attachmentsTurn.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "attachesImageToTurn",
+      "input": "",
+      "expectedOutput": "\"I see it!|true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "I see it!" }]
+    },
+    {
+      "nodeName": "plainMessageStaysString",
+      "input": "",
+      "expectedOutput": "\"Hi!|false\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "Hi!" }]
+    },
+    {
+      "nodeName": "modalitySkipsTextOnlyModel",
+      "input": "",
+      "expectedOutput": "\"ok|false\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "ok" }]
+    },
+    {
+      "nodeName": "subagentRouteIgnoresImagePath",
+      "input": "",
+      "expectedOutput": "\"code reply|false\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "code reply" }]
+    }
+  ]
+}
+```
+
+Test-design notes:
+- `subagentRouteIgnoresImagePath` pins spec decision 3 (direct-to-subagent routes stay text-only) — a refactor that runs detection on subagent routes now fails a test.
+- `modalitySkipsTextOnlyModel` proves the skip path end-to-end: the turn still succeeds AND no image part reached the thread.
+- The `📎` print lines themselves are unasserted — Known coverage gaps #3.
+
+- [ ] **Step 5: Build and run all touched agent tests**
+
+```bash
+make > /tmp/task5-make2.log 2>&1; tail -3 /tmp/task5-make2.log
+pnpm run agency test lib/agents/agency-agent/tests/attachmentsTurn.agency > /tmp/task5-turn.log 2>&1; tail -12 /tmp/task5-turn.log
+pnpm run agency test lib/agents/agency-agent/tests/attachments.agency > /tmp/task5-units2.log 2>&1; tail -6 /tmp/task5-units2.log
+pnpm run agency test lib/agents/agency-agent/tests/agentTurn.agency > /tmp/task5-regress.log 2>&1; tail -6 /tmp/task5-regress.log
+```
+Expected: all pass. `agentTurn.agency` is the regression gate for the `mainAgent` widening (its `respondsToAMessage` sends a plain string). If `attachesImageToTurn` returns `…|false`, read `/tmp/task5-turn.log` and inspect what `listThreads`/`getThread` actually returned before changing anything.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cat > /tmp/commit-msg.txt <<'EOF'
+Auto-attach referenced image/PDF files to the agent coordinator turn
+
+agentReplyVia now runs detectAttachments (modality-filtered via
+std::llm.modelSupportsInput against the resolved main slot) on the
+expanded user message, prints a visible line per attached or skipped
+file, and passes a multimodal array to mainAgent, whose prompt widened
+to string | (string | Attachment)[]. Direct-to-subagent routes stay
+text-only by design and are pinned by a regression test.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+git add lib/agents/agency-agent/agent.agency lib/agents/agency-agent/lib/attachments.agency lib/agents/agency-agent/tests/attachments.agency lib/agents/agency-agent/tests/attachments.test.json lib/agents/agency-agent/tests/attachmentsTurn.agency lib/agents/agency-agent/tests/attachmentsTurn.test.json
+git commit -F /tmp/commit-msg.txt
+```
+
+---
+
+### Task 6: Full verification + spec status
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md` (frontmatter `status: design` → `status: implemented`)
+
+- [ ] **Step 1: Structural linter + TS unit suite**
+
+```bash
+pnpm run lint:structure > /tmp/task6-lint.log 2>&1; tail -5 /tmp/task6-lint.log
+pnpm test:run lib/stdlib/threads.test.ts lib/stdlib/llm.test.ts > /tmp/task6-units.log 2>&1; tail -5 /tmp/task6-units.log
+```
+Expected: linter clean; both unit files pass.
+
+- [ ] **Step 2: Full agent test suite (no LLM, local-safe)**
+
+```bash
+make > /tmp/task6-make.log 2>&1; tail -3 /tmp/task6-make.log
+pnpm run test:agents > /tmp/task6-agents.log 2>&1; tail -15 /tmp/task6-agents.log
+```
+Expected: all agent tests pass (this runs `lib/agents` execution tests in parallel; it does NOT hit real LLMs). Do NOT run the full `tests/agency` suite — CI covers it.
+
+- [ ] **Step 3: Flip the spec status and commit**
+
+Edit the spec frontmatter `status: design` → `status: implemented`.
+
+```bash
+cat > /tmp/commit-msg.txt <<'EOF'
+Mark agent images-and-attachments spec implemented
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+EOF
+git add docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md
+git commit -F /tmp/commit-msg.txt
+```
+
+---
+
+## Spec-coverage map (self-review)
+
+- Part A tool (generate+edit, Result-checked write, agent-cwd, dirname split) → Task 4 (incl. negative process-cwd assertion + cost-accrual test)
+- Part A registration + system-prompt bullet → Task 4 (c)/(d)
+- Part B algorithm steps 1–9 (tokenize, normalize+tilde, resolve, dedupe, stat gate, size-skip, inline base64, cap, unchanged text) → Task 3 (all six MIME extensions + case-insensitivity + both quote styles + mixed types/order covered)
+- Attachment lifetime decision (inline at attach) → Task 3 Step 1 (readBinary inlining)
+- Wiring (`agentReplyVia`, visible 📎 lines, `mainAgent` widening) → Task 5
+- Spec decision 3 (subagent routes text-only) → Task 5 `subagentRouteIgnoresImagePath`
+- Risk 4 modality plan (`modelSupportsInput`, tri-state, skip-on-false, image AND pdf) → Tasks 2 + 5
+- Risk 5 prerequisite (`_contentToString` placeholders) → Task 1 (incl. corner cases: null, empty array, missing text, unknown part type)
+- Testing section: detectAttachments units → Task 3; generateImageFile tests → Task 4; turn integration → Task 5 (asserted via the `getThread` placeholder, which also end-to-end-tests Task 1)
+- Non-goals (subagent attachments, view-back loop, eviction tools, non-media) → intentionally absent
+- Known limitations → "Known coverage gaps" in Global Constraints (4 items, each with rationale)

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md
@@ -1,0 +1,167 @@
+---
+name: Agent image generation + attachments
+description: Wire the merged multimodal capability into the built-in agency agent — a generate/modify-image tool that saves to disk, and auto-attaching image/PDF file paths (drag-drop or mentioned) from the user's message to the LLM turn.
+status: implemented
+date: 2026-07-02
+---
+
+# Agent image generation + attachments
+
+## Summary
+
+The multimodal work (image attachments on `llm()` / `userMessage()`, `std::image.generateImage`, `writeBinary`) is merged. This spec wires it into the built-in agent (`lib/agents/agency-agent/`) as two features:
+
+1. **Image generation tool** — the agent can generate or modify images and save them to disk.
+2. **User attachments** — when the user's message references an image/PDF file path (via terminal drag-drop, which inserts a path, or an explicit mention), the agent auto-attaches that file to the LLM turn.
+
+## Background: the agent turn
+
+- A user message flows `repl(onSubmit: _runTurn) → agentReply(userMsg) → agentReplyVia("", userMsg) → mainAgent(prompt) → llm(prompt, { tools: mainAgentTools })` (`agent.agency`).
+- `mainAgentTools` is a list of the subagent tools; adding a tool means adding a function to that list (in Agency, functions *are* tools).
+- `llm()` already accepts `string | (string | Attachment)[]` (merged), so the turn can carry attachments once we build the array.
+- Already imported by `agent.agency`: `exists` (`std::shell`), `setAgentCwd` (`std::index`); `writeBinary`/`readBinary`/`applyAgentCwd` are auto-imported. New imports needed: `generateImage` (`std::image`); `image`/`file` and the `Attachment` type (`std::thread`); `stat` (`std::shell`); `env` (`std::system`); `map` (`std::array`); `basename` (`std::path`).
+- The agent always has an agent cwd: `setupSession` calls `setAgentCwd(cwd())` unconditionally, and every existing agent file tool resolves against it (`read.partial(useAgentCwd: true)` etc. in the subagent tool lists). Both new features must follow that convention.
+
+## Feasibility: terminal drag-and-drop
+
+A terminal program cannot intercept the OS file-drop event. But every common terminal (Terminal.app, iTerm2, VS Code, GNOME Terminal, Windows Terminal) handles a drop by **inserting the file's path into the current input line** — usually absolute, often shell-quoted (`'…'`) or backslash-escaped (`my\ file.png`). Our REPL reads a line, so a dropped file arrives as a path token in the submitted message. Therefore drag-drop and explicit path mentions are the **same problem**: detect file paths in the message. No terminal integration is required (or possible from a TUI).
+
+## Part A — Image generation tool
+
+A new agent tool added to `mainAgentTools`. It generates (or modifies) and **saves to disk**, returning the path — never base64, which would flood the LLM context.
+
+```ts
+import { generateImage } from "std::image"
+import { map } from "std::array"
+
+def generateImageFile(
+  prompt: string,
+  path: string,
+  size: string = "",
+  images: string[] = [],
+): string {
+  """
+  Generate an image from a text prompt and save it to `path`. To MODIFY existing
+  images (edit / variation), pass their paths in `images`. Returns the saved path
+  on success. Use this when the user asks to create, draw, edit, or restyle an image.
+
+  @param prompt - What to generate, or how to modify the input images.
+  @param path - Where to save the resulting image (e.g. "diagram.png").
+  @param size - Optional size like "1024x1024".
+  @param images - Optional input image paths to edit / vary.
+  """
+  // LLM-supplied paths resolve against the agent cwd, like every other
+  // agent file tool.
+  const inputs = map(images) as p {
+    return applyAgentCwd(p)
+  }
+  const r = generateImage(prompt, size: size, images: inputs)
+  if (isFailure(r)) {
+    return "Image generation failed: ${r.error}"
+  }
+  // writeBinary rejects an absolute filename when dir is set (resolvePath
+  // security check), so split path into (dir, name) and resolve the dir.
+  let dir = dirname(path)
+  if (!isAbsolute(dir)) {
+    dir = applyAgentCwd(dir)
+  }
+  const w = writeBinary(basename(path), r.value.base64, dir)
+  if (isFailure(w)) {
+    return "Generated the image, but saving to ${path} failed: ${w.error}"
+  }
+  return "Saved image to ${path}"
+}
+```
+
+- **Generate and modify are one tool** — a non-empty `images` list switches it to edit/variation.
+- **The file write goes through the existing `writeBinary` interrupt gate**, so the user approves the write the same way they approve any agent file write (writes are not auto-approved by policy). Generation cost flows into the agent's existing cost tracking / `guard(cost:)`. Model defaults to `DEFAULT_IMAGE_MODEL`.
+- **The write's Result is checked.** `writeBinary` can fail (bad directory, denied interrupt, `create-only` conflict); the tool must not tell the LLM "Saved image to …" when nothing was written — the LLM would relay that to the user as fact.
+- **Both paths resolve against the agent cwd** (the dirname split on the write, `applyAgentCwd` on the edit inputs), matching `write.partial(useAgentCwd: true)` and friends. Without this, changing the agent cwd mid-session would send generated images to the process cwd while every other write goes to the agent cwd. The `images` inputs are read by smoltalk at request time, so they too must be absolute before the call. Note `writeBinary`/`readBinary` **reject absolute filenames** whenever `dir` is set (`resolvePath`'s escape check) — always pass `(basename, dir)` pairs, never a full path as the filename.
+- Registered by adding `generateImageFile` to `mainAgentTools`, plus a sentence in `mainAgentSystemPrompt` telling the coordinator it can generate/edit images directly (otherwise it may route the request to the code agent to script it).
+
+## Part B — Attachment detection
+
+A helper module `lib/agents/agency-agent/lib/attachments.agency`, unit-testable without a terminal:
+
+```ts
+import { Attachment } from "std::thread"
+
+// Returns the original text plus any auto-detected image/PDF attachments.
+// Each attachment carries its display label in one record (no index-coupled
+// parallel arrays); skipped files carry the reason for the visible 📎 line.
+type DetectedAttachment = { attachment: Attachment, label: string }
+type SkippedFile = { label: string, reason: string }
+type DetectedContent = { text: string, attached: DetectedAttachment[], skipped: SkippedFile[] }
+
+def detectAttachments(msg: string): DetectedContent
+```
+
+**Algorithm:**
+
+1. **Tokenize** `msg` on whitespace, but first pull out shell-quoted spans (`'…'` / `"…"`) as single tokens so drag-dropped paths with spaces survive.
+2. For each token, **normalize**: strip surrounding quotes, unescape `\ ` → space, trim trailing punctuation the user might have typed after a path (`,`, `.`, `?`, `:`), and expand a leading `~/` with `env("HOME")` (`std::system`) — drag-drop inserts absolute paths, but typed mentions are often `~/Desktop/foo.png`, and nothing downstream expands tildes.
+3. **Resolve to absolute**: if not absolute, `applyAgentCwd(token)`. In the agent this always yields an absolute path — `setupSession` calls `setAgentCwd(cwd())` unconditionally.
+4. **Dedupe** resolved paths — the same file mentioned twice attaches once.
+5. **Keep** the token only if `stat(absPath)` (`std::shell` — one call yields existence, type, and size) reports `type == "file"` AND its extension is attachable:
+   - `.png .jpg .jpeg .gif .webp` → image attachment
+   - `.pdf` → file attachment
+   - anything else (`.ts`, `.md`, …) → **not attached** (the agent has `read` for those).
+6. **Skip over-limit files** (`size` > smoltalk's 20 MB per-file limit) with their own visible line (`📎 skipped huge.png (too large to attach)`). An over-limit attachment must never reach the `llm()` call: smoltalk turns it into a Failure of the **whole turn**, not a skipped attachment, so relying on the send-time limit would make merely *mentioning* a 25 MB PNG fail the user's message.
+7. **Inline the bytes at attach time**: `readBinary(basename(absPath), dirname(absPath))` (a read — auto-approved by the default policy; the basename/dirname split is required because `readBinary` rejects an absolute filename when `dir` is set) and build the attachment as `image(b64, mimeType, base64: true)` or `file(b64, filename: basename(absPath), mimeType: mime, base64: true)`, mapping extension → MIME type. A failed read skips the file. See "Attachment lifetime" below for why we inline instead of passing the path.
+8. Cap at **10** attachments per message (avoid accidental floods).
+9. Return `{ text: msg (unchanged — the path stays for model context), attached: [{ attachment, label: "diagram.png" }, …], skipped: [{ label, reason }, …] }`.
+
+### Attachment lifetime in the persistent thread (why step 7 inlines)
+
+smoltalk resolves attachments **per request, on a copy of the config** (`prepareAttachments` in `baseClient`): the thread's stored message keeps whatever source the attachment was built with. The coordinator thread is `session: "main"` — persisted and resent on every turn, including across agent restarts. If the stored source is a *path*:
+
+- **Deleting or moving the file poisons the session**: every subsequent turn re-reads the path at send time and fails attachment resolution until summarization eventually drops the old message.
+- **Editing the file silently rewrites history**: an old user message would resend the file's *current* bytes, not what the user actually showed the model.
+- **The read bypasses policy**: smoltalk reads the file directly, outside the `std::readBinary` interrupt gate, so a policy that restricts reads wouldn't see it.
+
+Inlining base64 at attach time fixes all three. Cost: the persisted session file carries the base64 (bounded by the 20 MB × 10 caps per message; typical images are far smaller), which we accept for v1. The inlined image is also resent as input tokens on every subsequent turn until summarization drops the message — inherent to multimodal chat and visible in the agent's per-turn cost display.
+
+### Follow-up: attachment eviction + re-view tools (v2 sketch, not in scope)
+
+Dropping the attachment immediately after the first response is tempting but breaks the natural flow — "what's in this diagram?" → answer → "and the top-left box?" needs the image again, and vision follow-ups are the common case. The v2 shape:
+
+- **Recency window**: keep attachment parts for the last N user turns (N ≈ 3), then replace the part in the stored thread with a text placeholder naming the attachment and how to get it back. This reuses the same placeholder rendering the summarizer fix needs, captures most follow-ups, and bounds per-turn resend cost — a strict improvement with no new tools.
+- **Attachment store + agent tools** (the `readThread`/memory pattern): a runtime attachment registry keyed by content hash — per-execution state in the GlobalStore (never a TS module global), spilled to a session-scoped directory so placeholders in a persisted `session: "main"` thread survive restarts — plus `listAttachments()` / `viewAttachment(id)` agent tools. Belongs in `std::thread` (any Agency program with threads has this problem), with the agent tools as thin wrappers.
+- **Blocker for `viewAttachment`**: tool results are text-only in the current LLM loop. Getting an image back to the model from a tool needs smoltalk support for image parts in tool results, and provider support is uneven (Anthropic's API takes image blocks in `tool_result`; OpenAI support varies by API). Until then, eviction placeholders should tell the model to ask the user to re-share the file.
+
+**Wiring (`agent.agency`):**
+
+- In `agentReplyVia`, before dispatching the coordinator turn, call `detectAttachments(expanded)`. If it found attachments:
+  - print a visible line per attachment: `📎 attached diagram.png` (via the existing `color`/`pushMessage` helpers) — **never silent**;
+  - pass the multimodal array `[text, ...attachments]` to `mainAgent`.
+- **`mainAgent` signature widens** from `prompt: string` to `prompt: string | (string | Attachment)[]`, passed straight to `llm(prompt, …)`.
+
+## Decisions (approved)
+
+1. **Auto-detect** attachable files (no marker syntax, no per-file confirmation) — matches drag-drop UX; the visible `📎 attached` line is the safety valve.
+2. **Media-only** (images + PDF). Code/text paths stay with the `read` tool.
+3. **v1 scope: the main coordinator path** gets attachments. Routing a message *directly* to a subagent (`--agent code`) stays text-only for now.
+4. **Image tool saves to disk + returns the path**; no generate-then-view-back loop in v1.
+5. **Attachments are inlined as base64 at attach time** (not stored as paths in the persistent thread) — see "Attachment lifetime" above. Accepts session-file growth in exchange for a session that can't be poisoned by a later-deleted file, historically accurate thread content, and policy-gated reads.
+
+## Non-goals (v1)
+
+- Attachments on messages routed directly to a subagent (follow-up: widen the shared subagent `(userMsg, allowHandoff)` signature).
+- A generate → view-the-result → refine agent loop.
+- Attachment eviction and `listAttachments` / `viewAttachment` tools (see the v2 sketch above — partly blocked on image parts in tool results).
+- Non-media file attachment (code/text) — `read` covers it.
+- Any OS-level drag-drop event handling (not possible; path insertion covers it).
+
+## Testing
+
+- **`detectAttachments` units** (via a `.agency` execution test, no terminal; the test registers an approve handler for the `std::readBinary` interrupt that step 7 raises): a message with an existing `.png` path → one image attachment (base64 source) + label; a `.pdf` → one file attachment; a shell-quoted path with spaces → detected; an escaped-space path → detected; a `~/` path → expanded and detected; a **non-existent** path → ignored; a *directory* named `foo.png` → ignored (the `stat` type check); an over-limit file → skipped with a "too large" label; the same path mentioned twice → one attachment; a `.ts` path → ignored; a bare mention with no path → no attachments; the 10-cap; relative path resolves against the agent cwd.
+- **`generateImageFile`** (agency-js or agency test with the deterministic image client): success saves a file (`readBinary` round-trips) and returns "Saved image to …"; generation failure returns the error string; a **failing write** (e.g. bad directory) returns the "saving … failed" string, not success; `images:` passes through to an edit call; with a non-default agent cwd set, the file lands relative to the *agent* cwd.
+- **Turn integration** (`tests/agentTurn` harness): `agentReply("look at ./x.png")` with a real `x.png` present routes a multimodal array into the turn (assert via **statelog** — the deterministic mock can't inspect received messages; `redactPromptForLog` preserves the string-or-array shape with payloads redacted, so assert on the presence of an image part, not its content). Confirms the `mainAgent` widening end-to-end.
+
+## Open implementation risks
+
+1. **Path tokenization edge cases** — quoting/escaping from different terminals. Keep the normalizer small and covered by units; false negatives (a path we miss) are acceptable, false positives (attaching an unintended existing media file) are mitigated by the visible label + media-only + user-referenced-their-own-file.
+2. **Relative-path resolution** — attachments must be resolved to absolute against the agent cwd before the bytes are read (step 3); assert in a unit with a set agent cwd.
+3. **`mainAgent` widening** must not disturb the subagent paths (which stay `string`); keep the union change localized to the coordinator.
+4. **Model modality** — the main-slot model may not accept image or PDF input (local models, text-only hosted models). smoltalk's `validateModalities` fails the whole `llm()` call, so auto-attaching to a text-only model turns the user's message into a failed turn. An ahead-of-time check **is** possible and exact: `validateModalities` is a thin wrapper over smoltalk's exported `modelSupportsInputModality(model, "image" | "pdf", modelData)`, which returns `true` / `false` / `undefined` (unknown model or no modality data → "don't gate"). Plan: expose it as a tri-state `std::llm.modelSupportsInput(model, modality)` (a one-line `lib/stdlib/llm.ts` bridge — `HostedModelInfo` doesn't carry modalities today), and in the wiring check the resolved main-slot model (`getResolvedSlots()`): on explicit `false`, skip the attachments with a visible `📎 skipped (model has no image input)` line; on `true`/`undefined`, attach optimistically — `undefined` covers local/custom models where the send-time gate also doesn't fire, so the residual failure mode is a provider error, handled like any other turn Failure.
+5. **Summarization / thread readers dump base64 (CONFIRMED — prerequisite fix).** The summarizer flattens messages via `_contentToString` (`lib/stdlib/threads.ts:40`), which `JSON.stringify`s non-string content — a user message with an inlined base64 image part would dump megabytes of base64 into the summarize prompt (cost blowup / context overflow; eager summarize fails soft but still fires the call, and the lazy path repeats it). The same coercion backs the `getMessages` thread reader. This gap is *already reachable today* via `userMessage([...attachments])` + `summarize: true` — the multimodal work redacted statelog but not this reader path — but this feature makes it mainline. Prerequisite: render attachment parts as placeholders (e.g. `[image attachment]`, reusing the `redactAttachments` approach) in `_contentToString` before shipping attachments into the main thread.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md
@@ -91,7 +91,7 @@ import { Attachment } from "std::thread"
 // parallel arrays); skipped files carry the reason for the visible 📎 line.
 type DetectedAttachment = { attachment: Attachment, label: string }
 type SkippedFile = { label: string, reason: string }
-type DetectedContent = { text: string, attached: DetectedAttachment[], skipped: SkippedFile[] }
+type DetectedContent = { attached: DetectedAttachment[], skipped: SkippedFile[] }
 
 def detectAttachments(msg: string): DetectedContent
 ```
@@ -109,7 +109,7 @@ def detectAttachments(msg: string): DetectedContent
 6. **Skip over-limit files** (`size` > smoltalk's 20 MB per-file limit) with their own visible line (`📎 skipped huge.png (too large to attach)`). An over-limit attachment must never reach the `llm()` call: smoltalk turns it into a Failure of the **whole turn**, not a skipped attachment, so relying on the send-time limit would make merely *mentioning* a 25 MB PNG fail the user's message.
 7. **Inline the bytes at attach time**: `readBinary(basename(absPath), dirname(absPath))` (a read — auto-approved by the default policy; the basename/dirname split is required because `readBinary` rejects an absolute filename when `dir` is set) and build the attachment as `image(b64, mimeType, base64: true)` or `file(b64, filename: basename(absPath), mimeType: mime, base64: true)`, mapping extension → MIME type. A failed read skips the file. See "Attachment lifetime" below for why we inline instead of passing the path.
 8. Cap at **10** attachments per message (avoid accidental floods).
-9. Return `{ text: msg (unchanged — the path stays for model context), attached: [{ attachment, label: "diagram.png" }, …], skipped: [{ label, reason }, …] }`.
+9. Return `{ attached: [{ attachment, label: "diagram.png" }, …], skipped: [{ label, reason }, …] }` (the message text itself is not threaded through — the caller already has it). Post-review revisions: the lexical stage (steps 1–2 + the extension gate) lives in TS (`lib/stdlib/mediaPathScan.ts`) for speed and quote-robustness (apostrophes in prose must not open quote spans); the stat uses `followSymlinks: true` so links to media attach; and files dropped by the 10-cap get a visible `skipped` entry like size/read failures.
 
 ### Attachment lifetime in the persistent thread (why step 7 inlines)
 

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -30,10 +30,11 @@ import { exists } from "std::shell"
 import { commandsDir, expandSlash } from "std::skills"
 import { highlight } from "std::syntax"
 import { cwd, env, isTTY, readStdin, setTitle } from "std::system"
-import { getCost, getModelCosts, systemMessage } from "std::thread"
+import { Attachment, getCost, getModelCosts, systemMessage } from "std::thread"
 import { chooseOption, ChoiceItem } from "std::ui"
 
 import { figs, title } from "./images/images.agency"
+import { detectAttachments, modalityFilter } from "./lib/attachments.agency"
 import { POLICY_PATH, HISTORY_PATH, ALWAYS_FIELDS } from "./lib/config.agency"
 import {
   minimalAutoApprovePolicy,
@@ -867,7 +868,7 @@ static const mainAgentTools = [
   generateImageFile,
 ]
 
-def mainAgent(prompt: string): string {
+def mainAgent(prompt: string | (string | Attachment)[]): string {
   thread(label: "main", summarize: true, session: "main") {
     setMemoryId("main")
     if (first) {
@@ -907,7 +908,28 @@ export def agentReplyVia(target: string, userMsg: string): string {
   if (target == "review") {
     return reviewAgent(expanded, false)
   }
-  return mainAgent(expanded)
+  // Auto-attach image/PDF files the user referenced (drag-drop or typed
+  // path), filtered to what the resolved model accepts. Never silent:
+  // every attach and every skip prints a visible line.
+  const detected = modalityFilter(detectAttachments(expanded))
+  for (skippedFile in detected.skipped) {
+    pushMessage(color.yellow("📎 skipped ${skippedFile.label} (${skippedFile.reason})"))
+  }
+  if (detected.attached.length == 0) {
+    // Deliberate special case: a text-only turn stays a bare string. A
+    // one-element array is API-equivalent, but the stored thread message
+    // shape (string vs parts array) — and with it every serialized
+    // session and message fixture — would change for EVERY turn.
+    return mainAgent(expanded)
+  }
+  for (item in detected.attached) {
+    pushMessage(color.dim("📎 attached ${item.label}"))
+  }
+  const attachments = map(detected.attached) as item {
+    return item.attachment
+  }
+  const parts: (string | Attachment)[] = [expanded, ...attachments]
+  return mainAgent(parts)
 }
 
 // The agent's core turn, decoupled from the terminal: expand any project

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -5,6 +5,7 @@ import {
   listModelNames,
  } from "std::agency/local"
 import { parseArgs } from "std::args"
+import { map } from "std::array"
 import {
   clearMessages,
   pushMessage,
@@ -13,7 +14,9 @@ import {
   clearHistory,
  } from "std::ui/cli"
 import { today } from "std::date"
-import { setAgentCwd } from "std::index"
+import { generateImage } from "std::image"
+import { applyAgentCwd, setAgentCwd } from "std::index"
+import { basename, dirname, isAbsolute } from "std::path"
 import { box, render } from "std::ui/layout"
 import { listHostedModels, hostedModelInfo } from "std::llm"
 import { setMemoryId, disableMemory } from "std::memory"
@@ -639,8 +642,8 @@ static const mainAgentSystemPrompt = """
 You are the top-level coordinator of an Agency-language assistant. You
 receive every user message and decide how to respond.
 
-You have five subagent tools, each running in its own isolated
-context:
+You have five subagent tools (each running in its own isolated
+context) and one direct tool:
 
 - `codeAgent(userMsg)` — anything that touches code or the filesystem:
   reading, writing, editing, typechecking, running shell commands,
@@ -657,6 +660,11 @@ context:
 - `explorerAgent(userMsg)` — a read-only researcher that produces
   broad, synthesizing answers about the codebase or bundled docs.
   Read the **Explorer** section below.
+- `generateImageFile(prompt, path, size, images)` — generate an image
+  from a text prompt (or modify existing images by passing their paths
+  in `images`) and save it to `path`. Call it directly whenever the
+  user asks you to create, draw, edit, or restyle an image — do NOT
+  route image generation to `codeAgent`.
 
 **Answer directly (no tool call) when** the message is conversational,
 a clarifying question, or something you can answer from context alone.
@@ -799,12 +807,64 @@ unless the user has clearly asked for an action ("do X", "fix Y",
 with them — don't sprint to implementation.
 """
 
+// Exported for tests: agent-cwd resolution of edit inputs is a spec
+// invariant with no other observable (the deterministic image client
+// ignores its images argument).
+export def resolveEditInputs(images: string[]): string[] {
+  return map(images) as inputPath {
+    return applyAgentCwd(inputPath)
+  }
+}
+
+// Direct image generation for the coordinator. Saves to disk and
+// returns the path — never base64, which would flood the LLM context.
+// The write rides the std::writeBinary interrupt gate (writes are not
+// auto-approved by policy) and generation cost accrues to the agent's
+// cost tracking like any llm() call.
+export def generateImageFile(
+  prompt: string,
+  path: string,
+  size: string = "",
+  images: string[] = [],
+): string {
+  """
+  Generate an image from a text prompt and save it to `path`. To MODIFY
+  existing images (edit / variation), pass their paths in `images`.
+  Returns the saved path on success. Use this when the user asks to
+  create, draw, edit, or restyle an image.
+
+  @param prompt - What to generate, or how to modify the input images.
+  @param path - Where to save the resulting image (e.g. "diagram.png").
+  @param size - Optional size like "1024x1024".
+  @param images - Optional input image paths to edit / vary.
+  """
+  // LLM-supplied paths resolve against the agent cwd, like every other
+  // agent file tool.
+  const inputs = resolveEditInputs(images)
+  const generated = generateImage(prompt, size: size, images: inputs)
+  if (isFailure(generated)) {
+    return "Image generation failed: ${generated.error}"
+  }
+  // writeBinary rejects an absolute filename when dir is set, so split
+  // path into (dir, name) and resolve the dir against the agent cwd.
+  let dir = dirname(path)
+  if (!isAbsolute(dir)) {
+    dir = applyAgentCwd(dir)
+  }
+  const written = writeBinary(basename(path), generated.value.base64, dir)
+  if (isFailure(written)) {
+    return "Generated the image, but saving to ${path} failed: ${written.error}"
+  }
+  return "Saved image to ${path}"
+}
+
 static const mainAgentTools = [
   researchAgent.partial(allowHandoff: false),
   codeAgent.partial(allowHandoff: false),
   reviewAgent.partial(allowHandoff: false),
   oracleAgent.partial(allowHandoff: false),
   explorerAgent.partial(allowHandoff: false),
+  generateImageFile,
 ]
 
 def mainAgent(prompt: string): string {

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -16,7 +16,7 @@ import {
 import { today } from "std::date"
 import { generateImage } from "std::image"
 import { applyAgentCwd, setAgentCwd } from "std::index"
-import { basename, dirname, isAbsolute } from "std::path"
+import { basename, dirname } from "std::path"
 import { box, render } from "std::ui/layout"
 import { listHostedModels, hostedModelInfo } from "std::llm"
 import { setMemoryId, disableMemory } from "std::memory"
@@ -810,9 +810,15 @@ with them — don't sprint to implementation.
 
 // Exported for tests: agent-cwd resolution of edit inputs is a spec
 // invariant with no other observable (the deterministic image client
-// ignores its images argument).
+// ignores its images argument). generateImage accepts path / URL /
+// data-URI strings, so only local paths get agent-cwd resolution —
+// running a URL through applyAgentCwd would mangle it into
+// "<agentCwd>/https:/…".
 export def resolveEditInputs(images: string[]): string[] {
   return map(images) as inputPath {
+    if (inputPath.startsWith("http://") || inputPath.startsWith("https://") || inputPath.startsWith("data:")) {
+      return inputPath
+    }
     return applyAgentCwd(inputPath)
   }
 }
@@ -847,12 +853,9 @@ export def generateImageFile(
     return "Image generation failed: ${generated.error}"
   }
   // writeBinary rejects an absolute filename when dir is set, so split
-  // path into (dir, name) and resolve the dir against the agent cwd.
-  let dir = dirname(path)
-  if (!isAbsolute(dir)) {
-    dir = applyAgentCwd(dir)
-  }
-  const written = writeBinary(basename(path), generated.value.base64, dir)
+  // path into (dir, name); useAgentCwd resolves a relative dir against
+  // the agent cwd (absolute dirs pass through untouched).
+  const written = writeBinary(basename(path), generated.value.base64, dirname(path), useAgentCwd: true)
   if (isFailure(written)) {
     return "Generated the image, but saving to ${path} failed: ${written.error}"
   }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/attachments.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/attachments.agency
@@ -1,0 +1,155 @@
+import { applyAgentCwd } from "std::index"
+import { stat } from "std::shell"
+import { env } from "std::system"
+import { basename, extname, dirname, isAbsolute } from "std::path"
+import { Attachment, image, file } from "std::thread"
+
+// Detects image/PDF file paths in a user message (terminal drag-drop
+// inserts a quoted/escaped path; typed mentions are plain tokens) and
+// returns them as inline-base64 attachments for the coordinator turn.
+// Media-only by design: code/text paths stay with the read tool.
+
+export type DetectedAttachment = { attachment: Attachment, label: string }
+export type SkippedFile = { label: string, reason: string }
+
+export type DetectedContent = {
+  text: string,
+  attached: DetectedAttachment[],
+  skipped: SkippedFile[]
+}
+
+// A token that survived the pure (no-I/O) gates: normalized, media
+// extension, resolved to an absolute path.
+type Candidate = { abs: string, mime: string }
+
+// extension (lowercase, with dot) -> MIME type. Media-only by design.
+static const MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".pdf": "application/pdf"
+}
+
+static const MAX_ATTACHMENTS = 10
+
+// Split msg into candidate tokens. Shell-quoted spans ('…' / "…")
+// become single tokens (drag-drop quotes paths with spaces), and a
+// backslash-escaped space is unescaped into the current token.
+// Hand-written scanner — order-dependent state is fine here (parsers
+// are exempt per docs/dev/anti-patterns.md).
+def tokenize(msg: string): string[] {
+  let tokens: string[] = []
+  let current = ""
+  let quote = ""
+  let index = 0
+  while (index < msg.length) {
+    const ch = msg.slice(index, index + 1)
+    if (quote != "") {
+      if (ch == quote) {
+        quote = ""
+      } else {
+        current = current + ch
+      }
+    } else if (ch == "'" || ch == "\"") {
+      quote = ch
+    } else if (ch == "\\" && index + 1 < msg.length && msg.slice(index + 1, index + 2) == " ") {
+      current = current + " "
+      index = index + 1
+    } else if (ch == " " || ch == "\t" || ch == "\n") {
+      if (current != "") {
+        tokens.push(current)
+        current = ""
+      }
+    } else {
+      current = current + ch
+    }
+    index = index + 1
+  }
+  if (current != "") {
+    tokens.push(current)
+  }
+  return tokens
+}
+
+// Trim trailing punctuation typed after a path, and expand a leading ~/
+// (drag-drop inserts absolute paths, but typed mentions are often ~/…).
+def normalizeToken(token: string): string {
+  let normalized = token
+  while (normalized.length > 0 && (normalized.endsWith(",") || normalized.endsWith(".") || normalized.endsWith("?") || normalized.endsWith(":"))) {
+    normalized = normalized.slice(0, normalized.length - 1)
+  }
+  if (normalized.startsWith("~/")) {
+    const home = env("HOME")
+    if (home != null && home != "") {
+      normalized = home + normalized.slice(1)
+    }
+  }
+  return normalized
+}
+
+// Pure stage (spec steps 2-3 + extension gate): normalize, keep only
+// media extensions, resolve to an absolute path. Returns null for
+// tokens that are not candidate media paths. No filesystem access.
+def tokenToCandidate(token: string): Candidate | null {
+  const normalized = normalizeToken(token)
+  const ext = extname(normalized).toLowerCase()
+  const mime = MIME_TYPES[ext]
+  if (mime == null) {
+    return null
+  }
+  if (isAbsolute(normalized)) {
+    return { abs: normalized, mime: mime }
+  }
+  return { abs: applyAgentCwd(normalized), mime: mime }
+}
+
+export def detectAttachments(msg: string, maxBytes: number = 20971520): DetectedContent {
+  """
+  Scan a user message for image/PDF file paths and return them as
+  inline-base64 attachments with display labels. Non-existent paths,
+  directories, non-media extensions, unreadable files, and files over
+  maxBytes (default 20971520 = smoltalk's 20 MB per-file cap) are not
+  attached; size/read skips are reported in `skipped`. Caps at 10
+  attachments per message.
+  """
+  let attached: DetectedAttachment[] = []
+  let skipped: SkippedFile[] = []
+  let seen: string[] = []
+  // Positive `if` nesting rather than `continue` guards: flow narrowing
+  // (candidate != null, isSuccess) is only tracked into guarded blocks.
+  for (token in tokenize(msg)) {
+    const candidate = tokenToCandidate(token)
+    if (candidate != null) {
+      if (attached.length < MAX_ATTACHMENTS && !seen.includes(candidate.abs)) {
+        seen.push(candidate.abs)
+        const info = stat(candidate.abs)
+        if (info.type == "file") {
+          const label = basename(candidate.abs)
+          if (info.size > maxBytes) {
+            skipped.push({ label: label, reason: "too large to attach" })
+          } else {
+            // readBinary rejects an absolute filename when dir is set, so
+            // pass the (basename, dirname) split. Inlining the bytes here
+            // (instead of letting smoltalk read the path at every send)
+            // keeps the persistent thread immune to later file deletion or
+            // edits and keeps the read inside the std::readBinary policy
+            // gate.
+            const bytes = readBinary(label, dirname(candidate.abs))
+            if (isSuccess(bytes)) {
+              if (candidate.mime == "application/pdf") {
+                attached.push({ attachment: file(bytes.value, filename: label, mimeType: candidate.mime, base64: true), label: label })
+              } else {
+                attached.push({ attachment: image(bytes.value, candidate.mime, base64: true), label: label })
+              }
+            } else {
+              skipped.push({ label: label, reason: "could not read" })
+            }
+          }
+        }
+      }
+    }
+  }
+  return { text: msg, attached: attached, skipped: skipped }
+}

--- a/packages/agency-lang/lib/agents/agency-agent/lib/attachments.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/attachments.agency
@@ -1,8 +1,8 @@
+import { _scanMediaPaths } from "agency-lang/stdlib-lib/mediaPathScan.js"
 import { applyAgentCwd } from "std::index"
 import { modelSupportsInput } from "std::llm"
 import { stat } from "std::shell"
-import { env } from "std::system"
-import { basename, extname, dirname, isAbsolute } from "std::path"
+import { basename, dirname } from "std::path"
 import { Attachment, image, file } from "std::thread"
 
 import { getResolvedSlots } from "../shared.agency"
@@ -11,150 +11,71 @@ import { getResolvedSlots } from "../shared.agency"
 // inserts a quoted/escaped path; typed mentions are plain tokens) and
 // returns them as inline-base64 attachments for the coordinator turn.
 // Media-only by design: code/text paths stay with the read tool.
+//
+// The lexical stage (tokenizing, quote/escape handling, tilde expansion,
+// extension gate) lives in TS (`lib/stdlib/mediaPathScan.ts`) — it runs
+// on every user message, and a per-character Agency loop would pay the
+// Runner step machinery per iteration. This module keeps the stateful
+// stages: agent-cwd resolution, dedupe, stat, read, attachment building.
 
 export type DetectedAttachment = { attachment: Attachment, label: string }
 export type SkippedFile = { label: string, reason: string }
 
 export type DetectedContent = {
-  text: string,
   attached: DetectedAttachment[],
   skipped: SkippedFile[]
 }
 
-// A token that survived the pure (no-I/O) gates: normalized, media
-// extension, resolved to an absolute path.
-type Candidate = { abs: string, mime: string }
-
-// extension (lowercase, with dot) -> MIME type. Media-only by design.
-static const MIME_TYPES: Record<string, string> = {
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-  ".pdf": "application/pdf"
-}
-
 static const MAX_ATTACHMENTS = 10
-
-// Split msg into candidate tokens. Shell-quoted spans ('…' / "…")
-// become single tokens (drag-drop quotes paths with spaces), and a
-// backslash-escaped space is unescaped into the current token.
-// Hand-written scanner — order-dependent state is fine here (parsers
-// are exempt per docs/dev/anti-patterns.md).
-def tokenize(msg: string): string[] {
-  let tokens: string[] = []
-  let current = ""
-  let quote = ""
-  let index = 0
-  while (index < msg.length) {
-    const ch = msg.slice(index, index + 1)
-    if (quote != "") {
-      if (ch == quote) {
-        quote = ""
-      } else {
-        current = current + ch
-      }
-    } else if (ch == "'" || ch == "\"") {
-      quote = ch
-    } else if (ch == "\\" && index + 1 < msg.length && msg.slice(index + 1, index + 2) == " ") {
-      current = current + " "
-      index = index + 1
-    } else if (ch == " " || ch == "\t" || ch == "\n") {
-      if (current != "") {
-        tokens.push(current)
-        current = ""
-      }
-    } else {
-      current = current + ch
-    }
-    index = index + 1
-  }
-  if (current != "") {
-    tokens.push(current)
-  }
-  return tokens
-}
-
-// Trim trailing punctuation typed after a path, and expand a leading ~/
-// (drag-drop inserts absolute paths, but typed mentions are often ~/…).
-def normalizeToken(token: string): string {
-  let normalized = token
-  while (normalized.length > 0 && (normalized.endsWith(",") || normalized.endsWith(".") || normalized.endsWith("?") || normalized.endsWith(":"))) {
-    normalized = normalized.slice(0, normalized.length - 1)
-  }
-  if (normalized.startsWith("~/")) {
-    const home = env("HOME")
-    if (home != null && home != "") {
-      normalized = home + normalized.slice(1)
-    }
-  }
-  return normalized
-}
-
-// Pure stage (spec steps 2-3 + extension gate): normalize, keep only
-// media extensions, resolve to an absolute path. Returns null for
-// tokens that are not candidate media paths. No filesystem access.
-def tokenToCandidate(token: string): Candidate | null {
-  const normalized = normalizeToken(token)
-  const ext = extname(normalized).toLowerCase()
-  const mime = MIME_TYPES[ext]
-  if (mime == null) {
-    return null
-  }
-  if (isAbsolute(normalized)) {
-    return { abs: normalized, mime: mime }
-  }
-  return { abs: applyAgentCwd(normalized), mime: mime }
-}
 
 export def detectAttachments(msg: string, maxBytes: number = 20971520): DetectedContent {
   """
   Scan a user message for image/PDF file paths and return them as
   inline-base64 attachments with display labels. Non-existent paths,
-  directories, non-media extensions, unreadable files, and files over
-  maxBytes (default 20971520 = smoltalk's 20 MB per-file cap) are not
-  attached; size/read skips are reported in `skipped`. Caps at 10
-  attachments per message.
+  directories, and non-media extensions are not attached; files that
+  exist but cannot be attached (over maxBytes — default 20971520,
+  smoltalk's 20 MB per-file cap — unreadable, or beyond the 10-per-
+  message limit) are reported in `skipped` so the drop is never silent.
   """
   let attached: DetectedAttachment[] = []
   let skipped: SkippedFile[] = []
   let seen: string[] = []
-  // Positive `if` nesting rather than `continue` guards: flow narrowing
-  // (candidate != null, isSuccess) is only tracked into guarded blocks.
-  for (token in tokenize(msg)) {
-    const candidate = tokenToCandidate(token)
-    if (candidate != null) {
-      if (attached.length < MAX_ATTACHMENTS && !seen.includes(candidate.abs)) {
-        seen.push(candidate.abs)
-        const info = stat(candidate.abs)
-        if (info.type == "file") {
-          const label = basename(candidate.abs)
-          if (info.size > maxBytes) {
-            skipped.push({ label: label, reason: "too large to attach" })
-          } else {
-            // readBinary rejects an absolute filename when dir is set, so
-            // pass the (basename, dirname) split. Inlining the bytes here
-            // (instead of letting smoltalk read the path at every send)
-            // keeps the persistent thread immune to later file deletion or
-            // edits and keeps the read inside the std::readBinary policy
-            // gate.
-            const bytes = readBinary(label, dirname(candidate.abs))
-            if (isSuccess(bytes)) {
-              if (candidate.mime == "application/pdf") {
-                attached.push({ attachment: file(bytes.value, filename: label, mimeType: candidate.mime, base64: true), label: label })
-              } else {
-                attached.push({ attachment: image(bytes.value, candidate.mime, base64: true), label: label })
-              }
+  for (candidate in _scanMediaPaths(msg)) {
+    // applyAgentCwd short-circuits absolute paths, so no isAbsolute guard.
+    const abs = applyAgentCwd(candidate.path)
+    if (!seen.includes(abs)) {
+      seen.push(abs)
+      // followSymlinks: a link to an image must report the TARGET's type
+      // and size (lstat would say "symlink" and the link blob's size).
+      const info = stat(abs, followSymlinks: true)
+      if (info.type == "file") {
+        const label = basename(abs)
+        if (attached.length >= MAX_ATTACHMENTS) {
+          skipped.push({ label: label, reason: "too many attachments (limit ${MAX_ATTACHMENTS})" })
+        } else if (info.size > maxBytes) {
+          skipped.push({ label: label, reason: "too large to attach" })
+        } else {
+          // readBinary rejects an absolute filename when dir is set, so
+          // pass the (basename, dirname) split. Inlining the bytes here
+          // (instead of letting smoltalk read the path at every send)
+          // keeps the persistent thread immune to later file deletion or
+          // edits and keeps the read inside the std::readBinary policy
+          // gate.
+          const bytes = readBinary(label, dirname(abs))
+          if (isSuccess(bytes)) {
+            if (candidate.mime == "application/pdf") {
+              attached.push({ attachment: file(bytes.value, filename: label, mimeType: candidate.mime, base64: true), label: label })
             } else {
-              skipped.push({ label: label, reason: "could not read" })
+              attached.push({ attachment: image(bytes.value, candidate.mime, base64: true), label: label })
             }
+          } else {
+            skipped.push({ label: label, reason: "could not read" })
           }
         }
       }
     }
   }
-  return { text: msg, attached: attached, skipped: skipped }
+  return { attached: attached, skipped: skipped }
 }
 
 // Drop attachments the resolved main model explicitly cannot accept.
@@ -162,6 +83,11 @@ export def detectAttachments(msg: string, maxBytes: number = 20971520): Detected
 // models (null) attach optimistically — smoltalk's send-time gate does
 // not fire for them either, so this can never be stricter than send.
 export def modalityFilter(detected: DetectedContent): DetectedContent {
+  // Text-only turns (the overwhelming majority) pay nothing: no slot
+  // lookup, no catalog probes.
+  if (detected.attached.length == 0) {
+    return detected
+  }
   const slots = getResolvedSlots()
   const main = slots["main"]
   if (main == null) {
@@ -185,5 +111,5 @@ export def modalityFilter(detected: DetectedContent): DetectedContent {
       attached.push(item)
     }
   }
-  return { text: detected.text, attached: attached, skipped: skipped }
+  return { attached: attached, skipped: skipped }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/attachments.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/attachments.agency
@@ -1,8 +1,11 @@
 import { applyAgentCwd } from "std::index"
+import { modelSupportsInput } from "std::llm"
 import { stat } from "std::shell"
 import { env } from "std::system"
 import { basename, extname, dirname, isAbsolute } from "std::path"
 import { Attachment, image, file } from "std::thread"
+
+import { getResolvedSlots } from "../shared.agency"
 
 // Detects image/PDF file paths in a user message (terminal drag-drop
 // inserts a quoted/escaped path; typed mentions are plain tokens) and
@@ -152,4 +155,35 @@ export def detectAttachments(msg: string, maxBytes: number = 20971520): Detected
     }
   }
   return { text: msg, attached: attached, skipped: skipped }
+}
+
+// Drop attachments the resolved main model explicitly cannot accept.
+// Tri-state on purpose: only a catalog `false` drops a part. Unknown
+// models (null) attach optimistically — smoltalk's send-time gate does
+// not fire for them either, so this can never be stricter than send.
+export def modalityFilter(detected: DetectedContent): DetectedContent {
+  const slots = getResolvedSlots()
+  const main = slots["main"]
+  if (main == null) {
+    return detected
+  }
+  const imageOk = modelSupportsInput(main.model, "image")
+  const pdfOk = modelSupportsInput(main.model, "pdf")
+  let attached: DetectedAttachment[] = []
+  let skipped: SkippedFile[] = [...detected.skipped]
+  for (item in detected.attached) {
+    const noImageInput = item.attachment.type == "image" && imageOk == false
+    const noPdfInput = item.attachment.type == "file" && pdfOk == false
+    const drop = noImageInput || noPdfInput
+    if (drop) {
+      let modality = "image"
+      if (item.attachment.type == "file") {
+        modality = "PDF"
+      }
+      skipped.push({ label: item.label, reason: "model ${main.model} has no ${modality} input" })
+    } else {
+      attached.push(item)
+    }
+  }
+  return { text: detected.text, attached: attached, skipped: skipped }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -269,8 +269,8 @@ fences. Code fences are especially important — they're how code in
 your reply gets per-language coloring.
 
 **Important:** put a blank line between a heading and any bullet list
-or paragraph that follows it (`## Heading\\n\\n- item`, not
-`## Heading\\n- item`). Without the blank line our Markdown renderer
+or paragraph that follows it (`## Heading\n\n- item`, not
+`## Heading\n- item`). Without the blank line our Markdown renderer
 silently truncates everything after the heading.
 
 ### ASCII diagrams

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachments.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachments.agency
@@ -1,0 +1,135 @@
+import { detectAttachments } from "../lib/attachments.agency"
+import { setAgentCwd } from "std::index"
+import { exec } from "std::shell"
+import { setEnv } from "std::system"
+
+// 1x1 PNG, 89 bytes decoded. Content is irrelevant to detection (the
+// gate is extension + stat), but a real PNG keeps fixtures honest.
+static const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+node detectsPngPath(): string {
+  writeBinary("da-a.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("look at /tmp/da-a.png please") with approve
+  if (detected.attached.length != 1) {
+    return "count=${detected.attached.length}"
+  }
+  const item = detected.attached[0]
+  return "1|${item.label}|${item.attachment.type}|${item.attachment.source.kind}"
+}
+
+node detectsPdfPath(): string {
+  writeBinary("da-doc.pdf", "JVBERi0xLjQK", "/tmp") with approve
+  const detected = detectAttachments("summarize /tmp/da-doc.pdf") with approve
+  if (detected.attached.length != 1) {
+    return "count=${detected.attached.length}"
+  }
+  return "1|${detected.attached[0].label}|${detected.attached[0].attachment.type}"
+}
+
+node quotedPathWithSpaces(): string {
+  writeBinary("da b.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see '/tmp/da b.png' now") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node doubleQuotedPath(): string {
+  writeBinary("da b.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see \"/tmp/da b.png\" now") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node escapedSpacePath(): string {
+  writeBinary("da b.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da\\ b.png now") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node tildeExpansion(): string {
+  writeBinary("da-tilde.png", PNG, "/tmp") with approve
+  setEnv("HOME", "/tmp") with approve
+  const detected = detectAttachments("see ~/da-tilde.png") with approve
+  return "${detected.attached.length}"
+}
+
+node trailingPunctuation(): string {
+  writeBinary("da-p.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("is it /tmp/da-p.png?") with approve
+  return "${detected.attached.length}"
+}
+
+node nonexistentIgnored(): string {
+  const detected = detectAttachments("see /tmp/da-not-there-xyz.png") with approve
+  return "${detected.attached.length}"
+}
+
+node codePathIgnored(): string {
+  writeBinary("da-code.ts", "AQID", "/tmp") with approve
+  const detected = detectAttachments("read /tmp/da-code.ts") with approve
+  return "${detected.attached.length}"
+}
+
+node directoryIgnored(): string {
+  exec("rm", ["-rf", "/tmp/da-dir.png"]) with approve
+  exec("mkdir", ["-p", "/tmp/da-dir.png"]) with approve
+  const detected = detectAttachments("see /tmp/da-dir.png") with approve
+  return "${detected.attached.length}"
+}
+
+node overLimitSkipped(): string {
+  writeBinary("da-big.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-big.png", maxBytes: 4) with approve
+  return "${detected.attached.length}|${detected.skipped[0].label}|${detected.skipped[0].reason}"
+}
+
+node dedupes(): string {
+  writeBinary("da-dup.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("/tmp/da-dup.png and again /tmp/da-dup.png") with approve
+  return "${detected.attached.length}"
+}
+
+node capsAtTen(): number {
+  let msg = "look at"
+  for (i in range(11)) {
+    writeBinary("da-cap-${i}.png", PNG, "/tmp") with approve
+    msg = msg + " /tmp/da-cap-${i}.png"
+  }
+  const detected = detectAttachments(msg) with approve
+  return detected.attached.length
+}
+
+node allImageExtensions(): number {
+  writeBinary("da-e1.jpg", PNG, "/tmp") with approve
+  writeBinary("da-e2.jpeg", PNG, "/tmp") with approve
+  writeBinary("da-e3.gif", PNG, "/tmp") with approve
+  writeBinary("da-e4.webp", PNG, "/tmp") with approve
+  writeBinary("da-e5.PNG", PNG, "/tmp") with approve
+  const detected = detectAttachments("/tmp/da-e1.jpg /tmp/da-e2.jpeg /tmp/da-e3.gif /tmp/da-e4.webp /tmp/da-e5.PNG") with approve
+  return detected.attached.length
+}
+
+node mixedTypesPreserveOrder(): string {
+  writeBinary("da-m1.png", PNG, "/tmp") with approve
+  writeBinary("da-m2.pdf", "JVBERi0xLjQK", "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-m1.png then /tmp/da-m2.pdf") with approve
+  if (detected.attached.length != 2) {
+    return "count=${detected.attached.length}"
+  }
+  return "2|${detected.attached[0].label}|${detected.attached[0].attachment.type}|${detected.attached[1].label}|${detected.attached[1].attachment.type}"
+}
+
+node relativeResolvesAgainstAgentCwd(): string {
+  writeBinary("da-rel.png", PNG, "/tmp") with approve
+  setAgentCwd("/tmp")
+  const detected = detectAttachments("see da-rel.png") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node bareTextNoAttachments(): string {
+  const detected = detectAttachments("please draw me a diagram") with approve
+  return "${detected.attached.length}|${detected.text}"
+}
+
+node emptyMessage(): string {
+  const detected = detectAttachments("") with approve
+  return "${detected.attached.length}|${detected.skipped.length}|${detected.text}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachments.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachments.agency
@@ -88,14 +88,34 @@ node dedupes(): string {
   return "${detected.attached.length}"
 }
 
-node capsAtTen(): number {
+node capsAtTenWithVisibleSkip(): string {
   let msg = "look at"
   for (i in range(11)) {
     writeBinary("da-cap-${i}.png", PNG, "/tmp") with approve
     msg = msg + " /tmp/da-cap-${i}.png"
   }
   const detected = detectAttachments(msg) with approve
-  return detected.attached.length
+  return "${detected.attached.length}|${detected.skipped[0].label}|${detected.skipped[0].reason}"
+}
+
+node apostropheInProse(): string {
+  writeBinary("da-apos.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("here's /tmp/da-apos.png") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node apostropheThenQuotedPath(): string {
+  writeBinary("da b.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("here's '/tmp/da b.png'") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
+}
+
+node symlinkFollowed(): string {
+  writeBinary("da-target.png", PNG, "/tmp") with approve
+  exec("rm", ["-f", "/tmp/da-link.png"]) with approve
+  exec("ln", ["-s", "/tmp/da-target.png", "/tmp/da-link.png"]) with approve
+  const detected = detectAttachments("see /tmp/da-link.png") with approve
+  return "${detected.attached.length}|${detected.attached[0].label}"
 }
 
 node allImageExtensions(): number {
@@ -127,12 +147,12 @@ node relativeResolvesAgainstAgentCwd(): string {
 
 node bareTextNoAttachments(): string {
   const detected = detectAttachments("please draw me a diagram") with approve
-  return "${detected.attached.length}|${detected.text}"
+  return "${detected.attached.length}|${detected.skipped.length}"
 }
 
 node emptyMessage(): string {
   const detected = detectAttachments("") with approve
-  return "${detected.attached.length}|${detected.skipped.length}|${detected.text}"
+  return "${detected.attached.length}|${detected.skipped.length}"
 }
 
 node modalityFilterPassthroughWhenNoSlots(): string {

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachments.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachments.agency
@@ -1,4 +1,5 @@
-import { detectAttachments } from "../lib/attachments.agency"
+import { detectAttachments, modalityFilter } from "../lib/attachments.agency"
+import { applyResolved } from "../shared.agency"
 import { setAgentCwd } from "std::index"
 import { exec } from "std::shell"
 import { setEnv } from "std::system"
@@ -132,4 +133,35 @@ node bareTextNoAttachments(): string {
 node emptyMessage(): string {
   const detected = detectAttachments("") with approve
   return "${detected.attached.length}|${detected.skipped.length}|${detected.text}"
+}
+
+node modalityFilterPassthroughWhenNoSlots(): string {
+  writeBinary("da-mf.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mf.png") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}"
+}
+
+node modalityFilterDropsForTextOnlyModel(): string {
+  applyResolved({ main: { model: "gpt-3.5-turbo", provider: "openai", via: "test" } })
+  writeBinary("da-mf2.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mf2.png") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}|${filtered.skipped[0].label}|${filtered.skipped[0].reason}"
+}
+
+node modalityFilterDropsPdfForNoPdfModel(): string {
+  applyResolved({ main: { model: "gpt-3.5-turbo", provider: "openai", via: "test" } })
+  writeBinary("da-mfp.pdf", "JVBERi0xLjQK", "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mfp.pdf") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}|${filtered.skipped[0].label}|${filtered.skipped[0].reason}"
+}
+
+node modalityFilterKeepsForVisionModel(): string {
+  applyResolved({ main: { model: "gpt-4o", provider: "openai", via: "test" } })
+  writeBinary("da-mf3.png", PNG, "/tmp") with approve
+  const detected = detectAttachments("see /tmp/da-mf3.png") with approve
+  const filtered = modalityFilter(detected)
+  return "${filtered.attached.length}"
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachments.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachments.test.json
@@ -121,9 +121,39 @@
       ]
     },
     {
-      "nodeName": "capsAtTen",
+      "nodeName": "capsAtTenWithVisibleSkip",
       "input": "",
-      "expectedOutput": "10",
+      "expectedOutput": "\"10|da-cap-10.png|too many attachments (limit 10)\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "apostropheInProse",
+      "input": "",
+      "expectedOutput": "\"1|da-apos.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "apostropheThenQuotedPath",
+      "input": "",
+      "expectedOutput": "\"1|da b.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "symlinkFollowed",
+      "input": "",
+      "expectedOutput": "\"1|da-link.png\"",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -163,7 +193,7 @@
     {
       "nodeName": "bareTextNoAttachments",
       "input": "",
-      "expectedOutput": "\"0|please draw me a diagram\"",
+      "expectedOutput": "\"0|0\"",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -173,7 +203,7 @@
     {
       "nodeName": "emptyMessage",
       "input": "",
-      "expectedOutput": "\"0|0|\"",
+      "expectedOutput": "\"0|0\"",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachments.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachments.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    { "nodeName": "detectsPngPath", "input": "", "expectedOutput": "\"1|da-a.png|image|base64\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "detectsPdfPath", "input": "", "expectedOutput": "\"1|da-doc.pdf|file\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "quotedPathWithSpaces", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "doubleQuotedPath", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "escapedSpacePath", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "tildeExpansion", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "trailingPunctuation", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "nonexistentIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "codePathIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "directoryIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "overLimitSkipped", "input": "", "expectedOutput": "\"0|da-big.png|too large to attach\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "dedupes", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "capsAtTen", "input": "", "expectedOutput": "10", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "allImageExtensions", "input": "", "expectedOutput": "5", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "mixedTypesPreserveOrder", "input": "", "expectedOutput": "\"2|da-m1.png|image|da-m2.pdf|file\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "relativeResolvesAgainstAgentCwd", "input": "", "expectedOutput": "\"1|da-rel.png\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "bareTextNoAttachments", "input": "", "expectedOutput": "\"0|please draw me a diagram\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "emptyMessage", "input": "", "expectedOutput": "\"0|0|\"", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachments.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachments.test.json
@@ -1,22 +1,224 @@
 {
   "tests": [
-    { "nodeName": "detectsPngPath", "input": "", "expectedOutput": "\"1|da-a.png|image|base64\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "detectsPdfPath", "input": "", "expectedOutput": "\"1|da-doc.pdf|file\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "quotedPathWithSpaces", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "doubleQuotedPath", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "escapedSpacePath", "input": "", "expectedOutput": "\"1|da b.png\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "tildeExpansion", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "trailingPunctuation", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "nonexistentIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "codePathIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "directoryIgnored", "input": "", "expectedOutput": "\"0\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "overLimitSkipped", "input": "", "expectedOutput": "\"0|da-big.png|too large to attach\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "dedupes", "input": "", "expectedOutput": "\"1\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "capsAtTen", "input": "", "expectedOutput": "10", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "allImageExtensions", "input": "", "expectedOutput": "5", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "mixedTypesPreserveOrder", "input": "", "expectedOutput": "\"2|da-m1.png|image|da-m2.pdf|file\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "relativeResolvesAgainstAgentCwd", "input": "", "expectedOutput": "\"1|da-rel.png\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "bareTextNoAttachments", "input": "", "expectedOutput": "\"0|please draw me a diagram\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "emptyMessage", "input": "", "expectedOutput": "\"0|0|\"", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "detectsPngPath",
+      "input": "",
+      "expectedOutput": "\"1|da-a.png|image|base64\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "detectsPdfPath",
+      "input": "",
+      "expectedOutput": "\"1|da-doc.pdf|file\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "quotedPathWithSpaces",
+      "input": "",
+      "expectedOutput": "\"1|da b.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "doubleQuotedPath",
+      "input": "",
+      "expectedOutput": "\"1|da b.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "escapedSpacePath",
+      "input": "",
+      "expectedOutput": "\"1|da b.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "tildeExpansion",
+      "input": "",
+      "expectedOutput": "\"1\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "trailingPunctuation",
+      "input": "",
+      "expectedOutput": "\"1\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "nonexistentIgnored",
+      "input": "",
+      "expectedOutput": "\"0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "codePathIgnored",
+      "input": "",
+      "expectedOutput": "\"0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "directoryIgnored",
+      "input": "",
+      "expectedOutput": "\"0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "overLimitSkipped",
+      "input": "",
+      "expectedOutput": "\"0|da-big.png|too large to attach\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "dedupes",
+      "input": "",
+      "expectedOutput": "\"1\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "capsAtTen",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "allImageExtensions",
+      "input": "",
+      "expectedOutput": "5",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "mixedTypesPreserveOrder",
+      "input": "",
+      "expectedOutput": "\"2|da-m1.png|image|da-m2.pdf|file\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "relativeResolvesAgainstAgentCwd",
+      "input": "",
+      "expectedOutput": "\"1|da-rel.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "bareTextNoAttachments",
+      "input": "",
+      "expectedOutput": "\"0|please draw me a diagram\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "emptyMessage",
+      "input": "",
+      "expectedOutput": "\"0|0|\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modalityFilterPassthroughWhenNoSlots",
+      "input": "",
+      "expectedOutput": "\"1\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modalityFilterDropsForTextOnlyModel",
+      "input": "",
+      "expectedOutput": "\"0|da-mf2.png|model gpt-3.5-turbo has no image input\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modalityFilterDropsPdfForNoPdfModel",
+      "input": "",
+      "expectedOutput": "\"0|da-mfp.pdf|model gpt-3.5-turbo has no PDF input\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modalityFilterKeepsForVisionModel",
+      "input": "",
+      "expectedOutput": "\"1\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachmentsTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachmentsTurn.agency
@@ -1,0 +1,58 @@
+import { agentReply, agentReplyVia } from "../agent.agency"
+import { applyResolved } from "../shared.agency"
+import { getThread, listThreads } from "std::thread"
+
+static const PNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+// The thread reader renders attachment parts as "[image attachment]"
+// (see _contentToString), so finding that placeholder in a user message
+// proves the multimodal array reached the llm() turn. listThreads with
+// lazySummarize: false enumerates real thread ids without triggering
+// the on-demand LLM summarization of closed threads (which would burn
+// mocks). currentThreadId() would NOT work here: after agentReply
+// returns, the active thread is the node root, not the main thread.
+def threadHasImagePlaceholder(): boolean {
+  const threads = listThreads(lazySummarize: false)
+  if (isFailure(threads)) {
+    return false
+  }
+  for (info in threads.value) {
+    const messages = getThread(info.id, 0, 200)
+    if (isSuccess(messages)) {
+      for (message in messages.value) {
+        if (message.role == "user" && message.content.includes("[image attachment]")) {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+node attachesImageToTurn(): string {
+  writeBinary("at-x.png", PNG, "/tmp") with approve
+  const reply = agentReply("look at /tmp/at-x.png") with approve
+  return "${reply}|${threadHasImagePlaceholder()}"
+}
+
+node plainMessageStaysString(): string {
+  const reply = agentReply("hello there") with approve
+  return "${reply}|${threadHasImagePlaceholder()}"
+}
+
+node modalitySkipsTextOnlyModel(): string {
+  applyResolved({ main: { model: "gpt-3.5-turbo", provider: "openai", via: "test" } })
+  writeBinary("at-y.png", PNG, "/tmp") with approve
+  const reply = agentReply("look at /tmp/at-y.png") with approve
+  return "${reply}|${threadHasImagePlaceholder()}"
+}
+
+node subagentRouteIgnoresImagePath(): string {
+  // Pins spec decision 3: direct-to-subagent routes stay text-only. The
+  // code agent's reply shape is its own business (multi-llm choreography
+  // under sequential mocks) — this test only asserts the turn completed
+  // and no image part reached any thread.
+  writeBinary("at-z.png", PNG, "/tmp") with approve
+  const reply = agentReplyVia("code", "look at /tmp/at-z.png") with approve
+  return "${reply != null}|${threadHasImagePlaceholder()}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/attachmentsTurn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/attachmentsTurn.test.json
@@ -1,0 +1,83 @@
+{
+  "tests": [
+    {
+      "nodeName": "attachesImageToTurn",
+      "input": "",
+      "expectedOutput": "\"I see it!|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "I see it!"
+        }
+      ]
+    },
+    {
+      "nodeName": "plainMessageStaysString",
+      "input": "",
+      "expectedOutput": "\"Hi!|false\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "Hi!"
+        }
+      ]
+    },
+    {
+      "nodeName": "modalitySkipsTextOnlyModel",
+      "input": "",
+      "expectedOutput": "\"ok|false\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "ok"
+        }
+      ]
+    },
+    {
+      "nodeName": "subagentRouteIgnoresImagePath",
+      "input": "",
+      "expectedOutput": "\"true|false\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "code reply"
+        },
+        {
+          "return": "code reply"
+        },
+        {
+          "return": "code reply"
+        },
+        {
+          "return": "code reply"
+        },
+        {
+          "return": "code reply"
+        },
+        {
+          "return": "code reply"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.agency
@@ -1,0 +1,43 @@
+import { generateImageFile, resolveEditInputs } from "../agent.agency"
+import { setAgentCwd } from "std::index"
+import { cwd } from "std::system"
+import { getCost } from "std::thread"
+
+node savesToAgentCwd(): string {
+  setAgentCwd("/tmp")
+  const msg = generateImageFile("a red bicycle", "it-gencwd.png") with approve
+  const inAgentCwd = readBinary("it-gencwd.png", "/tmp") with approve
+  const inProcessCwd = readBinary("it-gencwd.png", cwd()) with approve
+  return "${msg}|${isSuccess(inAgentCwd)}|${isFailure(inProcessCwd)}"
+}
+
+node savesToAbsolutePath(): string {
+  const msg = generateImageFile("a red bicycle", "/tmp/it-abs.png") with approve
+  const back = readBinary("it-abs.png", "/tmp") with approve
+  return "${msg}|${isSuccess(back)}"
+}
+
+node reportsWriteFailure(): boolean {
+  const msg = generateImageFile("x", "/nonexistent-dir-e51b/x.png") with approve
+  return msg.startsWith("Generated the image, but saving to /nonexistent-dir-e51b/x.png failed")
+}
+
+node editInputsResolveAgainstAgentCwd(): string {
+  setAgentCwd("/tmp")
+  const resolved = resolveEditInputs(["a.png", "/abs/b.png"])
+  return "${resolved[0]}|${resolved[1]}"
+}
+
+node editInputsPassThrough(): string {
+  setAgentCwd("/tmp")
+  generateImageFile("seed", "it-seed.png") with approve
+  return generateImageFile("restyle it", "it-edit.png", images: ["it-seed.png"]) with approve
+}
+
+node costRecordedForGeneration(): string {
+  setAgentCwd("/tmp")
+  const before = getCost()
+  generateImageFile("a red bicycle", "it-cost.png") with approve
+  const after = getCost()
+  return "${(after - before).toFixed(2)}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.agency
@@ -28,6 +28,14 @@ node editInputsResolveAgainstAgentCwd(): string {
   return "${resolved[0]}|${resolved[1]}"
 }
 
+node editInputsPassUrlsThrough(): string {
+  // generateImage accepts URLs and data URIs; agent-cwd resolution must
+  // not mangle them into local paths.
+  setAgentCwd("/tmp")
+  const resolved = resolveEditInputs(["https://example.com/cat.png", "data:image/png;base64,AAAA", "http://example.com/dog.png"])
+  return "${resolved[0]}|${resolved[1]}|${resolved[2]}"
+}
+
 node editInputsPassThrough(): string {
   setAgentCwd("/tmp")
   generateImageFile("seed", "it-seed.png") with approve

--- a/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.test.json
@@ -1,0 +1,10 @@
+{
+  "tests": [
+    { "nodeName": "savesToAgentCwd", "input": "", "expectedOutput": "\"Saved image to it-gencwd.png|true|true\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "savesToAbsolutePath", "input": "", "expectedOutput": "\"Saved image to /tmp/it-abs.png|true\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "reportsWriteFailure", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "editInputsResolveAgainstAgentCwd", "input": "", "expectedOutput": "\"/tmp/a.png|/abs/b.png\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "editInputsPassThrough", "input": "", "expectedOutput": "\"Saved image to it-edit.png\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
+    { "nodeName": "costRecordedForGeneration", "input": "", "expectedOutput": "\"0.04\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/imageTool.test.json
@@ -1,10 +1,81 @@
 {
   "tests": [
-    { "nodeName": "savesToAgentCwd", "input": "", "expectedOutput": "\"Saved image to it-gencwd.png|true|true\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
-    { "nodeName": "savesToAbsolutePath", "input": "", "expectedOutput": "\"Saved image to /tmp/it-abs.png|true\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
-    { "nodeName": "reportsWriteFailure", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
-    { "nodeName": "editInputsResolveAgainstAgentCwd", "input": "", "expectedOutput": "\"/tmp/a.png|/abs/b.png\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
-    { "nodeName": "editInputsPassThrough", "input": "", "expectedOutput": "\"Saved image to it-edit.png\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true },
-    { "nodeName": "costRecordedForGeneration", "input": "", "expectedOutput": "\"0.04\"", "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true }
+    {
+      "nodeName": "savesToAgentCwd",
+      "input": "",
+      "expectedOutput": "\"Saved image to it-gencwd.png|true|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true
+    },
+    {
+      "nodeName": "savesToAbsolutePath",
+      "input": "",
+      "expectedOutput": "\"Saved image to /tmp/it-abs.png|true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true
+    },
+    {
+      "nodeName": "reportsWriteFailure",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true
+    },
+    {
+      "nodeName": "editInputsResolveAgainstAgentCwd",
+      "input": "",
+      "expectedOutput": "\"/tmp/a.png|/abs/b.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true
+    },
+    {
+      "nodeName": "editInputsPassUrlsThrough",
+      "input": "",
+      "expectedOutput": "\"https://example.com/cat.png|data:image/png;base64,AAAA|http://example.com/dog.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true
+    },
+    {
+      "nodeName": "editInputsPassThrough",
+      "input": "",
+      "expectedOutput": "\"Saved image to it-edit.png\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true
+    },
+    {
+      "nodeName": "costRecordedForGeneration",
+      "input": "",
+      "expectedOutput": "\"0.04\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true
+    }
   ]
 }

--- a/packages/agency-lang/lib/agents/eval/judgePairwise.agency
+++ b/packages/agency-lang/lib/agents/eval/judgePairwise.agency
@@ -26,14 +26,14 @@ node judgePairwise(
   ${responseB}
   </response>
 
-  Decide which response better meets the goal. Pick \"A\", \"B\", or \"tie\". Return confidence as an integer from 0 to 100:
+  Decide which response better meets the goal. Pick "A", "B", or "tie". Return confidence as an integer from 0 to 100:
   - 0-20 means nearly indistinguishable / coin flip
   - 21-40 means weak preference
   - 41-60 means moderate preference
   - 61-80 means strong preference
   - 81-100 means overwhelming preference
 
-  Be honest about confidence — \"tie\" is the right call when responses are genuinely indistinguishable, not a way to dodge the question. Give a brief reasoning (1-3 sentences) that cites specifics from each response.
+  Be honest about confidence — "tie" is the right call when responses are genuinely indistinguishable, not a way to dodge the question. Give a brief reasoning (1-3 sentences) that cites specifics from each response.
   """
   const result: PairwiseJudgeResult = llm(prompt)
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3909,7 +3909,9 @@ export class TypeScriptBuilder {
               ts.consoleError(
                 ts.template([
                   {
-                    text: "\\nAgent crashed: ",
+                    // Real newline char: template part text is raw runtime
+                    // characters; the printer escapes, not the caller.
+                    text: "\nAgent crashed: ",
                     expr: $(ts.id("__error")).prop("message").done(),
                   },
                 ]),

--- a/packages/agency-lang/lib/ir/prettyPrint.test.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.test.ts
@@ -302,6 +302,13 @@ describe("prettyPrint", () => {
     expect(printTs(node)).toBe("`a\n\tb`");
   });
 
+  it("TsTemplateLit escapes carriage returns (template source normalizes raw CR to LF)", () => {
+    const node = ts.template([{ text: "a\rb" }]);
+    expect(printTs(node)).toBe("`a\\rb`");
+    // eslint-disable-next-line no-eval
+    expect(eval(printTs(node))).toBe("a\rb");
+  });
+
   it("TsComment line", () => {
     expect(printTs(ts.comment("TODO: fix this"))).toBe("// TODO: fix this");
   });

--- a/packages/agency-lang/lib/ir/prettyPrint.test.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.test.ts
@@ -274,14 +274,32 @@ describe("prettyPrint", () => {
     expect(printTs(node)).toBe("`price: \\${5}`");
   });
 
-  it("TsTemplateLit passes backslash escape sequences through unmodified", () => {
-    // Agency relies on JS template-literal escape interpretation at runtime,
-    // so `\n`, `\t`, etc. must reach the output verbatim (NOT be re-escaped
-    // to `\\n`, which would print a literal backslash + n).
+  it("TsTemplateLit escapes backslashes (part text is raw, not pre-escaped)", () => {
+    // Part text carries the RAW runtime characters (the Agency parser has
+    // already interpreted `\n` / `\\` etc. into real chars). A raw
+    // backslash must therefore be escaped, or it swallows whatever
+    // follows it in the emitted template (a lone `\` before the closing
+    // backtick produces an unterminated template literal).
     const node = ts.template([{ text: "line1\\nline2" }]);
-    // The JS string literal `"line1\\nline2"` is the 12 chars
-    // `l i n e 1 \ n l i n e 2`. The template printer should emit them as-is.
-    expect(printTs(node)).toBe("`line1\\nline2`");
+    // The JS string literal `"line1\\nline2"` is the 12 raw chars
+    // `l i n e 1 \ n l i n e 2` — a literal backslash then the letter n.
+    // The printer must emit `line1\\nline2` so runtime evaluation yields
+    // the original backslash + n, not a newline.
+    expect(printTs(node)).toBe("`line1\\\\nline2`");
+  });
+
+  it("TsTemplateLit round-trips a lone backslash", () => {
+    const node = ts.template([{ text: "a\\" }]);
+    expect(printTs(node)).toBe("`a\\\\`");
+    // eslint-disable-next-line no-eval
+    expect(eval(printTs(node))).toBe("a\\");
+  });
+
+  it("TsTemplateLit keeps real newlines/tabs untouched", () => {
+    // Parser-interpreted escapes arrive as real characters — they need no
+    // escaping inside a template literal.
+    const node = ts.template([{ text: "a\n\tb" }]);
+    expect(printTs(node)).toBe("`a\n\tb`");
   });
 
   it("TsComment line", () => {

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -144,15 +144,18 @@ export function printTs(node: TsNode, indent = 0): string {
     }
 
     case "templateLit": {
-      // Escape only the two sequences that would terminate the template or
-      // start an unintended interpolation:
+      // Part text is RAW runtime characters — the Agency parser has already
+      // interpreted `\n` / `\\` etc. into real chars, so real newlines/tabs
+      // pass straight through (valid inside a template literal). Three
+      // sequences must be escaped or they corrupt the emitted template:
+      //   `\`     → `\\`  (a raw backslash would escape whatever follows —
+      //                    a lone `\` before the closing backtick yields an
+      //                    unterminated template; must run FIRST so it
+      //                    doesn't double the escapes added below)
       //   `` ` `` → `\``  (otherwise closes the template)
       //   `${`    → `\${` (otherwise starts an interpolation)
-      // We deliberately do NOT escape `\` — agency strings pass backslash
-      // sequences through to the JS template literal so `\n`, `\t`, etc.
-      // get interpreted as escape sequences at runtime.
       const escapeForTemplate = (text: string): string =>
-        text.replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+        text.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
       let s = "`";
       for (const part of node.parts) {
         s += escapeForTemplate(part.text);

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -146,16 +146,22 @@ export function printTs(node: TsNode, indent = 0): string {
     case "templateLit": {
       // Part text is RAW runtime characters — the Agency parser has already
       // interpreted `\n` / `\\` etc. into real chars, so real newlines/tabs
-      // pass straight through (valid inside a template literal). Three
+      // pass straight through (valid inside a template literal). Four
       // sequences must be escaped or they corrupt the emitted template:
       //   `\`     → `\\`  (a raw backslash would escape whatever follows —
       //                    a lone `\` before the closing backtick yields an
       //                    unterminated template; must run FIRST so it
       //                    doesn't double the escapes added below)
+      //   CR      → `\r`  (ECMAScript normalizes a raw CR/CRLF in template
+      //                    source to LF, silently changing the value)
       //   `` ` `` → `\``  (otherwise closes the template)
       //   `${`    → `\${` (otherwise starts an interpolation)
       const escapeForTemplate = (text: string): string =>
-        text.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+        text
+          .replace(/\\/g, "\\\\")
+          .replace(/\r/g, "\\r")
+          .replace(/`/g, "\\`")
+          .replace(/\$\{/g, "\\${");
       let s = "`";
       for (const part of node.parts) {
         s += escapeForTemplate(part.text);

--- a/packages/agency-lang/lib/stdlib/llm.test.ts
+++ b/packages/agency-lang/lib/stdlib/llm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { _setLlmOptions, _listHostedModels, _hostedModelInfo } from "./llm.js";
+import { _setLlmOptions, _listHostedModels, _hostedModelInfo, _modelSupportsInput } from "./llm.js";
 import { agencyStore } from "../runtime/asyncContext.js";
 
 // Deterministic smoltalk catalog so the shim's mapping/filtering is tested
@@ -19,6 +19,18 @@ vi.mock("smoltalk", () => ({
   getModel: (name: string) => FIXTURE_MODELS.find((model) => model.modelName === name),
   refreshModels: vi.fn(),
   registerModelData: vi.fn(),
+  // Fixture modality data. Deliberately answers for ANY modality string so
+  // the bridge's image/pdf safelist is what the safelist test exercises —
+  // if the safelist were removed, "audio" would return true, not null.
+  modelSupportsInputModality: (name: string, _modality: string) => {
+    if (name === "fixture-vision") {
+      return true;
+    }
+    if (name === "fixture-text") {
+      return false;
+    }
+    return undefined;
+  },
 }));
 
 // _setLlmOptions writes the ACTIVE stack's `other.llmDefaults`. A bare
@@ -96,5 +108,34 @@ describe("hosted catalog accessor (over a fixture)", () => {
     // Non-text name → null (the `&& model.type === "text"` guard). Drop the
     // guard and this returns a malformed HostedModelInfo instead of null:
     expect(_hostedModelInfo("fixture-embed")).toBeNull();
+  });
+});
+
+describe("_modelSupportsInput", () => {
+  // Real-catalog values (gpt-4o image/pdf true, gpt-3.5-turbo image/pdf
+  // false) are pinned by the agent modalityFilter execution tests, which go
+  // through the unmocked catalog; here the smoltalk mock isolates the
+  // bridge's safelist + null-coercion semantics.
+  it("passes through true for a vision model", () => {
+    expect(_modelSupportsInput("fixture-vision", "image")).toBe(true);
+  });
+
+  it("passes through false for a text-only model", () => {
+    expect(_modelSupportsInput("fixture-text", "image")).toBe(false);
+  });
+
+  it("passes the pdf modality through", () => {
+    expect(_modelSupportsInput("fixture-vision", "pdf")).toBe(true);
+    expect(_modelSupportsInput("fixture-text", "pdf")).toBe(false);
+  });
+
+  it("returns null for an unknown model", () => {
+    expect(_modelSupportsInput("no-such-model-xyz", "image")).toBe(null);
+  });
+
+  it("returns null for a modality outside the image/pdf safelist", () => {
+    // The mock would answer true for fixture-vision with ANY modality, so
+    // this only passes if the bridge's safelist short-circuits first.
+    expect(_modelSupportsInput("fixture-vision", "audio")).toBe(null);
   });
 });

--- a/packages/agency-lang/lib/stdlib/llm.ts
+++ b/packages/agency-lang/lib/stdlib/llm.ts
@@ -10,6 +10,7 @@ import {
   getRegisteredModelData,
   mergeModelData,
   mergeHostedTools,
+  modelSupportsInputModality,
 } from "smoltalk";
 
 /**
@@ -108,6 +109,17 @@ export function _listHostedModels(): HostedModelInfo[] {
 export function _hostedModelInfo(name: string): HostedModelInfo | null {
   const model = getModel(name as any);
   return model && model.type === "text" ? toHostedInfo(model) : null;
+}
+
+/** Tri-state modality probe backing `std::llm.modelSupportsInput`. Returns
+ *  null (not undefined — Agency has no undefined) when the model is unknown
+ *  or carries no modality data; that matches smoltalk's send-time gate,
+ *  which only blocks on an explicit false. */
+export function _modelSupportsInput(model: string, modality: string): boolean | null {
+  if (modality !== "image" && modality !== "pdf") {
+    return null;
+  }
+  return modelSupportsInputModality(model, modality) ?? null;
 }
 
 /** Fetch the latest model-data blob and return it pre-serialized. No

--- a/packages/agency-lang/lib/stdlib/mediaPathScan.test.ts
+++ b/packages/agency-lang/lib/stdlib/mediaPathScan.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import * as os from "os";
+import { _scanMediaPaths } from "./mediaPathScan.js";
+
+function paths(msg: string): string[] {
+  return _scanMediaPaths(msg).map((candidate) => candidate.path);
+}
+
+describe("_scanMediaPaths", () => {
+  it("finds a plain path token with its MIME type", () => {
+    expect(_scanMediaPaths("look at /tmp/pic.png please")).toEqual([
+      { path: "/tmp/pic.png", mime: "image/png" },
+    ]);
+  });
+
+  it("returns [] for text-only messages (cheap bail-out)", () => {
+    expect(_scanMediaPaths("please draw me a diagram")).toEqual([]);
+    expect(_scanMediaPaths("")).toEqual([]);
+  });
+
+  it("an apostrophe in prose does not defeat detection", () => {
+    // Regression (PR #395 review, finding 1): a stateful quote scanner
+    // treated the apostrophe in "here's" as opening a quote and swallowed
+    // the rest of the message into one garbage token.
+    expect(paths("here's /tmp/pic.png")).toEqual(["/tmp/pic.png"]);
+    expect(paths("it's Bob's file /tmp/pic.png ok")).toEqual(["/tmp/pic.png"]);
+  });
+
+  it("an apostrophe in prose does not defeat a LATER quoted path", () => {
+    expect(paths("here's '/tmp/my pic.png'")).toEqual(["/tmp/my pic.png"]);
+  });
+
+  it("lifts single- and double-quoted paths with spaces", () => {
+    expect(paths("see '/tmp/da b.png' now")).toEqual(["/tmp/da b.png"]);
+    expect(paths('see "/tmp/da b.png" now')).toEqual(["/tmp/da b.png"]);
+  });
+
+  it("ignores quoted spans that are not media paths", () => {
+    expect(paths("he said 'hello there' about /tmp/pic.png")).toEqual(["/tmp/pic.png"]);
+  });
+
+  it("a quote glued to a word does not open a span", () => {
+    expect(paths("dogs' /tmp/a.png cats' /tmp/b.png")).toEqual(["/tmp/a.png", "/tmp/b.png"]);
+  });
+
+  it("unescapes backslash-escaped spaces in unquoted tokens", () => {
+    expect(paths("see /tmp/da\\ b.png now")).toEqual(["/tmp/da b.png"]);
+  });
+
+  it("trims trailing punctuation and stray quotes", () => {
+    expect(paths("is it /tmp/pic.png?")).toEqual(["/tmp/pic.png"]);
+    expect(paths("check /tmp/pic.png, then /tmp/doc.pdf.")).toEqual([
+      "/tmp/pic.png",
+      "/tmp/doc.pdf",
+    ]);
+  });
+
+  it("expands a leading tilde via expandPath", () => {
+    expect(paths("see ~/pic.png")).toEqual([`${os.homedir()}/pic.png`]);
+  });
+
+  it("leaves ~user paths alone instead of throwing", () => {
+    // expandPath throws on `~user/...`; a media mention must never crash
+    // detection. The token passes through and dies at the stat gate.
+    expect(paths("see ~bob/pic.png")).toEqual(["~bob/pic.png"]);
+  });
+
+  it("preserves message order across quoted and unquoted mentions", () => {
+    expect(paths("/tmp/a.png then '/tmp/b b.pdf' then /tmp/c.gif")).toEqual([
+      "/tmp/a.png",
+      "/tmp/b b.pdf",
+      "/tmp/c.gif",
+    ]);
+  });
+
+  it("matches extensions case-insensitively and maps all six", () => {
+    expect(_scanMediaPaths("a.PNG b.jpg c.jpeg d.gif e.webp f.pdf").map((c) => c.mime)).toEqual([
+      "image/png",
+      "image/jpeg",
+      "image/jpeg",
+      "image/gif",
+      "image/webp",
+      "application/pdf",
+    ]);
+  });
+
+  it("ignores non-media extensions", () => {
+    expect(paths("read /tmp/notes.md and /tmp/code.ts")).toEqual([]);
+  });
+
+  it("does not treat a mid-word dot-ext substring as a path", () => {
+    // "x.pngs" has no media extension per extname; the hint regex lets it
+    // into tokenization but the candidate gate drops it.
+    expect(paths("weird x.pngs token")).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/mediaPathScan.ts
+++ b/packages/agency-lang/lib/stdlib/mediaPathScan.ts
@@ -1,0 +1,108 @@
+import * as path from "path";
+import { expandPath } from "./expandPath.js";
+
+/**
+ * Media-path scanner backing the agent's `detectAttachments`
+ * (`lib/agents/agency-agent/lib/attachments.agency`). Pure string work —
+ * no filesystem access — so the Agency side keeps only the stateful
+ * stages (agent-cwd resolution, dedupe, stat, read).
+ *
+ * Lives in TS rather than Agency for speed: detection runs on EVERY user
+ * message, and an Agency per-character loop pays the Runner step
+ * machinery per iteration. This is one JS pass.
+ *
+ * Not a tarsec grammar on purpose: this is span-extraction from
+ * arbitrary prose, not a structured parse. Quote handling needs boundary
+ * + content guards (an apostrophe in "here's" must not open a quote; a
+ * quoted span only counts when it is its own whitespace-delimited token
+ * AND its content ends in a media extension), which is regex-with-
+ * anchors territory — a combinator version would be a hand-rolled
+ * backtracking scanner wearing tarsec types.
+ */
+
+export type MediaPathCandidate = { path: string; mime: string };
+
+/** extension (lowercase, with dot) -> MIME type. Media-only by design:
+ *  code/text paths stay with the agent's read tool. */
+const MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".pdf": "application/pdf",
+};
+
+/** Cheap bail-out probe so text-only messages (the overwhelming majority)
+ *  cost one regex test, not a tokenize pass. */
+const MEDIA_EXT_HINT = /\.(png|jpe?g|gif|webp|pdf)/i;
+
+/** A quoted span is only a token when the quote opens at a token boundary
+ *  (start-of-string or after whitespace — terminal drag-drop inserts
+ *  `'path'` as its own token), the closing quote is followed by a
+ *  boundary, and the content ends in a media extension. Anything else
+ *  (apostrophes in prose, quoted non-media text) falls through to plain
+ *  word tokenization. Content excludes quotes and newlines. */
+const QUOTED_MEDIA_SPAN =
+  /(?:^|(?<=\s))(['"])([^'"\n]+?\.(?:png|jpe?g|gif|webp|pdf))\1(?=\s|$)/gi;
+
+/** Sentinel standing in for a backslash-escaped space inside an unquoted token
+ *  (`my\ file.png`) so it survives whitespace splitting; NUL cannot
+ *  appear in terminal line input. */
+const ESCAPED_SPACE = "\u0000";
+
+function pushWords(segment: string, out: string[]): void {
+  const words = segment.replace(/\\ /g, ESCAPED_SPACE).split(/\s+/);
+  for (const word of words) {
+    if (word !== "") {
+      out.push(word.split(ESCAPED_SPACE).join(" "));
+    }
+  }
+}
+
+/** Trim trailing punctuation typed right after a path (`, . ? :` plus a
+ *  stray quote from a partially-recognized quoted span), then expand a
+ *  leading tilde. `expandPath` is the stdlib's single owner of path-
+ *  shorthand policy; it throws on `~user/...`, which is not a media
+ *  mention worth failing detection over — leave those tokens as-is (the
+ *  Agency side drops them at the stat gate). */
+function normalizeToken(token: string): string {
+  let normalized = token;
+  while (normalized.length > 0 && /[,.?:'"]$/.test(normalized)) {
+    normalized = normalized.slice(0, normalized.length - 1);
+  }
+  if (normalized === "~" || normalized.startsWith("~/")) {
+    normalized = expandPath(normalized);
+  }
+  return normalized;
+}
+
+/** Scan a user message for media-file mentions (drag-dropped quoted
+ *  paths, escaped-space paths, plain path tokens) and return them in
+ *  message order as `{ path, mime }` candidates. Purely lexical: paths
+ *  are NOT resolved or checked for existence here. */
+export function _scanMediaPaths(msg: string): MediaPathCandidate[] {
+  if (!MEDIA_EXT_HINT.test(msg)) {
+    return [];
+  }
+  // Single ordered pass: quoted media spans are lifted out whole; the
+  // gaps between them tokenize as words.
+  const tokens: string[] = [];
+  let last = 0;
+  for (const match of msg.matchAll(QUOTED_MEDIA_SPAN)) {
+    pushWords(msg.slice(last, match.index), tokens);
+    tokens.push(match[2]);
+    last = match.index + match[0].length;
+  }
+  pushWords(msg.slice(last), tokens);
+
+  const candidates: MediaPathCandidate[] = [];
+  for (const token of tokens) {
+    const normalized = normalizeToken(token);
+    const mime = MIME_TYPES[path.extname(normalized).toLowerCase()];
+    if (mime !== undefined) {
+      candidates.push({ path: normalized, mime });
+    }
+  }
+  return candidates;
+}

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -500,10 +500,13 @@ export async function _stat(
   filename: string,
   dir: string = "",
   allowedPaths?: string[],
+  followSymlinks: boolean = false,
 ): Promise<StatInfo> {
   const full = await resolveProbePath(dir, filename, allowedPaths ?? []);
   try {
-    const st = await fs.lstat(full);
+    // With followSymlinks, fs.stat reports the TARGET's type and size
+    // (a broken link throws → "missing", same as a nonexistent path).
+    const st = followSymlinks ? await fs.stat(full) : await fs.lstat(full);
     let type: StatInfo["type"] = "other";
     if (st.isSymbolicLink()) type = "symlink";
     else if (st.isDirectory()) type = "dir";

--- a/packages/agency-lang/lib/stdlib/threads.test.ts
+++ b/packages/agency-lang/lib/stdlib/threads.test.ts
@@ -23,7 +23,7 @@ import { RuntimeContext } from "../runtime/state/context.js";
 import { ThreadStore } from "../runtime/state/threadStore.js";
 import { MessageThread } from "../runtime/state/messageThread.js";
 import { runPrompt } from "../runtime/prompt.js";
-import { _eagerSummarizeIfNeeded } from "./threads.js";
+import { _eagerSummarizeIfNeeded, _contentToString } from "./threads.js";
 
 function makeCtx(): RuntimeContext<any> {
   return new RuntimeContext({
@@ -236,5 +236,51 @@ describe("_eagerSummarizeIfNeeded", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(threads.threads["custom-id"].summary).toBe("spy-summary");
+  });
+});
+
+describe("_contentToString", () => {
+  it("passes plain strings through", () => {
+    expect(_contentToString("hello")).toBe("hello");
+  });
+
+  it("renders text parts and attachment placeholders", () => {
+    const content = [
+      { type: "text", text: "look at this" },
+      { type: "image", source: { kind: "base64", base64: "AAAA", mimeType: "image/png" } },
+      { type: "file", filename: "report.pdf", source: { kind: "base64", base64: "BBBB", mimeType: "application/pdf" } },
+    ];
+    expect(_contentToString(content as any)).toBe(
+      "look at this [image attachment] [file attachment: report.pdf]",
+    );
+  });
+
+  it("never leaks base64 payloads into the transcript", () => {
+    const content = [
+      { type: "image", source: { kind: "base64", base64: "SECRETPAYLOAD", mimeType: "image/png" } },
+    ];
+    expect(_contentToString(content as any)).not.toContain("SECRETPAYLOAD");
+  });
+
+  it("handles null content and empty part arrays", () => {
+    expect(_contentToString(null as any)).toBe("");
+    expect(_contentToString([] as any)).toBe("");
+  });
+
+  it("renders a file part without filename generically", () => {
+    const content = [{ type: "file", source: { kind: "base64", base64: "CCCC", mimeType: "application/pdf" } }];
+    expect(_contentToString(content as any)).toBe("[file attachment]");
+  });
+
+  it("renders a text part with a missing text field as empty", () => {
+    expect(_contentToString([{ type: "text" }] as any)).toBe("");
+  });
+
+  it("falls back to JSON for unknown part types", () => {
+    expect(_contentToString([{ type: "mystery", x: 1 }] as any)).toBe('{"type":"mystery","x":1}');
+  });
+
+  it("keeps JSON fallback for unknown non-string content", () => {
+    expect(_contentToString({ weird: true } as any)).toBe('{"weird":true}');
   });
 });

--- a/packages/agency-lang/lib/stdlib/threads.test.ts
+++ b/packages/agency-lang/lib/stdlib/threads.test.ts
@@ -276,8 +276,18 @@ describe("_contentToString", () => {
     expect(_contentToString([{ type: "text" }] as any)).toBe("");
   });
 
-  it("falls back to JSON for unknown part types", () => {
+  it("falls back to JSON for unknown payload-free part types", () => {
     expect(_contentToString([{ type: "mystery", x: 1 }] as any)).toBe('{"type":"mystery","x":1}');
+  });
+
+  it("renders unknown source-carrying parts as placeholders (never dumps payloads)", () => {
+    // A future smoltalk part kind (e.g. audio/video) must not regress
+    // into base64-in-the-summarizer via the JSON fallback.
+    const content = [
+      { type: "video", source: { kind: "base64", base64: "FUTUREPAYLOAD", mimeType: "video/mp4" } },
+    ];
+    expect(_contentToString(content as any)).toBe("[video attachment]");
+    expect(_contentToString(content as any)).not.toContain("FUTUREPAYLOAD");
   });
 
   it("keeps JSON fallback for unknown non-string content", () => {

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -30,16 +30,42 @@ import { registerGlobalHook } from "../runtime/hooks.js";
 import { MessageThread } from "../runtime/state/messageThread.js";
 import { createLogger } from "../logger.js";
 
-/** Coerce a `smoltalk` message's `content` to a flat string. Non-string
- *  content (tool-call / structured) is JSON-stringified; nullish
- *  content (common on tool-call assistant messages where the LLM
- *  emitted tool calls but no text) maps to `""` instead of the literal
- *  JSON-encoded `'""'`. Shared by `_getThread` (the Agency-facing
- *  reader) and `_buildSummaryTranscript` (the eager summarizer
- *  prompt) so both surfaces agree on the same coercion rule. */
-function _contentToString(content: smoltalk.MessageJSON["content"]): string {
-  if (typeof content === "string") return content;
-  if (content == null) return "";
+/** Coerce a `smoltalk` message's `content` to a flat string. Multimodal
+ *  part arrays render text parts verbatim and attachment parts as
+ *  placeholders ("[image attachment]" / "[file attachment: name]") so
+ *  base64 payloads never reach the summarizer prompt or the Agency
+ *  thread reader. Other non-string content (tool-call / structured) is
+ *  JSON-stringified; nullish content (common on tool-call assistant
+ *  messages where the LLM emitted tool calls but no text) maps to `""`
+ *  instead of the literal JSON-encoded `'""'`. Shared by `_getThread`
+ *  (the Agency-facing reader) and `_buildSummaryTranscript` (the eager
+ *  summarizer prompt) so both surfaces agree on the same coercion
+ *  rule. Exported for tests. */
+export function _contentToString(content: smoltalk.MessageJSON["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (content == null) {
+    return "";
+  }
+  if (Array.isArray(content)) {
+    const rendered = content.map((part) => {
+      if (part && typeof part === "object" && "type" in part) {
+        const typedPart = part as { type?: string; text?: unknown; filename?: string };
+        if (typedPart.type === "text") {
+          return String(typedPart.text ?? "");
+        }
+        if (typedPart.type === "image") {
+          return "[image attachment]";
+        }
+        if (typedPart.type === "file") {
+          return typedPart.filename ? `[file attachment: ${typedPart.filename}]` : "[file attachment]";
+        }
+      }
+      return JSON.stringify(part);
+    });
+    return rendered.join(" ");
+  }
   return JSON.stringify(content);
 }
 

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -61,6 +61,13 @@ export function _contentToString(content: smoltalk.MessageJSON["content"]): stri
         if (typedPart.type === "file") {
           return typedPart.filename ? `[file attachment: ${typedPart.filename}]` : "[file attachment]";
         }
+        // Defense in depth: a part kind this function doesn't know yet
+        // (a future smoltalk modality) but that carries a `source` field
+        // is payload-bearing — JSON.stringify would dump its base64 into
+        // the summarizer prompt, the exact leak this function prevents.
+        if ("source" in part) {
+          return `[${typedPart.type} attachment]`;
+        }
       }
       return JSON.stringify(part);
     });

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -4,6 +4,7 @@ import {
   _listHostedModels,
   _hostedModelInfo,
   _loadModelData,
+  _modelSupportsInput,
 } from "agency-lang/stdlib-lib/llm.js"
 import { env } from "std::system"
 
@@ -148,6 +149,19 @@ export def hostedModelInfo(name: string): HostedModelInfo | null {
   @param name - The hosted model name (e.g. "gpt-4o-mini")
   """
   return _hostedModelInfo(name)
+}
+
+export safe def modelSupportsInput(model: string, modality: string): boolean | null {
+  """
+  Whether a model accepts a given input modality ("image" or "pdf").
+  Tri-state: true / false when the model catalog says so, null when the
+  model or its modality data is unknown. Treat null as "do not gate" —
+  that is the same rule llm() applies at send time.
+
+  @param model - The model name (e.g. "gpt-4o-mini")
+  @param modality - "image" or "pdf"
+  """
+  return _modelSupportsInput(model, modality)
 }
 
 // Accumulation details (kept out of the docstring, which is also the LLM tool

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -242,6 +242,7 @@ export safe def stat(
   dir: string = "",
   allowedPaths: string[] = [],
   useAgentCwd: boolean = false,
+  followSymlinks: boolean = false,
 ): StatInfo {
   """
   Return metadata about a filesystem entry: whether it exists, its type ("file", "dir", "symlink", "other", or "missing" if absent), size in bytes, and mtime in ms. Set allowedPaths to restrict which paths may be stat-ed.
@@ -252,11 +253,12 @@ export safe def stat(
   @param dir - Optional directory to resolve `filename` against (default: process cwd, absolute paths allowed)
   @param allowedPaths - Only allow paths under these prefixes
   @param useAgentCwd - When true, resolve a relative filename against the agent working directory (see setAgentCwd) if one is set. Absolute filenames are unaffected. Defaults to false.
+  @param followSymlinks - When true, report the symlink TARGET's type and size (a broken link reports "missing"). Defaults to false: the link itself is reported with type "symlink".
   """
   if (useAgentCwd && !isAbsolute(filename)) {
     dir = applyAgentCwd(dir)
   }
-  return _stat(filename, dir, allowedPaths)
+  return _stat(filename, dir, allowedPaths, followSymlinks)
 }
 
 export safe def exists(

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, read, write, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, read, write, writeBinary, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -164,6 +164,7 @@ __registerTool(sleep);
 __registerTool(round);
 __registerTool(read);
 __registerTool(write);
+__registerTool(writeBinary);
 __registerTool(readBinary);
 __registerTool(notify);
 __registerTool(range);
@@ -461,7 +462,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, read, write, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, read, write, writeBinary, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -164,6 +164,7 @@ __registerTool(sleep);
 __registerTool(round);
 __registerTool(read);
 __registerTool(write);
+__registerTool(writeBinary);
 __registerTool(readBinary);
 __registerTool(notify);
 __registerTool(range);
@@ -301,7 +302,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, read, write, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, read, write, writeBinary, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -164,6 +164,7 @@ __registerTool(sleep);
 __registerTool(round);
 __registerTool(read);
 __registerTool(write);
+__registerTool(writeBinary);
 __registerTool(readBinary);
 __registerTool(notify);
 __registerTool(range);
@@ -332,7 +333,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, read, write, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, read, write, writeBinary, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -164,6 +164,7 @@ __registerTool(sleep);
 __registerTool(round);
 __registerTool(read);
 __registerTool(write);
+__registerTool(writeBinary);
 __registerTool(readBinary);
 __registerTool(notify);
 __registerTool(range);
@@ -288,7 +289,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, read, write, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, read, write, writeBinary, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -164,6 +164,7 @@ __registerTool(sleep);
 __registerTool(round);
 __registerTool(read);
 __registerTool(write);
+__registerTool(writeBinary);
 __registerTool(readBinary);
 __registerTool(notify);
 __registerTool(range);
@@ -603,7 +604,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, read, write, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, read, write, writeBinary, readBinary, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -164,6 +164,7 @@ __registerTool(sleep);
 __registerTool(round);
 __registerTool(read);
 __registerTool(write);
+__registerTool(writeBinary);
 __registerTool(readBinary);
 __registerTool(notify);
 __registerTool(range);
@@ -289,7 +290,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -276,7 +276,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -582,7 +582,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -287,7 +287,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -327,7 +327,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -276,7 +276,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -454,7 +454,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -287,7 +287,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -456,7 +456,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -437,7 +437,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -421,7 +421,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -273,7 +273,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -470,7 +470,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -492,7 +492,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -291,7 +291,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -450,7 +450,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -279,7 +279,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -294,7 +294,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -278,7 +278,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -470,7 +470,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -605,7 +605,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -280,7 +280,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -492,7 +492,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -572,7 +572,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -297,7 +297,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -492,7 +492,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -330,7 +330,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -1238,7 +1238,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -545,7 +545,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -730,7 +730,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -449,7 +449,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -357,7 +357,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -364,7 +364,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -434,7 +434,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -470,7 +470,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -480,7 +480,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -304,7 +304,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -290,7 +290,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -326,7 +326,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -318,7 +318,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -505,7 +505,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -494,7 +494,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -482,7 +482,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -287,7 +287,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -290,7 +290,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -768,7 +768,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -296,7 +296,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -263,7 +263,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -288,7 +288,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -278,7 +278,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -700,7 +700,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -294,7 +294,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -287,7 +287,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -280,7 +280,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -265,7 +265,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -434,7 +434,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -280,7 +280,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -256,7 +256,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -735,7 +735,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -324,7 +324,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -292,7 +292,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -322,7 +322,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -294,7 +294,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -292,7 +292,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -281,7 +281,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -296,7 +296,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -296,7 +296,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -439,7 +439,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -292,7 +292,8 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     reportUnhandledInterrupts(__result)
   } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(`
+Agent crashed: ${__error.message}`)
     throw __error
   }
 }


### PR DESCRIPTION
## Summary

Wires the merged multimodal capability into the built-in agent, per the spec (`docs/superpowers/specs/2026-07-02-agent-images-and-attachments-design.md`, included in this PR with its plan and plan-review):

1. **`generateImageFile` coordinator tool** — generates (or, with input paths in `images`, edits) an image via `std::image` and saves it to disk through the `writeBinary` interrupt gate, resolving paths against the agent cwd. Returns the saved path — never base64 — and a failure message when generation or the write fails (never a false success).
2. **Auto-attached user files** — `agentReplyVia` detects image/PDF paths in the user's message (drag-drop quoting, escaped spaces, `~/`, trailing punctuation), inlines the bytes as base64 attachments, and passes a multimodal array to `mainAgent` (widened to `string | (string | Attachment)[]`). Every attach/skip prints a visible `📎` line. Direct-to-subagent routes stay text-only by design, pinned by a test.

Supporting changes:

- **`std::llm.modelSupportsInput(model, "image" | "pdf")`** — tri-state probe over the same smoltalk predicate the send-time modality gate uses; the wiring drops attachments only on an explicit catalog `false` (unknown models attach optimistically, matching the send gate).
- **Thread transcripts render attachment placeholders** — `_contentToString` (backs the summarizer transcript and `getThread`) used to `JSON.stringify` multimodal content, which would dump base64 into the summarize prompt; parts now render as `[image attachment]` / `[file attachment: name]`.
- **Compiler fix: raw backslashes in emitted template literals** — the parser fully unescapes string literals (`"\\"` → one backslash char) but the template printer passed part text through raw, so a lone backslash corrupted the generated code. The printer now escapes backslashes; fixtures regenerated (68 files change by one banner line each).

## Design decisions (from the spec)

- Attachments are **inlined as base64 at attach time**, not stored as paths: smoltalk re-resolves path sources on every send of the persistent `session: "main"` thread, so a later-deleted file would poison every subsequent turn, an edited file would silently rewrite history, and the read would bypass the `std::readBinary` policy gate.
- Over-limit files (> 20 MB, smoltalk's cap) are **skipped at detection with a visible reason** — reaching the send-time gate would fail the user's whole turn.
- Text-only turns keep passing a bare string to `llm()` so the stored thread shape (and serialized sessions/fixtures) is unchanged for the 99% path.

## Testing

- 22 execution tests for `detectAttachments`/`modalityFilter` (quoting, escapes, tilde, dedupe, cap, size-skip, all six MIME extensions, case-insensitivity, order preservation, directory/nonexistent/code-path rejection, modality drops for image AND pdf).
- 6 execution tests for `generateImageFile` (agent-cwd vs process-cwd negative assertion, absolute paths, write-failure reporting, edit-input resolution, cost accrual).
- 4 turn-integration tests via the `agentTurn` harness (multimodal array reaches the thread — asserted through the new placeholder rendering — plain-string turns unchanged, modality skip end-to-end, subagent route text-only).
- 8 unit tests for `_contentToString`, 5 for `_modelSupportsInput`, 3 new printer tests for the backslash fix.
- Full local verification: `lint:structure` clean, full agent suite 120/120, full vitest unit suite 6858 passed — the 19 failures present are all pre-existing on main at e4ab093b (effect-declaration tests; verified by running them on the untouched main checkout).

Known coverage gaps are named in the plan (generation-failure branch not exercisable with the always-succeeding deterministic image client; `📎` print lines have no capture surface; read-failure skip branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Behavior note: string-escape semantics in generated code (post-review)

The backslash printer fix changes what escape sequences inside `"""` multiline strings render to at runtime. The new behavior matches the documented semantics (`basic-syntax.md`: `"""` strings do not interpret backslash escapes) — previously the raw pass-through let the emitted JS template literal interpret them. Any user program that relied on the old accidental interpretation (e.g. `\"` in a `"""` string arriving as `"`) will see its output change on upgrade; the two in-repo prompts written against the old behavior (`judgePairwise.agency`, the code agent's markdown guidance) are updated in this PR.

## Review follow-ups applied

All 8 confirmed/plausible findings + the 4 minors from review: media-path scanning moved to a single-pass TS scanner (`lib/stdlib/mediaPathScan.ts`) with boundary-gated quote handling (apostrophes in prose can no longer defeat detection), `std::shell.stat` gained `followSymlinks` (symlinked media now attaches), cap overflow gets a visible `📎 skipped` entry, CR is escaped in emitted templates, URL/data-URI edit inputs pass through unresolved, unknown source-carrying thread parts render as placeholders instead of JSON, `modalityFilter` early-returns on text-only turns, and `DetectedContent` dropped its redundant `text` field.
