### PR TITLE
Support ${ escape in triple-quoted strings

### DIFF
--- a/packages/agency-lang/docs/site/guide/basic-syntax.md
+++ b/packages/agency-lang/docs/site/guide/basic-syntax.md
@@ -28,12 +28,19 @@ const greeting2 = 'Hello, ${name}!'
 const greeting3 = `Hello, ${name}!`
 ```
 
-Multi-line strings use `"""` triple-quotes and do **not** interpret backslash escapes (i.e. `\n` is not a newline, it's just a backslash followed by an `n`):
+To write a literal `${` without starting an interpolation, escape it as `\${`. This works in every string kind, including triple-quoted strings:
+
+```ts
+const price = "costs \${5}"        // -> costs ${5}
+const template = """let x = \${y}"""  // -> let x = ${y}  (useful for embedding code)
+```
+
+Multi-line strings use `"""` triple-quotes. They **also** support `${...}` interpolation, but otherwise do **not** interpret backslash escapes — `\n` is a backslash followed by an `n`, not a newline. The one exception is `\${`, which escapes an interpolation as shown above:
 
 ```ts
 const block = """
-  first line\n
-  second line
+  ${name} on the first line\n
+  literal \${skip} on the second
 """
 ```
 

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -655,6 +655,47 @@ describe("AgencyGenerator - string escape round-tripping", () => {
   });
 });
 
+describe("AgencyGenerator - multi-line string escape round-tripping", () => {
+  // A parsed literal `${...}` (written `\${...}` in a triple-quoted string) must
+  // survive emit + re-parse as a literal text segment, not silently become a
+  // live interpolation. Other raw content (a literal `\n`) must stay raw.
+  const cases = [
+    { name: "escaped interpolation only", source: '"""a \\${x} b"""' },
+    { name: "raw backslash-n stays raw", source: '"""raw \\n text"""' },
+    { name: "real interp next to escaped", source: '"""hi ${name} lit \\${skip}"""' },
+  ];
+
+  const segsOf = (program: { nodes: unknown[] }) => {
+    const a = program.nodes.find((n: any) => n?.type === "assignment") as
+      | { value?: { type?: string; segments?: any[] } }
+      | undefined;
+    if (a?.value?.type !== "multiLineString") return null;
+    return (a.value.segments ?? []).map((s: any) =>
+      s.type === "text"
+        ? { type: "text", value: s.value }
+        : { type: "interpolation", name: s.expression?.value },
+    );
+  };
+
+  cases.forEach(({ name, source }) => {
+    it(`round-trips: ${name}`, () => {
+      const r1 = parseAgency(`let s = ${source}`, {}, false);
+      expect(r1.success, "first parse").toBe(true);
+      if (!r1.success) return;
+
+      const emitted = new AgencyGenerator().generate(r1.result).output;
+
+      const r2 = parseAgency(emitted, {}, false);
+      expect(r2.success, `re-parse of ${JSON.stringify(emitted)}`).toBe(true);
+      if (!r2.success) return;
+
+      const segs1 = segsOf(r1.result);
+      expect(segs1, "first parse produced a multi-line string").not.toBeNull();
+      expect(segsOf(r2.result)).toEqual(segs1);
+    });
+  });
+});
+
 describe("AgencyGenerator - string delimiter round-tripping", () => {
   // Emit, parse, and check that (a) the emitted source is exactly the
   // input source (no delimiter rewrite, no needless escapes) and (b)

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -122,6 +122,16 @@ function escapeStringText(s: string, delim: '"' | "'" | "`"): string {
   return out;
 }
 
+/** Re-escape `${` -> `\${` when printing a triple-quoted (raw) string's text.
+ * The parser decodes `\${` -> a literal `${` text segment; without re-escaping
+ * here, the formatter would emit a bare `${` and silently turn a literal back
+ * into a live interpolation on the next parse. Everything else stays raw —
+ * triple-quoted strings do not escape backslashes, newlines, or quotes. Uses
+ * split/join so `$` in the replacement is not treated as a special pattern. */
+function escapeMultiLineText(s: string): string {
+  return s.split("${").join("\\${");
+}
+
 export class AgencyGenerator {
   protected graphNodes: GraphNodeDefinition[] = [];
   protected generatedStatements: string[] = [];
@@ -903,7 +913,7 @@ export class AgencyGenerator {
     let result = '"""';
     for (const segment of node.segments) {
       if (segment.type === "text") {
-        result += segment.value;
+        result += escapeMultiLineText(segment.value);
       } else if (segment.type === "interpolation") {
         result += `\${${this.processNode(segment.expression).trim()}}`;
       }
@@ -969,7 +979,7 @@ export class AgencyGenerator {
       let content = "";
       for (const seg of node.docString.segments) {
         if (seg.type === "text") {
-          content += seg.value;
+          content += escapeMultiLineText(seg.value);
         } else {
           content += `\${${this.processNode(seg.expression).trim()}}`;
         }
@@ -1445,7 +1455,7 @@ export class AgencyGenerator {
       let content = "";
       for (const seg of node.docString.segments) {
         if (seg.type === "text") {
-          content += seg.value;
+          content += escapeMultiLineText(seg.value);
         } else {
           content += `\${${this.processNode(seg.expression).trim()}}`;
         }

--- a/packages/agency-lang/lib/parsers/literals.test.ts
+++ b/packages/agency-lang/lib/parsers/literals.test.ts
@@ -1457,6 +1457,45 @@ describe("literals parsers", () => {
         },
       },
 
+      // Escaped interpolation: \${ -> literal ${ (the ONE backslash escape in
+      // triple-quoted strings; all other backslashes stay raw).
+      {
+        input: '"""a \\${x} b"""',
+        expected: {
+          success: true,
+          result: {
+            type: "multiLineString",
+            segments: [{ type: "text", value: "a ${x} b" }],
+          },
+        },
+      },
+      // Only \${ is special: a literal \n (backslash-n) stays raw alongside it.
+      {
+        input: '"""raw \\n and escaped \\${x}"""',
+        expected: {
+          success: true,
+          result: {
+            type: "multiLineString",
+            segments: [{ type: "text", value: "raw \\n and escaped ${x}" }],
+          },
+        },
+      },
+      // Mixed: real interpolation next to an escaped literal ${}.
+      {
+        input: '"""real ${a} literal \\${b}"""',
+        expected: {
+          success: true,
+          result: {
+            type: "multiLineString",
+            segments: [
+              { type: "text", value: "real " },
+              { type: "interpolation", expression: { type: "variableName", value: "a" } },
+              { type: "text", value: " literal ${b}" },
+            ],
+          },
+        },
+      },
+
       // Failure cases
       { input: '"""hello', expected: { success: false } },
       { input: 'hello"""', expected: { success: false } },

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -450,13 +450,31 @@ const stringTextSegmentParserFor = (delim: '"' | "'" | "`"): Parser<TextSegment>
     return success({ type: "text" as const, value }, input.slice(i));
   };
 
-export const multiLineStringTextSegmentParser: Parser<TextSegment> = map(
-  many1Till(or(str('"""'), str("${"))),
-  (text) => ({
-    type: "text",
-    value: text,
-  }),
-);
+// Text segment inside a triple-quoted string. Raw by design — backslash escapes
+// like `\n` are NOT interpreted (a literal backslash then `n`) — with ONE
+// exception: `\${` decodes to a literal `${` so a raw string can contain literal
+// interpolation syntax (e.g. embedded Agency/shell/JS source) without opening an
+// interpolation. A lone backslash, and every other `\x`, stays verbatim. Stops
+// at the closing `"""` or an unescaped `${` (which starts interpolation).
+export const multiLineStringTextSegmentParser: Parser<TextSegment> = (
+  input: string,
+): ParserResult<TextSegment> => {
+  let i = 0;
+  let value = "";
+  while (i < input.length) {
+    if (input.startsWith('"""', i)) break;
+    if (input[i] === "\\" && input[i + 1] === "$" && input[i + 2] === "{") {
+      value += "${";
+      i += 3;
+      continue;
+    }
+    if (input[i] === "$" && input[i + 1] === "{") break;
+    value += input[i];
+    i++;
+  }
+  if (i === 0) return failure("expected string text", input);
+  return success({ type: "text" as const, value }, input.slice(i));
+};
 
 export const interpolationSegmentParser: Parser<InterpolationSegment> = withLoc((
   input: string,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -450,31 +450,25 @@ const stringTextSegmentParserFor = (delim: '"' | "'" | "`"): Parser<TextSegment>
     return success({ type: "text" as const, value }, input.slice(i));
   };
 
+// One character of raw multi-line text: any char that does not begin the close
+// delimiter (`"""`) or an interpolation (`${`). `not(...)` is a zero-width
+// negative lookahead; `capture(anyChar)` then consumes the single char.
+const multiLineRawChar: Parser<string> = map(
+  seqC(not(or(str('"""'), str("${"))), capture(anyChar, "c")),
+  (r) => r.c,
+);
+
 // Text segment inside a triple-quoted string. Raw by design — backslash escapes
 // like `\n` are NOT interpreted (a literal backslash then `n`) — with ONE
-// exception: `\${` decodes to a literal `${` so a raw string can contain literal
-// interpolation syntax (e.g. embedded Agency/shell/JS source) without opening an
-// interpolation. A lone backslash, and every other `\x`, stays verbatim. Stops
-// at the closing `"""` or an unescaped `${` (which starts interpolation).
-export const multiLineStringTextSegmentParser: Parser<TextSegment> = (
-  input: string,
-): ParserResult<TextSegment> => {
-  let i = 0;
-  let value = "";
-  while (i < input.length) {
-    if (input.startsWith('"""', i)) break;
-    if (input[i] === "\\" && input[i + 1] === "$" && input[i + 2] === "{") {
-      value += "${";
-      i += 3;
-      continue;
-    }
-    if (input[i] === "$" && input[i + 1] === "{") break;
-    value += input[i];
-    i++;
-  }
-  if (i === 0) return failure("expected string text", input);
-  return success({ type: "text" as const, value }, input.slice(i));
-};
+// exception: `\${` decodes to a literal `${` (via `dollarBraceEscape`) so a raw
+// string can contain literal interpolation syntax (e.g. embedded Agency/shell/JS
+// source) without opening an interpolation. `\${` is tried first so its `${` is
+// consumed as an escape rather than starting one; a lone backslash and every
+// other `\x` stays verbatim. Ends at the closing `"""` or an unescaped `${`.
+export const multiLineStringTextSegmentParser: Parser<TextSegment> = map(
+  many1WithJoin(or(dollarBraceEscape, multiLineRawChar)),
+  (value) => ({ type: "text", value }),
+);
 
 export const interpolationSegmentParser: Parser<InterpolationSegment> = withLoc((
   input: string,

--- a/packages/agency-lang/tests/agency/triple-quote-dollar-escape.agency
+++ b/packages/agency-lang/tests/agency/triple-quote-dollar-escape.agency
@@ -1,0 +1,9 @@
+// A triple-quoted string mixes real interpolation (${name}) with an escaped
+// literal ${} (\${skip}). Proves the \${ escape survives parser -> codegen ->
+// runtime: the printer must emit the literal ${ into the JS template literal
+// without re-interpolating it.
+node main() {
+  let name: string = "world"
+  const s = """hi ${name} and literal \${skip}"""
+  return s
+}

--- a/packages/agency-lang/tests/agency/triple-quote-dollar-escape.test.json
+++ b/packages/agency-lang/tests/agency/triple-quote-dollar-escape.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Triple-quoted string interpolates ${name} but keeps \\${skip} literal",
+      "input": "",
+      "expectedOutput": "\"hi world and literal ${skip}\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `\${` → literal `${` as an escape inside triple-quoted (`"""..."""`) strings, so you can write a literal `${` in a raw string.

## Why

Triple-quoted strings support `${...}` interpolation but intentionally treat backslash as literal (so `\n`, Windows paths, and regex stay raw). That combination left **no way** to write a literal `${` inside one — which breaks embedding any text/code that legitimately contains `${`: shell/JS templates, or Agency source passed to `std::agency run()`. (This is the bug from #419, found while implementing subprocess callback forwarding.)

The docs claimed triple-quoted strings were raw with no interpolation — that was wrong; interpolation is intentional. The real gap was the missing escape.

## How

- **Parser** (`multiLineStringTextSegmentParser`): decode `\${` → literal `${`; every other backslash stays verbatim. This is the single text-segment parser shared by expression, tag-arg, and doc-string triple-quoted literals, so the fix lands uniformly. The JS printer already escapes `${` in text segments, so no JS-codegen change was needed.
- **Formatter** (`AgencyGenerator`): it emitted triple-quoted text raw, so after the parser change `fmt` would silently turn a parsed literal `${x}` back into a live interpolation. Now re-escapes `${` → `\${` when printing triple-quoted text and doc-string text (`escapeMultiLineText`).
- **Docs**: corrected `basic-syntax.md` — triple-quoted strings interpolate, and `\${` is the one escape.

## Behavior change

`\${` in a triple-quoted string now means a literal `${` (previously: a literal backslash followed by an interpolation). In-repo blast radius is **zero** — no `.agency` file across `lib/`, `tests/`, or `docs/` contains `\${` in a triple-quoted string. Regular strings (`"`/`'`/`` ` ``) are unchanged — they already supported `\${`.

Known edge: `\\${x}` in a triple-quoted string is a literal `\` followed by a literal `${x}` (only `\${` is special; `\\` isn't processed in raw strings). Rare.

## Tests

- Parser: escaped-only, raw `\n` stays raw alongside an escape, and real interpolation next to an escaped `${}`.
- Formatter: emit → re-parse round-trip for the same three shapes (guards the `fmt` regression above).
- Execution: `"""hi ${name} and literal \${skip}"""` → `hi world and literal ${skip}`, through parser → codegen → runtime.

Full unit suite (7119 tests), typecheck, and `lint:structure` pass; `fmt` round-trips the execution fixture unchanged.

Closes #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
