### PR TITLE
Fix for-loop record iteration + allow match expressions in handler bodies

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -233,6 +233,11 @@ export class TypeScriptBuilder {
   // checks. This counter gives each one a unique name.
   private handlerFuncResultCounter: number = 0;
   private insideGlobalInit: boolean = false;
+  // Set while emitting the body of a plain-mode (handler) match EXPRESSION,
+  // whose arms are wrapped in an async IIFE. Inside it, a `matchYield` compiles
+  // to a real `return <value>` (exiting the IIFE) instead of the stepped
+  // `runner.exitMatch`, so the handler never touches the `_matchExit` flag.
+  private insidePlainMatchExpr: boolean = false;
 
   /*
   We break up every function and node body into steps,
@@ -526,7 +531,9 @@ export class TypeScriptBuilder {
         return ts.empty();
       case "matchBlock":
         return this.insideHandlerBody
-          ? this.processBlockPlain(node)
+          ? node.matchExprId !== undefined
+            ? this.processMatchExpressionPlain(node)
+            : this.processBlockPlain(node)
           : this.processMatchBlockWithSteps(node);
       case "number":
       case "unitLiteral":
@@ -564,7 +571,9 @@ export class TypeScriptBuilder {
           : this.processWhileLoopWithSteps(node);
       case "ifElse":
         return this.insideHandlerBody
-          ? this.processBlockPlain(node)
+          ? node.matchExprId !== undefined
+            ? this.processMatchExpressionPlain(node)
+            : this.processBlockPlain(node)
           : this.processIfElseWithSteps(node);
       case "newLine":
         return ts.empty();
@@ -1360,7 +1369,43 @@ export class TypeScriptBuilder {
       );
     }
     const value = node.value ? this.processNode(node.value) : ts.id("undefined");
+    // Plain-mode (handler) match expressions wrap their arms in an async IIFE
+    // (see processMatchExpressionPlain): a yield is a real `return` out of that
+    // IIFE, not the stepped `runner.exitMatch` unwind — so the handler never
+    // sets the `_matchExit` flag that it has no `runner.ifElse` to clear.
+    if (this.insidePlainMatchExpr) {
+      return ts.return(value);
+    }
     return ts.runnerExitMatch({ matchId: node.matchId, value });
+  }
+
+  /**
+   * Compile an expression-position `match` inside a handler body (plain mode).
+   *
+   * Stepped code unwinds a match arm's value via `runner.exitMatch` + the owning
+   * `runner.ifElse` clearing `_matchExit`. A handler body compiles to plain JS
+   * with no owning `runner.ifElse`, so that protocol would leak the flag and
+   * silently skip the rest of the enclosing node. Instead we emit the arm
+   * dispatch as an async IIFE whose arms `return` their value, and store the
+   * result in the `__matchval_<id>` frame local the consumer reads:
+   *
+   *   __stack.locals.__matchval_<id> = await (async () => { <if-chain> })();
+   *
+   * `node` is either the pass-through `matchBlock` (literal arms) or the lowered
+   * `ifElse` chain (pattern arms) — both carry `matchExprId`. `processBlockPlain`
+   * builds the plain if/else for either; `insidePlainMatchExpr` makes the arms'
+   * `matchYield` nodes emit real returns out of the IIFE.
+   */
+  private processMatchExpressionPlain(node: MatchBlock | IfElse): TsNode {
+    const matchId = node.matchExprId!;
+    const prev = this.insidePlainMatchExpr;
+    this.insidePlainMatchExpr = true;
+    const ifChain = this.processBlockPlain(node);
+    this.insidePlainMatchExpr = prev;
+    return ts.assign(
+      ts.scopedVar(`__matchval_${matchId}`, "local", this.moduleId),
+      ts.await(ts.iife({ async: true, body: [ifChain] })),
+    );
   }
 
   private processImportStatement(node: ImportStatement): TsNode {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -74,6 +74,7 @@ import {
 } from "../types/importStatement.js";
 import { MatchBlock, MatchBlockCase } from "../types/matchBlock.js";
 import { MatchYield } from "../types/matchYield.js";
+import { matchValName, isMatchValName } from "../matchVal.js";
 import { ReturnStatement } from "../types/returnStatement.js";
 import { GotoStatement } from "../types/gotoStatement.js";
 import { WhileLoop } from "../types/whileLoop.js";
@@ -233,10 +234,26 @@ export class TypeScriptBuilder {
   // checks. This counter gives each one a unique name.
   private handlerFuncResultCounter: number = 0;
   private insideGlobalInit: boolean = false;
+  // Gives each plain-mode (handler) for-loop unique names for its normalization
+  // temps, so nested loops in the same block don't collide.
+  private plainForLoopCounter: number = 0;
   // Set while emitting the body of a plain-mode (handler) match EXPRESSION,
   // whose arms are wrapped in an async IIFE. Inside it, a `matchYield` compiles
   // to a real `return <value>` (exiting the IIFE) instead of the stepped
   // `runner.exitMatch`, so the handler never touches the `_matchExit` flag.
+  //
+  // INVARIANT: this must be true ONLY where a `return` lands directly in the
+  // IIFE. Today that holds because (a) `matchYield` nodes exist only inside
+  // expression-match regions, every one of which routes through
+  // `processMatchExpressionPlain` in a handler, and (b) the builder never
+  // switches OUT of plain mode within the IIFE — it does not reset
+  // `insideHandlerBody` at block-argument / nested-frame boundaries, so nothing
+  // stepped compiles inside a handler. At every yield site this flag therefore
+  // currently equals `insideHandlerBody`. If a future change starts compiling
+  // stepped constructs inside a handler (e.g. resetting `insideHandlerBody` per
+  // frame), reset THIS flag at those same boundaries too — otherwise a stepped
+  // match nested in a plain arm would emit a bare `return` inside a step
+  // callback (value discarded, `_matchExit` never set: a silent wrong answer).
   private insidePlainMatchExpr: boolean = false;
 
   /*
@@ -531,9 +548,7 @@ export class TypeScriptBuilder {
         return ts.empty();
       case "matchBlock":
         return this.insideHandlerBody
-          ? node.matchExprId !== undefined
-            ? this.processMatchExpressionPlain(node)
-            : this.processBlockPlain(node)
+          ? this.processPlainBranching(node)
           : this.processMatchBlockWithSteps(node);
       case "number":
       case "unitLiteral":
@@ -571,9 +586,7 @@ export class TypeScriptBuilder {
           : this.processWhileLoopWithSteps(node);
       case "ifElse":
         return this.insideHandlerBody
-          ? node.matchExprId !== undefined
-            ? this.processMatchExpressionPlain(node)
-            : this.processBlockPlain(node)
+          ? this.processPlainBranching(node)
           : this.processIfElseWithSteps(node);
       case "newLine":
         return ts.empty();
@@ -925,7 +938,7 @@ export class TypeScriptBuilder {
           if (
             !isBuiltinVar &&
             !isLoopVar &&
-            /^__matchval_\d+$/.test(literal.value)
+            isMatchValName(literal.value)
           ) {
             return ts.scopedVar(literal.value, "local", this.moduleId);
           }
@@ -1380,6 +1393,21 @@ export class TypeScriptBuilder {
   }
 
   /**
+   * Plain-mode (handler body) routing for the two lowered shapes of a branching
+   * construct: a match expression (literal arms → `matchBlock`, pattern arms →
+   * `ifElse`, both carrying `matchExprId`) becomes a self-contained IIFE; a plain
+   * statement match / if compiles as ordinary JS. Single source of truth so the
+   * `matchBlock` and `ifElse` dispatch cases can't drift apart — a mismatch would
+   * silently emit a statement match whose consumer reads an unassigned
+   * `__matchval_N` as `undefined`.
+   */
+  private processPlainBranching(node: MatchBlock | IfElse): TsNode {
+    return node.matchExprId !== undefined
+      ? this.processMatchExpressionPlain(node)
+      : this.processBlockPlain(node);
+  }
+
+  /**
    * Compile an expression-position `match` inside a handler body (plain mode).
    *
    * Stepped code unwinds a match arm's value via `runner.exitMatch` + the owning
@@ -1400,10 +1428,16 @@ export class TypeScriptBuilder {
     const matchId = node.matchExprId!;
     const prev = this.insidePlainMatchExpr;
     this.insidePlainMatchExpr = true;
-    const ifChain = this.processBlockPlain(node);
-    this.insidePlainMatchExpr = prev;
+    let ifChain: TsNode;
+    try {
+      ifChain = this.processBlockPlain(node);
+    } finally {
+      // Restore in a finally so an emission error inside an arm can't leak the
+      // flag and turn a later sibling `matchYield` into a bare `return`.
+      this.insidePlainMatchExpr = prev;
+    }
     return ts.assign(
-      ts.scopedVar(`__matchval_${matchId}`, "local", this.moduleId),
+      ts.scopedVar(matchValName(matchId), "local", this.moduleId),
       ts.await(ts.iife({ async: true, body: [ifChain] })),
     );
   }
@@ -3376,36 +3410,64 @@ export class TypeScriptBuilder {
         { elseIfs, elseBody },
       );
     }
-    // forLoop — for-of with optional index
+    return this.processPlainForLoop(node);
+  }
+
+  /**
+   * Emit a plain-JS for-loop (used inside handler bodies) that iterates arrays
+   * by (element, index) and records/plain objects by (key, value) — the same
+   * array-vs-record normalization `Runner.loop` applies in stepped mode. The
+   * old emission looped `i < iterable.length` over `iterable[i]`, which over a
+   * record iterated zero times (`.length` is undefined) and made `for (k in
+   * record)` a `for...of` over a non-iterable object (a TypeError). All three
+   * for-loop implementations (this, `Runner.loop`, the type checker) now agree.
+   *
+   *   const __src = <iterable>;
+   *   const __isArr = Array.isArray(__src);
+   *   const __keys = __isArr ? __src
+   *     : (__src != null && typeof __src === "object" ? Object.keys(__src) : []);
+   *   for (let __i = 0; __i < __keys.length; __i++) {
+   *     const <item>   = __keys[__i];                        // element | key
+   *     const <second> = __isArr ? __i : __src[__keys[__i]]; // index   | value
+   *     ...body
+   *   }
+   */
+  private processPlainForLoop(node: ForLoop): TsNode {
+    const n = this.plainForLoopCounter++;
+    const src = `__forsrc_${n}`;
+    const isArr = `__forisarr_${n}`;
+    const keys = `__forkeys_${n}`;
+    const i = `__fori_${n}`;
+
+    const loopBody: TsNode[] = [
+      ts.constDecl(node.itemVar as string, ts.index(ts.id(keys), ts.id(i))),
+    ];
     if (node.indexVar) {
-      // for (item, index in iterable) → for (let index = 0; index < iterable.length; index++) { const item = iterable[index]; ... }
-      const iterableNode = this.processNode(node.iterable);
-      const iterableVar = `__iter_${node.itemVar}`;
-      return ts.statements([
-        ts.constDecl(iterableVar, iterableNode),
-        ts.forC(
-          ts.letDecl(node.indexVar, ts.num(0)),
-          ts.binOp(
-            ts.id(node.indexVar),
-            "<",
-            ts.prop(ts.id(iterableVar), "length"),
-          ),
-          ts.postfix(ts.id(node.indexVar), "++"),
-          ts.statements([
-            ts.constDecl(
-              node.itemVar as string,
-              ts.index(ts.id(iterableVar), ts.id(node.indexVar)),
-            ),
-            ...node.body.map((s) => this.processNode(s)),
-          ]),
+      loopBody.push(
+        ts.constDecl(
+          node.indexVar,
+          ts.raw(`${isArr} ? ${i} : ${src}[${keys}[${i}]]`),
         ),
-      ]);
+      );
     }
-    return ts.forOf(
-      node.itemVar as string,
-      this.processNode(node.iterable),
-      processBody(node.body),
-    );
+    for (const s of node.body) loopBody.push(this.processNode(s));
+
+    return ts.statements([
+      ts.constDecl(src, this.processNode(node.iterable)),
+      ts.constDecl(isArr, ts.raw(`Array.isArray(${src})`)),
+      ts.constDecl(
+        keys,
+        ts.raw(
+          `${isArr} ? ${src} : (${src} != null && typeof ${src} === "object" ? Object.keys(${src}) : [])`,
+        ),
+      ),
+      ts.forC(
+        ts.letDecl(i, ts.num(0)),
+        ts.binOp(ts.id(i), "<", ts.prop(ts.id(keys), "length")),
+        ts.postfix(ts.id(i), "++"),
+        ts.statements(loopBody),
+      ),
+    ]);
   }
 
   /**

--- a/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
@@ -362,15 +362,22 @@ describe("statement-position return-in-arm errors", () => {
 }`, /return match\(/));
 });
 
-describe("expression match inside a handler body is rejected", () => {
-  function expectError(src: string, re: RegExp) {
+describe("expression match inside a handler body lowers like anywhere else", () => {
+  // The builder compiles these to a self-contained async IIFE in the handler's
+  // plain-mode codegen (never touching the runner's `_matchExit` flag), so
+  // lowering treats them exactly as it would in a normal body.
+  function handlerBody(src: string): any[] {
     const parsed = parseAgency(src);
-    expect(parsed.success).toBe(false);
-    if (!parsed.success) expect(parsed.message).toMatch(re);
+    if (!parsed.success) throw new Error(parsed.message);
+    const main: any = parsed.result.nodes.find(
+      (n: any) => n.type === "graphNode" || n.type === "function",
+    );
+    const handle: any = main.body.find((n: any) => n.type === "handleBlock");
+    return handle.handler.body;
   }
 
-  it("`const x = match(...)` inside a `with` handler body is a lowering error", () =>
-    expectError(`node main() {
+  it("`const x = match(...)` inside a `with` handler body lowers to temp + consumer", () => {
+    const body = handlerBody(`node main() {
   handle {
     interrupt("check")
   } with (data) {
@@ -381,10 +388,20 @@ describe("expression match inside a handler body is rejected", () => {
     return approve()
   }
   return "ok"
-}`, /match expressions are not supported inside handler bodies/));
+}`);
+    const matchStmt = body.find((n: any) => n.type === "matchBlock");
+    expect(matchStmt.matchExprId).toBeTypeOf("number");
+    const arm = matchStmt.cases.find((c: any) => c.type === "matchBlockCase");
+    expect(arm.body[0].type).toBe("matchYield");
+    const assign = body.find(
+      (n: any) => n.type === "assignment" && n.variableName === "x",
+    );
+    expect(assign.value.value).toBe(`__matchval_${matchStmt.matchExprId}`);
+    expect(body.indexOf(matchStmt)).toBeLessThan(body.indexOf(assign));
+  });
 
-  it("`return match(...)` inside a `with` handler body is a lowering error", () =>
-    expectError(`node main() {
+  it("`return match(...)` inside a `with` handler body lowers to temp + return", () => {
+    const body = handlerBody(`node main() {
   handle {
     interrupt("check")
   } with (data) {
@@ -394,7 +411,13 @@ describe("expression match inside a handler body is rejected", () => {
     }
   }
   return "ok"
-}`, /match expressions are not supported inside handler bodies/));
+}`);
+    const matchStmt = body.find((n: any) => n.type === "matchBlock");
+    expect(matchStmt.matchExprId).toBeTypeOf("number");
+    const ret = body.find((n: any) => n.type === "returnStatement");
+    expect(ret.value.value).toBe(`__matchval_${matchStmt.matchExprId}`);
+    expect(body.indexOf(matchStmt)).toBeLessThan(body.indexOf(ret));
+  });
 
   it("a `match` in the guarded `handle` body (not the handler) is still allowed", () => {
     const parsed = parseAgency(`node main() {

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -26,6 +26,7 @@ import type {
 import { isExpressionNode } from "../types.js";
 import type { MatchYield } from "../types/matchYield.js";
 import { LoweringError } from "./loweringError.js";
+import { matchValName } from "../matchVal.js";
 import type { BinOpExpression, Operator } from "../types/binop.js";
 import type { AgencyArray } from "../types/dataStructures.js";
 import type {
@@ -424,7 +425,7 @@ class PatternLowerer {
         : c,
     );
     const statements = this.lowerMatchBlock({ ...match, cases }, matchId);
-    return { statements, valueRef: varRef(`__matchval_${matchId}`, loc), matchId };
+    return { statements, valueRef: varRef(matchValName(matchId), loc), matchId };
   }
 
   /**

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -59,19 +59,10 @@ class PatternLowerer {
 
   /** True while lowering the top-level (module) node list; flipped to false by
    *  `lowerBody` when descending into any body-bearing container (function /
-   *  node / if / loop / match arm / block). Used to reject `match` expressions
-   *  in module-level initializers, which have no execution frame to unwind. */
+   *  node / if / loop / match arm / block / handler). Used to reject `match`
+   *  expressions in module-level initializers, which have no execution frame
+   *  to unwind. */
   private atModuleLevel = true;
-
-  /** True while lowering, in the SAME execution frame, the body of a `with`
-   *  handler. Handler bodies compile through `processBlockPlain` (no owning
-   *  `runner.ifElse` to clear `_matchExit`), so an expression `match` there
-   *  would emit `exitMatch(...); return;` that exits the handler and leaves
-   *  `_matchExit` set — silently skipping every later construct in the node.
-   *  Expression matches are rejected while this is set. Reset at frame
-   *  boundaries (nested functions/nodes/blocks/concurrency) by
-   *  `lowerNewFrameBody`, since those compile in their own frames. */
-  private insideHandlerBody = false;
 
   private freshName(prefix: string): string {
     return `__${prefix}_${++this.counter}`;
@@ -81,9 +72,11 @@ class PatternLowerer {
     return nodes.flatMap((n) => this.lowerNode(n));
   }
 
-  /** Lower a nested body in the SAME execution frame (if/else, loop, match arm,
-   *  guarded `handle` body): temporarily clears the `atModuleLevel` flag but
-   *  PRESERVES `insideHandlerBody`, since these run in the enclosing frame. */
+  /** Lower a nested body (any body-bearing container): temporarily clears the
+   *  `atModuleLevel` flag so `match` expressions inside are allowed. Match
+   *  expressions inside a handler body are fine — the builder compiles them to
+   *  a self-contained async IIFE in the handler's plain-mode codegen, so they
+   *  never touch the runner's `_matchExit` unwind flag. */
   private lowerBody(nodes: AgencyNode[]): AgencyNode[] {
     const prev = this.atModuleLevel;
     this.atModuleLevel = false;
@@ -91,38 +84,6 @@ class PatternLowerer {
       return this.lower(nodes);
     } finally {
       this.atModuleLevel = prev;
-    }
-  }
-
-  /** Lower the body of a construct that runs in its OWN execution frame
-   *  (nested function / node / block argument / concurrency block / function
-   *  call block). Clears `atModuleLevel` AND `insideHandlerBody`: a `match`
-   *  inside such a body compiles against its own frame, not the handler's. */
-  private lowerNewFrameBody(nodes: AgencyNode[]): AgencyNode[] {
-    const prevModule = this.atModuleLevel;
-    const prevHandler = this.insideHandlerBody;
-    this.atModuleLevel = false;
-    this.insideHandlerBody = false;
-    try {
-      return this.lower(nodes);
-    } finally {
-      this.atModuleLevel = prevModule;
-      this.insideHandlerBody = prevHandler;
-    }
-  }
-
-  /** Lower an inline `with` handler body, marking `insideHandlerBody` so that
-   *  expression matches within it (same frame) are rejected. */
-  private lowerHandlerBody(nodes: AgencyNode[]): AgencyNode[] {
-    const prevModule = this.atModuleLevel;
-    const prevHandler = this.insideHandlerBody;
-    this.atModuleLevel = false;
-    this.insideHandlerBody = true;
-    try {
-      return this.lower(nodes);
-    } finally {
-      this.atModuleLevel = prevModule;
-      this.insideHandlerBody = prevHandler;
     }
   }
 
@@ -139,28 +100,24 @@ class PatternLowerer {
       case "forLoop":
         return [this.lowerForLoop(node)];
       case "handleBlock": {
-        // Descend the guarded body in the SAME frame, but mark the inline
-        // handler body so expression matches within it are rejected (see
-        // `insideHandlerBody`). Non-inline handlers have no body to descend.
+        // Descend both the guarded body and the inline handler body. Non-inline
+        // handlers have no body to descend.
         const hb = node as HandleBlock;
         const body = this.lowerBody(hb.body);
         const handler =
           hb.handler.kind === "inline"
-            ? { ...hb.handler, body: this.lowerHandlerBody(hb.handler.body) }
+            ? { ...hb.handler, body: this.lowerBody(hb.handler.body) }
             : hb.handler;
         return [{ ...hb, body, handler }];
       }
       case "returnStatement": {
         const ret = node as ReturnStatement;
         // Expression-position match: `return match(E) { ... }`. Hoist the match
-        // region and return the temp it produces.
+        // region and return the temp it produces. This is allowed inside handler
+        // bodies too: the builder compiles the hoisted region to a self-contained
+        // async IIFE there (plain mode), so it never sets the runner's
+        // `_matchExit` unwind flag that a handler has no `runner.ifElse` to clear.
         if (ret.value !== undefined && (ret.value as AgencyNode).type === "matchBlock") {
-          if (this.insideHandlerBody) {
-            throw new LoweringError(
-              "match expressions are not supported inside handler bodies",
-              ret.loc,
-            );
-          }
           const region = this.lowerMatchExpressionCore(ret.value as MatchBlock, ret.loc);
           return [...region.statements, { ...ret, value: region.valueRef }];
         }
@@ -187,10 +144,8 @@ class PatternLowerer {
         // graphNode / parallelBlock / seqBlock / blockArgument /
         // functionCall.block / …; `handleBlock` is handled explicitly above).
         // For nodes that are also Expressions, additionally walk the expression
-        // tree so nested `isExpression` is lowered. Each of these bodies runs in
-        // its own execution frame, so clear both module-level AND handler-body
-        // flags via `lowerNewFrameBody`.
-        const withRecursedBodies = mapBodies(node, (b) => this.lowerNewFrameBody(b));
+        // tree so nested `isExpression` is lowered.
+        const withRecursedBodies = mapBodies(node, (b) => this.lowerBody(b));
         if (isExpr(withRecursedBodies as unknown)) {
           return [this.lowerExpression(withRecursedBodies as unknown as Expression) as unknown as AgencyNode];
         }
@@ -220,7 +175,7 @@ class PatternLowerer {
     }
     if (expr.type === "functionCall") {
       const block = expr.block
-        ? { ...expr.block, body: this.lowerNewFrameBody(expr.block.body) }
+        ? { ...expr.block, body: this.lowerBody(expr.block.body) }
         : expr.block;
       return {
         ...expr,
@@ -279,17 +234,13 @@ class PatternLowerer {
     // Expression-position match: `const x = match(E) { ... }`. Hoist the match
     // region above and rewrite the assignment value to the temp the region
     // produces. Module-level initializers have no execution frame to unwind, so
-    // they are rejected.
+    // they are rejected. Handler bodies ARE allowed: the builder compiles the
+    // hoisted region to a self-contained async IIFE there (plain mode), which
+    // never sets the runner's `_matchExit` flag.
     if (node.value && (node.value as AgencyNode).type === "matchBlock") {
       if (this.atModuleLevel) {
         throw new LoweringError(
           "match expressions are not supported in module-level initializers",
-          node.loc,
-        );
-      }
-      if (this.insideHandlerBody) {
-        throw new LoweringError(
-          "match expressions are not supported inside handler bodies",
           node.loc,
         );
       }

--- a/packages/agency-lang/lib/matchVal.ts
+++ b/packages/agency-lang/lib/matchVal.ts
@@ -1,0 +1,30 @@
+/**
+ * The `__matchval_<id>` naming contract for expression-position `match`.
+ *
+ * A match expression lowers to a hoisted region that stores its result in a
+ * synthetic frame-local, which the consumer (`return match(...)` /
+ * `const x = match(...)`) then reads. Several layers touch this name — the
+ * runtime writes it (`Runner.exitMatch`), pattern lowering builds the read
+ * reference, the TS builder emits the plain-mode write and resolves the read,
+ * and the type checker recognizes the ref to type it. A typo at any one site
+ * produces a silently-`undefined` match value rather than an error, so all of
+ * them go through these helpers instead of hand-spelling the prefix.
+ */
+
+const MATCHVAL_RE = /^__matchval_(\d+)$/;
+
+/** The frame-local name holding the result of the match with the given id. */
+export function matchValName(id: number): string {
+  return `__matchval_${id}`;
+}
+
+/** Whether `name` is a `__matchval_<id>` synthetic temp. */
+export function isMatchValName(name: string): boolean {
+  return MATCHVAL_RE.test(name);
+}
+
+/** The match id when `name` is a `__matchval_<id>` ref, else `undefined`. */
+export function parseMatchValId(name: string): number | undefined {
+  const m = MATCHVAL_RE.exec(name);
+  return m ? Number(m[1]) : undefined;
+}

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -423,6 +423,42 @@ describe("Runner", () => {
       expect(collected.sort()).toEqual(["alice", "bob"]);
     });
 
+    it("passes the value as the second callback arg when iterating a Record", async () => {
+      const frame = makeFrame();
+      const runner = new Runner(makeMockCtx(), frame);
+      const pairs: [string, unknown][] = [];
+
+      await runner.loop(
+        0,
+        { a: 1, b: 2, c: 3 },
+        async (key, value) => {
+          pairs.push([key, value]);
+        },
+      );
+
+      expect(pairs).toEqual([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]);
+    });
+
+    it("passes the numeric index as the second callback arg when iterating an array", async () => {
+      const frame = makeFrame();
+      const runner = new Runner(makeMockCtx(), frame);
+      const pairs: [unknown, unknown][] = [];
+
+      await runner.loop(0, ["x", "y", "z"], async (item, index) => {
+        pairs.push([item, index]);
+      });
+
+      expect(pairs).toEqual([
+        ["x", 0],
+        ["y", 1],
+        ["z", 2],
+      ]);
+    });
+
     it("does nothing when iterating an empty Record", async () => {
       const frame = makeFrame();
       const runner = new Runner(makeMockCtx(), frame);

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -815,7 +815,8 @@ export class Runner {
   async loop(
     id: number,
     items: any[] | Record<string, any>,
-    callback: (item: any, index: number, runner: Runner) => Promise<void>,
+    // Second arg is the numeric index for arrays, or the value for records.
+    callback: (item: any, second: any, runner: Runner) => Promise<void>,
   ): Promise<void> {
     if (this.shouldSkip()) return;
     if (this.getCounter() > id) return;
@@ -836,10 +837,12 @@ export class Runner {
     // iterable, matching how a JS `for...of` over a non-iterable would
     // simply do nothing rather than crash mid-flow.
     let iterable: any[];
+    let isRecord = false;
     if (Array.isArray(items)) {
       iterable = items;
     } else if (items != null && typeof items === "object") {
       iterable = Object.keys(items);
+      isRecord = true;
     } else {
       iterable = [];
     }
@@ -854,7 +857,12 @@ export class Runner {
       this._continue = false;
       this.path.push(id);
       try {
-        await this.runInScope(() => callback(iterable[i], i, this));
+        // `for (item, second in x)`: for arrays the second variable is the
+        // numeric index; for records it is the value at the current key. The
+        // first callback arg is the element (array) or the key (record).
+        const item = iterable[i];
+        const second = isRecord ? (items as Record<string, any>)[item] : i;
+        await this.runInScope(() => callback(item, second, this));
       } finally {
         this.path.pop();
       }

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -17,6 +17,7 @@ import {
 } from "./state/stateStack.js";
 import type { ThreadStore } from "./state/threadStore.js";
 import type { HandlerFn } from "./types.js";
+import { matchValName } from "../matchVal.js";
 
 /** Options bag for the new `Runner.thread(id, method, opts, callback)`
  *  signature. All fields are optional; emitter passes only the ones
@@ -259,7 +260,7 @@ export class Runner {
   /** Yield `value` from a match arm: store it as the match result and skip
    *  everything until the owning ifElse (matchId) consumes the flag. */
   exitMatch(matchId: number, value: unknown): void {
-    this.frame.locals[`__matchval_${matchId}`] = value;
+    this.frame.locals[matchValName(matchId)] = value;
     this._matchExit = matchId;
   }
 

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -2236,6 +2236,68 @@ describe("TypeChecker", () => {
       expect(errors[0].actualType).toBe("number");
       expect(errors[0].expectedType).toBe("string");
     });
+
+    it("index access on an object literal yields the property value type (not any)", () => {
+      // Shared with the for-loop typer: `obj[k]` must agree with `for (k, v in
+      // obj)` that an object literal's value type is the union of its property
+      // values — here `number`, so passing it where a string is expected errors.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectStr",
+            parameters: [
+              {
+                type: "functionParameter",
+                name: "s",
+                typeHint: { type: "primitiveType", value: "string" },
+              },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "obj",
+            value: {
+              type: "agencyObject",
+              entries: [
+                { key: "a", value: { type: "number", value: "1" } },
+                { key: "b", value: { type: "number", value: "2" } },
+              ],
+            },
+          },
+          {
+            type: "forLoop",
+            itemVar: "key",
+            iterable: { type: "variableName", value: "obj" },
+            body: [
+              {
+                type: "functionCall",
+                functionName: "expectStr",
+                arguments: [
+                  {
+                    type: "valueAccess",
+                    base: { type: "variableName", value: "obj" },
+                    chain: [
+                      {
+                        kind: "index",
+                        index: { type: "variableName", value: "key" },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { errors } = typeCheck(program);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].actualType).toBe("number");
+      expect(errors[0].expectedType).toBe("string");
+    });
   });
 
   describe("inferred variable used correctly", () => {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -1997,6 +1997,245 @@ describe("TypeChecker", () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toMatch(/For-loop iterable must be an array/);
     });
+
+    it("should accept an object literal (objectType) as iterable and type the key as string", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectStr",
+            parameters: [
+              {
+                type: "functionParameter",
+                name: "s",
+                typeHint: { type: "primitiveType", value: "string" },
+              },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "obj",
+            value: {
+              type: "agencyObject",
+              entries: [
+                { key: "a", value: { type: "number", value: "1" } },
+                { key: "b", value: { type: "number", value: "2" } },
+              ],
+            },
+          },
+          {
+            type: "forLoop",
+            itemVar: "key",
+            iterable: { type: "variableName", value: "obj" },
+            body: [
+              {
+                type: "functionCall",
+                functionName: "expectStr",
+                arguments: [{ type: "variableName", value: "key" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { errors } = typeCheck(program);
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should error when an object-literal key is used as a number", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectNum",
+            parameters: [
+              {
+                type: "functionParameter",
+                name: "n",
+                typeHint: { type: "primitiveType", value: "number" },
+              },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "obj",
+            value: {
+              type: "agencyObject",
+              entries: [{ key: "a", value: { type: "number", value: "1" } }],
+            },
+          },
+          {
+            type: "forLoop",
+            itemVar: "key",
+            iterable: { type: "variableName", value: "obj" },
+            body: [
+              {
+                type: "functionCall",
+                functionName: "expectNum",
+                arguments: [{ type: "variableName", value: "key" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { errors } = typeCheck(program);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].actualType).toBe("string");
+      expect(errors[0].expectedType).toBe("number");
+    });
+
+    it("types the second loop variable as the property value for an object literal", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectNum",
+            parameters: [
+              {
+                type: "functionParameter",
+                name: "n",
+                typeHint: { type: "primitiveType", value: "number" },
+              },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "obj",
+            value: {
+              type: "agencyObject",
+              entries: [
+                { key: "a", value: { type: "number", value: "1" } },
+                { key: "b", value: { type: "number", value: "2" } },
+              ],
+            },
+          },
+          {
+            type: "forLoop",
+            itemVar: "key",
+            indexVar: "value",
+            iterable: { type: "variableName", value: "obj" },
+            body: [
+              {
+                type: "functionCall",
+                functionName: "expectNum",
+                // `value` is number here, so this is fine...
+                arguments: [{ type: "variableName", value: "value" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { errors } = typeCheck(program);
+      expect(errors).toHaveLength(0);
+    });
+
+    it("errors when an object-literal value is used at the wrong type", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectStr",
+            parameters: [
+              {
+                type: "functionParameter",
+                name: "s",
+                typeHint: { type: "primitiveType", value: "string" },
+              },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "obj",
+            value: {
+              type: "agencyObject",
+              entries: [{ key: "a", value: { type: "number", value: "1" } }],
+            },
+          },
+          {
+            type: "forLoop",
+            itemVar: "key",
+            indexVar: "value",
+            iterable: { type: "variableName", value: "obj" },
+            body: [
+              {
+                type: "functionCall",
+                functionName: "expectStr",
+                // `value` is number, expected string -> error.
+                arguments: [{ type: "variableName", value: "value" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { errors } = typeCheck(program);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].actualType).toBe("number");
+      expect(errors[0].expectedType).toBe("string");
+    });
+
+    it("still types the second loop variable as the index for arrays", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectStr",
+            parameters: [
+              {
+                type: "functionParameter",
+                name: "s",
+                typeHint: { type: "primitiveType", value: "string" },
+              },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "arr",
+            typeHint: {
+              type: "arrayType",
+              elementType: { type: "primitiveType", value: "string" },
+            },
+            value: {
+              type: "agencyArray",
+              items: [
+                { type: "string", segments: [{ type: "text", value: "x" }] },
+              ],
+            },
+          },
+          {
+            type: "forLoop",
+            itemVar: "item",
+            indexVar: "i",
+            iterable: { type: "variableName", value: "arr" },
+            body: [
+              {
+                type: "functionCall",
+                functionName: "expectStr",
+                // `i` is the numeric index, expected string -> error.
+                arguments: [{ type: "variableName", value: "i" }],
+              },
+            ],
+          },
+        ],
+      };
+
+      const { errors } = typeCheck(program);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].actualType).toBe("number");
+      expect(errors[0].expectedType).toBe("string");
+    });
   });
 
   describe("inferred variable used correctly", () => {

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -5,6 +5,7 @@ import {
   VariableType,
 } from "../types.js";
 import { walkNodes, isInsideBlock, type WalkAncestor } from "../utils/node.js";
+import { parseMatchValId } from "../matchVal.js";
 import { scopeKey as getScopeKey } from "../compilationUnit.js";
 import type { Scope as WalkScope } from "../types.js";
 import { formatTypeHint } from "../utils/formatType.js";
@@ -797,8 +798,7 @@ function checkReturnTypesInScope(
  *  `return match(...)` produces, else undefined. */
 function matchvalRefId(expr: AgencyNode): number | undefined {
   if (expr.type !== "variableName") return undefined;
-  const m = /^__matchval_(\d+)$/.exec(expr.value);
-  return m ? Number(m[1]) : undefined;
+  return parseMatchValId(expr.value);
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/recordLike.ts
+++ b/packages/agency-lang/lib/typeChecker/recordLike.ts
@@ -1,0 +1,32 @@
+import type { VariableType } from "../types.js";
+import { STRING_T, ANY_T } from "./primitives.js";
+import { unionTypes } from "./inference.js";
+
+/**
+ * The key and value types of a "record-like" type — a `Record<K, V>` generic or
+ * a structural object literal (`objectType`) — or `undefined` for anything else.
+ *
+ * Object literals iterate and index by string key; their value type is the
+ * union of all property value types (or `any` for the empty object, which
+ * carries no value-type info). Centralizing this keeps the for-loop typer
+ * (`scopes.ts`) and index-access synthesis (`synthesizer.ts`) from each
+ * inventing their own rule for what an object literal's value type is — so
+ * `for (k, v in obj)` and `obj[k]` agree by construction.
+ *
+ * Expects an already-resolved type (aliases expanded).
+ */
+export function recordLikeKeyValue(
+  t: VariableType,
+): { key: VariableType; value: VariableType } | undefined {
+  if (t.type === "genericType" && t.name === "Record") {
+    return { key: t.typeArgs[0], value: t.typeArgs[1] };
+  }
+  if (t.type === "objectType") {
+    const value =
+      t.properties.length === 0
+        ? ANY_T
+        : unionTypes(t.properties.map((p) => p.value));
+    return { key: STRING_T, value };
+  }
+  return undefined;
+}

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -21,7 +21,8 @@ import type { FlowNode } from "./flow.js";
 import { formatTypeHint } from "../utils/formatType.js";
 import { checkType, getBlockSlot } from "./utils.js";
 import { checkMatchExprYields } from "./matchExprTypes.js";
-import { NUMBER_T } from "./primitives.js";
+import { NUMBER_T, STRING_T } from "./primitives.js";
+import { unionTypes } from "./inference.js";
 import { analyzeCondition, walkWithNarrowing, postGuardFacts } from "./narrowing.js";
 import { expressionChildren } from "../utils/node.js";
 
@@ -380,26 +381,52 @@ export function walkScopeBody(
         break;
       case "forLoop": {
         const iterableType = synthType(node.iterable, scope, ctx);
+        // `for (item, second in x)` binds two variables. `itemType` is the
+        // first (element for arrays, key for records/objects); `secondType`
+        // is the second (numeric index for arrays, VALUE for records/objects),
+        // mirroring how the runtime `Runner.loop` passes callback arguments.
+        let itemType: VariableType | "any";
+        let secondType: VariableType | "any";
         if (iterableType === "any") {
-          scope.declare(node.itemVar as string, "any");
+          itemType = "any";
+          // Iterable kind is unknown, so the second var could be either an
+          // index or a value — leave it as `any` rather than assume a number.
+          secondType = "any";
         } else if (iterableType.type === "arrayType") {
-          scope.declare(node.itemVar as string, iterableType.elementType);
+          itemType = iterableType.elementType;
+          secondType = NUMBER_T;
         } else if (
           iterableType.type === "genericType" &&
           iterableType.name === "Record"
         ) {
-          // for (k in record): iteration variable is the key type.
-          scope.declare(node.itemVar as string, iterableType.typeArgs[0]);
+          // for (k, v in record): key is Record's key type, value is its
+          // value type.
+          itemType = iterableType.typeArgs[0];
+          secondType = iterableType.typeArgs[1];
+        } else if (iterableType.type === "objectType") {
+          // for (k, v in obj): an object literal iterates by its (string)
+          // keys, with the value being the property value at that key. Object
+          // literals synthesize to a structural `objectType`, not a `Record`
+          // generic, so they need their own branch here or iteration is
+          // wrongly rejected. The value type is the union of all property
+          // value types.
+          itemType = STRING_T;
+          secondType =
+            iterableType.properties.length === 0
+              ? "any"
+              : unionTypes(iterableType.properties.map((p) => p.value));
         } else {
-          scope.declare(node.itemVar as string, "any");
+          itemType = "any";
+          secondType = "any";
           ctx.errors.push({
             message: `For-loop iterable must be an array or Record, got '${formatTypeHint(iterableType)}'.`,
             actualType: formatTypeHint(iterableType),
             loc: node.iterable.loc,
           });
         }
+        scope.declare(node.itemVar as string, itemType);
         if (node.indexVar) {
-          scope.declare(node.indexVar, NUMBER_T);
+          scope.declare(node.indexVar, secondType);
         }
         walkScopeBody(node.body, scope, ctx);
         break;

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -21,8 +21,8 @@ import type { FlowNode } from "./flow.js";
 import { formatTypeHint } from "../utils/formatType.js";
 import { checkType, getBlockSlot } from "./utils.js";
 import { checkMatchExprYields } from "./matchExprTypes.js";
-import { NUMBER_T, STRING_T } from "./primitives.js";
-import { unionTypes } from "./inference.js";
+import { NUMBER_T } from "./primitives.js";
+import { recordLikeKeyValue } from "./recordLike.js";
 import { analyzeCondition, walkWithNarrowing, postGuardFacts } from "./narrowing.js";
 import { expressionChildren } from "../utils/node.js";
 
@@ -387,6 +387,14 @@ export function walkScopeBody(
         // mirroring how the runtime `Runner.loop` passes callback arguments.
         let itemType: VariableType | "any";
         let secondType: VariableType | "any";
+        // Record-like: `for (k, v in obj)` binds key + value. A shared helper
+        // (`recordLikeKeyValue`) handles both `Record<K, V>` and structural
+        // object literals (`objectType`), so this typer and index-access
+        // synthesis agree on an object literal's value type. Object literals
+        // synthesize to `objectType`, not `Record`, so without this they'd be
+        // wrongly rejected as non-iterable.
+        const recordLike =
+          iterableType === "any" ? undefined : recordLikeKeyValue(iterableType);
         if (iterableType === "any") {
           itemType = "any";
           // Iterable kind is unknown, so the second var could be either an
@@ -395,26 +403,9 @@ export function walkScopeBody(
         } else if (iterableType.type === "arrayType") {
           itemType = iterableType.elementType;
           secondType = NUMBER_T;
-        } else if (
-          iterableType.type === "genericType" &&
-          iterableType.name === "Record"
-        ) {
-          // for (k, v in record): key is Record's key type, value is its
-          // value type.
-          itemType = iterableType.typeArgs[0];
-          secondType = iterableType.typeArgs[1];
-        } else if (iterableType.type === "objectType") {
-          // for (k, v in obj): an object literal iterates by its (string)
-          // keys, with the value being the property value at that key. Object
-          // literals synthesize to a structural `objectType`, not a `Record`
-          // generic, so they need their own branch here or iteration is
-          // wrongly rejected. The value type is the union of all property
-          // value types.
-          itemType = STRING_T;
-          secondType =
-            iterableType.properties.length === 0
-              ? "any"
-              : unionTypes(iterableType.properties.map((p) => p.value));
+        } else if (recordLike) {
+          itemType = recordLike.key;
+          secondType = recordLike.value;
         } else {
           itemType = "any";
           secondType = "any";

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -1,4 +1,6 @@
 import { AgencyNode, Expression, VariableType, ValueAccess, formatUnitLiteral } from "../types.js";
+import { parseMatchValId } from "../matchVal.js";
+import { recordLikeKeyValue } from "./recordLike.js";
 import type { ResultType, UnionType, TypeAliasEntry } from "../types/typeHints.js";
 import type { SourceLocation } from "../types/base.js";
 import { resultToObjectUnion } from "./resultUnion.js";
@@ -254,9 +256,9 @@ export function synthType(
       // lowerer leaves as an expression-match's value. It is never declared in
       // scope; resolve it directly to the match's computed value type so an
       // outer yield that reads an inner match's temp gets the inner union.
-      const matchvalMatch = /^__matchval_(\d+)$/.exec(expr.value);
-      if (matchvalMatch) {
-        return ctx.matchExprTypes[Number(matchvalMatch[1])] ?? "any";
+      const matchvalId = parseMatchValId(expr.value);
+      if (matchvalId !== undefined) {
+        return ctx.matchExprTypes[matchvalId] ?? "any";
       }
       const scopeType = scope.lookup(expr.value);
       if (scopeType) {
@@ -923,11 +925,16 @@ export function synthValueAccess(
       case "index": {
         if (resolved.type === "arrayType") {
           currentType = resolved.elementType;
-        } else if (resolved.type === "genericType" && resolved.name === "Record") {
-          // Record<K, V>: index access yields V.
-          currentType = resolved.typeArgs[1];
         } else {
-          return "any";
+          // Record-like (`Record<K, V>` or an object literal): index access
+          // yields the value type. Shared with the for-loop typer so `obj[k]`
+          // and `for (k, v in obj)` agree on an object literal's value type.
+          const recordLike = recordLikeKeyValue(resolved);
+          if (recordLike) {
+            currentType = recordLike.value;
+          } else {
+            return "any";
+          }
         }
         break;
       }

--- a/packages/agency-lang/tests/agency/for-loop-in-handler.agency
+++ b/packages/agency-lang/tests/agency/for-loop-in-handler.agency
@@ -1,0 +1,80 @@
+// For-loops inside handler bodies compile through plain-mode codegen. They must
+// iterate records by (key, value) and arrays by (element, index), matching
+// `Runner.loop` (stepped mode) and the type checker. A handler is a natural
+// place to loop over interrupt data.
+
+def guarded(): number {
+  const check = interrupt("confirm?")
+  return 42
+}
+
+// two-variable form over a record: second var is the VALUE.
+node twoVarOverRecord() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    const scores = {
+      alice: 10,
+      bob: 20,
+      carol: 30
+    }
+    let total = 0
+    for (name, score in scores) {
+      total = total + score
+    }
+    // 10 + 20 + 30 = 60. A broken loop (zero iterations) leaves total at 0.
+    if (total == 60) {
+      return approve()
+    }
+    return reject()
+  }
+}
+
+// one-variable form over a record: iterate keys.
+node oneVarOverRecord() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    const scores = {
+      alice: 10,
+      bob: 20
+    }
+    let names = ""
+    for (name in scores) {
+      names = names + name
+    }
+    if (names == "alicebob") {
+      return approve()
+    }
+    return reject()
+  }
+}
+
+// arrays still bind the index as the second variable.
+node twoVarOverArray() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    const items = ["a", "b", "c"]
+    let out = ""
+    for (item, i in items) {
+      out = out + item + i
+    }
+    if (out == "a0b1c2") {
+      return approve()
+    }
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency/for-loop-in-handler.test.json
+++ b/packages/agency-lang/tests/agency/for-loop-in-handler.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "twoVarOverRecord",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "oneVarOverRecord",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "twoVarOverArray",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/forLoopRecordValue.agency
+++ b/packages/agency-lang/tests/agency/forLoopRecordValue.agency
@@ -1,0 +1,14 @@
+node main() {
+  const scores = {
+    alice: 10,
+    bob: 20,
+    carol: 30
+  }
+  // for (key, value in record): the second variable is the VALUE, not the
+  // numeric index. Arrays still bind the index as their second variable.
+  let out = ""
+  for (name, score in scores) {
+    out = out + name + "=" + score + ";"
+  }
+  return out
+}

--- a/packages/agency-lang/tests/agency/forLoopRecordValue.test.json
+++ b/packages/agency-lang/tests/agency/forLoopRecordValue.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"alice=10;bob=20;carol=30;\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/match-expr-in-handler.agency
+++ b/packages/agency-lang/tests/agency/match-expr-in-handler.agency
@@ -1,0 +1,99 @@
+// Match expressions (`return match(...)` / `const x = match(...)`) inside a
+// handler body. These used to be rejected by pattern lowering; they now
+// compile to a self-contained async IIFE in the handler's plain-mode codegen,
+// so they never touch the runner's `_matchExit` unwind flag.
+
+def guarded(): number {
+  const check = interrupt("confirm?")
+  return 42
+}
+
+// return-position match: approves because the effect matches.
+node approvesOnMatch() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    return match(data.effect) {
+      "unknown" => approve()
+      _ => reject()
+    }
+  }
+}
+
+// return-position match: rejects because no arm matches the effect.
+node rejectsOnNoMatch() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    return match(data.effect) {
+      "std::run" => approve()
+      _ => reject()
+    }
+  }
+}
+
+// assignment-position match: `const x = match(...)`.
+node assignsFromMatch() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    const decision = match(data.effect) {
+      "unknown" => approve()
+      _ => reject()
+    }
+    return decision
+  }
+}
+
+// pattern arm: an object-pattern arm lowers to a hoisted scrutinee temp plus a
+// tagged `ifElse` chain (a different codegen path than literal arms). It must
+// also compile to the plain-mode IIFE inside a handler.
+node approvesOnPatternArm() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    return match(data) {
+      { effect: "unknown" } => approve()
+      _ => reject()
+    }
+  }
+}
+
+// multi-path block arm: the arm has two return paths. The IIFE's real `return`
+// must short-circuit so the FIRST matching path wins (a naive plain-assignment
+// lowering would fall through and let the later path overwrite the value).
+node blockArmShortCircuits() {
+  handle {
+    const r = guarded()
+    if (isFailure(r)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    return match(data.effect) {
+      "unknown" => {
+        if (data.message == "confirm?") {
+          return approve()
+        }
+        return reject()
+      }
+      _ => reject()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/match-expr-in-handler.test.json
+++ b/packages/agency-lang/tests/agency/match-expr-in-handler.test.json
@@ -1,0 +1,34 @@
+{
+  "tests": [
+    {
+      "nodeName": "approvesOnMatch",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "rejectsOnNoMatch",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "assignsFromMatch",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "approvesOnPatternArm",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "blockArmShortCircuits",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. For-loop over records binds the value, not the index

`for (key, value in record)` bound the second variable to the numeric iteration index instead of the value at that key, contradicting the docs. `for (val, i in array)` still binds the index. Both are now supported.

- **Runtime (`Runner.loop`)** — pass the value (`items[key]`) as the second callback argument for records/objects; keep the index (`i`) for arrays.
- **Type checker** — type the second loop variable as the value type for `Record<K, V>` and object literals, and as `number` (index) for arrays. Also accept structural object-literal types (`objectType`) as iterables; they were previously rejected because only `Record` generics were recognized, so iterating a plain `{ a: 1, b: 2 }` errored with *"For-loop iterable must be an array or Record"*.

Tests: runner unit tests (record → `[key, value]`, array → `[item, index]`), type-checker tests (value typing + object-literal iterable), and an execution test.

## 2. Match expressions inside handler bodies

`return match(...)` / `const x = match(...)` were rejected inside `with` handler bodies with *"match expressions are not supported inside handler bodies."*

**Why they were rejected:** stepped code unwinds a match arm's value via `runner.exitMatch` plus the owning `runner.ifElse` clearing the `_matchExit` flag. Handler bodies compile to plain JS with no owning `runner.ifElse` to clear it, so the flag would leak out of the handler and silently skip the rest of the enclosing node.

**The fix:** handler bodies now compile an expression-position match to a self-contained async IIFE whose arms `return` their value, storing the result in the `__matchval_<id>` frame local the consumer reads:

```js
__stack.locals.__matchval_1 = await (async () => {
  if (data.effect === "std::run") { return await approve(); }
  return await reject();
})();
return __stack.locals.__matchval_1;
```

This never touches `_matchExit`. Lowering is unchanged (only TS emission diverges), so the type checker is unaffected. Covers both the literal-arm (`matchBlock`) and pattern-arm (`ifElse`) lowered forms.

Tests: execution tests for return-position, assignment-position, an object-pattern arm, and a multi-path block arm (proving the IIFE's `return` short-circuits — a naive plain-assignment lowering would fall through and overwrite the value). Obsolete "is rejected" lowering tests were rewritten to assert correct lowering.

## Verification

- New execution tests pass (`forLoopRecordValue`, `match-expr-in-handler`).
- Unit suites green: `lib/lowering/`, `lib/runtime/runner.test.ts`, `lib/typeChecker.test.ts`.
- Structural linter clean.
- Existing handler/interrupt tests unaffected (statement matches and plain `if/else` in handlers still route through plain mode unchanged — the divert only applies to expression-position matches).

Note: two pre-existing fixture failures (`matchExpression`, `matchBlockBlockArms`) exist on `main` independent of this change — they fail on a stale `console.error` epilogue and are node-body matches on the stepped path this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
