### PR TITLE
Allow `goto` in match arms for node dispatch (#415)

### DIFF
--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -271,36 +271,10 @@ Here are the places you can't use match blocks right now:
 - At the module level (outside of a function or node).
 - Inside `parallel`, `seq`, `thread`, and `subthread` blocks.
 
-### Dispatching to a node from a match arm
-
-Inside a node, a match arm can `goto` another node. Each arm performs a
-real node transition — it does not yield a value — so a `goto`-dispatching
-match must be a statement, not the value of a `return` or assignment. Arms
-may be written bare or as a block, and the two forms can be mixed:
+You can't use `goto` with match blocks:
 
 ```ts
-node dispatch(x: string) {
-  match(x) {
-    "a" => goto landA()
-    "b" => {
-      prepare()
-      goto landB()
-    }
-    _   => goto landC()
-  }
-}
-```
-
-Because it is an ordinary statement match, a `goto`-dispatching match is
-not required to be exhaustive: an unmatched value simply falls through and
-execution continues after the `match`.
-
-The **prefix** form, where a single `goto` precedes the whole `match` and
-arms name a bare node target, is not supported — put the `goto` inside each
-arm instead:
-
-```ts
-// not allowed — no `goto match(...)` prefix form
+// not allowed
 goto match(x) {
   "next" => next
   _ => end

--- a/packages/agency-lang/docs/site/guide/pattern-matching.md
+++ b/packages/agency-lang/docs/site/guide/pattern-matching.md
@@ -271,10 +271,36 @@ Here are the places you can't use match blocks right now:
 - At the module level (outside of a function or node).
 - Inside `parallel`, `seq`, `thread`, and `subthread` blocks.
 
-You can't use `goto` with match blocks:
+### Dispatching to a node from a match arm
+
+Inside a node, a match arm can `goto` another node. Each arm performs a
+real node transition — it does not yield a value — so a `goto`-dispatching
+match must be a statement, not the value of a `return` or assignment. Arms
+may be written bare or as a block, and the two forms can be mixed:
 
 ```ts
-// not allowed
+node dispatch(x: string) {
+  match(x) {
+    "a" => goto landA()
+    "b" => {
+      prepare()
+      goto landB()
+    }
+    _   => goto landC()
+  }
+}
+```
+
+Because it is an ordinary statement match, a `goto`-dispatching match is
+not required to be exhaustive: an unmatched value simply falls through and
+execution continues after the `match`.
+
+The **prefix** form, where a single `goto` precedes the whole `match` and
+arms name a bare node target, is not supported — put the `goto` inside each
+arm instead:
+
+```ts
+// not allowed — no `goto match(...)` prefix form
 goto match(x) {
   "next" => next
   _ => end

--- a/packages/agency-lang/lib/parsers/matchBlock.test.ts
+++ b/packages/agency-lang/lib/parsers/matchBlock.test.ts
@@ -134,6 +134,24 @@ describe("matchBlockParserCase", () => {
       },
     },
     {
+      input: "x => goto next()",
+      expected: {
+        success: true,
+        result: {
+          type: "matchBlockCase",
+          caseValue: { type: "variableName", value: "x" },
+          body: [{
+            type: "gotoStatement",
+            nodeCall: {
+              type: "functionCall",
+              functionName: "next",
+              arguments: [],
+            },
+          }],
+        },
+      },
+    },
+    {
       input: "x -> y",
       expected: { success: false },
     },

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3120,7 +3120,7 @@ export const matchBlockParserCase: Parser<MatchBlockCase> = (
           seqC(
             not(char("{")),
             capture(
-              or(returnStatementParser, lazy(() => assignmentParser), exprParser),
+              or(returnStatementParser, gotoStatementParser, lazy(() => assignmentParser), exprParser),
               "n",
             ),
           ),

--- a/packages/agency-lang/tests/agency/goto-match-arm.agency
+++ b/packages/agency-lang/tests/agency/goto-match-arm.agency
@@ -1,0 +1,14 @@
+node landA() { return "landed on A" }
+node landB() { return "landed on B" }
+node landC() { return "landed on C" }
+
+// Dispatch to a graph node from a match arm using `goto`. Bare `goto next()`
+// arms and braced `{ goto next() }` arms may be mixed; each performs a real
+// node transition rather than yielding a value.
+node dispatch(x: string) {
+  match(x) {
+    "a" => goto landA()
+    "b" => { goto landB() }
+    _   => goto landC()
+  }
+}

--- a/packages/agency-lang/tests/agency/goto-match-arm.test.json
+++ b/packages/agency-lang/tests/agency/goto-match-arm.test.json
@@ -1,0 +1,7 @@
+{
+  "tests": [
+    { "nodeName": "dispatch", "input": "\"a\"", "expectedOutput": "\"landed on A\"", "evaluationCriteria": [{ "type": "exact" }], "description": "bare `goto` arm transitions to the matched node" },
+    { "nodeName": "dispatch", "input": "\"b\"", "expectedOutput": "\"landed on B\"", "evaluationCriteria": [{ "type": "exact" }], "description": "braced `{ goto }` arm coexists with bare goto arms" },
+    { "nodeName": "dispatch", "input": "\"other\"", "expectedOutput": "\"landed on C\"", "evaluationCriteria": [{ "type": "exact" }], "description": "wildcard `goto` arm transitions on fall-through" }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #415 (per-arm form).

A `match` arm can now `goto` a graph node directly, so node dispatch can be written as a `match` instead of an `if`/`else` chain:

```ts
node dispatch(x: string) {
  match(x) {
    "a" => goto landA()        // bare arm
    "b" => {                    // block arm — mix freely
      prepare()
      goto landB()
    }
    _   => goto landC()
  }
}
```

Both the **bare** (`"a" => goto landA()`) and **block** (`"b" => { goto landB() }`) forms are supported and can be mixed. Each arm performs a real node transition, not a value yield.

## Why this is small

The block form already parsed and compiled correctly; only the *bare* `goto` arm was rejected, because the non-braced arm RHS accepted only return/assignment/expression. The change is one line: add `gotoStatementParser` to that alternative set. A bare `goto` arm then produces the same AST as today's block arm, and everything downstream (statement-match lowering → nested `if`/`else` emitting `goToNode(...)`, adjacency/`conditionalEdge` registration) is reused unchanged. No lowering, codegen, or exhaustiveness changes.

## Design decisions

- **Not exhaustive.** A `goto`-dispatching match is an ordinary statement match, so an unmatched value falls through and execution continues after the `match` (matches the discussion on #415: exhaustiveness would only be forced by a `goto match(...)` prefix form).
- **Prefix `goto match(...)` deliberately skipped.** It is brittle under change (one arm needing a block forces "yield a node target" semantics or a full rewrite) and offers no expressiveness the per-arm form lacks. The per-arm form scales locally — wrap an arm in braces and the `goto` comes along. Docs updated to describe the per-arm form and mark only the prefix form as unsupported.

## Testing

- **Parser unit test** (`lib/parsers/matchBlock.test.ts`): a bare `x => goto next()` arm parses to a `gotoStatement` body. Watched it fail before the fix, pass after.
- **Execution test** (`tests/agency/goto-match-arm.agency`): a `dispatch` node routes to three different target nodes via a bare arm, a block arm, and the wildcard arm; each asserts the correct terminal node is reached. All 3 pass.
- Full unit suite: **7130 passed, 0 failures** (incl. the 121 typecheck fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
