### PR TITLE
Subprocess callback forwarding

### DIFF
--- a/packages/agency-lang/docs/dev/subprocess-ipc.md
+++ b/packages/agency-lang/docs/dev/subprocess-ipc.md
@@ -95,6 +95,7 @@ On the parent side, `_run` — a `runBatch` adopter with a single child (`subpro
 { type: "error", error: string }
 { type: "lockAcquire" | "lockRelease", ... }
 { type: "telemetry", costUsd }   // fire-and-forget, one per paid call
+{ type: "callback", name, data } // fire-and-forget, one per lifecycle event (see Callback forwarding)
 ```
 
 **Parent → Subprocess:**
@@ -151,6 +152,48 @@ completion) still charges budgets via the shared guard references, but
 can be invisible to `getCost()` if the owning fork branch already joined.
 Budgets never undercount; `getCost()` may, on abnormal termination only.
 
+## Callback forwarding
+
+A parent's registered lifecycle callbacks fire for events that happen inside a
+`std::agency run()` child. Every lifecycle event in a child fire-and-forgets
+`{ type: "callback", name, data }` upward, emitted from `invokeCallbacks`
+(`hooks.ts`) — the choke point every event funnels through. The wire type and
+child-side sender live in the dependency-light leaf `callbackForwarding.ts`
+(`hooks.ts` must not import `ipc.ts`, mirroring the `costTelemetry.ts` layering).
+
+- **Serialization.** The child JSON-serializes once up front: function-valued
+  fields (e.g. `onAgentStart.cancel`) are stripped, and an unserializable
+  (circular / BigInt) payload degrades to a dropped event rather than a throw.
+- **Parent side.** `handleCallbackMessage` (synchronous, like
+  `handleTelemetryMessage`) validates the name against `VALID_CALLBACK_NAMES`
+  (the child is the less-trusted party), drops post-settle events, then
+  `void invokeCallbacks(...)` fire-and-forget so a slow/throwing parent callback
+  cannot wedge the message pump. It fires inside the parent's captured ALS store
+  frame (`RunSession.parentStore`) and walks the parent's full `ctx.stateStack`,
+  so an AgencyFunction callback body resolves `__globals()`/`__threads()` and a
+  callback registered on an ancestor frame (e.g. a node-level
+  `callback("onNodeStart")` above the `run()` call) is found — matching
+  in-process firing.
+- **Nested relay is automatic.** `invokeCallbacks` re-emits when THIS process is
+  itself a subprocess, so a grandchild's event relays to the root through a
+  callbackless mid-tier with no explicit relay code (same shape as cost telemetry).
+- **`onAgentStart.cancel` is reconstructed** parent-side to a REAL cancel: a
+  parent `onAgentStart` callback that calls `cancel()` kills the child and settles
+  `run()` as cancelled. This is best-effort and async (the child already started;
+  it is a kill, not the in-process synchronous prevent-start), and a no-op if the
+  child's result wins the race.
+- **Observational, never fatal.** Forwarding is purely observational: an oversize
+  or unserializable `callback` message is dropped, not settled (the
+  `isObservationalMessage` carve-out in `handleChildMessage`), preserving the
+  invariant that a forwarded event can never kill the run.
+- **Unconditional + heavy.** The child cannot know which callbacks the parent
+  registered, so every event (except the denylist below) is serialized and sent
+  on every occurrence, even with no parent callback — an accepted v1 tradeoff.
+- **Not forwarded:** `onStream` (dispatched outside `invokeCallbacks`) and
+  `onOAuthRequired` (carries a `Promise`/functions needing a live bidirectional
+  channel) are denylisted in `sendCallbackToParent`; `onTrace` is never dispatched
+  today so it simply never forwards.
+
 ## The `std::run` interrupt gate
 
 `run()` throws a `std::run` interrupt before executing the subprocess. Running agent-generated code is a dangerous operation: the caller must either have a handler that approves `std::run`, or the interrupt propagates to the user for approval — which, with pause/resume, is a real question rather than an auto-reject.
@@ -184,7 +227,6 @@ A subprocess may itself call `run()`. Safety is the language's own idiom plus a 
 ## Remaining limitations
 
 - **Debugger/trace integration**: the debugger sees `run()` as an opaque step. No stepping into subprocess code.
-- **Callback forwarding**: parent-registered lifecycle callbacks are not triggered by subprocess events; follow-up.
 
 ## Tests
 
@@ -218,6 +260,8 @@ Execution tests live in `tests/agency/subprocess/`; agency-js tests in `tests/ag
 | `cost-nested-relay-trips-root` | grandchild spend relays through a guardless mid-tier to the root guard |
 | `cost-two-children-share-budget` | two concurrent children share ONE budget (the ship-guards-into-child counterexample) |
 | `cost-no-double-charge-across-pause` | pause/resume replay does not re-emit completed calls' telemetry |
+| `callback-forwarding-child-events` | parent onNodeStart callback fires for a child subprocess node entry |
+| `callback-forwarding-nested-relay` | root callback fires for a grandchild event relayed through a callbackless mid-tier |
 | `nested-gate-unapproved` | the gate exists on every hop |
 | `subprocess-no-handler` (js) | std::run gate surfaces without a handler |
 | `subprocess-pause-basic` (js) | end-to-end pause → respond → resume |

--- a/packages/agency-lang/docs/dev/subprocess-ipc.md
+++ b/packages/agency-lang/docs/dev/subprocess-ipc.md
@@ -265,6 +265,7 @@ Execution tests live in `tests/agency/subprocess/`; agency-js tests in `tests/ag
 | `cost-no-double-charge-across-pause` | pause/resume replay does not re-emit completed calls' telemetry |
 | `callback-forwarding-child-events` | parent onNodeStart callback fires for a child subprocess node entry |
 | `callback-forwarding-nested-relay` | root callback fires for a grandchild event relayed through a callbackless mid-tier |
+| `callback-forwarding-relay-both-fire` | mid-tier's own callback AND the root's both fire for the same grandchild event, filters respected |
 | `nested-gate-unapproved` | the gate exists on every hop |
 | `subprocess-no-handler` (js) | std::run gate surfaces without a handler |
 | `subprocess-pause-basic` (js) | end-to-end pause → respond → resume |

--- a/packages/agency-lang/docs/dev/subprocess-ipc.md
+++ b/packages/agency-lang/docs/dev/subprocess-ipc.md
@@ -189,10 +189,13 @@ child-side sender live in the dependency-light leaf `callbackForwarding.ts`
 - **Unconditional + heavy.** The child cannot know which callbacks the parent
   registered, so every event (except the denylist below) is serialized and sent
   on every occurrence, even with no parent callback — an accepted v1 tradeoff.
-- **Not forwarded:** `onStream` (dispatched outside `invokeCallbacks`) and
-  `onOAuthRequired` (carries a `Promise`/functions needing a live bidirectional
-  channel) are denylisted in `sendCallbackToParent`; `onTrace` is never dispatched
-  today so it simply never forwards.
+- **Not forwarded:** `onStream` (dispatched outside `invokeCallbacks`; forwarding
+  it is tracked in #418) and `onOAuthRequired` (carries a `Promise`/functions
+  needing a live bidirectional channel) are denylisted in `sendCallbackToParent`;
+  `onTrace` is never dispatched today so it simply never forwards.
+- **Child-side diagnostics** (`callback_send_failed`, `callback_dropped_oversize`,
+  `callback_unserializable`) go to a statelog `debug` event (best-effort, via
+  `ipcChildDebug`) plus stderr under `AGENCY_IPC_DEBUG=1`.
 
 ## The `std::run` interrupt gate
 

--- a/packages/agency-lang/docs/misc/lifecycleHooks.md
+++ b/packages/agency-lang/docs/misc/lifecycleHooks.md
@@ -20,6 +20,28 @@ All hooks are fully typed via the `AgencyCallbacks` type exported from `agency-l
 | `onToolCallEnd` | After a tool function returns | `{ toolName, result, timeTaken }` |
 | `onStream` | Streaming chunks *(see Streaming)* | `StreamChunk` |
 
+## Subprocess forwarding
+
+A parent's registered callbacks **also fire for events that happen inside a
+`std::agency run()` subprocess** (and, recursively, grandchildren). The child
+forwards each lifecycle event to the parent fire-and-forget over IPC, and the
+parent re-fires its own callbacks. Notes:
+
+- **Observational.** Forwarded callbacks cannot affect the child's outcome — a
+  forwarding failure (dead channel, oversize, unserializable payload) is silently
+  dropped and never kills the run. The one flow-affecting exception is
+  `onAgentStart.cancel`: calling it from a parent callback kills the child and
+  fails the `run()` as cancelled (best-effort — the child has already started, so
+  it is an async kill, not the in-process synchronous prevent-start).
+- **Unconditional.** Every event is forwarded even when no parent callback is
+  registered, and payloads are the full in-process ones (e.g. `messages` arrays),
+  so forwarding is heavier than in-process firing.
+- **Not forwarded:** `onStream` (streamed outside the forwarding choke point),
+  `onOAuthRequired` (needs a live bidirectional channel), and `onTrace` (not
+  currently dispatched). All other hooks forward.
+
+See `docs/dev/subprocess-ipc.md` (Callback forwarding) for the mechanism.
+
 ## Usage
 
 Hooks are passed in the `callbacks` object when calling an agent from TypeScript:

--- a/packages/agency-lang/docs/misc/lifecycleHooks.md
+++ b/packages/agency-lang/docs/misc/lifecycleHooks.md
@@ -36,9 +36,9 @@ parent re-fires its own callbacks. Notes:
 - **Unconditional.** Every event is forwarded even when no parent callback is
   registered, and payloads are the full in-process ones (e.g. `messages` arrays),
   so forwarding is heavier than in-process firing.
-- **Not forwarded:** `onStream` (streamed outside the forwarding choke point),
-  `onOAuthRequired` (needs a live bidirectional channel), and `onTrace` (not
-  currently dispatched). All other hooks forward.
+- **Not forwarded:** `onStream` (streamed outside the forwarding choke point —
+  forwarding it is tracked in #418), `onOAuthRequired` (needs a live bidirectional
+  channel), and `onTrace` (not currently dispatched). All other hooks forward.
 
 See `docs/dev/subprocess-ipc.md` (Callback forwarding) for the mechanism.
 

--- a/packages/agency-lang/lib/runtime/callbackForwarding.test.ts
+++ b/packages/agency-lang/lib/runtime/callbackForwarding.test.ts
@@ -33,10 +33,14 @@ describe("sendCallbackToParent", () => {
     expect(() => sendCallbackToParent("onNodeStart", { nodeName: "n" })).not.toThrow();
   });
 
-  it("strips function-valued fields (e.g. onAgentStart.cancel)", () => {
+  it("strips function-valued fields (e.g. onAgentStart.cancel) on the wire", () => {
     vi.stubEnv("AGENCY_IPC", "1");
     const sent: any[] = [];
-    process.send = ((m: any) => { sent.push(m); return true; }) as any;
+    // Emulate the real fork's default ("json") IPC serialization: process.send
+    // JSON-serializes internally, which is what strips function fields. The
+    // sender hands off the object directly (no redundant parse round-trip), so
+    // the mock must serialize to reflect the actual wire payload.
+    process.send = ((m: any) => { sent.push(JSON.parse(JSON.stringify(m))); return true; }) as any;
     sendCallbackToParent("onAgentStart", { nodeName: "n", args: {}, messages: [], cancel: () => {} });
     expect(sent).toEqual([
       { type: "callback", name: "onAgentStart", data: { nodeName: "n", args: {}, messages: [] } },

--- a/packages/agency-lang/lib/runtime/callbackForwarding.test.ts
+++ b/packages/agency-lang/lib/runtime/callbackForwarding.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { sendCallbackToParent } from "./callbackForwarding.js";
+
+// process.send has no vi.stubEnv equivalent — save/restore it manually.
+// A leaked AGENCY_IPC=1 would make later tests emit unexpectedly.
+const originalSend = process.send;
+
+afterEach(() => {
+  process.send = originalSend;
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("sendCallbackToParent", () => {
+  it("sends a callback message when in IPC mode", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const sent: any[] = [];
+    process.send = ((m: any) => { sent.push(m); return true; }) as any;
+    sendCallbackToParent("onNodeStart", { nodeName: "n" });
+    expect(sent).toEqual([{ type: "callback", name: "onNodeStart", data: { nodeName: "n" } }]);
+  });
+
+  it("no-ops outside IPC mode", () => {
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCallbackToParent("onNodeStart", { nodeName: "n" });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when process.send is unavailable", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    (process as any).send = undefined;
+    expect(() => sendCallbackToParent("onNodeStart", { nodeName: "n" })).not.toThrow();
+  });
+
+  it("strips function-valued fields (e.g. onAgentStart.cancel)", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const sent: any[] = [];
+    process.send = ((m: any) => { sent.push(m); return true; }) as any;
+    sendCallbackToParent("onAgentStart", { nodeName: "n", args: {}, messages: [], cancel: () => {} });
+    expect(sent).toEqual([
+      { type: "callback", name: "onAgentStart", data: { nodeName: "n", args: {}, messages: [] } },
+    ]);
+  });
+
+  it("drops an oversize payload instead of sending", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCallbackToParent("onNodeStart", { nodeName: "x".repeat(100) }, 10);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("drops an unserializable payload instead of throwing", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const circular: any = {};
+    circular.self = circular;
+    expect(() => sendCallbackToParent("onNodeStart", circular)).not.toThrow();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("swallows a dead-channel send error", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    process.send = vi.fn(() => { throw new Error("channel closed"); }) as any;
+    expect(() => sendCallbackToParent("onNodeStart", { nodeName: "n" })).not.toThrow();
+  });
+
+  it("does not forward a denylisted callback (onStream)", () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    sendCallbackToParent("onStream", { type: "text", text: "hi" } as any);
+    sendCallbackToParent("onOAuthRequired", { serverName: "s", authUrl: "u" } as any);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agency-lang/lib/runtime/callbackForwarding.ts
+++ b/packages/agency-lang/lib/runtime/callbackForwarding.ts
@@ -1,8 +1,8 @@
 /**
  * Fire-and-forget forwarding of lifecycle callbacks from a subprocess to its
  * parent, so a parent's registered AgencyCallbacks fire for events that happen
- * inside a std::agency run() child (see
- * docs/superpowers/specs/2026-07-02-subprocess-callback-forwarding-design.md).
+ * inside a std::agency run() child (see the "Callback forwarding" section of
+ * docs/dev/subprocess-ipc.md).
  *
  * Dependency-light leaf (mirrors costTelemetry.ts): the only runtime import is
  * subprocessRunInfo.ts (for isIpcMode + the shared ipcChildDebug). invokeCallbacks
@@ -43,8 +43,10 @@ export const CALLBACK_PAYLOAD_LIMIT = 1024 * 1024 * 1024; // 1gb
  * defensive guard against a future refactor routing them through the choke
  * point. onTrace is function-free and simply never fires today, so it is
  * excluded by non-existence rather than listed here. See the plan's
- * "Scope & design tradeoffs" section. */
-const NON_FORWARDABLE_CALLBACKS: readonly CallbackName[] = ["onStream", "onOAuthRequired"];
+ * "Scope & design tradeoffs" section. Exported so the parent-side handler
+ * (ipc.ts) rejects the same names — the guard should match its intent even under
+ * parent/child version skew. */
+export const NON_FORWARDABLE_CALLBACKS: readonly CallbackName[] = ["onStream", "onOAuthRequired"];
 
 /** Forward one lifecycle event to the parent. No-op unless this process is a
  * forked Agency subprocess with a live IPC channel. `maxBytes` is overridable
@@ -72,9 +74,13 @@ export function sendCallbackToParent(
     return;
   }
   try {
-    // Re-parse so the sent object is guaranteed function-free regardless of the
-    // channel's serialization mode.
-    process.send(JSON.parse(serialized) as IpcCallbackMessage);
+    // Send the object directly: the fork uses the default ("json") IPC
+    // serialization (buildForkOptions sets no `serialization` option), so
+    // process.send JSON-serializes internally — stripping function fields and
+    // producing the SAME wire bytes we just measured. The up-front JSON.stringify
+    // stays only to validate serializability + measure size; a redundant
+    // parse-then-re-serialize round-trip would triple the hot-path cost.
+    process.send({ type: "callback", name, data } as IpcCallbackMessage);
   } catch (err) {
     // Channel gone — parent died; the watchdog will reap this process.
     ipcChildDebug(`callback_send_failed ${name} ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/agency-lang/lib/runtime/callbackForwarding.ts
+++ b/packages/agency-lang/lib/runtime/callbackForwarding.ts
@@ -1,0 +1,82 @@
+/**
+ * Fire-and-forget forwarding of lifecycle callbacks from a subprocess to its
+ * parent, so a parent's registered AgencyCallbacks fire for events that happen
+ * inside a std::agency run() child (see
+ * docs/superpowers/specs/2026-07-02-subprocess-callback-forwarding-design.md).
+ *
+ * Dependency-light leaf (mirrors costTelemetry.ts): the only runtime import is
+ * subprocessRunInfo.ts (for isIpcMode + the shared ipcChildDebug). invokeCallbacks
+ * (hooks.ts) calls sendCallbackToParent on every event; hooks.ts must not import
+ * ipc.ts, so the wire type + sender live here.
+ *
+ * Never blocks, never throws, and never kills the run: no reply, no listener; a
+ * dead channel or an over-limit / unserializable payload is swallowed — the
+ * event is observational, so dropping it is always safe.
+ *
+ * Forwarding is UNCONDITIONAL: the child cannot know which callbacks the parent
+ * registered, so every event (except the NON_FORWARDABLE_CALLBACKS denylist) is
+ * serialized and sent on every occurrence, even when no parent callback exists.
+ * Payloads can be large (full messages arrays, run results). Accepted v1
+ * tradeoff — see the plan's "Scope & design tradeoffs".
+ */
+
+import { isIpcMode, ipcChildDebug } from "./subprocessRunInfo.js";
+import type { CallbackName } from "../types/function.js";
+
+export type IpcCallbackMessage = {
+  type: "callback";
+  name: CallbackName;
+  // JSON-sanitized payload; function fields (e.g. onAgentStart.cancel) dropped.
+  data: any;
+};
+
+/** Skip threshold for a forwarded callback payload. Matches the default
+ * ipcPayload limit (ipc.ts DEFAULT_LIMITS) so the child's skip and the parent's
+ * drop agree. Purely defensive: real callback payloads are KB-MB, far under it. */
+export const CALLBACK_PAYLOAD_LIMIT = 1024 * 1024 * 1024; // 1gb
+
+/** Callbacks that MUST NOT be forwarded. onStream and onOAuthRequired carry
+ * function / Promise fields (cancel, complete) whose semantics require a live
+ * local channel; JSON forwarding would strip them and fire a broken callback in
+ * the parent. Neither currently reaches this function (onStream dispatches
+ * outside invokeCallbacks; onOAuthRequired is never fired), so this is a
+ * defensive guard against a future refactor routing them through the choke
+ * point. onTrace is function-free and simply never fires today, so it is
+ * excluded by non-existence rather than listed here. See the plan's
+ * "Scope & design tradeoffs" section. */
+const NON_FORWARDABLE_CALLBACKS: readonly CallbackName[] = ["onStream", "onOAuthRequired"];
+
+/** Forward one lifecycle event to the parent. No-op unless this process is a
+ * forked Agency subprocess with a live IPC channel. `maxBytes` is overridable
+ * only so tests can exercise the oversize-skip without a gigabyte payload. */
+export function sendCallbackToParent(
+  name: CallbackName,
+  data: unknown,
+  maxBytes: number = CALLBACK_PAYLOAD_LIMIT,
+): void {
+  if (!isIpcMode() || typeof process.send !== "function") return;
+  if (NON_FORWARDABLE_CALLBACKS.includes(name)) return; // functions/Promises can't survive JSON
+  // JSON.stringify drops function-valued fields (e.g. onAgentStart.cancel) and
+  // throws on circular refs / BigInt. Serialize ONCE up front so an
+  // un-serializable payload degrades to a dropped event instead of a throw
+  // inside process.send, and so what we measure equals what we send.
+  let serialized: string;
+  try {
+    serialized = JSON.stringify({ type: "callback", name, data });
+  } catch (err) {
+    ipcChildDebug(`callback_unserializable ${name} ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  if (Buffer.byteLength(serialized, "utf8") > maxBytes) {
+    ipcChildDebug(`callback_dropped_oversize ${name}`);
+    return;
+  }
+  try {
+    // Re-parse so the sent object is guaranteed function-free regardless of the
+    // channel's serialization mode.
+    process.send(JSON.parse(serialized) as IpcCallbackMessage);
+  } catch (err) {
+    // Channel gone — parent died; the watchdog will reap this process.
+    ipcChildDebug(`callback_send_failed ${name} ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/packages/agency-lang/lib/runtime/costTelemetry.ts
+++ b/packages/agency-lang/lib/runtime/costTelemetry.ts
@@ -13,7 +13,7 @@
  * to reap this process anyway.
  */
 
-import { isIpcMode } from "./subprocessRunInfo.js";
+import { isIpcMode, ipcChildDebug } from "./subprocessRunInfo.js";
 
 export type IpcTelemetryMessage = {
   type: "telemetry";
@@ -36,13 +36,9 @@ export function sendCostTelemetryToParent(costUsd: number): void {
     process.send(msg);
   } catch (err) {
     // Channel gone — parent died; the watchdog will exit this process.
-    // Deliberately swallowed (fire-and-forget invariant), but traceable:
-    // ipcLog is unreachable from this leaf module, so mirror its line
-    // format (this sender only ever runs in a child) and env gating.
-    if (process.env.AGENCY_IPC_DEBUG === "1") {
-      const ts = new Date().toISOString().slice(11, 23);
-      const detail = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`[ipc:child] ${ts} send telemetry_send_failed ${detail}\n`);
-    }
+    // Deliberately swallowed (fire-and-forget invariant), but traceable via the
+    // shared child-debug logger (ipcLog is unreachable from this leaf module).
+    const detail = err instanceof Error ? err.message : String(err);
+    ipcChildDebug(`send telemetry_send_failed ${detail}`);
   }
 }

--- a/packages/agency-lang/lib/runtime/hooks.test.ts
+++ b/packages/agency-lang/lib/runtime/hooks.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
-import { callHook, registerGlobalHook } from "./hooks.js";
+import { callHook, invokeCallbacks, registerGlobalHook } from "./hooks.js";
 import { State, StateStack } from "./state/stateStack.js";
 
 function ctxWithStack(
@@ -168,5 +168,46 @@ describe("registerGlobalHook", () => {
     const ctx = fakeCtx();
     await callHook({ ctx, name: "onEmit", data: "hello" as any });
     expect(calls).toContain("global");
+  });
+});
+
+describe("invokeCallbacks subprocess forwarding", () => {
+  const originalSend = process.send;
+  afterEach(() => {
+    process.send = originalSend;
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("forwards the event to the parent when in IPC mode", async () => {
+    vi.stubEnv("AGENCY_IPC", "1");
+    const sent: any[] = [];
+    process.send = ((m: any) => { sent.push(m); return true; }) as any;
+    const ctx: any = { callbacks: {}, topLevelCallbacks: [], stateStack: new StateStack() };
+    await invokeCallbacks({ ctx, name: "onNodeStart", data: { nodeName: "x" }, stateStack: ctx.stateStack });
+    expect(sent).toEqual([{ type: "callback", name: "onNodeStart", data: { nodeName: "x" } }]);
+  });
+
+  it("does not forward outside IPC mode", async () => {
+    const send = vi.fn(() => true);
+    process.send = send as any;
+    const ctx: any = { callbacks: {}, topLevelCallbacks: [], stateStack: new StateStack() };
+    await invokeCallbacks({ ctx, name: "onNodeStart", data: { nodeName: "x" }, stateStack: ctx.stateStack });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("forwarding is ADDITIVE: the local callback still fires in IPC mode", async () => {
+    // Guards the "purely additive" invariant: the emit line must not replace or
+    // short-circuit the existing local callback firing. A registered callback
+    // must BOTH fire locally AND be forwarded.
+    vi.stubEnv("AGENCY_IPC", "1");
+    const sent: any[] = [];
+    process.send = ((m: any) => { sent.push(m); return true; }) as any;
+    const fired: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: { onNodeStart: (d: any) => fired.push(d) }, topLevelCallbacks: [], stateStack: stack };
+    await invokeCallbacks({ ctx, name: "onNodeStart", data: { nodeName: "x" }, stateStack: stack });
+    expect(fired).toEqual([{ nodeName: "x" }]); // local callback still fired
+    expect(sent).toEqual([{ type: "callback", name: "onNodeStart", data: { nodeName: "x" } }]); // and forwarded
   });
 });

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -12,6 +12,7 @@ import type { CallbackName } from "../types/function.js";
 import type { LLMRetryReason } from "./llmRetry.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { agencyStore, getRuntimeContext } from "./asyncContext.js";
+import { sendCallbackToParent } from "./callbackForwarding.js";
 import { AgencyAbort, RestoreSignal } from "./errors.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
@@ -276,6 +277,14 @@ export async function invokeCallbacks<K extends keyof CallbackMap>(args: {
   stateStack?: StateStack;
 }): Promise<void> {
   const { name, data, stateStack } = args;
+
+  // Forward every event to the parent when running inside a std::agency run()
+  // subprocess, so the parent's registered callbacks fire for child events
+  // (fire-and-forget; strips functions; no-op outside IPC). Purely additive: the
+  // child still fires its own callbacks below. When THIS process is itself a
+  // subprocess, this re-forwards relayed events upward -> automatic nested relay.
+  sendCallbackToParent(name, data);
+
   const ctx = args.ctx ?? getRuntimeContext().ctx;
   const walkStack = stateStack ?? ctx.stateStack;
 

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -8,11 +8,13 @@ import {
   resolveDepthCap,
   attachSessionHandlers,
   handleTelemetryMessage,
+  handleCallbackMessage,
   withParentStatelog,
   DEFAULT_MAX_SUBPROCESS_DEPTH,
   SUBPROCESS_DEPTH_CEILING,
 } from "./ipc.js";
 import { StateStack } from "./state/stateStack.js";
+import { AgencyCancelledError } from "./errors.js";
 import { CostGuard, isGuardExceededError } from "./guard.js";
 
 describe("withParentStatelog", () => {
@@ -343,5 +345,78 @@ describe("handleTelemetryMessage", () => {
     handleTelemetryMessage(session, { type: "telemetry", costUsd: -5 } as any);
     handleTelemetryMessage(session, { type: "telemetry" } as any);
     expect(stack.localCost).toBe(0);
+  });
+});
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe("handleCallbackMessage", () => {
+  it("fires the parent's registered callback with the forwarded data", async () => {
+    const fired: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: { onNodeStart: (d: any) => fired.push(d) }, topLevelCallbacks: [], stateStack: stack };
+    const session = makeSession({ ctx, stateStack: stack, limits: { wallClock: 1000, memory: 1, ipcPayload: 1e9, stdout: 1 } });
+
+    handleCallbackMessage(session, { type: "callback", name: "onNodeStart", data: { nodeName: "childNode" } });
+    await flush();
+
+    expect(fired).toEqual([{ nodeName: "childNode" }]);
+  });
+
+  it("ignores an unknown callback name (child is less-trusted)", async () => {
+    // Register the handler UNDER the bogus name. gatherCallbacks reads
+    // ctx.callbacks[name] dynamically, so WITHOUT the isForwardableCallbackName
+    // guard this would fire. This makes the test actually discriminate the guard
+    // (registering it under a valid name would pass either way — false confidence).
+    const fired: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: { onBogus: (d: any) => fired.push(d) }, topLevelCallbacks: [], stateStack: stack };
+    const session = makeSession({ ctx, stateStack: stack });
+
+    handleCallbackMessage(session, { type: "callback", name: "onBogus" as any, data: { x: 1 } });
+    await flush();
+
+    expect(fired).toEqual([]);
+  });
+
+  it("drops a callback that arrives after the session settled", async () => {
+    const fired: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: { onNodeStart: (d: any) => fired.push(d) }, topLevelCallbacks: [], stateStack: stack };
+    const session = makeSession({ ctx, stateStack: stack, settled: true });
+
+    handleCallbackMessage(session, { type: "callback", name: "onNodeStart", data: { nodeName: "late" } });
+    await flush();
+
+    expect(fired).toEqual([]);
+  });
+
+  it("reconstructs onAgentStart.cancel to kill the child and settle cancelled", async () => {
+    const kills: string[] = [];
+    const rejections: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = {
+      callbacks: { onAgentStart: (d: any) => d.cancel("parent said stop") },
+      topLevelCallbacks: [],
+      stateStack: stack,
+    };
+    const session = makeSession({
+      ctx,
+      stateStack: stack,
+      child: { kill: (sig: string) => { kills.push(sig); return true; }, connected: true },
+      rejectPromise: (err: any) => { rejections.push(err); },
+    });
+
+    handleCallbackMessage(session, {
+      type: "callback",
+      name: "onAgentStart",
+      data: { nodeName: "childToCancel", args: {}, messages: [] },
+    });
+    await flush();
+
+    expect(kills).toEqual(["SIGKILL"]);
+    expect(rejections).toHaveLength(1);
+    expect(rejections[0]).toBeInstanceOf(AgencyCancelledError);
+    expect(session.settled).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -477,10 +477,8 @@ describe("handleCallbackMessage", () => {
     // Models a MID-TIER that is itself a subprocess: on a forwarded grandchild
     // event it must BOTH fire its own registered callback AND re-forward the
     // event to its parent (invokeCallbacks re-emits because this process is in
-    // IPC mode). This is the deterministic equivalent of a "both fire" E2E —
-    // which cannot be written cleanly because a run()-compiled child can't hold
-    // top-level globals and a forwarded-event callback fires on the parentStore
-    // frame (so node-locals aren't observable).
+    // IPC mode). Fast/deterministic complement to the E2E
+    // callback-forwarding-relay-both-fire.agency.
     vi.stubEnv("AGENCY_IPC", "1");
     const originalSend = process.send;
     const sent: any[] = [];

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -473,6 +473,34 @@ describe("handleCallbackMessage", () => {
     expect(session.settled).toBe(true);
   });
 
+  it("re-fires the mid-tier's own callback AND re-forwards upward (nested relay, both fire)", async () => {
+    // Models a MID-TIER that is itself a subprocess: on a forwarded grandchild
+    // event it must BOTH fire its own registered callback AND re-forward the
+    // event to its parent (invokeCallbacks re-emits because this process is in
+    // IPC mode). This is the deterministic equivalent of a "both fire" E2E —
+    // which cannot be written cleanly because a run()-compiled child can't hold
+    // top-level globals and a forwarded-event callback fires on the parentStore
+    // frame (so node-locals aren't observable).
+    vi.stubEnv("AGENCY_IPC", "1");
+    const originalSend = process.send;
+    const sent: any[] = [];
+    process.send = ((m: any) => { sent.push(m); return true; }) as any;
+    try {
+      const fired: any[] = [];
+      const stack = new StateStack();
+      const ctx: any = { callbacks: { onNodeStart: (d: any) => fired.push(d) }, topLevelCallbacks: [], stateStack: stack };
+      const session = makeSession({ ctx, stateStack: stack, limits: { wallClock: 1000, memory: 1, ipcPayload: 1e9, stdout: 1 } });
+
+      handleCallbackMessage(session, { type: "callback", name: "onNodeStart", data: { nodeName: "grandNode" } });
+      await flush();
+
+      expect(fired).toEqual([{ nodeName: "grandNode" }]); // mid-tier's own callback fired
+      expect(sent).toEqual([{ type: "callback", name: "onNodeStart", data: { nodeName: "grandNode" } }]); // and re-forwarded upward
+    } finally {
+      process.send = originalSend;
+    }
+  });
+
   it("does not fire a denylisted callback name even if the parent registered it", async () => {
     // onStream/onOAuthRequired are non-forwardable (function/Promise fields). The
     // parent guard must reject them too — not just the child sender — else a

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -15,7 +15,7 @@ import {
   SUBPROCESS_DEPTH_CEILING,
 } from "./ipc.js";
 import { State, StateStack } from "./state/stateStack.js";
-import { AgencyCancelledError } from "./errors.js";
+import { AgencyAbort, AgencyCancelledError } from "./errors.js";
 import { CostGuard, isGuardExceededError } from "./guard.js";
 
 describe("withParentStatelog", () => {
@@ -442,6 +442,51 @@ describe("handleCallbackMessage", () => {
     expect(rejections[0]).toBeInstanceOf(AgencyCancelledError);
     expect(session.settled).toBe(true);
   });
+
+  it("routes an AgencyAbort thrown by a parent callback to kill + settle (guard trip / cancel)", async () => {
+    // fireWithGuard re-throws AgencyAbort, so invokeCallbacks can reject. The
+    // fire-and-forget `.catch` must route it to the session (not orphan it as an
+    // unhandledRejection and lose the trip), mirroring handleTelemetryMessage.
+    const kills: string[] = [];
+    const rejections: any[] = [];
+    const stack = new StateStack();
+    const abort = new AgencyCancelledError("callback tripped a guard"); // an AgencyAbort
+    const ctx: any = {
+      callbacks: { onNodeStart: () => { throw abort; } },
+      topLevelCallbacks: [],
+      stateStack: stack,
+    };
+    const session = makeSession({
+      ctx,
+      stateStack: stack,
+      child: { kill: (sig: string) => { kills.push(sig); return true; }, connected: true },
+      rejectPromise: (e: any) => { rejections.push(e); },
+      limits: { wallClock: 1000, memory: 1, ipcPayload: 1e9, stdout: 1 },
+    });
+
+    handleCallbackMessage(session, { type: "callback", name: "onNodeStart", data: { nodeName: "n" } });
+    await flush();
+
+    expect(kills).toEqual(["SIGKILL"]);
+    expect(rejections).toEqual([abort]);
+    expect(rejections[0]).toBeInstanceOf(AgencyAbort);
+    expect(session.settled).toBe(true);
+  });
+
+  it("does not fire a denylisted callback name even if the parent registered it", async () => {
+    // onStream/onOAuthRequired are non-forwardable (function/Promise fields). The
+    // parent guard must reject them too — not just the child sender — else a
+    // version-skewed child could fire a broken (function-stripped) callback.
+    const fired: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: { onStream: (d: any) => fired.push(d) }, topLevelCallbacks: [], stateStack: stack };
+    const session = makeSession({ ctx, stateStack: stack });
+
+    handleCallbackMessage(session, { type: "callback", name: "onStream" as any, data: { type: "text", text: "x" } });
+    await flush();
+
+    expect(fired).toEqual([]);
+  });
 });
 
 describe("handleChildMessage oversize handling", () => {
@@ -466,6 +511,21 @@ describe("handleChildMessage oversize handling", () => {
     await handleChildMessage(session, { type: "result", value: { big: "x".repeat(50) } } as any);
 
     expect(session.settled).toBe(true); // settleWithLimitFailure fired
+  });
+
+  it("does not throw on a malformed (undefined) child message; settles instead of hanging", async () => {
+    // Regression for the null-safety fix: undefined -> serializedByteLength !ok
+    // -> isObservationalMessage(undefined) must NOT throw (a throw would escape
+    // the void-invoked handler, leaving the session unsettled = a hung run).
+    const rejections: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { lockReleasers: {}, stateStack: stack };
+    const session = makeSession({ ctx, stateStack: stack, rejectPromise: (e: any) => rejections.push(e) });
+
+    await expect(handleChildMessage(session, undefined as any)).resolves.toBeUndefined();
+
+    expect(session.settled).toBe(true); // settled via the serialize-error path, not a throw
+    expect(rejections).toHaveLength(1);
   });
 
   it("drops an UNSERIALIZABLE callback message instead of killing the run", async () => {

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -9,6 +9,7 @@ import {
   attachSessionHandlers,
   handleTelemetryMessage,
   handleCallbackMessage,
+  handleChildMessage,
   withParentStatelog,
   DEFAULT_MAX_SUBPROCESS_DEPTH,
   SUBPROCESS_DEPTH_CEILING,
@@ -418,5 +419,69 @@ describe("handleCallbackMessage", () => {
     expect(rejections).toHaveLength(1);
     expect(rejections[0]).toBeInstanceOf(AgencyCancelledError);
     expect(session.settled).toBe(true);
+  });
+});
+
+describe("handleChildMessage oversize handling", () => {
+  it("drops an oversize callback message instead of killing the run", async () => {
+    const rejections: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: {}, topLevelCallbacks: [], stateStack: stack };
+    // makeSession default ipcPayload is 1 byte, so any callback payload is oversize.
+    const session = makeSession({ ctx, stateStack: stack, rejectPromise: (e: any) => rejections.push(e) });
+
+    await handleChildMessage(session, { type: "callback", name: "onNodeStart", data: { nodeName: "big" } });
+
+    expect(session.settled).toBe(false);
+    expect(rejections).toEqual([]);
+  });
+
+  it("still kills the run for an oversize non-callback message", async () => {
+    const stack = new StateStack();
+    const ctx: any = { lockReleasers: {}, stateStack: stack };
+    const session = makeSession({ ctx, stateStack: stack });
+
+    await handleChildMessage(session, { type: "result", value: { big: "x".repeat(50) } } as any);
+
+    expect(session.settled).toBe(true); // settleWithLimitFailure fired
+  });
+
+  it("drops an UNSERIALIZABLE callback message instead of killing the run", async () => {
+    // Covers the `!serialized.ok` observational branch (separate from oversize).
+    const rejections: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: {}, topLevelCallbacks: [], stateStack: stack };
+    const session = makeSession({
+      ctx, stateStack: stack,
+      limits: { wallClock: 1000, memory: 1, ipcPayload: 1e9, stdout: 1 }, // large, so oversize is NOT the cause
+      rejectPromise: (e: any) => rejections.push(e),
+    });
+    const circular: any = { type: "callback", name: "onNodeStart", data: {} };
+    circular.data.self = circular; // JSON.stringify throws -> serialized.ok === false
+
+    await handleChildMessage(session, circular);
+
+    expect(session.settled).toBe(false);
+    expect(rejections).toEqual([]);
+  });
+
+  it("routes a within-limit callback through the dispatch case to the parent callback", async () => {
+    // Directly exercises Task 3(d) — the `msg.type === "callback"` dispatch case
+    // in handleChildMessage. The other handleCallbackMessage tests call it
+    // directly, and the oversize test drops BEFORE dispatch, so without this the
+    // dispatch wiring is only covered by the slow E2E (Task 5). A missing/typo'd
+    // dispatch case would leave `fired` empty here.
+    const fired: any[] = [];
+    const stack = new StateStack();
+    const ctx: any = { callbacks: { onNodeStart: (d: any) => fired.push(d) }, topLevelCallbacks: [], stateStack: stack };
+    const session = makeSession({
+      ctx, stateStack: stack,
+      limits: { wallClock: 1000, memory: 1, ipcPayload: 1e9, stdout: 1 },
+    });
+
+    await handleChildMessage(session, { type: "callback", name: "onNodeStart", data: { nodeName: "routed" } });
+    await flush(); // handleCallbackMessage void-invokes invokeCallbacks; let the microtask chain drain
+
+    expect(fired).toEqual([{ nodeName: "routed" }]);
   });
 });

--- a/packages/agency-lang/lib/runtime/ipc.test.ts
+++ b/packages/agency-lang/lib/runtime/ipc.test.ts
@@ -14,7 +14,7 @@ import {
   DEFAULT_MAX_SUBPROCESS_DEPTH,
   SUBPROCESS_DEPTH_CEILING,
 } from "./ipc.js";
-import { StateStack } from "./state/stateStack.js";
+import { State, StateStack } from "./state/stateStack.js";
 import { AgencyCancelledError } from "./errors.js";
 import { CostGuard, isGuardExceededError } from "./guard.js";
 
@@ -362,6 +362,28 @@ describe("handleCallbackMessage", () => {
     await flush();
 
     expect(fired).toEqual([{ nodeName: "childNode" }]);
+  });
+
+  it("fires a SCOPED parent callback registered on an ancestor stack frame", async () => {
+    // Regression guard: a node-level `callback("onNodeStart")` registers a
+    // SCOPED callback on the parent's stack, found only by walking
+    // ctx.stateStack. s.stateStack is the run() call-site SLICE and does NOT
+    // contain the ancestor frame — the handler must ignore it and walk
+    // ctx.stateStack (as in-process callHook does). With the old
+    // `stateStack: s.stateStack` this callback was silently missed.
+    const fired: any[] = [];
+    const frame = new State();
+    frame.addScopedCallback("onNodeStart", (d: any) => fired.push(d));
+    const fullStack = new StateStack();
+    fullStack.stack = [frame];
+    const ctx: any = { callbacks: {}, topLevelCallbacks: [], stateStack: fullStack };
+    // A DIFFERENT, empty slice — mimics the run() call-site slice.
+    const session = makeSession({ ctx, stateStack: new StateStack(), limits: { wallClock: 1000, memory: 1, ipcPayload: 1e9, stdout: 1 } });
+
+    handleCallbackMessage(session, { type: "callback", name: "onNodeStart", data: { nodeName: "child" } });
+    await flush();
+
+    expect(fired).toEqual([{ nodeName: "child" }]);
   });
 
   it("ignores an unknown callback name (child is less-trusted)", async () => {

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -15,11 +15,11 @@ import type { AgencyConfig } from "../config.js";
 import { getRuntimeContext, agencyStore } from "./asyncContext.js";
 import { gatherChainOutcome, type HandlerChainOutcome, type Interrupt } from "./interrupts.js";
 import { runBatch } from "./runBatch.js";
-import { AgencyCancelledError } from "./errors.js";
+import { AgencyAbort, AgencyCancelledError } from "./errors.js";
 import type { State, StateStack } from "./state/stateStack.js";
 import { getSubprocessRunInfo, setSubprocessRunInfo, isIpcMode, type SubprocessRunInfo } from "./subprocessRunInfo.js";
 import { isPayableCost, type IpcTelemetryMessage } from "./costTelemetry.js";
-import { type IpcCallbackMessage } from "./callbackForwarding.js";
+import { type IpcCallbackMessage, NON_FORWARDABLE_CALLBACKS } from "./callbackForwarding.js";
 import { invokeCallbacks } from "./hooks.js";
 import { VALID_CALLBACK_NAMES, type CallbackName } from "../types/function.js";
 // isIpcMode lives in subprocessRunInfo.ts (dependency-free, so the telemetry
@@ -897,7 +897,13 @@ export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage):
 }
 
 function isForwardableCallbackName(name: unknown): name is CallbackName {
-  return typeof name === "string" && (VALID_CALLBACK_NAMES as readonly string[]).includes(name);
+  return typeof name === "string"
+    && (VALID_CALLBACK_NAMES as readonly string[]).includes(name)
+    // Reject the same names the child-side sender denylists. The child never
+    // forwards these, but a version-skewed or future-refactored child might; a
+    // JSON-stripped onOAuthRequired/onStream would fire a broken (function-less)
+    // parent callback, so the guard must match its name and exclude them.
+    && !(NON_FORWARDABLE_CALLBACKS as readonly string[]).includes(name);
 }
 
 /**
@@ -955,9 +961,26 @@ export function handleCallbackMessage(s: RunSession, msg: IpcCallbackMessage): v
   // Fire within the parent's captured ALS frame so an AgencyFunction callback
   // body resolves __globals()/__threads() against the parent's real state (we
   // run from the event-loop message handler, outside any agencyStore frame).
-  // The synchronous `void invokeCallbacks` starts inside agencyStore.run, so its
-  // async continuations inherit the frame while FIFO ordering is preserved.
-  const fire = () => void invokeCallbacks({ ctx: s.ctx, name: msg.name, data });
+  // Firing is fire-and-forget, but NOT bare `void`: fireWithGuard re-throws
+  // AgencyAbort (a cost-guard trip or cancellation raised inside a parent
+  // callback), so invokeCallbacks can reject. A bare void would orphan that as
+  // an unhandledRejection (Node may terminate) AND lose the trip. Route an
+  // AgencyAbort to the session exactly as handleTelemetryMessage routes a
+  // guard trip (kill the child, settle the run); log anything else. Attaching
+  // the handler is synchronous, so FIFO arrival-order processing still holds.
+  const fire = () =>
+    invokeCallbacks({ ctx: s.ctx, name: msg.name, data }).catch((err) => {
+      if (err instanceof AgencyAbort) {
+        killChildSafely(s);
+        settle(s, s.rejectPromise, err);
+        return;
+      }
+      ipcLog("recv", {
+        type: "callback_fire_error",
+        name: msg.name,
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    });
   if (s.parentStore) {
     agencyStore.run(s.parentStore, fire);
   } else {
@@ -971,8 +994,13 @@ export function handleCallbackMessage(s: RunSession, msg: IpcCallbackMessage): v
  * kill the run). Extend this list when adding another fire-and-forget message. */
 const OBSERVATIONAL_MESSAGE_TYPES: readonly string[] = ["callback"];
 
-function isObservationalMessage(msg: { type?: string }): boolean {
-  return typeof msg.type === "string" && OBSERVATIONAL_MESSAGE_TYPES.includes(msg.type);
+function isObservationalMessage(msg: unknown): boolean {
+  // Null-safe: handleChildMessage runs on arbitrary values from an untrusted
+  // child. A child sending `undefined`/`null` makes serializedByteLength !ok and
+  // reaches here; reading `.type` off a non-object must not throw (that would
+  // leave the session unsettled — the exact failure the serialize guard avoids).
+  const type = (msg as { type?: unknown } | null | undefined)?.type;
+  return typeof type === "string" && OBSERVATIONAL_MESSAGE_TYPES.includes(type);
 }
 
 export async function handleChildMessage(s: RunSession, msg: any): Promise<void> {

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -12,7 +12,7 @@ import type { ForkOptions } from "child_process";
 import { rmSync, writeFileSync, mkdirSync } from "fs";
 import { nanoid } from "nanoid";
 import type { AgencyConfig } from "../config.js";
-import { getRuntimeContext } from "./asyncContext.js";
+import { getRuntimeContext, agencyStore } from "./asyncContext.js";
 import { gatherChainOutcome, type HandlerChainOutcome, type Interrupt } from "./interrupts.js";
 import { runBatch } from "./runBatch.js";
 import { AgencyCancelledError } from "./errors.js";
@@ -451,6 +451,12 @@ export type RunSession = {
   limits: RunLimits;
   ctx: any;
   stateStack: any;
+  /** The parent's full ALS store frame captured at run() time. Forwarded
+   * callbacks (handleCallbackMessage) fire from the event-loop message handler,
+   * OUTSIDE any agencyStore frame; re-establishing this frame lets an
+   * AgencyFunction callback body resolve __globals()/__threads() against the
+   * parent's real globals, exactly as an in-process callback would. */
+  parentStore?: any;
   resolvePromise: (v: SessionOutcome) => void;
   rejectPromise: (v: any) => void;
   settled: boolean;
@@ -933,13 +939,30 @@ function withParentCancel(s: RunSession, data: unknown): unknown {
  *
  * invokeCallbacks re-emits upward when THIS process is itself a subprocess, so a
  * grandchild's event relays to the root with no explicit relay code.
+ *
+ * Fires on the parent's FULL stack (ctx.stateStack), NOT the run() call-site
+ * slice s.stateStack: a parent callback registered on an ancestor frame (e.g. a
+ * node-level `callback("onNodeStart")` above the run() call) is only reachable by
+ * walking the full stack, exactly as an in-process event does via callHook (which
+ * omits stateStack and defaults to ctx.stateStack). Passing s.stateStack here
+ * would silently miss those ancestor-frame callbacks.
  */
 export function handleCallbackMessage(s: RunSession, msg: IpcCallbackMessage): void {
   if (s.settled) return; // drop post-settle events
   if (!isForwardableCallbackName(msg.name)) return; // child is less-trusted
 
   const data = msg.name === "onAgentStart" ? withParentCancel(s, msg.data) : msg.data;
-  void invokeCallbacks({ ctx: s.ctx, name: msg.name, data, stateStack: s.stateStack });
+  // Fire within the parent's captured ALS frame so an AgencyFunction callback
+  // body resolves __globals()/__threads() against the parent's real state (we
+  // run from the event-loop message handler, outside any agencyStore frame).
+  // The synchronous `void invokeCallbacks` starts inside agencyStore.run, so its
+  // async continuations inherit the frame while FIFO ordering is preserved.
+  const fire = () => void invokeCallbacks({ ctx: s.ctx, name: msg.name, data });
+  if (s.parentStore) {
+    agencyStore.run(s.parentStore, fire);
+  } else {
+    fire();
+  }
 }
 
 /** Message types whose delivery is observational — an oversize or
@@ -1048,6 +1071,7 @@ export function attachSessionHandlers(s: RunSession, instruction: RunInstruction
 async function runSubprocessSession(opts: {
   ctx: any;
   stateStack: any;
+  parentStore?: any;
   instruction: RunInstruction | ResumeInstruction;
   limits: RunLimits;
   cwd?: string;
@@ -1065,6 +1089,7 @@ async function runSubprocessSession(opts: {
       limits: opts.limits,
       ctx: opts.ctx,
       stateStack: opts.stateStack,
+      parentStore: opts.parentStore,
       resolvePromise,
       rejectPromise,
       settled: false,
@@ -1131,6 +1156,7 @@ function resolveInstruction(args: {
 async function invokeSubprocess(args: {
   ctx: any;
   stateStack: any;
+  parentStore?: any;
   parentFrame: State;
   compiled: { moduleId: string; code: string };
   node: string;
@@ -1181,6 +1207,7 @@ async function invokeSubprocess(args: {
     const outcome = await runSubprocessSession({
       ctx: args.ctx,
       stateStack: args.stateStack,
+      parentStore: args.parentStore,
       instruction,
       limits: args.limits,
       cwd: args.cwd,
@@ -1297,6 +1324,7 @@ export async function _run(
           invokeSubprocess({
             ctx,
             stateStack,
+            parentStore: store,
             parentFrame,
             compiled,
             node,

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -19,6 +19,9 @@ import { AgencyCancelledError } from "./errors.js";
 import type { State, StateStack } from "./state/stateStack.js";
 import { getSubprocessRunInfo, setSubprocessRunInfo, isIpcMode, type SubprocessRunInfo } from "./subprocessRunInfo.js";
 import { isPayableCost, type IpcTelemetryMessage } from "./costTelemetry.js";
+import { type IpcCallbackMessage } from "./callbackForwarding.js";
+import { invokeCallbacks } from "./hooks.js";
+import { VALID_CALLBACK_NAMES, type CallbackName } from "../types/function.js";
 // isIpcMode lives in subprocessRunInfo.ts (dependency-free, so the telemetry
 // leaf can share it); re-exported here for the existing consumers.
 export { isIpcMode };
@@ -276,7 +279,8 @@ export type SubprocessToParent =
   | IpcErrorMessage
   | IpcLockAcquireMessage
   | IpcLockReleaseMessage
-  | IpcTelemetryMessage;
+  | IpcTelemetryMessage
+  | IpcCallbackMessage;
 export type ParentToSubprocess = IpcDecisionMessage | IpcLockGrantedMessage;
 
 const sessionLockOwners: Record<string, string[]> = {};
@@ -886,6 +890,58 @@ export function handleTelemetryMessage(s: RunSession, msg: IpcTelemetryMessage):
   }
 }
 
+function isForwardableCallbackName(name: unknown): name is CallbackName {
+  return typeof name === "string" && (VALID_CALLBACK_NAMES as readonly string[]).includes(name);
+}
+
+/**
+ * Give a forwarded onAgentStart payload a REAL parent-owned cancel().
+ *
+ * The child's own cancel function was stripped by JSON. The parent owns the
+ * child session, so a parent onAgentStart callback that calls cancel() kills the
+ * child (SIGKILL) and settles run() as cancelled.
+ *
+ * BEST-EFFORT and ASYNC — NOT the in-process semantic. In-process, cancel()
+ * throws synchronously and PREVENTS the agent from running. Here the child fires
+ * onAgentStart and proceeds without back-pressure (fire-and-forget), so the
+ * parent's cancel arrives later and kills a child that may already be mid-run or
+ * finished. If the child's terminal result wins the race, settle()'s `s.settled`
+ * guard makes the cancel a silent no-op. Killing the child is the closest
+ * approximation this one-way channel allows.
+ *
+ * The `typeof data === object` guard is defensive: the child is the less-trusted
+ * party, so we do not spread a malformed non-object payload.
+ */
+function withParentCancel(s: RunSession, data: unknown): unknown {
+  if (typeof data !== "object" || data === null) return data;
+  return {
+    ...(data as Record<string, unknown>),
+    cancel: (reason?: string) => {
+      killChildSafely(s);
+      settle(s, s.rejectPromise, new AgencyCancelledError(reason));
+    },
+  };
+}
+
+/**
+ * Fire the PARENT's registered callbacks for an event forwarded from a child.
+ *
+ * MUST STAY SYNCHRONOUS (like handleTelemetryMessage): handleChildMessage
+ * void-invokes its async dispatch, so FIFO arrival-order processing holds only
+ * while this path has no awaits. Parent callbacks fire fire-and-forget (void
+ * invokeCallbacks) so a slow or throwing parent callback cannot wedge the pump.
+ *
+ * invokeCallbacks re-emits upward when THIS process is itself a subprocess, so a
+ * grandchild's event relays to the root with no explicit relay code.
+ */
+export function handleCallbackMessage(s: RunSession, msg: IpcCallbackMessage): void {
+  if (s.settled) return; // drop post-settle events
+  if (!isForwardableCallbackName(msg.name)) return; // child is less-trusted
+
+  const data = msg.name === "onAgentStart" ? withParentCancel(s, msg.data) : msg.data;
+  void invokeCallbacks({ ctx: s.ctx, name: msg.name, data, stateStack: s.stateStack });
+}
+
 async function handleChildMessage(s: RunSession, msg: any): Promise<void> {
   ipcLog("recv", msg);
   // Defensively serialize once: a non-serializable value (circular refs,
@@ -912,6 +968,8 @@ async function handleChildMessage(s: RunSession, msg: any): Promise<void> {
     settle(s, s.resolvePromise, { type: "interrupted", msg } satisfies SessionOutcome);
   } else if (msg.type === "telemetry") {
     handleTelemetryMessage(s, msg);
+  } else if (msg.type === "callback") {
+    handleCallbackMessage(s, msg);
   } else if (msg.type === "error") {
     handleErrorMessage(s, msg);
   } else if (msg.type === "lockAcquire") {

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -942,19 +942,40 @@ export function handleCallbackMessage(s: RunSession, msg: IpcCallbackMessage): v
   void invokeCallbacks({ ctx: s.ctx, name: msg.name, data, stateStack: s.stateStack });
 }
 
-async function handleChildMessage(s: RunSession, msg: any): Promise<void> {
+/** Message types whose delivery is observational — an oversize or
+ * unserializable one is DROPPED, never fatal, because it cannot affect the run
+ * outcome (unlike result/interrupt/error/lock messages, which must settle or
+ * kill the run). Extend this list when adding another fire-and-forget message. */
+const OBSERVATIONAL_MESSAGE_TYPES: readonly string[] = ["callback"];
+
+function isObservationalMessage(msg: { type?: string }): boolean {
+  return typeof msg.type === "string" && OBSERVATIONAL_MESSAGE_TYPES.includes(msg.type);
+}
+
+export async function handleChildMessage(s: RunSession, msg: any): Promise<void> {
   ipcLog("recv", msg);
   // Defensively serialize once: a non-serializable value (circular refs,
   // BigInt) would otherwise throw inside the event handler and leave the
   // session unsettled, hanging _run's Promise.
   const serialized = serializedByteLength(msg);
   if (!serialized.ok) {
+    // An observational message is never worth killing the run over.
+    if (isObservationalMessage(msg)) {
+      ipcLog("recv", { type: "observational_dropped", messageType: msg.type, reason: "unserializable" });
+      return;
+    }
     settle(s, s.rejectPromise, new Error(
       `Failed to serialize subprocess message: ${serialized.error}`,
     ));
     return;
   }
   if (serialized.byteLength > s.limits.ipcPayload) {
+    // Drop an oversize observational message rather than settleWithLimitFailure
+    // (which kills the run) — preserves the pure-observation invariant.
+    if (isObservationalMessage(msg)) {
+      ipcLog("recv", { type: "observational_dropped", messageType: msg.type, reason: "oversize" });
+      return;
+    }
     settleWithLimitFailure(s, "ipc_payload", s.limits.ipcPayload, serialized.byteLength, {
       samplePrefix: serialized.serialized.slice(0, 1024),
     });

--- a/packages/agency-lang/lib/runtime/subprocessRunInfo.test.ts
+++ b/packages/agency-lang/lib/runtime/subprocessRunInfo.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ipcChildDebug } from "./subprocessRunInfo.js";
+import { agencyStore } from "./asyncContext.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("ipcChildDebug", () => {
+  it("posts a statelog debug event when an ALS frame has a statelog client", () => {
+    const debugCalls: any[] = [];
+    const store: any = {
+      ctx: {
+        statelogClient: {
+          debug: (m: string, d: any) => { debugCalls.push([m, d]); return Promise.resolve(); },
+        },
+      },
+    };
+    agencyStore.run(store, () => {
+      ipcChildDebug("callback_send_failed onNodeStart boom");
+    });
+    expect(debugCalls).toEqual([["[ipc:child] callback_send_failed onNodeStart boom", {}]]);
+  });
+
+  it("does not throw when there is no active ALS frame / statelog client", () => {
+    expect(() => ipcChildDebug("callback_dropped_oversize onNodeStart")).not.toThrow();
+  });
+
+  it("swallows a throwing statelog client (never affects the run)", () => {
+    const store: any = {
+      ctx: { statelogClient: { debug: () => { throw new Error("statelog down"); } } },
+    };
+    expect(() =>
+      agencyStore.run(store, () => { ipcChildDebug("callback_unserializable onNodeStart"); }),
+    ).not.toThrow();
+  });
+});

--- a/packages/agency-lang/lib/runtime/subprocessRunInfo.ts
+++ b/packages/agency-lang/lib/runtime/subprocessRunInfo.ts
@@ -36,6 +36,16 @@ export function isIpcMode(): boolean {
   return process.env.AGENCY_IPC === "1";
 }
 
+/** Emit one child-side IPC debug line to stderr, gated on AGENCY_IPC_DEBUG=1.
+ * Lives here (the dependency-free leaf) so both callbackForwarding.ts and
+ * costTelemetry.ts share one implementation; ipcLog (ipc.ts) is unreachable from
+ * these leaves without violating the layering rule. */
+export function ipcChildDebug(line: string): void {
+  if (process.env.AGENCY_IPC_DEBUG !== "1") return;
+  const ts = new Date().toISOString().slice(11, 23);
+  process.stderr.write(`[ipc:child] ${ts} ${line}\n`);
+}
+
 let info: SubprocessRunInfo = { depth: 0 };
 
 export function setSubprocessRunInfo(next: SubprocessRunInfo): void {

--- a/packages/agency-lang/lib/runtime/subprocessRunInfo.ts
+++ b/packages/agency-lang/lib/runtime/subprocessRunInfo.ts
@@ -4,10 +4,15 @@
  *
  * A subprocess executes exactly one run per process, so module scope is the
  * correct lifetime here (the same arrangement as the bootstrap's
- * ipcPayloadLimit). This lives in its own dependency-free module so both
- * `ipc.ts` and `state/context.ts` / `node.ts` can read it without import
- * cycles.
+ * ipcPayloadLimit). Kept intentionally minimal so both `ipc.ts` and
+ * `state/context.ts` / `node.ts` can read it without import cycles. Its only
+ * runtime import is `asyncContext` (for `ipcChildDebug`'s best-effort statelog
+ * emission); that edge is cycle-safe because asyncContext's value-chain
+ * (bootstrapThreadStore -> threadStore -> statelogClient / messageThread) never
+ * imports back into this module, ipc.ts, or the leaf senders.
  */
+
+import { agencyStore } from "./asyncContext.js";
 
 export type SubprocessRunInfo = {
   /** The parent's runId — the child adopts it instead of minting its own,
@@ -36,11 +41,26 @@ export function isIpcMode(): boolean {
   return process.env.AGENCY_IPC === "1";
 }
 
-/** Emit one child-side IPC debug line to stderr, gated on AGENCY_IPC_DEBUG=1.
- * Lives here (the dependency-free leaf) so both callbackForwarding.ts and
- * costTelemetry.ts share one implementation; ipcLog (ipc.ts) is unreachable from
- * these leaves without violating the layering rule. */
+/** Emit one child-side IPC diagnostic. Shared by callbackForwarding.ts and
+ * costTelemetry.ts (ipcLog in ipc.ts is unreachable from these leaves without
+ * violating the layering rule). Two independent sinks:
+ *   - statelog `debug` event (best-effort) so the diagnostic is visible in the
+ *     trace when observability is on — resolved from the active ALS frame's
+ *     ctx.statelogClient; no-ops with no frame/client, never throws;
+ *   - stderr, gated on AGENCY_IPC_DEBUG=1, for local IPC debugging. */
 export function ipcChildDebug(line: string): void {
+  const client = agencyStore.getStore()?.ctx?.statelogClient;
+  if (client) {
+    try {
+      // Fire-and-forget; a failed statelog post must never affect the run. The
+      // real client.debug is async (rejection handled by .catch); the try guards
+      // the defensive case of a synchronous throw. Intentionally swallowed — this
+      // IS the diagnostic sink, so there is nowhere else to surface an error.
+      void Promise.resolve(client.debug(`[ipc:child] ${line}`, {})).catch(() => {});
+    } catch {
+      // no-op: statelog diagnostics are best-effort
+    }
+  }
   if (process.env.AGENCY_IPC_DEBUG !== "1") return;
   const ts = new Date().toISOString().slice(11, 23);
   process.stderr.write(`[ipc:child] ${ts} ${line}\n`);

--- a/packages/agency-lang/tests/agency/subprocess/callback-forwarding-child-events.agency
+++ b/packages/agency-lang/tests/agency/subprocess/callback-forwarding-child-events.agency
@@ -1,0 +1,35 @@
+import { compile, run } from "std::agency"
+
+// The parent registers an onNodeStart callback filtered to a node name that
+// ONLY the child uses. Without forwarding, the parent's callback never sees the
+// child's node entry, so `seen` stays 0. With forwarding, the child's
+// onNodeStart is delivered to the parent and increments `seen`.
+let seen: number = 0
+
+node main() {
+  callback("onNodeStart") as data {
+    if (data.nodeName == "childOnlyNode") {
+      seen = seen + 1
+    }
+  }
+  const source = """
+node childOnlyNode() {
+  return "child done"
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "childOnlyNode")
+    if (isFailure(result)) {
+      return "run failed"
+    }
+    return "childNodeSeen:${seen > 0}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/callback-forwarding-child-events.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/callback-forwarding-child-events.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Parent onNodeStart callback fires for the child subprocess node entry",
+      "input": "",
+      "expectedOutput": "\"childNodeSeen:true\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/callback-forwarding-nested-relay.agency
+++ b/packages/agency-lang/tests/agency/subprocess/callback-forwarding-nested-relay.agency
@@ -1,0 +1,59 @@
+import { compile, run } from "std::agency"
+
+// The grandchild fires onNodeStart for "grandNode". The mid-tier child has no
+// callbacks of its own but relays the event upward (its invokeCallbacks
+// re-emits because that process is in IPC mode). The ROOT parent's callback,
+// filtered to "grandNode", must fire -> proves automatic nested relay.
+let seen: number = 0
+
+node main() {
+  callback("onNodeStart") as data {
+    if (data.nodeName == "grandNode") {
+      seen = seen + 1
+    }
+  }
+  const grandSource = """
+node grandNode() {
+  return "grandchild done"
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const result = run(compiled: c.value, node: "grandNode")
+    if (isFailure(result)) {
+      return "inner run failed"
+    }
+    return "middle done"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isFailure(result)) {
+      return "run failed"
+    }
+    return "grandchildSeen:${seen > 0}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/callback-forwarding-nested-relay.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/callback-forwarding-nested-relay.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Root parent callback fires for a grandchild node event relayed through a callbackless mid-tier",
+      "input": "",
+      "expectedOutput": "\"grandchildSeen:true\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/callback-forwarding-relay-both-fire.agency
+++ b/packages/agency-lang/tests/agency/subprocess/callback-forwarding-relay-both-fire.agency
@@ -1,0 +1,74 @@
+import { compile, run } from "std::agency"
+
+// Both the ROOT and the MID-TIER register their own onNodeStart callback,
+// filtered to "grandNode". The grandchild fires onNodeStart for grandNode; the
+// mid-tier's own callback fires (from the forwarded event) AND the mid re-forwards
+// to the root, whose callback also fires. Proves the two observers fire
+// independently with no interference, and that each callback's filter is
+// respected (neither the mid's own "main" entry nor the root's "main" entry
+// increments the "grandNode"-filtered counters).
+//
+// NOTE: the nested source strings deliberately avoid `${...}` — a triple-quoted
+// raw string interpolates it at THIS level (see issue on raw-string `${}`
+// codegen), so the mid returns its count as a number instead of an interpolated
+// string.
+let rootSeen: number = 0
+
+node main() {
+  callback("onNodeStart") as data {
+    if (data.nodeName == "grandNode") {
+      rootSeen = rootSeen + 1
+    }
+  }
+  const grandSource = """
+node grandNode() {
+  return "grandchild done"
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+let midSeen: number = 0
+node main(grandSource: string) {
+  callback("onNodeStart") as data {
+    if (data.nodeName == "grandNode") {
+      midSeen = midSeen + 1
+    }
+  }
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return 0 - 1
+  }
+  handle {
+    const result = run(compiled: c.value, node: "grandNode")
+    if (isFailure(result)) {
+      return 0 - 2
+    }
+    return midSeen
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isFailure(result)) {
+      return "run failed"
+    }
+    const midCount: number = result.value.data
+    return "root:${rootSeen}|mid:${midCount}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/callback-forwarding-relay-both-fire.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/callback-forwarding-relay-both-fire.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Both the mid-tier and the root callbacks fire for the same grandchild event, independently and with filters respected",
+      "input": "",
+      "expectedOutput": "\"root:1|mid:1\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Forwards a subprocess's lifecycle callbacks to its parent over IPC, so a parent's registered `AgencyCallbacks` fire for events that happen inside a `std::agency run()` child (and, recursively, grandchildren).

Mirrors the shipped cost-telemetry design (PR #404): a single choke point (`invokeCallbacks` in `hooks.ts`) fire-and-forgets every event upward via a dependency-light leaf module; the parent re-fires its own callbacks by re-entering `invokeCallbacks`, which makes nested (grandchild) relay automatic.

## How it works

- **Child side** (`callbackForwarding.ts`, new leaf): `invokeCallbacks` calls `sendCallbackToParent(name, data)` on every event. JSON-serialized once (strips functions like `onAgentStart.cancel`; unserializable payloads degrade to a dropped event). `hooks.ts` must not import `ipc.ts`, so the wire type + sender live in the leaf.
- **Parent side** (`ipc.ts`): a new `{ type: "callback", name, data }` message on `SubprocessToParent`; `handleCallbackMessage` (synchronous, like `handleTelemetryMessage`) validates the name against `VALID_CALLBACK_NAMES`, drops post-settle events, and `void invokeCallbacks(...)` fire-and-forget.
- **Nested relay is automatic** — `invokeCallbacks` re-emits when THIS process is itself a subprocess.
- **`onAgentStart.cancel` reconstructed** parent-side to a real (best-effort, async) kill + settle-cancelled.
- **Observational, never fatal** — an oversize/unserializable `callback` message is dropped, not settled (`isObservationalMessage` carve-out in `handleChildMessage`).
- **Not forwarded:** `onStream` and `onOAuthRequired` (denylisted — carry functions/Promises needing a live channel); `onTrace` (never dispatched today).

## Notable fix (found by the E2E tests)

The E2E tests exposed a real bug the unit tests missed (they used plain-JS callbacks via `ctx.callbacks`, bypassing both the scoped-callback stack walk and the `AgencyFunction` body path):

1. `handleCallbackMessage` walked the `run()` call-site slice (`s.stateStack`), so a node-level `callback("onNodeStart")` registered on an ancestor frame was never gathered. Fix: fire with `callHook` semantics (walk the full `ctx.stateStack`), matching in-process firing.
2. It fired from the event-loop message handler with no `agencyStore` frame, so an `AgencyFunction` callback body threw on `__globals()` (undefined store) and was swallowed by `fireWithGuard`. Fix: capture the parent's ALS store frame at `run()` time (`RunSession.parentStore`, threaded through `invokeSubprocess` → `runSubprocessSession`) and re-establish it around the fire.

A scoped-callback regression unit test now covers this (fails on the old slice-walk).

## Tests

- Unit: `callbackForwarding.test.ts` (sender: IPC gate, function-stripping, oversize/unserializable drop, dead-channel, denylist); `hooks.test.ts` (choke-point emit + additive firing); `ipc.test.ts` (parent handler, scoped-callback regression, guard discrimination, post-settle drop, `onAgentStart.cancel` reconstruction, observational drop for oversize + unserializable, `handleChildMessage` dispatch routing).
- E2E (`tests/agency/subprocess/`): `callback-forwarding-child-events` (parent callback fires for a child node entry), `callback-forwarding-nested-relay` (root callback fires for a grandchild event through a callbackless mid-tier).
- Ride-along: hoisted `ipcChildDebug` into `subprocessRunInfo.ts` and refactored `costTelemetry.ts` to share it.

Local: 63 unit tests (4 files) + both E2E pass; `tsc --noEmit` and `lint:structure` clean. The full agency suite runs in CI.

## Docs

`docs/dev/subprocess-ipc.md` (new "Callback forwarding" section, removed the limitation bullet, added both E2E rows) and `docs/misc/lifecycleHooks.md` (subprocess-forwarding note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
