### PR TITLE
Fix #317: allow comments between array/object literal entries

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -748,3 +748,51 @@ describe("AgencyGenerator - optional key shorthand (nullish unification)", () =>
     expect(result.output).not.toContain("string | null");
   });
 });
+
+describe("AgencyGenerator - literal comment trivia (issue #317)", () => {
+  const roundTrip = (input: string): string => {
+    const parseResult = parseAgency(input, {}, false);
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) throw new Error("parse failed");
+    const generator = new AgencyGenerator();
+    return generator.generate(parseResult.result).output;
+  };
+
+  it("preserves a line comment between object-literal entries", () => {
+    const input = `const policy = {
+  "a": 1,
+  // keep me
+  "b": 2
+}`;
+    expect(roundTrip(input)).toContain("// keep me");
+  });
+
+  it("preserves a line comment between array-literal items", () => {
+    const input = `const xs = [
+  1,
+  // keep me
+  2
+]`;
+    expect(roundTrip(input)).toContain("// keep me");
+  });
+
+  it("preserves a block comment between object-literal entries", () => {
+    const input = `const policy = {
+  "a": 1,
+  /* keep me */
+  "b": 2
+}`;
+    expect(roundTrip(input)).toContain("/* keep me */");
+  });
+
+  it("is idempotent: formatting the formatted output is a fixed point", () => {
+    const input = `const policy = {
+  "a": 1,
+  // keep me
+  "b": 2
+}`;
+    const once = roundTrip(input);
+    const twice = roundTrip(once);
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -28,6 +28,7 @@ import {
   AgencyArray,
   AgencyObject,
   AgencyObjectKV,
+  Trivia,
 } from "../types/dataStructures.js";
 import {
   FunctionCall,
@@ -660,26 +661,34 @@ export class AgencyGenerator {
     return str;
   }
 
+  // Append the comment/blank-line trivia anchored at `anchorIndex` to `lines`,
+  // one rendered line per comment. Shared by object types and array/object
+  // literals so all three preserve trivia identically. Accepts either
+  // `ObjectTypeTrivia[]` or `Trivia[]` (structurally identical).
+  protected emitTriviaAt(
+    trivia: (ObjectTypeTrivia | Trivia)[] | undefined,
+    anchorIndex: number,
+    lines: string[],
+  ): void {
+    const match = (trivia ?? []).find((t) => t.anchorIndex === anchorIndex);
+    for (const n of match?.comments ?? []) {
+      if (n.type === "newLine") lines.push("");
+      else if (n.type === "comment") lines.push(this.processComment(n));
+      else lines.push(this.processMultiLineComment(n));
+    }
+  }
+
   protected aliasedTypeToString(aliasedType: VariableType): string {
     if (aliasedType.type === "objectType") {
       this.increaseIndent();
-      const byAnchor: Record<number, ObjectTypeTrivia> = {};
-      for (const t of aliasedType.trivia ?? []) byAnchor[t.anchorIndex] = t;
       const lines: string[] = [];
-      const emit = (i: number) => {
-        for (const n of byAnchor[i]?.comments ?? []) {
-          if (n.type === "newLine") lines.push("");
-          else if (n.type === "comment") lines.push(this.processComment(n));
-          else lines.push(this.processMultiLineComment(n));
-        }
-      };
       const props = aliasedType.properties;
       for (let i = 0; i < props.length; i++) {
-        emit(i);
+        this.emitTriviaAt(aliasedType.trivia, i, lines);
         const sep = i === props.length - 1 ? "" : ";";
         lines.push(this.indentStr(this.stringifyProp(props[i])) + sep);
       }
-      emit(props.length);
+      this.emitTriviaAt(aliasedType.trivia, props.length, lines);
       this.decreaseIndent();
       return "{\n" + lines.join("\n") + "\n" + this.indentStr("}");
     }
@@ -1079,37 +1088,61 @@ export class AgencyGenerator {
   // Data structures
 
   protected processAgencyArray(node: AgencyArray): string {
-    const items = node.items.map((item) => {
-      if (item.type === "splat") {
-        return `...${this.processNode(item.value).trim()}`;
-      }
-      return this.processNode(item).trim();
-    });
-    return this.wrapList(items, "", "[", "]");
+    // With no interleaved comments, keep the compact `wrapList` formatting
+    // (which may render on a single line). Trivia forces the multi-line form
+    // so each comment gets its own line.
+    if (!node.trivia?.length) {
+      const items = node.items.map((item) => {
+        if (item.type === "splat") {
+          return `...${this.processNode(item.value).trim()}`;
+        }
+        return this.processNode(item).trim();
+      });
+      return this.wrapList(items, "", "[", "]");
+    }
+
+    this.increaseIndent();
+    const lines: string[] = [];
+    for (let i = 0; i < node.items.length; i++) {
+      this.emitTriviaAt(node.trivia, i, lines);
+      const item = node.items[i];
+      const itemStr =
+        item.type === "splat"
+          ? `...${this.processNode(item.value).trim()}`
+          : this.processNode(item).trim();
+      const sep = i === node.items.length - 1 ? "" : ",";
+      lines.push(this.indentStr(itemStr) + sep);
+    }
+    this.emitTriviaAt(node.trivia, node.items.length, lines);
+    this.decreaseIndent();
+    return "[\n" + lines.join("\n") + "\n" + this.indentStr("]");
   }
 
   protected processAgencyObject(node: AgencyObject): string {
-    this.increaseIndent();
-
-    const entries = node.entries.map((entry) => {
-      if ("type" in entry && entry.type === "splat") {
-        return this.indentStr(`...${this.processNode(entry.value).trim()}`);
-      }
-      const kv = entry as AgencyObjectKV;
-      const valueCode = this.processNode(kv.value).trim();
-      if (kv.computedKey) {
-        const keyCode = this.processNode(kv.computedKey).trim();
-        return this.indentStr(`[${keyCode}]: ${valueCode}`);
-      }
-      return this.indentStr(`${this.addQuotesToKey(kv.key)}: ${valueCode}`);
-    });
-    this.decreaseIndent();
-    if (entries.length === 0) {
+    if (node.entries.length === 0 && !node.trivia?.length) {
       return `{}`;
     }
-    const entriesStr = "\n" + entries.join(",\n") + "\n";
-
-    return `{${entriesStr}` + this.indentStr("}");
+    this.increaseIndent();
+    const lines: string[] = [];
+    for (let i = 0; i < node.entries.length; i++) {
+      this.emitTriviaAt(node.trivia, i, lines);
+      const entry = node.entries[i];
+      let entryStr: string;
+      if ("type" in entry && entry.type === "splat") {
+        entryStr = `...${this.processNode(entry.value).trim()}`;
+      } else {
+        const kv = entry as AgencyObjectKV;
+        const valueCode = this.processNode(kv.value).trim();
+        entryStr = kv.computedKey
+          ? `[${this.processNode(kv.computedKey).trim()}]: ${valueCode}`
+          : `${this.addQuotesToKey(kv.key)}: ${valueCode}`;
+      }
+      const sep = i === node.entries.length - 1 ? "" : ",";
+      lines.push(this.indentStr(entryStr) + sep);
+    }
+    this.emitTriviaAt(node.trivia, node.entries.length, lines);
+    this.decreaseIndent();
+    return "{\n" + lines.join("\n") + "\n" + this.indentStr("}");
   }
 
   private addQuotesToKey(key: string): string {

--- a/packages/agency-lang/lib/parsers/dataStructures.test.ts
+++ b/packages/agency-lang/lib/parsers/dataStructures.test.ts
@@ -799,4 +799,96 @@ describe("dataStructures parsers", () => {
       }
     });
   });
+
+  // Regression tests for issue #317: `//` and `/* */` comments between
+  // object-literal entries / array items must parse AND be preserved as
+  // trivia so `agency fmt` round-trips losslessly.
+  describe("comments between entries (issue #317)", () => {
+    it("parses a line comment between object entries and preserves it as trivia", () => {
+      const input = `{
+  "a": 1,
+  // keep me
+  "b": 2
+}`;
+      const result = agencyObjectParser(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.entries).toHaveLength(2);
+        expect(result.result.trivia).toEqual([
+          {
+            anchorIndex: 1,
+            comments: [{ type: "comment", content: " keep me" }],
+          },
+        ]);
+      }
+    });
+
+    it("preserves a leading comment (anchorIndex 0) and a trailing comment", () => {
+      const input = `{
+  // lead
+  "a": 1
+  // trail
+}`;
+      const result = agencyObjectParser(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.entries).toHaveLength(1);
+        expect(result.result.trivia).toEqual([
+          { anchorIndex: 0, comments: [{ type: "comment", content: " lead" }] },
+          { anchorIndex: 1, comments: [{ type: "comment", content: " trail" }] },
+        ]);
+      }
+    });
+
+    it("parses a block comment between object entries and preserves it", () => {
+      const input = `{
+  "a": 1,
+  /* keep me */
+  "b": 2
+}`;
+      const result = agencyObjectParser(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.trivia?.[0].anchorIndex).toBe(1);
+        const comment = result.result.trivia?.[0].comments[0];
+        expect(comment?.type).toBe("multiLineComment");
+        expect((comment as { content: string }).content).toBe(" keep me ");
+      }
+    });
+
+    it("omits the trivia field entirely when there are no comments", () => {
+      const result = agencyObjectParser(`{ "a": 1, "b": 2 }`);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).not.toHaveProperty("trivia");
+      }
+    });
+
+    it("parses a line comment between array items and preserves it as trivia", () => {
+      const input = `[
+  1,
+  // keep me
+  2
+]`;
+      const result = agencyArrayParser(input);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.items).toHaveLength(2);
+        expect(result.result.trivia).toEqual([
+          {
+            anchorIndex: 1,
+            comments: [{ type: "comment", content: " keep me" }],
+          },
+        ]);
+      }
+    });
+
+    it("omits the trivia field on arrays with no comments", () => {
+      const result = agencyArrayParser(`[1, 2, 3]`);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).not.toHaveProperty("trivia");
+      }
+    });
+  });
 });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -91,7 +91,6 @@ import {
   NumberLiteralType,
   ObjectProperty,
   ObjectType,
-  ObjectTypeTrivia,
   GenericType,
   PrimitiveType,
   ResultType,
@@ -127,6 +126,8 @@ import {
   AgencyObject,
   AgencyObjectKV,
   SplatExpression,
+  Trivia,
+  TriviaNode,
 } from "../types/dataStructures.js";
 import {
   DefaultImport,
@@ -1189,109 +1190,101 @@ export const taggedObjectPropertyParser: Parser<ObjectProperty> = memo(
   },
 );
 
-type ObjectBodyEntry =
-  | { kind: "prop"; prop: ObjectProperty }
-  | {
-    kind: "trivia";
-    node: AgencyComment | AgencyMultiLineComment | NewLine;
-  };
+// -----------------------------------------------------------------------------
+// Shared trivia handling for `{ ... }` / `[ ... ]` bodies.
+//
+// Object types, object literals, and array literals all allow blank lines and
+// `//` / `/* */` comments interleaved between their members. Each body is
+// parsed as `many(or(triviaEntry, itemEntry(...)))`, producing a flat list of
+// tagged entries that `partitionTrivia` folds into the item array plus
+// anchor-indexed trivia. These are parse-time tagging types, not AST nodes.
+// -----------------------------------------------------------------------------
 
-const objectMemberWithDelimiter: Parser<ObjectBodyEntry> = (input: string) => {
-  const parser = seqC(
-    capture(
-      or(
-        taggedObjectPropertyParser,
-        objectPropertyWithDescriptionParser,
-        objectPropertyParser,
-      ),
-      "prop",
-    ),
-    optional(objectPropertyDelimiter),
-  );
-  const result = parser(input);
-  if (!result.success) return result;
-  return success(
-    { kind: "prop" as const, prop: result.result.prop as ObjectProperty },
-    result.rest,
-  );
-};
+type ItemEntry<T> = { kind: "item"; item: T };
+type TriviaEntry = { kind: "trivia"; node: TriviaNode };
+type InterleavedEntry<T> = ItemEntry<T> | TriviaEntry;
 
-// Consumes a single trivia entry (blank line, line comment, or multi-line
-// comment) plus any trailing whitespace/newlines so the cursor is left at
-// the start of the next member or trivia entry. `multiLineCommentParser`
-// in particular does NOT eat its trailing newline, so we add it here to
-// keep `many(or(...))` making progress.
-const objectTrivia: Parser<ObjectBodyEntry> = (input: string) => {
-  const parser = seqC(
-    capture(
-      or(blankLineParser, commentParser, multiLineCommentParser),
-      "node",
-    ),
-    optionalSpacesOrNewline,
-  );
-  const result = parser(input);
-  if (!result.success) return result;
-  return success(
-    {
-      kind: "trivia" as const,
-      node: result.result.node as
-        | AgencyComment
-        | AgencyMultiLineComment
-        | NewLine,
-    },
-    result.rest,
-  );
-};
+// One trivia entry (blank line / line comment / block comment) plus any
+// trailing whitespace so the cursor lands on the next member. `set` tags it
+// so `partitionTrivia` can distinguish it — no manual result unwrapping.
+// `multiLineCommentParser` does NOT eat its trailing newline, which the
+// trailing `optionalSpacesOrNewline` handles so `many(...)` keeps progressing.
+const triviaEntry: Parser<TriviaEntry> = seqC(
+  set("kind", "trivia"),
+  capture(or(blankLineParser, commentParser, multiLineCommentParser), "node"),
+  optionalSpacesOrNewline,
+) as Parser<TriviaEntry>;
+
+// Wrap an item parser as a tagged `{ kind: "item", item }` entry, consuming
+// the trailing delimiter (`delimiter`) after it.
+const itemEntry = <T>(
+  itemParser: Parser<T>,
+  delimiter: Parser<unknown>,
+): Parser<ItemEntry<T>> =>
+  seqC(
+    set("kind", "item"),
+    capture(itemParser, "item"),
+    delimiter,
+  ) as Parser<ItemEntry<T>>;
+
+// Fold an interleaved item/trivia list into the item array plus anchor-indexed
+// trivia. Trivia is anchored to the index of the item it precedes; trailing
+// trivia is anchored at `items.length`. The one place this rule lives.
+function partitionTrivia<T>(
+  entries: InterleavedEntry<T>[],
+): { items: T[]; trivia: Trivia[] } {
+  const items: T[] = [];
+  const trivia: Trivia[] = [];
+  let pending: TriviaNode[] = [];
+  for (const entry of entries) {
+    if (entry.kind === "trivia") {
+      pending.push(entry.node);
+    } else {
+      if (pending.length > 0) {
+        trivia.push({ anchorIndex: items.length, comments: pending });
+        pending = [];
+      }
+      items.push(entry.item);
+    }
+  }
+  if (pending.length > 0) {
+    trivia.push({ anchorIndex: items.length, comments: pending });
+  }
+  return { items, trivia };
+}
+
+const objectMember = itemEntry(
+  or(
+    taggedObjectPropertyParser,
+    objectPropertyWithDescriptionParser,
+    objectPropertyParser,
+  ),
+  optional(objectPropertyDelimiter),
+);
 
 export const objectTypeParser: Parser<ObjectType> = memo(
   "objectTypeParser",
-  (input: string): ParserResult<ObjectType> => {
-    const parser = seqC(
-      set("type", "objectType"),
+  map(
+    seqC(
       char("{"),
       optionalSpacesOrNewline,
-      capture(many(or(objectTrivia, objectMemberWithDelimiter)), "entries"),
+      capture(many(or(triviaEntry, objectMember)), "entries"),
       optionalSpacesOrNewline,
       parseError(
         "Expected `}`. Did you forget to add a comma between object properties?",
         char("}"),
       ),
       optionalSpacesOrNewline,
-    );
-    const result = parser(input);
-    if (!result.success) {
-      return result;
-    }
-
-    // Walk the interleaved entries and split into `properties` + `trivia`.
-    // Trivia is anchored to the next property's index. Any trailing trivia
-    // (after the last property) is anchored at `properties.length`.
-    const properties: ObjectProperty[] = [];
-    const trivia: ObjectTypeTrivia[] = [];
-    let pending: (AgencyComment | AgencyMultiLineComment | NewLine)[] = [];
-
-    const entries = result.result.entries as ObjectBodyEntry[];
-    for (const entry of entries) {
-      if (entry.kind === "trivia") {
-        pending.push(entry.node);
-      } else {
-        if (pending.length > 0) {
-          trivia.push({ anchorIndex: properties.length, comments: pending });
-          pending = [];
-        }
-        properties.push(entry.prop);
-      }
-    }
-    if (pending.length > 0) {
-      trivia.push({ anchorIndex: properties.length, comments: pending });
-    }
-
-    const objectType: ObjectType = { type: "objectType", properties };
-    if (trivia.length > 0) {
-      objectType.trivia = trivia;
-    }
-    return success(objectType, result.rest);
-  },
+    ),
+    (r) => {
+      const { items, trivia } = partitionTrivia(
+        r.entries as InterleavedEntry<ObjectProperty>[],
+      );
+      const objectType: ObjectType = { type: "objectType", properties: items };
+      if (trivia.length > 0) objectType.trivia = trivia;
+      return objectType;
+    },
+  ),
 );
 
 export const unionItemParser: Parser<VariableType> = memo(
@@ -2019,32 +2012,43 @@ export const splatParser: Parser<SplatExpression> = seqC(
   capture(lazy(() => exprParser), "value"),
 );
 
-export const agencyArrayParser: Parser<AgencyArray> = (
-  input: string,
-): ParserResult<AgencyArray> => {
-  const parser = trace(
-    "agencyArrayParser",
+// The delimiter between literal items: whitespace/newlines may sit on either
+// side of the separating comma (matching the old `commaWithNewline`), and the
+// comma itself is optional so a trailing comma before `}`/`]` is allowed.
+const literalDelimiter = seqR(
+  optionalSpacesOrNewline,
+  optional(char(",")),
+  optionalSpacesOrNewline,
+);
+
+export const agencyArrayParser: Parser<AgencyArray> = trace(
+  "agencyArrayParser",
+  map(
     seqC(
-      set("type", "agencyArray"),
       char("["),
       optionalSpacesOrNewline,
       capture(
-        sepBy(
-          commaWithNewline,
+        many(
           or(
-            splatParser,
-            lazy(() => exprParser),
+            triviaEntry,
+            itemEntry(or(splatParser, lazy(() => exprParser)), literalDelimiter),
           ),
         ),
-        "items",
+        "entries",
       ),
       optionalSpacesOrNewline,
       char("]"),
     ),
-  );
-
-  return parser(input);
-};
+    (r) => {
+      const { items, trivia } = partitionTrivia(
+        r.entries as InterleavedEntry<Expression | SplatExpression>[],
+      );
+      const node: AgencyArray = { type: "agencyArray", items };
+      if (trivia.length > 0) node.trivia = trivia;
+      return node;
+    },
+  ),
+);
 
 const agencyObjectComputedKVParser: Parser<AgencyObjectKV> = memo(
   "agencyObjectComputedKVParser",
@@ -2089,20 +2093,30 @@ export const agencyObjectKVParser: Parser<AgencyObjectKV> = (
 ): ParserResult<AgencyObjectKV> =>
   or(agencyObjectComputedKVParser, agencyObjectStaticKVParser)(input);
 
-export const agencyObjectParser: Parser<AgencyObject> = seqC(
-  set("type", "agencyObject"),
-  char("{"),
-  optionalSpacesOrNewline,
-  capture(
-    or(
-      sepBy(commaWithNewline, or(splatParser, agencyObjectKVParser)),
-      succeed([]),
+export const agencyObjectParser: Parser<AgencyObject> = map(
+  seqC(
+    char("{"),
+    optionalSpacesOrNewline,
+    capture(
+      many(
+        or(
+          triviaEntry,
+          itemEntry(or(splatParser, agencyObjectKVParser), literalDelimiter),
+        ),
+      ),
+      "entries",
     ),
-    "entries",
+    optionalSpacesOrNewline,
+    char("}"),
   ),
-  optional(char(",")),
-  optionalSpacesOrNewline,
-  char("}"),
+  (r) => {
+    const { items, trivia } = partitionTrivia(
+      r.entries as InterleavedEntry<AgencyObjectKV | SplatExpression>[],
+    );
+    const node: AgencyObject = { type: "agencyObject", entries: items };
+    if (trivia.length > 0) node.trivia = trivia;
+    return node;
+  },
 );
 
 // =============================================================================

--- a/packages/agency-lang/lib/types/dataStructures.ts
+++ b/packages/agency-lang/lib/types/dataStructures.ts
@@ -1,5 +1,25 @@
-import { Expression } from "../types.js";
+import {
+  Expression,
+  AgencyComment,
+  AgencyMultiLineComment,
+  NewLine,
+} from "../types.js";
 import { BaseNode } from "./base.js";
+
+/** A single comment or blank-line node preserved as trivia. */
+export type TriviaNode = AgencyComment | AgencyMultiLineComment | NewLine;
+
+/**
+ * Comment / blank-line trivia preserved inside array and object literals so
+ * `agency fmt` round-trips losslessly. `anchorIndex` is the index of the
+ * item/entry that the trivia immediately precedes; trailing trivia (after the
+ * last item) is anchored at the item count. Same shape as
+ * `ObjectTypeTrivia`, which does the equivalent for object *type* bodies.
+ */
+export type Trivia = {
+  anchorIndex: number;
+  comments: TriviaNode[];
+};
 
 export type SplatExpression = {
   type: "splat";
@@ -15,6 +35,8 @@ export type NamedArgument = {
 export type AgencyArray = BaseNode & {
   type: "agencyArray";
   items: (Expression | SplatExpression)[];
+  /** Comments/blank lines between items, preserved for the formatter. */
+  trivia?: Trivia[];
 };
 
 export type AgencyObjectKV = {
@@ -30,4 +52,6 @@ export type AgencyObjectKV = {
 export type AgencyObject = BaseNode & {
   type: "agencyObject";
   entries: (AgencyObjectKV | SplatExpression)[];
+  /** Comments/blank lines between entries, preserved for the formatter. */
+  trivia?: Trivia[];
 };


### PR DESCRIPTION
Fixes #317. Supersedes #422 (which was accidentally stacked on #420's commit; this branch is based on a clean `main`).

## Problem

A `//` or `/* */` comment between entries of an array or object literal was a parse error, even though comments work between statements and between object *type* properties:

```
const policy = {
  "a": [{ action: "approve" }],
  // this comment between entries breaks the parse
  "b": [{ action: "reject" }]
}
```

### Root cause

The literal parsers separated entries with `sepBy(commaWithNewline, …)`, and the whitespace helpers consume only whitespace — never comments. A comment stalled the separator, terminated the literal early, and re-surfaced as a confusing top-level error far from the comment.

## Fix (lossless — comments preserved, not dropped)

Parse the interior of `{ … }` / `[ … ]` as `many(or(triviaEntry, itemEntry(…)))` and fold the tagged entries with `partitionTrivia`, anchoring each comment to the index of the entry it precedes (trailing trivia at `length`). Trivia is stored on `AgencyArray` / `AgencyObject` and emitted by the `AgencyGenerator`, so `agency fmt` round-trips losslessly and idempotently for **both** `//` and `/* */` comments. The `trivia` field is omitted when there are no comments, so existing AST consumers are unaffected.

Both array and object literals are fixed (the issue's "worth checking" note).

## Addressing review feedback from #422

- **Shared, combinator-based parsing**: `triviaEntry` (uses `set(...)`, no manual result unwrapping), an `itemEntry(itemParser, delimiter)` wrapper, and a `partitionTrivia` fold are now shared by object literals, array literals, **and** `objectTypeParser` — replacing that parser's previously duplicated split loop. The literal parsers use `map(...)` instead of hand-rolled `parser(input); if (!success)` plumbing. A shared `emitTriviaAt` helper does the same dedup on the formatter side.
- **Types placement**: `TriviaNode` moved to `types/dataStructures.ts` next to `Trivia`; the remaining tagging types are parse-time-only and stay local to the parser.
- **No unrelated changes**: only the 5 parser/formatter/type/test files.

## Testing

- **TDD**: failing parser + formatter tests first, then implementation.
- New tests: 6 parser (`dataStructures.test.ts`) + 4 formatter incl. an **idempotency** fixed-point test (`agencyGenerator.test.ts`), covering both comment styles.
- Full vitest unit suite passes; object-type trivia tests remain green after the shared refactor.
- End-to-end: the issue repro compiles and `fmt` preserves comments; nested array-of-objects, comment-inside-inner-array, splat + comment, block comments, and trailing commas all round-trip losslessly.
- `tsc` and structural linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
