### PR TITLE
Match-aware definite-return checking + while(true) divergence

### DIFF
--- a/packages/agency-lang/docs/dev/typechecker/definite-returns-remaining-work.md
+++ b/packages/agency-lang/docs/dev/typechecker/definite-returns-remaining-work.md
@@ -1,0 +1,91 @@
+# Definite-return checking — remaining work
+
+Status of the feature shipped in **PR #386** (safe subset) and extended by the
+match-aware follow-up branch (`match-aware-definite-returns`). Read alongside
+the type-checker dev docs:
+
+- [`docs/dev/typechecker/README.md`](./README.md) — bidirectional checking, the pass pipeline, `synthType`.
+- [`docs/dev/typechecker/narrowing/README.md`](./narrowing/README.md) — flow-sensitive narrowing, the flow graph, `exit` nodes, `match` exhaustiveness.
+- Config knobs: [`docs/misc/config.md`](../../misc/config.md) (`typechecker.definiteReturns`).
+
+---
+
+## 1. What shipped
+
+**Rule:** a function that declares a non-void return type must `return` a value on every control-flow path (Agency has no implicit returns), else `Not all code paths return a value in 'f'.`
+
+**How it works — the flow graph already computes this.** `buildFlowGraph(body, start, env)` returns the flow node *at the end of a body*; that node is `{ kind: "exit" }` iff every path diverges (a `return` produces `exit`; `if`/`else` collapses to `exit` when both branches return, via `mergeFlows`). See:
+
+- `lib/typeChecker/flow.ts` — the `{ kind: "exit" }` flow-node variant.
+- `lib/typeChecker/flow.ts` — `mergeFlows(flows)`: drops `exit` inputs; returns `exit` iff **all** inputs are `exit`.
+- `lib/typeChecker/flowBuilder.ts` — `returnStatement` rule returns `{ kind: "exit" }`; `ifElse` merges then/else via `mergeFlows`; `buildFlowGraphs` records each scope's terminal into `FlowEnvironment.scopeTerminals` (null-prototype dict).
+- `lib/typeChecker/definiteReturns.ts` — `checkDefiniteReturns(scopes, ctx)`: `requiresReturn(rt)` exempts absent/`null`, `void`, `never` return types; the loop skips `top-level` and nodes (`ctx.nodeDefs[info.name]`, bare-keyed); flags when `scopeTerminals[scopeKey].kind !== "exit"`.
+- `lib/config.ts` — `typechecker.definiteReturns: "silent" | "warn" | "error"`. **Ships at `"warn"`** (default read-site is `?? "warn"` in `definiteReturns.ts`).
+- Registered in the pipeline immediately after `checkMatchExhaustiveness` (`index.ts`).
+- Tests: `lib/typeChecker/definiteReturns.test.ts`.
+
+**Match-aware (this branch):** match-containing functions are fully checked — the #386 `containsMatch` safe-subset skip is gone (§2 below). **`while (true)` divergence (was §5b):** the flow builder's `whileLoop` rule yields `{ kind: "exit" }` for a literal-`true` loop with no reachable `break` (`hasReachableBreak` — break binds to the nearest loop; nested loops/definitions are excluded, everything else conservatively counts). Post-infinite-loop statements are dead code to all flow consumers.
+
+**Measured clean:** #386 scanned 841 execution-test `.agency` programs at `error` level — 0 hits. The match-aware branch re-scanned **855** programs (the base plus the match-expression suite added by `7eefd7c1`) at `error` — **0 hits, 0 crashes**, and the full unit suite is at parity with base `main`.
+
+---
+
+## 2. HISTORY: the match problem, and how it dissolved
+
+**The original problem (#386).** Whether a `match`-ending function returned on every path depended on match **exhaustiveness** (`match (r) { success(v) => return v  failure(e) => return 0 }` over a Result: total; `match (x) { 1 => return 1  2 => return 2 }` over a number: not), which lives in `checkMatchExhaustiveness`, not the flow graph — and a `_`-less match lowered to an if-chain whose tail had no `else`, so even an exhaustive match looked like a fall-through. #386 therefore **skipped** any match-containing function (`containsMatch`), and this doc's earlier revision designed a follow-up around a reachability walk + a tri-state exhaustiveness oracle + per-arm `bodyReturns` metadata.
+
+**The redesign that made all of that unnecessary.** Match expressions (`7eefd7c1`, design spec `docs/superpowers/specs/2026-07-01-match-expressions-design.md`) changed `return` semantics: **`return` inside a match arm yields to the match, never returns from the enclosing function.** Concretely:
+
+- A `return` in a **statement-position** arm is a **compile error** (fixit: hoist to `return match(...)`). Statement matches are effect-only, so they can never make the function return — the flow graph threading through them without `exit` is now *exact*, not conservative.
+- An **expression-position** arm's `return` lowers to a `matchYield` node (`lib/lowering/patternLowering.ts`) — passThrough to the flow builder, so it can never fake a function `exit`. All-paths-yield and expression-position exhaustiveness are enforced by the lowering and exhaustiveness passes themselves.
+- `return match(...)` lowers to the match region **plus a real trailing `returnStatement`** — a genuine `exit`.
+- `const x = match(...)` lowers to the region plus a plain (tagged) assignment — a genuine non-exit.
+
+So the flow terminal is exact for every match shape, and the entire follow-up collapsed to *deleting `containsMatch`*. No exhaustiveness oracle, no walk, no lowering metadata. The old false-positive driver (the idiomatic Result match with arm returns as a function tail) is now a compile error whose fix is precisely the form the checker handles correctly.
+
+**Known degenerate limitation (recorded, not worth engineering around):** a statement match whose every arm ends in `while (true)` is still flagged — the `matchBlock` flow rule discards arm end-flows, so arm-internal divergence never reaches the terminal.
+
+---
+
+## 3. Flip the default `warn` → `error`
+
+Same trajectory as `matchExhaustiveness` (flipped in PR #383) and now the main remaining item. The match-aware branch's sweep is the fresh measurement: **855 execution-test programs at `error` = 0 hits**, so the blast radius is currently zero.
+
+- Change the default read-site in `definiteReturns.ts` from `?? "warn"` to `?? "error"`, and update the docstring + `docs/misc/config.md`.
+- Re-measure first anyway (the discipline used for #383/#366): full typeChecker suite, fixture integration test, and the `discoverAgencyFiles` sweep over `tests/agency`, `tests/agency-js`, `tests/integration` at `error`.
+- Fix any genuine offenders (missing returns) rather than weakening the check.
+- Let match-aware checking bake at `warn` for a while first — it newly covers every match-containing function.
+
+---
+
+## 4. Edge-case refinement: trailing `raise` (documented limitation)
+
+`def f(): number { raise e::x("m", {}) }` is flagged, because `raise`/`interrupt` are `passThrough` (non-diverging) in the flow builder, matching the `alwaysExits` convention ("a raise may resume"). Sound but noisy. To refine: treat a `raise` as diverging when it can be *proven* not to resume (no handler up the static chain resumes it). The interrupt-effects analysis already computes per-function effect sets and the handler call-graph — see `lib/typeChecker/interruptAnalysis.ts` (`analyzeInterruptsFromScopes`, `buildInterruptCallGraph`) and `docs/dev/interrupts.md`. This is a bigger analysis; only worth it if the trailing-raise false positive proves common. It matters more once the default flips to `error` (§3).
+
+(The other refinement listed here previously — infinite loops — shipped with the match-aware branch; see §1.)
+
+---
+
+## 5. Adjacent: dead-code / unreachable-statement detection
+
+The flow builder already knows a statement is unreachable — `buildFlowGraph` short-circuits when the running flow is `exit`, which now also covers code after a provably-infinite loop. Surfacing that as a warning (`code after return/infinite-loop is unreachable`) is a cheap, high-signal addition reusing the exact `exit`-node reasoning. It is a *separate* diagnostic, not part of definite-return, but it lives in the same conceptual space.
+
+---
+
+## 6. Test + gotcha reference
+
+- Tests: `lib/typeChecker/definiteReturns.test.ts`. Harness note: `typecheckSource` (in `testUtils.ts`) hardcodes empty config, so the config-knob tests use a local `check(src, config)` helper that forwards `config` to `typeCheck`. Anchor assertions to the exact message with `^Not all code paths return a value in '`.
+- **Gotchas:**
+  - `return` in a statement-position match arm is a compile error; expression matches are legal only as an assignment RHS or a return operand (v1 grammar restriction).
+  - Type-mismatch and many diagnostics carry **no explicit `severity`** (they render as errors). Assert with `(e.severity ?? "error") === "error"`, never `=== "error"`.
+  - `ctx.nodeDefs` is **bare-name-keyed**, so `ctx.nodeDefs[info.name]` is the correct node-vs-function test. `ScopeInfo` carries `returnType` directly (but `functionDefs[name].loc` IS used for the diagnostic location — the signature, not the first body statement).
+  - Object-literal call args widen (`{ tag: 1 }` → `{ tag: number }`), so they won't match a `tag: 1` discriminated union at a call site. Test function-body behavior via **def-only** programs (bodies are type-checked without a call), not `node main() { f({...}) }`.
+  - Scope keys derive from user-controlled names → `scopeTerminals` is a **null-prototype** dict (`Object.create(null)`), mirroring the flow memo dicts in `flow.ts`.
+
+---
+
+## 7. Suggested order
+
+1. **§3 flip warn → error** — after match-aware checking bakes at `warn`; re-measure first (last sweep: 855 programs, 0 hits).
+2. **§5 dead-code detection** — cheap adjacent win, any time.
+3. **§4 trailing-raise refinement** — only if it proves to be a common false positive.

--- a/packages/agency-lang/docs/misc/config.md
+++ b/packages/agency-lang/docs/misc/config.md
@@ -77,11 +77,15 @@ This lets you prevent specific built-in functions from being generated in the ou
   - **`definiteReturns`** (`"silent" | "warn" | "error"`): What to do when a
     function that declares a non-void return type can reach the end of its body
     without `return`ing a value (Agency has no implicit returns). Default:
-    `"warn"`. Exempt: functions with no return type, or a `void`/`never` return
-    type, and graph nodes. This first release also **skips any function that uses
-    a `match`** — whether a match-ending function returns on every path depends on
-    match exhaustiveness, which will be integrated in a follow-up; until then such
-    functions are never flagged (no false positives).
+    `"warn"`; set `"error"` to make it a compile failure (the same
+    promote-when-baked path `matchExhaustiveness` took). Exempt: functions with
+    no return type, or a `void`/`never` return type, and graph nodes.
+    Match-containing functions are fully checked: since match expressions, an
+    arm cannot return from the enclosing function (a statement-position arm
+    `return` is a compile error; an expression-arm `return` yields to the
+    match), so what matters is the code around the match — use
+    `return match(...)` to return a match's value. `while (true)` with no
+    `break` counts as never falling through.
 
 **Example:**
 ```json

--- a/packages/agency-lang/lib/typeChecker/definiteReturns.test.ts
+++ b/packages/agency-lang/lib/typeChecker/definiteReturns.test.ts
@@ -212,10 +212,10 @@ def g(x: number): number { if (x > 0) { return 2 } }`;
     expect(misses(`def f(x: bool): number { while (x) { return 1 } }`)).toBe(true);
   });
 
-  it("counts a break inside a handle body as reachable", () => {
-    // Pins hasReachableBreak's traversal: walkNodes descends into
-    // handleBlock.body (node.ts walkNodes handleBlock case), so this break is
-    // seen and the loop is escapable → the function can fall through.
+  it("counts a break inside a guarded handle body as reachable", () => {
+    // Pins hasReachableBreak's traversal: the guarded `handle { ... }` body
+    // runs in the loop's frame (break compiles to runner.breakLoop()), so this
+    // break is seen and the loop is escapable → the function can fall through.
     expect(
       misses(`effect e::x { }
 def f(x: bool): number {
@@ -224,6 +224,20 @@ def f(x: bool): number {
   }
 }`),
     ).toBe(true);
+  });
+
+  it("a break inside an inline HANDLER body cannot escape the loop", () => {
+    // Handler bodies codegen as separate arrow functions (insideHandlerBody →
+    // bare `break`, typescriptBuilder.ts processKeyword), so this break can
+    // never reach the enclosing while(true): the loop still diverges.
+    expect(
+      misses(`effect e::x { }
+def f(x: bool): number {
+  while (true) {
+    handle { let y = 1 } with (ev) { if (x) { break } }
+  }
+}`),
+    ).toBe(false);
   });
 
   // --- config knob ---

--- a/packages/agency-lang/lib/typeChecker/definiteReturns.test.ts
+++ b/packages/agency-lang/lib/typeChecker/definiteReturns.test.ts
@@ -195,9 +195,35 @@ def g(x: number): number { if (x > 0) { return 2 } }`;
     expect(drDiags(src).length).toBe(2);
   });
 
-  // --- documented limitations, pinned ---
-  it("LIMITATION: an infinite loop is flagged (flow model has no exit for while(true))", () => {
-    expect(misses(`def f(): number { while (true) { let x = 1 } }`)).toBe(true);
+  // --- while(true) divergence (§5b) ---
+  it("accepts an infinite loop — while(true) with no break never falls through", () => {
+    expect(misses(`def f(): number { while (true) { let x = 1 } }`)).toBe(false);
+  });
+
+  it("flags while(true) containing a reachable break", () => {
+    expect(misses(`def f(x: bool): number { while (true) { if (x) { break } } }`)).toBe(true);
+  });
+
+  it("a break bound to a nested loop does not escape while(true)", () => {
+    expect(misses(`def f(x: bool): number { while (true) { while (x) { break } } }`)).toBe(false);
+  });
+
+  it("flags a non-literal-true loop even if its body returns", () => {
+    expect(misses(`def f(x: bool): number { while (x) { return 1 } }`)).toBe(true);
+  });
+
+  it("counts a break inside a handle body as reachable", () => {
+    // Pins hasReachableBreak's traversal: walkNodes descends into
+    // handleBlock.body (node.ts walkNodes handleBlock case), so this break is
+    // seen and the loop is escapable → the function can fall through.
+    expect(
+      misses(`effect e::x { }
+def f(x: bool): number {
+  while (true) {
+    handle { if (x) { break } } with (e) { let z = 1 }
+  }
+}`),
+    ).toBe(true);
   });
 
   // --- config knob ---

--- a/packages/agency-lang/lib/typeChecker/definiteReturns.test.ts
+++ b/packages/agency-lang/lib/typeChecker/definiteReturns.test.ts
@@ -54,15 +54,14 @@ describe("definite-return checking", () => {
     ).toBe(false);
   });
 
-  // SAFE SUBSET: functions that use a `match` are skipped for now (whether they
-  // return on all paths depends on match exhaustiveness — deferred to a follow-up).
-  it("skips a match-containing function (surviving statement matchBlock)", () => {
-    // Originally this arm-returned on every path; `return` in a statement-
-    // position arm is now a compile error (Task 10), so the nearest equivalent
-    // is a statement match that assigns on every arm. The trailing return is
-    // CONDITIONAL, so the flow graph sees a fall-through path with no return —
-    // only the containsMatch skip (hitting the surviving pure-literal
-    // `matchBlock` node) suppresses the diagnostic.
+  // --- match-aware definite-return (the #386 safe-subset skip is gone) ---
+  // Since match expressions (7eefd7c1), `return` in a statement-position arm is
+  // a compile error and expression-arm returns are matchYield unwinds, so a
+  // match can never itself return from the function. The flow terminal is
+  // therefore exact for match-containing functions: what matters is whether the
+  // statements AROUND the match return on every path.
+
+  it("flags a conditional return after a statement match (genuine fall-through)", () => {
     expect(
       misses(`def f(x: string): number {
   let out = 0
@@ -72,29 +71,99 @@ describe("definite-return checking", () => {
   }
   if (x == "a") { return out }
 }`),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("skips a match-containing function that does not return on all paths (no false positive)", () => {
-    // A statement match with no trailing return: the function misses a return,
-    // but is skipped because it contains a match.
-    expect(misses(`def f(x: string): number { match (x) { "a" => print("hi")  _ => print("no") } }`)).toBe(false);
+  it("flags a statement match with no trailing return", () => {
+    expect(misses(`def f(x: string): number { match (x) { "a" => print("hi")  _ => print("no") } }`)).toBe(true);
   });
 
-  it("skips a function with a pattern match (idiomatic Result match, no `_`)", () => {
-    // The false-positive case that drove the safe-subset decision: an exhaustive
-    // Result match with no `_`. Arm returns are now illegal (Task 10), so the
-    // idiomatic form is an expression match; this shape exercises the LOWERED
-    // detection path (the scrutinee `assignment` carrying `matchSource`, since
-    // pattern arms are lowered to an if-chain). The trailing return is
-    // conditional so the flow graph sees a fall-through; only the containsMatch
-    // skip suppresses the diagnostic.
+  it("flags a conditional return after a Result expression match (genuine fall-through)", () => {
     expect(
       misses(`def mk(): Result<number, string> { return success(1) }
 def f(): number {
   let r = mk()
   let out = match (r) { success(v) => v  failure(e) => 0 }
   if (out > 0) { return out }
+}`),
+    ).toBe(true);
+  });
+
+  it("flags a conditional return after a boolean expression match (genuine fall-through)", () => {
+    expect(
+      misses(`def f(x: bool): number {
+  const out = match (x) { true => 1  false => 2 }
+  if (x) { return out }
+}`),
+    ).toBe(true);
+  });
+
+  it("accepts a returned match expression (literal arms)", () => {
+    // `return match(...)` lowers to the match region + a real trailing return.
+    expect(misses(`def f(x: bool): number { return match (x) { true => 1  false => 2 } }`)).toBe(false);
+  });
+
+  it("accepts a returned match expression (pattern arms — the old idiomatic Result tail)", () => {
+    expect(
+      misses(`def mk(): Result<number, string> { return success(1) }
+def f(): number {
+  let r = mk()
+  return match (r) { success(v) => v  failure(e) => 0 }
+}`),
+    ).toBe(false);
+  });
+
+  it("accepts an expression match with a block arm followed by an unconditional return", () => {
+    // The mid-arm `return 1` is a matchYield (yields to the match), NOT a
+    // function return — the function's own return is the trailing statement.
+    expect(
+      misses(`def f(x: bool): number {
+  const out = match (x) {
+    true => {
+      print("t")
+      return 1
+    }
+    false => 2
+  }
+  return out
+}`),
+    ).toBe(false);
+  });
+
+  it("accepts a statement match followed by an unconditional return", () => {
+    expect(
+      misses(`def f(x: string): number {
+  let out = 0
+  match (x) {
+    "a" => out = 1
+    _ => out = 2
+  }
+  return out
+}`),
+    ).toBe(false);
+  });
+
+  it("a matchYield is not a function return: expression match as the last statement still flags", () => {
+    // Every arm "returns" (yields), but the match value is assigned and the
+    // function then falls through.
+    expect(
+      misses(`def f(x: bool): number { const out = match (x) { true => { return 1 }  false => 2 } }`),
+    ).toBe(true);
+  });
+
+  it("accepts return match with a block-arm mid-yield", () => {
+    // Pins that the returned-match form stays exit even when an arm body is a
+    // block whose yield is mid-arm (protects against a future flowBuilder
+    // change to arm-body threading).
+    expect(
+      misses(`def f(x: bool): number {
+  return match (x) {
+    true => {
+      print("t")
+      return 1
+    }
+    false => 0
+  }
 }`),
     ).toBe(false);
   });
@@ -129,22 +198,6 @@ def g(x: number): number { if (x > 0) { return 2 } }`;
   // --- documented limitations, pinned ---
   it("LIMITATION: an infinite loop is flagged (flow model has no exit for while(true))", () => {
     expect(misses(`def f(): number { while (true) { let x = 1 } }`)).toBe(true);
-  });
-
-  it("skips a `_`-less match (safe subset — no false positive on exhaustive matches)", () => {
-    // A boolean match over true/false is exhaustive, but the safe subset simply
-    // skips any match-containing function rather than reasoning about
-    // exhaustiveness. (Arms can no longer `return` — Task 10 — so the value
-    // flows out via a `_`-less expression match instead.) The conditional
-    // trailing return leaves a fall-through path, so without the containsMatch
-    // skip this exhaustive match WOULD be flagged — the exact false positive
-    // the safe subset exists to avoid.
-    expect(
-      misses(`def f(x: bool): number {
-  const out = match (x) { true => 1  false => 2 }
-  if (x) { return out }
-}`),
-    ).toBe(false);
   });
 
   // --- config knob ---

--- a/packages/agency-lang/lib/typeChecker/definiteReturns.ts
+++ b/packages/agency-lang/lib/typeChecker/definiteReturns.ts
@@ -1,28 +1,7 @@
 import type { ScopeInfo, TypeCheckerContext } from "./types.js";
-import type { AgencyNode, VariableType } from "../types.js";
-import { walkNodes } from "../utils/node.js";
+import type { VariableType } from "../types.js";
 
 type Severity = "silent" | "warn" | "error";
-
-/**
- * SAFE-SUBSET GUARD: skip any function whose body contains a `match`. Whether a
- * match-ending function returns on every path depends on whether the match is
- * EXHAUSTIVE (a `Result` match over success/failure always is; a `number` match
- * over `1`/`2` is not), which lives in `checkMatchExhaustiveness`, not in the
- * flow graph. A `match` lowers to an if-chain (or stays a `matchBlock` for pure
- * literals) whose "no arm matched" tail looks like a fall-through, so checking
- * these here would false-positive on the idiomatic exhaustive Result match.
- * Definite-return over matches is deferred to a follow-up that reuses the
- * exhaustiveness result. Detect both lowered matches (an `assignment` carrying
- * `matchSource`) and un-lowered pure-literal matches (`matchBlock`).
- */
-function containsMatch(body: AgencyNode[]): boolean {
-  for (const { node } of walkNodes(body)) {
-    if (node.type === "matchBlock") return true;
-    if (node.type === "assignment" && node.matchSource) return true;
-  }
-  return false;
-}
 
 /** A declared return type that requires a value on every path. Exempt: absent/
  *  `null` (nothing declared), `void` (nothing to return), and `never` (means
@@ -40,8 +19,14 @@ function requiresReturn(rt: VariableType | null | undefined): boolean {
  * Diagnostic: a function that declares a non-void return type but whose body can
  * reach its end without `return`ing. Uses the flow graph's terminal node
  * (`ctx.flowEnv.scopeTerminals`): `exit` means every path diverges. Nodes and
- * the top-level scope are exempt (not value-returning functions). Functions that
- * use a `match` are skipped in this first release (see `containsMatch`).
+ * the top-level scope are exempt (not value-returning functions).
+ *
+ * Matches need no special handling since match expressions (7eefd7c1): a
+ * statement-position arm cannot contain `return` (compile error), an
+ * expression-position arm's `return` is a matchYield unwind (never a function
+ * return, and passThrough to the flow graph), and `return match(...)` lowers to
+ * the match region plus a REAL trailing return that the flow graph sees as
+ * `exit`. So the terminal is exact for match-containing functions.
  * Config-gated via `typechecker.definiteReturns` (ships at `warn`).
  */
 export function checkDefiniteReturns(
@@ -57,7 +42,6 @@ export function checkDefiniteReturns(
     if (!info.name || info.name === "top-level") continue;
     if (ctx.nodeDefs[info.name]) continue; // nodes are exempt (bare-keyed — index.ts:88)
     if (!requiresReturn(info.returnType)) continue;
-    if (containsMatch(info.body)) continue; // safe subset: matches deferred
     const terminal = terminals[info.scopeKey];
     if (terminal && terminal.kind !== "exit") {
       ctx.errors.push({

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -114,6 +114,36 @@ export function assignedNames(body: AgencyNode[]): string[] {
   return names;
 }
 
+/** The literal condition `true` — no constant folding (`1 == 1` doesn't count). */
+function isLiteralTrue(cond: AgencyNode): boolean {
+  return cond.type === "boolean" && cond.value === true;
+}
+
+/** A `break` that can exit the loop whose body this is: found anywhere in the
+ *  body except inside a nested loop (break binds to the nearest loop) or a
+ *  nested function/node definition (same ancestor filter as assignedNames).
+ *  Conservative toward the loop being escapable: a break inside e.g. a handle
+ *  block still counts as reachable. Traversal note (verified): walkNodes
+ *  descends into every statement-bearing construct that could carry a
+ *  loop-bound break — ifElse, loops, handleBlock body + inline handler body,
+ *  thread/parallel/seq blocks, match arm bodies, withModifier — the only
+ *  non-descended wrapper is staticStatement, which cannot meaningfully
+ *  contain a break. */
+function hasReachableBreak(body: AgencyNode[]): boolean {
+  for (const { node, ancestors } of walkNodes(body)) {
+    if (node.type !== "keyword" || node.value !== "break") continue;
+    const bindsElsewhere = ancestors.some(
+      (a) =>
+        a.type === "whileLoop" ||
+        a.type === "forLoop" ||
+        a.type === "function" ||
+        a.type === "graphNode",
+    );
+    if (!bindsElsewhere) return true;
+  }
+  return false;
+}
+
 /** statement kind → its flow transformation. The "what". */
 type StatementRuleTable = {
   [K in AgencyNode["type"]]?: (
@@ -185,6 +215,19 @@ const statementRules: StatementRuleTable = {
     attachExpressionsToFlow(node.condition as AgencyNode, flow, env);
     const facts = analyzeCondition(node.condition);
     const bodyEnd = buildFlowGraph(node.body, wrapFacts(flow, facts.then), env);
+    // `while (true)` with no break that can exit THIS loop never falls
+    // through: the post-loop flow is unreachable, so the loop diverges like a
+    // `return` (definite-return §5b; also makes trailing statements dead code
+    // to downstream consumers). The body was still built above so its refs
+    // keep their flowOf entries; skipping widenAtLoopBackEdge here is
+    // deliberate — widening only shapes the POST-loop flow, which does not
+    // exist for a diverging loop (do not "restore" it). Scope note: only the
+    // literal-true condition counts; `while (cond) { raise ... }` is out of
+    // scope (raise is passThrough / may resume — same convention as
+    // alwaysExits).
+    if (isLiteralTrue(node.condition as AgencyNode) && !hasReachableBreak(node.body)) {
+      return { kind: "exit" };
+    }
     return wrapFacts(
       widenAtLoopBackEdge(flow, bodyEnd, assignedNames(node.body), env),
       facts.else,

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -120,18 +120,36 @@ function isLiteralTrue(cond: AgencyNode): boolean {
 }
 
 /** A `break` that can exit the loop whose body this is: found anywhere in the
- *  body except inside a nested loop (break binds to the nearest loop) or a
- *  nested function/node definition (same ancestor filter as assignedNames).
- *  Conservative toward the loop being escapable: a break inside e.g. a handle
- *  block still counts as reachable. Traversal note (verified): walkNodes
- *  descends into every statement-bearing construct that could carry a
- *  loop-bound break — ifElse, loops, handleBlock body + inline handler body,
+ *  body except (a) inside a nested loop — break binds to the nearest loop,
+ *  (b) inside a nested function/node definition (same ancestor filter as
+ *  assignedNames), or (c) inside an INLINE HANDLER body — handler bodies are
+ *  codegen'd as separate arrow functions (`insideHandlerBody`;
+ *  typescriptBuilder.ts processKeyword emits a bare `break` there), so a
+ *  break in a `with (e) { ... }` body can never reach the enclosing Agency
+ *  loop. Everything else counts, conservative toward the loop being
+ *  escapable — a break in the guarded `handle { ... }` body or in a callback
+ *  block compiles to runner.breakLoop(), which genuinely breaks the loop when
+ *  it runs during an iteration. Traversal note (verified): walkNodes descends
+ *  into every statement-bearing construct that could carry a loop-bound
+ *  break — ifElse, loops, handleBlock body + inline handler body,
  *  thread/parallel/seq blocks, match arm bodies, withModifier — the only
  *  non-descended wrapper is staticStatement, which cannot meaningfully
  *  contain a break. */
 function hasReachableBreak(body: AgencyNode[]): boolean {
+  // Breaks under inline handler bodies can't escape the loop (see (c) above).
+  // Collected by node identity so the main walk can skip exactly those.
+  const handlerBodyBreaks: AgencyNode[] = [];
+  for (const { node } of walkNodes(body)) {
+    if (node.type !== "handleBlock" || node.handler.kind !== "inline") continue;
+    for (const { node: inner } of walkNodes(node.handler.body)) {
+      if (inner.type === "keyword" && inner.value === "break") {
+        handlerBodyBreaks.push(inner);
+      }
+    }
+  }
   for (const { node, ancestors } of walkNodes(body)) {
     if (node.type !== "keyword" || node.value !== "break") continue;
+    if (handlerBodyBreaks.includes(node)) continue;
     const bindsElsewhere = ancestors.some(
       (a) =>
         a.type === "whileLoop" ||

--- a/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
+++ b/packages/agency-lang/lib/typeChecker/memberPathNarrowing.test.ts
@@ -32,7 +32,7 @@ def f(b: Box): void {
 type Env = { result: Result<number, string> }
 def takesNumber(n: number): number { return n }
 def f(env: Env): number {
-  match (env) {
+  return match (env) {
     { result: success(v) } => takesNumber(v)
     { result: failure(e) } => 0
   }
@@ -265,7 +265,7 @@ def f(rs: Result<number, string>[]): void {
     expect(check(`${TRY}
 def takesNumber(n: number): number { return n }
 def f(pair: Result<number, string>[]): number {
-  match (pair) {
+  return match (pair) {
     [success(v), _] => takesNumber(v)
     _ => 0
   }


### PR DESCRIPTION
## Summary

Definite-return checking now covers **match-containing functions** (removing the #386 `containsMatch` safe-subset skip) and treats **`while (true)` with no reachable `break` as diverging** (remaining-work §5b). Config default stays `warn`.

### Why removing the skip is sound now

The hard problem #386 deferred — "does a match-ending function return on every path?" depends on exhaustiveness, which the flow graph can't see — was **dissolved by match expressions (7eefd7c1)**. Since `return` in an arm yields to the match instead of returning from the function:

- A **statement-position** arm `return` is a compile error → statement matches are effect-only and can never make the function return. The flow graph threading through them without `exit` is now *exact*, not conservative.
- An **expression-arm** `return` lowers to a `matchYield` (passThrough to the flow builder) → can never fake a function `exit`.
- `return match(...)` lowers to the match region **plus a real trailing `returnStatement`** → genuine `exit`.
- `const x = match(...)` lowers to the region plus a plain assignment → genuine non-exit.

So the flow terminal is exact for every match shape and the fix is simply deleting the skip — no exhaustiveness oracle, no reachability walk, no lowering metadata. The old false-positive driver (the idiomatic arm-returning Result match as a function tail) is now a compile error whose fixit (`return match(...)`) is exactly the form the checker handles correctly.

### while(true) divergence

The flow builder's `whileLoop` rule yields `{kind: "exit"}` for a literal-`true` loop with no `break` that can exit *this* loop (`hasReachableBreak`: break binds to the nearest loop; nested loops/definitions excluded; anything else — e.g. a break inside a `handle` body — conservatively counts as reachable). Also makes post-infinite-loop statements dead code to all flow consumers.

### Measurement

- Blast-radius sweep at `definiteReturns: "error"` over **855** execution-test programs (`tests/agency`, `tests/agency-js`, `tests/integration`, including the new match-expression suite): **0 hits, 0 crashes**.
- Full unit suite at exact parity with base `main`: 6980 passed. Two `memberPathNarrowing` fixtures were statement matches with expression arms inside `def f(): number` — genuine fall-throughs under the new semantics — modernized to `return match(...)` (narrowing shape unchanged).
- Known degenerate limitation (documented, not engineered around): a statement match whose every arm ends in `while (true)` is still flagged, because the `matchBlock` flow rule discards arm end-flows.

### Handler safety

Type-checker only: zero codegen/runtime/handler-registration impact.

### Note: pre-existing failures on main

Base `main` (01c7b02c) currently has **21 failing unit tests** unrelated to this change (14 `effectPayloadCheck`, 2 `compile`, 2 `typescriptGenerator.integration`, 2 `effectDeclCollection`, 1 `handlerBodyInterrupts` — e.g. `Effect 'std::read' data field 'filename' is missing`). All 21 reproduce identically on a clean checkout of the base commit; this branch adds none.

### Docs

- `docs/misc/config.md`: `definiteReturns` bullet rewritten for the new semantics (match coverage, `while (true)`, how to promote to `error`).
- `docs/dev/typechecker/definite-returns-remaining-work.md` (new): the shipped state, the history of how the match problem dissolved, and what remains (§ flip warn→error — last sweep 855/0; § trailing-raise refinement; § dead-code detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
