### PR TITLE
Add default maxCallDepth guard to catch runaway recursion before OOM (#243)

### DIFF
--- a/packages/agency-lang/docs/dev/config.md
+++ b/packages/agency-lang/docs/dev/config.md
@@ -44,6 +44,7 @@ If both are set, only domains in the allowed list that are NOT in the disallowed
 | Option | Type | Description |
 |--------|------|-------------|
 | `maxToolCallRounds` | `number` | Max LLM-to-tool iterations before halting (default: 10) |
+| `maxCallDepth` | `number` | Max logical function-call nesting depth before the runaway-recursion guard throws `CallDepthExceededError` (default: 2048). Catches unbounded recursion — especially the async kind, which grows the promise chain until the process OOMs with no diagnostic — before it exhausts memory. Raise it for programs that legitimately recurse very deeply. |
 | `client` | `Partial<SmolConfig>` | Smoltalk client defaults — `logLevel`, `defaultModel`, `defaultProvider`, nested `apiKey`/`baseUrl` maps, and nested `statelog` config |
 
 > **Breaking change (smoltalk 0.6.0):** the flat `client.openAiApiKey` /

--- a/packages/agency-lang/docs/dev/config.md
+++ b/packages/agency-lang/docs/dev/config.md
@@ -44,7 +44,7 @@ If both are set, only domains in the allowed list that are NOT in the disallowed
 | Option | Type | Description |
 |--------|------|-------------|
 | `maxToolCallRounds` | `number` | Max LLM-to-tool iterations before halting (default: 10) |
-| `maxCallDepth` | `number` | Max logical function-call nesting depth before the runaway-recursion guard throws `CallDepthExceededError` (default: 2048). Catches unbounded recursion — especially the async kind, which grows the promise chain until the process OOMs with no diagnostic — before it exhausts memory. Raise it for programs that legitimately recurse very deeply. |
+| `maxCallDepth` | `number` (positive int) | Max logical function-call nesting depth before the runaway-recursion guard throws `CallDepthExceededError` (default: 2048). Catches unbounded recursion — especially the async kind, which grows the promise chain until the process OOMs with no diagnostic — before it exhausts memory. Raise it for programs that legitimately recurse very deeply. Note: recursing through the stdlib higher-order functions (`map`/`filter`/`reduce`/`flatMap`) consumes ~2 depth levels per user level (the HOF call plus its callback dispatch), so the effective budget for HOF-style recursion is roughly half of what a `for`-loop equivalent gets. |
 | `client` | `Partial<SmolConfig>` | Smoltalk client defaults — `logLevel`, `defaultModel`, `defaultProvider`, nested `apiKey`/`baseUrl` maps, and nested `statelog` config |
 
 > **Breaking change (smoltalk 0.6.0):** the flat `client.openAiApiKey` /

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3841,6 +3841,11 @@ export class TypeScriptBuilder {
         String(this.agencyConfig.checkpoints.maxRestores),
       );
     }
+    if (this.agencyConfig.maxCallDepth !== undefined) {
+      runtimeCtxArgs.maxCallDepth = ts.raw(
+        String(this.agencyConfig.maxCallDepth),
+      );
+    }
     if (cfg.client?.maxToolResultChars !== undefined) {
       runtimeCtxArgs.maxToolResultChars = ts.raw(
         String(cfg.client.maxToolResultChars),

--- a/packages/agency-lang/lib/config.test.ts
+++ b/packages/agency-lang/lib/config.test.ts
@@ -76,6 +76,29 @@ describe("AgencyConfigSchema", () => {
   });
 });
 
+describe("AgencyConfig maxCallDepth key", () => {
+  it("accepts a positive integer", () => {
+    expect(AgencyConfigSchema.safeParse({ maxCallDepth: 4096 }).success).toBe(
+      true,
+    );
+  });
+
+  it("rejects 0 (would make every call throw at depth 1)", () => {
+    expect(AgencyConfigSchema.safeParse({ maxCallDepth: 0 }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects negative and non-integer values", () => {
+    expect(AgencyConfigSchema.safeParse({ maxCallDepth: -10 }).success).toBe(
+      false,
+    );
+    expect(AgencyConfigSchema.safeParse({ maxCallDepth: 12.5 }).success).toBe(
+      false,
+    );
+  });
+});
+
 describe("AgencyConfig typechecker key", () => {
   it("accepts the new typechecker object", () => {
     const result = AgencyConfigSchema.safeParse({

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -475,7 +475,10 @@ export const AgencyConfigSchema = z
     debugger: z.boolean(),
     instrument: z.boolean(),
     checkpoints: z.object({ maxRestores: z.number() }).partial(),
-    maxCallDepth: z.number(),
+    // A positive integer. The guard trips when depth > limit and the first
+    // call is depth 1, so a value < 1 (or a float/NaN) would make every call
+    // throw — reject it at config-load rather than bricking the program.
+    maxCallDepth: z.number().int().positive(),
     trace: z.boolean(),
     traceFile: z.string(),
     traceDir: z.string(),

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -250,6 +250,13 @@ export interface AgencyConfig {
     maxRestores?: number;
   };
 
+  /** Maximum logical function-call nesting depth before the runaway-recursion
+   * guard throws CallDepthExceededError. Catches unbounded recursion — most
+   * importantly the async kind, which grows the promise chain until the process
+   * OOMs with no useful diagnostic — before it exhausts memory. Raise this for
+   * programs that legitimately recurse very deeply. Default: 2048. */
+  maxCallDepth?: number;
+
   /** Enable execution tracing — writes checkpoints to a .trace file */
   trace?: boolean;
 
@@ -468,6 +475,7 @@ export const AgencyConfigSchema = z
     debugger: z.boolean(),
     instrument: z.boolean(),
     checkpoints: z.object({ maxRestores: z.number() }).partial(),
+    maxCallDepth: z.number(),
     trace: z.boolean(),
     traceFile: z.string(),
     traceDir: z.string(),

--- a/packages/agency-lang/lib/runtime/agencyFunction.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.test.ts
@@ -4,6 +4,26 @@ import { AgencyFunction, UNSET } from "./agencyFunction.js";
 import { runInTestContext } from "./asyncContext.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 import { ThreadStore } from "./state/threadStore.js";
+import { CallDepthExceededError } from "./errors.js";
+
+function makeNamedFunction(
+  name: string,
+  fn: (...args: any[]) => any,
+  params: { name: string }[] = [],
+) {
+  return new AgencyFunction({
+    name,
+    module: "test.agency",
+    fn,
+    params: params.map((p) => ({
+      name: p.name,
+      hasDefault: false,
+      defaultValue: undefined,
+      variadic: false,
+    })),
+    toolDefinition: null,
+  });
+}
 
 function makeFunction(
   params: { name: string; hasDefault?: boolean; defaultValue?: unknown; variadic?: boolean }[],
@@ -71,6 +91,58 @@ describe("AgencyFunction", () => {
       const fn = makeFunction([]);
       const result = await fn.invoke({ type: "positional", args: [] });
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("call-depth guard", () => {
+    const noArgs = { type: "positional" as const, args: [] };
+
+    it("trips CallDepthExceededError on unbounded mutual recursion", async () => {
+      const ctx = makeMockCtx();
+      ctx.maxCallDepth = 5;
+      // foo's body references bar before bar is declared; the arrow only runs
+      // at call time (after both exist), so const forward-reference is fine.
+      const foo = makeNamedFunction("foo", () => bar.invoke(noArgs));
+      const bar = makeNamedFunction("bar", () => foo.invoke(noArgs));
+      await runInTestContext(ctx, ctx.stateStack, ctx.threads, async () => {
+        await expect(foo.invoke(noArgs)).rejects.toBeInstanceOf(
+          CallDepthExceededError,
+        );
+      });
+    });
+
+    it("allows recursion that stays under the limit", async () => {
+      const ctx = makeMockCtx();
+      ctx.maxCallDepth = 100;
+      const countdown: AgencyFunction = makeNamedFunction(
+        "countdown",
+        (n: number) =>
+          n <= 0
+            ? "done"
+            : countdown.invoke({ type: "positional", args: [n - 1] }),
+        [{ name: "n" }],
+      );
+      await runInTestContext(ctx, ctx.stateStack, ctx.threads, async () => {
+        await expect(
+          countdown.invoke({ type: "positional", args: [10] }),
+        ).resolves.toBe("done");
+      });
+    });
+
+    it("counts logical depth, not V8 stack (async recursion trips)", async () => {
+      const ctx = makeMockCtx();
+      ctx.maxCallDepth = 20;
+      // Each call awaits before recursing, flattening V8's stack — only the
+      // logical depth counter can catch this.
+      const self: AgencyFunction = makeNamedFunction("selfAsync", async () => {
+        await Promise.resolve();
+        return self.invoke(noArgs);
+      });
+      await runInTestContext(ctx, ctx.stateStack, ctx.threads, async () => {
+        await expect(self.invoke(noArgs)).rejects.toBeInstanceOf(
+          CallDepthExceededError,
+        );
+      });
     });
   });
 

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { stripBoundParams } from "./stripBoundParams.js";
 import { approve } from "./interrupts.js";
 import { agencyStore, withPushedHandler } from "./asyncContext.js";
+import { withCallDepth, DEFAULT_MAX_CALL_DEPTH } from "./callDepth.js";
 import { formatRequiredUnboundRuntimeError } from "./toolBlockDiagnostics.js";
 
 export const UNSET: unique symbol = Symbol("UNSET");
@@ -136,10 +137,20 @@ export class AgencyFunction {
   }
 
   async invoke(descriptor: CallType): Promise<unknown> {
-    const args = this._isBound
-      ? this.mergeWithBound(this.resolveArgs(descriptor))
-      : this.resolveArgs(descriptor);
-    return this._fn(...args);
+    // Guard every Agency call against runaway recursion. `invoke()` is the
+    // single chokepoint all calls pass through, so counting logical nesting
+    // here catches the async-recursion case that never trips V8's stack but
+    // grows the promise chain until the process OOMs. Limit is read from the
+    // active execution context (config-overridable), falling back to the
+    // default when no context is installed. See lib/runtime/callDepth.ts.
+    const limit =
+      agencyStore.getStore()?.ctx?.maxCallDepth ?? DEFAULT_MAX_CALL_DEPTH;
+    return withCallDepth(this.name, limit, () => {
+      const args = this._isBound
+        ? this.mergeWithBound(this.resolveArgs(descriptor))
+        : this.resolveArgs(descriptor);
+      return this._fn(...args);
+    });
   }
 
   partial(bindings: Record<string, unknown>): AgencyFunction {

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { stripBoundParams } from "./stripBoundParams.js";
 import { approve } from "./interrupts.js";
 import { agencyStore, withPushedHandler } from "./asyncContext.js";
-import { withCallDepth, DEFAULT_MAX_CALL_DEPTH } from "./callDepth.js";
+import { withCallDepth } from "./callDepth.js";
 import { formatRequiredUnboundRuntimeError } from "./toolBlockDiagnostics.js";
 
 export const UNSET: unique symbol = Symbol("UNSET");
@@ -140,12 +140,10 @@ export class AgencyFunction {
     // Guard every Agency call against runaway recursion. `invoke()` is the
     // single chokepoint all calls pass through, so counting logical nesting
     // here catches the async-recursion case that never trips V8's stack but
-    // grows the promise chain until the process OOMs. Limit is read from the
-    // active execution context (config-overridable), falling back to the
-    // default when no context is installed. See lib/runtime/callDepth.ts.
-    const limit =
-      agencyStore.getStore()?.ctx?.maxCallDepth ?? DEFAULT_MAX_CALL_DEPTH;
-    return withCallDepth(this.name, limit, () => {
+    // grows the promise chain until the process OOMs. The limit (config-
+    // overridable `maxCallDepth`) is resolved from the active execution context
+    // inside `withCallDepth`, once per lineage. See lib/runtime/callDepth.ts.
+    return withCallDepth(this.name, () => {
       const args = this._isBound
         ? this.mergeWithBound(this.resolveArgs(descriptor))
         : this.resolveArgs(descriptor);

--- a/packages/agency-lang/lib/runtime/callDepth.test.ts
+++ b/packages/agency-lang/lib/runtime/callDepth.test.ts
@@ -1,27 +1,39 @@
 import { describe, expect, test } from "vitest";
-import { withCallDepth, currentCallDepth } from "./callDepth.js";
-import { CallDepthExceededError } from "./errors.js";
-import { AgencyAbort, readCause } from "./errors.js";
+import { withCallDepth } from "./callDepth.js";
+import { CallDepthExceededError, AgencyAbort, readCause } from "./errors.js";
+import { runInTestContext } from "./asyncContext.js";
+import { makeMockCtx } from "./__tests__/testHelpers.js";
+
+/** Run `fn` inside an execution context whose maxCallDepth is `limit`. The
+ *  call-depth guard resolves its ceiling from the active context, so tests
+ *  exercise the real resolution path rather than an injected value. */
+function withLimit<T>(limit: number, fn: () => Promise<T>): Promise<T> {
+  const ctx = makeMockCtx();
+  ctx.maxCallDepth = limit;
+  return runInTestContext(ctx, ctx.stateStack, ctx.threads, fn);
+}
 
 describe("call-depth guard", () => {
   test("allows nesting up to the limit", async () => {
     const recurse = async (n: number): Promise<number> =>
-      n >= 4 ? 42 : withCallDepth(`f${n}`, 5, () => recurse(n + 1));
-    await expect(recurse(0)).resolves.toBe(42);
+      n >= 4 ? 42 : withCallDepth(`f${n}`, () => recurse(n + 1));
+    await expect(withLimit(5, () => recurse(0))).resolves.toBe(42);
   });
 
   test("throws CallDepthExceededError when nesting exceeds the limit", async () => {
     const recurse = async (n: number): Promise<number> =>
-      withCallDepth(`f${n}`, 3, () => recurse(n + 1));
-    await expect(recurse(0)).rejects.toBeInstanceOf(CallDepthExceededError);
+      withCallDepth(`f${n}`, () => recurse(n + 1));
+    await expect(withLimit(3, () => recurse(0))).rejects.toBeInstanceOf(
+      CallDepthExceededError,
+    );
   });
 
   test("the error is an AgencyAbort carrying a callDepthExceeded cause with the limit", async () => {
     const recurse = async (n: number): Promise<number> =>
-      withCallDepth(`f${n}`, 2, () => recurse(n + 1));
+      withCallDepth(`f${n}`, () => recurse(n + 1));
     let caught: unknown;
     try {
-      await recurse(0);
+      await withLimit(2, () => recurse(0));
     } catch (e) {
       caught = e;
     }
@@ -33,10 +45,10 @@ describe("call-depth guard", () => {
 
   test("the error message includes the recent call chain and the config knob", async () => {
     const recurse = async (n: number): Promise<number> =>
-      withCallDepth(`fn${n}`, 3, () => recurse(n + 1));
+      withCallDepth(`fn${n}`, () => recurse(n + 1));
     let msg = "";
     try {
-      await recurse(0);
+      await withLimit(3, () => recurse(0));
     } catch (e) {
       msg = (e as Error).message;
     }
@@ -52,28 +64,22 @@ describe("call-depth guard", () => {
     // limit of 3. With per-lineage ALS tracking, each sibling independently
     // sees depth 2, so a limit of 3 is never exceeded.
     const run = () =>
-      withCallDepth("root", 3, () =>
+      withCallDepth("root", () =>
         Promise.all(
           Array.from({ length: 10 }, (_, i) =>
-            withCallDepth(`sib${i}`, 3, async () => {
+            withCallDepth(`sib${i}`, async () => {
               await Promise.resolve();
               return "ok";
             }),
           ),
         ),
       );
-    await expect(run()).resolves.toHaveLength(10);
+    await expect(withLimit(3, run)).resolves.toHaveLength(10);
   });
 
-  test("currentCallDepth reflects the active nesting", async () => {
-    expect(currentCallDepth()).toBe(0);
-    const depths: number[] = [];
-    await withCallDepth("a", 10, () =>
-      withCallDepth("b", 10, async () => {
-        depths.push(currentCallDepth());
-        return null;
-      }),
-    );
-    expect(depths).toEqual([2]);
+  test("falls back to the default limit when no context is installed", async () => {
+    // No runInTestContext wrapper → no agencyStore ctx. A shallow call must
+    // still work (guarded by DEFAULT_MAX_CALL_DEPTH), not throw.
+    await expect(withCallDepth("solo", async () => "ok")).resolves.toBe("ok");
   });
 });

--- a/packages/agency-lang/lib/runtime/callDepth.test.ts
+++ b/packages/agency-lang/lib/runtime/callDepth.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import { withCallDepth, currentCallDepth } from "./callDepth.js";
+import { CallDepthExceededError } from "./errors.js";
+import { AgencyAbort, readCause } from "./errors.js";
+
+describe("call-depth guard", () => {
+  test("allows nesting up to the limit", async () => {
+    const recurse = async (n: number): Promise<number> =>
+      n >= 4 ? 42 : withCallDepth(`f${n}`, 5, () => recurse(n + 1));
+    await expect(recurse(0)).resolves.toBe(42);
+  });
+
+  test("throws CallDepthExceededError when nesting exceeds the limit", async () => {
+    const recurse = async (n: number): Promise<number> =>
+      withCallDepth(`f${n}`, 3, () => recurse(n + 1));
+    await expect(recurse(0)).rejects.toBeInstanceOf(CallDepthExceededError);
+  });
+
+  test("the error is an AgencyAbort carrying a callDepthExceeded cause with the limit", async () => {
+    const recurse = async (n: number): Promise<number> =>
+      withCallDepth(`f${n}`, 2, () => recurse(n + 1));
+    let caught: unknown;
+    try {
+      await recurse(0);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AgencyAbort);
+    const cause = readCause(caught);
+    expect(cause?.kind).toBe("callDepthExceeded");
+    expect((caught as CallDepthExceededError).message).toContain("2");
+  });
+
+  test("the error message includes the recent call chain and the config knob", async () => {
+    const recurse = async (n: number): Promise<number> =>
+      withCallDepth(`fn${n}`, 3, () => recurse(n + 1));
+    let msg = "";
+    try {
+      await recurse(0);
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    // Names of the deepest frames appear so the user can see what recursed.
+    expect(msg).toContain("fn3");
+    // Points the user at the override knob.
+    expect(msg).toContain("maxCallDepth");
+  });
+
+  test("concurrent sibling calls do not accumulate depth (per-lineage, not global)", async () => {
+    // root is depth 1; each of 10 concurrent siblings is depth 2. With a naive
+    // global counter, 10 in-flight siblings would read depth ~11 and trip a
+    // limit of 3. With per-lineage ALS tracking, each sibling independently
+    // sees depth 2, so a limit of 3 is never exceeded.
+    const run = () =>
+      withCallDepth("root", 3, () =>
+        Promise.all(
+          Array.from({ length: 10 }, (_, i) =>
+            withCallDepth(`sib${i}`, 3, async () => {
+              await Promise.resolve();
+              return "ok";
+            }),
+          ),
+        ),
+      );
+    await expect(run()).resolves.toHaveLength(10);
+  });
+
+  test("currentCallDepth reflects the active nesting", async () => {
+    expect(currentCallDepth()).toBe(0);
+    const depths: number[] = [];
+    await withCallDepth("a", 10, () =>
+      withCallDepth("b", 10, async () => {
+        depths.push(currentCallDepth());
+        return null;
+      }),
+    );
+    expect(depths).toEqual([2]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/callDepth.ts
+++ b/packages/agency-lang/lib/runtime/callDepth.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { agencyStore } from "./asyncContext.js";
 import { CallDepthExceededError } from "./errors.js";
 
 /**
@@ -13,15 +14,29 @@ import { CallDepthExceededError } from "./errors.js";
  * infinite async cycle never throws `RangeError` — it just grows the promise
  * chain until the heap is exhausted, minutes later, with no diagnostic. We
  * track the LOGICAL depth of the async call tree instead.
+ *
+ * Budget accuracy caveat: EVERY Agency call — including the stdlib higher-order
+ * functions `map`/`filter`/`reduce`/`flatMap` — consumes one depth level, and a
+ * HOF also dispatches its callback through another call. So recursion written as
+ * `walk(n) { children.map(walk) }` burns ~2 levels per user level (more when
+ * HOFs nest), i.e. the effective budget is roughly halved versus the same walk
+ * written with a `for` loop, which costs 1 level per user level. The default is
+ * generous enough that this rarely matters; raise `maxCallDepth` for very deep
+ * HOF-style recursion. (Counting is by call, not by heap growth, so a bounded
+ * fire-and-forget spawn like `async produce(n-1)` also climbs the depth and can
+ * trip even though it holds only a bounded promise queue — a conservative false
+ * positive, acceptable for a safety net.)
  */
 export const DEFAULT_MAX_CALL_DEPTH = 2048;
 
 /** A node in the active async lineage's call chain. Linked (not an array) so
  *  entering a call is O(1) with a single small allocation — the frame names
- *  are only walked on the cold overflow path. */
+ *  are only walked on the cold overflow path. `limit` is resolved once at the
+ *  root of the lineage and carried down, so nested calls never re-read it. */
 type CallFrame = {
   readonly name: string;
   readonly depth: number;
+  readonly limit: number;
   readonly parent: CallFrame | null;
 };
 
@@ -55,27 +70,27 @@ function collectRecentFrames(parent: CallFrame | null, name: string): string[] {
   return names.reverse();
 }
 
-/** Logical call depth of the active async lineage (0 at the top level). */
-export function currentCallDepth(): number {
-  return callDepthALS.getStore()?.depth ?? 0;
-}
-
 /**
  * Run `fn` one level deeper in the call-depth lineage. Throws
  * `CallDepthExceededError` (an `AgencyAbort`) if entering this call would push
- * the logical depth past `limit`, instead of letting an unbounded recursion run
- * until the process OOMs. `name` labels the call for the overflow diagnostic.
+ * the logical depth past the active limit, instead of letting an unbounded
+ * recursion run until the process OOMs. `name` labels the call for the overflow
+ * diagnostic. The limit is read from the active execution context's
+ * `maxCallDepth` once at the root of each lineage and inherited by nested calls
+ * (so a deep recursion pays a single `agencyStore` lookup, not one per frame).
  */
-export function withCallDepth<T>(name: string, limit: number, fn: () => T): T {
-  const parent = callDepthALS.getStore() ?? null;
+export function withCallDepth<T>(name: string, fn: () => T): T {
+  const parent = callDepthALS.getStore();
+  const limit = parent
+    ? parent.limit
+    : agencyStore.getStore()?.ctx?.maxCallDepth ?? DEFAULT_MAX_CALL_DEPTH;
   const depth = (parent?.depth ?? 0) + 1;
   if (depth > limit) {
     throw new CallDepthExceededError(
       limit,
       depth,
-      collectRecentFrames(parent, name),
+      collectRecentFrames(parent ?? null, name),
     );
   }
-  const frame: CallFrame = { name, depth, parent };
-  return callDepthALS.run(frame, fn);
+  return callDepthALS.run({ name, depth, limit, parent: parent ?? null }, fn);
 }

--- a/packages/agency-lang/lib/runtime/callDepth.ts
+++ b/packages/agency-lang/lib/runtime/callDepth.ts
@@ -1,0 +1,81 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { CallDepthExceededError } from "./errors.js";
+
+/**
+ * Default ceiling on logical function-call nesting depth. Sits well above any
+ * realistic call nesting (deep tree walks, recursive descent) yet far below
+ * where an unbounded async recursion would OOM the process — the failure this
+ * guard exists to turn into an actionable error. Overridable per program via
+ * the `maxCallDepth` config option.
+ *
+ * Why a logical counter rather than V8's native stack limit: most Agency
+ * functions are async (they `await`), so each call flattens V8's frame and an
+ * infinite async cycle never throws `RangeError` — it just grows the promise
+ * chain until the heap is exhausted, minutes later, with no diagnostic. We
+ * track the LOGICAL depth of the async call tree instead.
+ */
+export const DEFAULT_MAX_CALL_DEPTH = 2048;
+
+/** A node in the active async lineage's call chain. Linked (not an array) so
+ *  entering a call is O(1) with a single small allocation — the frame names
+ *  are only walked on the cold overflow path. */
+type CallFrame = {
+  readonly name: string;
+  readonly depth: number;
+  readonly parent: CallFrame | null;
+};
+
+/**
+ * Current call frame for the active async lineage.
+ *
+ * Depth is a property of the async call TREE, not a global count — storing it
+ * in AsyncLocalStorage (rather than a counter on `ctx`) means concurrent
+ * siblings (a `parallel`/`fork` fan-out, or an LLM firing many tool calls in
+ * one round) each inherit the SAME parent depth and independently descend one
+ * level. Their breadth never accumulates, so a wide fan-out is not mistaken for
+ * deep recursion; only a call whose own body calls further descends inside this
+ * scope and climbs the depth. Mirrors `handlerChainDepthALS` in interrupts.ts.
+ *
+ * ALS is never serialized, so there is nothing to reset across checkpoints or
+ * resumes — each frame unwinds automatically when its call returns or throws.
+ */
+const callDepthALS = new AsyncLocalStorage<CallFrame>();
+
+/** How many of the most-recent frame names to surface in the overflow error. */
+const RECENT_FRAMES = 8;
+
+function collectRecentFrames(parent: CallFrame | null, name: string): string[] {
+  const names: string[] = [name];
+  let frame = parent;
+  while (frame && names.length < RECENT_FRAMES) {
+    names.push(frame.name);
+    frame = frame.parent;
+  }
+  // Oldest-of-window first so the chain reads in call order.
+  return names.reverse();
+}
+
+/** Logical call depth of the active async lineage (0 at the top level). */
+export function currentCallDepth(): number {
+  return callDepthALS.getStore()?.depth ?? 0;
+}
+
+/**
+ * Run `fn` one level deeper in the call-depth lineage. Throws
+ * `CallDepthExceededError` (an `AgencyAbort`) if entering this call would push
+ * the logical depth past `limit`, instead of letting an unbounded recursion run
+ * until the process OOMs. `name` labels the call for the overflow diagnostic.
+ */
+export function withCallDepth<T>(name: string, limit: number, fn: () => T): T {
+  const parent = callDepthALS.getStore() ?? null;
+  const depth = (parent?.depth ?? 0) + 1;
+  if (depth > limit) {
+    throw new CallDepthExceededError(
+      limit,
+      depth,
+      collectRecentFrames(parent, name),
+    );
+  }
+  const frame: CallFrame = { name, depth, parent };
+  return callDepthALS.run(frame, fn);
+}

--- a/packages/agency-lang/lib/runtime/configOverrides.ts
+++ b/packages/agency-lang/lib/runtime/configOverrides.ts
@@ -35,17 +35,21 @@ export function getRuntimeConfigOverrides(): Partial<AgencyConfig> | undefined {
 /**
  * Apply runtime config overrides (set per-subprocess via
  * `setRuntimeConfigOverrides`) to the args used to construct a
- * `RuntimeContext`. Today only `log.*` fields and the top-level
- * `observability` flag flow into the statelog config; other
- * `AgencyConfig` fields are ignored because the runtime has its own
- * pathways for them. If a new statelog-relevant override field is added,
- * it will be picked up automatically by the shallow merge below.
+ * `RuntimeContext`. `log.*` fields and the top-level `observability` flag flow
+ * into the statelog config; `client.providerModules` and `maxCallDepth` are
+ * forwarded explicitly (see below). Other `AgencyConfig` fields are ignored
+ * because the runtime has its own pathways for them. If a new statelog-relevant
+ * override field is added, it will be picked up automatically by the shallow
+ * merge below.
  *
- * `client.providerModules` is also honored: `_run` forwards the parent's
+ * `client.providerModules` is honored: `_run` forwards the parent's
  * (absolutized) provider-module paths here so a subprocess loads the same
  * custom/local providers the parent has, regardless of how the child was
  * compiled. They are merged with any baked-in `providerModules` on `args`;
  * `loadProviderModules` de-duplicates by resolved path at load time.
+ *
+ * `maxCallDepth` is honored so a subprocess inherits the parent's runaway-
+ * recursion ceiling rather than falling back to the default.
  */
 export function applyRuntimeConfigOverridesToContextArgs(
   args: RuntimeContextConstructorArgs,

--- a/packages/agency-lang/lib/runtime/configOverrides.ts
+++ b/packages/agency-lang/lib/runtime/configOverrides.ts
@@ -13,6 +13,7 @@ export type RuntimeContextConstructorArgs = {
   providerModules?: string[];
   dirname: string;
   maxRestores?: number;
+  maxCallDepth?: number;
   traceConfig?: TraceConfig;
   verbose?: boolean;
   memory?: MemoryConfig;
@@ -70,6 +71,11 @@ export function applyRuntimeConfigOverridesToContextArgs(
       ...(args.providerModules ?? []),
       ...overrideModules,
     ];
+  }
+
+  // Let a subprocess inherit the parent's runaway-recursion ceiling.
+  if (overrides.maxCallDepth !== undefined) {
+    merged.maxCallDepth = overrides.maxCallDepth;
   }
 
   return merged;

--- a/packages/agency-lang/lib/runtime/errors.test.ts
+++ b/packages/agency-lang/lib/runtime/errors.test.ts
@@ -65,6 +65,17 @@ describe("AgencyAbort (unified abort base)", () => {
     });
     expect(isAbortError(crossRealm)).toBe(true);
   });
+
+  it("name-fallback also recognizes a cross-realm CallDepthExceededError", () => {
+    // A runaway-recursion trip crossing the subprocess shim loses its prototype
+    // chain; its name is still "CallDepthExceededError", so isAbortError must
+    // classify it as an abort — otherwise it would be converted to a Failure
+    // instead of propagating and halting the runaway.
+    const crossRealm = Object.assign(new Error("simulated cross-realm depth trip"), {
+      name: "CallDepthExceededError",
+    });
+    expect(isAbortError(crossRealm)).toBe(true);
+  });
 });
 
 describe("CheckpointError", () => {

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -237,6 +237,7 @@ export function isAbortError(error: unknown): boolean {
       error.name === "AgencyAbort" ||
       error.name === "AgencyCancelledError" ||
       error.name === "GuardExceededError" ||
+      error.name === "CallDepthExceededError" ||
       error.name === "AbortError"
     );
   }

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -72,6 +72,11 @@ export type AbortCause =
     }
   | { kind: "raceLoser" }
   | { kind: "cleanup" }
+  // A runaway-recursion trip: logical function-call nesting exceeded
+  // `maxCallDepth`. Modeled as an abort (like `guardTrip`) so it propagates
+  // untouched through every generated catch and halts the run instead of being
+  // converted to a Failure that could silently re-descend into the recursion.
+  | { kind: "callDepthExceeded"; limit: number; observed: number }
   // An abort WE initiate when a single llm() call exceeds its per-call deadline.
   // (This is the cause on the call's AbortController while retrying. A transient
   // LLM failure that EXHAUSTS retries is NOT an abort — it surfaces as a plain
@@ -158,6 +163,32 @@ export class AgencyCancelledError extends AgencyAbort {
       cause ?? makeAbortCause({ kind: "userKill", reason }),
     );
     this.name = "AgencyCancelledError";
+  }
+}
+
+/** Thrown by the call-depth guard (lib/runtime/callDepth.ts, invoked from
+ *  every `AgencyFunction.invoke()`) when the logical function-call nesting
+ *  depth exceeds `maxCallDepth`. Almost always indicates unbounded recursion —
+ *  most dangerously the async kind, which flattens V8's stack and grows the
+ *  promise chain until the process OOMs with no useful diagnostic. Modeled as
+ *  an `AgencyAbort` (like `GuardExceededError`) so it propagates untouched
+ *  through every generated catch rung and halts the run rather than being
+ *  converted to a Failure and silently re-descending into the recursion. */
+export class CallDepthExceededError extends AgencyAbort {
+  readonly limit: number;
+  readonly observed: number;
+  constructor(limit: number, observed: number, recentFrames: string[]) {
+    const chain = recentFrames.join(" → ");
+    super(
+      `Maximum call depth exceeded (${observed} > ${limit}). This usually ` +
+        `means unbounded recursion. Recent calls: ${chain}. If your program ` +
+        `legitimately recurses this deeply, raise the limit via the ` +
+        `\`maxCallDepth\` config option.`,
+      makeAbortCause({ kind: "callDepthExceeded", limit, observed }),
+    );
+    this.name = "CallDepthExceededError";
+    this.limit = limit;
+    this.observed = observed;
   }
 }
 

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -105,6 +105,7 @@ export {
   RestoreSignal,
   AgencyAbort,
   AgencyCancelledError,
+  CallDepthExceededError,
   isAbortError,
 } from "./errors.js";
 export { GuardExceededError, isGuardExceededError } from "./guard.js";

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -9,6 +9,7 @@ import { CoverageCollector } from "../coverageCollector.js";
 import { AgencyCancelledError, makeAbortCause } from "../errors.js";
 import type { AbortCause } from "../errors.js";
 import { agencyStore } from "../asyncContext.js";
+import { DEFAULT_MAX_CALL_DEPTH } from "../callDepth.js";
 import { getSubprocessRunInfo } from "../subprocessRunInfo.js";
 import type { AgencyCallbacks } from "../hooks.js";
 import type { InterruptResponse } from "../interrupts.js";
@@ -165,6 +166,9 @@ export class RuntimeContext<T> {
   // stored so createExecutionContext can create new StatelogClients
   private statelogConfig: StatelogConfig;
   maxRestores: number;
+  /** Ceiling on logical function-call nesting depth before the runaway-
+   *  recursion guard trips. See lib/runtime/callDepth.ts. */
+  maxCallDepth: number;
 
   // Memory layer (resolved decisions in
   // docs/superpowers/plans/2026-05-12-memory-layer.md and
@@ -192,6 +196,7 @@ export class RuntimeContext<T> {
     providerModules?: string[];
     dirname: string;
     maxRestores?: number;
+    maxCallDepth?: number;
     traceConfig?: TraceConfig;
     verbose?: boolean;
     memory?: MemoryConfig;
@@ -208,6 +213,7 @@ export class RuntimeContext<T> {
 
     this.statelogConfig = statelogConfig;
     this.maxRestores = args.maxRestores ?? 100;
+    this.maxCallDepth = args.maxCallDepth ?? DEFAULT_MAX_CALL_DEPTH;
     this.statelogClient = new StatelogClient(statelogConfig);
     this.stateStack = new StateStack();
     this.globals = GlobalStore.withTokenStats();
@@ -293,6 +299,7 @@ export class RuntimeContext<T> {
     execCtx.stateStack = new StateStack();
     execCtx.globals = GlobalStore.withTokenStats();
     execCtx.maxRestores = this.maxRestores;
+    execCtx.maxCallDepth = this.maxCallDepth;
     execCtx.checkpoints = new CheckpointStore(this.maxRestores);
     execCtx.handlers = [];
     execCtx.callbacks = {};

--- a/packages/agency-lang/tests/agency/call-depth-bounded.agency
+++ b/packages/agency-lang/tests/agency/call-depth-bounded.agency
@@ -1,0 +1,13 @@
+// Deep-but-bounded recursion must run to completion. The runaway-recursion
+// guard (maxCallDepth, default 2048) only trips on UNBOUNDED recursion; a
+// program that recurses a few hundred levels and terminates must be unaffected.
+// Regression guard against the call-depth check being too aggressive.
+
+def sumTo(n: number): number {
+  if (n <= 0) { return 0 }
+  return n + sumTo(n - 1)
+}
+
+node main() {
+  return sumTo(300)
+}

--- a/packages/agency-lang/tests/agency/call-depth-bounded.test.json
+++ b/packages/agency-lang/tests/agency/call-depth-bounded.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "45150",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "deep-but-bounded recursion (depth 300) runs to completion under the call-depth guard"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #243 — Agency had no default protection against runaway function-call recursion.

The dangerous case is **async** recursion. Most Agency functions are async (they `await`), and each `await` flattens V8's call frame — so an infinite async cycle never throws `RangeError`. Instead it grows the promise chain until the process **OOMs, minutes later, with no useful diagnostic**. (Synchronous recursion already trips V8's stack with an actionable error; this closes the async gap.)

## What this adds

A logical call-depth guard at the single chokepoint every Agency call passes through — `AgencyFunction.invoke()`.

- **`lib/runtime/callDepth.ts`** — tracks the logical nesting depth of the active async *lineage* in an `AsyncLocalStorage` (mirrors `handlerChainDepthALS` in interrupts.ts). Because depth is a property of the async call **tree**, not a global count:
  - concurrent `fork`/`parallel`/tool-call fan-out each inherit the parent depth and descend independently — a wide fan-out is never mistaken for deep recursion;
  - it's never serialized, so there's nothing to reset across checkpoint/resume.

  Frames are a linked list (O(1) per call; names are walked only on the cold overflow path). Default ceiling **2048** — well above realistic nesting (deep tree walks, recursive descent), far below where async recursion exhausts memory.

- **`CallDepthExceededError extends AgencyAbort`** with a new `callDepthExceeded` `AbortCause`, modeled exactly like `GuardExceededError`. As an abort it propagates untouched through every generated catch rung and **halts the run**, rather than being converted to a `Failure` that could silently re-descend into the recursion. The message names the limit, the observed depth, the recent call chain, and points at the config knob:

  ```
  Maximum call depth exceeded (2049 > 2048). This usually means unbounded
  recursion. Recent calls: bar → foo → bar → foo → bar → foo → bar → foo.
  If your program legitimately recurses this deeply, raise the limit via the
  `maxCallDepth` config option.
  ```

- **`maxCallDepth` config option** (top-level in `AgencyConfig`, zod-validated), plumbed through codegen → `RuntimeContext` args → field → execCtx exactly like `maxRestores`, and honored as a subprocess config override. Documented in `docs/dev/config.md`.

## Testing

- `lib/runtime/callDepth.test.ts` — guard logic: trips over the limit, allows up to it, per-lineage (not global) counting, abort cause + message contents.
- `lib/runtime/agencyFunction.test.ts` — `invoke()` integration: mutual recursion and async-self recursion trip; bounded recursion succeeds. (Written TDD — without the guard these crash the vitest worker with a stack blowup.)
- `tests/agency/call-depth-bounded.agency` — e2e regression guard that deep-but-bounded recursion (depth 300) still runs to completion.
- Full `lib/runtime` + `lib/config` unit suite (1092 tests) and `lib/backends` codegen suite (339 tests) pass; structural linter clean; `tsc --noEmit` clean.
- **Manual e2e**: the issue's exact async-recursion repro now trips at 2049 > 2048 with the diagnostic and exits code 1 instead of OOMing; a low `maxCallDepth` config trips earlier; `map` over 5000 elements does not false-trip; an interrupt suspend/resume test still passes through the new wrapper.

## Notes / decisions

- **Why hook `invoke()`** rather than `__call`: `invoke()` is the one point all Agency calls funnel through (direct calls, method calls, and LLM tool-loop dispatch), so a single guard covers every path.
- **Why an `AgencyAbort`** rather than a plain `Error`: generated `def`/`node` bodies convert thrown `Error`s to `Failure`. A plain error would be swallowed per-frame and could let a degenerate loop re-descend; an abort propagates untouched and halts, matching how guard trips already behave.
- The 2048 default is deliberately conservative-aggressive (the issue suggested 1000–2500). It's fully overridable for legitimate deep-recursion workloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
