### PR TITLE
Cost guards meter subprocess spend via per-call telemetry

### DIFF
--- a/packages/agency-lang/docs/dev/subprocess-ipc.md
+++ b/packages/agency-lang/docs/dev/subprocess-ipc.md
@@ -94,6 +94,7 @@ On the parent side, `_run` — a `runBatch` adopter with a single child (`subpro
 { type: "interrupted", interrupts: SerializedInterrupt[], checkpoint, subprocessSessionId }
 { type: "error", error: string }
 { type: "lockAcquire" | "lockRelease", ... }
+{ type: "telemetry", costUsd }   // fire-and-forget, one per paid call
 ```
 
 **Parent → Subprocess:**
@@ -134,6 +135,22 @@ Token stats live in the child's per-execution `GlobalStore` (`__tokenStats`), wh
 
 Locks brokered through the parent are released at segment settle, and lock-acquisition steps are completed steps that replay skips — **locks do not survive a pause**, which is already the in-process checkpoint semantic (releasers are not serialized there either).
 
+**Cost guards** meter subprocess spend live: every paid call in a child
+fire-and-forgets `{ type: "telemetry", costUsd }` upward (emitted from
+`StateStack.chargeGuards`, the choke point every paid site funnels
+through). The parent bills the charge via `billCharge` on the run()
+call-site stack — so parent `getCost()` includes child spend — and a trip
+kills the child and surfaces the standard cost-limit Failure at the
+owning `guard(cost:)` boundary. Relay to the root is automatic in nested
+trees (the mid-tier handler's own `chargeGuards` re-emits upward).
+Detection latency is at most one paid call, matching in-process CostGuard
+semantics. Telemetry is cost-only; tokens arrive terminally via
+`result.tokens`. One `getCost()` edge: telemetry arriving after a kill
+(abort, wall-clock, stdout, memory — FIFO rules this out on normal
+completion) still charges budgets via the shared guard references, but
+can be invisible to `getCost()` if the owning fork branch already joined.
+Budgets never undercount; `getCost()` may, on abnormal termination only.
+
 ## The `std::run` interrupt gate
 
 `run()` throws a `std::run` interrupt before executing the subprocess. Running agent-generated code is a dangerous operation: the caller must either have a handler that approves `std::run`, or the interrupt propagates to the user for approval — which, with pause/resume, is a real question rather than an auto-reject.
@@ -167,7 +184,6 @@ A subprocess may itself call `run()`. Safety is the language's own idiom plus a 
 ## Remaining limitations
 
 - **Debugger/trace integration**: the debugger sees `run()` as an opaque step. No stepping into subprocess code.
-- **Cost-guard telemetry**: the parent learns child spend only at terminal messages; incremental cost telemetry is a follow-up.
 - **Callback forwarding**: parent-registered lifecycle callbacks are not triggered by subprocess events; follow-up.
 
 ## Tests
@@ -197,6 +213,11 @@ Execution tests live in `tests/agency/subprocess/`; agency-js tests in `tests/ag
 | `nested-pause-resume` | grandchild interrupt surfaces through both hops; one respond resumes the tree |
 | `nested-reject-middle` | mid-tree reject is final |
 | `nested-lock-relay` | grandchild locks contend with the root's lock domain (marker-file handshake — no duration-based coordination) |
+| `cost-guard-trips-on-child-spend` | parent guard trips on child telemetry; child killed; standard Failure |
+| `cost-child-spend-in-getcost` | parent getCost() reflects child spend live |
+| `cost-nested-relay-trips-root` | grandchild spend relays through a guardless mid-tier to the root guard |
+| `cost-two-children-share-budget` | two concurrent children share ONE budget (the ship-guards-into-child counterexample) |
+| `cost-no-double-charge-across-pause` | pause/resume replay does not re-emit completed calls' telemetry |
 | `nested-gate-unapproved` | the gate exists on every hop |
 | `subprocess-no-handler` (js) | std::run gate surfaces without a handler |
 | `subprocess-pause-basic` (js) | end-to-end pause → respond → resume |

--- a/packages/agency-lang/docs/dev/subprocess-ipc.md
+++ b/packages/agency-lang/docs/dev/subprocess-ipc.md
@@ -137,7 +137,7 @@ Locks brokered through the parent are released at segment settle, and lock-acqui
 
 **Cost guards** meter subprocess spend live: every paid call in a child
 fire-and-forgets `{ type: "telemetry", costUsd }` upward (emitted from
-`StateStack.chargeGuards`, the choke point every paid site funnels
+`StateStack.billCharge`, the choke point every paid site funnels
 through). The parent bills the charge via `billCharge` on the run()
 call-site stack — so parent `getCost()` includes child spend — and a trip
 kills the child and surfaces the standard cost-limit Failure at the

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -50,6 +50,12 @@ node main() {
 
 The cost check fires every time an LLM call's cost is added to the per-branch accumulator. The time check fires at the next runner step boundary after the timer expires.
 
+Cost guards also meter subprocesses: spend from `std::agency` `run()` —
+including nested subprocesses — is charged to enclosing cost guards in
+real time, and a tripped budget terminates the subprocess and fails the
+guard block with the usual cost-limit failure. `getCost()` reflects
+subprocess spend as it happens.
+
 ## Timeout
 
 ```ts

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -87,6 +87,8 @@ Execute a compiled Agency program in a subprocess. The parent's handler chain ex
 
   Resource limits clamp the subprocess: it is killed and a limit_exceeded failure is returned if it exceeds wallClock, memory, ipcPayload, or stdout (each budget applies per execution segment). Subprocesses may themselves call run() — nesting is gated by the std::run interrupt at every level (its data includes the prospective depth) and hard-capped by maxDepth.
 
+  Enclosing cost guards meter the subprocess: each paid call inside it is charged to the parent's guard(cost:) budgets in real time, and a tripped budget terminates the subprocess and fails the guard block.
+
   @param compiled - A CompiledProgram from compile()
   @param node - Which exported node to run
   @param args - Arguments to pass to the node (defaults to no args)
@@ -159,7 +161,7 @@ Compile and execute an Agency file in a subprocess. The file is read from dir/fi
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L122))
 
 ### typecheck
 
@@ -181,7 +183,7 @@ Type-check Agency source code without compiling or running it. Returns a TypeChe
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L165))
 
 ### parseAST
 
@@ -203,7 +205,7 @@ Parse Agency source code into an abstract syntax tree. Returns the raw AST as a 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L181))
 
 ### writeAST
 
@@ -235,7 +237,7 @@ Format an AST as Agency source and write it to dir/filename. The AST is typicall
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L190))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L192))
 
 ### format
 
@@ -257,7 +259,7 @@ Format Agency source code using the standard Agency formatter (the same one used
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L216))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L218))
 
 ### formatFile
 
@@ -285,7 +287,7 @@ Format an Agency file in place. Reads dir/filename, formats it with the standard
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L227))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L229))
 
 ### walkAST
 
@@ -311,7 +313,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor with each
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L245))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L247))
 
 ### getNodesOfType
 
@@ -335,7 +337,7 @@ Parse Agency source code and return all AST nodes whose `type` field matches any
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L263))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L265))
 
 ### getImports
 
@@ -355,7 +357,7 @@ Return all import statements in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L275))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L277))
 
 ### getFunctions
 
@@ -375,7 +377,7 @@ Return all function definitions (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L284))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L286))
 
 ### getGraphNodes
 
@@ -395,7 +397,7 @@ Return all graph node definitions (`node main() { ... }`) in the source. Note: "
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L293))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L295))
 
 ### filterImports
 
@@ -438,7 +440,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L302))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L304))
 
 ### typecheckFile
 
@@ -468,7 +470,7 @@ Type-check an Agency file on disk. The file is read from dir/filename, and relat
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L342))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L344))
 
 ### getVersion
 
@@ -480,4 +482,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L362))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L364))

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-02-subprocess-cost-telemetry.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-02-subprocess-cost-telemetry.md
@@ -1,0 +1,907 @@
+# Subprocess Cost-Guard Telemetry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. (This project's owner has said NOT to use subagent-driven development — work inline in the main session.) Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parent cost guards see subprocess LLM spend live: each paid call in a child fire-and-forgets a telemetry message upward; the parent charges its guards and kills the child on a trip, which surfaces as the standard cost-limit Failure at the owning `guard(cost:)` boundary.
+
+**Architecture:** One dependency-free leaf sender (`costTelemetry.ts`, which also owns the shared `isPayableCost` wire-contract predicate) called from `StateStack.chargeGuards` — the choke point every paid site funnels through — plus one new `handleChildMessage` case in `ipc.ts` that bills the charge and enforces. The billing pair (`localCost += x; chargeGuards(x)`) is extracted as `StateStack.billCharge` so `prompt.ts`, `addCost`, and the new handler share one named sequence instead of three inline copies (enforcement stays at call sites — it legitimately varies). Nested relay is automatic: the mid-tier handler's own `chargeGuards` re-emits upward because that process is itself in IPC mode.
+
+**Tech Stack:** TypeScript runtime, Node IPC (`process.send`), existing guard machinery (`CostGuard`, `enforceGuards`, guard-trip abort ownership), `DeterministicClient` synthetic cost for tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md`. All paths relative to `packages/agency-lang/`.
+
+## Global Constraints
+
+- Agency syntax rules apply to test files (verify with `pnpm run ast <file>` when unsure).
+- Save all test output to files under `/tmp/cost-telemetry/` (`mkdir -p` once); never rerun slow tests to re-read failures.
+- Test commands: unit `pnpm vitest run <file>`; execution `pnpm run agency test <file>`. `make` after any stdlib/*.agency change. Do NOT run the full agency suite locally.
+- No dynamic imports; objects not Maps; arrays not Sets; types not interfaces; never amend/force-push; no apostrophes in `-m` commit messages (use `-F` file if needed).
+- Spec invariants: telemetry is fire-and-forget (never parks the child); charges are per-call incremental (no double-charge across pause/resume); post-settle telemetry charges but does not enforce; trip rejection must carry the guard-trip abort so the OWNING boundary converts it (the stdlib run()'s plain `try` re-throws trips — do not convert them in ipc.ts).
+- ORDERING INVARIANT: `handleTelemetryMessage` must stay fully synchronous. `handleChildMessage` is void-invoked (`ipc.ts:896`), so arrival-order processing (telemetry before the child's own terminal `result`, per IPC FIFO) holds only while the telemetry path contains no `await` — an await before enforcement would let a fast child's result settle the session before the trip fires. Do not add async work (statelog etc.) to this path.
+
+## Verified facts the tasks rely on
+
+- `StateStack.chargeGuards(amount)` is at `lib/runtime/state/stateStack.ts` (~line 515): `for (const g of this.guards) g.charge(amount);` — its only direct callers are `prompt.ts` (~559-562) and `cost.ts` `addCost` (the memory subsystem pays via `addCost` at `memory/manager.ts:44`, image generation at `stdlib/image.ts:96`). Both sites run the same inline pair `localCost += amount; chargeGuards(amount)` then enforce — Task 1 extracts that pair as `StateStack.billCharge`.
+- `stack.enforceGuards()` throws the guard-trip abort; a plain `try` re-throws it; the owning `guard(cost:)` boundary converts it to `failure` with `error.type === "guardFailure"`, `error.maxCost`, `error.actualCost`.
+- `GuardExceededError` (`guard.ts:474`) extends `AgencyAbort` and carries the `guardId` the ownership conversion matches on; `isGuardExceededError` is exported at `guard.ts:493`. Unit tests must assert the rejection IS this error (identity matters for `ownedGuardIds` matching), not just match message text.
+- `handleChildMessage` is invoked as `void handleChildMessage(s, msg)` (`ipc.ts:896`) — see the ORDERING INVARIANT above.
+- `docs/superpowers/specs/` is gitignored by repo convention: the spec will NOT be visible in the PR, so the PR body must inline the design summary rather than link the spec path.
+- `DeterministicClient` charges `SYNTHETIC_COST.totalCost = 0.000002` per `llm()` call (`lib/runtime/deterministicClient.ts:62`).
+- Execution tests provide mocks via test.json `"useTestLLMProvider": true, "llmMocks": [...]` → the runner sets `AGENCY_LLM_MOCKS` env → `buildForkOptions` spreads `process.env`, so mocks reach subprocesses; EACH process gets its own full mock queue (count mocks per process, not per test).
+- Guard syntax: `import { guard } from "std::thread"`; `guard(cost: 0.000003) as { ... }` returns a Result. `getCost()` from `std::thread` reads `stack.localCost`.
+- `RunSession` (ipc.ts) has `{ sessionId, child, limits, ctx, stateStack, resolvePromise, rejectPromise, settled, ... }`; `settle(s, fn, value)` funnels every terminal path; the kill-log pattern is `ipcLog("send", { type: "kill_failed", detail })`.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `lib/runtime/costTelemetry.ts` (new) | Leaf fire-and-forget sender + `IpcTelemetryMessage` type + `isPayableCost` wire predicate (shared by sender and handler so both ends enforce the same contract). Imports nothing from the runtime (the `subprocessRunInfo.ts` layering pattern) so `stateStack.ts` can call it without cycles. |
+| `lib/runtime/state/stateStack.ts` | New `billCharge` method (the localCost + chargeGuards pair) + one emission line in `chargeGuards`. |
+| `lib/runtime/prompt.ts` | Switch the inline billing pair (~559-561) to `billCharge`. No behavior change. |
+| `lib/runtime/cost.ts` | Switch `addCost`'s inline billing pair to `billCharge`. No behavior change. |
+| `lib/runtime/ipc.ts` | `handleTelemetryMessage` + dispatch case + ipcLog case; union membership. |
+| `tests/agency/subprocess/cost-*` | Four E2E scenarios. |
+| Docs | `docs/site/guide/guards.md`, `docs/dev/subprocess-ipc.md`, `stdlib/agency.agency` run() docstring. |
+
+---
+
+### Task 0: Branch setup
+
+The previous worktree branch (`worktree-subprocess-pause-resume`) is merged; start fresh from origin/main in the same worktree.
+
+- [ ] **Step 1: Sync and branch**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/subprocess-pause-resume
+git fetch origin
+git checkout -b subprocess-cost-telemetry origin/main
+cp /Users/adityabhargava/agency-lang/packages/agency-lang/docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md packages/agency-lang/docs/superpowers/specs/
+cp /Users/adityabhargava/agency-lang/packages/agency-lang/docs/superpowers/plans/2026-07-02-subprocess-cost-telemetry.md packages/agency-lang/docs/superpowers/plans/
+mkdir -p /tmp/cost-telemetry
+cd packages/agency-lang
+make > /tmp/cost-telemetry/setup-make.log 2>&1; echo "make: $?"
+```
+
+- [ ] **Step 2: Baseline**
+
+```bash
+pnpm vitest run lib/runtime/ipc.test.ts lib/runtime/guard.test.ts > /tmp/cost-telemetry/baseline.log 2>&1; echo "unit: $?"
+pnpm run agency test tests/agency/guards/guard-cost-trip.agency >> /tmp/cost-telemetry/baseline.log 2>&1; echo "guard: $?"
+pnpm run agency test tests/agency/subprocess/run-basic.agency >> /tmp/cost-telemetry/baseline.log 2>&1; echo "subprocess: $?"
+```
+Expected: all exit 0.
+
+---
+
+### Task 1: Leaf sender + `billCharge` + emission in `chargeGuards`
+
+**Files:**
+- Create: `lib/runtime/costTelemetry.ts`
+- Modify: `lib/runtime/state/stateStack.ts` (~line 515: add `billCharge`, emit in `chargeGuards`)
+- Modify: `lib/runtime/prompt.ts` (~559-561: switch to `billCharge`)
+- Modify: `lib/runtime/cost.ts` (`addCost`: switch to `billCharge`)
+- Test: `lib/runtime/costTelemetry.test.ts` (new)
+
+**Interfaces:**
+- Produces (Task 2 depends on these exact shapes):
+
+```typescript
+// costTelemetry.ts
+export type IpcTelemetryMessage = {
+  type: "telemetry";
+  costUsd: number;
+};
+export function isPayableCost(costUsd: unknown): costUsd is number;
+export function sendCostTelemetryToParent(costUsd: number): void;
+
+// stateStack.ts
+billCharge(amount: number): void;  // method on StateStack
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/runtime/costTelemetry.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isPayableCost, sendCostTelemetryToParent } from "./costTelemetry.js";
+import { StateStack } from "./state/stateStack.js";
+import { CostGuard } from "./guard.js";
+
+describe("isPayableCost", () => {
+  it("accepts positive finite numbers only", () => {
+    expect(isPayableCost(0.5)).toBe(true);
+    expect(isPayableCost(0)).toBe(false);
+    expect(isPayableCost(-1)).toBe(false);
+    expect(isPayableCost(NaN)).toBe(false);
+    expect(isPayableCost(Infinity)).toBe(false);
+    expect(isPayableCost("0.5")).toBe(false);
+    expect(isPayableCost(undefined)).toBe(false);
+  });
+});
+
+describe("sendCostTelemetryToParent", () => {
+  const originalSend = process.send;
+  const originalIpc = process.env.AGENCY_IPC;
+
+  afterEach(() => {
+    process.send = originalSend;
+    if (originalIpc === undefined) delete process.env.AGENCY_IPC;
+    else process.env.AGENCY_IPC = originalIpc;
+    vi.restoreAllMocks();
+  });
+
+  it("sends the telemetry message when in IPC mode", () => {
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCostTelemetryToParent(0.5);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "telemetry", costUsd: 0.5 });
+  });
+
+  it("no-ops outside IPC mode", () => {
+    delete process.env.AGENCY_IPC;
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCostTelemetryToParent(0.5);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("no-ops for zero, negative, and non-finite cost", () => {
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCostTelemetryToParent(0);
+    sendCostTelemetryToParent(-1);
+    sendCostTelemetryToParent(NaN);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("swallows a dead-channel send error", () => {
+    process.env.AGENCY_IPC = "1";
+    process.send = vi.fn(() => { throw new Error("channel closed"); }) as any;
+    expect(() => sendCostTelemetryToParent(0.5)).not.toThrow();
+  });
+});
+
+describe("StateStack.chargeGuards emission", () => {
+  const originalSend = process.send;
+  const originalIpc = process.env.AGENCY_IPC;
+
+  afterEach(() => {
+    process.send = originalSend;
+    if (originalIpc === undefined) delete process.env.AGENCY_IPC;
+    else process.env.AGENCY_IPC = originalIpc;
+    vi.restoreAllMocks();
+  });
+
+  it("emits exactly once per charge, even with zero guards installed", () => {
+    // Emission must be unconditional on guards being present: a mid-tier
+    // relay process may have NO local guards but must still forward the
+    // grandchild spend upward.
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const stack = new StateStack();
+    stack.chargeGuards(0.25);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "telemetry", costUsd: 0.25 });
+  });
+
+  it("does not emit for a zero charge", () => {
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    new StateStack().chargeGuards(0);
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("StateStack.billCharge", () => {
+  it("accumulates localCost and really charges guards in one call", () => {
+    const stack = new StateStack();
+    const guard = new CostGuard(0.1);
+    stack.guards.push(guard);
+    stack.billCharge(0.25);
+    expect(stack.localCost).toBe(0.25);
+    // 0.25 > 0.1: check() reporting a trip proves the guard was charged,
+    // not just localCost.
+    expect(guard.check(stack)).not.toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm vitest run lib/runtime/costTelemetry.test.ts > /tmp/cost-telemetry/t1-red.log 2>&1; echo "exit: $?"; tail -5 /tmp/cost-telemetry/t1-red.log
+```
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the leaf sender**
+
+Create `lib/runtime/costTelemetry.ts`:
+
+```typescript
+/**
+ * Fire-and-forget cost telemetry from a subprocess to its parent, so
+ * parent-side cost guards see child LLM spend live (see
+ * docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md).
+ *
+ * Deliberately dependency-free (the subprocessRunInfo.ts layering
+ * pattern): `StateStack.chargeGuards` calls this on every paid charge,
+ * and stateStack must not import ipc.ts. The message type lives here and
+ * is re-exported by ipc.ts into the SubprocessToParent union.
+ *
+ * Never blocks and never throws: there is no reply, no listener, and a
+ * dead channel is swallowed — the bootstrap disconnect watchdog is about
+ * to reap this process anyway.
+ */
+
+export type IpcTelemetryMessage = {
+  type: "telemetry";
+  costUsd: number;
+};
+
+/** The wire contract for a billable cost: a positive finite number.
+ * Shared by the sender and the parent-side handler so both ends of the
+ * channel enforce the same rule (the receiving side matters more — the
+ * child is the less-trusted party). */
+export function isPayableCost(costUsd: unknown): costUsd is number {
+  return typeof costUsd === "number" && Number.isFinite(costUsd) && costUsd > 0;
+}
+
+export function sendCostTelemetryToParent(costUsd: number): void {
+  if (process.env.AGENCY_IPC !== "1" || typeof process.send !== "function") return;
+  if (!isPayableCost(costUsd)) return;
+  const msg: IpcTelemetryMessage = { type: "telemetry", costUsd };
+  try {
+    process.send(msg);
+  } catch (err) {
+    // Channel gone — parent died; the watchdog will exit this process.
+    // Deliberately swallowed (fire-and-forget invariant), but traceable:
+    // ipcLog is unreachable from this leaf module, so mirror its gating.
+    if (process.env.AGENCY_IPC_DEBUG === "1") {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[ipc:telemetry] send failed: ${detail}\n`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: `billCharge` + emit from `chargeGuards`**
+
+In `lib/runtime/state/stateStack.ts`, add the import (top of file, alongside the other runtime imports):
+
+```typescript
+import { sendCostTelemetryToParent } from "../costTelemetry.js";
+```
+
+add `billCharge` directly above `chargeGuards`, and change `chargeGuards` (~line 515):
+
+```typescript
+  /**
+   * Bill one paid charge to this stack: accumulate the branch-local cost
+   * accumulator and charge every active guard. The single billing
+   * sequence every paid site runs — llm (prompt.ts), addCost (cost.ts;
+   * memory and image generation pay through it), and the parent-side
+   * subprocess telemetry handler (ipc.ts). Enforcement stays at call
+   * sites because it legitimately varies: prompt/addCost always enforce;
+   * the telemetry handler skips enforcement once its session has settled.
+   */
+  billCharge(amount: number): void {
+    this.localCost += amount;
+    this.chargeGuards(amount);
+  }
+
+  chargeGuards(amount: number): void {
+    for (const g of this.guards) g.charge(amount);
+    // Subprocess: forward this charge to the parent so ITS cost guards
+    // see the spend live. Emission is per paid call and unconditional on
+    // local guards existing: a mid-tier relay may have none but must
+    // still forward grandchild spend upward. No-op outside IPC mode.
+    sendCostTelemetryToParent(amount);
+  }
+```
+
+(Keep the existing doc comment on `chargeGuards`; only the body gains the emission line.)
+
+- [ ] **Step 5: Switch the two existing paid sites to `billCharge`**
+
+`lib/runtime/prompt.ts` (~559-561) — replace the inline pair, keeping the tokens line and the enforce:
+
+```typescript
+  const callCost = completion.cost?.totalCost ?? 0;
+  targetStack.billCharge(callCost);
+  targetStack.localTokens += completion.usage?.totalTokens ?? 0;
+  targetStack.enforceGuards();
+```
+
+`lib/runtime/cost.ts` `addCost` — same substitution (docstring stays accurate as written):
+
+```typescript
+export function addCost(amount: number): void {
+  const stack = getRuntimeContext().stack;
+  stack.billCharge(amount);
+  stack.enforceGuards();
+}
+```
+
+- [ ] **Step 6: Run tests + typecheck + paid-site regression**
+
+```bash
+pnpm vitest run lib/runtime/costTelemetry.test.ts lib/runtime/guard.test.ts lib/runtime/memory/manager.test.ts > /tmp/cost-telemetry/t1-green.log 2>&1; echo "unit: $?"; grep -E "Tests " /tmp/cost-telemetry/t1-green.log
+npx tsc --noEmit >> /tmp/cost-telemetry/t1-green.log 2>&1; echo "tsc: $?"
+pnpm run agency test tests/agency/guards/guard-cost-trip.agency > /tmp/cost-telemetry/t1-guard-regress.log 2>&1; echo "guard-cost-trip: $?"
+```
+Expected: PASS / clean / exit 0. `manager.test.ts` and `guard-cost-trip` cover the two switched paid sites (`addCost` and the llm path). (If `toHaveBeenCalledExactlyOnceWith` is unavailable in this vitest version, use `toHaveBeenCalledTimes(1)` + `toHaveBeenCalledWith(...)`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/subprocess-pause-resume
+git add packages/agency-lang/lib/runtime/costTelemetry.ts packages/agency-lang/lib/runtime/costTelemetry.test.ts packages/agency-lang/lib/runtime/state/stateStack.ts packages/agency-lang/lib/runtime/prompt.ts packages/agency-lang/lib/runtime/cost.ts packages/agency-lang/docs/superpowers/plans/2026-07-02-subprocess-cost-telemetry.md
+git commit -m "feat: emit per-call cost telemetry from chargeGuards; extract billCharge"
+cd packages/agency-lang
+```
+
+---
+
+### Task 2: Parent-side telemetry handler
+
+**Files:**
+- Modify: `lib/runtime/ipc.ts` (import/re-export the type; add to `SubprocessToParent`; `handleTelemetryMessage`; dispatch case in `handleChildMessage`; `ipcLog` case)
+- Test: `lib/runtime/ipc.test.ts`
+
+**Interfaces:**
+- Consumes: `IpcTelemetryMessage` / `isPayableCost` (Task 1); `StateStack.billCharge` (Task 1); `settle`, `RunSession`, `ipcLog` (existing).
+- Produces: `export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage): void` — exported for unit tests (`RunSession` becomes an exported type for the same reason).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `lib/runtime/ipc.test.ts`:
+
+```typescript
+import { handleTelemetryMessage } from "./ipc.js";
+import { StateStack } from "./state/stateStack.js";
+import { CostGuard, isGuardExceededError } from "./guard.js";
+
+describe("handleTelemetryMessage", () => {
+  const makeSession = (stack: StateStack) => {
+    const kills: string[] = [];
+    const rejections: any[] = [];
+    const session: any = {
+      sessionId: "s1",
+      child: { kill: (sig: string) => { kills.push(sig); return true; }, connected: true },
+      limits: { wallClock: 1000, memory: 1, ipcPayload: 1, stdout: 1 },
+      ctx: { lockReleasers: {} },
+      stateStack: stack,
+      resolvePromise: () => {},
+      rejectPromise: (err: any) => { rejections.push(err); },
+      settled: false,
+      startedAt: Date.now(),
+      wallClockTimer: null,
+      stdoutBytes: 0,
+      stoppedForwarding: false,
+      detachAbortListener: null,
+    };
+    return { session, kills, rejections };
+  };
+
+  it("charges localCost and guards; no trip under budget", () => {
+    const stack = new StateStack();
+    const guard = new CostGuard(1.0);
+    stack.guards.push(guard);
+    const { session, kills, rejections } = makeSession(stack);
+
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.25 });
+
+    expect(stack.localCost).toBe(0.25);
+    expect(guard.check(stack)).toBeNull();
+    expect(kills).toEqual([]);
+    expect(rejections).toEqual([]);
+    expect(session.settled).toBe(false);
+  });
+
+  it("a trip kills the child and rejects the session with the guard-trip abort", () => {
+    const stack = new StateStack();
+    stack.guards.push(new CostGuard(0.1));
+    const { session, kills, rejections } = makeSession(stack);
+
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
+
+    expect(kills).toEqual(["SIGKILL"]);
+    expect(rejections).toHaveLength(1);
+    expect(session.settled).toBe(true);
+    // The rejection must be the guard-trip abort ITSELF (identity, not a
+    // wrapper or re-thrown copy) so the OWNING boundary's ownedGuardIds
+    // matching converts it (the stdlib run() plain try re-throws).
+    expect(isGuardExceededError(rejections[0])).toBe(true);
+    expect(String(rejections[0])).toMatch(/cost/i);
+  });
+
+  it("post-settle telemetry still charges (the spend was real) but does not enforce", () => {
+    const stack = new StateStack();
+    stack.guards.push(new CostGuard(0.1));
+    const { session, kills, rejections } = makeSession(stack);
+    session.settled = true;
+
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
+
+    expect(stack.localCost).toBe(0.2);
+    expect(kills).toEqual([]);
+    expect(rejections).toEqual([]);
+  });
+
+  it("ignores malformed cost values", () => {
+    const stack = new StateStack();
+    const { session } = makeSession(stack);
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: NaN } as any);
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: -5 } as any);
+    handleTelemetryMessage(session, { type: "telemetry" } as any);
+    expect(stack.localCost).toBe(0);
+  });
+});
+```
+
+(Check `CostGuard`'s import path/export and `stack.guards` mutability against `lib/runtime/guard.ts` / `stateStack.ts` — if `guards` is not directly pushable, use the stack's guard-push method the generated code uses; `grep -n "pushGuard\|guards.push" lib/runtime/state/stateStack.ts`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+pnpm vitest run lib/runtime/ipc.test.ts > /tmp/cost-telemetry/t2-red.log 2>&1; echo "exit: $?"; grep -E "FAIL|Tests " /tmp/cost-telemetry/t2-red.log | head -3
+```
+Expected: FAIL — `handleTelemetryMessage` not exported.
+
+- [ ] **Step 3: Implement**
+
+In `lib/runtime/ipc.ts`:
+
+1. Import + re-export the type so the wire union stays discoverable in one place (the predicate comes along for the handler):
+
+```typescript
+import { isPayableCost, type IpcTelemetryMessage } from "./costTelemetry.js";
+export { type IpcTelemetryMessage };
+```
+
+2. Add `| IpcTelemetryMessage` to the `SubprocessToParent` union.
+
+3. Export the `RunSession` type (change `type RunSession` to `export type RunSession`).
+
+4. Add the handler (next to `handleErrorMessage`):
+
+```typescript
+/** Child (or descendant, via relay) reported a paid call. Bill it to the
+ * run() call-site stack via the same billCharge every in-process paid
+ * site uses: localCost (parent getCost() reflects child spend live) plus
+ * the guards — whose chargeGuards re-emits upward when THIS process is
+ * itself a subprocess, which is what relays grandchild spend to the root
+ * with no explicit plumbing. Billing is unconditional (the spend already
+ * happened, even post-settle); enforcement only runs on a live session:
+ * a trip kills the child and REJECTS the session with the guard-trip
+ * abort, which propagates through invokeSubprocess → runBatch (errors
+ * win over interrupts) → the stdlib run() plain `try` re-throws trips →
+ * the user's owning guard(cost:) boundary converts it to the standard
+ * cost-limit Failure.
+ *
+ * MUST STAY SYNCHRONOUS: handleChildMessage void-invokes its async
+ * dispatch, so arrival-order processing (all telemetry before the
+ * child's own terminal message, per IPC FIFO) holds only while this
+ * path contains no awaits — an await before enforcement would let a
+ * fast child's result settle the session before the trip fires.
+ *
+ * Known getCost() edge: post-settle billing (possible only on kill
+ * paths — FIFO rules it out on normal completion) charges the shared
+ * guard REFERENCES correctly, but the localCost increment can land
+ * after a fork branch's cost delta has already propagated at join, so
+ * getCost() may slightly undercount on abnormal termination. Budgets
+ * never undercount; do not "fix" this by skipping post-settle billing. */
+export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage): void {
+  if (!isPayableCost(msg.costUsd)) return;
+  s.stateStack.billCharge(msg.costUsd);
+  if (s.settled) return;
+  try {
+    s.stateStack.enforceGuards();
+  } catch (err) {
+    try {
+      s.child.kill("SIGKILL");
+    } catch (killErr) {
+      ipcLog("send", { type: "kill_failed", detail: killErr instanceof Error ? killErr.message : String(killErr) });
+    }
+    settle(s, s.rejectPromise, err);
+  }
+}
+```
+
+5. Dispatch case in `handleChildMessage` (after the `interrupted` case):
+
+```typescript
+  } else if (msg.type === "telemetry") {
+    handleTelemetryMessage(s, msg);
+```
+
+6. `ipcLog` detail case:
+
+```typescript
+  else if (type === "telemetry") detail = `costUsd=${msg.costUsd}`;
+```
+
+- [ ] **Step 4: Run tests + typecheck**
+
+```bash
+pnpm vitest run lib/runtime/ipc.test.ts lib/runtime/costTelemetry.test.ts > /tmp/cost-telemetry/t2-green.log 2>&1; echo "unit: $?"; grep -E "Tests " /tmp/cost-telemetry/t2-green.log
+npx tsc --noEmit >> /tmp/cost-telemetry/t2-green.log 2>&1; echo "tsc: $?"
+```
+Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/subprocess-pause-resume
+git add packages/agency-lang/lib/runtime/ipc.ts packages/agency-lang/lib/runtime/ipc.test.ts
+git commit -m "feat: parent charges cost guards from subprocess telemetry and kills on trip"
+cd packages/agency-lang
+```
+
+---
+
+### Task 3: E2E suite
+
+Budget math throughout: `SYNTHETIC_COST.totalCost = 0.000002` per mocked `llm()` call; each PROCESS gets its own full mock queue from the inherited env, so `llmMocks` needs as many entries as the busiest single process makes calls.
+
+**Files:**
+- Test: `tests/agency/subprocess/cost-guard-trips-on-child-spend.agency` + `.test.json`
+- Test: `tests/agency/subprocess/cost-child-spend-in-getcost.agency` + `.test.json`
+- Test: `tests/agency/subprocess/cost-nested-relay-trips-root.agency` + `.test.json`
+- Test: `tests/agency/subprocess/cost-two-children-share-budget.agency` + `.test.json`
+- Test: `tests/agency/subprocess/cost-no-double-charge-across-pause.agency` + `.test.json`
+
+**Interfaces:** consumes Tasks 1-2; produces nothing new. If any test exposes a bug, fix it in this task.
+
+- [ ] **Step 1: Trip test**
+
+`cost-guard-trips-on-child-spend.agency`:
+
+```agency
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+
+// The child makes 3 mocked llm() calls at 0.000002 each. The parent guard
+// caps at 0.000003: the second call's telemetry pushes spent to 0.000004,
+// the guard trips, the child is killed, and the trip surfaces as the
+// standard cost-limit Failure at this guard boundary.
+node main() {
+  const source = """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  const c = llm("Reply with: three")
+  return c
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = guard(cost: 0.000003) as {
+      return run(compiled: compileResult.value, node: "main")
+    }
+    if (isFailure(result)) {
+      return "tripped:${result.error.type}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+`.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Parent cost guard trips on subprocess spend and kills the child",
+      "input": "",
+      "expectedOutput": "\"tripped:guardFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    }
+  ]
+}
+```
+
+Note the guard block returns `run(...)`'s Result on success — if the block-return shape misbehaves, bind to a `let` outside the guard instead (`guard-cost-no-trip.agency` demonstrates the working block-return pattern).
+
+- [ ] **Step 2: getCost test**
+
+`cost-child-spend-in-getcost.agency`:
+
+```agency
+import { compile, run } from "std::agency"
+import { getCost } from "std::thread"
+
+// Under budget: the run succeeds AND the parent's getCost() reflects the
+// child's spend live (the parent itself makes zero llm calls, so any
+// positive cost came through telemetry).
+node main() {
+  const source = """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  return b
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "main")
+    if (isFailure(result)) {
+      return "run failed"
+    }
+    return "childSpendVisible:${getCost() > 0}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+`.test.json`: expected `"childSpendVisible:true"`, `useTestLLMProvider: true`, two mocks (`one`, `two`), no interruptHandlers.
+
+- [ ] **Step 3: Nested relay test**
+
+`cost-nested-relay-trips-root.agency` — the grandchild spends; only the ROOT holds a guard; the mid-tier has none and must relay:
+
+```agency
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+
+node main() {
+  const grandSource = """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  const c = llm("Reply with: three")
+  return c
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const result = run(compiled: c.value, node: "main")
+    if (isSuccess(result)) {
+      return result.value.data
+    }
+    return "inner run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = guard(cost: 0.000003) as {
+      return run(
+        compiled: compileResult.value,
+        node: "main",
+        args: { grandSource: grandSource },
+      )
+    }
+    if (isFailure(result)) {
+      return "tripped:${result.error.type}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+`.test.json`: expected `"tripped:guardFailure"`, `useTestLLMProvider: true`, three mocks. (The trip kills the MID process; the grandchild is reaped by the disconnect watchdog — the chain-reap shipped with pause/resume.)
+
+- [ ] **Step 4: Shared-budget test**
+
+`cost-two-children-share-budget.agency` — the discriminating case for the rejected ship-guards-into-child design: each child alone (2 × 0.000002 = 0.000004) is under the 0.000005 cap, but the two together (0.000008) must trip the ONE shared budget:
+
+```agency
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+
+node main() {
+  const source = """
+node main(tag: string) {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  return tag
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  const compiled = compileResult.value
+  handle {
+    const result = guard(cost: 0.000005) as {
+      const results = fork(["a", "b"]) as item {
+        return run(compiled: compiled, node: "main", args: { tag: item })
+      }
+      return results
+    }
+    if (isFailure(result)) {
+      return "tripped:${result.error.type}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+`.test.json`: expected `"tripped:guardFailure"`, `useTestLLMProvider: true`, two mocks (each child process consumes its own queue). The outcome is interleaving-independent: total spend strictly exceeds the cap while each child alone stays under it.
+
+- [ ] **Step 5: Pause/resume no-double-charge test**
+
+`cost-no-double-charge-across-pause.agency` — one paid call before the pause, one after the resume; the parent's total must be EXACTLY two calls' worth (a replay that re-emitted the first call's telemetry would make it three). `0.000002 + 0.000002 = 0.000004` is exact in floating point (`x + x`), so the equality assertion is safe:
+
+```agency
+import { compile, run } from "std::agency"
+import { getCost } from "std::thread"
+
+node main() {
+  const source = """
+import { bash } from "std::shell"
+node main() {
+  const a = llm("Reply with: one")
+  let r = bash("echo pause-here")
+  const b = llm("Reply with: two")
+  return b
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "main")
+    if (isFailure(result)) {
+      return "run failed"
+    }
+    return "exactlyTwoCalls:${getCost() == 0.000004}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+`.test.json`: expected `"exactlyTwoCalls:true"`, `useTestLLMProvider: true`, two mocks (`one`, `two`), and `"interruptHandlers": [{ "action": "approve" }]` (the unhandled bash pauses the child; the approval resumes it — the resumed segment replays the completed first llm() step without re-emitting).
+
+- [ ] **Step 6: Parse-check, rebuild, run all five**
+
+```bash
+make > /tmp/cost-telemetry/t3-make.log 2>&1; echo "make: $?"
+for t in cost-guard-trips-on-child-spend cost-child-spend-in-getcost cost-nested-relay-trips-root cost-two-children-share-budget cost-no-double-charge-across-pause; do
+  if pnpm run ast tests/agency/subprocess/$t.agency > /dev/null 2>&1; then echo "$t: parses"; else echo "$t: PARSE FAIL"; continue; fi
+  pnpm run agency test tests/agency/subprocess/$t.agency > /tmp/cost-telemetry/t3-$t.log 2>&1
+  echo "$t: exit $?"
+done
+```
+Expected: all PASS. Debug with `AGENCY_IPC_DEBUG=1` (telemetry lines show `costUsd=`). Likely failure spots: guard-block return shape (see Step 1 note); fork+guard composition timing (the trip rejection surfaces after `Promise.allSettled` — both children finish or die first; the assertion is outcome-only so this is fine).
+
+- [ ] **Step 7: Regression sweep + commit**
+
+```bash
+for t in run-basic pause-multi-cycle concurrent-handled nested-pause-resume; do
+  pnpm run agency test tests/agency/subprocess/$t.agency > /tmp/cost-telemetry/t3-regress-$t.log 2>&1; echo "$t: $?"
+done
+pnpm run agency test tests/agency/guards/guard-cost-trip.agency > /tmp/cost-telemetry/t3-regress-guard.log 2>&1; echo "guard-cost-trip: $?"
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/subprocess-pause-resume
+git add packages/agency-lang/tests/agency/subprocess/cost-*
+git commit -m "test: subprocess cost telemetry E2E suite"
+cd packages/agency-lang
+```
+
+---
+
+### Task 4: Docs, final verification, PR
+
+**Files:**
+- Modify: `docs/site/guide/guards.md` (cost guards cover subprocess spend — add a short subsection after the cost-guard section)
+- Modify: `docs/dev/subprocess-ipc.md` (telemetry message in the protocol block; a "Cost guards" paragraph; REMOVE the cost-guard bullet from Remaining limitations)
+- Modify: `stdlib/agency.agency` (`run()` docstring: enclosing cost guards meter the subprocess) — then `make`
+
+- [ ] **Step 1: Docs edits**
+
+`docs/dev/subprocess-ipc.md` — add to the Subprocess → Parent protocol block:
+
+```typescript
+{ type: "telemetry", costUsd }   // fire-and-forget, one per paid call
+```
+
+and a paragraph under Limits:
+
+```markdown
+**Cost guards** meter subprocess spend live: every paid call in a child
+fire-and-forgets `{ type: "telemetry", costUsd }` upward (emitted from
+`StateStack.chargeGuards`, the choke point every paid site funnels
+through). The parent charges `localCost` + its guards on the run()
+call-site stack — so parent `getCost()` includes child spend — and a trip
+kills the child and surfaces the standard cost-limit Failure at the
+owning `guard(cost:)` boundary. Relay to the root is automatic in nested
+trees (the mid-tier handler's own `chargeGuards` re-emits upward).
+Detection latency is at most one paid call, matching in-process CostGuard
+semantics. Telemetry is cost-only; tokens arrive terminally via
+`result.tokens`. One `getCost()` edge: telemetry arriving after a kill
+(abort, wall-clock, stdout, memory — FIFO rules this out on normal
+completion) still charges budgets via the shared guard references, but
+can be invisible to `getCost()` if the owning fork branch already joined.
+Budgets never undercount; `getCost()` may, on abnormal termination only.
+```
+
+Delete the `- **Cost-guard telemetry**: ...` bullet from Remaining limitations.
+
+`docs/site/guide/guards.md` — locate the cost-guard section and add:
+
+```markdown
+Cost guards also meter subprocesses: spend from `std::agency run()` —
+including nested subprocesses — is charged to enclosing cost guards in
+real time, and a tripped budget terminates the subprocess and fails the
+guard block with the usual cost-limit failure. `getCost()` reflects
+subprocess spend as it happens.
+```
+
+`stdlib/agency.agency` `run()` docstring — after the resource-limits paragraph add:
+
+```
+  Enclosing cost guards meter the subprocess: each paid call inside it is charged to the parent's guard(cost:) budgets in real time, and a tripped budget terminates the subprocess and fails the guard block.
+```
+
+Then `make` (stdlib changed) and check `git status` for regenerated `docs/site/stdlib/` output — commit whatever `agency doc` regenerates.
+
+- [ ] **Step 2: Final verification**
+
+```bash
+npx tsc --noEmit > /tmp/cost-telemetry/final.log 2>&1; echo "tsc: $?"
+pnpm run lint:structure >> /tmp/cost-telemetry/final.log 2>&1; echo "lint: $?"
+pnpm vitest run lib/runtime > /tmp/cost-telemetry/final-unit.log 2>&1; echo "runtime unit: $?"; grep -E "Tests " /tmp/cost-telemetry/final-unit.log
+for f in tests/agency/subprocess/cost-*.agency; do pnpm run agency test "$f" > "/tmp/cost-telemetry/final-$(basename $f .agency).log" 2>&1; echo "$(basename $f .agency): $?"; done
+```
+Expected: all clean/green.
+
+- [ ] **Step 3: PR**
+
+Write the PR body to `/tmp/cost-telemetry/pr-body.md`. Do NOT link the spec path — `docs/superpowers/specs/` is gitignored, so the link would be dead for reviewers; inline the design summary instead (the chargeGuards-choke-point + automatic-relay architecture; the `billCharge` extraction unifying the three paid-site billing sequences; the getCost decision; the at-most-one-call detection latency, trip-kills-not-pauses, and abnormal-termination getCost-undercount limitations; the five E2E scenarios; end with the standard Claude Code attribution footer), then:
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/subprocess-pause-resume
+git push -u origin subprocess-cost-telemetry
+gh pr create --title "Cost guards meter subprocess spend via per-call telemetry" --body-file /tmp/cost-telemetry/pr-body.md
+```

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md
@@ -1,0 +1,190 @@
+# Subprocess Cost-Guard Telemetry — Design
+
+**Date:** 2026-07-02
+**Status:** Approved cadence (per-call, owner); getCost scope chosen by recommendation (owner review pending)
+**Depends on:** subprocess pause/resume (PR #398, merged)
+
+## Problem
+
+A parent `guard(cost: $X) { run(...) }` is blind to subprocess spend: the
+child compiles with its own empty guard stack, and the parent learns about
+child LLM cost only from the terminal `result` message — after the money is
+spent. With nesting unblocked, an agent-written child (or grandchild) can
+make unbounded LLM calls outside every cost guard. The abort half already
+works (a parent TimeGuard's abort kills the child via the composed signal →
+SIGKILL path); this design closes the cost half.
+
+## How cost accounting works today (the facts the design builds on)
+
+- `CostGuard` owns a `spent` counter. Every paid site runs the same
+  sequence: `stack.localCost += amount; stack.chargeGuards(amount);
+  stack.enforceGuards()` — LLM calls (`lib/runtime/prompt.ts`), TS helpers
+  via `addCost` (`lib/runtime/cost.ts`, e.g. image generation), and the
+  memory subsystem. `chargeGuards` walks `stack.guards`, which includes
+  shared REFERENCES to enclosing/parent-branch guards (real-time
+  cross-branch accounting in one process).
+- `enforceGuards()` throws a guard-trip abort carrying `guardId`. The
+  abort-taxonomy contract (§4.1.1): a `try` boundary converts a trip ONLY
+  if it owns the guard (`ownedGuardIds`); a plain `try` re-throws. The
+  stdlib `run()`'s `return try _run(...)` is a plain try, so a trip thrown
+  out of `_run` propagates to the user's owning `guard(cost:)` boundary and
+  converts to the standard cost-limit Failure there. No new trip plumbing
+  is needed.
+- Guards serialize (`spent` in `toJSON`) — a paused parent's budget
+  survives durable resume.
+
+## Design
+
+### Emission: inside `StateStack.chargeGuards`, per paid call
+
+`chargeGuards(amount)` gains one line: after charging local guards, when
+this process is a subprocess, fire-and-forget the amount upward. This is
+the single choke point every paid site already funnels through — LLM,
+`addCost`, memory, and any future site are covered by construction.
+
+**Nested relay is automatic**: the parent-side telemetry handler charges
+its own stack via `chargeGuards`, and when that process is itself a
+subprocess, that call re-emits upward. Grandchild spend reaches the root
+with zero explicit relay code.
+
+Rejected alternatives:
+- **Per-site emission** — reintroduces the missed-site bug class.
+- **Shipping parent guards into the child** — unsound: in-process sharing
+  works via references to ONE counter; a cross-process copy diverges (two
+  children under one $1 guard would each get the full dollar).
+- **Periodic batching** — rejected by owner; per-call is exact, and paid
+  calls are seconds apart while a telemetry message costs microseconds.
+
+### Wire
+
+```typescript
+// SubprocessToParent union gains:
+export type IpcTelemetryMessage = {
+  type: "telemetry";
+  costUsd: number;
+};
+```
+
+Sent by a new dependency-free leaf module `lib/runtime/costTelemetry.ts`
+(the `subprocessRunInfo.ts` layering pattern — `stateStack.ts` must not
+import `ipc.ts`):
+
+```typescript
+export function sendCostTelemetryToParent(costUsd: number): void {
+  if (process.env.AGENCY_IPC !== "1" || typeof process.send !== "function") return;
+  if (!(costUsd > 0)) return;
+  try {
+    process.send({ type: "telemetry", costUsd });
+  } catch (_) {
+    // Channel gone — the bootstrap disconnect watchdog is about to reap
+    // this process anyway.
+  }
+}
+```
+
+Fire-and-forget: no reply, no listener, never parks the child. IPC channel
+FIFO ordering guarantees every telemetry message lands before the child's
+own terminal message, so no spend goes missing at settle.
+
+### Parent-side handler (`ipc.ts`)
+
+New `handleChildMessage` case:
+
+```typescript
+function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage): void {
+  const cost = typeof msg.costUsd === "number" && msg.costUsd > 0 ? msg.costUsd : 0;
+  if (cost === 0) return;
+  // Charge unconditionally — the spend already happened, even if the
+  // session has settled (e.g. a queued message after a kill). The same
+  // sequence every in-process paid site runs; chargeGuards re-emits
+  // upward when this process is itself a subprocess (nested relay).
+  s.stateStack.localCost += cost;
+  s.stateStack.chargeGuards(cost);
+  if (s.settled) return;
+  try {
+    s.stateStack.enforceGuards();
+  } catch (err) {
+    // A parent cost guard tripped on child spend: kill the child and
+    // REJECT the session with the trip. The rejection propagates through
+    // invokeSubprocess → runBatch (errors win over interrupts) → the
+    // stdlib run()'s plain `try` re-throws guard trips → the user's
+    // owning guard(cost:) boundary converts it to the cost-limit Failure.
+    try { s.child.kill("SIGKILL"); } catch (killErr) { ipcLog("send", { type: "kill_failed", detail: String(killErr) }); }
+    settle(s, s.rejectPromise, err);
+  }
+}
+```
+
+`s.stateStack` is the `run()` call-site slice, whose `guards` array already
+holds references to every enclosing guard — including guards inherited
+through fork branches — so multi-child and in-fork compositions charge the
+right shared counters.
+
+### Semantics and properties
+
+- **getCost() scope (owner review pending — recommended option chosen):**
+  telemetry updates `localCost` alongside the guard charge, so parent
+  `getCost()` reflects subprocess spend live. Nothing folds child cost into
+  parent accumulators at terminal today, so there is no double-count.
+  **Tokens are a non-goal**: guards are cost-based, `getTokens()` keeps its
+  in-process meaning, and cumulative child tokens already arrive terminally
+  via `result.tokens`.
+- **No double-charging across pause/resume**: charges are per-call
+  incremental, and a resumed child's replay skips completed LLM steps, so
+  nothing re-emits. Parent guard `spent` serializes into parent
+  checkpoints, so budgets survive durable pauses (a resumed run continues
+  from the spent-so-far, not a fresh budget).
+- **Detection latency is at most one paid call**: the pre-call
+  `enforceGuards()` gate inside the CHILD does not know about parent
+  guards, so the child can start one more call after the budget is
+  exhausted; the parent trips on that call's telemetry and kills. This
+  mirrors the in-process CostGuard behavior (no mid-flight cancellation of
+  sibling calls; the post-call check is authoritative).
+- **Trip kills; it does not pause.** A busy child cannot be checkpointed on
+  demand (the same constraint that shaped the pause design), so
+  raise-the-budget-and-resume is not possible: `run()` returns the
+  cost-limit Failure and partial child work is lost. Possible future
+  refinement: a "pause at the next interrupt-safe point" instruction.
+- The `interrupted` pause path is unaffected: a paused child has already
+  reported all its spend (FIFO), holds no budget, and its resume segment
+  reports fresh spend as it happens.
+
+### Testing
+
+Unit (`ipc.test.ts`, `costTelemetry.test.ts`):
+- Sender no-ops outside IPC mode / without a channel / for zero cost.
+- Handler charges localCost + guards; trips settle-with-rejection and kill;
+  post-settle telemetry charges but does not enforce.
+- `chargeGuards` emits exactly once per charge (spy on the leaf sender).
+
+E2E (agency execution + agency-js). Child spend is driven through the
+deterministic LLM client with cost injection — extend `DeterministicClient`
+to carry `cost.totalCost` (and usage) in mocked completions if it does not
+already (verify at plan time); mocks reach the child via the inherited
+`AGENCY_LLM_MOCKS` env var:
+1. `guard(cost: $X) { run(child-that-overspends) }` → the block yields the
+   standard cost-limit Failure; the child process is dead (no orphaned
+   work after the trip).
+2. Under-budget child → run succeeds AND parent `getCost()` includes the
+   child's spend.
+3. Nested: grandchild spend trips the ROOT guard through the automatic
+   relay.
+4. Two concurrent subprocesses under one guard share the single budget
+   (the shape the ship-guards-into-child alternative would get wrong).
+
+### Docs
+
+- `docs/site/guide/guards.md`: cost guards now cover subprocess spend.
+- `docs/dev/subprocess-ipc.md`: telemetry message, handler, relay; remove
+  the cost-guard bullet from Remaining limitations.
+- `stdlib/agency.agency` `run()` docstring: note that enclosing cost
+  guards meter the subprocess.
+
+## Out of scope
+
+- Live token mirroring into parent `getTokens()`.
+- Global `__tokenStats` /cost-style roll-up of child spend (terminal
+  `result.tokens` already exists).
+- Trip-to-pause (checkpoint on guard trip) — requires on-demand
+  checkpointing of a busy child.
+- Callback forwarding and the `agency resume` CLI (separate follow-ups).

--- a/packages/agency-lang/lib/runtime/cost.ts
+++ b/packages/agency-lang/lib/runtime/cost.ts
@@ -8,8 +8,7 @@ import { getRuntimeContext } from "./asyncContext.js";
  *  Throws (a guard-trip) if enforcement fails — callers must not swallow it. */
 export function addCost(amount: number): void {
   const stack = getRuntimeContext().stack;
-  stack.localCost += amount;
-  stack.chargeGuards(amount);
+  stack.billCharge(amount);
   stack.enforceGuards();
 }
 

--- a/packages/agency-lang/lib/runtime/costTelemetry.test.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isPayableCost, sendCostTelemetryToParent } from "./costTelemetry.js";
+import { StateStack } from "./state/stateStack.js";
+import { CostGuard } from "./guard.js";
+
+describe("isPayableCost", () => {
+  it("accepts positive finite numbers only", () => {
+    expect(isPayableCost(0.5)).toBe(true);
+    expect(isPayableCost(0)).toBe(false);
+    expect(isPayableCost(-1)).toBe(false);
+    expect(isPayableCost(NaN)).toBe(false);
+    expect(isPayableCost(Infinity)).toBe(false);
+    expect(isPayableCost("0.5")).toBe(false);
+    expect(isPayableCost(undefined)).toBe(false);
+  });
+});
+
+describe("sendCostTelemetryToParent", () => {
+  const originalSend = process.send;
+  const originalIpc = process.env.AGENCY_IPC;
+
+  afterEach(() => {
+    process.send = originalSend;
+    if (originalIpc === undefined) delete process.env.AGENCY_IPC;
+    else process.env.AGENCY_IPC = originalIpc;
+    vi.restoreAllMocks();
+  });
+
+  it("sends the telemetry message when in IPC mode", () => {
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCostTelemetryToParent(0.5);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "telemetry", costUsd: 0.5 });
+  });
+
+  it("no-ops outside IPC mode", () => {
+    delete process.env.AGENCY_IPC;
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCostTelemetryToParent(0.5);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("no-ops for zero, negative, and non-finite cost", () => {
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCostTelemetryToParent(0);
+    sendCostTelemetryToParent(-1);
+    sendCostTelemetryToParent(NaN);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("swallows a dead-channel send error", () => {
+    process.env.AGENCY_IPC = "1";
+    process.send = vi.fn(() => { throw new Error("channel closed"); }) as any;
+    expect(() => sendCostTelemetryToParent(0.5)).not.toThrow();
+  });
+});
+
+describe("StateStack.chargeGuards emission", () => {
+  const originalSend = process.send;
+  const originalIpc = process.env.AGENCY_IPC;
+
+  afterEach(() => {
+    process.send = originalSend;
+    if (originalIpc === undefined) delete process.env.AGENCY_IPC;
+    else process.env.AGENCY_IPC = originalIpc;
+    vi.restoreAllMocks();
+  });
+
+  it("emits exactly once per charge, even with zero guards installed", () => {
+    // Emission must be unconditional on guards being present: a mid-tier
+    // relay process may have NO local guards but must still forward the
+    // grandchild spend upward.
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const stack = new StateStack();
+    stack.chargeGuards(0.25);
+    expect(send).toHaveBeenCalledExactlyOnceWith({ type: "telemetry", costUsd: 0.25 });
+  });
+
+  it("does not emit for a zero charge", () => {
+    process.env.AGENCY_IPC = "1";
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    new StateStack().chargeGuards(0);
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("StateStack.billCharge", () => {
+  it("accumulates localCost and really charges guards in one call", () => {
+    const stack = new StateStack();
+    const guard = new CostGuard(0.1);
+    stack.guards.push(guard);
+    stack.billCharge(0.25);
+    expect(stack.localCost).toBe(0.25);
+    // 0.25 > 0.1: check() reporting a trip proves the guard was charged,
+    // not just localCost.
+    expect(guard.check(stack)).not.toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/runtime/costTelemetry.test.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.test.ts
@@ -3,6 +3,17 @@ import { isPayableCost, sendCostTelemetryToParent } from "./costTelemetry.js";
 import { StateStack } from "./state/stateStack.js";
 import { CostGuard } from "./guard.js";
 
+// process.send has no vi.stubEnv equivalent — save/restore it manually.
+// Env vars are stubbed per test and reset via vi.unstubAllEnvs(): a leaked
+// AGENCY_IPC=1 would make every billCharge in later tests emit telemetry.
+const originalSend = process.send;
+
+afterEach(() => {
+  process.send = originalSend;
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
 describe("isPayableCost", () => {
   it("accepts positive finite numbers only", () => {
     expect(isPayableCost(0.5)).toBe(true);
@@ -16,18 +27,8 @@ describe("isPayableCost", () => {
 });
 
 describe("sendCostTelemetryToParent", () => {
-  const originalSend = process.send;
-  const originalIpc = process.env.AGENCY_IPC;
-
-  afterEach(() => {
-    process.send = originalSend;
-    if (originalIpc === undefined) delete process.env.AGENCY_IPC;
-    else process.env.AGENCY_IPC = originalIpc;
-    vi.restoreAllMocks();
-  });
-
   it("sends the telemetry message when in IPC mode", () => {
-    process.env.AGENCY_IPC = "1";
+    vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
     sendCostTelemetryToParent(0.5);
@@ -35,7 +36,6 @@ describe("sendCostTelemetryToParent", () => {
   });
 
   it("no-ops outside IPC mode", () => {
-    delete process.env.AGENCY_IPC;
     const send = vi.fn(() => true);
     process.send = send as any;
     sendCostTelemetryToParent(0.5);
@@ -43,7 +43,7 @@ describe("sendCostTelemetryToParent", () => {
   });
 
   it("no-ops for zero, negative, and non-finite cost", () => {
-    process.env.AGENCY_IPC = "1";
+    vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
     sendCostTelemetryToParent(0);
@@ -53,45 +53,43 @@ describe("sendCostTelemetryToParent", () => {
   });
 
   it("swallows a dead-channel send error", () => {
-    process.env.AGENCY_IPC = "1";
+    vi.stubEnv("AGENCY_IPC", "1");
     process.send = vi.fn(() => { throw new Error("channel closed"); }) as any;
     expect(() => sendCostTelemetryToParent(0.5)).not.toThrow();
   });
 });
 
-describe("StateStack.chargeGuards emission", () => {
-  const originalSend = process.send;
-  const originalIpc = process.env.AGENCY_IPC;
-
-  afterEach(() => {
-    process.send = originalSend;
-    if (originalIpc === undefined) delete process.env.AGENCY_IPC;
-    else process.env.AGENCY_IPC = originalIpc;
-    vi.restoreAllMocks();
-  });
-
+describe("StateStack.billCharge", () => {
   it("emits exactly once per charge, even with zero guards installed", () => {
     // Emission must be unconditional on guards being present: a mid-tier
     // relay process may have NO local guards but must still forward the
     // grandchild spend upward.
-    process.env.AGENCY_IPC = "1";
+    vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
     const stack = new StateStack();
-    stack.chargeGuards(0.25);
+    stack.billCharge(0.25);
     expect(send).toHaveBeenCalledExactlyOnceWith({ type: "telemetry", costUsd: 0.25 });
   });
 
   it("does not emit for a zero charge", () => {
-    process.env.AGENCY_IPC = "1";
+    vi.stubEnv("AGENCY_IPC", "1");
     const send = vi.fn(() => true);
     process.send = send as any;
-    new StateStack().chargeGuards(0);
+    new StateStack().billCharge(0);
     expect(send).not.toHaveBeenCalled();
   });
-});
 
-describe("StateStack.billCharge", () => {
+  it("a direct chargeGuards call does NOT emit — emission rides the fresh-paid-charge semantic", () => {
+    // Pins the hoist: re-applying spend to guard accumulators (restore /
+    // reconciliation paths) must never double-bill the parent.
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    new StateStack().chargeGuards(0.25);
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it("accumulates localCost and really charges guards in one call", () => {
     const stack = new StateStack();
     const guard = new CostGuard(0.1);

--- a/packages/agency-lang/lib/runtime/costTelemetry.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.ts
@@ -3,15 +3,17 @@
  * parent-side cost guards see child LLM spend live (see
  * docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md).
  *
- * Deliberately dependency-free (the subprocessRunInfo.ts layering
- * pattern): `StateStack.chargeGuards` calls this on every paid charge,
- * and stateStack must not import ipc.ts. The message type lives here and
- * is re-exported by ipc.ts into the SubprocessToParent union.
+ * Deliberately dependency-light (the subprocessRunInfo.ts layering
+ * pattern — the only import IS subprocessRunInfo, itself dependency-free):
+ * `StateStack.billCharge` calls this on every paid charge, and stateStack
+ * must not import ipc.ts.
  *
  * Never blocks and never throws: there is no reply, no listener, and a
  * dead channel is swallowed — the bootstrap disconnect watchdog is about
  * to reap this process anyway.
  */
+
+import { isIpcMode } from "./subprocessRunInfo.js";
 
 export type IpcTelemetryMessage = {
   type: "telemetry";
@@ -27,7 +29,7 @@ export function isPayableCost(costUsd: unknown): costUsd is number {
 }
 
 export function sendCostTelemetryToParent(costUsd: number): void {
-  if (process.env.AGENCY_IPC !== "1" || typeof process.send !== "function") return;
+  if (!isIpcMode() || typeof process.send !== "function") return;
   if (!isPayableCost(costUsd)) return;
   const msg: IpcTelemetryMessage = { type: "telemetry", costUsd };
   try {
@@ -35,10 +37,12 @@ export function sendCostTelemetryToParent(costUsd: number): void {
   } catch (err) {
     // Channel gone — parent died; the watchdog will exit this process.
     // Deliberately swallowed (fire-and-forget invariant), but traceable:
-    // ipcLog is unreachable from this leaf module, so mirror its gating.
+    // ipcLog is unreachable from this leaf module, so mirror its line
+    // format (this sender only ever runs in a child) and env gating.
     if (process.env.AGENCY_IPC_DEBUG === "1") {
+      const ts = new Date().toISOString().slice(11, 23);
       const detail = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[ipc:telemetry] send failed: ${detail}\n`);
+      process.stderr.write(`[ipc:child] ${ts} send telemetry_send_failed ${detail}\n`);
     }
   }
 }

--- a/packages/agency-lang/lib/runtime/costTelemetry.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.ts
@@ -1,0 +1,44 @@
+/**
+ * Fire-and-forget cost telemetry from a subprocess to its parent, so
+ * parent-side cost guards see child LLM spend live (see
+ * docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md).
+ *
+ * Deliberately dependency-free (the subprocessRunInfo.ts layering
+ * pattern): `StateStack.chargeGuards` calls this on every paid charge,
+ * and stateStack must not import ipc.ts. The message type lives here and
+ * is re-exported by ipc.ts into the SubprocessToParent union.
+ *
+ * Never blocks and never throws: there is no reply, no listener, and a
+ * dead channel is swallowed — the bootstrap disconnect watchdog is about
+ * to reap this process anyway.
+ */
+
+export type IpcTelemetryMessage = {
+  type: "telemetry";
+  costUsd: number;
+};
+
+/** The wire contract for a billable cost: a positive finite number.
+ * Shared by the sender and the parent-side handler so both ends of the
+ * channel enforce the same rule (the receiving side matters more — the
+ * child is the less-trusted party). */
+export function isPayableCost(costUsd: unknown): costUsd is number {
+  return typeof costUsd === "number" && Number.isFinite(costUsd) && costUsd > 0;
+}
+
+export function sendCostTelemetryToParent(costUsd: number): void {
+  if (process.env.AGENCY_IPC !== "1" || typeof process.send !== "function") return;
+  if (!isPayableCost(costUsd)) return;
+  const msg: IpcTelemetryMessage = { type: "telemetry", costUsd };
+  try {
+    process.send(msg);
+  } catch (err) {
+    // Channel gone — parent died; the watchdog will exit this process.
+    // Deliberately swallowed (fire-and-forget invariant), but traceable:
+    // ipcLog is unreachable from this leaf module, so mirror its gating.
+    if (process.env.AGENCY_IPC_DEBUG === "1") {
+      const detail = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[ipc:telemetry] send failed: ${detail}\n`);
+    }
+  }
+}

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -7,10 +7,13 @@ import {
   getSubprocessRunInfo,
   resolveDepthCap,
   attachSessionHandlers,
+  handleTelemetryMessage,
   withParentStatelog,
   DEFAULT_MAX_SUBPROCESS_DEPTH,
   SUBPROCESS_DEPTH_CEILING,
 } from "./ipc.js";
+import { StateStack } from "./state/stateStack.js";
+import { CostGuard, isGuardExceededError } from "./guard.js";
 
 describe("withParentStatelog", () => {
   it("forwards the parent logFile (absolutized) when the parent logs and the caller set none", () => {
@@ -260,5 +263,82 @@ describe("wall-clock timer is per execution segment", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("handleTelemetryMessage", () => {
+  const makeSession = (stack: StateStack) => {
+    const kills: string[] = [];
+    const rejections: any[] = [];
+    const session: any = {
+      sessionId: "s1",
+      child: { kill: (sig: string) => { kills.push(sig); return true; }, connected: true },
+      limits: { wallClock: 1000, memory: 1, ipcPayload: 1, stdout: 1 },
+      ctx: { lockReleasers: {} },
+      stateStack: stack,
+      resolvePromise: () => {},
+      rejectPromise: (err: any) => { rejections.push(err); },
+      settled: false,
+      startedAt: Date.now(),
+      wallClockTimer: null,
+      stdoutBytes: 0,
+      stoppedForwarding: false,
+      detachAbortListener: null,
+    };
+    return { session, kills, rejections };
+  };
+
+  it("charges localCost and guards; no trip under budget", () => {
+    const stack = new StateStack();
+    const guard = new CostGuard(1.0);
+    stack.guards.push(guard);
+    const { session, kills, rejections } = makeSession(stack);
+
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.25 });
+
+    expect(stack.localCost).toBe(0.25);
+    expect(guard.check(stack)).toBeNull();
+    expect(kills).toEqual([]);
+    expect(rejections).toEqual([]);
+    expect(session.settled).toBe(false);
+  });
+
+  it("a trip kills the child and rejects the session with the guard-trip abort", () => {
+    const stack = new StateStack();
+    stack.guards.push(new CostGuard(0.1));
+    const { session, kills, rejections } = makeSession(stack);
+
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
+
+    expect(kills).toEqual(["SIGKILL"]);
+    expect(rejections).toHaveLength(1);
+    expect(session.settled).toBe(true);
+    // The rejection must be the guard-trip abort ITSELF (identity, not a
+    // wrapper or re-thrown copy) so the OWNING boundary's ownedGuardIds
+    // matching converts it (the stdlib run() plain try re-throws).
+    expect(isGuardExceededError(rejections[0])).toBe(true);
+    expect(String(rejections[0])).toMatch(/cost/i);
+  });
+
+  it("post-settle telemetry still charges (the spend was real) but does not enforce", () => {
+    const stack = new StateStack();
+    stack.guards.push(new CostGuard(0.1));
+    const { session, kills, rejections } = makeSession(stack);
+    session.settled = true;
+
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
+
+    expect(stack.localCost).toBe(0.2);
+    expect(kills).toEqual([]);
+    expect(rejections).toEqual([]);
+  });
+
+  it("ignores malformed cost values", () => {
+    const stack = new StateStack();
+    const { session } = makeSession(stack);
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: NaN } as any);
+    handleTelemetryMessage(session, { type: "telemetry", costUsd: -5 } as any);
+    handleTelemetryMessage(session, { type: "telemetry" } as any);
+    expect(stack.localCost).toBe(0);
   });
 });

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -158,6 +158,27 @@ describe("clampLimits", () => {
   });
 });
 
+/** One canonical RunSession mock — when `RunSession` gains a field the
+ * code under test reads, add it HERE so every suite sees it (the mocks
+ * are `any`-typed, so a second hand-rolled literal would go stale
+ * silently). Suites layer their specifics via `overrides`. */
+const makeSession = (overrides: Record<string, any> = {}): any => ({
+  sessionId: "test-session",
+  child: { stdout: null, stderr: null, on: () => {}, send: () => true, connected: true, kill: () => true },
+  limits: { wallClock: 1000, memory: 1, ipcPayload: 1, stdout: 1 },
+  ctx: { lockReleasers: {} },
+  stateStack: {},
+  resolvePromise: () => {},
+  rejectPromise: () => {},
+  settled: false,
+  startedAt: Date.now(),
+  wallClockTimer: null,
+  stdoutBytes: 0,
+  stoppedForwarding: false,
+  detachAbortListener: null,
+  ...overrides,
+});
+
 describe("wall-clock timer is per execution segment", () => {
   // Replaces the deleted pause-limit-wallclock-resets execution test: the
   // per-segment property (paused time never counts against wallClock)
@@ -180,20 +201,12 @@ describe("wall-clock timer is per execution segment", () => {
     };
   };
 
-  const makeSession = (child: any, outcomes: any[]): any => ({
+  const makeSegmentSession = (child: any, outcomes: any[]): any => makeSession({
     sessionId: "seg-test",
     child,
     limits: { wallClock: 5000, memory: 1, ipcPayload: 1024 * 1024 * 1024, stdout: 1024 * 1024 * 1024 },
-    ctx: { lockReleasers: {} },
-    stateStack: {},
     resolvePromise: (v: any) => outcomes.push({ kind: "resolve", v }),
     rejectPromise: (e: any) => outcomes.push({ kind: "reject", e }),
-    settled: false,
-    startedAt: Date.now(),
-    wallClockTimer: null,
-    stdoutBytes: 0,
-    stoppedForwarding: false,
-    detachAbortListener: null,
   });
 
   it("arms on session start and is cleared when the child pauses; never fires afterward", async () => {
@@ -201,7 +214,7 @@ describe("wall-clock timer is per execution segment", () => {
     try {
       const { child, listeners } = makeFakeChild();
       const outcomes: any[] = [];
-      const session = makeSession(child, outcomes);
+      const session = makeSegmentSession(child, outcomes);
 
       attachSessionHandlers(session, { type: "run", scriptPath: "/x.js", node: "main", args: {} });
       expect(session.wallClockTimer).not.toBeNull();
@@ -229,7 +242,7 @@ describe("wall-clock timer is per execution segment", () => {
     try {
       const { child } = makeFakeChild();
       const outcomes: any[] = [];
-      const session = makeSession(child, outcomes);
+      const session = makeSegmentSession(child, outcomes);
 
       attachSessionHandlers(session, { type: "run", scriptPath: "/x.js", node: "main", args: {} });
       await vi.advanceTimersByTimeAsync(5001);
@@ -248,7 +261,7 @@ describe("wall-clock timer is per execution segment", () => {
     try {
       const first = makeFakeChild();
       const firstOutcomes: any[] = [];
-      const s1 = makeSession(first.child, firstOutcomes);
+      const s1 = makeSegmentSession(first.child, firstOutcomes);
       attachSessionHandlers(s1, { type: "run", scriptPath: "/x.js", node: "main", args: {} });
       first.listeners["message"]({ type: "interrupted", interrupts: [], checkpoint: {}, subprocessSessionId: "s" });
 
@@ -256,7 +269,7 @@ describe("wall-clock timer is per execution segment", () => {
       // independent of how much the first segment used.
       const second = makeFakeChild();
       const secondOutcomes: any[] = [];
-      const s2 = makeSession(second.child, secondOutcomes);
+      const s2 = makeSegmentSession(second.child, secondOutcomes);
       attachSessionHandlers(s2, { type: "resume", scriptPath: "/x.js", node: "main", checkpoint: {}, interrupts: [], responses: [] });
       expect(s2.wallClockTimer).not.toBeNull();
       expect(s2.wallClockTimer).not.toBe(s1.wallClockTimer);
@@ -267,24 +280,14 @@ describe("wall-clock timer is per execution segment", () => {
 });
 
 describe("handleTelemetryMessage", () => {
-  const makeSession = (stack: StateStack) => {
+  const makeTelemetrySession = (stack: StateStack) => {
     const kills: string[] = [];
     const rejections: any[] = [];
-    const session: any = {
-      sessionId: "s1",
+    const session = makeSession({
       child: { kill: (sig: string) => { kills.push(sig); return true; }, connected: true },
-      limits: { wallClock: 1000, memory: 1, ipcPayload: 1, stdout: 1 },
-      ctx: { lockReleasers: {} },
       stateStack: stack,
-      resolvePromise: () => {},
       rejectPromise: (err: any) => { rejections.push(err); },
-      settled: false,
-      startedAt: Date.now(),
-      wallClockTimer: null,
-      stdoutBytes: 0,
-      stoppedForwarding: false,
-      detachAbortListener: null,
-    };
+    });
     return { session, kills, rejections };
   };
 
@@ -292,7 +295,7 @@ describe("handleTelemetryMessage", () => {
     const stack = new StateStack();
     const guard = new CostGuard(1.0);
     stack.guards.push(guard);
-    const { session, kills, rejections } = makeSession(stack);
+    const { session, kills, rejections } = makeTelemetrySession(stack);
 
     handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.25 });
 
@@ -306,7 +309,7 @@ describe("handleTelemetryMessage", () => {
   it("a trip kills the child and rejects the session with the guard-trip abort", () => {
     const stack = new StateStack();
     stack.guards.push(new CostGuard(0.1));
-    const { session, kills, rejections } = makeSession(stack);
+    const { session, kills, rejections } = makeTelemetrySession(stack);
 
     handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
 
@@ -323,7 +326,7 @@ describe("handleTelemetryMessage", () => {
   it("post-settle telemetry still charges (the spend was real) but does not enforce", () => {
     const stack = new StateStack();
     stack.guards.push(new CostGuard(0.1));
-    const { session, kills, rejections } = makeSession(stack);
+    const { session, kills, rejections } = makeTelemetrySession(stack);
     session.settled = true;
 
     handleTelemetryMessage(session, { type: "telemetry", costUsd: 0.2 });
@@ -335,7 +338,7 @@ describe("handleTelemetryMessage", () => {
 
   it("ignores malformed cost values", () => {
     const stack = new StateStack();
-    const { session } = makeSession(stack);
+    const { session } = makeTelemetrySession(stack);
     handleTelemetryMessage(session, { type: "telemetry", costUsd: NaN } as any);
     handleTelemetryMessage(session, { type: "telemetry", costUsd: -5 } as any);
     handleTelemetryMessage(session, { type: "telemetry" } as any);

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -18,6 +18,8 @@ import { runBatch } from "./runBatch.js";
 import { AgencyCancelledError } from "./errors.js";
 import type { State, StateStack } from "./state/stateStack.js";
 import { getSubprocessRunInfo, setSubprocessRunInfo, type SubprocessRunInfo } from "./subprocessRunInfo.js";
+import { isPayableCost, type IpcTelemetryMessage } from "./costTelemetry.js";
+export { type IpcTelemetryMessage };
 
 export { getSubprocessRunInfo, setSubprocessRunInfo, type SubprocessRunInfo };
 import {
@@ -169,6 +171,7 @@ export function ipcLog(direction: "send" | "recv", msg: any): void {
   else if (type === "error") detail = `error=${truncate(msg.error)}`;
   else if (type === "run") detail = `node=${msg.node} script=${msg.scriptPath}`;
   else if (type === "resume") detail = `node=${msg.node} responses=${msg.responses?.length}`;
+  else if (type === "telemetry") detail = `costUsd=${msg.costUsd}`;
   else detail = truncate(msg);
   process.stderr.write(`[ipc:${role}] ${ts} ${direction} ${type} ${detail}\n`);
 }
@@ -274,7 +277,8 @@ export type SubprocessToParent =
   | IpcInterruptedMessage
   | IpcErrorMessage
   | IpcLockAcquireMessage
-  | IpcLockReleaseMessage;
+  | IpcLockReleaseMessage
+  | IpcTelemetryMessage;
 export type ParentToSubprocess = IpcDecisionMessage | IpcLockGrantedMessage;
 
 const sessionLockOwners: Record<string, string[]> = {};
@@ -439,7 +443,7 @@ export async function sendLockAcquireToParent(
  * Bundled into one object so helpers can be extracted to module scope
  * without each one needing 8 closure parameters.
  */
-type RunSession = {
+export type RunSession = {
   sessionId: string;
   child: ReturnType<typeof fork>;
   limits: RunLimits;
@@ -831,6 +835,47 @@ function handleErrorMessage(s: RunSession, msg: any): void {
   }
 }
 
+/** Child (or descendant, via relay) reported a paid call. Bill it to the
+ * run() call-site stack via the same billCharge every in-process paid
+ * site uses: localCost (parent getCost() reflects child spend live) plus
+ * the guards — whose chargeGuards re-emits upward when THIS process is
+ * itself a subprocess, which is what relays grandchild spend to the root
+ * with no explicit plumbing. Billing is unconditional (the spend already
+ * happened, even post-settle); enforcement only runs on a live session:
+ * a trip kills the child and REJECTS the session with the guard-trip
+ * abort, which propagates through invokeSubprocess → runBatch (errors
+ * win over interrupts) → the stdlib run() plain `try` re-throws trips →
+ * the user's owning guard(cost:) boundary converts it to the standard
+ * cost-limit Failure.
+ *
+ * MUST STAY SYNCHRONOUS: handleChildMessage void-invokes its async
+ * dispatch, so arrival-order processing (all telemetry before the
+ * child's own terminal message, per IPC FIFO) holds only while this
+ * path contains no awaits — an await before enforcement would let a
+ * fast child's result settle the session before the trip fires.
+ *
+ * Known getCost() edge: post-settle billing (possible only on kill
+ * paths — FIFO rules it out on normal completion) charges the shared
+ * guard REFERENCES correctly, but the localCost increment can land
+ * after a fork branch's cost delta has already propagated at join, so
+ * getCost() may slightly undercount on abnormal termination. Budgets
+ * never undercount; do not "fix" this by skipping post-settle billing. */
+export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage): void {
+  if (!isPayableCost(msg.costUsd)) return;
+  s.stateStack.billCharge(msg.costUsd);
+  if (s.settled) return;
+  try {
+    s.stateStack.enforceGuards();
+  } catch (err) {
+    try {
+      s.child.kill("SIGKILL");
+    } catch (killErr) {
+      ipcLog("send", { type: "kill_failed", detail: killErr instanceof Error ? killErr.message : String(killErr) });
+    }
+    settle(s, s.rejectPromise, err);
+  }
+}
+
 async function handleChildMessage(s: RunSession, msg: any): Promise<void> {
   ipcLog("recv", msg);
   // Defensively serialize once: a non-serializable value (circular refs,
@@ -855,6 +900,8 @@ async function handleChildMessage(s: RunSession, msg: any): Promise<void> {
     settle(s, s.resolvePromise, { type: "result", value: msg.value } satisfies SessionOutcome);
   } else if (msg.type === "interrupted") {
     settle(s, s.resolvePromise, { type: "interrupted", msg } satisfies SessionOutcome);
+  } else if (msg.type === "telemetry") {
+    handleTelemetryMessage(s, msg);
   } else if (msg.type === "error") {
     handleErrorMessage(s, msg);
   } else if (msg.type === "lockAcquire") {

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -17,9 +17,11 @@ import { gatherChainOutcome, type HandlerChainOutcome, type Interrupt } from "./
 import { runBatch } from "./runBatch.js";
 import { AgencyCancelledError } from "./errors.js";
 import type { State, StateStack } from "./state/stateStack.js";
-import { getSubprocessRunInfo, setSubprocessRunInfo, type SubprocessRunInfo } from "./subprocessRunInfo.js";
+import { getSubprocessRunInfo, setSubprocessRunInfo, isIpcMode, type SubprocessRunInfo } from "./subprocessRunInfo.js";
 import { isPayableCost, type IpcTelemetryMessage } from "./costTelemetry.js";
-export { type IpcTelemetryMessage };
+// isIpcMode lives in subprocessRunInfo.ts (dependency-free, so the telemetry
+// leaf can share it); re-exported here for the existing consumers.
+export { isIpcMode };
 
 export { getSubprocessRunInfo, setSubprocessRunInfo, type SubprocessRunInfo };
 import {
@@ -34,10 +36,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** Resolved filesystem path to the subprocess bootstrap script. */
 export const subprocessBootstrapPath = path.join(__dirname, "subprocess-bootstrap.js");
-
-export function isIpcMode(): boolean {
-  return process.env.AGENCY_IPC === "1";
-}
 
 // ── Resource limits ──
 // Hardcoded ceilings clamp any user-supplied limit value to a safe maximum.
@@ -662,6 +660,17 @@ function clearTimer(s: RunSession): void {
   }
 }
 
+/** Hard-kill a session's child, logging (never throwing) on failure. The
+ * one teardown used by every kill path — limit violations, aborts, and
+ * guard trips — so termination mechanics can't drift between them. */
+function killChildSafely(s: RunSession): void {
+  try {
+    s.child.kill("SIGKILL");
+  } catch (err) {
+    ipcLog("send", { type: "kill_failed", detail: err instanceof Error ? err.message : String(err) });
+  }
+}
+
 function settle(s: RunSession, fn: (v: any) => void, value: any): void {
   if (s.settled) return;
   s.settled = true;
@@ -688,11 +697,7 @@ function settleWithLimitFailure(
   extras: Record<string, any> = {},
 ): void {
   if (s.settled) return;
-  try {
-    s.child.kill("SIGKILL");
-  } catch (err) {
-    ipcLog("send", { type: "kill_failed", detail: err instanceof Error ? err.message : String(err) });
-  }
+  killChildSafely(s);
   settle(s, s.resolvePromise, {
     type: "result",
     value: makeLimitFailure(limit, threshold, value, extras),
@@ -793,6 +798,15 @@ async function handleLockAcquireMessage(s: RunSession, msg: IpcLockAcquireMessag
     const release = isIpcMode()
       ? await sendLockAcquireToParent(msg.name, lockOpts)
       : await acquireLocalLock(s.ctx, msg.name, lockOpts);
+    if (s.settled) {
+      // The session died while this acquire was parked (kill paths: guard
+      // trip, wall-clock, abort...). Registering now would mint a lock on a
+      // dead session that nothing ever releases — settle-time
+      // cleanupSessionLocks already ran, and if the dying child held the
+      // contended lock, that cleanup is exactly what resolved this acquire.
+      release();
+      return;
+    }
     registerSessionLock(s.ctx, s.sessionId, lockReleaserKey(msg.name, ownerId), release);
     trySendDecision(s, {
       type: "lockGranted",
@@ -838,7 +852,7 @@ function handleErrorMessage(s: RunSession, msg: any): void {
 /** Child (or descendant, via relay) reported a paid call. Bill it to the
  * run() call-site stack via the same billCharge every in-process paid
  * site uses: localCost (parent getCost() reflects child spend live) plus
- * the guards — whose chargeGuards re-emits upward when THIS process is
+ * the guards — and billCharge re-emits upward when THIS process is
  * itself a subprocess, which is what relays grandchild spend to the root
  * with no explicit plumbing. Billing is unconditional (the spend already
  * happened, even post-settle); enforcement only runs on a live session:
@@ -867,11 +881,7 @@ export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage):
   try {
     s.stateStack.enforceGuards();
   } catch (err) {
-    try {
-      s.child.kill("SIGKILL");
-    } catch (killErr) {
-      ipcLog("send", { type: "kill_failed", detail: killErr instanceof Error ? killErr.message : String(killErr) });
-    }
+    killChildSafely(s);
     settle(s, s.rejectPromise, err);
   }
 }
@@ -988,11 +998,7 @@ async function runSubprocessSession(opts: {
     if (opts.abortSignal) {
       const signal = opts.abortSignal;
       const onAbort = () => {
-        try {
-          child.kill("SIGKILL");
-        } catch (err) {
-          ipcLog("send", { type: "kill_failed", detail: err instanceof Error ? err.message : String(err) });
-        }
+        killChildSafely(session);
         settle(session, rejectPromise, new AgencyCancelledError());
       };
       if (signal.aborted) {

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -562,9 +562,8 @@ async function _runPrompt({
   // enforceGuards() call. See docs/superpowers/specs/2026-05-20-thread-
   // builtins-and-stdlib-design.md.
   const callCost = completion.cost?.totalCost ?? 0;
-  targetStack.localCost += callCost;
+  targetStack.billCharge(callCost);
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
-  targetStack.chargeGuards(callCost);
   targetStack.enforceGuards();
 
   // Memory layer: auto-extraction and compaction run unconditionally

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -529,16 +529,27 @@ export class StateStack {
 
   /**
    * Bill one paid charge to this stack: accumulate the branch-local cost
-   * accumulator and charge every active guard. The single billing
-   * sequence every paid site runs — llm (prompt.ts), addCost (cost.ts;
-   * memory and image generation pay through it), and the parent-side
-   * subprocess telemetry handler (ipc.ts). Enforcement stays at call
-   * sites because it legitimately varies: prompt/addCost always enforce;
-   * the telemetry handler skips enforcement once its session has settled.
+   * accumulator, charge every active guard, and — in a subprocess —
+   * forward the charge to the parent so ITS cost guards see the spend
+   * live. The single billing sequence every paid site runs — llm
+   * (prompt.ts), addCost (cost.ts; memory and image generation pay
+   * through it), and the parent-side subprocess telemetry handler
+   * (ipc.ts, which is what relays grandchild spend upward in nested
+   * trees). Enforcement stays at call sites because it legitimately
+   * varies: prompt/addCost always enforce; the telemetry handler skips
+   * enforcement once its session has settled.
+   *
+   * Telemetry emission lives HERE, on the fresh-paid-charge semantic —
+   * not in chargeGuards — so re-applying spend to guard accumulators
+   * (e.g. a future restore/reconciliation path) can never double-bill
+   * the parent. Emission is per paid call and unconditional on local
+   * guards existing: a mid-tier relay may have none but must still
+   * forward. No-op outside IPC mode.
    */
   billCharge(amount: number): void {
     this.localCost += amount;
     this.chargeGuards(amount);
+    sendCostTelemetryToParent(amount);
   }
 
   /**
@@ -547,14 +558,12 @@ export class StateStack {
    * descendant spend in real time — this is what makes mid-fork trip
    * detection work without waiting for the fork to settle. TimeGuard's
    * charge is a no-op.
+   *
+   * Guard-accumulator update ONLY — no localCost, no telemetry. Paid
+   * sites must go through billCharge.
    */
   chargeGuards(amount: number): void {
     for (const g of this.guards) g.charge(amount);
-    // Subprocess: forward this charge to the parent so ITS cost guards
-    // see the spend live. Emission is per paid call and unconditional on
-    // local guards existing: a mid-tier relay may have none but must
-    // still forward grandchild spend upward. No-op outside IPC mode.
-    sendCostTelemetryToParent(amount);
   }
 
   /**

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -1,6 +1,7 @@
 import type { Guard, GuardJSON } from "../guard.js";
 import type { ReplyAttachmentPart } from "../replyAttachments.js";
 import { guardFromJSON } from "../guard.js";
+import { sendCostTelemetryToParent } from "../costTelemetry.js";
 import { Checkpoint } from "../index.js";
 import { MemoryFrame } from "../memory/frame.js";
 import { deepClone } from "../utils.js";
@@ -527,6 +528,20 @@ export class StateStack {
   }
 
   /**
+   * Bill one paid charge to this stack: accumulate the branch-local cost
+   * accumulator and charge every active guard. The single billing
+   * sequence every paid site runs — llm (prompt.ts), addCost (cost.ts;
+   * memory and image generation pay through it), and the parent-side
+   * subprocess telemetry handler (ipc.ts). Enforcement stays at call
+   * sites because it legitimately varies: prompt/addCost always enforce;
+   * the telemetry handler skips enforcement once its session has settled.
+   */
+  billCharge(amount: number): void {
+    this.localCost += amount;
+    this.chargeGuards(amount);
+  }
+
+  /**
    * Charge every active guard with this call's cost. Shared parent
    * guards (CostGuard.cloneForBranch returns `this`) accumulate
    * descendant spend in real time — this is what makes mid-fork trip
@@ -535,6 +550,11 @@ export class StateStack {
    */
   chargeGuards(amount: number): void {
     for (const g of this.guards) g.charge(amount);
+    // Subprocess: forward this charge to the parent so ITS cost guards
+    // see the spend live. Emission is per paid call and unconditional on
+    // local guards existing: a mid-tier relay may have none but must
+    // still forward grandchild spend upward. No-op outside IPC mode.
+    sendCostTelemetryToParent(amount);
   }
 
   /**

--- a/packages/agency-lang/lib/runtime/subprocessRunInfo.ts
+++ b/packages/agency-lang/lib/runtime/subprocessRunInfo.ts
@@ -29,6 +29,13 @@ export type SubprocessRunInfo = {
   maxDepth?: number;
 };
 
+/** Whether this process is a forked Agency subprocess (AGENCY_IPC=1 is set
+ * by `buildForkOptions` before every fork). The single source of truth for
+ * the mode signal — ipc.ts and the telemetry leaf both read it from here. */
+export function isIpcMode(): boolean {
+  return process.env.AGENCY_IPC === "1";
+}
+
 let info: SubprocessRunInfo = { depth: 0 };
 
 export function setSubprocessRunInfo(next: SubprocessRunInfo): void {

--- a/packages/agency-lang/lib/stdlib/image.test.ts
+++ b/packages/agency-lang/lib/stdlib/image.test.ts
@@ -5,12 +5,19 @@ import { _generateImage } from "./image.js";
 type ImageImpl = (input: any, config: any) => Promise<any>;
 
 function makeStack() {
-  return {
+  // billCharge mirrors the real StateStack pair (localCost + chargeGuards)
+  // so the existing per-piece assertions keep observing the same effects.
+  const stack = {
     localCost: 0,
     localTokens: 0,
     chargeGuards: vi.fn(),
     enforceGuards: vi.fn(),
+    billCharge: vi.fn((amount: number) => {
+      stack.localCost += amount;
+      stack.chargeGuards(amount);
+    }),
   };
+  return stack;
 }
 
 /** Run `fn` inside a real ALS frame whose ctx carries a mock image client +

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -79,6 +79,8 @@ export def run(
 
   Resource limits clamp the subprocess: it is killed and a limit_exceeded failure is returned if it exceeds wallClock, memory, ipcPayload, or stdout (each budget applies per execution segment). Subprocesses may themselves call run() — nesting is gated by the std::run interrupt at every level (its data includes the prospective depth) and hard-capped by maxDepth.
 
+  Enclosing cost guards meter the subprocess: each paid call inside it is charged to the parent's guard(cost:) budgets in real time, and a tripped budget terminates the subprocess and fails the guard block.
+
   @param compiled - A CompiledProgram from compile()
   @param node - Which exported node to run
   @param args - Arguments to pass to the node (defaults to no args)

--- a/packages/agency-lang/tests/agency/subprocess/cost-child-spend-in-getcost.agency
+++ b/packages/agency-lang/tests/agency/subprocess/cost-child-spend-in-getcost.agency
@@ -1,0 +1,30 @@
+import { compile, run } from "std::agency"
+import { getCost } from "std::thread"
+
+// Under budget: the run succeeds AND the parent's getCost() reflects the
+// child's spend live (the parent itself makes zero llm calls, so any
+// positive cost came through telemetry).
+node main() {
+  const source = """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  return b
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "main")
+    if (isFailure(result)) {
+      return "run failed"
+    }
+    return "childSpendVisible:${getCost() > 0}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-child-spend-in-getcost.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/cost-child-spend-in-getcost.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Parent getCost() reflects subprocess spend delivered via telemetry",
+      "input": "",
+      "expectedOutput": "\"childSpendVisible:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-guard-trips-on-child-spend.agency
+++ b/packages/agency-lang/tests/agency/subprocess/cost-guard-trips-on-child-spend.agency
@@ -1,0 +1,34 @@
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+
+// The child makes 3 mocked llm() calls at 0.000002 each. The parent guard
+// caps at 0.000003: the second call's telemetry pushes spent to 0.000004,
+// the guard trips, the child is killed, and the trip surfaces as the
+// standard cost-limit Failure at this guard boundary.
+node main() {
+  const source = """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  const c = llm("Reply with: three")
+  return c
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = guard(cost: 0.000003) as {
+      return run(compiled: compileResult.value, node: "main")
+    }
+    if (isFailure(result)) {
+      return "tripped:${result.error.type}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-guard-trips-on-child-spend.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/cost-guard-trips-on-child-spend.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Parent cost guard trips on subprocess spend and kills the child",
+      "input": "",
+      "expectedOutput": "\"tripped:guardFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-nested-relay-trips-root.agency
+++ b/packages/agency-lang/tests/agency/subprocess/cost-nested-relay-trips-root.agency
@@ -1,0 +1,59 @@
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+
+// The grandchild spends; only the ROOT holds a guard. The mid-tier has no
+// guards of its own and must relay the grandchild's telemetry upward (its
+// handler's chargeGuards re-emits because that process is in IPC mode).
+// The trip kills the MID process; the grandchild is reaped by the
+// disconnect watchdog.
+node main() {
+  const grandSource = """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  const c = llm("Reply with: three")
+  return c
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const result = run(compiled: c.value, node: "main")
+    if (isSuccess(result)) {
+      return result.value.data
+    }
+    return "inner run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = guard(cost: 0.000003) as {
+      return run(
+        compiled: compileResult.value,
+        node: "main",
+        args: { grandSource: grandSource },
+      )
+    }
+    if (isFailure(result)) {
+      return "tripped:${result.error.type}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-nested-relay-trips-root.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/cost-nested-relay-trips-root.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Grandchild spend relays through the guardless mid-tier and trips the root guard",
+      "input": "",
+      "expectedOutput": "\"tripped:guardFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-no-double-charge-across-pause.agency
+++ b/packages/agency-lang/tests/agency/subprocess/cost-no-double-charge-across-pause.agency
@@ -1,0 +1,33 @@
+import { compile, run } from "std::agency"
+import { getCost } from "std::thread"
+
+// One paid call before the pause, one after the resume; the parent's
+// total must be EXACTLY two calls' worth (a replay that re-emitted the
+// first call's telemetry would make it three). 0.000002 + 0.000002 =
+// 0.000004 is exact in floating point (x + x), so equality is safe.
+node main() {
+  const source = """
+import { bash } from "std::shell"
+node main() {
+  const a = llm("Reply with: one")
+  let r = bash("echo pause-here")
+  const b = llm("Reply with: two")
+  return b
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "main")
+    if (isFailure(result)) {
+      return "run failed"
+    }
+    return "exactlyTwoCalls:${getCost() == 0.000004}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-no-double-charge-across-pause.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/cost-no-double-charge-across-pause.test.json
@@ -1,0 +1,19 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "A pause/resume cycle does not re-emit telemetry for completed paid calls",
+      "input": "",
+      "expectedOutput": "\"exactlyTwoCalls:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-two-children-share-budget.agency
+++ b/packages/agency-lang/tests/agency/subprocess/cost-two-children-share-budget.agency
@@ -1,0 +1,38 @@
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+
+// The discriminating case for the rejected ship-guards-into-child design:
+// each child alone (2 calls x 0.000002 = 0.000004) is under the 0.000005
+// cap, but the two together (0.000008) must trip the ONE shared budget.
+// Interleaving-independent: total spend strictly exceeds the cap while
+// each child alone stays under it.
+node main() {
+  const source = """
+node main(tag: string) {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  return tag
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  const compiled = compileResult.value
+  handle {
+    const result = guard(cost: 0.000005) as {
+      const results = fork(["a", "b"]) as item {
+        return run(compiled: compiled, node: "main", args: { tag: item })
+      }
+      return results
+    }
+    if (isFailure(result)) {
+      return "tripped:${result.error.type}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/cost-two-children-share-budget.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/cost-two-children-share-budget.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two concurrent subprocesses under one guard share the single budget",
+      "input": "",
+      "expectedOutput": "\"tripped:guardFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes the cost half of subprocess guard safety (the abort/kill half shipped with pause/resume, PR #398): a parent `guard(cost: $X) { run(...) }` was blind to subprocess LLM spend until the terminal message — after the money was spent. With nesting unblocked, an agent-written child (or grandchild) could make unbounded LLM calls outside every cost guard.

Design doc: `packages/agency-lang/docs/superpowers/specs/2026-07-02-subprocess-cost-telemetry-design.md` (committed with this PR).

## How it works

**Child side — one emission line at the choke point.** Every paid site (llm via `prompt.ts`, `addCost` — which memory and image generation pay through) funnels through `StateStack.chargeGuards`. That method now fire-and-forgets `{ type: "telemetry", costUsd }` to the parent via a new dependency-free leaf module (`costTelemetry.ts`, the `subprocessRunInfo.ts` layering pattern — `stateStack.ts` must not import `ipc.ts`). No-op outside IPC mode; never blocks; never throws; a dead channel is swallowed (the disconnect watchdog is about to reap the process anyway).

**Parent side — one new message case.** `handleTelemetryMessage` bills the charge to the `run()` call-site stack and enforces. On a trip it SIGKILLs the child and rejects the session with the guard-trip abort itself, which propagates through runBatch (errors win over interrupts) → the stdlib `run()`'s plain `try` re-throws trips → the user's owning `guard(cost:)` boundary converts it to the standard cost-limit Failure. No new failure shapes.

**Nested relay is automatic.** The mid-tier's handler charges its own `chargeGuards`, which re-emits upward because that process is itself in IPC mode. Grandchild spend reaches the root with zero explicit relay code.

**`billCharge` extraction.** The billing pair (`localCost += x; chargeGuards(x)`) previously existed inline in `prompt.ts` and `cost.ts`; the telemetry handler would have been a third copy. It is now a named `StateStack.billCharge` that all three sites call (enforcement stays at call sites — the handler skips it post-settle, the others always enforce).

## Decisions and semantics

- **getCost() includes child spend live** — telemetry updates `localCost` alongside the guard charge. Nothing folded child cost into parent accumulators at terminal before, so there is no double-count.
- **Per-call cadence** (owner-approved): paid calls are seconds apart; a telemetry message costs microseconds. Detection latency is at most one paid call, matching in-process CostGuard semantics.
- **Trip kills; it does not pause.** A busy child cannot be checkpointed on demand, so raise-the-budget-and-resume is not possible; partial child work is lost.
- **No double-charge across pause/resume**: charges are per-call incremental and a resumed child's replay skips completed LLM steps (pinned by E2E test).
- **Handler must stay synchronous** (documented invariant): `handleChildMessage` void-invokes its dispatch, so telemetry-before-terminal ordering holds only while the telemetry path contains no awaits.
- **Known getCost() edge** (documented, deliberate): telemetry arriving after a kill still charges budgets via the shared guard references, but can be invisible to `getCost()` if the owning fork branch already joined. Budgets never undercount; `getCost()` may, on abnormal termination only.
- **Tokens are a non-goal**: telemetry is cost-only; cumulative child tokens still arrive terminally via `result.tokens`.

## Tests

Unit (`costTelemetry.test.ts`, `ipc.test.ts`): sender gating/validation/dead-channel, `chargeGuards` emits exactly once per charge even with zero guards (the relay invariant), `billCharge` really charges guards, handler charge/trip/post-settle/malformed paths — the trip test asserts the rejection is the `GuardExceededError` itself (identity matters for `ownedGuardIds` conversion).

E2E (`tests/agency/subprocess/cost-*`), all against the deterministic client's synthetic cost:
1. `cost-guard-trips-on-child-spend` — parent guard trips mid-run; child killed; standard `guardFailure` at the guard boundary.
2. `cost-child-spend-in-getcost` — under budget: run succeeds AND parent `getCost()` shows the spend.
3. `cost-nested-relay-trips-root` — grandchild spend relays through a guardless mid-tier and trips the ROOT guard.
4. `cost-two-children-share-budget` — each child alone is under the cap; together they must trip the ONE shared budget (the counterexample to shipping guards into children).
5. `cost-no-double-charge-across-pause` — one paid call before a pause, one after resume; total is exactly two calls' worth.

Regression: subprocess suite spot checks (run-basic, pause-multi-cycle, concurrent-handled, nested-pause-resume), guard-cost-trip, full `lib/runtime` unit suite (1043 tests), tsc, structural lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
