### PR TITLE
feat(littlesis): add std::data/people/littlesis connector

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -270,6 +270,10 @@ export default defineConfig({
                   text: "data/finance/dbnomics",
                   link: "/stdlib/data/finance/dbnomics",
                 },
+                {
+                  text: "data/people/littlesis",
+                  link: "/stdlib/data/people/littlesis",
+                },
               ],
             },
             { text: "date", link: "/stdlib/date" },

--- a/packages/agency-lang/docs/site/stdlib/capabilities.md
+++ b/packages/agency-lang/docs/site/stdlib/capabilities.md
@@ -85,7 +85,7 @@ Anything that talks to the outside world over the network.
 
 ```ts
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis>
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L45))

--- a/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
+++ b/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
@@ -292,7 +292,7 @@ Shared failure message for a failed LittleSis fetch. Pure.
 ### entityListFinalize
 
 ```ts
-entityListFinalize(fetchResult: any): Result
+entityListFinalize(fetchResult: any): Result<Entity[]>
 ```
 
 Turn a fetchJSON Result into an entity-list Result. Used by BOTH search and connections
@@ -304,14 +304,14 @@ Turn a fetchJSON Result into an entity-list Result. Used by BOTH search and conn
 |---|---|---|
 | fetchResult | `any` |  |
 
-**Returns:** `Result`
+**Returns:** `Result<Entity[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L228))
 
 ### entityFinalize
 
 ```ts
-entityFinalize(fetchResult: any): Result
+entityFinalize(fetchResult: any): Result<Entity>
 ```
 
 Turn a fetchJSON Result into a single-entity Result; missing data → failure. Pure.
@@ -322,14 +322,14 @@ Turn a fetchJSON Result into a single-entity Result; missing data → failure. P
 |---|---|---|
 | fetchResult | `any` |  |
 
-**Returns:** `Result`
+**Returns:** `Result<Entity>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L237))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L236))
 
 ### relationshipsFinalize
 
 ```ts
-relationshipsFinalize(fetchResult: any): Result
+relationshipsFinalize(fetchResult: any): Result<Relationship[]>
 ```
 
 Turn a fetchJSON Result into a relationships Result. Pure.
@@ -340,9 +340,9 @@ Turn a fetchJSON Result into a relationships Result. Pure.
 |---|---|---|
 | fetchResult | `any` |  |
 
-**Returns:** `Result`
+**Returns:** `Result<Relationship[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L251))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L250))
 
 ### littlesisSearch
 
@@ -368,7 +368,7 @@ Search LittleSis for people and organizations by name. Returns matching entities
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L258))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L257))
 
 ### littlesisEntity
 
@@ -391,7 +391,7 @@ Fetch one LittleSis entity by its numeric id (from littlesisSearch). Returns the
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L273))
 
 ### littlesisRelationships
 
@@ -419,7 +419,7 @@ List an entity's relationships (typed edges) by its id. Each edge carries the tw
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L286))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L285))
 
 ### littlesisConnections
 
@@ -445,4 +445,4 @@ List the entities connected to an entity (neighbors, by name), optionally filter
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L310))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L309))

--- a/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
+++ b/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
@@ -1,0 +1,448 @@
+---
+name: "littlesis"
+---
+
+# littlesis
+
+## LittleSis — people, organizations, and the ties between them
+
+  Query the [LittleSis](https://littlesis.org/api/) API — an open database of powerful
+  people and organizations and their **relationships** (employment, board seats,
+  ownership/investment, donations). Use this connector when the question is about *entities and
+  the edges between them* (who worked where, who funds whom, who sits on which board), as opposed
+  to macro numbers (`std::data/finance/fred`), company filings (`std::data/finance/edgar`), or
+  news (`std::data/finance/gdelt`).
+
+  No API key required (the API is rate-limited; HTTP 503 means "Rate Limit Exceeded").
+
+  **Two-step recipe.** LittleSis edges carry entity *IDs*, not names. So:
+  use `littlesisConnections` to see *who* an entity is tied to (neighbor entities **by name**,
+  filtered by category); use `littlesisRelationships` to get the *terms* of a tie (amount, dates,
+  roles). Resolve a name to an id first with `littlesisSearch`.
+
+  Relationship categories are friendly strings: `position` (employment/roles), `education`,
+  `membership`, `family`, `donation`, `transaction`, `lobbying`, `social`, `professional`,
+  `ownership`, `hierarchy`, `generic`.
+
+  ### Usage
+
+  ```ts
+  import { littlesisSearch, littlesisConnections } from "std::data/people/littlesis"
+
+  node main() {
+    const hits = littlesisSearch("Andreessen Horowitz") catch []
+    if (hits.length > 0) {
+      const linked = littlesisConnections(hits[0].id, "ownership") catch []
+      for (e in linked) { print("${e.type}  ${e.name}") }
+    }
+  }
+  ```
+
+## Types
+
+### Entity
+
+A LittleSis person or organization. `type` is "Person" or "Org" (from primary_ext).
+    `relationshipId`/`relationshipCategory` are populated only on connections results.
+
+```ts
+/** A LittleSis person or organization. `type` is "Person" or "Org" (from primary_ext).
+    `relationshipId`/`relationshipCategory` are populated only on connections results. */
+export type Entity = {
+  id: number;
+  name: string;
+  type: string;
+  blurb: string;
+  types: string[];
+  aliases: string[];
+  website: string;
+  url: string;
+  relationshipId?: number;
+  relationshipCategory: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L49))
+
+### Relationship
+
+One typed edge. entity1Id/entity2Id are LittleSis entity IDs, NOT names.
+
+```ts
+/** One typed edge. entity1Id/entity2Id are LittleSis entity IDs, NOT names. */
+export type Relationship = {
+  id: number;
+  category: string;
+  categoryId: number;
+  entity1Id: number;
+  entity2Id: number;
+  description1: string;
+  description2: string;
+  amount?: number;
+  startDate: string;
+  endDate: string;
+  isCurrent?: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L63))
+
+## Effects
+
+### std::littlesis
+
+```ts
+effect std::littlesis {
+  op: string;
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L39))
+
+## Functions
+
+### categoryIdToName
+
+```ts
+categoryIdToName(id: number): string
+```
+
+Map a LittleSis category_id (1–12) to its friendly name; unknown id → "". Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L78))
+
+### categoryNameToId
+
+```ts
+categoryNameToId(name: string): number
+```
+
+Map a friendly category name to its LittleSis category_id (1–12); unknown → -1. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+
+**Returns:** `number`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L86))
+
+### buildSearchPath
+
+```ts
+buildSearchPath(name: string, page: number): string
+```
+
+Build the entity-search path. `page` is appended only when > 1. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+| page | `number` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L95))
+
+### buildEntityPath
+
+```ts
+buildEntityPath(id: number): string
+```
+
+Build the single-entity path. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L104))
+
+### buildRelationshipsPath
+
+```ts
+buildRelationshipsPath(id: number, categoryId: number, sort: string): string
+```
+
+Build the relationships path. Appends category_id (when >= 1) and sort (when non-empty). Pure.
+    Builds a present-params list and joins it, so it scales linearly with params instead of
+    enumerating every on/off combination.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+| categoryId | `number` |  |
+| sort | `string` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L111))
+
+### buildConnectionsPath
+
+```ts
+buildConnectionsPath(id: number, categoryId: number): string
+```
+
+Build the connections path. Appends category_id when >= 1. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+| categoryId | `number` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L127))
+
+### parseEntity
+
+```ts
+parseEntity(node: any): Entity
+```
+
+Reshape one LittleSis entity node ({ id, attributes, links }) into an Entity.
+    Reads connection-only relationship fields defensively (null/"" when absent). Pure/total.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| node | `any` |  |
+
+**Returns:** [Entity](#entity)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L136))
+
+### parseEntities
+
+```ts
+parseEntities(raw: any): Entity[]
+```
+
+Reshape a LittleSis list body ({ data: [node] }) into Entity[]. Pure/total.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| raw | `any` |  |
+
+**Returns:** `Entity[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L156))
+
+### parseRelationships
+
+```ts
+parseRelationships(raw: any): Relationship[]
+```
+
+Reshape a LittleSis relationships body ({ data: [rel] }) into Relationship[]. Pure/total.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| raw | `any` |  |
+
+**Returns:** `Relationship[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L165))
+
+### littlesisError
+
+```ts
+littlesisError(err: any): string
+```
+
+Shared failure message for a failed LittleSis fetch. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| err | `any` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L189))
+
+### entityListFinalize
+
+```ts
+entityListFinalize(fetchResult: any): Result
+```
+
+Turn a fetchJSON Result into an entity-list Result. Used by BOTH search and connections
+    (identical shape). Pure — testable with mock Results.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| fetchResult | `any` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L229))
+
+### entityFinalize
+
+```ts
+entityFinalize(fetchResult: any): Result
+```
+
+Turn a fetchJSON Result into a single-entity Result; missing data → failure. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| fetchResult | `any` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L237))
+
+### relationshipsFinalize
+
+```ts
+relationshipsFinalize(fetchResult: any): Result
+```
+
+Turn a fetchJSON Result into a relationships Result. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| fetchResult | `any` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L251))
+
+### littlesisSearch
+
+```ts
+littlesisSearch(name: string, page: number): Result<Entity[]>
+```
+
+Search LittleSis for people and organizations by name. Returns matching entities (id, name,
+  type "Person"/"Org", blurb, aliases, website, url). Use the returned id with the other
+  littlesis functions. Empty result set returns an empty list.
+
+  @param name - The person or organization name to search for
+  @param page - Result page, 10 per page (default 1)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+| page | `number` | 1 |
+
+**Returns:** `Result<Entity[]>`
+
+**Throws:** `std::littlesis`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L258))
+
+### littlesisEntity
+
+```ts
+littlesisEntity(id: number): Result<Entity>
+```
+
+Fetch one LittleSis entity by its numeric id (from littlesisSearch). Returns the full profile
+  (name, type, blurb, aliases, website, url). Unknown id returns a failure.
+
+  @param id - The LittleSis entity id
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+
+**Returns:** `Result<Entity>`
+
+**Throws:** `std::littlesis`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L274))
+
+### littlesisRelationships
+
+```ts
+littlesisRelationships(id: number, category: string, sort: string): Result<Relationship[]>
+```
+
+List an entity's relationships (typed edges) by its id. Each edge carries the two entity IDs,
+  role labels (description1/description2), amount, dates, and category. Filter with a friendly
+  category name. Edges carry entity IDs, not names — use littlesisConnections for neighbor names.
+
+  @param id - The LittleSis entity id
+  @param category - Optional category filter: position, education, membership, family, donation, transaction, lobbying, social, professional, ownership, hierarchy, generic (empty = all)
+  @param sort - Optional sort: "amount", "oldest", or "recent" (empty = default)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+| category | `string` | "" |
+| sort | `string` | "" |
+
+**Returns:** `Result<Relationship[]>`
+
+**Throws:** `std::littlesis`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L286))
+
+### littlesisConnections
+
+```ts
+littlesisConnections(id: number, category: string): Result<Entity[]>
+```
+
+List the entities connected to an entity (neighbors, by name), optionally filtered by a
+  friendly category name. Lighter than littlesisRelationships and name-bearing — the preferred
+  first hop for "who is X tied to". Each result also carries the linking relationshipId/category.
+
+  @param id - The LittleSis entity id
+  @param category - Optional category filter: position, education, membership, family, donation, transaction, lobbying, social, professional, ownership, hierarchy, generic (empty = all)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+| category | `string` | "" |
+
+**Returns:** `Result<Entity[]>`
+
+**Throws:** `std::littlesis`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L310))

--- a/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
+++ b/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
@@ -87,6 +87,21 @@ export type Relationship = {
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L63))
 
+### CategoryFilter
+
+A category filter for relationship/connection queries: either "all" (no filter) or a specific
+    category by id. Produced by parseCategoryFilter, consumed by the path builders — this replaces
+    the old numeric sentinels (no more -1 for "invalid" or 0 for "all").
+
+```ts
+/** A category filter for relationship/connection queries: either "all" (no filter) or a specific
+    category by id. Produced by parseCategoryFilter, consumed by the path builders — this replaces
+    the old numeric sentinels (no more -1 for "invalid" or 0 for "all"). */
+export type CategoryFilter = { type: "all" } | { type: "category"; id: number }
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L80))
+
 ## Effects
 
 ### std::littlesis
@@ -118,15 +133,16 @@ Map a LittleSis category_id (1–12) to its friendly name; unknown id → "". Pu
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L83))
 
-### categoryNameToId
+### parseCategoryFilter
 
 ```ts
-categoryNameToId(name: string): number
+parseCategoryFilter(name: string): Result<CategoryFilter>
 ```
 
-Map a friendly category name to its LittleSis category_id (1–12); unknown → -1. Pure.
+Parse a friendly category name into a CategoryFilter. "" (or not given) → all; a valid name →
+    that category; an unknown name → failure (listing the valid names). Pure.
 
 **Parameters:**
 
@@ -134,9 +150,9 @@ Map a friendly category name to its LittleSis category_id (1–12); unknown → 
 |---|---|---|
 | name | `string` |  |
 
-**Returns:** `number`
+**Returns:** `Result<CategoryFilter>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L98))
 
 ### buildSearchPath
 
@@ -155,7 +171,7 @@ Build the entity-search path. `page` is appended only when > 1. Pure.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L110))
 
 ### buildEntityPath
 
@@ -173,48 +189,47 @@ Build the single-entity path. Pure.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L119))
 
 ### buildRelationshipsPath
 
 ```ts
-buildRelationshipsPath(id: number, categoryId: number, sort: string): string
+buildRelationshipsPath(id: number, filter: CategoryFilter, sort: string): string
 ```
 
-Build the relationships path. Appends category_id (when >= 1) and sort (when non-empty). Pure.
-    Builds a present-params list and joins it, so it scales linearly with params instead of
-    enumerating every on/off combination.
+Build the relationships path from a category filter and optional sort. Builds a present-params
+    list and joins it, so it scales linearly with params instead of enumerating combinations. Pure.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | id | `number` |  |
-| categoryId | `number` |  |
+| filter | [CategoryFilter](#categoryfilter) |  |
 | sort | `string` |  |
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L125))
 
 ### buildConnectionsPath
 
 ```ts
-buildConnectionsPath(id: number, categoryId: number): string
+buildConnectionsPath(id: number, filter: CategoryFilter): string
 ```
 
-Build the connections path. Appends category_id when >= 1. Pure.
+Build the connections path from a category filter. Pure.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | id | `number` |  |
-| categoryId | `number` |  |
+| filter | [CategoryFilter](#categoryfilter) |  |
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L141))
 
 ### parseEntity
 
@@ -233,7 +248,7 @@ Reshape one LittleSis entity node ({ id, attributes, links }) into an Entity.
 
 **Returns:** [Entity](#entity)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L136))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L150))
 
 ### parseEntities
 
@@ -251,7 +266,7 @@ Reshape a LittleSis list body ({ data: [node] }) into Entity[]. Pure/total.
 
 **Returns:** `Entity[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L170))
 
 ### parseRelationships
 
@@ -269,7 +284,7 @@ Reshape a LittleSis relationships body ({ data: [rel] }) into Relationship[]. Pu
 
 **Returns:** `Relationship[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L165))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L179))
 
 ### littlesisError
 
@@ -287,7 +302,7 @@ Shared failure message for a failed LittleSis fetch. Pure.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L189))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L203))
 
 ### entityListFinalize
 
@@ -306,7 +321,7 @@ Turn a fetchJSON Result into an entity-list Result. Used by BOTH search and conn
 
 **Returns:** `Result<Entity[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L228))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L223))
 
 ### entityFinalize
 
@@ -324,7 +339,7 @@ Turn a fetchJSON Result into a single-entity Result; missing data → failure. P
 
 **Returns:** `Result<Entity>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L236))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L231))
 
 ### relationshipsFinalize
 
@@ -342,7 +357,7 @@ Turn a fetchJSON Result into a relationships Result. Pure.
 
 **Returns:** `Result<Relationship[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L250))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L245))
 
 ### littlesisSearch
 
@@ -368,7 +383,7 @@ Search LittleSis for people and organizations by name. Returns matching entities
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L257))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L252))
 
 ### littlesisEntity
 
@@ -391,7 +406,7 @@ Fetch one LittleSis entity by its numeric id (from littlesisSearch). Returns the
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L273))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L268))
 
 ### littlesisRelationships
 
@@ -419,7 +434,7 @@ List an entity's relationships (typed edges) by its id. Each edge carries the tw
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L285))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L280))
 
 ### littlesisConnections
 
@@ -445,4 +460,4 @@ List the entities connected to an entity (neighbors, by name), optionally filter
 
 **Throws:** `std::littlesis`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L309))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/people/littlesis.agency#L304))

--- a/packages/agency-lang/stdlib/capabilities.agency
+++ b/packages/agency-lang/stdlib/capabilities.agency
@@ -42,7 +42,7 @@ export effectSet FileSystem = <FileRead, FileWrite>
 export effectSet Shell = <std::bash, std::exec, std::run>
 
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis>
 
 /** The std::data/finance connectors (news + macro + filings). Each also raises
     std::http::fetchJSON, which is covered by the broader Network set. */

--- a/packages/agency-lang/stdlib/data/people/littlesis.agency
+++ b/packages/agency-lang/stdlib/data/people/littlesis.agency
@@ -38,11 +38,11 @@ import { fetchJSON } from "std::http"
 
 effect std::littlesis { op: string, query: string }
 
-const LITTLESIS_BASE = "https://littlesis.org/api"
-const LITTLESIS_DOMAINS = ["littlesis.org"]
+static const LITTLESIS_BASE = "https://littlesis.org/api"
+static const LITTLESIS_DOMAINS = ["littlesis.org"]
 
 // Index 0 is unused ("" sentinel); indices 1–12 are LittleSis category_id values.
-const CATEGORY_NAMES = ["", "position", "education", "membership", "family", "donation", "transaction", "lobbying", "social", "professional", "ownership", "hierarchy", "generic"]
+static const CATEGORY_NAMES = ["", "position", "education", "membership", "family", "donation", "transaction", "lobbying", "social", "professional", "ownership", "hierarchy", "generic"]
 
 /** A LittleSis person or organization. `type` is "Person" or "Org" (from primary_ext).
     `relationshipId`/`relationshipCategory` are populated only on connections results. */
@@ -209,11 +209,10 @@ safe def resolveCategoryId(category: string): Result<number> {
   return success(id)
 }
 
-/** Fetch a LittleSis path and return the parsed-JSON Result. Option C: this raises
-    std::http::fetchJSON but approves it internally, so a plain caller sees only the connector's
-    std::littlesis prompt while any OUTER fetch handler still receives (and can reject/propagate)
-    the fetch — those beat this approve(). allowedDomains is enforced inside fetchJSON regardless.
-    Factored out so the Option-C gating "how" lives in ONE place. Private. */
+/** Fetch a LittleSis path and return the parsed-JSON Result. Raises std::http::fetchJSON but
+    approves it internally, so a plain caller sees only the connector's own std::littlesis prompt,
+    while any OUTER fetch handler still receives (and can reject or propagate) the fetch — those
+    beat this approve(). allowedDomains is enforced inside fetchJSON regardless. Private. */
 safe def littlesisFetch(path: string): Result raises <std::http::fetchJSON> {
   handle {
     return fetchJSON(baseUrl: LITTLESIS_BASE, path: path, allowedDomains: LITTLESIS_DOMAINS)
@@ -226,7 +225,7 @@ safe def littlesisFetch(path: string): Result raises <std::http::fetchJSON> {
 
 /** Turn a fetchJSON Result into an entity-list Result. Used by BOTH search and connections
     (identical shape). Pure — testable with mock Results. */
-export safe def entityListFinalize(fetchResult: any): Result {
+export safe def entityListFinalize(fetchResult: any): Result<Entity[]> {
   return match (fetchResult) {
     success(body) => success(parseEntities(body))
     failure(err) => failure(littlesisError(err))
@@ -234,7 +233,7 @@ export safe def entityListFinalize(fetchResult: any): Result {
 }
 
 /** Turn a fetchJSON Result into a single-entity Result; missing data → failure. Pure. */
-export safe def entityFinalize(fetchResult: any): Result {
+export safe def entityFinalize(fetchResult: any): Result<Entity> {
   return match (fetchResult) {
     success(body) => {
       const bodyObj: any = body ?? {}
@@ -248,7 +247,7 @@ export safe def entityFinalize(fetchResult: any): Result {
 }
 
 /** Turn a fetchJSON Result into a relationships Result. Pure. */
-export safe def relationshipsFinalize(fetchResult: any): Result {
+export safe def relationshipsFinalize(fetchResult: any): Result<Relationship[]> {
   return match (fetchResult) {
     success(body) => success(parseRelationships(body))
     failure(err) => failure(littlesisError(err))

--- a/packages/agency-lang/stdlib/data/people/littlesis.agency
+++ b/packages/agency-lang/stdlib/data/people/littlesis.agency
@@ -1,0 +1,328 @@
+import { fetchJSON } from "std::http"
+
+/** @module
+  ## LittleSis — people, organizations, and the ties between them
+
+  Query the [LittleSis](https://littlesis.org/api/) API — an open database of powerful
+  people and organizations and their **relationships** (employment, board seats,
+  ownership/investment, donations). Use this connector when the question is about *entities and
+  the edges between them* (who worked where, who funds whom, who sits on which board), as opposed
+  to macro numbers (`std::data/finance/fred`), company filings (`std::data/finance/edgar`), or
+  news (`std::data/finance/gdelt`).
+
+  No API key required (the API is rate-limited; HTTP 503 means "Rate Limit Exceeded").
+
+  **Two-step recipe.** LittleSis edges carry entity *IDs*, not names. So:
+  use `littlesisConnections` to see *who* an entity is tied to (neighbor entities **by name**,
+  filtered by category); use `littlesisRelationships` to get the *terms* of a tie (amount, dates,
+  roles). Resolve a name to an id first with `littlesisSearch`.
+
+  Relationship categories are friendly strings: `position` (employment/roles), `education`,
+  `membership`, `family`, `donation`, `transaction`, `lobbying`, `social`, `professional`,
+  `ownership`, `hierarchy`, `generic`.
+
+  ### Usage
+
+  ```ts
+  import { littlesisSearch, littlesisConnections } from "std::data/people/littlesis"
+
+  node main() {
+    const hits = littlesisSearch("Andreessen Horowitz") catch []
+    if (hits.length > 0) {
+      const linked = littlesisConnections(hits[0].id, "ownership") catch []
+      for (e in linked) { print("${e.type}  ${e.name}") }
+    }
+  }
+  ```
+*/
+
+effect std::littlesis { op: string, query: string }
+
+const LITTLESIS_BASE = "https://littlesis.org/api"
+const LITTLESIS_DOMAINS = ["littlesis.org"]
+
+// Index 0 is unused ("" sentinel); indices 1–12 are LittleSis category_id values.
+const CATEGORY_NAMES = ["", "position", "education", "membership", "family", "donation", "transaction", "lobbying", "social", "professional", "ownership", "hierarchy", "generic"]
+
+/** A LittleSis person or organization. `type` is "Person" or "Org" (from primary_ext).
+    `relationshipId`/`relationshipCategory` are populated only on connections results. */
+export type Entity = {
+  id: number;
+  name: string;
+  type: string;
+  blurb: string;
+  types: string[];
+  aliases: string[];
+  website: string;
+  url: string;
+  relationshipId: number | null;
+  relationshipCategory: string
+}
+
+/** One typed edge. entity1Id/entity2Id are LittleSis entity IDs, NOT names. */
+export type Relationship = {
+  id: number;
+  category: string;
+  categoryId: number;
+  entity1Id: number;
+  entity2Id: number;
+  description1: string;
+  description2: string;
+  amount: number | null;
+  startDate: string;
+  endDate: string;
+  isCurrent: boolean | null
+}
+
+/** Map a LittleSis category_id (1–12) to its friendly name; unknown id → "". Pure. */
+export safe def categoryIdToName(id: number): string {
+  if (id >= 1 && id < CATEGORY_NAMES.length) {
+    return CATEGORY_NAMES[id]
+  }
+  return ""
+}
+
+/** Map a friendly category name to its LittleSis category_id (1–12); unknown → -1. Pure. */
+export safe def categoryNameToId(name: string): number {
+  const idx = CATEGORY_NAMES.indexOf(name)
+  if (idx >= 1) {
+    return idx
+  }
+  return -1
+}
+
+/** Build the entity-search path. `page` is appended only when > 1. Pure. */
+export safe def buildSearchPath(name: string, page: number): string {
+  const q = encodeURIComponent(name)
+  if (page > 1) {
+    return "/entities/search?q=${q}&page=${page}"
+  }
+  return "/entities/search?q=${q}"
+}
+
+/** Build the single-entity path. Pure. */
+export safe def buildEntityPath(id: number): string {
+  return "/entities/${id}"
+}
+
+/** Build the relationships path. Appends category_id (when >= 1) and sort (when non-empty). Pure.
+    Builds a present-params list and joins it, so it scales linearly with params instead of
+    enumerating every on/off combination. */
+export safe def buildRelationshipsPath(id: number, categoryId: number, sort: string): string {
+  const base = "/entities/${id}/relationships"
+  let params: string[] = []
+  if (categoryId >= 1) {
+    params.push("category_id=${categoryId}")
+  }
+  if (sort != "") {
+    params.push("sort=${encodeURIComponent(sort)}")
+  }
+  if (params.length == 0) {
+    return base
+  }
+  return "${base}?${params.join("&")}"
+}
+
+/** Build the connections path. Appends category_id when >= 1. Pure. */
+export safe def buildConnectionsPath(id: number, categoryId: number): string {
+  if (categoryId >= 1) {
+    return "/entities/${id}/connections?category_id=${categoryId}"
+  }
+  return "/entities/${id}/connections"
+}
+
+/** Reshape one LittleSis entity node ({ id, attributes, links }) into an Entity.
+    Reads connection-only relationship fields defensively (null/"" when absent). Pure/total. */
+export safe def parseEntity(node: any): Entity {
+  const safeNode: any = node ?? {}
+  const attrs: any = safeNode.attributes ?? {}
+  const links: any = safeNode.links ?? {}
+  const relCatId = attrs.relationship_category_id ?? safeNode.relationship_category_id ?? 0
+  return {
+    id: attrs.id ?? 0,
+    name: attrs.name ?? "",
+    type: attrs.primary_ext ?? "",
+    blurb: attrs.blurb ?? "",
+    types: attrs.types ?? [],
+    aliases: attrs.aliases ?? [],
+    website: attrs.website ?? "",
+    url: links.self ?? "",
+    relationshipId: attrs.relationship_id ?? safeNode.relationship_id ?? null,
+    relationshipCategory: categoryIdToName(relCatId)
+  }
+}
+
+/** Reshape a LittleSis list body ({ data: [node] }) into Entity[]. Pure/total. */
+export safe def parseEntities(raw: any): Entity[] {
+  const r: any = raw ?? {}
+  const data = r.data ?? []
+  return map(data) as node {
+    return parseEntity(node)
+  }
+}
+
+/** Reshape a LittleSis relationships body ({ data: [rel] }) into Relationship[]. Pure/total. */
+export safe def parseRelationships(raw: any): Relationship[] {
+  const r: any = raw ?? {}
+  const data = r.data ?? []
+  return map(data) as node {
+    const safeNode: any = node ?? {}
+    const attrs: any = safeNode.attributes ?? {}
+    const catId = attrs.category_id ?? 0
+    return {
+      id: attrs.id ?? 0,
+      category: categoryIdToName(catId),
+      categoryId: catId,
+      entity1Id: attrs.entity1_id ?? 0,
+      entity2Id: attrs.entity2_id ?? 0,
+      description1: attrs.description1 ?? "",
+      description2: attrs.description2 ?? "",
+      amount: attrs.amount ?? null,
+      startDate: attrs.start_date ?? "",
+      endDate: attrs.end_date ?? "",
+      isCurrent: attrs.is_current ?? null
+    }
+  }
+}
+
+/** Shared failure message for a failed LittleSis fetch. Pure. */
+export safe def littlesisError(err: any): string {
+  return "LittleSis request failed (the API may be rate-limited; HTTP 503 = Rate Limit Exceeded): ${err}"
+}
+
+/** The friendly category names as a comma-separated string (drops the index-0 "" sentinel).
+    Single source of truth for the valid-category list in error messages. Pure. */
+safe def categoryNamesList(): string {
+  return CATEGORY_NAMES.slice(1).join(", ")
+}
+
+/** Resolve a friendly category name to a category_id: "" → 0 (all); unknown → failure. Pure.
+    Encapsulates the resolve-or-fail logic shared by relationships and connections. */
+safe def resolveCategoryId(category: string): Result<number> {
+  if (category == "") {
+    return success(0)
+  }
+  const id = categoryNameToId(category)
+  if (id < 0) {
+    return failure("unknown category '${category}'; valid: ${categoryNamesList()}")
+  }
+  return success(id)
+}
+
+/** Fetch a LittleSis path and return the parsed-JSON Result. Option C: this raises
+    std::http::fetchJSON but approves it internally, so a plain caller sees only the connector's
+    std::littlesis prompt while any OUTER fetch handler still receives (and can reject/propagate)
+    the fetch — those beat this approve(). allowedDomains is enforced inside fetchJSON regardless.
+    Factored out so the Option-C gating "how" lives in ONE place. Private. */
+safe def littlesisFetch(path: string): Result raises <std::http::fetchJSON> {
+  handle {
+    return fetchJSON(baseUrl: LITTLESIS_BASE, path: path, allowedDomains: LITTLESIS_DOMAINS)
+  } with (data) {
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+  }
+}
+
+/** Turn a fetchJSON Result into an entity-list Result. Used by BOTH search and connections
+    (identical shape). Pure — testable with mock Results. */
+export safe def entityListFinalize(fetchResult: any): Result {
+  return match (fetchResult) {
+    success(body) => success(parseEntities(body))
+    failure(err) => failure(littlesisError(err))
+  }
+}
+
+/** Turn a fetchJSON Result into a single-entity Result; missing data → failure. Pure. */
+export safe def entityFinalize(fetchResult: any): Result {
+  return match (fetchResult) {
+    success(body) => {
+      const bodyObj: any = body ?? {}
+      if ((bodyObj.data ?? null) == null) {
+        return failure("LittleSis returned no entity")
+      }
+      return success(parseEntity(bodyObj.data))
+    }
+    failure(err) => failure(littlesisError(err))
+  }
+}
+
+/** Turn a fetchJSON Result into a relationships Result. Pure. */
+export safe def relationshipsFinalize(fetchResult: any): Result {
+  return match (fetchResult) {
+    success(body) => success(parseRelationships(body))
+    failure(err) => failure(littlesisError(err))
+  }
+}
+
+export safe def littlesisSearch(name: string, page: number = 1): Result<Entity[]> raises <std::littlesis, std::http::fetchJSON> {
+  """
+  Search LittleSis for people and organizations by name. Returns matching entities (id, name,
+  type "Person"/"Org", blurb, aliases, website, url). Use the returned id with the other
+  littlesis functions. Empty result set returns an empty list.
+
+  @param name - The person or organization name to search for
+  @param page - Result page, 10 per page (default 1)
+  """
+  return interrupt std::littlesis("Search LittleSis for this name?", { op: "search", query: name })
+  // Bind the fetch to its own statement so the std::http::fetchJSON interrupt fires at statement
+  // level (resumable / gateable by outer handlers) rather than inside a call argument.
+  const result = littlesisFetch(buildSearchPath(name, page))
+  return entityListFinalize(result)
+}
+
+export safe def littlesisEntity(id: number): Result<Entity> raises <std::littlesis, std::http::fetchJSON> {
+  """
+  Fetch one LittleSis entity by its numeric id (from littlesisSearch). Returns the full profile
+  (name, type, blurb, aliases, website, url). Unknown id returns a failure.
+
+  @param id - The LittleSis entity id
+  """
+  return interrupt std::littlesis("Fetch this LittleSis entity?", { op: "entity", query: "${id}" })
+  const result = littlesisFetch(buildEntityPath(id))
+  return entityFinalize(result)
+}
+
+export safe def littlesisRelationships(id: number, category: string = "", sort: string = ""): Result<Relationship[]> raises <std::littlesis, std::http::fetchJSON> {
+  """
+  List an entity's relationships (typed edges) by its id. Each edge carries the two entity IDs,
+  role labels (description1/description2), amount, dates, and category. Filter with a friendly
+  category name. Edges carry entity IDs, not names — use littlesisConnections for neighbor names.
+
+  @param id - The LittleSis entity id
+  @param category - Optional category filter: position, education, membership, family, donation, transaction, lobbying, social, professional, ownership, hierarchy, generic (empty = all)
+  @param sort - Optional sort: "amount", "oldest", or "recent" (empty = default)
+  """
+  // Validate the category BEFORE the interrupt: fail fast on bad input without bothering the user,
+  // and keep the Result-narrowing out of the interrupt-resume flow (a match/.value over a typed
+  // Result placed after `return interrupt` does not narrow). Bonus: makes the unknown-category
+  // failure path reachable OFFLINE (returns before any interrupt).
+  const catResult = resolveCategoryId(category)
+  if (catResult is failure(msg)) {
+    return failure(msg)
+  }
+  const categoryId = catResult.value
+  return interrupt std::littlesis("Fetch relationships for this LittleSis entity?", { op: "relationships", query: "${id}" })
+  const result = littlesisFetch(buildRelationshipsPath(id, categoryId, sort))
+  return relationshipsFinalize(result)
+}
+
+export safe def littlesisConnections(id: number, category: string = ""): Result<Entity[]> raises <std::littlesis, std::http::fetchJSON> {
+  """
+  List the entities connected to an entity (neighbors, by name), optionally filtered by a
+  friendly category name. Lighter than littlesisRelationships and name-bearing — the preferred
+  first hop for "who is X tied to". Each result also carries the linking relationshipId/category.
+
+  @param id - The LittleSis entity id
+  @param category - Optional category filter: position, education, membership, family, donation, transaction, lobbying, social, professional, ownership, hierarchy, generic (empty = all)
+  """
+  // Validate the category BEFORE the interrupt (see littlesisRelationships for the rationale).
+  const catResult = resolveCategoryId(category)
+  if (catResult is failure(msg)) {
+    return failure(msg)
+  }
+  const categoryId = catResult.value
+  return interrupt std::littlesis("Fetch connections for this LittleSis entity?", { op: "connections", query: "${id}" })
+  const result = littlesisFetch(buildConnectionsPath(id, categoryId))
+  return entityListFinalize(result)
+}

--- a/packages/agency-lang/stdlib/data/people/littlesis.agency
+++ b/packages/agency-lang/stdlib/data/people/littlesis.agency
@@ -74,6 +74,11 @@ export type Relationship = {
   isCurrent: boolean | null
 }
 
+/** A category filter for relationship/connection queries: either "all" (no filter) or a specific
+    category by id. Produced by parseCategoryFilter, consumed by the path builders — this replaces
+    the old numeric sentinels (no more -1 for "invalid" or 0 for "all"). */
+export type CategoryFilter = { type: "all" } | { type: "category", id: number }
+
 /** Map a LittleSis category_id (1–12) to its friendly name; unknown id → "". Pure. */
 export safe def categoryIdToName(id: number): string {
   if (id >= 1 && id < CATEGORY_NAMES.length) {
@@ -82,13 +87,23 @@ export safe def categoryIdToName(id: number): string {
   return ""
 }
 
-/** Map a friendly category name to its LittleSis category_id (1–12); unknown → -1. Pure. */
-export safe def categoryNameToId(name: string): number {
-  const idx = CATEGORY_NAMES.indexOf(name)
-  if (idx >= 1) {
-    return idx
+/** The friendly category names as a comma-separated string (drops the index-0 "" sentinel).
+    Single source of truth for the valid-category list in error messages. Pure. */
+safe def categoryNamesList(): string {
+  return CATEGORY_NAMES.slice(1).join(", ")
+}
+
+/** Parse a friendly category name into a CategoryFilter. "" (or not given) → all; a valid name →
+    that category; an unknown name → failure (listing the valid names). Pure. */
+export safe def parseCategoryFilter(name: string): Result<CategoryFilter> {
+  if (name == "") {
+    return success({ type: "all" })
   }
-  return -1
+  const idx = CATEGORY_NAMES.indexOf(name)
+  if (idx < 1) {
+    return failure("unknown category '${name}'; valid: ${categoryNamesList()}")
+  }
+  return success({ type: "category", id: idx })
 }
 
 /** Build the entity-search path. `page` is appended only when > 1. Pure. */
@@ -105,14 +120,13 @@ export safe def buildEntityPath(id: number): string {
   return "/entities/${id}"
 }
 
-/** Build the relationships path. Appends category_id (when >= 1) and sort (when non-empty). Pure.
-    Builds a present-params list and joins it, so it scales linearly with params instead of
-    enumerating every on/off combination. */
-export safe def buildRelationshipsPath(id: number, categoryId: number, sort: string): string {
+/** Build the relationships path from a category filter and optional sort. Builds a present-params
+    list and joins it, so it scales linearly with params instead of enumerating combinations. Pure. */
+export safe def buildRelationshipsPath(id: number, filter: CategoryFilter, sort: string): string {
   const base = "/entities/${id}/relationships"
   let params: string[] = []
-  if (categoryId >= 1) {
-    params.push("category_id=${categoryId}")
+  if (filter is { type: "category", id: catId }) {
+    params.push("category_id=${catId}")
   }
   if (sort != "") {
     params.push("sort=${encodeURIComponent(sort)}")
@@ -123,10 +137,10 @@ export safe def buildRelationshipsPath(id: number, categoryId: number, sort: str
   return "${base}?${params.join("&")}"
 }
 
-/** Build the connections path. Appends category_id when >= 1. Pure. */
-export safe def buildConnectionsPath(id: number, categoryId: number): string {
-  if (categoryId >= 1) {
-    return "/entities/${id}/connections?category_id=${categoryId}"
+/** Build the connections path from a category filter. Pure. */
+export safe def buildConnectionsPath(id: number, filter: CategoryFilter): string {
+  if (filter is { type: "category", id: catId }) {
+    return "/entities/${id}/connections?category_id=${catId}"
   }
   return "/entities/${id}/connections"
 }
@@ -188,25 +202,6 @@ export safe def parseRelationships(raw: any): Relationship[] {
 /** Shared failure message for a failed LittleSis fetch. Pure. */
 export safe def littlesisError(err: any): string {
   return "LittleSis request failed (the API may be rate-limited; HTTP 503 = Rate Limit Exceeded): ${err}"
-}
-
-/** The friendly category names as a comma-separated string (drops the index-0 "" sentinel).
-    Single source of truth for the valid-category list in error messages. Pure. */
-safe def categoryNamesList(): string {
-  return CATEGORY_NAMES.slice(1).join(", ")
-}
-
-/** Resolve a friendly category name to a category_id: "" → 0 (all); unknown → failure. Pure.
-    Encapsulates the resolve-or-fail logic shared by relationships and connections. */
-safe def resolveCategoryId(category: string): Result<number> {
-  if (category == "") {
-    return success(0)
-  }
-  const id = categoryNameToId(category)
-  if (id < 0) {
-    return failure("unknown category '${category}'; valid: ${categoryNamesList()}")
-  }
-  return success(id)
 }
 
 /** Fetch a LittleSis path and return the parsed-JSON Result. Raises std::http::fetchJSON but
@@ -296,13 +291,13 @@ export safe def littlesisRelationships(id: number, category: string = "", sort: 
   // and keep the Result-narrowing out of the interrupt-resume flow (a match/.value over a typed
   // Result placed after `return interrupt` does not narrow). Bonus: makes the unknown-category
   // failure path reachable OFFLINE (returns before any interrupt).
-  const catResult = resolveCategoryId(category)
-  if (catResult is failure(msg)) {
+  const filterResult = parseCategoryFilter(category)
+  if (filterResult is failure(msg)) {
     return failure(msg)
   }
-  const categoryId = catResult.value
+  const filter = filterResult.value
   return interrupt std::littlesis("Fetch relationships for this LittleSis entity?", { op: "relationships", query: "${id}" })
-  const result = littlesisFetch(buildRelationshipsPath(id, categoryId, sort))
+  const result = littlesisFetch(buildRelationshipsPath(id, filter, sort))
   return relationshipsFinalize(result)
 }
 
@@ -316,12 +311,12 @@ export safe def littlesisConnections(id: number, category: string = ""): Result<
   @param category - Optional category filter: position, education, membership, family, donation, transaction, lobbying, social, professional, ownership, hierarchy, generic (empty = all)
   """
   // Validate the category BEFORE the interrupt (see littlesisRelationships for the rationale).
-  const catResult = resolveCategoryId(category)
-  if (catResult is failure(msg)) {
+  const filterResult = parseCategoryFilter(category)
+  if (filterResult is failure(msg)) {
     return failure(msg)
   }
-  const categoryId = catResult.value
+  const filter = filterResult.value
   return interrupt std::littlesis("Fetch connections for this LittleSis entity?", { op: "connections", query: "${id}" })
-  const result = littlesisFetch(buildConnectionsPath(id, categoryId))
+  const result = littlesisFetch(buildConnectionsPath(id, filter))
   return entityListFinalize(result)
 }

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis-live/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis-live/agent.agency
@@ -1,0 +1,19 @@
+import { littlesisSearch } from "std::data/people/littlesis"
+
+node liveSearch(): number {
+  handle {
+    const hits = littlesisSearch("Andreessen Horowitz") catch []
+    return hits.length
+  } with (data) {
+    // Option C: approve BOTH effects. std::littlesis is the connector's own gate; std::http::fetchJSON
+    // still reaches this outer handler (Option C only suppresses the prompt for callers WITHOUT a
+    // handler), and this handler's catch-all reject() would beat the connector's internal approve.
+    if (data.effect == "std::littlesis") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis-live/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis-live/agent.agency
@@ -5,9 +5,9 @@ node liveSearch(): number {
     const hits = littlesisSearch("Andreessen Horowitz") catch []
     return hits.length
   } with (data) {
-    // Option C: approve BOTH effects. std::littlesis is the connector's own gate; std::http::fetchJSON
-    // still reaches this outer handler (Option C only suppresses the prompt for callers WITHOUT a
-    // handler), and this handler's catch-all reject() would beat the connector's internal approve.
+    // Approve BOTH effects. std::littlesis is the connector's own gate; std::http::fetchJSON still
+    // reaches this outer handler (the connector's internal approve only suppresses the prompt for
+    // callers WITHOUT a handler), and this handler's catch-all reject() would beat that approve.
     if (data.effect == "std::littlesis") {
       return approve()
     }

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis-live/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis-live/fixture.json
@@ -1,0 +1,1 @@
+{ "skipped": true }

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis-live/test.js
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis-live/test.js
@@ -1,0 +1,12 @@
+import { liveSearch } from "./agent.js";
+import { writeFileSync } from "node:fs";
+
+// Opt-in: only hits the live LittleSis API when AGENCY_LIVE_TESTS is set. Under Option C the handler
+// approves both std::littlesis and std::http::fetchJSON, then resumes into the real fetch. If either
+// approval is missing (or the internal approve regresses), the fetch is rejected and the count is 0.
+if (!process.env.AGENCY_LIVE_TESTS) {
+  writeFileSync("__result.json", JSON.stringify({ skipped: true }, null, 2));
+} else {
+  const n = (await liveSearch())?.data ?? -1;
+  writeFileSync("__result.json", JSON.stringify({ ok: n >= 1 }, null, 2));
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis-live/test.js
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis-live/test.js
@@ -1,9 +1,9 @@
 import { liveSearch } from "./agent.js";
 import { writeFileSync } from "node:fs";
 
-// Opt-in: only hits the live LittleSis API when AGENCY_LIVE_TESTS is set. Under Option C the handler
-// approves both std::littlesis and std::http::fetchJSON, then resumes into the real fetch. If either
-// approval is missing (or the internal approve regresses), the fetch is rejected and the count is 0.
+// Opt-in: only hits the live LittleSis API when AGENCY_LIVE_TESTS is set. The handler approves both
+// std::littlesis and std::http::fetchJSON, then resumes into the real fetch. If either approval is
+// missing (or the internal approve regresses), the fetch is rejected and the count is 0.
 if (!process.env.AGENCY_LIVE_TESTS) {
   writeFileSync("__result.json", JSON.stringify({ skipped: true }, null, 2));
 } else {

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/agent.agency
@@ -1,0 +1,111 @@
+import { categoryIdToName, categoryNameToId, buildSearchPath, buildEntityPath, buildRelationshipsPath, buildConnectionsPath, parseEntity, parseEntities, parseRelationships, entityListFinalize, entityFinalize, relationshipsFinalize, littlesisError, littlesisSearch, littlesisRelationships } from "std::data/people/littlesis"
+import { Network } from "std::capabilities"
+
+// Compile-time capability assertion: littlesisSearch raises std::littlesis + std::http::fetchJSON,
+// so this compiles only if BOTH are covered by Network. Never called at runtime.
+node netCheck() raises <Network> {
+  const r = littlesisSearch("x") catch []
+  return r.length
+}
+
+node tCatIdToName(id: number): string {
+  return categoryIdToName(id)
+}
+
+node tCatNameToId(name: string): number {
+  return categoryNameToId(name)
+}
+
+node tSearchPath(name: string, page: number): string {
+  return buildSearchPath(name, page)
+}
+
+node tEntityPath(id: number): string {
+  return buildEntityPath(id)
+}
+
+node tRelPath(id: number, categoryId: number, sort: string): string {
+  return buildRelationshipsPath(id, categoryId, sort)
+}
+
+node tConnPath(id: number, categoryId: number): string {
+  return buildConnectionsPath(id, categoryId)
+}
+
+node tParseEntities(raw: any): any {
+  return parseEntities(raw)
+}
+
+node tParseEntity(raw: any): any {
+  const r: any = raw
+  return parseEntity(r.data)
+}
+
+node tParseRelationships(raw: any): any {
+  return parseRelationships(raw)
+}
+
+node tParseEmpty(): any {
+  return parseEntities({ data: [] })
+}
+
+node tParseNull(): any {
+  return parseEntities(null)
+}
+
+node tSearchFinalizeErr(): string {
+  const r = entityListFinalize(failure("boom"))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tEntityFinalizeMissing(): string {
+  const r = entityFinalize(success({}))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tRelFinalizeEmpty(): any {
+  return relationshipsFinalize(success({ data: [] })) catch "FAIL"
+}
+
+node tError(): string {
+  return littlesisError("boom")
+}
+
+// Plain caller: no fetch-level handler. Raises std::littlesis; with Option C, approving it would
+// resume into the internally-approved fetch (a real network call), so tests only inspect/reject it.
+node callSearch(name: string): any {
+  return littlesisSearch(name)
+}
+
+// Governed caller: approves std::littlesis, then PROPAGATES the fetch. propagate() beats the
+// connector's internal approve(), so std::http::fetchJSON surfaces to the agency-js caller — which
+// (a) proves an outer handler still receives the fetch effect, and (b) lets us assert the built
+// URL ({ baseUrl, path }) OFFLINE, then reject it so no network call happens.
+node callSearchGoverned(name: string): any {
+  handle {
+    return littlesisSearch(name)
+  } with (data) {
+    if (data.effect == "std::littlesis") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return propagate()
+    }
+  }
+}
+
+// Bad category now fails BEFORE the interrupt, so this returns a failure Result offline (no fetch,
+// no interrupt) — and its message exercises the derived categoryNamesList() valid-list string.
+node callRelBadCategory(id: number): string {
+  const r = littlesisRelationships(id, "bogus")
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS_OR_INTERRUPT"
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/agent.agency
@@ -77,8 +77,8 @@ node tError(): string {
   return littlesisError("boom")
 }
 
-// Plain caller: no fetch-level handler. Raises std::littlesis; with Option C, approving it would
-// resume into the internally-approved fetch (a real network call), so tests only inspect/reject it.
+// Plain caller: no fetch-level handler. Raises std::littlesis; approving it would resume into the
+// internally-approved fetch (a real network call), so tests only inspect/reject it.
 node callSearch(name: string): any {
   return littlesisSearch(name)
 }

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/agent.agency
@@ -1,4 +1,4 @@
-import { categoryIdToName, categoryNameToId, buildSearchPath, buildEntityPath, buildRelationshipsPath, buildConnectionsPath, parseEntity, parseEntities, parseRelationships, entityListFinalize, entityFinalize, relationshipsFinalize, littlesisError, littlesisSearch, littlesisRelationships } from "std::data/people/littlesis"
+import { categoryIdToName, parseCategoryFilter, buildSearchPath, buildEntityPath, buildRelationshipsPath, buildConnectionsPath, parseEntity, parseEntities, parseRelationships, entityListFinalize, entityFinalize, relationshipsFinalize, littlesisError, littlesisSearch, littlesisRelationships } from "std::data/people/littlesis"
 import { Network } from "std::capabilities"
 
 // Compile-time capability assertion: littlesisSearch raises std::littlesis + std::http::fetchJSON,
@@ -12,8 +12,13 @@ node tCatIdToName(id: number): string {
   return categoryIdToName(id)
 }
 
-node tCatNameToId(name: string): number {
-  return categoryNameToId(name)
+// Parse a friendly category name into a CategoryFilter (or its failure message).
+node tFilterCat(name: string): any {
+  const r = parseCategoryFilter(name)
+  if (r is failure(e)) {
+    return "FAIL: ${e}"
+  }
+  return r.value
 }
 
 node tSearchPath(name: string, page: number): string {
@@ -24,12 +29,21 @@ node tEntityPath(id: number): string {
   return buildEntityPath(id)
 }
 
-node tRelPath(id: number, categoryId: number, sort: string): string {
-  return buildRelationshipsPath(id, categoryId, sort)
+// Exercise parse → build together: a category NAME through parseCategoryFilter into the path.
+node tRelPath(id: number, category: string, sort: string): any {
+  const r = parseCategoryFilter(category)
+  if (r is failure(e)) {
+    return "FAIL: ${e}"
+  }
+  return buildRelationshipsPath(id, r.value, sort)
 }
 
-node tConnPath(id: number, categoryId: number): string {
-  return buildConnectionsPath(id, categoryId)
+node tConnPath(id: number, category: string): any {
+  const r = parseCategoryFilter(category)
+  if (r is failure(e)) {
+    return "FAIL: ${e}"
+  }
+  return buildConnectionsPath(id, r.value)
 }
 
 node tParseEntities(raw: any): any {
@@ -70,7 +84,7 @@ node tEntityFinalizeMissing(): string {
 }
 
 node tRelFinalizeEmpty(): any {
-  return relationshipsFinalize(success({ data: [] })) catch "FAIL"
+  return relationshipsFinalize(success({ data: [] })) catch []
 }
 
 node tError(): string {

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/fixture.json
@@ -1,0 +1,34 @@
+{
+  "ownershipId": 10,
+  "donationName": "donation",
+  "positionId": 1,
+  "unknownName": -1,
+  "unknownId": "",
+  "zeroId": "",
+  "searchPath": "/entities/search?q=Andreessen%20Horowitz",
+  "searchPathPaged": "/entities/search?q=a%20b&page=3",
+  "entityPath": "/entities/41946",
+  "relPathPlain": "/entities/41946/relationships",
+  "relPathCat": "/entities/41946/relationships?category_id=10",
+  "relPathCatSort": "/entities/41946/relationships?category_id=10&sort=amount",
+  "relPathSort": "/entities/41946/relationships?sort=recent",
+  "connPathPlain": "/entities/41946/connections",
+  "connPathCat": "/entities/41946/connections?category_id=10",
+  "entities": [
+    { "id": 41946, "name": "a16z", "type": "Org", "blurb": "Venture capital firm founded in 2009 by Ben Horowitz and Marc Andreessen", "types": ["Organization", "Business"], "aliases": ["Andreessen Horowitz", "a16z"], "website": "", "url": "https://littlesis.org/entities/41946-a16z", "relationshipId": null, "relationshipCategory": "" }
+  ],
+  "entity": { "id": 13503, "name": "Marc Andreessen", "type": "Person", "blurb": "Co-founder of Andreessen Horowitz", "types": ["Person", "Business Person"], "aliases": ["Marc Andreessen"], "website": "https://a16z.com", "url": "https://littlesis.org/entities/13503-Marc_Andreessen", "relationshipId": null, "relationshipCategory": "" },
+  "relationships": [
+    { "id": 999001, "category": "ownership", "categoryId": 10, "entity1Id": 41946, "entity2Id": 55555, "description1": "Investor", "description2": "Investee", "amount": 25000000, "startDate": "2021-01-01", "endDate": "", "isCurrent": true }
+  ],
+  "connections": [
+    { "id": 55555, "name": "Example Portfolio Co", "type": "Org", "blurb": "A company", "types": ["Organization"], "aliases": [], "website": "", "url": "https://littlesis.org/entities/55555-Example", "relationshipId": 999001, "relationshipCategory": "ownership" }
+  ],
+  "empty": [],
+  "parseNull": [],
+  "searchFinalizeErr": "LittleSis request failed (the API may be rate-limited; HTTP 503 = Rate Limit Exceeded): boom",
+  "entityFinalizeMissing": "LittleSis returned no entity",
+  "relFinalizeEmpty": [],
+  "errorMsg": "LittleSis request failed (the API may be rate-limited; HTTP 503 = Rate Limit Exceeded): boom",
+  "badCategory": "unknown category 'bogus'; valid: position, education, membership, family, donation, transaction, lobbying, social, professional, ownership, hierarchy, generic"
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/fixture.json
@@ -1,10 +1,10 @@
 {
-  "ownershipId": 10,
   "donationName": "donation",
-  "positionId": 1,
-  "unknownName": -1,
   "unknownId": "",
   "zeroId": "",
+  "filterAll": { "type": "all" },
+  "filterCat": { "type": "category", "id": 10 },
+  "filterBad": "FAIL: unknown category 'bogus'; valid: position, education, membership, family, donation, transaction, lobbying, social, professional, ownership, hierarchy, generic",
   "searchPath": "/entities/search?q=Andreessen%20Horowitz",
   "searchPathPaged": "/entities/search?q=a%20b&page=3",
   "entityPath": "/entities/41946",

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-connections.json
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-connections.json
@@ -1,0 +1,21 @@
+{
+  "meta": { "currentPage": 1, "apiVersion": "1.0" },
+  "data": [
+    {
+      "type": "entities",
+      "id": 55555,
+      "attributes": {
+        "id": 55555,
+        "name": "Example Portfolio Co",
+        "blurb": "A company",
+        "website": null,
+        "primary_ext": "Org",
+        "aliases": [],
+        "types": ["Organization"],
+        "relationship_id": 999001,
+        "relationship_category_id": 10
+      },
+      "links": { "self": "https://littlesis.org/entities/55555-Example" }
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-entity.json
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-entity.json
@@ -1,0 +1,17 @@
+{
+  "meta": { "apiVersion": "1.0" },
+  "data": {
+    "type": "entities",
+    "id": 13503,
+    "attributes": {
+      "id": 13503,
+      "name": "Marc Andreessen",
+      "blurb": "Co-founder of Andreessen Horowitz",
+      "website": "https://a16z.com",
+      "primary_ext": "Person",
+      "aliases": ["Marc Andreessen"],
+      "types": ["Person", "Business Person"]
+    },
+    "links": { "self": "https://littlesis.org/entities/13503-Marc_Andreessen" }
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-relationships.json
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-relationships.json
@@ -1,0 +1,21 @@
+{
+  "meta": { "currentPage": 1, "apiVersion": "1.0" },
+  "data": [
+    {
+      "type": "relationships",
+      "id": 999001,
+      "attributes": {
+        "id": 999001,
+        "entity1_id": 41946,
+        "entity2_id": 55555,
+        "category_id": 10,
+        "description1": "Investor",
+        "description2": "Investee",
+        "amount": 25000000,
+        "start_date": "2021-01-01",
+        "end_date": null,
+        "is_current": true
+      }
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-search.json
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/sample-search.json
@@ -1,0 +1,21 @@
+{
+  "meta": { "currentPage": 1, "pageCount": 1, "apiVersion": "1.0" },
+  "data": [
+    {
+      "type": "entities",
+      "id": 41946,
+      "attributes": {
+        "id": 41946,
+        "name": "a16z",
+        "blurb": "Venture capital firm founded in 2009 by Ben Horowitz and Marc Andreessen",
+        "summary": null,
+        "website": null,
+        "primary_ext": "Org",
+        "aliases": ["Andreessen Horowitz", "a16z"],
+        "types": ["Organization", "Business"],
+        "tags": ["tech"]
+      },
+      "links": { "self": "https://littlesis.org/entities/41946-a16z" }
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/test.js
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/test.js
@@ -1,5 +1,4 @@
-import { tCatIdToName, tCatNameToId, tSearchPath, tEntityPath, tRelPath, tConnPath, tParseEntities, tParseEntity, tParseRelationships, tParseEmpty, tParseNull, tSearchFinalizeErr, tEntityFinalizeMissing, tRelFinalizeEmpty, tError, callRelBadCategory } from "./agent.js";
-import { hasInterrupts, approve, reject, respondToInterrupts, callSearch, callSearchGoverned } from "./agent.js";
+import { tCatIdToName, tCatNameToId, tSearchPath, tEntityPath, tRelPath, tConnPath, tParseEntities, tParseEntity, tParseRelationships, tParseEmpty, tParseNull, tSearchFinalizeErr, tEntityFinalizeMissing, tRelFinalizeEmpty, tError, callRelBadCategory, hasInterrupts, approve, reject, respondToInterrupts, callSearch, callSearchGoverned } from "./agent.js";
 import { readFileSync, writeFileSync } from "node:fs";
 
 const unwrap = (r) => r?.data ?? r;
@@ -22,15 +21,15 @@ if (iv.data.op !== "search") throw new Error("wrong op discriminant: " + iv.data
 const rejected = await respondToInterrupts(i1.data, [reject()]);
 if (hasInterrupts(rejected.data)) throw new Error("rejecting std::littlesis must short-circuit before any fetch");
 
-// (B) Option C ergonomics: a plain caller (no fetch handler) sees ONLY std::littlesis. We do NOT
-// approve here (Option C would resume into the internally-approved fetch = a real network call).
+// (B) Single-prompt ergonomics: a plain caller (no fetch handler) sees ONLY std::littlesis. We do NOT
+// approve here (approving would resume into the internally-approved fetch = a real network call).
 if (i1.data.filter((x) => x.effect && x.effect !== "std::littlesis").length > 0) {
   throw new Error("plain caller must see only std::littlesis at the first hop");
 }
 
 // (C) Governance + offline URL wiring: the governed caller approves std::littlesis and PROPAGATES
 // the fetch, so std::http::fetchJSON surfaces with its { baseUrl, path }. This proves (a) an outer
-// handler still receives the fetch effect despite Option C's internal approve, and (b) the built
+// handler still receives the fetch effect despite the connector's internal approve, and (b) the built
 // URL is correct — asserted OFFLINE, then rejected so no network call happens.
 const g1 = await callSearchGoverned("Andreessen Horowitz");
 if (!hasInterrupts(g1.data)) throw new Error("governed caller should surface std::http::fetchJSON via propagate()");

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/test.js
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/test.js
@@ -1,0 +1,83 @@
+import { tCatIdToName, tCatNameToId, tSearchPath, tEntityPath, tRelPath, tConnPath, tParseEntities, tParseEntity, tParseRelationships, tParseEmpty, tParseNull, tSearchFinalizeErr, tEntityFinalizeMissing, tRelFinalizeEmpty, tError, callRelBadCategory } from "./agent.js";
+import { hasInterrupts, approve, reject, respondToInterrupts, callSearch, callSearchGoverned } from "./agent.js";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const unwrap = (r) => r?.data ?? r;
+const load = (f) => JSON.parse(readFileSync(new URL(f, import.meta.url), "utf8"));
+const sampleSearch = load("./sample-search.json");
+const sampleEntity = load("./sample-entity.json");
+const sampleRels = load("./sample-relationships.json");
+const sampleConns = load("./sample-connections.json");
+
+// --- interrupt / effect assertions (throw on mismatch) ---
+
+// (A) The domain interrupt gates the call: rejecting std::littlesis short-circuits with NO fetch.
+const i1 = await callSearch("Andreessen Horowitz");
+if (!hasInterrupts(i1.data)) throw new Error("littlesisSearch did not raise an interrupt");
+const iv = i1.data[0];
+if (iv.effect !== "std::littlesis") throw new Error("wrong effect: " + iv.effect);
+if (iv.message !== "Search LittleSis for this name?") throw new Error("wrong message: " + iv.message);
+if (iv.data.query !== "Andreessen Horowitz") throw new Error("wrong payload: " + iv.data.query);
+if (iv.data.op !== "search") throw new Error("wrong op discriminant: " + iv.data.op); // tagged-union: per-op gating
+const rejected = await respondToInterrupts(i1.data, [reject()]);
+if (hasInterrupts(rejected.data)) throw new Error("rejecting std::littlesis must short-circuit before any fetch");
+
+// (B) Option C ergonomics: a plain caller (no fetch handler) sees ONLY std::littlesis. We do NOT
+// approve here (Option C would resume into the internally-approved fetch = a real network call).
+if (i1.data.filter((x) => x.effect && x.effect !== "std::littlesis").length > 0) {
+  throw new Error("plain caller must see only std::littlesis at the first hop");
+}
+
+// (C) Governance + offline URL wiring: the governed caller approves std::littlesis and PROPAGATES
+// the fetch, so std::http::fetchJSON surfaces with its { baseUrl, path }. This proves (a) an outer
+// handler still receives the fetch effect despite Option C's internal approve, and (b) the built
+// URL is correct — asserted OFFLINE, then rejected so no network call happens.
+const g1 = await callSearchGoverned("Andreessen Horowitz");
+if (!hasInterrupts(g1.data)) throw new Error("governed caller should surface std::http::fetchJSON via propagate()");
+const gv = g1.data[0];
+if (gv.effect !== "std::http::fetchJSON") throw new Error("expected std::http::fetchJSON, got: " + gv.effect);
+if (gv.data.baseUrl !== "https://littlesis.org/api") throw new Error("wrong baseUrl wired to fetch: " + gv.data.baseUrl);
+if (gv.data.path !== "/entities/search?q=Andreessen%20Horowitz") throw new Error("wrong path wired to fetch: " + gv.data.path);
+await respondToInterrupts(g1.data, [reject()]); // reject the fetch — no network
+
+// (D) Unknown-category failure path, now OFFLINE-testable: because the connector validates the
+// category BEFORE the interrupt, a bogus category returns a failure Result with NO interrupt and NO
+// fetch. This also exercises the derived categoryNamesList() valid-list string (single source of truth).
+const bad = await callRelBadCategory(41946);
+if (hasInterrupts(bad.data)) throw new Error("bad category must fail before raising std::littlesis (no interrupt)");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      ownershipId: unwrap(await tCatNameToId("ownership")),
+      donationName: unwrap(await tCatIdToName(5)),
+      positionId: unwrap(await tCatNameToId("position")),
+      unknownName: unwrap(await tCatNameToId("bogus")),
+      unknownId: unwrap(await tCatIdToName(99)),
+      zeroId: unwrap(await tCatIdToName(0)),
+      searchPath: unwrap(await tSearchPath("Andreessen Horowitz", 1)),
+      searchPathPaged: unwrap(await tSearchPath("a b", 3)),
+      entityPath: unwrap(await tEntityPath(41946)),
+      relPathPlain: unwrap(await tRelPath(41946, 0, "")),
+      relPathCat: unwrap(await tRelPath(41946, 10, "")),
+      relPathCatSort: unwrap(await tRelPath(41946, 10, "amount")),
+      relPathSort: unwrap(await tRelPath(41946, 0, "recent")),
+      connPathPlain: unwrap(await tConnPath(41946, 0)),
+      connPathCat: unwrap(await tConnPath(41946, 10)),
+      entities: unwrap(await tParseEntities(sampleSearch)),
+      entity: unwrap(await tParseEntity(sampleEntity)),
+      relationships: unwrap(await tParseRelationships(sampleRels)),
+      connections: unwrap(await tParseEntities(sampleConns)),
+      empty: unwrap(await tParseEmpty()),
+      parseNull: unwrap(await tParseNull()),
+      searchFinalizeErr: unwrap(await tSearchFinalizeErr()),
+      entityFinalizeMissing: unwrap(await tEntityFinalizeMissing()),
+      relFinalizeEmpty: unwrap(await tRelFinalizeEmpty()),
+      errorMsg: unwrap(await tError()),
+      badCategory: unwrap(await callRelBadCategory(41946)),
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/data-people-littlesis/test.js
+++ b/packages/agency-lang/tests/agency-js/data-people-littlesis/test.js
@@ -1,4 +1,4 @@
-import { tCatIdToName, tCatNameToId, tSearchPath, tEntityPath, tRelPath, tConnPath, tParseEntities, tParseEntity, tParseRelationships, tParseEmpty, tParseNull, tSearchFinalizeErr, tEntityFinalizeMissing, tRelFinalizeEmpty, tError, callRelBadCategory, hasInterrupts, approve, reject, respondToInterrupts, callSearch, callSearchGoverned } from "./agent.js";
+import { tCatIdToName, tFilterCat, tSearchPath, tEntityPath, tRelPath, tConnPath, tParseEntities, tParseEntity, tParseRelationships, tParseEmpty, tParseNull, tSearchFinalizeErr, tEntityFinalizeMissing, tRelFinalizeEmpty, tError, callRelBadCategory, hasInterrupts, approve, reject, respondToInterrupts, callSearch, callSearchGoverned } from "./agent.js";
 import { readFileSync, writeFileSync } from "node:fs";
 
 const unwrap = (r) => r?.data ?? r;
@@ -49,21 +49,21 @@ writeFileSync(
   "__result.json",
   JSON.stringify(
     {
-      ownershipId: unwrap(await tCatNameToId("ownership")),
       donationName: unwrap(await tCatIdToName(5)),
-      positionId: unwrap(await tCatNameToId("position")),
-      unknownName: unwrap(await tCatNameToId("bogus")),
       unknownId: unwrap(await tCatIdToName(99)),
       zeroId: unwrap(await tCatIdToName(0)),
+      filterAll: unwrap(await tFilterCat("")),
+      filterCat: unwrap(await tFilterCat("ownership")),
+      filterBad: unwrap(await tFilterCat("bogus")),
       searchPath: unwrap(await tSearchPath("Andreessen Horowitz", 1)),
       searchPathPaged: unwrap(await tSearchPath("a b", 3)),
       entityPath: unwrap(await tEntityPath(41946)),
-      relPathPlain: unwrap(await tRelPath(41946, 0, "")),
-      relPathCat: unwrap(await tRelPath(41946, 10, "")),
-      relPathCatSort: unwrap(await tRelPath(41946, 10, "amount")),
-      relPathSort: unwrap(await tRelPath(41946, 0, "recent")),
-      connPathPlain: unwrap(await tConnPath(41946, 0)),
-      connPathCat: unwrap(await tConnPath(41946, 10)),
+      relPathPlain: unwrap(await tRelPath(41946, "", "")),
+      relPathCat: unwrap(await tRelPath(41946, "ownership", "")),
+      relPathCatSort: unwrap(await tRelPath(41946, "ownership", "amount")),
+      relPathSort: unwrap(await tRelPath(41946, "", "recent")),
+      connPathPlain: unwrap(await tConnPath(41946, "")),
+      connPathCat: unwrap(await tConnPath(41946, "ownership")),
       entities: unwrap(await tParseEntities(sampleSearch)),
       entity: unwrap(await tParseEntity(sampleEntity)),
       relationships: unwrap(await tParseRelationships(sampleRels)),


### PR DESCRIPTION
## Summary

Adds `std::data/people/littlesis` — a keyless entity/power-network stdlib connector over the [LittleSis](https://littlesis.org/api/) REST API. Four thin primitives:

- `littlesisSearch(name, page?)` — resolve a name to matching entities
- `littlesisEntity(id)` — full profile by id
- `littlesisRelationships(id, category?, sort?)` — typed edges (entity IDs, amounts, dates, roles)
- `littlesisConnections(id, category?)` — neighbor entities **by name**, with the linking relationship

Follows the shipped `std::data/finance/*` recipe (pure `build*Path` URL builders, `parse*` reshapers, `*Finalize` Result handlers).

## Design decisions

- **Interrupt gating "Option C":** each function raises one `std::littlesis` prompt, then calls `std::http`'s `fetchJSON` inside an internal handler that approves the resulting `std::http::fetchJSON`. A plain caller sees a **single** prompt; an outer egress/audit handler **still receives** the fetch and can `reject()`/`propagate()` it (those beat the internal approve). `allowedDomains: ["littlesis.org"]` pins the host regardless. Net: single-prompt ergonomics without an egress-governance blind spot.
- **Tagged-union effect payload** `{ op, query }` so a handler or `std::policy` rule can gate individual operations (`match: { op: "relationships" }`) without splitting into four effects.
- **Fail-fast category validation** before the interrupt (better UX — don't prompt for an operation that will immediately fail on bad input; also makes the bad-category path offline-testable).
- Registers `std::littlesis` in the `Network` capability set.

## Testing

Offline agency-js tests (no LLM, no network): category mapping, URL builders, JSON:API parsers, finalize error paths, and interrupt behavior — gating (rejecting short-circuits before any fetch), single-prompt, governance (an outer `propagate()` surfaces the fetch and the test asserts the exact built URL offline), and offline bad-category. Plus an opt-in live test (`AGENCY_LIVE_TESTS`) run once end-to-end against the real API (search returned and parsed ≥1 entity).

Generated stdlib reference page + VitePress nav entry.

## Notes / follow-ups

- The `sample-*.json` fixtures backing the parser tests are hand-authored. The live run validated the **search** path against real data; the connections/relationships parser shapes are currently only checked against the samples (could be hardened by capturing real bodies and/or exercising the two-step recipe in the live test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
