### PR TITLE
Make code agent exec-first, quarantine bash, auto-approve read-only git

### DIFF
--- a/packages/agency-lang/lib/agents/agency-agent/lib/defaultPolicy.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/defaultPolicy.agency
@@ -29,6 +29,55 @@ def agencyExecApproveRules(): any[] {
   }
 }
 
+// Read-only `git` subcommands the code agent runs via `exec`. Same
+// (command + subcommand) matching as the agency rules above — the
+// matcher only sees `args[0]`, never later flags, so this list may
+// contain ONLY subcommands that are read-only regardless of any flag.
+// Flag-dependent ones are deliberately excluded (they would over-
+// approve a destructive form): `branch` (-D deletes), `tag`, `config`
+// (writes without --get), `remote` (add), `stash` (bare = push),
+// `worktree` (add), `reflog` (expire/delete), `symbolic-ref` (writes
+// with two args), and all mutators (commit/push/reset/checkout/...).
+// A global-option prefix (`git -C dir log`, `git -c x=y commit`) lands
+// with subcommand "-C"/"-c" and correctly fails to match, so it still
+// prompts.
+static const GIT_SAFE_SUBCOMMANDS = [
+  "status",
+  "log",
+  "diff",
+  "show",
+  "blame",
+  "describe",
+  "shortlog",
+  "rev-parse",
+  "rev-list",
+  "ls-files",
+  "ls-tree",
+  "cat-file",
+  "for-each-ref",
+  "merge-base",
+  "name-rev",
+  "diff-tree",
+  "diff-index",
+  "diff-files",
+  "whatchanged",
+  "grep",
+  "cherry",
+  "count-objects",
+]
+
+def gitExecApproveRules(): any[] {
+  return map(GIT_SAFE_SUBCOMMANDS) as sub {
+    return {
+      match: {
+        command: "git",
+        subcommand: sub
+      },
+      action: "approve"
+    }
+  }
+}
+
 export static const minimalAutoApprovePolicy = {
   "std::memory::remember": [{
     action: "approve"
@@ -50,6 +99,9 @@ export static const minimalAutoApprovePolicy = {
 
 export static const recommendedAutoApprovePolicy = {
   ...minimalAutoApprovePolicy,
+  // Re-declare `std::exec` (the spread above set it to the agency rules
+  // only) so it carries BOTH the agency and read-only git safelists.
+  "std::exec": [...agencyExecApproveRules(), ...gitExecApproveRules()],
   "std::read": [{
     action: "approve"
   }],

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -17,18 +17,19 @@ import { filter } from "std::array"
 import { edit } from "std::fs"
 import { setAgentCwd, getAgentCwd } from "std::index"
 import { remember, recall, setMemoryId } from "std::memory"
-import { exec, ls, glob, grep, bash } from "std::shell"
+import { exec, ls, glob, grep } from "std::shell"
 import { skillsDir } from "std::skills"
 import { systemMessage } from "std::thread"
 
 import { agentNames } from "../lib/config.agency"
 import { withWebSearch } from "../lib/search.agency"
 import { oracleAgent } from "./oracle.agency"
+import { shellAgent } from "./shell.agency"
 import { review, renderFeedback, feedbackHasErrors } from "./review.agency"
 
 
-// The file-system tools (`read` / `write` / `edit` / `ls` / `glob` /
-// `grep` / `bash`) resolve relative paths against the agent working
+// The file-system / shell tools (`read` / `write` / `edit` / `ls` /
+// `glob` / `grep` / `exec`) resolve relative paths against the agent working
 // directory, which `agent.agency` pins to the user's cwd at startup and
 // the LLM can change via `setAgentCwd`. No per-tool anchoring needed.
 
@@ -47,14 +48,14 @@ static const cliSkill = skillsDir("../docs/cli", "flat") with approve
 export def agencyCli(args: string[]): any {
   """
   Run the `agency` CLI with the given arguments. Returns an object with
-  `stdout`, `stderr`, and `exitCode` (same shape as `bash`). Use this for
+  `stdout`, `stderr`, and `exitCode` (same shape as `exec`). Use this for
   agency subcommands such as `parse`, `ast`, and `typecheck` — e.g.
   agencyCli(["ast", "foo.agency"]) or agencyCli(["typecheck",
   "foo.agency"]). Arguments are passed directly to the executable (no
   shell interpretation), so they cannot be chained or redirected. The
   default agent policies auto-approve the read-only agency subcommands;
-  other subcommands still prompt for approval. Prefer this over `bash`
-  for running agency.
+  other subcommands still prompt for approval. Prefer this over a bare
+  `exec("agency", ...)` for running agency.
 
   @param args - CLI arguments, e.g. ["typecheck", "foo.agency"]. The
     first element is the subcommand.
@@ -224,12 +225,31 @@ live in `.agency` files you can `read` directly.
    more than one change to make to the same file. The user will be
    prompted to approve every write.
 6. After every change, run `typecheck` (rule 3 above) and any
-   relevant tests via `bash`.
-7. Use `bash` to run project-level commands (tests, git, formatters,
-   package managers). Prefer the dedicated file tools above for file
-   operations; use `bash` for everything else. The user is asked to
-   approve each command.
-8. You have a persistent knowledge graph scoped to coding work. Call
+   relevant tests via `exec`.
+7. Run project-level commands (tests, git, formatters, package
+   managers) with `exec` — it takes a command plus a structured array
+   of args (`exec("git", ["status"])`, `exec("make", [])`) and runs
+   with no shell, so it's safe and the recommended policy auto-approves
+   read-only git (`status`, `log`, `diff`, `show`, `blame`, ...). Use
+   the dedicated file tools above for file operations. `exec` is your
+   default for everything else; the user approves each command unless a
+   policy auto-approves it.
+8. `exec` has no shell, so express shell idioms with tools instead of
+   reaching for a shell:
+   - redirect (`cmd > out.log`): `exec` the command, then `write` its
+     `.stdout` to the file.
+   - pipe (`a | b`): `exec(b, stdin: exec(a).stdout)` — `exec` takes a
+     `stdin`. For search/list stages prefer the `grep` / `glob` tools.
+   - chaining (`a && b`): call `exec` in sequence, checking `.exitCode`
+     between steps.
+   - working directory (`cd X && cmd`): pass `cwd` to `exec`.
+   - glob args (`rm *.tmp`): `glob` for the matches, then `exec` with
+     the expanded list.
+   When you genuinely need real shell features — a complex pipeline,
+   builtins like `export`/`source`, subshells, or a heredoc — call
+   `shellAgent(task)`. It owns `bash`; every command it runs prompts
+   the user. Don't reach for it for a single structured command.
+9. You have a persistent knowledge graph scoped to coding work. Call
    `recall(query)` to retrieve anything the user told you in a
    previous session (project conventions, decisions made earlier).
    Call `remember(content)` to persist a fact worth keeping across
@@ -238,7 +258,7 @@ live in `.agency` files you can `read` directly.
    Don't `remember` transient details or things already in
    AGENTS.md. Relevant facts are also auto-injected before each turn,
    so often you don't need to call `recall` explicitly.
-9. For **larger coding tasks that benefit from up-front thinking**
+10. For **larger coding tasks that benefit from up-front thinking**
    — building a new feature, designing a non-trivial component,
    refactoring across multiple files, debugging something the user
    has already tried once — call `superpowersSkill` to read the
@@ -316,7 +336,8 @@ export static const codeTools: any[] = [
   ls.partial(useAgentCwd: true),
   glob.partial(useAgentCwd: true),
   grep.partial(useAgentCwd: true),
-  bash.partial(useAgentCwd: true),
+  exec.partial(useAgentCwd: true),
+  shellAgent.partial(allowHandoff: false),
   agencyCli,
   typecheck,
   parseAST,

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/shell.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/shell.agency
@@ -1,0 +1,81 @@
+import { bash } from "std::shell"
+import { systemMessage } from "std::thread"
+
+/*
+ * Shell subagent — the quarantined home of raw `bash`.
+ *
+ * The code agent is exec-first: it runs single commands through the
+ * structured, policy-matchable `exec`. Raw shell (pipes, redirects,
+ * `&&`/`;` chaining, builtins) lives ONLY here, behind an explicit
+ * `shellAgent(...)` call, so the general-purpose shell capability is
+ * isolated to one place instead of always being in reach.
+ *
+ * Quarantine, not auto-run: `bash` still raises its `std::bash`
+ * interrupt and is in NO auto-approve policy, so every command prompts
+ * the user. This subagent isolates the capability; it does not
+ * pre-authorize it.
+ */
+
+export static const shellSysPrompt = """
+You are the **shell specialist**. Other agents call you to run shell
+commands they cannot express with structured `exec` — anything that
+needs real shell features:
+
+- pipelines (`a | b | c`)
+- redirects (`> out.log`, `2>&1`, `tee`)
+- chaining (`a && b`, `a; b`)
+- shell builtins (`export`, `source`, `cd` that must persist)
+- subshells, process substitution, heredocs
+
+## How to work
+
+- Run exactly what the caller asked for. Don't second-guess the
+  command or substitute a different one.
+- You have `bash` and `read`. Use `read` only to check a file you
+  need for context; you do not write or edit files — the calling
+  agent owns file changes.
+- Report the result plainly: the command's stdout, stderr, and exit
+  code. If it failed, say so and quote the error — don't paper over
+  a non-zero exit code.
+- Every `bash` command prompts the user for approval. That is
+  expected and correct. Do NOT try to route around the prompt or
+  bundle commands to reduce approvals at the cost of clarity.
+"""
+
+export static const shellTools: any[] = [
+  bash.partial(useAgentCwd: true),
+  read.partial(useAgentCwd: true),
+]
+
+// only add the system message the first time
+let first = true
+
+export def shellAgent(task: string, allowHandoff: boolean): string {
+  """
+  Run a shell command that needs real shell features the structured
+  `exec` tool can't express — pipelines (`a | b`), redirects
+  (`> out.log`, `2>&1`), chaining (`a && b`), shell builtins
+  (`export`, `source`), subshells, or heredocs. For a single command
+  with structured arguments (git, make, a test runner with no pipe),
+  prefer `exec` directly — don't call this.
+
+  Pass a self-contained description of the shell work; this agent
+  starts fresh and does not see your conversation. Each command it
+  runs prompts the user for approval. It returns the command output
+  (stdout / stderr / exit code) as text.
+
+  @param task - the shell work to perform, with any context needed
+  @param allowHandoff - whether this agent is allowed to handoff to
+    other agents.
+  """
+  thread(label: "shell", summarize: true, session: "shell") {
+    if (first) {
+      systemMessage(shellSysPrompt)
+      first = false
+    }
+    reply = llm(task, {
+      tools: shellTools
+    })
+  }
+  return reply
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.agency
@@ -44,3 +44,50 @@ node doesNotApproveOtherSubcommands(): boolean {
   // `run` is not in the allow-list, so it must NOT be auto-approved.
   return checkPolicy(minimalAutoApprovePolicy, execIntr("run")).type != "approve"
 }
+
+def gitIntr(subcommand: string): any {
+  // Mirrors `exec("git", [subcommand, ...])`: subcommand = args[0].
+  return {
+    effect: "std::exec",
+    data: {
+      command: "git",
+      subcommand: subcommand,
+      args: [subcommand]
+    }
+  }
+}
+
+node recommendedApprovesGitStatus(): boolean {
+  return checkPolicy(recommendedAutoApprovePolicy, gitIntr("status")).type == "approve"
+}
+
+node recommendedApprovesGitLog(): boolean {
+  return checkPolicy(recommendedAutoApprovePolicy, gitIntr("log")).type == "approve"
+}
+
+node recommendedApprovesGitDiff(): boolean {
+  return checkPolicy(recommendedAutoApprovePolicy, gitIntr("diff")).type == "approve"
+}
+
+node minimalDoesNotApproveGit(): boolean {
+  // Git rules live only in the recommended policy, not the minimal one.
+  return checkPolicy(minimalAutoApprovePolicy, gitIntr("status")).type != "approve"
+}
+
+node recommendedDoesNotApproveGitPush(): boolean {
+  // A mutating subcommand must still prompt.
+  return checkPolicy(recommendedAutoApprovePolicy, gitIntr("push")).type != "approve"
+}
+
+node recommendedDoesNotApproveGitBranch(): boolean {
+  // `branch` is deliberately excluded (`git branch -D` deletes), so
+  // even bare `git branch` must NOT auto-approve — the matcher can't
+  // see the flags.
+  return checkPolicy(recommendedAutoApprovePolicy, gitIntr("branch")).type != "approve"
+}
+
+node recommendedDoesNotApproveGitDashC(): boolean {
+  // `git -C dir log` lands with subcommand "-C" (the first arg), so it
+  // must NOT match and must still prompt.
+  return checkPolicy(recommendedAutoApprovePolicy, gitIntr("-C")).type != "approve"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/execPolicy.test.json
@@ -29,6 +29,48 @@
       "input": "",
       "expectedOutput": "true",
       "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "recommendedApprovesGitStatus",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "recommendedApprovesGitLog",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "recommendedApprovesGitDiff",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "minimalDoesNotApproveGit",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "recommendedDoesNotApproveGitPush",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "recommendedDoesNotApproveGitBranch",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "recommendedDoesNotApproveGitDashC",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
     }
   ]
 }


### PR DESCRIPTION
## What

Makes the agency **code agent exec-first**, quarantines raw `bash` into a dedicated subagent, and **auto-approves read-only git** in the recommended policy.

The trigger was the request to auto-allow read-related git actions. That can only be done safely if git flows through the structured `exec` path: `exec()` raises `std::exec` with a `command` + synthetic `subcommand` (`args[0]`) and runs with no shell, so the policy matcher can pin a rule to `(command, subcommand)`. `bash()` raises `std::bash` with only a raw shell string that can chain (`git log; rm -rf x`), so it can't be reasoned about. This is the same mechanism the existing `AGENCY_SAFE_SUBCOMMANDS` list already uses for the `agency` CLI.

## Changes

- **`defaultPolicy.agency`** — add a conservative read-only git safelist + `gitExecApproveRules()` to `recommendedAutoApprovePolicy`. The matcher only sees `args[0]`, so the list contains **only** subcommands that are read-only regardless of any flag (`status`, `log`, `diff`, `show`, `blame`, `rev-parse`, `ls-files`, ...). Deliberately excluded (they have destructive flag forms, so subcommand-alone would over-approve): `branch` (`-D`), `tag`, `config`, `remote`, `stash`, `worktree`, `reflog`, `symbolic-ref`, plus all mutators. A global-option prefix like `git -C dir log` lands with subcommand `-C` and also still prompts.
- **`code.agency`** — expose `exec` as a tool; remove `bash` from the code agent; add `shellAgent`; rewrite the prompt to be exec-first with documented composition patterns for shell idioms (redirect → `write`, pipe → `exec` `stdin`, chain → sequential `exec`, `cwd` param, glob args).
- **`shell.agency`** (new) — a quarantined shell subagent that owns `bash`, called only when real shell features are needed. `bash` still raises its interrupt and is in no auto-approve policy, so **every command still prompts the user** — the subagent isolates the capability, it does not pre-authorize it.
- **`execPolicy` tests** — git read-only approvals + must-prompt cases (`push`, `branch`, `git -C`, minimal policy).

No new stdlib tools; an `env` param on `exec` is deferred (YAGNI).

## Testing

- `execPolicy` — **12/12 pass** (3 new git-approve, 4 must-prompt).
- `toolWiring` (deterministic provider) — **4/4 pass**; the new toolset builds a valid, unique-named `llm` request.
- `shell.agency` typechecks clean; `make` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
