### PR TITLE
Allow match-arm return to yield from standalone seq and thread/subthread (#414)

### DIFF
--- a/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
@@ -180,8 +180,6 @@ describe("expression match lowering errors", () => {
     expectError(WRAP(`"a" => { return }`), /must return a value/i));
   it("return inside parallel in an arm errors", () =>
     expectError(WRAP(`"a" => {\n      parallel {\n        return 1\n      }\n    }`), /parallel|concurrency/i));
-  it("return inside a thread block in an expression arm errors", () =>
-    expectError(WRAP(`"a" => {\n      thread {\n        return 1\n      }\n      return 2\n    }`), /thread/i));
   it("thread block without a return inside an expression arm passes", () => {
     const parsed = parseAgency(WRAP(`"a" => {\n      thread {\n        print("hi")\n      }\n      return 2\n    }`));
     expect(parsed.success).toBe(true);
@@ -190,6 +188,73 @@ describe("expression match lowering errors", () => {
     expectError(`node main(x: any) {\n  const val = match(x is { k }) {\n    _ => 2\n  }\n  return val\n}`, /cannot be used as an expression/i));
   it("module-level match expression errors", () =>
     expectError(`const g = match("a") {\n  "a" => 1\n  _ => 2\n}\nnode main() { return g }`, /module-level|top-level/i));
+});
+
+describe("expression match arm: seq/thread yield to the match", () => {
+  const WRAPN = (arm: string) => `node main(x: any) {
+  const val = match(x) {
+    ${arm}
+    _ => 2
+  }
+  return val
+}`;
+
+  function armBodyOf(src: string): any[] {
+    const body = lowerBody(src);
+    const m = body.find(
+      (n: any) => n.type === "matchBlock" && n.matchExprId !== undefined,
+    );
+    const arm = m.cases.find((c: any) => c.type === "matchBlockCase");
+    return arm.body;
+  }
+
+  it("standalone seq: return rewrites to a matchYield inside the seq", () => {
+    const arm = armBodyOf(WRAPN(`"a" => {\n      seq {\n        return 1\n      }\n    }`));
+    const seq = arm.find((s: any) => s.type === "seqBlock");
+    expect(seq).toBeDefined();
+    const y = seq.body.find((s: any) => s.type === "matchYield");
+    expect(y).toBeDefined();
+    expect(y.value).toEqual(expect.objectContaining({ type: "number", value: "1" }));
+    expect(seq.body.some((s: any) => s.type === "returnStatement")).toBe(false);
+  });
+
+  it("thread: return rewrites to a matchYield inside the thread", () => {
+    const arm = armBodyOf(WRAPN(`"a" => {\n      thread {\n        return 1\n      }\n    }`));
+    const th = arm.find((s: any) => s.type === "messageThread");
+    expect(th).toBeDefined();
+    const y = th.body.find((s: any) => s.type === "matchYield");
+    expect(y).toBeDefined();
+    expect(y.value).toEqual(expect.objectContaining({ type: "number", value: "1" }));
+  });
+
+  it("subthread: return rewrites to a matchYield inside the subthread", () => {
+    const arm = armBodyOf(WRAPN(`"a" => {\n      subthread {\n        return 1\n      }\n    }`));
+    const th = arm.find((s: any) => s.type === "messageThread");
+    expect(th).toBeDefined();
+    expect(th.threadType).toBe("subthread");
+    expect(th.body.some((s: any) => s.type === "matchYield")).toBe(true);
+  });
+
+  it("seq nested inside an if branch yields on that path", () => {
+    const parsed = parseAgency(
+      WRAPN(`"a" => {\n      if (true) {\n        seq { return 1 }\n      } else {\n        return 2\n      }\n    }`),
+    );
+    expect(parsed.success).toBe(true);
+  });
+
+  it("a seq arm that does not yield on every path still errors", () => {
+    const parsed = parseAgency(WRAPN(`"a" => {\n      seq {\n        print("hi")\n      }\n    }`));
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) expect(parsed.message).toMatch(/must return a value/i);
+  });
+
+  it("a seq used as a parallel arm is still rejected (concurrent branch)", () => {
+    const parsed = parseAgency(
+      WRAPN(`"a" => {\n      parallel {\n        seq { return 1 }\n      }\n    }`),
+    );
+    // The parallel block does not yield the match, so the arm has no value.
+    expect(parsed.success).toBe(false);
+  });
 });
 
 describe("statement-position return-in-arm errors", () => {

--- a/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
@@ -242,6 +242,45 @@ describe("expression match arm: seq/thread yield to the match", () => {
     expect(parsed.success).toBe(true);
   });
 
+  it("thread nested in a thread: matchYield lands in the innermost body", () => {
+    const arm = armBodyOf(WRAPN(`"a" => {\n      thread {\n        thread {\n          return 1\n        }\n      }\n    }`));
+    const outer = arm.find((s: any) => s.type === "messageThread");
+    const inner = outer.body.find((s: any) => s.type === "messageThread");
+    expect(inner).toBeDefined();
+    expect(inner.body.some((s: any) => s.type === "matchYield")).toBe(true);
+  });
+
+  it("seq nested in a thread (and vice versa) rewrites the innermost return", () => {
+    const st = armBodyOf(WRAPN(`"a" => { thread { seq { return 1 } } }`));
+    const seqInThread = st
+      .find((s: any) => s.type === "messageThread")
+      .body.find((s: any) => s.type === "seqBlock");
+    expect(seqInThread.body.some((s: any) => s.type === "matchYield")).toBe(true);
+
+    const ts = armBodyOf(WRAPN(`"a" => { seq { thread { return 1 } } }`));
+    const threadInSeq = ts
+      .find((s: any) => s.type === "seqBlock")
+      .body.find((s: any) => s.type === "messageThread");
+    expect(threadInSeq.body.some((s: any) => s.type === "matchYield")).toBe(true);
+  });
+
+  it("seq inside a for loop body rewrites the return (loop still needs a trailing yield)", () => {
+    const arm = armBodyOf(
+      WRAPN(`"a" => {\n      for (i in [1]) {\n        seq { return 1 }\n      }\n      return 2\n    }`),
+    );
+    const loop = arm.find((s: any) => s.type === "forLoop");
+    const seqInLoop = loop.body.find((s: any) => s.type === "seqBlock");
+    expect(seqInLoop.body.some((s: any) => s.type === "matchYield")).toBe(true);
+  });
+
+  it("a parallel nested inside a standalone seq is still rejected", () => {
+    const parsed = parseAgency(
+      WRAPN(`"a" => {\n      seq {\n        parallel {\n          return 1\n        }\n      }\n    }`),
+    );
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) expect(parsed.message).toMatch(/parallel/i);
+  });
+
   it("a seq arm that does not yield on every path still errors", () => {
     const parsed = parseAgency(WRAPN(`"a" => {\n      seq {\n        print("hi")\n      }\n    }`));
     expect(parsed.success).toBe(false);

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -491,12 +491,30 @@ class PatternLowerer {
         out.push(mapBodies(stmt, (b) => this.rewriteReturnsToYields(b, matchId)));
         continue;
       }
-      // Opaque node. A `return` inside a concurrency block would otherwise
-      // survive as a raw function return the `_matchExit` unwind can't reach, so
-      // reject it explicitly.
-      if (isConcurrencyBlock(stmt) && containsReturn(concurrencyBlockBody(stmt))) {
+      // A standalone `seq` inlines into the enclosing body, and `thread` /
+      // `subthread` bodies run inline on this same runner, so a `return` inside
+      // them yields into THIS match — the `_matchExit` lands on the arm's own
+      // runner. Recurse the rewrite into their bodies. (A `seq` that is an arm
+      // of a `parallel` is a concurrent `fork` branch and is never reached here:
+      // we never descend into the `parallelBlock` below.)
+      if (stmt.type === "seqBlock" || stmt.type === "messageThread") {
+        out.push({
+          ...stmt,
+          body: this.rewriteReturnsToYields(
+            (stmt as { body: AgencyNode[] }).body,
+            matchId,
+          ),
+        });
+        continue;
+      }
+      // A `parallel` branch is lifted into a separate `fork` frame whose child
+      // runner the `_matchExit` unwind can't reach, and concurrent branches
+      // would race the scalar flag — so a `return` that would yield this match
+      // is rejected. (A `return` inside a `seq` arm of the parallel is a
+      // branch-local result, not seen by `containsReturn`, and stays legal.)
+      if (stmt.type === "parallelBlock" && containsReturn(stmt.body)) {
         throw new LoweringError(
-          "cannot return from a match arm inside a parallel, fork, race, seq, or thread block",
+          "cannot return from a match arm inside a parallel or fork block",
           stmt.loc,
         );
       }
@@ -513,6 +531,15 @@ class PatternLowerer {
   private alwaysYields(body: AgencyNode[]): boolean {
     for (const stmt of body) {
       if (stmt.type === "matchYield") return true;
+      // A standalone `seq` and a `thread`/`subthread` body run unconditionally
+      // and inline on this runner, so the arm yields on every path iff their
+      // body does.
+      if (
+        (stmt.type === "seqBlock" || stmt.type === "messageThread") &&
+        this.alwaysYields((stmt as { body: AgencyNode[] }).body)
+      ) {
+        return true;
+      }
       if (
         stmt.type === "ifElse" &&
         stmt.elseBody &&
@@ -969,26 +996,6 @@ function isExpr(v: unknown): v is Expression {
   return t !== "messageThread";
 }
 
-/** True when `node` is a block whose body a `return` cannot legally cross to
- *  reach an enclosing match arm. `parallel`/`seq` branch bodies are lifted into
- *  separate frames (desugared to `fork` calls later); `thread` bodies run
- *  inline in the same frame, but a `return` there is a raw function return the
- *  `_matchExit` unwind cannot reach, so it is rejected the same way. The
- *  fork/race forms in the error message are surface concepts that desugar to
- *  calls before lowering. */
-function isConcurrencyBlock(node: AgencyNode): boolean {
-  return (
-    node.type === "parallelBlock" ||
-    node.type === "seqBlock" ||
-    node.type === "messageThread"
-  );
-}
-
-/** The guarded body of a concurrency/sequencing/thread block. */
-function concurrencyBlockBody(node: AgencyNode): AgencyNode[] {
-  return (node as { body: AgencyNode[] }).body;
-}
-
 /** Location of the first `thread { ... }` block within the arm's return-flow
  *  that hides a `return`, or undefined. Thread bodies run inline in the same
  *  frame, so a `return` there is a genuine function return; statement-position
@@ -1012,12 +1019,18 @@ function threadBlockReturnLoc(nodes: AgencyNode[]): SourceLocation | undefined {
  * THE single source of truth for the match-arm return-flow descent boundary.
  * Returns the child bodies of `node` that a `return` flows through to reach the
  * enclosing arm: the `if`/`else` branches and `for`/`while` loop bodies ONLY.
- * Every other body-bearing node is opaque — a `return` inside a nested
+ * Every other body-bearing node is opaque here — a `return` inside a nested
  * `matchBlock` arm, a `handleBlock` (guarded body OR `with` handler),
- * `blockArgument`/callback body, or concurrency block does NOT flow to this arm
+ * `blockArgument`/callback body, or `parallel` branch does NOT flow to this arm
  * (it belongs to that inner construct / a separate frame). Shared by
  * `rewriteReturnsToYields`, `containsReturn`, and `firstReturnLoc` so their
  * boundaries can never diverge again.
+ *
+ * NOTE: standalone `seq` and `thread`/`subthread` bodies DO flow a `return` to
+ * the enclosing match arm (they run inline on the arm's own runner), but that
+ * transparency is applied explicitly in `rewriteReturnsToYields`/`alwaysYields`
+ * — NOT here — so the statement-arm diagnostics and the `parallel` rejection
+ * that consume this boundary keep treating them as opaque.
  */
 function returnFlowBodies(node: AgencyNode): AgencyNode[][] {
   if (node.type === "ifElse") {

--- a/packages/agency-lang/tests/agency/match-yield-seq-thread.agency
+++ b/packages/agency-lang/tests/agency/match-yield-seq-thread.agency
@@ -1,6 +1,8 @@
 // A `return` inside a standalone `seq` block or a `thread`/`subthread` block
 // yields the value of an enclosing `match` expression arm. These blocks run
 // inline on the arm's own runner, so the match-exit unwind reaches its owner.
+
+// --- The three block types directly in an arm. ---
 node dispatch(x: string): string {
   const r = match(x) {
     "seq" => {
@@ -18,6 +20,55 @@ node dispatch(x: string): string {
       subthread {
         return "from-subthread"
       }
+    }
+    _ => "default"
+  }
+  return "got: ${r}"
+}
+
+// --- Nested concurrency blocks: a return in the innermost block still yields
+// the outer match, because every one of these runs inline on the same runner. ---
+node nested(x: string): string {
+  const r = match(x) {
+    "tt" => { thread { thread { return "tt" } } }
+    "st" => { thread { seq { return "st" } } }
+    "ts" => { seq { thread { return "ts" } } }
+    "ss" => { seq { seq { return "ss" } } }
+    _ => "default"
+  }
+  return "got: ${r}"
+}
+
+// --- Combined with ordinary control flow (if / for / while) and nested match. ---
+node controlFlow(x: string): string {
+  const r = match(x) {
+    "if" => {
+      if (x == "if") {
+        thread { return "if-thread" }
+      } else {
+        return "if-else"
+      }
+    }
+    "for" => {
+      for (i in [1, 2]) {
+        seq { return "for-seq" }
+      }
+      return "after-for"
+    }
+    "while" => {
+      let n = 0
+      while (n < 1) {
+        n = n + 1
+        thread { return "while-thread" }
+      }
+      return "after-while"
+    }
+    "nestedmatch" => {
+      const inner = match(x) {
+        "nestedmatch" => { thread { return "inner-thread" } }
+        _ => "inner-default"
+      }
+      return inner
     }
     _ => "default"
   }

--- a/packages/agency-lang/tests/agency/match-yield-seq-thread.agency
+++ b/packages/agency-lang/tests/agency/match-yield-seq-thread.agency
@@ -1,0 +1,25 @@
+// A `return` inside a standalone `seq` block or a `thread`/`subthread` block
+// yields the value of an enclosing `match` expression arm. These blocks run
+// inline on the arm's own runner, so the match-exit unwind reaches its owner.
+node dispatch(x: string): string {
+  const r = match(x) {
+    "seq" => {
+      seq {
+        let v = "from-seq"
+        return v
+      }
+    }
+    "thread" => {
+      thread {
+        return "from-thread"
+      }
+    }
+    "subthread" => {
+      subthread {
+        return "from-subthread"
+      }
+    }
+    _ => "default"
+  }
+  return "got: ${r}"
+}

--- a/packages/agency-lang/tests/agency/match-yield-seq-thread.test.json
+++ b/packages/agency-lang/tests/agency/match-yield-seq-thread.test.json
@@ -3,6 +3,16 @@
     { "nodeName": "dispatch", "input": "\"seq\"", "expectedOutput": "\"got: from-seq\"", "evaluationCriteria": [{ "type": "exact" }], "description": "return inside a standalone seq yields the match value" },
     { "nodeName": "dispatch", "input": "\"thread\"", "expectedOutput": "\"got: from-thread\"", "evaluationCriteria": [{ "type": "exact" }], "description": "return inside a thread block yields the match value" },
     { "nodeName": "dispatch", "input": "\"subthread\"", "expectedOutput": "\"got: from-subthread\"", "evaluationCriteria": [{ "type": "exact" }], "description": "return inside a subthread block yields the match value" },
-    { "nodeName": "dispatch", "input": "\"other\"", "expectedOutput": "\"got: default\"", "evaluationCriteria": [{ "type": "exact" }], "description": "wildcard arm still yields normally" }
+    { "nodeName": "dispatch", "input": "\"other\"", "expectedOutput": "\"got: default\"", "evaluationCriteria": [{ "type": "exact" }], "description": "wildcard arm still yields normally" },
+
+    { "nodeName": "nested", "input": "\"tt\"", "expectedOutput": "\"got: tt\"", "evaluationCriteria": [{ "type": "exact" }], "description": "thread nested in thread yields" },
+    { "nodeName": "nested", "input": "\"st\"", "expectedOutput": "\"got: st\"", "evaluationCriteria": [{ "type": "exact" }], "description": "seq nested in thread yields" },
+    { "nodeName": "nested", "input": "\"ts\"", "expectedOutput": "\"got: ts\"", "evaluationCriteria": [{ "type": "exact" }], "description": "thread nested in seq yields" },
+    { "nodeName": "nested", "input": "\"ss\"", "expectedOutput": "\"got: ss\"", "evaluationCriteria": [{ "type": "exact" }], "description": "seq nested in seq yields" },
+
+    { "nodeName": "controlFlow", "input": "\"if\"", "expectedOutput": "\"got: if-thread\"", "evaluationCriteria": [{ "type": "exact" }], "description": "thread return inside an if branch yields" },
+    { "nodeName": "controlFlow", "input": "\"for\"", "expectedOutput": "\"got: for-seq\"", "evaluationCriteria": [{ "type": "exact" }], "description": "seq return inside a for loop yields and unwinds through the loop" },
+    { "nodeName": "controlFlow", "input": "\"while\"", "expectedOutput": "\"got: while-thread\"", "evaluationCriteria": [{ "type": "exact" }], "description": "thread return inside a while loop yields and unwinds through the loop" },
+    { "nodeName": "controlFlow", "input": "\"nestedmatch\"", "expectedOutput": "\"got: inner-thread\"", "evaluationCriteria": [{ "type": "exact" }], "description": "thread return in an inner match arm yields the inner match, returned to the outer" }
   ]
 }

--- a/packages/agency-lang/tests/agency/match-yield-seq-thread.test.json
+++ b/packages/agency-lang/tests/agency/match-yield-seq-thread.test.json
@@ -1,0 +1,8 @@
+{
+  "tests": [
+    { "nodeName": "dispatch", "input": "\"seq\"", "expectedOutput": "\"got: from-seq\"", "evaluationCriteria": [{ "type": "exact" }], "description": "return inside a standalone seq yields the match value" },
+    { "nodeName": "dispatch", "input": "\"thread\"", "expectedOutput": "\"got: from-thread\"", "evaluationCriteria": [{ "type": "exact" }], "description": "return inside a thread block yields the match value" },
+    { "nodeName": "dispatch", "input": "\"subthread\"", "expectedOutput": "\"got: from-subthread\"", "evaluationCriteria": [{ "type": "exact" }], "description": "return inside a subthread block yields the match value" },
+    { "nodeName": "dispatch", "input": "\"other\"", "expectedOutput": "\"got: default\"", "evaluationCriteria": [{ "type": "exact" }], "description": "wildcard arm still yields normally" }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #414 and folds in the `thread`/`subthread` companion.

A `return` inside a match **expression** arm can now yield the match value when it sits in a **standalone `seq { }`** block or a **`thread` / `subthread`** block:

```ts
node dispatch(x: string): string {
  const r = match(x) {
    "seq"    => { seq    { let v = "from-seq";    return v } }
    "thread" => { thread    { return "from-thread" } }
    "sub"    => { subthread { return "from-subthread" } }
    _        => "default"
  }
  return "got: ${r}"
}
```

Previously all three were a hard compile error: *"cannot return from a match arm inside a parallel, fork, race, seq, or thread block."*

## Why these are safe (and `parallel` is not)

The whole thing turns on one fact: `_matchExit` is a **per-`Runner` scalar**, so the yield unwind only works when `exitMatch(matchId)` and the owning `ifElse({matchId})` run on the **same Runner**.

- **Standalone `seq`** desugars to *nothing* — its body is spliced inline into the enclosing body (`parallelDesugar.ts`), so there is no child Runner. A `return` there is exactly as safe as in a plain block arm.
- **`thread` / `subthread`** bodies run **inline on the parent Runner** (`runner.thread` → `callback(this)`), so again the flag is set and consumed on one Runner — no race.
- **`parallel`** lifts each branch into a separate `fork` frame with its **own child Runner**, and branches run concurrently — the scalar would race. It stays rejected (message narrowed to "parallel or fork block"). A `return` inside a `seq` arm *of* a `parallel` is unaffected: it remains a branch-local `fork` result, not a match-yield.

## Implementation

One file of logic (`lib/lowering/patternLowering.ts`):
- `rewriteReturnsToYields` recurses into `seqBlock` / `messageThread` bodies (rewriting `return` → `matchYield`) instead of rejecting them; the reject branch is narrowed to `parallelBlock`.
- `alwaysYields` sees through `seq`/`thread`/`subthread` for the all-paths-yield check (they run unconditionally and inline).
- Removed the now-unused `isConcurrencyBlock` / `concurrencyBlockBody` helpers; annotated the shared `returnFlowBodies` boundary to note the carve-out is applied explicitly, not there.

The **statement-arm** path is deliberately untouched — a `return` inside a thread block in a *statement* match arm still errors loudly (there the arm value is discarded, so it would silently exit the enclosing function).

## Testing

- **Lowering unit tests** (`patternLowering.matchExpr.test.ts`): standalone `seq`, `thread`, and `subthread` each rewrite their `return` to a `matchYield` in the right block; a non-yielding `seq` arm still errors; `parallel` and `seq`-in-`parallel` stay rejected. Watched the new cases fail before the change, pass after.
- **Execution test** (`tests/agency/match-yield-seq-thread.agency`): a `dispatch` node yields through a standalone `seq`, a `thread`, and a `subthread`, plus the wildcard arm — all 4 assert the right runtime value. This is the real proof the `_matchExit` unwind reaches its owner across the thread callback boundary.
- Full unit suite: **7136 passed, 0 failures**.

## Related

- #413 (`parallel`) — recommend closing as by-design; this PR keeps that rejection and narrows its message. Happy to open a follow-up that improves the error text / docs if wanted.
- A short guide note documenting the newly-allowed forms could be added to `pattern-matching.md`; left out here so you can decide the wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
