### PR TITLE
Type-constrained optimizer mutations: typed optimize const targets

### DIFF
--- a/packages/agency-lang/docs/site/cli/optimize.md
+++ b/packages/agency-lang/docs/site/cli/optimize.md
@@ -60,7 +60,39 @@ Complete: champion iteration 1, accepted 1, rejected 0, invalid 0 (10.0s)
 Optimize demo-run completed: 1 accepted, 0 rejected
 ```
 
-You can put `optimize` on any string `const` `let` to tell the the optimizer to rewrite it.
+You can put `optimize` on any literal `const` or `let` — strings, numbers, booleans, records, and arrays — to tell the optimizer to rewrite it.
+
+## Typed targets
+
+A plain string target is freeform: the optimizer may propose any text (interpolation placeholders are preserved). Every other kind of target is **typed** — you declare its type, and every proposed value is checked against that type before it is ever written:
+
+```ts
+type Strategy = "fast" | "cheap" | "thorough"
+
+optimize const strategy: Strategy = "fast"
+optimize const maxRetries: number = 2
+optimize const style = "Be concise."   // freeform string, works as before
+```
+
+A record target keeps its shape too:
+
+```ts
+type JudgeConfig = { rubric: string; samples: number }
+
+optimize const judge: JudgeConfig = { rubric: "prefer brevity", samples: 3 }
+```
+
+The rules, which are the language's own typechecking rules:
+
+- A proposal must fit the declared type: a union target only accepts one of its members, a `number` target only accepts numbers, and so on. Out-of-shape proposals are rejected and the rejection reason is fed back to the mutator model, which retries.
+- Record proposals must keep the declared fields and field types. Unknown fields are rejected. A field whose type includes `null` may be omitted or set to `null` explicitly.
+- Typed values must be self-contained: no `${...}` interpolations (only freeform string targets carry placeholders).
+- **A type annotation is required** for non-string targets in v1 — `optimize const n = 5` is an error asking you to write `optimize const n: number = 5`.
+- If a target's own initializer does not satisfy its annotation (for example the type comes from a package the optimizer cannot resolve), the target is left unconstrained rather than blocked — the optimizer never rejects a value shaped like the one you already wrote.
+
+One known soft spot, inherited from the current typechecker: a record proposal that includes an explicit `null` field skips the deep field check (the whole literal degrades to `any`). This fails open — it can admit an imperfect record, never reject a valid one.
+
+Not yet supported (planned): enforcing `@validate` rules and numeric bounds on proposed values, time/size unit literals (`5s`, `100mb`) as targets, and inferring types for unannotated non-string targets.
 
 ## Inputs, graders, optimizers
 

--- a/packages/agency-lang/lib/agents/optimize/mutatePrompt.agency
+++ b/packages/agency-lang/lib/agents/optimize/mutatePrompt.agency
@@ -35,6 +35,8 @@ node mutatePrompt(
   - "operations": one record per target you change. Each record needs "target" and "kind" copied exactly from the list above, "op" set to "replaceInitializer", "value" with the replacement as Agency source text including the surrounding quotes, and "rationale" with one sentence on what you changed. The replacement must preserve every interpolation placeholder the current value uses (no drops, no additions).
   - "rationale": 2-4 sentences explaining the overall change.
 
+  Each target lists a "type:" describing its allowed values. Your replacement must fit that type exactly - for a list of choices pick one of them, for a boolean use true or false, for a record keep the same fields and field types. Typed values must be self-contained: no interpolation placeholders at all. Only "free text" targets accept arbitrary prose (and those keep their existing placeholders, per the rule above).
+
   Write a general instruction that works for any input of this kind. Do NOT hard-code the specific expected answers shown in the feedback into the value — an answer that only works for these inputs will fail on held-out validation inputs.
 
   ${diagnostics}

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1742,3 +1742,12 @@ export function generateAgency(
       .replace(/[ \t]+$/gm, "") + "\n"
   );
 }
+
+/**
+ * Formatter-exact source rendering of a single expression — the same
+ * renderer interpolations use, so string quotes and escapes are preserved.
+ * NOT `expressionToString` (lib/utils/node.ts), which drops string quotes.
+ */
+export function generateExpression(expr: AgencyNode): string {
+  return new AgencyGenerator({}).processNode(expr).trim();
+}

--- a/packages/agency-lang/lib/optimize/artifacts.test.ts
+++ b/packages/agency-lang/lib/optimize/artifacts.test.ts
@@ -63,6 +63,7 @@ describe("createOptimizeArtifacts", () => {
         scope: "global",
         name: "prompt",
         valueKind: "string",
+        constraintText: null,
         value: "hi",
       }],
     };

--- a/packages/agency-lang/lib/optimize/artifacts.test.ts
+++ b/packages/agency-lang/lib/optimize/artifacts.test.ts
@@ -63,7 +63,7 @@ describe("createOptimizeArtifacts", () => {
         scope: "global",
         name: "prompt",
         valueKind: "string",
-        constraintText: null,
+        declaredType: null,
         value: "hi",
       }],
     };

--- a/packages/agency-lang/lib/optimize/artifacts.test.ts
+++ b/packages/agency-lang/lib/optimize/artifacts.test.ts
@@ -53,6 +53,7 @@ describe("createOptimizeArtifacts", () => {
     const targetSet: OptimizeTargetSet = {
       baseDir: tmpDir,
       entryFile: "agent.agency",
+      typeAliases: {},
       files: {},
       targets: [{
         id: "agent.agency:global:prompt",
@@ -71,6 +72,7 @@ describe("createOptimizeArtifacts", () => {
     expect(targetsPath).toBe(path.join(artifacts.runDir, "targets.json"));
     expect(JSON.parse(fs.readFileSync(targetsPath, "utf-8"))).toMatchObject({
       entryFile: "agent.agency",
+      typeAliases: {},
       targets: [{ id: "agent.agency:global:prompt" }],
     });
   });
@@ -130,7 +132,7 @@ describe("createOptimizeArtifacts", () => {
       }],
       diff: "--- foo.agency\n+++ foo.agency\n- old\n+ new",
       diagnostics: [],
-      targetSet: { baseDir: tmpDir, entryFile: "foo.agency", files: {}, targets: [] },
+      targetSet: { baseDir: tmpDir, entryFile: "foo.agency", files: {}, targets: [], typeAliases: {} },
     };
 
     const agent = artifacts.writeIterationAgent(1, preview.files);

--- a/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
@@ -118,7 +118,7 @@ describe("BaseOptimizer.evaluate", () => {
           entryFile: "agent.agency",
           typeAliases: {},
           files: {},
-          targets: [{ id: "t", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "p", valueKind: "string", value: "x", constraintText: null }],
+          targets: [{ id: "t", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "p", valueKind: "string", value: "x", declaredType: null }],
         }),
       },
     );

--- a/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
@@ -68,6 +68,7 @@ describe("BaseOptimizer.evaluate", () => {
   const source: OptimizeTargetSet = {
     baseDir: "",
     entryFile: "agent.agency",
+    typeAliases: {},
     files: {},
     targets: [],
   };
@@ -88,6 +89,7 @@ describe("BaseOptimizer.evaluate", () => {
     const scoreSource: OptimizeTargetSet = {
       baseDir: src,
       entryFile: "agent.agency",
+      typeAliases: {},
       files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "node main() {}\n", sha256: "x" } },
       targets: [],
     };
@@ -114,6 +116,7 @@ describe("BaseOptimizer.evaluate", () => {
         discover: () => ({
           baseDir: src,
           entryFile: "agent.agency",
+          typeAliases: {},
           files: {},
           targets: [{ id: "t", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "p", valueKind: "string", value: "x" }],
         }),

--- a/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.test.ts
@@ -118,7 +118,7 @@ describe("BaseOptimizer.evaluate", () => {
           entryFile: "agent.agency",
           typeAliases: {},
           files: {},
-          targets: [{ id: "t", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "p", valueKind: "string", value: "x" }],
+          targets: [{ id: "t", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "p", valueKind: "string", value: "x", constraintText: null }],
         }),
       },
     );

--- a/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
+++ b/packages/agency-lang/lib/optimize/baseOptimizer.workdir.test.ts
@@ -71,7 +71,7 @@ describe("BaseOptimizer.runInputViaEval threads seed + overlayFiles", () => {
   }
 
   function source(): OptimizeTargetSet {
-    return { baseDir: src, entryFile: "agent.agency", files: {}, targets: [] };
+    return { baseDir: src, entryFile: "agent.agency", files: {}, targets: [], typeAliases: {} };
   }
 
   it("passes seed + overlayFiles to evalRunLoadedInputs; no working_dir on input", async () => {

--- a/packages/agency-lang/lib/optimize/constraint.test.ts
+++ b/packages/agency-lang/lib/optimize/constraint.test.ts
@@ -72,12 +72,17 @@ describe("checkProposal", () => {
     expect(checkProposal("Job", `{ status: "nope", priority: null }`, aliases).ok).toBe(true);
   });
 
-  it("rejects bare variable references, but NOT interpolations (the mutator gates those)", () => {
-    expect(checkProposal("Status", `somevar`, {}).ok).toBe(false);
-    // The undefined-variable pass does not descend into interpolation
-    // segments, so the probe alone accepts this — which is why the mutator
-    // applies the explicit hasInterpolation gate before probing.
+  it("does NOT reject bare identifiers or interpolations — the mutator gates those", () => {
+    // An unknown bare identifier synthesizes to `any` and typechecks clean,
+    // and the undefined-variable pass does not descend into interpolation
+    // segments. Both are handled by the mutator's isLiteralExpression /
+    // hasInterpolation gates, not by the probe. Pinned so nobody assumes
+    // the probe covers them.
+    expect(checkProposal("Status", `somevar`, aliases).ok).toBe(true);
     expect(checkProposal("string", `"hi \${x}"`, {}).ok).toBe(true);
+    // With an EMPTY registry the same proposal is rejected — but only
+    // because the alias itself is unknown, not because of the identifier.
+    expect(checkProposal("Status", `somevar`, {}).ok).toBe(false);
   });
 
   it("rejects values that do not parse", () => {

--- a/packages/agency-lang/lib/optimize/constraint.test.ts
+++ b/packages/agency-lang/lib/optimize/constraint.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { exprParser } from "@/parsers/parsers.js";
 import type { TypeAliasEntry, VariableType } from "@/types.js";
+import { hasInterpolation, isNullLiteral } from "@/utils/node.js";
 import {
   checkProposal,
   describeConstraint,
-  hasInterpolation,
-  isNullLiteral,
-  renderConstraintText,
+  renderDeclaredType,
 } from "./constraint.js";
 
 const statusT: VariableType = {
@@ -89,6 +88,22 @@ describe("checkProposal", () => {
     expect(checkProposal("number", `{{{`, {}).ok).toBe(false);
   });
 
+  it("resolves aliases nested inside inline annotations (rendered by name, resolved lazily)", () => {
+    // formatTypeHint renders alias references by NAME ("Status"), and the
+    // probe resolves them against the registry at comparison time — so
+    // annotations that CONTAIN aliases work without any eager expansion.
+    expect(checkProposal(`{ status: Status }`, `{ status: "fail" }`, aliases).ok).toBe(true);
+    expect(checkProposal(`{ status: Status }`, `{ status: "nope" }`, aliases).ok).toBe(false);
+    expect(checkProposal(`Status | null`, `null`, aliases).ok).toBe(true);
+    expect(checkProposal(`Status | null`, `"exploded"`, aliases).ok).toBe(false);
+  });
+
+  it("keeps the internal probe variable out of rejection reasons", () => {
+    const bad = checkProposal("number", `"five"`, {});
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.reason).not.toContain("proposedValue");
+  });
+
   it("accepts anything against an any annotation", () => {
     expect(checkProposal("any", `{ a: 1 }`, {}).ok).toBe(true);
   });
@@ -122,14 +137,14 @@ describe("isNullLiteral", () => {
   });
 });
 
-describe("renderConstraintText + describeConstraint", () => {
+describe("renderDeclaredType + describeConstraint", () => {
   it("renders a union round-trippably and labels freeform / unconstrained", () => {
-    const text = renderConstraintText(statusT);
+    const text = renderDeclaredType(statusT);
     expect(checkProposal(text, `"pass"`, {}).ok).toBe(true);
     expect(checkProposal(text, `"exploded"`, {}).ok).toBe(false);
 
-    expect(describeConstraint({ constraintText: null, valueKind: "string" }).toLowerCase()).toContain("free");
-    expect(describeConstraint({ constraintText: null, valueKind: "literal" }).toLowerCase()).toContain("literal");
-    expect(describeConstraint({ constraintText: "Status", valueKind: "string" })).toBe("Status");
+    expect(describeConstraint({ declaredType: null, valueKind: "string" }).toLowerCase()).toContain("free");
+    expect(describeConstraint({ declaredType: null, valueKind: "literal" }).toLowerCase()).toContain("literal");
+    expect(describeConstraint({ declaredType: "Status", valueKind: "string" })).toBe("Status");
   });
 });

--- a/packages/agency-lang/lib/optimize/constraint.test.ts
+++ b/packages/agency-lang/lib/optimize/constraint.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { exprParser } from "@/parsers/parsers.js";
+import type { TypeAliasEntry, VariableType } from "@/types.js";
+import {
+  checkProposal,
+  describeConstraint,
+  hasInterpolation,
+  isNullLiteral,
+  renderConstraintText,
+} from "./constraint.js";
+
+const statusT: VariableType = {
+  type: "unionType",
+  types: [
+    { type: "stringLiteralType", value: "pass" },
+    { type: "stringLiteralType", value: "fail" },
+  ],
+};
+const jobT: VariableType = {
+  type: "objectType",
+  properties: [
+    { key: "status", value: { type: "typeAliasVariable", aliasName: "Status" } },
+    {
+      key: "priority",
+      value: {
+        type: "unionType",
+        types: [
+          { type: "primitiveType", value: "number" },
+          { type: "primitiveType", value: "null" },
+        ],
+      },
+    },
+  ],
+};
+const aliases: Record<string, TypeAliasEntry> = { Status: { body: statusT }, Job: { body: jobT } };
+
+describe("checkProposal", () => {
+  it("accepts a union member and rejects a non-member with the checker's message", () => {
+    expect(checkProposal("Status", `"fail"`, aliases).ok).toBe(true);
+    const bad = checkProposal("Status", `"exploded"`, aliases);
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) expect(bad.reason).toContain("Status");
+  });
+
+  it("enforces primitives in both directions", () => {
+    expect(checkProposal("number", `-5`, {}).ok).toBe(true);
+    expect(checkProposal("number", `"five"`, {}).ok).toBe(false);
+    expect(checkProposal("boolean", `true`, {}).ok).toBe(true);
+    expect(checkProposal("boolean", `"yes"`, {}).ok).toBe(false);
+  });
+
+  it("accepts null for a nullable annotation", () => {
+    expect(checkProposal("number | null", `null`, {}).ok).toBe(true);
+    expect(checkProposal("number | null", `6`, {}).ok).toBe(true);
+    expect(checkProposal("number | null", `"six"`, {}).ok).toBe(false);
+  });
+
+  it("matches the language on records (verified semantics)", () => {
+    // Nullable field may be omitted; nested unions are enforced through the
+    // alias registry; unknown fields are rejected.
+    expect(checkProposal("Job", `{ status: "fail" }`, aliases).ok).toBe(true);
+    expect(checkProposal("Job", `{ status: "nope" }`, aliases).ok).toBe(false);
+    expect(checkProposal("Job", `{ status: "fail", extra: 1 }`, aliases).ok).toBe(false);
+  });
+
+  it("KNOWN FAIL-OPEN: an explicit null field skips the record check (language behavior, inherited)", () => {
+    // synthObject degrades the whole literal to "any" when any field
+    // synthesizes "any" (a bare null does), and checkType skips "any".
+    // Fail-open is acceptable — it can never wrongly reject. Pinned as a
+    // tripwire: if the language tightens null synthesis, this test diffs
+    // and gets updated deliberately.
+    expect(checkProposal("Job", `{ status: "nope", priority: null }`, aliases).ok).toBe(true);
+  });
+
+  it("rejects bare variable references, but NOT interpolations (the mutator gates those)", () => {
+    expect(checkProposal("Status", `somevar`, {}).ok).toBe(false);
+    // The undefined-variable pass does not descend into interpolation
+    // segments, so the probe alone accepts this — which is why the mutator
+    // applies the explicit hasInterpolation gate before probing.
+    expect(checkProposal("string", `"hi \${x}"`, {}).ok).toBe(true);
+  });
+
+  it("rejects values that do not parse", () => {
+    expect(checkProposal("number", `{{{`, {}).ok).toBe(false);
+  });
+
+  it("accepts anything against an any annotation", () => {
+    expect(checkProposal("any", `{ a: 1 }`, {}).ok).toBe(true);
+  });
+});
+
+describe("hasInterpolation", () => {
+  function expr(src: string) {
+    const parsed = exprParser(src);
+    if (!parsed.success) throw new Error(`could not parse: ${src}`);
+    return parsed.result;
+  }
+
+  it("detects interpolations at top level and nested in objects/arrays", () => {
+    expect(hasInterpolation(expr(`"plain"`))).toBe(false);
+    expect(hasInterpolation(expr(`"hi \${x}"`))).toBe(true);
+    expect(hasInterpolation(expr(`{ a: "hi \${x}" }`))).toBe(true);
+    expect(hasInterpolation(expr(`[1, "\${x}"]`))).toBe(true);
+    expect(hasInterpolation(expr(`{ a: 1, b: [true, "ok"] }`))).toBe(false);
+  });
+});
+
+describe("isNullLiteral", () => {
+  it("recognizes the parser's variableName representation of null", () => {
+    const parsed = exprParser("null");
+    if (!parsed.success) throw new Error("parse failed");
+    expect(isNullLiteral(parsed.result)).toBe(true);
+
+    const other = exprParser("nullish");
+    if (!other.success) throw new Error("parse failed");
+    expect(isNullLiteral(other.result)).toBe(false);
+  });
+});
+
+describe("renderConstraintText + describeConstraint", () => {
+  it("renders a union round-trippably and labels freeform / unconstrained", () => {
+    const text = renderConstraintText(statusT);
+    expect(checkProposal(text, `"pass"`, {}).ok).toBe(true);
+    expect(checkProposal(text, `"exploded"`, {}).ok).toBe(false);
+
+    expect(describeConstraint({ constraintText: null, valueKind: "string" }).toLowerCase()).toContain("free");
+    expect(describeConstraint({ constraintText: null, valueKind: "literal" }).toLowerCase()).toContain("literal");
+    expect(describeConstraint({ constraintText: "Status", valueKind: "string" })).toBe("Status");
+  });
+});

--- a/packages/agency-lang/lib/optimize/constraint.ts
+++ b/packages/agency-lang/lib/optimize/constraint.ts
@@ -1,20 +1,10 @@
-import { AgencyGenerator } from "@/backends/agencyGenerator.js";
 import { GLOBAL_SCOPE_KEY, ScopedTypeAliases, type CompilationUnit } from "@/compilationUnit.js";
 import { parseAgency } from "@/parser.js";
 import { typeCheck } from "@/typeChecker/index.js";
-import type { Expression, TypeAliasEntry, VariableType } from "@/types.js";
+import type { TypeAliasEntry, VariableType } from "@/types.js";
 import { formatTypeHint } from "@/utils/formatType.js";
 
 export type ShapeResult = { ok: true } | { ok: false; reason: string };
-
-/**
- * The parser represents `null` as a variableName node — there is no
- * `{ type: "null" }` in parser output. Single point of truth for the check
- * so no caller ever tests `expr.type === "null"` (dead code).
- */
-export function isNullLiteral(expr: Expression): boolean {
-  return expr.type === "variableName" && expr.value === "null";
-}
 
 /**
  * A minimal CompilationUnit carrying only the alias registry, for
@@ -34,22 +24,12 @@ export function makeProbeUnit(typeAliases: Record<string, TypeAliasEntry>): Comp
   };
 }
 
-const PROBE_VARIABLE = "__optimizeProbe";
+// Chosen to read acceptably if it ever leaks into a diagnostic shown to the
+// mutator LLM ("assignment to 'proposedValue'" is self-explanatory).
+const PROBE_VARIABLE = "proposedValue";
 
 /**
- * Exact source rendering of a literal expression, via the Agency formatter
- * (`processNode` is the same renderer interpolations use, so string quotes
- * and escapes are preserved). NOT `expressionToString`, which drops string
- * quotes and makes `{a: "1"}` and `{a: 1}` render identically. Needed
- * because parsed initializer nodes carry no loc offsets, so the exact text
- * cannot be sliced from the source.
- */
-export function renderLiteralSource(expr: Expression): string {
-  return new AgencyGenerator({}).processNode(expr).trim();
-}
-
-/**
- * Does `valueText` fit the type written as `constraintText`? Decided by the
+ * Does `valueText` fit the type written as `declaredType`? Decided by the
  * language's own typechecker on a one-line probe program — parsed and
  * typechecked in memory, never executed. Any diagnostic (assignability,
  * unknown property, undefined variable inside an interpolation, parse
@@ -62,64 +42,26 @@ export function renderLiteralSource(expr: Expression): string {
  * right direction (a valid value is never wrongly rejected).
  */
 export function checkProposal(
-  constraintText: string,
+  declaredType: string,
   valueText: string,
   typeAliases: Record<string, TypeAliasEntry>,
 ): ShapeResult {
-  const probe = parseAgency(`const ${PROBE_VARIABLE}: ${constraintText} = ${valueText}`, {}, false);
+  const probe = parseAgency(`const ${PROBE_VARIABLE}: ${declaredType} = ${valueText}`, {}, false);
   if (!probe.success) {
+    // The parse failure may be the value OR the rendered type — surface the
+    // parser's own message so retry feedback (and baseline self-test
+    // fallbacks) are debuggable.
     return {
       ok: false,
-      reason: `value does not parse as an Agency expression of type ${constraintText}`,
+      reason: `value does not parse as an Agency expression of type ${declaredType}${probe.message ? `: ${probe.message}` : ""}`,
     };
   }
   const result = typeCheck(probe.result, {}, makeProbeUnit(typeAliases));
   if (result.errors.length === 0) return { ok: true };
   return {
     ok: false,
-    reason: result.errors[0].message.replace(` (assignment to '${PROBE_VARIABLE}')`, ""),
+    reason: result.errors[0].message.replaceAll(` (assignment to '${PROBE_VARIABLE}')`, ""),
   };
-}
-
-const LITERAL_EXPRESSION_TYPES = ["string", "multiLineString", "number", "boolean", "agencyObject", "agencyArray"];
-
-/**
- * True when the expression is a literal an optimize target/proposal may
- * carry: string, number, boolean, null, object, or array. The single gate
- * shared by discovery and the mutator — the probe alone cannot enforce
- * this, because an unknown bare identifier synthesizes to `any` and passes
- * typechecking unflagged.
- */
-export function isLiteralExpression(expr: Expression): boolean {
-  return LITERAL_EXPRESSION_TYPES.includes(expr.type) || isNullLiteral(expr);
-}
-
-/**
- * True when a literal expression contains a string interpolation anywhere —
- * at top level or nested inside object/array literals. Typed replacement
- * values must be self-contained: the mutator cannot know what identifiers
- * exist at the target's declaration site, and the probe's undefined-variable
- * pass does not descend into interpolation segments. Structural traversal
- * only — no type semantics.
- */
-export function hasInterpolation(expr: Expression): boolean {
-  switch (expr.type) {
-    case "string":
-    case "multiLineString":
-      return expr.segments.some((segment) => segment.type !== "text");
-    case "agencyArray":
-      return expr.items.some((item) =>
-        item.type === "splat" ? hasInterpolation(item.value) : hasInterpolation(item),
-      );
-    case "agencyObject":
-      return expr.entries.some((entry) => {
-        if ("type" in entry && entry.type === "splat") return hasInterpolation(entry.value);
-        const kv = entry as { value: Expression };
-        return hasInterpolation(kv.value);
-      });
-    default:
-      return false;
-  }
 }
 
 /**
@@ -128,21 +70,21 @@ export function hasInterpolation(expr: Expression): boolean {
  * round-trip: a rendered type that does not re-parse, or does not accept the
  * target's own original value, leaves the target unconstrained.
  */
-export function renderConstraintText(typeHint: VariableType): string {
+export function renderDeclaredType(typeHint: VariableType): string {
   return formatTypeHint(typeHint);
 }
 
 /**
  * One-line description of a target's allowed values for the mutator prompt.
- * `constraintText === null` means freeform for text targets and
+ * `declaredType === null` means freeform for text targets and
  * unconstrained for literal targets — see the valueKind-first invariant in
  * `OptimizeTarget`.
  */
 export function describeConstraint(target: {
-  constraintText: string | null;
+  declaredType: string | null;
   valueKind: string;
 }): string {
-  if (target.constraintText !== null) return target.constraintText;
+  if (target.declaredType !== null) return target.declaredType;
   if (target.valueKind === "literal") return "any literal value";
   return "free text (any string; keep every ${...} placeholder)";
 }

--- a/packages/agency-lang/lib/optimize/constraint.ts
+++ b/packages/agency-lang/lib/optimize/constraint.ts
@@ -1,0 +1,122 @@
+import { GLOBAL_SCOPE_KEY, ScopedTypeAliases, type CompilationUnit } from "@/compilationUnit.js";
+import { parseAgency } from "@/parser.js";
+import { typeCheck } from "@/typeChecker/index.js";
+import type { Expression, TypeAliasEntry, VariableType } from "@/types.js";
+import { formatTypeHint } from "@/utils/formatType.js";
+
+export type ShapeResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * The parser represents `null` as a variableName node — there is no
+ * `{ type: "null" }` in parser output. Single point of truth for the check
+ * so no caller ever tests `expr.type === "null"` (dead code).
+ */
+export function isNullLiteral(expr: Expression): boolean {
+  return expr.type === "variableName" && expr.value === "null";
+}
+
+/**
+ * A minimal CompilationUnit carrying only the alias registry, for
+ * typechecking probe programs. CompilationUnit is a plain data type (no
+ * closures — unlike TypeCheckerContext), so this construction is stable.
+ */
+export function makeProbeUnit(typeAliases: Record<string, TypeAliasEntry>): CompilationUnit {
+  return {
+    functionDefinitions: {},
+    typeAliases: new ScopedTypeAliases({ [GLOBAL_SCOPE_KEY]: typeAliases }),
+    graphNodes: [],
+    importedNodes: [],
+    importStatements: [],
+    safeFunctions: {},
+    importedFunctions: {},
+    jsImportedNames: {},
+  };
+}
+
+const PROBE_VARIABLE = "__optimizeProbe";
+
+/**
+ * Does `valueText` fit the type written as `constraintText`? Decided by the
+ * language's own typechecker on a one-line probe program — parsed and
+ * typechecked in memory, never executed. Any diagnostic (assignability,
+ * unknown property, undefined variable inside an interpolation, parse
+ * failure) is a rejection; the first message is the retry feedback for the
+ * mutator LLM.
+ *
+ * Known fail-open, inherited from the language: an object literal containing
+ * an explicit `null` field synthesizes to `any`, which skips the assignment
+ * check entirely — such proposals are accepted unchecked. Fail-open is the
+ * right direction (a valid value is never wrongly rejected).
+ */
+export function checkProposal(
+  constraintText: string,
+  valueText: string,
+  typeAliases: Record<string, TypeAliasEntry>,
+): ShapeResult {
+  const probe = parseAgency(`const ${PROBE_VARIABLE}: ${constraintText} = ${valueText}`, {}, false);
+  if (!probe.success) {
+    return {
+      ok: false,
+      reason: `value does not parse as an Agency expression of type ${constraintText}`,
+    };
+  }
+  const result = typeCheck(probe.result, {}, makeProbeUnit(typeAliases));
+  if (result.errors.length === 0) return { ok: true };
+  return {
+    ok: false,
+    reason: result.errors[0].message.replace(` (assignment to '${PROBE_VARIABLE}')`, ""),
+  };
+}
+
+/**
+ * True when a literal expression contains a string interpolation anywhere —
+ * at top level or nested inside object/array literals. Typed replacement
+ * values must be self-contained: the mutator cannot know what identifiers
+ * exist at the target's declaration site, and the probe's undefined-variable
+ * pass does not descend into interpolation segments. Structural traversal
+ * only — no type semantics.
+ */
+export function hasInterpolation(expr: Expression): boolean {
+  switch (expr.type) {
+    case "string":
+    case "multiLineString":
+      return expr.segments.some((segment) => segment.type !== "text");
+    case "agencyArray":
+      return expr.items.some((item) =>
+        item.type === "splat" ? hasInterpolation(item.value) : hasInterpolation(item),
+      );
+    case "agencyObject":
+      return expr.entries.some((entry) => {
+        if ("type" in entry && entry.type === "splat") return hasInterpolation(entry.value);
+        const kv = entry as { value: Expression };
+        return hasInterpolation(kv.value);
+      });
+    default:
+      return false;
+  }
+}
+
+/**
+ * Render an annotation back to parseable source text for probing and for the
+ * mutator prompt. The baseline self-test in discovery validates the
+ * round-trip: a rendered type that does not re-parse, or does not accept the
+ * target's own original value, leaves the target unconstrained.
+ */
+export function renderConstraintText(typeHint: VariableType): string {
+  return formatTypeHint(typeHint);
+}
+
+/**
+ * One-line description of a target's allowed values for the mutator prompt.
+ * `constraintText === null` means freeform for text targets and
+ * unconstrained for literal targets — see the valueKind-first invariant in
+ * `OptimizeTarget`.
+ */
+export function describeConstraint(target: {
+  constraintText: string | null;
+  valueKind: string;
+}): string {
+  if (target.constraintText !== null) return target.constraintText;
+  if (target.valueKind === "literal") return "any literal value";
+  return "free text (any string; keep every ${...} placeholder)";
+}

--- a/packages/agency-lang/lib/optimize/constraint.ts
+++ b/packages/agency-lang/lib/optimize/constraint.ts
@@ -1,3 +1,4 @@
+import { AgencyGenerator } from "@/backends/agencyGenerator.js";
 import { GLOBAL_SCOPE_KEY, ScopedTypeAliases, type CompilationUnit } from "@/compilationUnit.js";
 import { parseAgency } from "@/parser.js";
 import { typeCheck } from "@/typeChecker/index.js";
@@ -34,6 +35,18 @@ export function makeProbeUnit(typeAliases: Record<string, TypeAliasEntry>): Comp
 }
 
 const PROBE_VARIABLE = "__optimizeProbe";
+
+/**
+ * Exact source rendering of a literal expression, via the Agency formatter
+ * (`processNode` is the same renderer interpolations use, so string quotes
+ * and escapes are preserved). NOT `expressionToString`, which drops string
+ * quotes and makes `{a: "1"}` and `{a: 1}` render identically. Needed
+ * because parsed initializer nodes carry no loc offsets, so the exact text
+ * cannot be sliced from the source.
+ */
+export function renderLiteralSource(expr: Expression): string {
+  return new AgencyGenerator({}).processNode(expr).trim();
+}
 
 /**
  * Does `valueText` fit the type written as `constraintText`? Decided by the

--- a/packages/agency-lang/lib/optimize/constraint.ts
+++ b/packages/agency-lang/lib/optimize/constraint.ts
@@ -81,6 +81,19 @@ export function checkProposal(
   };
 }
 
+const LITERAL_EXPRESSION_TYPES = ["string", "multiLineString", "number", "boolean", "agencyObject", "agencyArray"];
+
+/**
+ * True when the expression is a literal an optimize target/proposal may
+ * carry: string, number, boolean, null, object, or array. The single gate
+ * shared by discovery and the mutator — the probe alone cannot enforce
+ * this, because an unknown bare identifier synthesizes to `any` and passes
+ * typechecking unflagged.
+ */
+export function isLiteralExpression(expr: Expression): boolean {
+  return LITERAL_EXPRESSION_TYPES.includes(expr.type) || isNullLiteral(expr);
+}
+
 /**
  * True when a literal expression contains a string interpolation anywhere —
  * at top level or nested inside object/array literals. Typed replacement

--- a/packages/agency-lang/lib/optimize/mutator.test.ts
+++ b/packages/agency-lang/lib/optimize/mutator.test.ts
@@ -170,3 +170,42 @@ describe("proposeMutation", () => {
     }
   });
 });
+
+describe("renderTargetsSection type descriptions", () => {
+  it("describes a union target's allowed values and a boolean target", () => {
+    const typed: OptimizeTarget[] = [
+      {
+        id: "a.agency:global:status",
+        kind: "variable",
+        file: "a.agency",
+        absoluteFile: "/abs/a.agency",
+        scope: "global",
+        name: "status",
+        valueKind: "string",
+        value: "pass",
+        constraintText: `"pass" | "fail"`,
+      },
+      {
+        id: "a.agency:global:enabled",
+        kind: "variable",
+        file: "a.agency",
+        absoluteFile: "/abs/a.agency",
+        scope: "global",
+        name: "enabled",
+        valueKind: "literal",
+        value: "false",
+        constraintText: "boolean",
+      },
+    ];
+
+    const sections = buildMutatorSections({ targets: typed, inputs: [], history: "" });
+
+    expect(sections.targets).toContain(`type: "pass" | "fail"`);
+    expect(sections.targets).toContain("type: boolean");
+  });
+
+  it("labels freeform and unconstrained targets", () => {
+    const sections = buildMutatorSections({ targets, inputs: [], history: "" });
+    expect(sections.targets.toLowerCase()).toContain("free text");
+  });
+});

--- a/packages/agency-lang/lib/optimize/mutator.test.ts
+++ b/packages/agency-lang/lib/optimize/mutator.test.ts
@@ -14,6 +14,7 @@ const targets: OptimizeTarget[] = [
     scope: "global",
     name: "systemPrompt",
     valueKind: "string",
+    constraintText: null,
     value: "be brief",
   },
   {
@@ -24,6 +25,7 @@ const targets: OptimizeTarget[] = [
     scope: "bar",
     name: "prompt",
     valueKind: "string",
+    constraintText: null,
     value: "Classify ${text}",
   },
 ];

--- a/packages/agency-lang/lib/optimize/mutator.test.ts
+++ b/packages/agency-lang/lib/optimize/mutator.test.ts
@@ -14,7 +14,7 @@ const targets: OptimizeTarget[] = [
     scope: "global",
     name: "systemPrompt",
     valueKind: "string",
-    constraintText: null,
+    declaredType: null,
     value: "be brief",
   },
   {
@@ -25,7 +25,7 @@ const targets: OptimizeTarget[] = [
     scope: "bar",
     name: "prompt",
     valueKind: "string",
-    constraintText: null,
+    declaredType: null,
     value: "Classify ${text}",
   },
 ];
@@ -183,7 +183,7 @@ describe("renderTargetsSection type descriptions", () => {
         name: "status",
         valueKind: "string",
         value: "pass",
-        constraintText: `"pass" | "fail"`,
+        declaredType: `"pass" | "fail"`,
       },
       {
         id: "a.agency:global:enabled",
@@ -194,7 +194,7 @@ describe("renderTargetsSection type descriptions", () => {
         name: "enabled",
         valueKind: "literal",
         value: "false",
-        constraintText: "boolean",
+        declaredType: "boolean",
       },
     ];
 

--- a/packages/agency-lang/lib/optimize/mutator.ts
+++ b/packages/agency-lang/lib/optimize/mutator.ts
@@ -9,6 +9,7 @@ import { executeNodeAsync } from "@/cli/util.js";
 import type { Input } from "@/eval/runTypes.js";
 import { getAgentsDir } from "@/importPaths.js";
 
+import { describeConstraint } from "./constraint.js";
 import type { OptimizeMutationDiagnostic } from "./sourceMutator.js";
 import type { OptimizeTarget } from "./targets.js";
 import type { MutationProposal } from "./types.js";
@@ -73,6 +74,7 @@ export function renderTargetsSection(targets: OptimizeTarget[]): string {
     .map((target) => [
       `- id: ${target.id}`,
       `  kind: ${target.kind}`,
+      `  type: ${describeConstraint(target)}`,
       `  current value: ${JSON.stringify(target.value)}`,
     ].join("\n"))
     .join("\n");

--- a/packages/agency-lang/lib/optimize/optimizers/example.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/example.test.ts
@@ -36,6 +36,7 @@ describe("ExampleOptimizer", () => {
   const fakeSource = (): OptimizeTargetSet => ({
     baseDir: src,
     entryFile: "agent.agency",
+    typeAliases: {},
     files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
     targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi" }],
   });

--- a/packages/agency-lang/lib/optimize/optimizers/example.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/example.test.ts
@@ -38,7 +38,7 @@ describe("ExampleOptimizer", () => {
     entryFile: "agent.agency",
     typeAliases: {},
     files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
-    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi" }],
+    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi", constraintText: null }],
   });
 
   const runInput: RunInput = async () => ({ output: "out", recordPath: "" });

--- a/packages/agency-lang/lib/optimize/optimizers/example.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/example.test.ts
@@ -38,7 +38,7 @@ describe("ExampleOptimizer", () => {
     entryFile: "agent.agency",
     typeAliases: {},
     files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
-    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi", constraintText: null }],
+    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi", declaredType: null }],
   });
 
   const runInput: RunInput = async () => ({ output: "out", recordPath: "" });

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
@@ -41,6 +41,7 @@ describe("Gepa (reflective Pareto optimizer)", () => {
   const fakeSource = (): OptimizeTargetSet => ({
     baseDir: src,
     entryFile: "agent.agency",
+    typeAliases: {},
     files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
     targets: [target("t-alpha"), target("t-beta")],
   });

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
@@ -35,7 +35,7 @@ describe("Gepa (reflective Pareto optimizer)", () => {
 
   const target = (id: string): OptimizeTargetSet["targets"][number] => ({
     id, kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"),
-    scope: "global", name: id, valueKind: "string", value: `"${id}"`, constraintText: null,
+    scope: "global", name: id, valueKind: "string", value: `"${id}"`, declaredType: null,
   });
 
   const fakeSource = (): OptimizeTargetSet => ({

--- a/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/gepa.test.ts
@@ -35,7 +35,7 @@ describe("Gepa (reflective Pareto optimizer)", () => {
 
   const target = (id: string): OptimizeTargetSet["targets"][number] => ({
     id, kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"),
-    scope: "global", name: id, valueKind: "string", value: `"${id}"`,
+    scope: "global", name: id, valueKind: "string", value: `"${id}"`, constraintText: null,
   });
 
   const fakeSource = (): OptimizeTargetSet => ({

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
@@ -8,8 +8,9 @@ import { BaseGrader } from "../grading/baseGrader.js";
 import { Scorecard } from "../grading/scorecard.js";
 import type { Grade, GraderInput, GraderOptions } from "../grading/types.js";
 import { GreedyReflective, type GreedyDeps } from "./greedyReflective.js";
-import type { OptimizeMutationPreview } from "../sourceMutator.js";
-import type { OptimizeTargetSet } from "../targets.js";
+import type { ProposeMutationArgs } from "../mutator.js";
+import { defaultPreview, type OptimizeMutationPreview } from "../sourceMutator.js";
+import { discoverOptimizeTargets, type OptimizeTargetSet } from "../targets.js";
 
 class ValueGrader extends BaseGrader {
   protected readonly defaultName = "value";
@@ -202,5 +203,72 @@ describe("GreedyReflective (pointwise)", () => {
       gatesPassed: false,
     }]);
     expect(failed.gatedObjective()).toBe(0);
+  });
+});
+
+describe("typed target end-to-end guarantee", () => {
+  let root: string;
+  let src: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "greedy-typed-"));
+    src = path.join(root, "src");
+    fs.mkdirSync(src);
+    fs.writeFileSync(
+      path.join(src, "agent.agency"),
+      `type Status = "pass" | "fail"\n\noptimize const status: Status = "pass"\n\nnode main() {\n  return status\n}\n`,
+    );
+  });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  const BAD_OPERATION = {
+    target: "agent.agency:global:status",
+    kind: "variable",
+    op: "replaceInitializer",
+    value: `"exploded"`,
+  } as const;
+
+  it("never accepts an out-of-shape value (preview level, atomic)", () => {
+    const set = discoverOptimizeTargets(path.join(src, "agent.agency"), { baseDir: src });
+
+    const bad = defaultPreview(set, [BAD_OPERATION]);
+    expect(bad.diagnostics[0]?.code).toBe("type-mismatch");
+    expect(bad.files).toEqual({}); // atomic: no candidate files on rejection
+
+    const good = defaultPreview(set, [{ ...BAD_OPERATION, value: `"fail"` }]);
+    expect(good.diagnostics).toEqual([]);
+    expect(good.files["agent.agency"]).toContain(`"fail"`);
+  });
+
+  it("feeds type-mismatch diagnostics back to the proposer and never writes the bad value", async () => {
+    const proposeCalls: ProposeMutationArgs[] = [];
+    const propose = vi.fn(async (args: ProposeMutationArgs) => {
+      proposeCalls.push(args);
+      return { rationale: "try exploded", operations: [BAD_OPERATION] };
+    });
+    const opt = new GreedyReflective(
+      // 0.5 keeps the baseline below the max objective so the iteration runs.
+      { graders: [new ValueGrader(() => 0.5)], iterations: 1, config: {}, runsDir: root, runId: "typed-e2e", writeback: false },
+      {
+        runInput: async () => ({ output: "out", recordPath: "" }),
+        discover: () => discoverOptimizeTargets(path.join(src, "agent.agency"), { baseDir: src }),
+        propose,
+        // no preview override: the REAL defaultPreview runs the shape check
+      },
+    );
+
+    const result = await opt.optimize({ agent: path.join(src, "agent.agency"), inputs: [{ id: "a", args: {} }] });
+
+    // Retried up to the attempt cap, every attempt rejected by the shape check.
+    expect(propose).toHaveBeenCalledTimes(3);
+    expect(result.validationFailedCount).toBe(1);
+    expect(result.championIter).toBe("baseline");
+
+    // The rejection reason flows back into the retry prompt inputs.
+    expect(proposeCalls[1]?.diagnostics?.[0]?.code).toBe("type-mismatch");
+    expect(proposeCalls[1]?.diagnostics?.[0]?.message).toContain("exploded");
+
+    // No candidate agent file was ever materialized with the bad value.
+    const iterAgent = path.join(root, "typed-e2e", "iter-1", "agent");
+    expect(fs.existsSync(iterAgent)).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
@@ -31,6 +31,7 @@ describe("GreedyReflective (pointwise)", () => {
   const fakeSource = (): OptimizeTargetSet => ({
     baseDir: src,
     entryFile: "agent.agency",
+    typeAliases: {},
     files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
     targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi" }],
   });

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
@@ -34,7 +34,7 @@ describe("GreedyReflective (pointwise)", () => {
     entryFile: "agent.agency",
     typeAliases: {},
     files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
-    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi", constraintText: null }],
+    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi", declaredType: null }],
   });
 
   const deps = (): GreedyDeps => ({
@@ -267,8 +267,21 @@ describe("typed target end-to-end guarantee", () => {
     expect(proposeCalls[1]?.diagnostics?.[0]?.code).toBe("type-mismatch");
     expect(proposeCalls[1]?.diagnostics?.[0]?.message).toContain("exploded");
 
-    // No candidate agent file was ever materialized with the bad value.
-    const iterAgent = path.join(root, "typed-e2e", "iter-1", "agent");
-    expect(fs.existsSync(iterAgent)).toBe(false);
+    // No .agency file anywhere under the run root ever carries the bad
+    // value — covers every path that materializes candidate/workspace
+    // sources, not a specific directory layout. (Diagnostics JSON may
+    // legitimately mention it; agent source must not.)
+    const agencyFiles: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".agency")) agencyFiles.push(full);
+      }
+    };
+    walk(root);
+    for (const file of agencyFiles) {
+      expect(fs.readFileSync(file, "utf8")).not.toContain("exploded");
+    }
   });
 });

--- a/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
+++ b/packages/agency-lang/lib/optimize/optimizers/greedyReflective.test.ts
@@ -33,7 +33,7 @@ describe("GreedyReflective (pointwise)", () => {
     entryFile: "agent.agency",
     typeAliases: {},
     files: { "agent.agency": { file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), source: "x", sha256: "x" } },
-    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi" }],
+    targets: [{ id: "agent.agency:global:prompt", kind: "variable", file: "agent.agency", absoluteFile: path.join(src, "agent.agency"), scope: "global", name: "prompt", valueKind: "string", value: "hi", constraintText: null }],
   });
 
   const deps = (): GreedyDeps => ({

--- a/packages/agency-lang/lib/optimize/reporter.test.ts
+++ b/packages/agency-lang/lib/optimize/reporter.test.ts
@@ -32,6 +32,7 @@ function makeTarget(overrides: Partial<OptimizeTarget> & { id: string; name: str
     absoluteFile: "/abs/foo.agency",
     scope: "bar",
     valueKind: "string",
+    constraintText: null,
     value: "xyz",
     ...overrides,
   };

--- a/packages/agency-lang/lib/optimize/reporter.test.ts
+++ b/packages/agency-lang/lib/optimize/reporter.test.ts
@@ -32,7 +32,7 @@ function makeTarget(overrides: Partial<OptimizeTarget> & { id: string; name: str
     absoluteFile: "/abs/foo.agency",
     scope: "bar",
     valueKind: "string",
-    constraintText: null,
+    declaredType: null,
     value: "xyz",
     ...overrides,
   };

--- a/packages/agency-lang/lib/optimize/reporter.test.ts
+++ b/packages/agency-lang/lib/optimize/reporter.test.ts
@@ -48,6 +48,7 @@ const systemTarget = makeTarget({
 const targetSet: OptimizeTargetSet = {
   baseDir: "/abs",
   entryFile: "foo.agency",
+  typeAliases: {},
   files: {},
   targets: [promptTarget, systemTarget],
 };

--- a/packages/agency-lang/lib/optimize/sourceMutator.test.ts
+++ b/packages/agency-lang/lib/optimize/sourceMutator.test.ts
@@ -83,6 +83,7 @@ function makeTargetSet(extraTargets: OptimizeTarget[] = []): OptimizeTargetSet {
         scope: "bar",
         name: "prompt",
         valueKind: "string",
+        constraintText: null,
         value: "xyz",
       },
       {
@@ -93,6 +94,7 @@ function makeTargetSet(extraTargets: OptimizeTarget[] = []): OptimizeTargetSet {
         scope: "global",
         name: "greeting",
         valueKind: "string",
+        constraintText: null,
         value: "hello ${name}",
       },
       ...extraTargets,
@@ -143,6 +145,7 @@ describe("OptimizeSourceMutator operation validation", () => {
       scope: "global",
       name: "ResultType",
       valueKind: "string",
+      constraintText: null,
       value: "string",
     } as unknown as OptimizeTarget;
     const diagnostics = previewDiagnostics(
@@ -581,6 +584,7 @@ describe("OptimizeSourceMutator.mutate", () => {
       scope: "global",
       name: "ResultType",
       valueKind: "string",
+      constraintText: null,
       value: "string",
     } as unknown as OptimizeTarget;
     const mutator = new OptimizeSourceMutator({ targetSet: makeTargetSet([typeTarget]) });

--- a/packages/agency-lang/lib/optimize/sourceMutator.test.ts
+++ b/packages/agency-lang/lib/optimize/sourceMutator.test.ts
@@ -65,6 +65,7 @@ function makeTargetSet(extraTargets: OptimizeTarget[] = []): OptimizeTargetSet {
   return {
     baseDir: "/abs",
     entryFile: "foo.agency",
+    typeAliases: {},
     files: {
       "foo.agency": {
         file: "foo.agency",

--- a/packages/agency-lang/lib/optimize/sourceMutator.test.ts
+++ b/packages/agency-lang/lib/optimize/sourceMutator.test.ts
@@ -83,7 +83,7 @@ function makeTargetSet(extraTargets: OptimizeTarget[] = []): OptimizeTargetSet {
         scope: "bar",
         name: "prompt",
         valueKind: "string",
-        constraintText: null,
+        declaredType: null,
         value: "xyz",
       },
       {
@@ -94,7 +94,7 @@ function makeTargetSet(extraTargets: OptimizeTarget[] = []): OptimizeTargetSet {
         scope: "global",
         name: "greeting",
         valueKind: "string",
-        constraintText: null,
+        declaredType: null,
         value: "hello ${name}",
       },
       ...extraTargets,
@@ -145,7 +145,7 @@ describe("OptimizeSourceMutator operation validation", () => {
       scope: "global",
       name: "ResultType",
       valueKind: "string",
-      constraintText: null,
+      declaredType: null,
       value: "string",
     } as unknown as OptimizeTarget;
     const diagnostics = previewDiagnostics(
@@ -584,7 +584,7 @@ describe("OptimizeSourceMutator.mutate", () => {
       scope: "global",
       name: "ResultType",
       valueKind: "string",
-      constraintText: null,
+      declaredType: null,
       value: "string",
     } as unknown as OptimizeTarget;
     const mutator = new OptimizeSourceMutator({ targetSet: makeTargetSet([typeTarget]) });
@@ -706,5 +706,66 @@ node main() {}
     expect(preview.files["a.agency"]).toContain("optimize const enabled: boolean = true");
     const refreshed = preview.targetSet.targets.find((target) => target.name === "enabled")!;
     expect(refreshed.value).toBe("true");
+  });
+});
+
+describe("review fixes: checked value must equal written value", () => {
+  function setup(source: string): OptimizeTargetSet {
+    const dir = fs.realpathSync(makeTempDir());
+    const entry = writeAgency(dir, "a.agency", source);
+    return discoverOptimizeTargets(entry, { baseDir: dir });
+  }
+
+  it("rejects an unquoted multi-word non-member (quote-recovery must probe the recovered value)", () => {
+    const set = setup(`type Status = "pass" | "fail"\noptimize const status: Status = "pass"\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    // Unquoted multi-word: parses partially ("totally" + rest), recovery wraps
+    // it into the string "totally bogus" — which is NOT a union member and
+    // must be rejected. Probing the raw unquoted text instead would parse as
+    // a bare identifier plus a stray statement and falsely typecheck clean.
+    const preview = mutator.mutate("a.agency:global:status", `totally bogus`);
+    expect(preview.diagnostics[0]?.code).toBe("type-mismatch");
+    expect(preview.files).toEqual({});
+  });
+
+  it("accepts an unquoted multi-word proposal that IS a union member (mirror case)", () => {
+    const set = setup(`type Status = "pass" | "totally bogus"\noptimize const status: Status = "pass"\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    const preview = mutator.mutate("a.agency:global:status", `totally bogus`);
+    expect(preview.diagnostics).toEqual([]);
+    expect(preview.files["a.agency"]).toContain(`"totally bogus"`);
+  });
+
+  it("rejects containers holding bare identifiers (nested literal gate)", () => {
+    const set = setup(`type P = { n: number }
+optimize const nums: number[] = [1, 2]
+optimize const p: P = { n: 1 }
+node main() {}
+`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    expect(mutator.mutate("a.agency:global:nums", `[x, y]`).diagnostics[0]?.code).toBe("unsupported-value-domain");
+    expect(mutator.mutate("a.agency:global:p", `{ n: someVar }`).diagnostics[0]?.code).toBe("unsupported-value-domain");
+    // Nested literals still pass.
+    expect(mutator.mutate("a.agency:global:nums", `[3, 4]`).diagnostics).toEqual([]);
+    expect(mutator.mutate("a.agency:global:p", `{ n: 2 }`).diagnostics).toEqual([]);
+  });
+
+  it("keeps an unconstrained literal target literal across refreshes (no freeform flip)", () => {
+    const set = setup(`optimize const x: NotDefined = 5\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    // Iter 1: a string proposal is accepted (unconstrained literal).
+    const first = mutator.mutate("a.agency:global:x", `"hi"`);
+    expect(first.diagnostics).toEqual([]);
+    const refreshed = first.targetSet.targets.find((target) => target.name === "x")!;
+    expect(refreshed.valueKind).toBe("literal"); // identity from the declaration, not the champion value
+
+    // Iter 2 against the refreshed set: a number proposal must still be
+    // accepted — the target must not have silently become a freeform string.
+    const second = new OptimizeSourceMutator({ targetSet: first.targetSet }).mutate("a.agency:global:x", `7`);
+    expect(second.diagnostics).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/optimize/sourceMutator.test.ts
+++ b/packages/agency-lang/lib/optimize/sourceMutator.test.ts
@@ -631,3 +631,80 @@ describe("OptimizeSourceMutator.apply", () => {
     expect(fs.existsSync(destination)).toBe(false);
   });
 });
+
+describe("typed target shape checking", () => {
+  function setup(source: string): OptimizeTargetSet {
+    const dir = fs.realpathSync(makeTempDir());
+    const entry = writeAgency(dir, "a.agency", source);
+    return discoverOptimizeTargets(entry, { baseDir: dir });
+  }
+
+  it("accepts in-shape and rejects out-of-shape union values", () => {
+    const set = setup(`type Status = "pass" | "fail"\noptimize const status: Status = "pass"\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    const ok = mutator.mutate("a.agency:global:status", `"fail"`);
+    expect(ok.diagnostics).toEqual([]);
+    expect(ok.files["a.agency"]).toContain(`"fail"`);
+
+    expect(mutator.mutate("a.agency:global:status", `"exploded"`).diagnostics[0]?.code).toBe("type-mismatch");
+  });
+
+  it("recovers an unquoted bare-word proposal for a string-y constraint", () => {
+    const set = setup(`type Status = "pass" | "fail"\noptimize const status: Status = "pass"\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    expect(mutator.mutate("a.agency:global:status", `fail`).diagnostics).toEqual([]);
+  });
+
+  it("handles boolean and nullable-number targets", () => {
+    const set = setup(`optimize const enabled: boolean = false\noptimize const n: number | null = 5\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    expect(mutator.mutate("a.agency:global:enabled", `true`).diagnostics).toEqual([]);
+    expect(mutator.mutate("a.agency:global:n", `null`).diagnostics).toEqual([]);
+    expect(mutator.mutate("a.agency:global:n", `6`).diagnostics).toEqual([]);
+    expect(mutator.mutate("a.agency:global:enabled", `"yes"`).diagnostics[0]?.code).toBe("type-mismatch");
+    expect(mutator.mutate("a.agency:global:n", `"six"`).diagnostics[0]?.code).toBe("type-mismatch");
+  });
+
+  it("records: wrong field type and unknown field rejected; nullable omission accepted", () => {
+    const set = setup(`type P = { name: string; age: number | null }
+optimize const p: P = { name: "a", age: 0 }
+node main() {}
+`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    expect(mutator.mutate("a.agency:global:p", `{ name: "b" }`).diagnostics).toEqual([]);
+    expect(mutator.mutate("a.agency:global:p", `{ name: 5 }`).diagnostics[0]?.code).toBe("type-mismatch");
+    expect(mutator.mutate("a.agency:global:p", `{ name: "b", zzz: 1 }`).diagnostics[0]?.code).toBe("type-mismatch");
+  });
+
+  it("rejects interpolated strings in typed values with an honest message", () => {
+    const set = setup(`type Status = "pass" | "fail"\noptimize const status: Status = "pass"\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    const diagnostic = mutator.mutate("a.agency:global:status", `"pass \${x}"`).diagnostics[0];
+    expect(diagnostic?.code).toBe("type-mismatch");
+    expect(diagnostic?.message.toLowerCase()).toContain("interpolat");
+  });
+
+  it("unconstrained literal target (failed baseline) accepts any literal, still not garbage", () => {
+    const set = setup(`optimize const x: NotDefined = 5\nnode main() {}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    expect(mutator.mutate("a.agency:global:x", `"anything"`).diagnostics).toEqual([]);
+    expect(mutator.mutate("a.agency:global:x", `{{{`).diagnostics[0]?.code).toBe("invalid-replacement-syntax");
+  });
+
+  it("writes a typed replacement into the rendered candidate", () => {
+    const set = setup(`optimize const enabled: boolean = false\nnode main() {\n  return enabled\n}\n`);
+    const mutator = new OptimizeSourceMutator({ targetSet: set });
+
+    const preview = mutator.mutate("a.agency:global:enabled", `true`);
+    expect(preview.diagnostics).toEqual([]);
+    expect(preview.files["a.agency"]).toContain("optimize const enabled: boolean = true");
+    const refreshed = preview.targetSet.targets.find((target) => target.name === "enabled")!;
+    expect(refreshed.value).toBe("true");
+  });
+});

--- a/packages/agency-lang/lib/optimize/sourceMutator.ts
+++ b/packages/agency-lang/lib/optimize/sourceMutator.ts
@@ -266,7 +266,7 @@ export class OptimizeSourceMutator {
     for (const entry of fileOperations) entriesById[entry.target.id] = entry;
 
     let replacedCount = 0;
-    for (const { target, assignment } of collectTargets(program, file, sourceFile.absoluteFile)) {
+    for (const { target, assignment } of collectTargets(program, file, sourceFile.absoluteFile, this.targetSet.typeAliases)) {
       const entry = entriesById[target.id];
       if (!entry) continue;
       assignment.value = entry.replacement;
@@ -284,7 +284,7 @@ export class OptimizeSourceMutator {
     if (!reparsed.success) {
       return errorDiagnostic(file, `Rendered candidate for ${file} does not parse: ${reparsed.message ?? "parse error"}`);
     }
-    const refreshedTargets = collectTargets(reparsed.result, file, sourceFile.absoluteFile)
+    const refreshedTargets = collectTargets(reparsed.result, file, sourceFile.absoluteFile, this.targetSet.typeAliases)
       .map((entry) => entry.target);
 
     return { rendered, refreshedTargets };

--- a/packages/agency-lang/lib/optimize/sourceMutator.ts
+++ b/packages/agency-lang/lib/optimize/sourceMutator.ts
@@ -7,6 +7,7 @@ import { exprParser } from "@/parsers/parsers.js";
 import type { AgencyProgram, Expression, PromptSegment } from "@/types.js";
 import { formatDiff } from "@/utils/diff.js";
 
+import { checkProposal, hasInterpolation, isLiteralExpression } from "./constraint.js";
 import {
   collectTargets,
   promptSegmentsToString,
@@ -75,6 +76,7 @@ export type OptimizeMutationDiagnostic = {
     | "invalid-replacement-syntax"
     | "unsupported-value-domain"
     | "interpolation-mismatch"
+    | "type-mismatch"
     | "duplicate-target-operation"
     | "parse-failed";
   message: string;
@@ -124,7 +126,7 @@ export type OptimizeMutationPreview = {
 type ResolvedOperation = {
   operation: ReplaceVariableInitializerOperation;
   target: OptimizeTarget;
-  replacement: Expression & { segments: PromptSegment[] };
+  replacement: Expression;
   newValue: string;
 };
 
@@ -353,8 +355,9 @@ export class OptimizeSourceMutator {
     operation: ReplaceVariableInitializerOperation,
     target: OptimizeTarget,
   ): ValidationOutcome {
+    const isFreeformText = target.valueKind !== "literal" && target.constraintText === null;
     let parsed = exprParser(operation.value);
-    if (!parsed.success || parsed.rest.trim() !== "") {
+    if ((!parsed.success || parsed.rest.trim() !== "") && target.valueKind !== "literal") {
       // The model frequently returns the raw prompt text without the surrounding
       // quotes. Recover by wrapping it in the target's quote style and re-parsing.
       // This is self-validating — values that don't wrap into a clean single
@@ -362,20 +365,60 @@ export class OptimizeSourceMutator {
       // fall through to the diagnostic, so we never emit broken source.
       const quote = target.valueKind === "multilineString" ? `"""` : `"`;
       const wrapped = exprParser(`${quote}${operation.value}${quote}`);
-      if (!wrapped.success || wrapped.rest.trim() !== "") {
-        return diagnostic({ operation, code: "invalid-replacement-syntax", message: `Replacement value for ${operation.target} must be a quoted Agency string literal (e.g. "new prompt"), but it did not parse as one even after wrapping it in quotes. Received: ${JSON.stringify(operation.value)}` });
+      if (wrapped.success && wrapped.rest.trim() === "") parsed = wrapped;
+    }
+    if (!parsed.success || parsed.rest.trim() !== "") {
+      return diagnostic({ operation, code: "invalid-replacement-syntax", message: `Replacement value for ${operation.target} did not parse as an Agency expression. Received: ${JSON.stringify(operation.value)}` });
+    }
+    let replacement = parsed.result;
+    let proposalText = operation.value.trim();
+
+    if (isFreeformText) {
+      // Today's freeform path, byte-identical behavior.
+      if (replacement.type !== "string" && replacement.type !== "multiLineString") {
+        return diagnostic({ operation, code: "unsupported-value-domain", message: `Replacement value for ${operation.target} must be a string or multiline string expression; got ${replacement.type}.` });
       }
-      parsed = wrapped;
+      const newValue = promptSegmentsToString(replacement.segments);
+      const validation = validateOptimizedStringValue(target.value, newValue);
+      if (!validation.ok) {
+        return diagnostic({ operation, code: "interpolation-mismatch", message: `Replacement value for ${operation.target} is invalid: ${validation.reason}` });
+      }
+      return { resolved: { operation, target, replacement, newValue } };
     }
-    const replacement = parsed.result;
-    if (replacement.type !== "string" && replacement.type !== "multiLineString") {
-      return diagnostic({ operation, code: "unsupported-value-domain", message: `Replacement value for ${operation.target} must be a string or multiline string expression in v1; got ${replacement.type}.` });
+
+    // Typed values must be self-contained: the mutator cannot know what
+    // identifiers exist at the declaration site, and the probe's
+    // undefined-variable pass does not descend into interpolation segments.
+    if (hasInterpolation(replacement)) {
+      return diagnostic({ operation, code: "type-mismatch", message: `Replacement value for ${operation.target} contains interpolations (\${...}); interpolated strings are not supported in typed optimize values.` });
     }
-    const newValue = promptSegmentsToString(replacement.segments);
-    const validation = validateOptimizedStringValue(target.value, newValue);
-    if (!validation.ok) {
-      return diagnostic({ operation, code: "interpolation-mismatch", message: `Replacement value for ${operation.target} is invalid: ${validation.reason}` });
+
+    // Literal gate. The probe cannot enforce this — an unknown bare
+    // identifier synthesizes to `any` and typechecks clean — so a bare-word
+    // proposal (`fail` instead of `"fail"`) is recovered by quoting, and
+    // anything else non-literal is rejected outright.
+    if (!isLiteralExpression(replacement)) {
+      const quoted = `"${proposalText}"`;
+      const reparsed = exprParser(quoted);
+      if (!reparsed.success || reparsed.rest.trim() !== "" || reparsed.result.type !== "string") {
+        return diagnostic({ operation, code: "unsupported-value-domain", message: `Replacement value for ${operation.target} must be a literal (string, number, boolean, null, object, or array); got ${replacement.type}.` });
+      }
+      replacement = reparsed.result;
+      proposalText = quoted;
     }
+
+    if (target.constraintText !== null) {
+      const check = checkProposal(target.constraintText, proposalText, this.targetSet.typeAliases);
+      if (!check.ok) {
+        return diagnostic({ operation, code: "type-mismatch", message: `Replacement value for ${operation.target} does not fit its type ${target.constraintText}: ${check.reason}` });
+      }
+    }
+    // constraintText === null with valueKind "literal": unconstrained — any
+    // parsed literal passes through.
+
+    const newValue = (replacement.type === "string" || replacement.type === "multiLineString")
+      ? promptSegmentsToString(replacement.segments)
+      : proposalText;
     return { resolved: { operation, target, replacement, newValue } };
   }
 }

--- a/packages/agency-lang/lib/optimize/sourceMutator.ts
+++ b/packages/agency-lang/lib/optimize/sourceMutator.ts
@@ -7,7 +7,9 @@ import { exprParser } from "@/parsers/parsers.js";
 import type { AgencyProgram, Expression, PromptSegment } from "@/types.js";
 import { formatDiff } from "@/utils/diff.js";
 
-import { checkProposal, hasInterpolation, isLiteralExpression } from "./constraint.js";
+import { generateExpression } from "@/backends/agencyGenerator.js";
+import { hasInterpolation, isLiteralExpression } from "@/utils/node.js";
+import { checkProposal } from "./constraint.js";
 import {
   collectTargets,
   promptSegmentsToString,
@@ -21,7 +23,9 @@ import { validateOptimizedStringValue } from "./validation.js";
 /**
  * Replaces an optimized variable's initializer expression. `value` is
  * Agency source text including the quotes; `expected` optionally guards
- * against stale catalogs by matching the target's current decoded value.
+ * against stale catalogs by matching the target's current value — the
+ * decoded text for string targets, the formatter-exact source text
+ * (quotes intact) for literal targets, i.e. exactly `OptimizeTarget.value`.
  *
  * ```ts
  * { target: "foo.agency:bar:prompt", kind: "variable", op: "replaceInitializer",
@@ -83,8 +87,10 @@ export type OptimizeMutationDiagnostic = {
 };
 
 /**
- * The target-level record of one applied operation, with decoded old/new
- * values (no quotes), as written to `mutation.json`.
+ * The target-level record of one applied operation, as written to
+ * `mutation.json`. Old/new values use the target's value representation:
+ * decoded text (no quotes) for string targets, formatter-exact source
+ * text for literal targets.
  *
  * ```ts
  * { target: "foo.agency:bar:prompt", kind: "variable", op: "replaceInitializer",
@@ -268,7 +274,7 @@ export class OptimizeSourceMutator {
     for (const entry of fileOperations) entriesById[entry.target.id] = entry;
 
     let replacedCount = 0;
-    for (const { target, assignment } of collectTargets(program, file, sourceFile.absoluteFile, this.targetSet.typeAliases)) {
+    for (const { target, assignment } of collectTargets(program, file, sourceFile.absoluteFile, this.targetSet.typeAliases, this.targetsById)) {
       const entry = entriesById[target.id];
       if (!entry) continue;
       assignment.value = entry.replacement;
@@ -286,7 +292,7 @@ export class OptimizeSourceMutator {
     if (!reparsed.success) {
       return errorDiagnostic(file, `Rendered candidate for ${file} does not parse: ${reparsed.message ?? "parse error"}`);
     }
-    const refreshedTargets = collectTargets(reparsed.result, file, sourceFile.absoluteFile, this.targetSet.typeAliases)
+    const refreshedTargets = collectTargets(reparsed.result, file, sourceFile.absoluteFile, this.targetSet.typeAliases, this.targetsById)
       .map((entry) => entry.target);
 
     return { rendered, refreshedTargets };
@@ -355,7 +361,7 @@ export class OptimizeSourceMutator {
     operation: ReplaceVariableInitializerOperation,
     target: OptimizeTarget,
   ): ValidationOutcome {
-    const isFreeformText = target.valueKind !== "literal" && target.constraintText === null;
+    const isFreeformText = target.valueKind !== "literal" && target.declaredType === null;
     let parsed = exprParser(operation.value);
     if ((!parsed.success || parsed.rest.trim() !== "") && target.valueKind !== "literal") {
       // The model frequently returns the raw prompt text without the surrounding
@@ -368,10 +374,14 @@ export class OptimizeSourceMutator {
       if (wrapped.success && wrapped.rest.trim() === "") parsed = wrapped;
     }
     if (!parsed.success || parsed.rest.trim() !== "") {
-      return diagnostic({ operation, code: "invalid-replacement-syntax", message: `Replacement value for ${operation.target} did not parse as an Agency expression. Received: ${JSON.stringify(operation.value)}` });
+      // Keep the text-target message prescriptive — it is retry feedback the
+      // mutator LLM acts on, and "send a quoted string" is the actual fix.
+      const message = target.valueKind === "literal"
+        ? `Replacement value for ${operation.target} did not parse as an Agency expression. Received: ${JSON.stringify(operation.value)}`
+        : `Replacement value for ${operation.target} must be a quoted Agency string literal (e.g. "new prompt"), but it did not parse as one even after wrapping it in quotes. Received: ${JSON.stringify(operation.value)}`;
+      return diagnostic({ operation, code: "invalid-replacement-syntax", message });
     }
     let replacement = parsed.result;
-    let proposalText = operation.value.trim();
 
     if (isFreeformText) {
       // Today's freeform path, byte-identical behavior.
@@ -393,27 +403,33 @@ export class OptimizeSourceMutator {
       return diagnostic({ operation, code: "type-mismatch", message: `Replacement value for ${operation.target} contains interpolations (\${...}); interpolated strings are not supported in typed optimize values.` });
     }
 
-    // Literal gate. The probe cannot enforce this — an unknown bare
-    // identifier synthesizes to `any` and typechecks clean — so a bare-word
-    // proposal (`fail` instead of `"fail"`) is recovered by quoting, and
-    // anything else non-literal is rejected outright.
+    // Literal gate, recursive. The probe cannot enforce this — an unknown
+    // bare identifier (top-level or nested inside a container) synthesizes
+    // to `any` and typechecks clean — so a bare-word proposal (`fail`
+    // instead of `"fail"`) is recovered by quoting, and anything else
+    // non-literal is rejected outright.
     if (!isLiteralExpression(replacement)) {
-      const quoted = `"${proposalText}"`;
-      const reparsed = exprParser(quoted);
-      if (!reparsed.success || reparsed.rest.trim() !== "" || reparsed.result.type !== "string") {
-        return diagnostic({ operation, code: "unsupported-value-domain", message: `Replacement value for ${operation.target} must be a literal (string, number, boolean, null, object, or array); got ${replacement.type}.` });
+      const quoted = replacement.type === "variableName" ? `"${operation.value.trim()}"` : null;
+      const reparsed = quoted === null ? null : exprParser(quoted);
+      if (!reparsed || !reparsed.success || reparsed.rest.trim() !== "" || reparsed.result.type !== "string") {
+        return diagnostic({ operation, code: "unsupported-value-domain", message: `Replacement value for ${operation.target} must be a literal (string, number, boolean, null, object, or array) with no variable references; got ${replacement.type}.` });
       }
       replacement = reparsed.result;
-      proposalText = quoted;
     }
 
-    if (target.constraintText !== null) {
-      const check = checkProposal(target.constraintText, proposalText, this.targetSet.typeAliases);
+    // Probe EXACTLY the value that will be written: the formatter rendering
+    // of the (possibly quote-recovered) replacement. Probing the raw
+    // operation text instead would diverge after recovery — an unquoted
+    // multi-word proposal would probe as a bare identifier plus a stray
+    // statement and falsely typecheck clean.
+    const proposalText = generateExpression(replacement);
+    if (target.declaredType !== null) {
+      const check = checkProposal(target.declaredType, proposalText, this.targetSet.typeAliases);
       if (!check.ok) {
-        return diagnostic({ operation, code: "type-mismatch", message: `Replacement value for ${operation.target} does not fit its type ${target.constraintText}: ${check.reason}` });
+        return diagnostic({ operation, code: "type-mismatch", message: `Replacement value for ${operation.target} does not fit its type ${target.declaredType}: ${check.reason}` });
       }
     }
-    // constraintText === null with valueKind "literal": unconstrained — any
+    // declaredType === null with valueKind "literal": unconstrained — any
     // parsed literal passes through.
 
     const newValue = (replacement.type === "string" || replacement.type === "multiLineString")

--- a/packages/agency-lang/lib/optimize/targets.test.ts
+++ b/packages/agency-lang/lib/optimize/targets.test.ts
@@ -288,6 +288,20 @@ node main() {
     );
   });
 
+  it("exposes aliases from the whole import closure, including imported ones", () => {
+    const dir = fs.realpathSync(makeTempDir());
+    writeAgency(dir, "types.agency", `export type Status = "pass" | "fail"\n`);
+    const entry = writeAgency(dir, "agent.agency", `
+import { Status } from "./types.agency"
+optimize const status: Status = "pass"
+node main() {}
+`);
+
+    const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
+
+    expect(targetSet.typeAliases.Status?.body.type).toBe("unionType");
+  });
+
   it("rejects legacy @optimize tags", () => {
     const dir = makeTempDir();
     const entry = writeAgency(dir, "foo.agency", `

--- a/packages/agency-lang/lib/optimize/targets.test.ts
+++ b/packages/agency-lang/lib/optimize/targets.test.ts
@@ -315,7 +315,7 @@ node main() {}
     const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
     const target = targetSet.targets.find((candidate) => candidate.name === "p")!;
 
-    expect(target.constraintText).toBeNull();
+    expect(target.declaredType).toBeNull();
     expect(target.valueKind).toBe("string");
     expect(target.value).toBe("hi ${x}");
   });
@@ -326,7 +326,7 @@ node main() {}
 
     const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
 
-    expect(targetSet.targets[0].constraintText).toBeNull();
+    expect(targetSet.targets[0].declaredType).toBeNull();
   });
 
   it("constrains an annotated boolean; value is the exact source text", () => {
@@ -338,7 +338,7 @@ node main() {}
 
     expect(target.valueKind).toBe("literal");
     expect(target.value).toBe("false");
-    expect(target.constraintText).toBe("boolean");
+    expect(target.declaredType).toBe("boolean");
   });
 
   it("preserves quotes in a record target's value (formatter-exact rendering)", () => {
@@ -355,7 +355,7 @@ node main() {}
     // is that string field values keep their quotes — `"foo"`, not `foo`.
     expect(target.value).toBe(`{\n  name: "foo",\n  age: 0\n}`);
     expect(target.value).toContain(`"foo"`);
-    expect(target.constraintText).toBe("Person");
+    expect(target.declaredType).toBe("Person");
   });
 
   it("accepts a null initializer (variableName representation)", () => {
@@ -379,7 +379,7 @@ node main() {}
     const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
     const target = targetSet.targets.find((candidate) => candidate.name === "x")!;
 
-    expect(target.constraintText).toBeNull();
+    expect(target.declaredType).toBeNull();
     expect(target.valueKind).toBe("literal");
   });
 

--- a/packages/agency-lang/lib/optimize/targets.test.ts
+++ b/packages/agency-lang/lib/optimize/targets.test.ts
@@ -266,7 +266,7 @@ node main() {
     );
   });
 
-  it("rejects unsupported initializer values", () => {
+  it("requires an annotation for non-string literal initializers (v1)", () => {
     const dir = makeTempDir();
     const entry = writeAgency(dir, "foo.agency", `
 node main() {
@@ -275,16 +275,22 @@ node main() {
 `);
 
     expect(() => discoverOptimizeTargets(entry, { baseDir: dir })).toThrow(
-      /only string and multiline string initializers are supported/i,
+      /needs a type annotation/i,
     );
   });
 
-  it("rejects optimize declarations with non-string initializers", () => {
+  it("rejects non-literal initializers", () => {
     const dir = makeTempDir();
-    const entry = writeAgency(dir, "foo.agency", "optimize const limit = 42\n");
+    const entry = writeAgency(dir, "foo.agency", `
+def f(): number {
+  return 1
+}
+optimize const x = f()
+node main() {}
+`);
 
     expect(() => discoverOptimizeTargets(entry, { baseDir: dir })).toThrow(
-      /Unsupported optimize target foo\.agency:global:limit/,
+      /must be a literal/i,
     );
   });
 
@@ -300,6 +306,81 @@ node main() {}
     const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
 
     expect(targetSet.typeAliases.Status?.body.type).toBe("unionType");
+  });
+
+  it("keeps a bare string target freeform (constraint null)", () => {
+    const dir = fs.realpathSync(makeTempDir());
+    const entry = writeAgency(dir, "a.agency", `optimize const p = "hi \${x}"\nnode main() {}\n`);
+
+    const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
+    const target = targetSet.targets.find((candidate) => candidate.name === "p")!;
+
+    expect(target.constraintText).toBeNull();
+    expect(target.valueKind).toBe("string");
+    expect(target.value).toBe("hi ${x}");
+  });
+
+  it("treats a plain string annotation as freeform", () => {
+    const dir = fs.realpathSync(makeTempDir());
+    const entry = writeAgency(dir, "a.agency", `optimize const p: string = "hi"\nnode main() {}\n`);
+
+    const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
+
+    expect(targetSet.targets[0].constraintText).toBeNull();
+  });
+
+  it("constrains an annotated boolean; value is the exact source text", () => {
+    const dir = fs.realpathSync(makeTempDir());
+    const entry = writeAgency(dir, "a.agency", `optimize const enabled: boolean = false\nnode main() {}\n`);
+
+    const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
+    const target = targetSet.targets.find((candidate) => candidate.name === "enabled")!;
+
+    expect(target.valueKind).toBe("literal");
+    expect(target.value).toBe("false");
+    expect(target.constraintText).toBe("boolean");
+  });
+
+  it("preserves quotes in a record target's value (formatter-exact rendering)", () => {
+    const dir = fs.realpathSync(makeTempDir());
+    const entry = writeAgency(dir, "a.agency", `type Person = { name: string; age: number }
+optimize const person: Person = { name: "foo", age: 0 }
+node main() {}
+`);
+
+    const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
+    const target = targetSet.targets.find((candidate) => candidate.name === "person")!;
+
+    // Formatter-canonical (multi-line) rendering; the load-bearing property
+    // is that string field values keep their quotes — `"foo"`, not `foo`.
+    expect(target.value).toBe(`{\n  name: "foo",\n  age: 0\n}`);
+    expect(target.value).toContain(`"foo"`);
+    expect(target.constraintText).toBe("Person");
+  });
+
+  it("accepts a null initializer (variableName representation)", () => {
+    const dir = fs.realpathSync(makeTempDir());
+    const entry = writeAgency(dir, "a.agency", `optimize const x: number | null = null\nnode main() {}\n`);
+
+    const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
+    const target = targetSet.targets.find((candidate) => candidate.name === "x")!;
+
+    expect(target.value).toBe("null");
+    expect(target.valueKind).toBe("literal");
+  });
+
+  it("BASELINE SELF-TEST: unconstrains a target whose own baseline fails its annotation", () => {
+    const dir = fs.realpathSync(makeTempDir());
+    // `NotDefined` is not in the closure — the original value cannot pass
+    // the probe, so the target must become unconstrained rather than
+    // un-mutatable. literal + null constraint = unconstrained, NOT freeform.
+    const entry = writeAgency(dir, "a.agency", `optimize const x: NotDefined = 5\nnode main() {}\n`);
+
+    const targetSet = discoverOptimizeTargets(entry, { baseDir: dir });
+    const target = targetSet.targets.find((candidate) => candidate.name === "x")!;
+
+    expect(target.constraintText).toBeNull();
+    expect(target.valueKind).toBe("literal");
   });
 
   it("rejects legacy @optimize tags", () => {

--- a/packages/agency-lang/lib/optimize/targets.ts
+++ b/packages/agency-lang/lib/optimize/targets.ts
@@ -7,7 +7,7 @@ import { parseAgency } from "@/parser.js";
 import { SymbolTable } from "@/symbolTable.js";
 import type { AgencyNode, AgencyProgram, Assignment, PromptSegment, TypeAliasEntry, VariableType } from "@/types.js";
 import { expressionToString, walkNodes } from "@/utils/node.js";
-import { checkProposal, isNullLiteral, renderConstraintText, renderLiteralSource } from "./constraint.js";
+import { checkProposal, isLiteralExpression, renderConstraintText, renderLiteralSource } from "./constraint.js";
 
 export type OptimizeTarget = {
   id: string;
@@ -255,8 +255,6 @@ function directOptimizeScope(ancestors: AgencyNode[]): string | null {
   return null;
 }
 
-const LITERAL_VALUE_TYPES = ["string", "multiLineString", "number", "boolean", "agencyObject", "agencyArray"];
-
 function buildTarget(
   assignment: Assignment,
   file: string,
@@ -265,7 +263,7 @@ function buildTarget(
   typeAliases: Record<string, TypeAliasEntry>,
 ): OptimizeTarget {
   const value = assignment.value;
-  if (value.type === "messageThread" || !(LITERAL_VALUE_TYPES.includes(value.type) || isNullLiteral(value))) {
+  if (value.type === "messageThread" || !isLiteralExpression(value)) {
     throw new Error(
       `Unsupported optimize target ${file}:${scope}:${assignment.variableName}. Its value must be a literal (string, number, boolean, null, object, or array).`,
     );

--- a/packages/agency-lang/lib/optimize/targets.ts
+++ b/packages/agency-lang/lib/optimize/targets.ts
@@ -1,9 +1,11 @@
 import crypto from "crypto";
 import fs from "fs";
 import path from "path";
+import { GLOBAL_SCOPE_KEY, buildCompilationUnit } from "@/compilationUnit.js";
 import { agencyImportTargets, resolveAgencyImportPath } from "@/importPaths.js";
 import { parseAgency } from "@/parser.js";
-import type { AgencyNode, AgencyProgram, Assignment, PromptSegment } from "@/types.js";
+import { SymbolTable } from "@/symbolTable.js";
+import type { AgencyNode, AgencyProgram, Assignment, PromptSegment, TypeAliasEntry } from "@/types.js";
 import { expressionToString, walkNodes } from "@/utils/node.js";
 
 export type OptimizeTarget = {
@@ -29,6 +31,11 @@ export type OptimizeTargetSet = {
   entryFile: string;
   files: Record<string, OptimizeSourceFile>;
   targets: OptimizeTarget[];
+  /** Global type aliases visible across the import closure, in the exact
+   *  registry shape the typechecker consumes (`TypeAliasEntry`). Built by the
+   *  compiler's own pipeline (SymbolTable + buildCompilationUnit), plain
+   *  data — serializable. Consumed by the typed-target probe (constraint.ts). */
+  typeAliases: Record<string, TypeAliasEntry>;
 };
 
 export type DiscoverOptimizeTargetsOptions = {
@@ -84,6 +91,7 @@ function buildTargetSet(
   baseDir: string,
   parsedFiles: ParsedSourceFile[],
 ): OptimizeTargetSet {
+  const typeAliases = collectClosureTypeAliases(absoluteEntryFile, parsedFiles);
 
   const files: Record<string, OptimizeSourceFile> = {};
   const targets: OptimizeTarget[] = [];
@@ -107,7 +115,40 @@ function buildTargetSet(
     entryFile: relativeFile(baseDir, absoluteEntryFile),
     files,
     targets,
+    typeAliases,
   };
+}
+
+/**
+ * Global type aliases visible across the entry file's import closure, built
+ * with the compiler's own pipeline (SymbolTable stitches imported/re-exported
+ * aliases into the compilation unit) rather than a hand-rolled walk. Only the
+ * global scope matters here: optimize targets constrain top-level literal
+ * initializers, and the probe (constraint.ts) checks them in a synthetic
+ * top-level program.
+ */
+function collectClosureTypeAliases(
+  absoluteEntryFile: string,
+  parsedFiles: ParsedSourceFile[],
+): Record<string, TypeAliasEntry> {
+  const entry = parsedFiles.find((parsed) => parsed.absoluteFile === fs.realpathSync(absoluteEntryFile));
+  if (!entry) return {};
+  // SymbolTable.build is stricter than this file's own closure walk: it
+  // follows pkg:: imports and validates re-exported symbols, either of which
+  // can throw on programs that discovery deliberately tolerates. A missing
+  // registry only DEGRADES typed targets to unconstrained (via the baseline
+  // self-test in constraint resolution) — it must never fail discovery.
+  try {
+    const symbolTable = SymbolTable.build(absoluteEntryFile);
+    const unit = buildCompilationUnit(entry.program, symbolTable, entry.absoluteFile, entry.source);
+    return unit.typeAliases.visibleIn(GLOBAL_SCOPE_KEY);
+  } catch (error) {
+    console.warn(
+      `optimize discovery: could not build the type-alias registry for ${absoluteEntryFile} (typed targets will be unconstrained): ${error instanceof Error ? error.message : String(error)}`,
+    );
+    const unit = buildCompilationUnit(entry.program);
+    return unit.typeAliases.visibleIn(GLOBAL_SCOPE_KEY);
+  }
 }
 
 type ParsedSourceFile = {

--- a/packages/agency-lang/lib/optimize/targets.ts
+++ b/packages/agency-lang/lib/optimize/targets.ts
@@ -5,8 +5,9 @@ import { GLOBAL_SCOPE_KEY, buildCompilationUnit } from "@/compilationUnit.js";
 import { agencyImportTargets, resolveAgencyImportPath } from "@/importPaths.js";
 import { parseAgency } from "@/parser.js";
 import { SymbolTable } from "@/symbolTable.js";
-import type { AgencyNode, AgencyProgram, Assignment, PromptSegment, TypeAliasEntry } from "@/types.js";
+import type { AgencyNode, AgencyProgram, Assignment, PromptSegment, TypeAliasEntry, VariableType } from "@/types.js";
 import { expressionToString, walkNodes } from "@/utils/node.js";
+import { checkProposal, isNullLiteral, renderConstraintText, renderLiteralSource } from "./constraint.js";
 
 export type OptimizeTarget = {
   id: string;
@@ -15,8 +16,16 @@ export type OptimizeTarget = {
   absoluteFile: string;
   scope: string;
   name: string;
-  valueKind: "string" | "multilineString";
+  valueKind: "string" | "multilineString" | "literal";
+  /** Decoded text for text targets (interpolations rendered as `${...}` —
+   *  the `expected`-guard contract); the EXACT source slice, quotes intact,
+   *  for literal targets. */
   value: string;
+  /** Parseable type text proposals are probed against (constraint.ts).
+   *  `null` means FREEFORM for text targets (today's string-only semantics,
+   *  interpolation rule and all) and UNCONSTRAINED for literal targets (any
+   *  literal accepted). Consumers must branch on `valueKind` first. */
+  constraintText: string | null;
 };
 
 export type OptimizeSourceFile = {
@@ -104,7 +113,10 @@ function buildTargetSet(
       sha256: sha256Text(parsed.source),
     };
     rejectLegacyOptimizeTags(parsed.program, file);
-    targets.push(...collectTargets(parsed.program, file, parsed.absoluteFile).map((entry) => entry.target));
+    targets.push(
+      ...collectTargets(parsed.program, file, parsed.absoluteFile, typeAliases)
+        .map((entry) => entry.target),
+    );
   }
 
   targets.sort((a, b) => a.id.localeCompare(b.id));
@@ -213,6 +225,7 @@ export function collectTargets(
   program: AgencyProgram,
   file: string,
   absoluteFile: string,
+  typeAliases: Record<string, TypeAliasEntry>,
 ): OptimizeTargetNode[] {
   const collected: OptimizeTargetNode[] = [];
   for (const { node, ancestors } of walkNodes(program.nodes)) {
@@ -225,7 +238,10 @@ export function collectTargets(
       );
     }
 
-    collected.push({ target: buildTarget(node, file, absoluteFile, scope), assignment: node });
+    collected.push({
+      target: buildTarget(node, file, absoluteFile, scope, typeAliases),
+      assignment: node,
+    });
   }
   return collected;
 }
@@ -239,15 +255,38 @@ function directOptimizeScope(ancestors: AgencyNode[]): string | null {
   return null;
 }
 
+const LITERAL_VALUE_TYPES = ["string", "multiLineString", "number", "boolean", "agencyObject", "agencyArray"];
+
 function buildTarget(
   assignment: Assignment,
   file: string,
   absoluteFile: string,
   scope: string,
+  typeAliases: Record<string, TypeAliasEntry>,
 ): OptimizeTarget {
-  if (assignment.value.type !== "string" && assignment.value.type !== "multiLineString") {
+  const value = assignment.value;
+  if (value.type === "messageThread" || !(LITERAL_VALUE_TYPES.includes(value.type) || isNullLiteral(value))) {
     throw new Error(
-      `Unsupported optimize target ${file}:${scope}:${assignment.variableName}. Only string and multiline string initializers are supported today.`,
+      `Unsupported optimize target ${file}:${scope}:${assignment.variableName}. Its value must be a literal (string, number, boolean, null, object, or array).`,
+    );
+  }
+
+  const isText = value.type === "string" || value.type === "multiLineString";
+  const valueKind: OptimizeTarget["valueKind"] = value.type === "multiLineString"
+    ? "multilineString"
+    : value.type === "string" ? "string" : "literal";
+
+  // Text targets keep the decoded representation (the `expected`-guard
+  // contract). Literal targets carry formatter-exact source text, quotes
+  // intact — parsed initializer nodes have no loc offsets to slice by.
+  const valueSource = renderLiteralSource(value);
+  const valueText = isText
+    ? promptSegmentsToString(value.segments)
+    : valueSource;
+
+  if (!isText && !assignment.typeHint) {
+    throw new Error(
+      `Optimize target ${file}:${scope}:${assignment.variableName} is a non-string literal and needs a type annotation, e.g. \`optimize const ${assignment.variableName}: number = ${valueText}\`.`,
     );
   }
 
@@ -258,9 +297,31 @@ function buildTarget(
     absoluteFile,
     scope,
     name: assignment.variableName,
-    valueKind: assignment.value.type === "multiLineString" ? "multilineString" : "string",
-    value: promptSegmentsToString(assignment.value.segments),
+    valueKind,
+    value: valueText,
+    constraintText: resolveConstraintText(assignment.typeHint, valueSource, typeAliases),
   };
+}
+
+/**
+ * The type text stored on a target, or null (freeform for text targets,
+ * unconstrained for literal targets). Two rules beyond "use the annotation":
+ * a plain `string` annotation is freeform, and the BASELINE SELF-TEST — if
+ * the target's ORIGINAL initializer does not pass the probe against its own
+ * annotation (unresolvable alias, exotic type, unrenderable annotation, a
+ * pre-existing type warning the user tolerates), the target is unconstrained
+ * so mutations are never blocked by a rule the baseline itself fails.
+ */
+function resolveConstraintText(
+  typeHint: VariableType | undefined,
+  originalValueSource: string,
+  typeAliases: Record<string, TypeAliasEntry>,
+): string | null {
+  if (!typeHint) return null;
+  if (typeHint.type === "primitiveType" && typeHint.value === "string") return null;
+  const text = renderConstraintText(typeHint);
+  if (!checkProposal(text, originalValueSource, typeAliases).ok) return null;
+  return text;
 }
 
 function rejectDuplicateTargetIds(targets: OptimizeTarget[]): void {

--- a/packages/agency-lang/lib/optimize/targets.ts
+++ b/packages/agency-lang/lib/optimize/targets.ts
@@ -6,8 +6,9 @@ import { agencyImportTargets, resolveAgencyImportPath } from "@/importPaths.js";
 import { parseAgency } from "@/parser.js";
 import { SymbolTable } from "@/symbolTable.js";
 import type { AgencyNode, AgencyProgram, Assignment, PromptSegment, TypeAliasEntry, VariableType } from "@/types.js";
-import { expressionToString, walkNodes } from "@/utils/node.js";
-import { checkProposal, isLiteralExpression, renderConstraintText, renderLiteralSource } from "./constraint.js";
+import { generateExpression } from "@/backends/agencyGenerator.js";
+import { expressionToString, isLiteralExpression, walkNodes } from "@/utils/node.js";
+import { checkProposal, renderDeclaredType } from "./constraint.js";
 
 export type OptimizeTarget = {
   id: string;
@@ -25,7 +26,7 @@ export type OptimizeTarget = {
    *  `null` means FREEFORM for text targets (today's string-only semantics,
    *  interpolation rule and all) and UNCONSTRAINED for literal targets (any
    *  literal accepted). Consumers must branch on `valueKind` first. */
-  constraintText: string | null;
+  declaredType: string | null;
 };
 
 export type OptimizeSourceFile = {
@@ -153,14 +154,21 @@ function collectClosureTypeAliases(
   try {
     const symbolTable = SymbolTable.build(absoluteEntryFile);
     const unit = buildCompilationUnit(entry.program, symbolTable, entry.absoluteFile, entry.source);
-    return unit.typeAliases.visibleIn(GLOBAL_SCOPE_KEY);
+    return nullPrototyped(unit.typeAliases.visibleIn(GLOBAL_SCOPE_KEY));
   } catch (error) {
     console.warn(
       `optimize discovery: could not build the type-alias registry for ${absoluteEntryFile} (typed targets will be unconstrained): ${error instanceof Error ? error.message : String(error)}`,
     );
     const unit = buildCompilationUnit(entry.program);
-    return unit.typeAliases.visibleIn(GLOBAL_SCOPE_KEY);
+    return nullPrototyped(unit.typeAliases.visibleIn(GLOBAL_SCOPE_KEY));
   }
+}
+
+/** Null-prototype copy: the registry is keyed by user-defined type names, so
+ *  a name like "__proto__" or "constructor" must land as a plain own
+ *  property (same hardening as optimize/registry.ts and evalCache.ts). */
+function nullPrototyped<T>(record: Record<string, T>): Record<string, T> {
+  return Object.assign(Object.create(null), record);
 }
 
 type ParsedSourceFile = {
@@ -226,6 +234,7 @@ export function collectTargets(
   file: string,
   absoluteFile: string,
   typeAliases: Record<string, TypeAliasEntry>,
+  priorTargets: Record<string, OptimizeTarget> = {},
 ): OptimizeTargetNode[] {
   const collected: OptimizeTargetNode[] = [];
   for (const { node, ancestors } of walkNodes(program.nodes)) {
@@ -239,7 +248,7 @@ export function collectTargets(
     }
 
     collected.push({
-      target: buildTarget(node, file, absoluteFile, scope, typeAliases),
+      target: buildTarget(node, file, absoluteFile, scope, typeAliases, priorTargets),
       assignment: node,
     });
   }
@@ -261,6 +270,7 @@ function buildTarget(
   absoluteFile: string,
   scope: string,
   typeAliases: Record<string, TypeAliasEntry>,
+  priorTargets: Record<string, OptimizeTarget>,
 ): OptimizeTarget {
   const value = assignment.value;
   if (value.type === "messageThread" || !isLiteralExpression(value)) {
@@ -269,27 +279,43 @@ function buildTarget(
     );
   }
 
-  const isText = value.type === "string" || value.type === "multiLineString";
-  const valueKind: OptimizeTarget["valueKind"] = value.type === "multiLineString"
-    ? "multilineString"
-    : value.type === "string" ? "string" : "literal";
+  const id = `${file}:${scope}:${assignment.variableName}`;
+
+  // A target's literal-vs-text identity and its constraint come from the
+  // DECLARATION, decided once at discovery. On refresh collects (the source
+  // mutator re-collecting after a mutation), the prior entry carries them:
+  // re-deriving the identity from the champion's current value would let an
+  // unconstrained literal target flip to freeform when a string value is
+  // accepted, and re-running the baseline self-test would re-typecheck every
+  // typed target on every preview. Within TEXT targets, the string /
+  // multilineString sub-flavor DOES track the current value — it selects the
+  // quote style unquoted proposals are recovered with.
+  const prior = priorTargets[id];
+  const isText = prior
+    ? prior.valueKind !== "literal"
+    : value.type === "string" || value.type === "multiLineString";
+  const valueKind: OptimizeTarget["valueKind"] = !isText
+    ? "literal"
+    : value.type === "multiLineString"
+      ? "multilineString"
+      : "string";
 
   // Text targets keep the decoded representation (the `expected`-guard
   // contract). Literal targets carry formatter-exact source text, quotes
   // intact — parsed initializer nodes have no loc offsets to slice by.
-  const valueSource = renderLiteralSource(value);
-  const valueText = isText
+  const valueSource = generateExpression(value);
+  const valueText = isText && (value.type === "string" || value.type === "multiLineString")
     ? promptSegmentsToString(value.segments)
     : valueSource;
 
-  if (!isText && !assignment.typeHint) {
+  if (!prior && !isText && !assignment.typeHint) {
     throw new Error(
       `Optimize target ${file}:${scope}:${assignment.variableName} is a non-string literal and needs a type annotation, e.g. \`optimize const ${assignment.variableName}: number = ${valueText}\`.`,
     );
   }
 
   return {
-    id: `${file}:${scope}:${assignment.variableName}`,
+    id,
     kind: "variable",
     file,
     absoluteFile,
@@ -297,7 +323,9 @@ function buildTarget(
     name: assignment.variableName,
     valueKind,
     value: valueText,
-    constraintText: resolveConstraintText(assignment.typeHint, valueSource, typeAliases),
+    declaredType: prior
+      ? prior.declaredType
+      : resolveDeclaredType(assignment.typeHint, valueSource, typeAliases),
   };
 }
 
@@ -310,14 +338,14 @@ function buildTarget(
  * pre-existing type warning the user tolerates), the target is unconstrained
  * so mutations are never blocked by a rule the baseline itself fails.
  */
-function resolveConstraintText(
+function resolveDeclaredType(
   typeHint: VariableType | undefined,
   originalValueSource: string,
   typeAliases: Record<string, TypeAliasEntry>,
 ): string | null {
   if (!typeHint) return null;
   if (typeHint.type === "primitiveType" && typeHint.value === "string") return null;
-  const text = renderConstraintText(typeHint);
+  const text = renderDeclaredType(typeHint);
   if (!checkProposal(text, originalValueSource, typeAliases).ok) return null;
   return text;
 }

--- a/packages/agency-lang/lib/optimize/workspace.test.ts
+++ b/packages/agency-lang/lib/optimize/workspace.test.ts
@@ -15,6 +15,7 @@ describe("WorkspaceManager", () => {
   const sourceFor = (file: string, source: string, sha: string): OptimizeTargetSet => ({
     baseDir: root,
     entryFile: "a.agency",
+    typeAliases: {},
     targets: [],
     files: { "a.agency": { file: "a.agency", absoluteFile: file, source, sha256: sha } },
   });

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -587,3 +587,67 @@ export function getAllVariablesInBodyArray(body: AgencyNode[]) {
   }
   return results;
 }
+
+/**
+ * The parser represents `null` as a variableName node — there is no
+ * `{ type: "null" }` in parser output. Single point of truth for the check
+ * so no caller ever tests `expr.type === "null"` (dead code).
+ */
+export function isNullLiteral(expr: Expression): boolean {
+  return expr.type === "variableName" && expr.value === "null";
+}
+
+/**
+ * True when the expression is a self-contained literal: string, number,
+ * boolean, null, or an object/array composed of literals all the way down.
+ * Used by the optimizer to gate targets and proposed values — the
+ * typechecker alone cannot enforce it, because an unknown bare identifier
+ * (top-level or nested in a container) synthesizes to `any` and passes
+ * typechecking unflagged.
+ */
+export function isLiteralExpression(expr: Expression): boolean {
+  switch (expr.type) {
+    case "string":
+    case "multiLineString":
+    case "number":
+    case "boolean":
+      return true;
+    case "agencyArray":
+      return expr.items.every((item) =>
+        item.type === "splat" ? isLiteralExpression(item.value) : isLiteralExpression(item),
+      );
+    case "agencyObject":
+      return expr.entries.every((entry) => {
+        if ("type" in entry && entry.type === "splat") return isLiteralExpression(entry.value);
+        const kv = entry as { value: Expression };
+        return isLiteralExpression(kv.value);
+      });
+    default:
+      return isNullLiteral(expr);
+  }
+}
+
+/**
+ * True when a literal expression contains a string interpolation anywhere —
+ * at top level or nested inside object/array literals. Structural traversal
+ * only — no type semantics.
+ */
+export function hasInterpolation(expr: Expression): boolean {
+  switch (expr.type) {
+    case "string":
+    case "multiLineString":
+      return expr.segments.some((segment) => segment.type !== "text");
+    case "agencyArray":
+      return expr.items.some((item) =>
+        item.type === "splat" ? hasInterpolation(item.value) : hasInterpolation(item),
+      );
+    case "agencyObject":
+      return expr.entries.some((entry) => {
+        if ("type" in entry && entry.type === "splat") return hasInterpolation(entry.value);
+        const kv = entry as { value: Expression };
+        return hasInterpolation(kv.value);
+      });
+    default:
+      return false;
+  }
+}


### PR DESCRIPTION
## What

`optimize const` targets can now be any literal type — string unions, numbers, booleans, records, arrays — and every value the mutator proposes is validated against the declared type before it is ever written into a candidate.

```ts
type Strategy = "fast" | "cheap" | "thorough"

optimize const strategy: Strategy = "fast"     // proposals must be one of the three
optimize const maxRetries: number = 2          // "three" is rejected, 3 is accepted
optimize const style = "Be concise."           // freeform strings unchanged
```

## How: the language is the judge

There is no hand-written shape checker. Validation is a **one-line probe program**: the proposal is spliced into `const __optimizeProbe: <Type> = <value>` and run through the public `typeCheck()` with a minimal compilation unit carrying the closure's type-alias registry (built by the compiler's own `SymbolTable.build` + `buildCompilationUnit` at discovery). The probe is parsed and typechecked in memory — never executed — and the checker's first diagnostic doubles as the retry feedback the mutator LLM sees. This buys the real record semantics for free: union membership through aliases (including imported ones), nullable-field omission, explicit `null`, and unknown-field rejection.

Design decisions (from the reviewed plan, rev 3):

- **Annotation required in v1.** Non-string literal targets must be annotated; there is no inference. `optimize const n = 5` errors with a fix-it message.
- **Baseline self-test.** If a target's *own initializer* does not pass the probe against its annotation (unresolvable alias, exotic type, pre-existing warning), the target is left unconstrained instead of blocked — the optimizer can never reject a value shaped like the one the user already wrote. This one rule replaces all per-type-variant special-casing.
- **`constraintText: null` is disambiguated by `valueKind`**: freeform for text targets (today's behavior, byte-identical path), unconstrained for literal targets.
- Two gates the probe cannot provide (verified empirically): interpolated strings are rejected in typed values (the undefined-variable pass does not descend into interpolation segments), and proposals must be literals (an unknown bare identifier synthesizes to `any` and typechecks clean) — with bare-word recovery, so an unquoted `fail` is requoted rather than rejected.
- Literal target values carry formatter-exact source text via the public `AgencyGenerator.processNode` (initializer nodes have no `loc` offsets to slice by, and `expressionToString` drops string quotes).

## Known limitation (inherited, pinned as a tripwire test)

A record proposal containing an explicit `null` field skips the deep field check: `synthObject` degrades the literal to `any` when any field synthesizes `any`, and a bare `null` does (it is a `variableName` the scope cannot resolve). This fails open — it can admit an imperfect record, never reject a valid one. A one-line fix in `synthType` (special-casing `variableName "null"` to the null type) would tighten this for the whole language; happy to file it separately.

## Guarantee, end to end

`greedyReflective.test.ts` drives the real pipeline with a fake proposer that insists on an out-of-shape value: `propose` is retried to the attempt cap with the `type-mismatch` reason fed back into each retry's inputs, the iteration lands validation-failed, the champion stays at baseline, and no candidate agent file is ever materialized.

## Testing

- 308 optimizer unit tests green (28 new across `constraint.test.ts`, `targets.test.ts`, `sourceMutator.test.ts`, `mutator.test.ts`, `greedyReflective.test.ts`), full repo vitest suite green, `make` green, `lint:structure` green.
- Freeform string behavior is regression-gated by the pre-existing mutator tests (untouched and passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
