### PR TITLE
Fix interrupt swallowed in single-expression match arm (#430)

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1367,20 +1367,32 @@ export class TypeScriptBuilder {
    *  the match result via `runner.exitMatch` and control unwinds to the owning
    *  ifElse rather than the enclosing function. Never produced by the parser —
    *  only by pattern lowering (Task 6). */
-  private processMatchYield(node: MatchYield): TsNode {
-    // A graph-node call compiles to a goto/halt transition statement (see
-    // generateNodeCallExpression), which is control flow — it cannot serve as
-    // the value argument of `runner.exitMatch(id, <value>)`. Reject it with a
-    // clear compile error rather than emitting invalid TypeScript.
+  /** A graph-node call is a control-flow transition, not a value, so it cannot
+   *  be the result of a match/if arm. `processMatchYield` catches the common
+   *  case where the arm value is yielded directly; but a single-expression arm
+   *  whose value may interrupt is hoisted to a temp binding first (#430), which
+   *  hides the call from that check — so `_processAssignmentInner` re-runs this
+   *  guard on the marked binding. Shared here to keep one error message. */
+  private assertMatchArmValueNotGraphNode(
+    value: Expression | MessageThread | undefined,
+  ): void {
     if (
-      node.value?.type === "functionCall" &&
-      this.names.isGraphNode(node.value.functionName)
+      value?.type === "functionCall" &&
+      this.names.isGraphNode(value.functionName)
     ) {
       throw new Error(
         "a match arm cannot return a graph node transition; a node call is " +
           "control flow, not a value — use if/else statements for node dispatch",
       );
     }
+  }
+
+  private processMatchYield(node: MatchYield): TsNode {
+    // A graph-node call compiles to a goto/halt transition statement (see
+    // generateNodeCallExpression), which is control flow — it cannot serve as
+    // the value argument of `runner.exitMatch(id, <value>)`. Reject it with a
+    // clear compile error rather than emitting invalid TypeScript.
+    this.assertMatchArmValueNotGraphNode(node.value);
     const value = node.value ? this.processNode(node.value) : ts.id("undefined");
     // Plain-mode (handler) match expressions wrap their arms in an async IIFE
     // (see processMatchExpressionPlain): a yield is a real `return` out of that
@@ -2995,6 +3007,13 @@ export class TypeScriptBuilder {
 
   private _processAssignmentInner(node: Assignment): TsNode {
     const { variableName, typeHint, value } = node;
+
+    // A single-expression match/if arm whose value may interrupt is lowered to
+    // this temp binding so the call sits at statement position (#430). The node
+    // call is now hidden from `processMatchYield`'s guard, so re-apply it here.
+    if (node.matchArmValueTemp) {
+      this.assertMatchArmValueNotGraphNode(value);
+    }
 
     if (value.type === "functionCall" && value.functionName === "llm") {
       return this.processLlmCall(variableName, typeHint, value, node.scope!);

--- a/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
@@ -22,9 +22,11 @@ describe("expression match lowering", () => {
     const matchStmt = body.find((n: any) => n.type === "matchBlock");
     expect(matchStmt.matchExprId).toBeTypeOf("number");
     const arm = matchStmt.cases.find((c: any) => c.type === "matchBlockCase");
-    expect(arm.body[0].type).toBe("matchYield");
-    expect(arm.body[0].matchId).toBe(matchStmt.matchExprId);
-    expect(arm.body[0].value).toEqual(expect.objectContaining({ type: "number", value: "1" }));
+    // Every single-expression arm hoists its value to a temp, then yields it.
+    const y = arm.body.find((s: any) => s.type === "matchYield");
+    expect(y.matchId).toBe(matchStmt.matchExprId);
+    // The type checker reads `typeSource` (the original literal), not the temp.
+    expect(y.typeSource).toEqual(expect.objectContaining({ type: "number", value: "1" }));
     const assign = body.find((n: any) => n.type === "assignment" && n.variableName === "val");
     expect(assign.value.value).toBe(`__matchval_${matchStmt.matchExprId}`);
     expect(assign.matchExprSource.matchId).toBe(matchStmt.matchExprId);
@@ -157,41 +159,45 @@ describe("single-expression arm interrupt hoisting (#430)", () => {
     return matchStmt.cases.find((c: any) => c.type === "matchBlockCase").body;
   }
 
-  it("a call arm binds to a temp at statement position, then yields the temp", () => {
-    const stmts = armStmts(`"a" => confirm()`);
-    // [ const __armval_N = confirm();  matchYield(__armval_N) ]
+  // Every single-expression arm is hoisted the same way, regardless of what
+  // the value is: the whole point is NOT to guess which values can interrupt.
+  // The temp binding puts the value at statement position (where codegen emits
+  // the interrupt guard); `typeSource` preserves the original expression for
+  // typing so literals/narrowing survive; `value` is the temp ref for codegen.
+  function expectHoisted(arm: string, valueType: string) {
+    const stmts = armStmts(arm);
     const binding = stmts.find((s: any) => s.type === "assignment");
     expect(binding).toBeDefined();
     expect(binding.matchArmValueTemp).toBe(true);
-    expect(binding.value.type).toBe("functionCall");
-    expect(binding.value.functionName).toBe("confirm");
+    expect(binding.value.type).toBe(valueType);
     const y = stmts.find((s: any) => s.type === "matchYield");
     expect(y.value.type).toBe("variableName");
     expect(y.value.value).toBe(binding.variableName);
+    // The temp binding precedes the yield of that temp.
+    expect(stmts.indexOf(binding)).toBeLessThan(stmts.indexOf(y));
+    // The yield carries the original expression for the type checker.
+    expect(y.typeSource).toEqual(binding.value);
+    return { binding, y };
+  }
+
+  it("a call arm binds to a temp, then yields the temp", () => {
+    const { binding } = expectHoisted(`"a" => confirm()`, "functionCall");
+    expect(binding.value.functionName).toBe("confirm");
   });
 
-  it("a literal arm stays a bare yield (no temp binding)", () => {
-    const stmts = armStmts(`"a" => 1`);
-    expect(stmts.some((s: any) => s.type === "assignment")).toBe(false);
-    expect(stmts[0].type).toBe("matchYield");
-    expect(stmts[0].value).toEqual(
+  it("a literal arm also hoists (uniform lowering, not case-detection)", () => {
+    const { y } = expectHoisted(`"a" => 1`, "number");
+    expect(y.typeSource).toEqual(
       expect.objectContaining({ type: "number", value: "1" }),
     );
   });
 
-  it("a variable-ref arm stays a bare yield (cannot interrupt)", () => {
-    const stmts = armStmts(`"a" => x`);
-    expect(stmts.some((s: any) => s.type === "assignment")).toBe(false);
-    expect(stmts[0].type).toBe("matchYield");
-    expect(stmts[0].value.type).toBe("variableName");
-    expect(stmts[0].value.value).toBe("x");
+  it("a variable-ref arm also hoists", () => {
+    expectHoisted(`"a" => x`, "variableName");
   });
 
-  it("a method-call arm binds to a temp (may interrupt)", () => {
-    const stmts = armStmts(`"a" => x.run()`);
-    const binding = stmts.find((s: any) => s.type === "assignment");
-    expect(binding?.matchArmValueTemp).toBe(true);
-    expect(stmts.some((s: any) => s.type === "matchYield")).toBe(true);
+  it("a method-call arm hoists", () => {
+    expectHoisted(`"a" => x.run()`, "valueAccess");
   });
 });
 
@@ -606,7 +612,7 @@ describe("expression match inside a handler body lowers like anywhere else", () 
     const matchStmt = body.find((n: any) => n.type === "matchBlock");
     expect(matchStmt.matchExprId).toBeTypeOf("number");
     const arm = matchStmt.cases.find((c: any) => c.type === "matchBlockCase");
-    expect(arm.body[0].type).toBe("matchYield");
+    expect(arm.body.some((s: any) => s.type === "matchYield")).toBe(true);
     const assign = body.find(
       (n: any) => n.type === "assignment" && n.variableName === "x",
     );

--- a/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.matchExpr.test.ts
@@ -144,6 +144,57 @@ describe("expression match lowering", () => {
   });
 });
 
+describe("single-expression arm interrupt hoisting (#430)", () => {
+  function armStmts(arm: string): any[] {
+    const body = lowerBody(`node main(x: any) {
+  const val = match(x) {
+    ${arm}
+    _ => "other"
+  }
+  return val
+}`);
+    const matchStmt = body.find((n: any) => n.type === "matchBlock");
+    return matchStmt.cases.find((c: any) => c.type === "matchBlockCase").body;
+  }
+
+  it("a call arm binds to a temp at statement position, then yields the temp", () => {
+    const stmts = armStmts(`"a" => confirm()`);
+    // [ const __armval_N = confirm();  matchYield(__armval_N) ]
+    const binding = stmts.find((s: any) => s.type === "assignment");
+    expect(binding).toBeDefined();
+    expect(binding.matchArmValueTemp).toBe(true);
+    expect(binding.value.type).toBe("functionCall");
+    expect(binding.value.functionName).toBe("confirm");
+    const y = stmts.find((s: any) => s.type === "matchYield");
+    expect(y.value.type).toBe("variableName");
+    expect(y.value.value).toBe(binding.variableName);
+  });
+
+  it("a literal arm stays a bare yield (no temp binding)", () => {
+    const stmts = armStmts(`"a" => 1`);
+    expect(stmts.some((s: any) => s.type === "assignment")).toBe(false);
+    expect(stmts[0].type).toBe("matchYield");
+    expect(stmts[0].value).toEqual(
+      expect.objectContaining({ type: "number", value: "1" }),
+    );
+  });
+
+  it("a variable-ref arm stays a bare yield (cannot interrupt)", () => {
+    const stmts = armStmts(`"a" => x`);
+    expect(stmts.some((s: any) => s.type === "assignment")).toBe(false);
+    expect(stmts[0].type).toBe("matchYield");
+    expect(stmts[0].value.type).toBe("variableName");
+    expect(stmts[0].value.value).toBe("x");
+  });
+
+  it("a method-call arm binds to a temp (may interrupt)", () => {
+    const stmts = armStmts(`"a" => x.run()`);
+    const binding = stmts.find((s: any) => s.type === "assignment");
+    expect(binding?.matchArmValueTemp).toBe(true);
+    expect(stmts.some((s: any) => s.type === "matchYield")).toBe(true);
+  });
+});
+
 describe("expression match lowering errors", () => {
   function expectError(src: string, re: RegExp) {
     const parsed = parseAgency(src);

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -541,7 +541,34 @@ class PatternLowerer {
     arm: MatchBlockCase,
   ): AgencyNode[] {
     if (body.length === 1 && isExpressionNode(body[0])) {
-      return [{ type: "matchYield", matchId, value: body[0] as Expression, loc: body[0].loc }];
+      const expr = body[0] as Expression;
+      // A call arm (`"go" => confirm()`) must bind its value to a temp at
+      // STATEMENT position, then yield the temp (#430): a bare
+      // `matchYield(await __call(f))` hands the call result straight to
+      // `exitMatch` with no interrupt-propagation check, so an interrupt is
+      // swallowed. Non-call values (literals, refs, ...) stay a bare yield —
+      // they can't interrupt, and keeping them direct preserves the per-arm
+      // unwidened literal check and the graph-node-transition guard, both of
+      // which read the yielded value.
+      if (armValueMayInterrupt(expr)) {
+        const tmp = this.freshName("armval");
+        const binding: Assignment = {
+          type: "assignment",
+          variableName: tmp,
+          declKind: "const",
+          value: expr,
+          loc: expr.loc,
+          matchArmValueTemp: true,
+        };
+        const yielded: MatchYield = {
+          type: "matchYield",
+          matchId,
+          value: varRef(tmp, expr.loc),
+          loc: expr.loc,
+        };
+        return [binding, yielded];
+      }
+      return [{ type: "matchYield", matchId, value: expr, loc: expr.loc }];
     }
     const rewritten = this.rewriteReturnsToYields(body, matchId);
     if (!this.alwaysYields(rewritten)) {
@@ -1096,6 +1123,36 @@ function isExpr(v: unknown): v is Expression {
   // in some fields (e.g. Assignment.value is `Expression | MessageThread`).
   const t = (v as { type: string }).type;
   return t !== "messageThread";
+}
+
+/**
+ * True when a single-expression match-arm value involves a function/method call
+ * — so it may return an interrupt that must propagate rather than be swallowed
+ * by `exitMatch` (#430). Such arms are bound to a temp at statement position
+ * before yielding; everything else (literals, variable refs, plain field/index
+ * access) stays a bare yield, which cannot interrupt and keeps the yielded value
+ * direct for the per-arm unwidened-literal check and the graph-node-transition
+ * guard. `try`/`raise`/binop calls surface as one of these node types too.
+ */
+function armValueMayInterrupt(expr: Expression): boolean {
+  switch (expr.type) {
+    case "functionCall":
+    case "tryExpression":
+    case "interruptStatement":
+      return true;
+    case "valueAccess":
+      return (
+        armValueMayInterrupt(expr.base as Expression) ||
+        expr.chain.some((el) => el.kind === "methodCall" || el.kind === "call")
+      );
+    case "binOpExpression":
+      return (
+        armValueMayInterrupt(expr.left as Expression) ||
+        armValueMayInterrupt(expr.right as Expression)
+      );
+    default:
+      return false;
+  }
 }
 
 /** Location of the first `thread { ... }` block within the arm's return-flow

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -542,33 +542,37 @@ class PatternLowerer {
   ): AgencyNode[] {
     if (body.length === 1 && isExpressionNode(body[0])) {
       const expr = body[0] as Expression;
-      // A call arm (`"go" => confirm()`) must bind its value to a temp at
-      // STATEMENT position, then yield the temp (#430): a bare
-      // `matchYield(await __call(f))` hands the call result straight to
-      // `exitMatch` with no interrupt-propagation check, so an interrupt is
-      // swallowed. Non-call values (literals, refs, ...) stay a bare yield —
-      // they can't interrupt, and keeping them direct preserves the per-arm
-      // unwidened literal check and the graph-node-transition guard, both of
-      // which read the yielded value.
-      if (armValueMayInterrupt(expr)) {
-        const tmp = this.freshName("armval");
-        const binding: Assignment = {
-          type: "assignment",
-          variableName: tmp,
-          declKind: "const",
-          value: expr,
-          loc: expr.loc,
-          matchArmValueTemp: true,
-        };
-        const yielded: MatchYield = {
-          type: "matchYield",
-          matchId,
-          value: varRef(tmp, expr.loc),
-          loc: expr.loc,
-        };
-        return [binding, yielded];
-      }
-      return [{ type: "matchYield", matchId, value: expr, loc: expr.loc }];
+      // Always bind a single-expression arm's value to a temp at STATEMENT
+      // position, then yield the temp (#430). A bare `matchYield(<expr>)`
+      // compiles to `exitMatch(id, <expr>)`; if the expression is a call that
+      // returns a bubbling interrupt, that interrupt is handed straight to
+      // `exitMatch` with no propagation check and is silently swallowed. At
+      // statement position the value flows through `_processAssignmentInner`,
+      // which emits the `hasInterrupts` halt guard. We hoist unconditionally
+      // rather than trying to detect which values "may interrupt": that
+      // detection is brittle (easy to miss a case) and a missed case silently
+      // reintroduces the swallow. The temp is tagged `matchArmValueTemp` so
+      // codegen re-applies the graph-node-transition guard (the node call is
+      // now hidden from `processMatchYield`, which reads the yielded value).
+      const tmp = this.freshName("armval");
+      const binding: Assignment = {
+        type: "assignment",
+        variableName: tmp,
+        declKind: "const",
+        value: expr,
+        loc: expr.loc,
+        matchArmValueTemp: true,
+      };
+      const yielded: MatchYield = {
+        type: "matchYield",
+        matchId,
+        value: varRef(tmp, expr.loc),
+        // The type checker types the arm from the original expression, not the
+        // temp ref, so literal types and discriminant narrowing survive (#430).
+        typeSource: expr,
+        loc: expr.loc,
+      };
+      return [binding, yielded];
     }
     const rewritten = this.rewriteReturnsToYields(body, matchId);
     if (!this.alwaysYields(rewritten)) {
@@ -1123,36 +1127,6 @@ function isExpr(v: unknown): v is Expression {
   // in some fields (e.g. Assignment.value is `Expression | MessageThread`).
   const t = (v as { type: string }).type;
   return t !== "messageThread";
-}
-
-/**
- * True when a single-expression match-arm value involves a function/method call
- * — so it may return an interrupt that must propagate rather than be swallowed
- * by `exitMatch` (#430). Such arms are bound to a temp at statement position
- * before yielding; everything else (literals, variable refs, plain field/index
- * access) stays a bare yield, which cannot interrupt and keeps the yielded value
- * direct for the per-arm unwidened-literal check and the graph-node-transition
- * guard. `try`/`raise`/binop calls surface as one of these node types too.
- */
-function armValueMayInterrupt(expr: Expression): boolean {
-  switch (expr.type) {
-    case "functionCall":
-    case "tryExpression":
-    case "interruptStatement":
-      return true;
-    case "valueAccess":
-      return (
-        armValueMayInterrupt(expr.base as Expression) ||
-        expr.chain.some((el) => el.kind === "methodCall" || el.kind === "call")
-      );
-    case "binOpExpression":
-      return (
-        armValueMayInterrupt(expr.left as Expression) ||
-        armValueMayInterrupt(expr.right as Expression)
-      );
-    default:
-      return false;
-  }
 }
 
 /** Location of the first `thread { ... }` block within the arm's return-flow

--- a/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
@@ -48,14 +48,20 @@ export function computeMatchExprTypes(
         .sort((a, b) => b - a);
       for (const id of ids) {
         const yields = yieldsByMatch[id];
-        const types = yields.map((y) =>
-          y.value ? synthType(y.value, info.scope, ctx) : "any",
-        );
+        // A single-expression arm is hoisted to a temp for interrupt
+        // propagation (#430); `typeSource` carries the arm's original
+        // expression so literal types and per-arm narrowing survive typing —
+        // the temp ref in `value` would widen them and lose narrowing.
+        const typeExpr = (y: MatchYield) => y.typeSource ?? y.value;
+        const types = yields.map((y) => {
+          const e = typeExpr(y);
+          return e ? synthType(e, info.scope, ctx) : "any";
+        });
         // Record each yield's UNWIDENED type + loc for CHECKED-position
         // per-arm assignability checking (see `checkMatchExprYields`).
         ctx.matchExprYieldTypes[id] = yields.map((y, i) => ({
           type: types[i],
-          loc: y.value?.loc ?? y.loc,
+          loc: typeExpr(y)?.loc ?? y.loc,
         }));
         // A yield of `any` (the sentinel string OR the `any` primitive) makes
         // the whole match's value type `any` — the union can't be narrowed.

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -255,6 +255,13 @@ export type Assignment = BaseNode & {
    *  and the `MatchBlock` passthrough carry the same tag (see ifElse.ts /
    *  matchBlock.ts). Ignored by codegen. */
   matchExprId?: number;
+  /** Set by pattern lowering on the synthetic temp binding that hoists a
+   *  single-expression match/if arm whose value may interrupt (`"go" => f()`),
+   *  so the call sits at statement position and gets the interrupt-propagation
+   *  check (#430). Codegen re-applies the graph-node-transition guard to a
+   *  binding carrying this tag: the node call is hidden inside a temp here, so
+   *  `processMatchYield` (which reads the yielded value) can no longer see it. */
+  matchArmValueTemp?: boolean;
 };
 
 export function globalScope(): Scope {

--- a/packages/agency-lang/lib/types/matchYield.ts
+++ b/packages/agency-lang/lib/types/matchYield.ts
@@ -7,4 +7,11 @@ export type MatchYield = BaseNode & {
   type: "matchYield";
   matchId: number;
   value?: Expression;
+  /** For a single-expression arm hoisted to a temp so the value flows through
+   *  statement-position interrupt propagation (#430), `value` is the temp ref
+   *  (`__armval_N`) — correct for codegen but too coarse for typing, which
+   *  needs the arm's real expression to preserve literal types and per-arm
+   *  discriminant narrowing. This holds that original expression; the type
+   *  checker synthesizes the arm's type from it instead of the temp ref. */
+  typeSource?: Expression;
 };

--- a/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.agency
+++ b/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.agency
@@ -1,16 +1,33 @@
 // Regression for #430: an interrupt thrown by a function call in a
-// SINGLE-EXPRESSION match arm must pause/resume, not be swallowed. The arm
-// value is bound to a temp at statement position (like a block arm), so the
-// call gets the interrupt-propagation check.
+// SINGLE-EXPRESSION match arm must pause/resume, not be swallowed. Every
+// single-expression arm is hoisted to a temp at statement position (like a
+// block arm), so the call gets the interrupt-propagation check — the fix does
+// not try to guess which arm values can interrupt, it hoists them all.
 def confirm(): string {
   interrupt("proceed?")
   return "approved"
 }
 
-node main(x: string): string {
+def deny(): string {
+  interrupt("really?")
+  return "denied"
+}
+
+// A matched literal arm whose value is a call.
+node matched(x: string): string {
   const val = match(x) {
     "go" => confirm()
     _    => "skip"
+  }
+  return "got:${val}"
+}
+
+// The wildcard arm is a call too: proves hoisting covers every arm, not just
+// the one that happens to be a literal-keyed match.
+node wildcard(x: string): string {
+  const val = match(x) {
+    "keep" => "kept"
+    _      => deny()
   }
   return "got:${val}"
 }

--- a/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.agency
+++ b/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.agency
@@ -1,0 +1,16 @@
+// Regression for #430: an interrupt thrown by a function call in a
+// SINGLE-EXPRESSION match arm must pause/resume, not be swallowed. The arm
+// value is bound to a temp at statement position (like a block arm), so the
+// call gets the interrupt-propagation check.
+def confirm(): string {
+  interrupt("proceed?")
+  return "approved"
+}
+
+node main(x: string): string {
+  const val = match(x) {
+    "go" => confirm()
+    _    => "skip"
+  }
+  return "got:${val}"
+}

--- a/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.test.json
+++ b/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.test.json
@@ -1,0 +1,6 @@
+{
+  "tests": [
+    { "nodeName": "main", "input": "\"go\"", "expectedOutput": "\"got:approved\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "proceed?" }] },
+    { "nodeName": "main", "input": "\"stop\"", "expectedOutput": "\"got:skip\"", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.test.json
+++ b/packages/agency-lang/tests/agency/substeps/interrupt-in-match-arm-call.test.json
@@ -1,6 +1,8 @@
 {
   "tests": [
-    { "nodeName": "main", "input": "\"go\"", "expectedOutput": "\"got:approved\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "proceed?" }] },
-    { "nodeName": "main", "input": "\"stop\"", "expectedOutput": "\"got:skip\"", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "matched", "input": "\"go\"", "expectedOutput": "\"got:approved\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "proceed?" }] },
+    { "nodeName": "matched", "input": "\"stop\"", "expectedOutput": "\"got:skip\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "wildcard", "input": "\"other\"", "expectedOutput": "\"got:denied\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "really?" }] },
+    { "nodeName": "wildcard", "input": "\"keep\"", "expectedOutput": "\"got:kept\"", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -224,14 +224,17 @@ return;
     condition: async () => __stack.args.x === `b`,
     body: async (runner) => {
 await runner.step(2, async (runner) => {
-runner.exitMatch(1, 2);
+__stack.locals.__armval_2 = 2;
+            });
+await runner.step(3, async (runner) => {
+runner.exitMatch(1, __stack.locals.__armval_2);
 return;
             });
     },
   },
 
 ], async (runner) => {
-await runner.ifElse(3, [
+await runner.ifElse(4, [
 
   {
     condition: async () => __eq(__stack.args.x, `z`),
@@ -244,7 +247,7 @@ return;
   },
 
 ]);
-await runner.step(4, async (runner) => {
+await runner.step(5, async (runner) => {
 runner.exitMatch(1, 0);
 return;
           });
@@ -329,4 +332,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"matchExpression.agency:main":{"1":{"line":1,"col":14},"2":{"line":1,"col":2},"3":{"line":14,"col":2},"1.0":{"line":3,"col":6},"1.1":{"line":4,"col":6},"1.3.0":{"line":9,"col":8},"1.3":{"line":8,"col":6},"1.4":{"line":11,"col":6}}};
+export const __sourceMap = {"matchExpression.agency:main":{"1":{"line":1,"col":14},"2":{"line":1,"col":2},"3":{"line":14,"col":2},"1.0":{"line":3,"col":6},"1.1":{"line":4,"col":6},"1.4.0":{"line":9,"col":8},"1.4":{"line":8,"col":6},"1.5":{"line":11,"col":6}}};


### PR DESCRIPTION
## Summary

Closes #430. An interrupt thrown from a call in a **single-expression** `match` arm was silently swallowed.

```ts
def confirm(): string {
  interrupt("proceed?")
  return "approved"
}

node main(x: string): string {
  const val = match(x) {
    "go" => confirm()   // interrupt from here was lost
    _    => "skip"
  }
  return "got:${val}"
}
```

## Root cause

A single-expression arm lowered directly to `matchYield(<expr>)`, which codegen turns into `runner.exitMatch(id, await __call(confirm))`. The interrupt-carrying value was handed straight to `exitMatch` with **no `hasInterrupts` check**, so the interrupt never propagated — `main("go")` returned `"got:approved"` without ever pausing.

Block arms never had this bug: a `return` inside `{ ... }` lowers to a statement-position temp, which *does* get the check. Single-expression arms were the gap.

## Fix: hoist every single-expression arm uniformly

Lowering now hoists **every** single-expression arm's value to a temp at statement position before yielding it:

```
"go" => confirm()   ⟶   const __armval = confirm()   // statement position → gets hasInterrupts check
                        matchYield(__armval)
```

An arm value therefore behaves **exactly like the same expression written as `const t = <expr>`** — it inherits whatever interrupt propagation a normal assignment has. (An earlier revision tried to *detect* which arm values could interrupt and hoist only those; that was brittle — a missed case silently reintroduces the swallow — so per review it was dropped in favor of unconditional hoisting.)

### Preserving type-checker behavior

Two things the checker got from the old bare-yield shape are preserved:

- **Literal precision + per-arm discriminant narrowing.** The checker types each arm from the yielded value; a temp ref would widen `"a"` to `string` and drop narrowing. `MatchYield` now carries a `typeSource` field with the arm's original expression — the checker types the arm from that, while codegen uses the temp ref in `value`.
- **Graph-node-transition guard.** `"a" => target()` (a node call) is control flow, not a value. The temp binding is tagged `matchArmValueTemp`, and codegen re-applies the guard to it, so a node call in a match arm stays a compile error rather than silently emitting a `goToNode` transition inside the arm.

### Known limitation (pre-existing, not introduced here)

A method call whose callback interrupts (`x.run()`, `items.map(f)`) is not guarded — but this is a **language-wide** gap: a plain `const r = items.map(f)` in ordinary code is unguarded too. Uniform hoisting makes arms behave identically to statement-position assignments; closing the general method-call gap is separate from #430.

## Testing

- **Execution** (`tests/agency/substeps/interrupt-in-match-arm-call.agency`, 4): a matched-arm call and a wildcard-arm call both pause on the interrupt and resume; the non-interrupting paths return their literals.
- **Lowering** (unit): every arm kind (call, literal, variable ref, method call) hoists to a tagged temp + yields it, with `typeSource` carrying the original expression.
- **Typecheck**: literal-union yields, discriminant-narrowed field-access yields, and per-arm error anchoring all still pass (via `typeSource`).
- **Guard**: a node-call arm still throws `match arm cannot return a graph node transition`.
- **Fixture**: `matchExpression.mjs` updated for the uniform-hoist shape.
- Full unit suite: **7180 passed**, 0 failures. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
