### PR TITLE
Fix streaming onStream to honor callback() builtin registrations

### DIFF
--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -244,6 +244,22 @@ export function gatherCallbacks<K extends keyof CallbackMap>(
   return out;
 }
 
+/** Whether any consumer is registered for `name` across all sources a fire
+ *  would reach: global hooks, scoped callbacks on `stack`, top-level
+ *  registrations, and a TS-passed callback. Mirrors what `invokeCallbacks`
+ *  actually fires, so callers can branch on "is anyone listening?" without
+ *  reaching into `ctx.callbacks` directly (which only sees the TS-passed
+ *  slot — the bug that made streaming ignore `callback("onStream")`). */
+export function hasCallbackConsumer<K extends keyof CallbackMap>(
+  ctx: RuntimeContext<any>,
+  name: K,
+  stateStack?: StateStack,
+): boolean {
+  if ((_globalHooks[name]?.length ?? 0) > 0) return true;
+  const walkStack = stateStack ?? ctx.stateStack;
+  return gatherCallbacks(ctx, name, walkStack).length > 0;
+}
+
 /** Fire every callback registered for `name`, sequentially. When
  *  `stateStack` is supplied, callbacks run on that stack (so scoped
  *  callbacks registered inside a branch's frame chain are found). When

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -96,11 +96,13 @@ async function dispatchLLMRequest({
   promptConfig,
   prompt,
   stream,
+  stateStack,
 }: {
   ctx: RuntimeContext<GraphState>;
   promptConfig: PromptConfig;
   prompt: string | UserContentInput;
   stream: boolean;
+  stateStack?: StateStack;
 }): Promise<{ completion: PromptResult; toolCalls: ToolCallJSON[] }> {
   if (stream) {
     const streamGen = ctx.llmClient.textStream(promptConfig);
@@ -108,6 +110,7 @@ async function dispatchLLMRequest({
       ctx,
       completion: streamGen,
       prompt,
+      stateStack,
     });
     if (!response) {
       throw new Error(
@@ -344,8 +347,10 @@ async function dispatchWithRetry(args: {
   stream: boolean;
   retryPolicy: RetryPolicy;
   parentSignal: AbortSignal | undefined;
+  stateStack?: StateStack;
 }): Promise<{ completion: PromptResult; toolCalls: ToolCallJSON[] }> {
-  const { ctx, promptConfig, prompt, stream, retryPolicy, parentSignal } = args;
+  const { ctx, promptConfig, prompt, stream, retryPolicy, parentSignal, stateStack } =
+    args;
 
   const normalizeError = (err: unknown): NormalizedLLMError => {
     if (ctx.llmClient.normalizeError) {
@@ -376,6 +381,7 @@ async function dispatchWithRetry(args: {
         promptConfig: { ...promptConfig, abortSignal: signal } as PromptConfig,
         prompt,
         stream,
+        stateStack,
       }),
     retryPolicy,
     parentSignal,
@@ -473,6 +479,7 @@ async function _runPrompt({
       stream,
       retryPolicy,
       parentSignal: ctx.getAbortSignal(stateStack),
+      stateStack,
     }));
   } catch (err) {
     // Cancellation normalization. When WE aborted the request (user pressed

--- a/packages/agency-lang/lib/runtime/streaming.ts
+++ b/packages/agency-lang/lib/runtime/streaming.ts
@@ -8,8 +8,10 @@ import {
 } from "smoltalk";
 import { builtinSleep } from "./builtins.js";
 import type { RuntimeContext } from "./state/context.js";
+import type { StateStack } from "./state/stateStack.js";
 import { GraphState } from "./types.js";
 import { isAbortError } from "./errors.js";
+import { hasCallbackConsumer, invokeCallbacks, type CallbackMap } from "./hooks.js";
 
 export function isGenerator(variable: any): boolean {
   const toString = Object.prototype.toString.call(variable);
@@ -22,13 +24,21 @@ export async function handleStreamingResponse(args: {
   ctx: RuntimeContext<GraphState>;
   completion: AsyncGenerator<StreamChunk>;
   prompt: string | UserContentInput;
+  /** The branch-local stack, if this call runs inside a fork/race branch.
+   *  Used to discover scoped `callback("onStream")` registrations on the
+   *  right frame chain — passed straight through to the callback machinery. */
+  stateStack?: StateStack;
 }): Promise<
   Result<{ completion: PromptResult; toolCalls: ToolCallJSON[] }> | undefined
 > {
-  const { ctx, completion, prompt } = args;
+  const { ctx, completion, prompt, stateStack } = args;
   const toolCalls: ToolCallJSON[] = [];
 
-  if (!ctx.callbacks.onStream) {
+  // Resolve `onStream` through the shared callback machinery so a callback
+  // registered via the Agency `callback("onStream")` builtin — scoped inside a
+  // node or at module top level — is found, not just a TS-passed one on
+  // `ctx.callbacks`. See gatherCallbacks / invokeCallbacks in hooks.ts.
+  if (!hasCallbackConsumer(ctx, "onStream", stateStack)) {
     console.log(
       "No onStream callback provided for streaming response, returning response synchronously",
     );
@@ -63,7 +73,12 @@ export async function handleStreamingResponse(args: {
     }
     return { success: true, value: { completion: syncResult!, toolCalls } };
   } else {
-    const onStream = ctx.callbacks.onStream;
+    // Fire every registered onStream consumer for this chunk. Awaited because
+    // Agency-registered callbacks are AgencyFunctions invoked through the
+    // runtime (async); this also applies natural backpressure — we finish
+    // delivering a chunk before pulling the next.
+    const emit = (data: CallbackMap["onStream"]) =>
+      invokeCallbacks({ ctx, name: "onStream", data, stateStack });
     // try to acquire lock
     let count = 0;
     // wait 60 seconds to acquire lock
@@ -80,23 +95,23 @@ export async function handleStreamingResponse(args: {
       for await (const chunk of completion) {
         switch (chunk.type) {
           case "text":
-            onStream({ type: "text", text: chunk.text });
+            await emit({ type: "text", text: chunk.text });
             break;
           case "tool_call":
             toolCalls.push(chunk.toolCall);
-            onStream({
+            await emit({
               type: "tool_call",
               toolCall: chunk.toolCall,
             });
             break;
           case "done":
-            onStream({ type: "done", result: chunk.result });
+            await emit({ type: "done", result: chunk.result });
             return {
               success: true,
               value: { completion: chunk.result, toolCalls },
             };
           case "error":
-            onStream({ type: "error", error: chunk.error });
+            await emit({ type: "error", error: chunk.error });
             break;
         }
       }

--- a/packages/agency-lang/lib/runtime/streaming.ts
+++ b/packages/agency-lang/lib/runtime/streaming.ts
@@ -92,6 +92,7 @@ export async function handleStreamingResponse(args: {
     ctx.onStreamLock = true;
 
     try {
+      let streamError: unknown = undefined;
       for await (const chunk of completion) {
         switch (chunk.type) {
           case "text":
@@ -111,10 +112,23 @@ export async function handleStreamingResponse(args: {
               value: { completion: chunk.result, toolCalls },
             };
           case "error":
+            streamError = chunk.error;
             await emit({ type: "error", error: chunk.error });
             break;
         }
       }
+      // Stream ended without a `done` chunk. If the provider signaled an
+      // `error` chunk, surface THAT so the real failure reaches the caller
+      // (dispatchLLMRequest turns a failure Result into a throw carrying the
+      // message) instead of a generic "No completion returned". Mirrors the
+      // sync-fallback branch, which never masks the error either.
+      return {
+        success: false,
+        error:
+          streamError !== undefined
+            ? String(streamError)
+            : "Streaming response ended without a completion.",
+      };
     } catch (error) {
       if (isAbortError(error)) throw error;
       console.error("Unexpected error consuming LLM stream:", error);

--- a/packages/agency-lang/tests/agency-js/streaming-error-chunk/agent.agency
+++ b/packages/agency-lang/tests/agency-js/streaming-error-chunk/agent.agency
@@ -1,0 +1,16 @@
+// A streaming provider that ends on an `error` chunk (no `done`) must surface
+// the real error to the caller, not a generic "No completion returned". An
+// onStream consumer is registered so the call routes through the streaming
+// (else) branch, which is where the error must now be carried out.
+let seen: string = ""
+
+node main(): string {
+  callback("onStream") as data {
+    seen = seen + data.type + ","
+  }
+  const result = try llm("ping", stream: true)
+  if (isFailure(result)) {
+    return "chunks=" + seen + " error=" + result.error
+  }
+  return "chunks=" + seen + " ok"
+}

--- a/packages/agency-lang/tests/agency-js/streaming-error-chunk/fixture.json
+++ b/packages/agency-lang/tests/agency-js/streaming-error-chunk/fixture.json
@@ -1,0 +1,3 @@
+{
+  "data": "chunks=error, error=Error getting completion from streaming response: provider exploded"
+}

--- a/packages/agency-lang/tests/agency-js/streaming-error-chunk/test.js
+++ b/packages/agency-lang/tests/agency-js/streaming-error-chunk/test.js
@@ -1,0 +1,26 @@
+import { main, __setLLMClient } from "./agent.js";
+import { writeFileSync } from "fs";
+
+// Stream terminates on an `error` chunk with no `done`. The onStream callback
+// should still see the "error" event, and the llm() call should fail with the
+// PROVIDER's error surfaced — not a generic "No completion returned".
+const client = {
+  async text() {
+    return { success: false, error: "provider exploded" };
+  },
+  async *textStream() {
+    yield { type: "error", error: "provider exploded" };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+const result = await main();
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ data: result.data }, null, 2),
+);

--- a/packages/agency-lang/tests/agency-js/streaming-scoped-onstream/agent.agency
+++ b/packages/agency-lang/tests/agency-js/streaming-scoped-onstream/agent.agency
@@ -1,0 +1,14 @@
+// Regression: a scoped `callback("onStream")` registered INSIDE a node body
+// must receive streaming chunks from a `stream: true` llm() call in that node.
+// Before the fix, handleStreamingResponse only looked at ctx.callbacks (the
+// TS-passed slot), so a callback registered via the Agency builtin was never
+// found and the stream fell back to synchronous — the callback never fired.
+let chunks: string = ""
+
+node main(): string {
+  callback("onStream") as data {
+    chunks = chunks + data.type + ","
+  }
+  const _response = llm("What is the capital of India?", stream: true)
+  return chunks
+}

--- a/packages/agency-lang/tests/agency-js/streaming-scoped-onstream/fixture.json
+++ b/packages/agency-lang/tests/agency-js/streaming-scoped-onstream/fixture.json
@@ -1,0 +1,3 @@
+{
+  "chunks": "text,text,done,"
+}

--- a/packages/agency-lang/tests/agency-js/streaming-scoped-onstream/test.js
+++ b/packages/agency-lang/tests/agency-js/streaming-scoped-onstream/test.js
@@ -1,0 +1,33 @@
+import { main, __setLLMClient } from "./agent.js";
+import { writeFileSync } from "fs";
+
+// A streaming client that emits two text chunks then done, so the onStream
+// callback should observe "text,text,done,". A custom client is used (rather
+// than the deterministic mock, whose textStream only emits "done") so the test
+// exercises intermediate chunk delivery, not just the terminal event.
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+const DONE = { output: "New Delhi", toolCalls: [], model: "test", usage: USAGE, cost: COST };
+
+const client = {
+  async text() {
+    return { success: true, value: DONE };
+  },
+  async *textStream() {
+    yield { type: "text", text: "New " };
+    yield { type: "text", text: "Delhi" };
+    yield { type: "done", result: DONE };
+  },
+  async embed() {
+    return { success: false, error: "captureClient does not implement embed" };
+  },
+};
+
+__setLLMClient(client);
+
+const result = await main();
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify({ chunks: result.data }, null, 2),
+);


### PR DESCRIPTION
## Problem

The documented streaming example doesn't work:

```ts
node main() {
  callback("onStream") as data {
    printJSON(data)
  }
  const response = llm("What is the capital of India?", stream: true)
}
```

It prints `No onStream callback provided for streaming response, returning response synchronously` and never delivers any chunk.

## Root cause

`handleStreamingResponse` resolved the callback by reading `ctx.callbacks.onStream` directly. That object is populated by **only one path** — the programmatic host API (`node.ts` does `Object.assign(execCtx.callbacks, callbacks)` with invocation-time callbacks). The Agency-level `callback("onStream")` builtin does **not** write there: it routes through `_callbackImpl` to either a **scoped** frame callback (registration inside a node body) or `ctx.topLevelCallbacks` (module scope).

Every *other* callback fires through `gatherCallbacks`, which merges all three sources (scoped stack-frame callbacks + top-level registrations + the TS-passed slot). Streaming bypassed that entirely, so a `callback("onStream")` registration was never seen and streaming fell back to synchronous.

## Fix

Route streaming through the same callback machinery as everything else:

- **`hooks.ts`**: add `hasCallbackConsumer(ctx, name, stack)` — reports whether any consumer is registered across all sources a fire would reach (global hooks + `gatherCallbacks`).
- **`streaming.ts`**: decide streaming-vs-sync via `hasCallbackConsumer`, and emit each chunk via `invokeCallbacks` so `AgencyFunction` callbacks are invoked correctly. Emits are `await`ed, which also applies natural backpressure.
- **`prompt.ts`**: thread the branch-local `stateStack` from `_runPrompt` → `dispatchWithRetry` → `dispatchLLMRequest` → `handleStreamingResponse`, so scoped callbacks inside a `fork`/`race` branch resolve on the right frame chain.

## Behavior-change note (corrected from an earlier version of this description)

Routing emits through `invokeCallbacks` **does** change one thing for host-passed `onStream` callbacks: a callback that throws an ordinary JS error is now logged and swallowed by `fireWithGuard` instead of throwing out of `handleStreamingResponse` and aborting the stream. This makes streaming **consistent with every other callback** (they all fire through `fireWithGuard`, which swallows). Intentional — streaming was the lone fail-fast outlier. Guard trips / cancellations still propagate (`fireWithGuard` re-throws `AgencyAbort` / `RestoreSignal`). (Thanks to the review for catching that my first description wrongly claimed "no behavior change.")

## Also fixed in this PR (review point #4)

The streaming branch only returned inside the `done` case; a provider that ended the stream on an `error` chunk (or ended without `done`) fell through to `undefined`, which `dispatchLLMRequest` turned into a generic `No completion returned...` throw — masking the real error. This path is more reachable now that scoped-callback streams route through the streaming branch. Fixed: the branch now surfaces the provider's real error. New test `streaming-error-chunk` pins it.

## Deferred to a follow-up ticket (review points #2 and #3)

The `ctx.onStreamLock` boolean does not provide real mutual exclusion across concurrent branches (serializes independent consumers; force-acquires after a 60s busy-wait; and, now that emits are awaited, is reentrant-hostile if a callback body itself streams). This predates the PR but is newly *reachable* now that multiple branches can register their own scoped `onStream`. Fixing it is a lock redesign (per-consumer async mutex via the existing `withLock`), out of scope for this focused bugfix. Captured as a ticket: **concurrent streaming serializes on a global boolean lock and degrades to interleaving after 60s** (`docs/superpowers/ideas/2026-07-03-concurrent-streaming-serializes-on-global-lock.md`).

## Tests

- `streaming-scoped-onstream` — registers a scoped `callback("onStream")` inside a node and asserts it receives `text,text,done,`. Fails without the fix (`chunks` empty + the exact `No onStream callback provided` message), passes with it.
- `streaming-error-chunk` — a stream ending on an `error` chunk surfaces the provider's real error (`provider exploded`), not the generic message.

## Verification

- Both new regression tests pass; the first fails without the fix.
- `lib/runtime/hooks.test.ts`: 11/11.
- Related agency-js tests (`block-callback-tool-resume`, `entry-module-callback-fires`, `llm-fork-scoped`, `threads-fix-callback-propagation`, `llm-timeout`): pass.
- Pure-Agency callback tests (`callback-basic`, `callback-recursion`, `callback-cleanup`, `callback-multi-same-hook`): pass.
- Full `tsc` build: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
