### PR TITLE
Add std::tag module with value tags and statelog redaction

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -128,6 +128,7 @@ export default defineConfig({
             { text: "Developer Tools", link: "/guide/developer-tools" },
             { text: "Debugging", link: "/guide/debugging" },
             { text: "Observability", link: "/guide/observability" },
+            { text: "Tags and Redaction", link: "/guide/tags" },
           ],
         },
 

--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -128,7 +128,6 @@ export default defineConfig({
             { text: "Developer Tools", link: "/guide/developer-tools" },
             { text: "Debugging", link: "/guide/debugging" },
             { text: "Observability", link: "/guide/observability" },
-            { text: "Tags and Redaction", link: "/guide/tags" },
           ],
         },
 
@@ -158,6 +157,7 @@ export default defineConfig({
               link: "/guide/value-parameterized-types",
             },
             { text: "Memory", link: "/guide/memory" },
+            { text: "Tags and Redaction", link: "/guide/tags" },
           ],
         },
         {

--- a/packages/agency-lang/docs/site/guide/tags.md
+++ b/packages/agency-lang/docs/site/guide/tags.md
@@ -1,0 +1,60 @@
+---
+name: Tags and Redaction
+description: Attach arbitrary tags to values with std::tag, and use the built-in redact tag to keep secrets like API keys out of state logs.
+---
+
+# Tags and Redaction
+
+The `std::tag` module lets you attach arbitrary tags to values and read them
+back anywhere in your program.
+
+```ts
+import { tag, getTags, redact } from "std::tag"
+
+tag(x, "source", "user-upload")   // attach a key/value tag
+tag(x, "reviewed")                // value defaults to true
+const tags = getTags(x)           // { source: "user-upload", reviewed: true }
+```
+
+## Value vs. reference semantics
+
+How a tag is stored depends on the kind of value:
+
+- **Primitives** (string, number, boolean) are keyed by **value**. Tagging one
+  copy of `"secret"` tags every equal `"secret"`. This is what makes redacting
+  an API key work no matter how the string was copied.
+- **Objects and arrays** are keyed by **reference**. Tagging one object does
+  *not* tag a structurally-equal but distinct object.
+
+> Object and array tags are branch-local: they do not survive `fork`, `race`,
+> or `parallel` branches, or an interrupt/resume. Primitive (value) tags
+> survive both.
+
+## Redaction
+
+The built-in `redact` tag marks a value so it is replaced with `"[REDACTED]"`
+in [state logs](/guide/observability). Use it for API keys and other secrets:
+
+```ts
+import { redact } from "std::tag"
+
+def callApi(apiKey: string) {
+  redact(apiKey)
+  return fetch("https://api.example.com", { headers: { key: apiKey } })
+}
+```
+
+`redact(x)` is shorthand for `tag(x, "redact", true)`.
+
+Three limits to know:
+
+- **Whole-value only.** A secret is redacted where it appears as a logged value
+  on its own. A secret concatenated into a larger logged string (for example a
+  URL query parameter) is *not* scrubbed — tag the exact string that gets
+  logged.
+- **State logs only.** Redaction governs what `std::statelog` records. It does
+  not affect `print()` or other direct output.
+- **Not a secrecy guarantee.** Redaction is best-effort scrubbing of state-log
+  events emitted while your program runs. It is not an information-flow or
+  security control — treat it as a way to keep secrets out of routine telemetry,
+  not as a guarantee a secret can never be observed.

--- a/packages/agency-lang/docs/site/guide/tags.md
+++ b/packages/agency-lang/docs/site/guide/tags.md
@@ -9,12 +9,18 @@ The `std::tag` module lets you attach arbitrary tags to values and read them
 back anywhere in your program.
 
 ```ts
-import { tag, getTags, redact } from "std::tag"
+import { tag, setTags, getTags, removeTag, removeAllTags } from "std::tag"
 
-tag(x, "source", "user-upload")   // attach a key/value tag
-tag(x, "reviewed")                // value defaults to true
-const tags = getTags(x)           // { source: "user-upload", reviewed: true }
+tag(x, "source", "user-upload")        // attach a key/value tag
+tag(x, "reviewed")                     // value defaults to true
+setTags(x, { team: "growth", tier: 2 }) // attach several at once
+const tags = getTags(x)                // { source: "user-upload", reviewed: true, team: "growth", tier: 2 }
+removeTag(x, "reviewed")               // drop one tag
+removeAllTags(x)                       // drop them all
 ```
+
+Every function returns the value's current tags (an empty object once cleared),
+which doubles as a confirmation when one of these is used as an LLM tool.
 
 ## Value vs. reference semantics
 
@@ -46,12 +52,15 @@ def callApi(apiKey: string) {
 
 `redact(x)` is shorthand for `tag(x, "redact", true)`.
 
-Three limits to know:
+Four limits to know:
 
 - **Whole-value only.** A secret is redacted where it appears as a logged value
   on its own. A secret concatenated into a larger logged string (for example a
   URL query parameter) is *not* scrubbed — tag the exact string that gets
   logged.
+- **Values, never keys.** Redaction rewrites values, not object keys. A secret
+  used as a key (e.g. `{ "sk-...": {...} }`) still appears in the log verbatim —
+  tag the value, not the thing that becomes a key.
 - **State logs only.** Redaction governs what `std::statelog` records. It does
   not affect `print()` or other direct output.
 - **Not a secrecy guarantee.** Redaction is best-effort scrubbing of state-log

--- a/packages/agency-lang/docs/site/stdlib/tag.md
+++ b/packages/agency-lang/docs/site/stdlib/tag.md
@@ -35,11 +35,11 @@ Note: object/array tags are branch-local — they do not survive `fork`/`race`/
 ### tag
 
 ```ts
-tag(value: any, key: string, val: any)
+tag(value: any, key: string, val: any): any
 ```
 
 Attach a tag to a value. Primitives are keyed by value; objects by
-  reference. `val` defaults to `true`.
+  reference. `val` defaults to `true`. Returns the value's current tags.
 
 **Parameters:**
 
@@ -49,7 +49,29 @@ Attach a tag to a value. Primitives are keyed by value; objects by
 | key | `string` |  |
 | val | `any` | true |
 
+**Returns:** `any`
+
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L30))
+
+### setTags
+
+```ts
+setTags(value: any, tags: any): any
+```
+
+Attach multiple tags at once from a `{ key: value }` object. Returns the
+  value's current tags.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+| tags | `any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L36))
 
 ### getTags
 
@@ -57,7 +79,8 @@ Attach a tag to a value. Primitives are keyed by value; objects by
 getTags(value: any): any
 ```
 
-Return all tags on a value as an object, or an empty object if none.
+Return all tags on a value as an object, or an empty object if none. The
+  result is a shallow copy; nested tag values are shared references.
 
 **Parameters:**
 
@@ -67,16 +90,16 @@ Return all tags on a value as an object, or an empty object if none.
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L42))
 
 ### redact
 
 ```ts
-redact(value: any)
+redact(value: any): any
 ```
 
 Mark a value so it is replaced with "[REDACTED]" in state logs. Shorthand
-  for tag(value, "redact", true).
+  for tag(value, "redact", true). Returns the value's current tags.
 
 **Parameters:**
 
@@ -84,4 +107,43 @@ Mark a value so it is replaced with "[REDACTED]" in state logs. Shorthand
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L41))
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L48))
+
+### removeTag
+
+```ts
+removeTag(value: any, key: string): any
+```
+
+Remove a single tag from a value. Returns the value's remaining tags.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+| key | `string` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L54))
+
+### removeAllTags
+
+```ts
+removeAllTags(value: any): any
+```
+
+Remove all tags from a value. Returns an empty object.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L59))

--- a/packages/agency-lang/docs/site/stdlib/tag.md
+++ b/packages/agency-lang/docs/site/stdlib/tag.md
@@ -1,0 +1,87 @@
+---
+name: "tag"
+---
+
+# tag
+
+Attach arbitrary tags to values and read them back anywhere in
+your program.
+
+Tags are stored in a side table, so nothing is attached to the value itself
+and TypeScript interop is unaffected. Two semantics, by value kind:
+
+- **Primitives** (string, number, boolean) are keyed by **value**: tagging one
+  copy of `"secret"` tags every equal `"secret"` in the current branch.
+- **Objects and arrays** are keyed by **reference**: tagging one object does
+  not tag a structurally-equal but distinct object.
+
+The built-in `redact` tag marks a value so it is replaced with `"[REDACTED]"`
+in state logs — useful for API keys and other secrets.
+
+  ```ts
+  import { redact } from "std::tag"
+
+  def callApi(apiKey: string) {
+    redact(apiKey)          // apiKey shows as "[REDACTED]" in state logs
+    return fetch("https://api.example.com", { headers: { key: apiKey } })
+  }
+  ```
+
+Note: object/array tags are branch-local — they do not survive `fork`/`race`/
+`parallel` branches or interrupt/resume. Primitive (value) tags survive both.
+
+## Functions
+
+### tag
+
+```ts
+tag(value: any, key: string, val: any)
+```
+
+Attach a tag to a value. Primitives are keyed by value; objects by
+  reference. `val` defaults to `true`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+| key | `string` |  |
+| val | `any` | true |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L30))
+
+### getTags
+
+```ts
+getTags(value: any): any
+```
+
+Return all tags on a value as an object, or an empty object if none.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L36))
+
+### redact
+
+```ts
+redact(value: any)
+```
+
+Mark a value so it is replaced with "[REDACTED]" in state logs. Shorthand
+  for tag(value, "redact", true).
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/tag.agency#L41))

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-07-value-tags-and-redaction-review.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-07-value-tags-and-redaction-review.md
@@ -1,0 +1,356 @@
+# Review: Value Tags & Statelog Redaction Implementation Plan
+
+**Plan:** `docs/superpowers/plans/2026-07-07-value-tags-and-redaction.md`
+**Spec:** `docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md`
+**Reviewer:** Claude (Opus 4.8)
+**Date:** 2026-07-07
+
+## Verdict
+
+Strong plan. It is TDD-structured, self-contained, and — importantly — its
+code-level claims are accurate. I verified every infrastructure touchpoint
+against the current code and all of them hold:
+
+- `GlobalStore` API (`get`/`set`/`INTERNAL_MODULE = "__internal"`/`clone`/
+  `toJSON`/`fromJSON`) matches `lib/runtime/state/globalStore.ts`. `__tokenStats`
+  under `__internal` is a real precedent for the `__valueTags` Map.
+- `MapReviver` serializes as `Array.from(value.entries())` and revives via
+  `new Map(entries)`, so primitive **key types survive** the round-trip
+  (`1` vs `"1"` stay distinct). The plan's claim is correct.
+- `fromJSON` constructs a **fresh** `GlobalStore`, so a new `objectTags` WeakMap
+  field is empty after clone/restore — exactly the branch-local behavior the
+  plan wants, for free.
+- `__globals()` returns `GlobalStore | undefined` (`lib/runtime/asyncContext.ts`).
+- `runInTestContext(ctx, stack, threads, fn)` seeds the ALS `globals` slot from
+  `ctx.globals`; `createExecutionContext` returns a `RuntimeContext` carrying
+  `.globals` / `.stateStack` / `.statelogClient`. The Task 3/4 test harness usage
+  is valid.
+- The `post()` body the plan patches (Task 4, Step 3) is a **verbatim** match of
+  `lib/statelogClient.ts` (~line 1164, not 1165–1173 — trivial). The exact-string
+  edit will apply.
+- `agency-lang/stdlib-lib/tag.js` is the established stdlib TS-import convention;
+  `./stdlib-lib/*` → `./dist/lib/stdlib/*` is a real export map entry. Default
+  params (`val: any = true`) are supported (`stdlib/fs.agency`). `std::` modules
+  resolve **by file** (`importPaths.ts`), so "drop `stdlib/tag.agency` + `make`"
+  is sufficient — there is no manifest/allowlist to update.
+
+So the plumbing is right. The issues below are about **correctness of the walker**
+and **coverage of the headline durability claim** — not about wrong file paths or
+APIs.
+
+---
+
+## Must-fix
+
+### 1. The `redactForStatelog` walker corrupts non-plain objects (Date, Error, Map, URL, class instances)
+
+**Severity: high (silent data corruption in telemetry).**
+
+The walker (Task 2) treats *every* `typeof value === "object"` as a plain record
+and deep-copies it via `Object.entries`:
+
+```ts
+if (value !== null && typeof value === "object") {
+  ...
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = walk(v, globals, seen);
+  }
+  return out;
+}
+```
+
+Today `post()` does a plain `JSON.stringify(body)` with **no replacer**. So a
+`Date` in an event body currently serializes via `Date.prototype.toJSON()` to an
+ISO string. After the walker runs first, `Object.entries(someDate)` is `[]`, so
+the Date becomes `{}` *before* `JSON.stringify` ever sees it — the timestamp is
+lost. The same flattening hits anything whose data lives in non-enumerable form
+or behind a custom `toJSON`: `Error`, `Map`, `Set`, `URL`, and ordinary class
+instances. These are exactly the types the codebase has revivers for because
+they show up in serialized runtime state.
+
+This is not hypothetical for `toolCall` output/args and `error` events: tool
+return values are arbitrary user data and routinely contain `Date`s or class
+instances. The result is a regression that only shows up in logs, so it will be
+easy to miss.
+
+**Fix:** in `walk`, recurse only into arrays and *plain* objects
+(`Object.getPrototypeOf(v) === Object.prototype || === null`). For any other
+object, redact-if-tagged, otherwise return it **unchanged by reference** and let
+`JSON.stringify` serialize it exactly as it does today.
+
+**Add a test:** a body containing `{ when: new Date("2026-01-01") }` still
+serializes to the ISO string after redaction (and an untagged `Error`/class
+instance is not flattened).
+
+---
+
+## Should-fix
+
+### 2. Redaction deep-copies every statelog event unconditionally, even with zero tags
+
+**Severity: medium (hot-path allocation regressing the common case).**
+
+`redactForStatelog` short-circuits only when `globals` is `undefined`. In the
+normal case `globals` exists but nothing is tagged — yet the walker still
+allocates a full deep copy of **every** event body on **every** `post()`. That is
+~40 event types firing continuously, including `promptCompletion` events with
+large message arrays and base64 image attachments. For programs that never call
+`redact`/`tag` (the overwhelming majority), this is pure overhead added to the
+telemetry hot path.
+
+**Fix:** add a cheap "any tags at all?" gate. WeakMap size isn't observable, so
+track object-tag presence with a boolean/counter on `GlobalStore` (set in
+`setTag` for the ref branch) and check the primitive `Map`'s `size`. Expose e.g.
+`GlobalStore.hasAnyTags(): boolean`, and have `redactForStatelog` return `body`
+unchanged when it's false. This keeps the zero-config, tag-free path at
+today's cost.
+
+### 3. No end-to-end test of the headline claim: redaction surviving `fork`/interrupt
+
+**Severity: medium (coverage gap on a stated Goal).**
+
+The spec's Goals lead with *"Make redaction of primitive secrets fully robust —
+including across fork/parallel/race branches and interrupt/resume,"* and its
+Testing section explicitly calls for: redaction surviving a fork and an
+interrupt/resume for a primitive; `shared: true` propagation; and pinning the
+object-tags-are-branch-local limitation with a test.
+
+The plan proves the *store* clones the Map (Task 1 unit tests) but explicitly
+defers the *compiled* fork/interrupt redaction fixture and does not test
+`shared: true`. The unit test does not prove that `__globals()` inside a
+**branch's** `post()` actually sees the inherited tag and emits `[REDACTED]` —
+which is the whole selling point. That gap is exactly where a wiring bug (e.g.
+the branch's cloned globals not being the one `post()` reads) would hide.
+
+**Recommendation:** promote at least one execution test out of "deferred":
+a program that `fork`s, sets or inherits a `redact` tag on a primitive in the
+branch, and asserts `[REDACTED]` appears in the branch's statelog output. That
+pins the durable path end-to-end. The object-tags-don't-survive-fork assertion
+(spec's explicit ask) is cheap to add alongside it and locks the documented
+limitation.
+
+---
+
+## Minor / confirm
+
+### 4. Events posted outside an ALS frame are silently not redacted (document it)
+
+`post()` reads `__globals()`; when an event is emitted outside a branch ALS
+frame (some bootstrap/flush paths), `__globals()` is `undefined` and redaction
+is a no-op passthrough. This is fail-open and fine for the API-key-in-a-node
+case, but it means redaction is not an airtight secrecy guarantee. The spec
+already says redaction is a statelog concern and not general secrecy — good — but
+the plan/guide should state this ALS-frame boundary explicitly so nobody assumes
+otherwise. (This dovetails with the spec's existing "not a secrecy guarantee"
+framing.)
+
+### 5. Verify the doc-comment parser tolerates a nested ```` ``` ```` fence
+
+The `tag.agency` `/** @module ... */` docstring (Task 5) embeds a fenced
+```` ```ts ```` code block *inside* the block comment. The block comment itself
+terminates on `*/`, so this should be inert to the parser — but confirm that
+`agency doc` (Task 6, Step 2) extracts and renders the nested fence correctly
+rather than truncating the module doc at the inner fence. A 30-second check when
+you run `agency doc`; flagging so it isn't a surprise.
+
+### 6. Nits (no action needed)
+
+- Task 4 cites `post()` at "line 1165–1173"; it's ~1164. The exact-string match
+  makes the line number irrelevant.
+- Test counts ("6 tests", "7 tests") match the `it(...)` blocks as written.
+- The spec's "optional low-entropy dev-mode warning" is correctly left in
+  deferred follow-ups — not a gap.
+
+---
+
+## Summary
+
+| # | Issue | Severity | Action |
+|---|-------|----------|--------|
+| 1 | Walker flattens Date/Error/Map/URL/class instances via `Object.entries` | High | Guard to plain-objects-and-arrays; pass others through by ref; add Date test |
+| 2 | Unconditional deep-copy of every event even with no tags | Medium | Add `hasAnyTags()` fast-path on `GlobalStore` |
+| 3 | No e2e test of redaction surviving fork/interrupt (a stated Goal) | Medium | Promote a fork-redaction execution test out of "deferred" |
+| 4 | Events outside an ALS frame aren't redacted | Low | Document the fail-open boundary |
+| 5 | Nested code fence in `@module` docstring | Low | Confirm `agency doc` renders it |
+
+Items 1 and 3 are the ones I would not ship without: 1 is a latent correctness
+bug the tests as written won't catch (they only use plain objects/primitives),
+and 3 leaves the feature's headline guarantee unverified end-to-end.
+
+---
+
+## Appendix: check against `docs/dev/anti-patterns.md`
+
+**Headline question — does the plan write declarative interfaces that encapsulate
+complexity, keeping imperative code in a few places?** *At the architecture level,
+yes — this is a strength.* The plan is a good example of the principle, not a
+violation:
+
+- `std::tag` exposes `tag` / `getTags` / `redact` — users write the *what*
+  (`redact(apiKey)`); the *how* (two side stores, value-vs-reference keying, ALS
+  access) is hidden.
+- `GlobalStore.setTag` / `getTagsFor` encapsulate the primitive-Map-vs-object-
+  WeakMap dispatch behind two methods; no caller sees the split.
+- Redaction is applied at the **single `post()` chokepoint** instead of imperative
+  scrubbing at ~40 event call sites — the textbook "encapsulate the *how* in one
+  place" move.
+- `_getTags` returns a **copy** (`{ ...t }`), with a test, so the live store
+  object never leaks to callers.
+
+The imperative internals (the `walk` loop, get-or-create) are fine *because* they
+sit behind those interfaces — the anti-pattern is imperative code *leaking
+everywhere*, which this avoids.
+
+**Not flagged (checked, but they match house style / aren't enforced):**
+
+- One-line guard returns (`if (!globals) return value;`). The doc lists
+  "one-line if statements," but `eslint lib/` (the `lint:structure` target) does
+  not enforce it and runtime code uses this guard form pervasively
+  (`if (!thread) return [];` etc.). Flagging it would be over-reading the doc.
+- Single-char temporaries (`m`, `t`, `g`) in tight scopes — the codebase uses the
+  same (`k`, `n`, `p`, `m`). Not worth a change.
+- No nested ternaries, dynamic requires, unlogged catch blocks, magic numbers,
+  nested type defs, or order-dependent mutable state in the plan's code.
+
+**Genuine anti-pattern findings:**
+
+### AP-1. Duplicating existing traversal — the walker should be a `JSON.stringify` replacer (ties to Must-fix #1)
+
+`redactForStatelog`'s hand-rolled `walk()` re-implements deep value traversal that
+the codebase **already owns**: `nativeTypeReplacer`
+(`lib/runtime/revivers/index.ts`), the replacer behind `GlobalStore.toJSON`,
+already walks values and correctly handles `Date`/`URL`/`Map`/`Set`/`Error`/
+`RegExp` — including recovering the *raw* pre-`toJSON` value via `this[key]`,
+which is exactly what value-identity redaction needs.
+
+This is the "Duplicating existing code" anti-pattern with real consequences: the
+parallel walker is *why* Must-fix #1 exists (it flattens Dates to `{}`). Since
+`post()` is about to `JSON.stringify(body)` anyway, redaction is more naturally a
+**stringify replacer**:
+
+```ts
+// one traversal, inside stringify, so toJSON/Date semantics are preserved
+const postBody = JSON.stringify({ ...envelope, data: { ...body, timestamp } },
+  redactReplacer(globals));
+```
+
+A replacer that reads the raw value via `this[key]`, returns `"[REDACTED]"` when
+`getTagsFor(raw)?.redact === true`, and otherwise returns `value` unchanged: (a)
+removes the separate deep-copy pass entirely — fixing the unconditional-copy perf
+finding (#2) as well, since a no-tag program pays only a per-key function call, not
+a full body clone; (b) preserves `Date`→ISO and other `toJSON` output for free —
+fixing #1; (c) is strictly less code. (Cycles: `JSON.stringify` throws on cycles
+regardless, so the walker's `seen`-map cycle handling doesn't actually protect the
+emitted log — the downstream stringify would already throw. One more reason the
+separate pass earns its keep only if it were doing something stringify can't.)
+
+### AP-2. Leaky abstraction — the meaning of "redacted" is a magic string spread across files
+
+The representation of redaction — the tag key `"redact"` with value `true` — is
+duplicated in `tag.ts` (`_redact` writes it), `redactForStatelog.ts` (reads
+`tags["redact"] === true`), and the docs. No single owner defines "what redacted
+means," so the walker is coupled to the tag's internal shape. The output string is
+nicely constified (`const REDACTED`), but the *key* is not. Encapsulate it: a
+shared `const REDACT_TAG = "redact"`, or better a `GlobalStore.isRedacted(value):
+boolean` predicate the walker/replacer calls, so redaction semantics live in one
+place.
+
+### AP-3. Minor duplication inside `setTag`
+
+The get-or-create-then-assign block is written twice (object-WeakMap branch and
+primitive-Map branch). A small `upsertTag(store, value, key, val)` helper — or
+resolving to the target store first, then a single upsert — removes the
+repetition. Low priority.
+
+**Net:** the plan gets the *interface* design right (declarative surface, single
+chokepoint, hidden two-store split). The anti-pattern worth acting on is AP-1 — and
+it's the same fix as Must-fix #1 and Should-fix #2, so reworking the walker into a
+replacer resolves all three at once.
+
+---
+
+## Appendix: test-plan review
+
+Three questions: do the tests test what they claim, will they fail if the code
+breaks, and what's missing?
+
+### What's genuinely well-tested (would fail if broken)
+
+- **Task 1 is the strongest part of the plan.** The discriminating tests are
+  exactly the right ones: `1` vs `"1"` staying distinct *directly* guards the
+  Map-not-plain-object decision (a plain-object impl coerces both to `"1"` and
+  the test fails); "clone keeps primitive, drops object" pins the whole durability
+  model; "merges multiple tags" guards against whole-record overwrite. These are
+  not happy-path rubber stamps — each one fails loudly if its specific behavior
+  regresses.
+- **Task 3** correctly exercises the layer Task 1 doesn't: the `__globals()` ALS
+  wiring, the `{ ...t }` copy (mutating the returned object doesn't dirty the
+  store), and the outside-a-frame no-op. Real guards.
+- **Task 4** is a proper end-to-end integration test of the primitive→`post()`
+  path: it asserts both presence of `[REDACTED]` *and* absence of the raw secret,
+  through the real `stdout` sink. It would fail if redaction weren't wired. I
+  traced the wiring — `runInTestContext` seeds ALS `globals` from `execCtx.globals`,
+  the test tags that same object, and `post()` reads it via `__globals()`, so the
+  test genuinely exercises the seam it claims to.
+
+### Where a broken implementation would still pass (the real problem)
+
+1. **The Date/Map/Error corruption bug (Must-fix #1) is invisible to every test.**
+   Every walker input in Task 2 is a plain object, array, string, or number.
+   Nothing feeds the walker a `Date`, `Error`, `Map`, `URL`, or class instance —
+   the exact values `Object.entries` flattens to `{}`. So the code can corrupt
+   native types in the log and **the suite stays green.** This is the classic
+   "tests confirm what the code does, not what it should do" trap, and it's why
+   the bug is latent. Required additions:
+   - `redactForStatelog({ when: new Date("2026-01-01T00:00:00Z") }, gs)` still
+     yields the ISO string (fails today).
+   - an untagged `Error` / `Map` in the body survives intact.
+
+2. **The headline durability claim (fork/parallel/race + interrupt/resume) has no
+   end-to-end test.** Task 1 proves the *store* clones its Map, but nothing proves
+   that `__globals()` inside a **real forked branch's** `post()` sees the inherited
+   tag and emits `[REDACTED]`. A regression in branch-ALS globals wiring — the most
+   likely place for this feature to break — ships green. This is the biggest
+   coverage gap relative to a stated Goal. Add at least one test that forks, tags a
+   primitive in/for the branch, and asserts `[REDACTED]` in the branch's statelog.
+   The spec also explicitly asks to pin the *opposite* for objects (tag does **not**
+   survive fork) and `shared: true` propagation — both untested.
+
+3. **`redact` has no compiled execution test.** Task 5 proves the module compiles
+   and value-keying works, but tags `"color"`, never `redact`. The flagship
+   feature's only redaction coverage is a TS-level unit test; nothing drives
+   `redact(x)` → `[REDACTED]` through compile → run → statelog. The spec's Testing
+   section asks for exactly this ("redact on a string → event shows [REDACTED] in
+   the emitted JSON"). Add a `tests/agency/` program with a logFile/stdout sink.
+
+4. **The deliberate v1 boundary — substring NOT redacted — is unpinned.** The spec
+   wants this locked by a test so a future change can't silently cross it:
+   `redactForStatelog({ url: "https://api.com?key=" + tagged }, gs)` leaves the URL
+   untouched. Missing.
+
+### Smaller discrimination gaps
+
+- **`redact: false` vs absent.** "does not redact tags without redact:true" uses a
+  `color` tag, so it wouldn't catch a check written as `"redact" in tags` instead
+  of `=== true`. Add an explicit `redact: false` → not redacted.
+- **Boolean/null primitive keys.** Only `1`/`"1"` distinctness is tested. `true`
+  vs `"true"` vs `1` (the low-entropy keys the spec calls out) aren't. A key-
+  stringifying regression would slip through for booleans.
+- **`getTagsFor` purity.** The impl comment claims a pure lookup "never mutates
+  state" (reads without creating the Map). No test pins it — if a refactor made
+  `getTagsFor` call `valueTagMap()` (which creates), every read would dirty the
+  store and clones would carry an empty Map. Cheap test: `getTagsFor("x")` on a
+  fresh store, then assert `toJSON().store` has no `__valueTags` key.
+- **Top-level tagged primitive** (`redactForStatelog("secret", gs)` → `[REDACTED]`)
+  and **object-node redaction end-to-end** (only primitive is integration-tested).
+  Low priority.
+
+### Verdict on the test plan
+
+Unit-level tests are strong and discriminating. The gaps are all at the
+**integration/behavioral edge**, and two of them are serious: the walker's native-
+type handling is untested (hiding a real bug), and the feature's headline
+durability guarantee is only proven at the store level, never end-to-end through a
+fork. Both are cases where the code breaks and nothing turns red — the exact
+failure mode this review is meant to catch. Fixing the walker per AP-1 (make it a
+stringify replacer) also makes the native-type test trivial to write and pass.

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-07-value-tags-and-redaction.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-07-value-tags-and-redaction.md
@@ -1,0 +1,1072 @@
+# Value Tags & Statelog Redaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Agency programs attach arbitrary tags to values (`tag`/`getTags`) and mark values for statelog redaction (`redact`), so secrets like API keys never appear in state logs.
+
+**Architecture:** Two tag stores live on the existing per-branch `GlobalStore`: a value-keyed `Map` for primitives (durable — clones and serializes with globals) and a reference-keyed `WeakMap` for objects (branch-local — reset on clone). A new `std::tag` module exposes `tag`/`getTags`/`redact` over TS helpers that read the branch-local store via the `__globals()` ALS accessor. The `redact` semantics are owned entirely by `GlobalStore` (`markRedacted`/`isRedacted`/`REDACT_TAG`) so no other file hard-codes the tag's shape. Statelog redaction runs at a single chokepoint (`StatelogClient.post`) as a **`JSON.stringify` replacer scoped to the event's `data` payload** — the envelope and payload are stringified separately and spliced, so the replacer rides one serialization pass over `data` (no second traversal), inherits `JSON.stringify`'s native handling of `Date`/`URL`/etc., and can never touch infra fields like `format_version`/`trace_id` (tagged values are swapped for `"[REDACTED]"`; everything else is untouched).
+
+**Tech Stack:** TypeScript, Agency stdlib (`.agency` + TS impl), Vitest (unit/integration), Agency execution tests (`tests/agency/`).
+
+**Design spec:** `docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md`
+
+**Review folded in:** `docs/superpowers/plans/2026-07-07-value-tags-and-redaction-review.md` (walker→replacer rework, redact-tag encapsulation, `hasAnyTags` fast path, native-type + fork-durability + substring-boundary tests).
+
+## Global Constraints
+
+- **Do NOT `git commit` or `git push`.** Per user instruction, all work stays in the local working tree. Each task's completion gate is its passing test, not a commit.
+- **No boxing of primitives.** Tags live only in side stores; values are never wrapped.
+- **Two store semantics (must be documented):** primitives are keyed by **value** (all equal primitives share tags); objects/arrays by **reference** (structurally-equal distinct objects do not share tags).
+- **Object tags are branch-local.** They do not survive `fork`/`parallel`/`race` cloning or interrupt/resume. Primitive tags survive both.
+- **Redaction is a `JSON.stringify` replacer, not a pre-copy walk.** This is load-bearing: a replacer runs inside statelog's existing single stringify (no extra deep copy) and preserves `Date`/`URL` and other `toJSON`-bearing values — a naive `Object.entries` deep-walk flattens those to `{}`. The replacer recovers the raw pre-`toJSON` value via `this[key]`, mirroring the existing `nativeTypeReplacer`.
+- **Redaction is scoped to the `data` payload, never the envelope.** The envelope (`format_version`, `trace_id`, `project_id`, span ids) and the payload are stringified separately and spliced, so a value-collision (e.g. a user tagging the number `1`, which equals `format_version`) can never corrupt an infra field. Worst case of a low-entropy tag is over-redaction *within* the user's own payload.
+- **v1 redaction is whole-value only.** A secret embedded inside a larger logged string is not scrubbed.
+- **Redaction governs statelog only, and only inside an execution frame.** `print()` and other direct output are unaffected. Events posted outside an ALS frame (no `__globals()`) are not redacted — redaction is best-effort statelog scrubbing, not a general secrecy guarantee.
+- **Rebuild after stdlib changes:** run `make` before any test that runs the compiled CLI (`pnpm run a ...`). Vitest tests run against TS source and need no build.
+- **Reserved names:** runtime/internal fields use the existing `__internal` module namespace convention on `GlobalStore`.
+
+---
+
+### Task 1: Tag storage on `GlobalStore`
+
+Add value-keyed (primitive) and reference-keyed (object) tag storage to `GlobalStore`, reusing its existing `toJSON`/`fromJSON`/`clone` machinery so primitive tags are durable and object tags reset on clone. Also add the `redact`-tag owner methods (`markRedacted`/`isRedacted`) and a cheap `hasAnyTags()` gate.
+
+**Files:**
+- Modify: `lib/runtime/state/globalStore.ts`
+- Test: `lib/runtime/state/globalStore.tags.test.ts` (create)
+
+**Interfaces:**
+- Consumes: existing `GlobalStore.get/set`, `GlobalStore.INTERNAL_MODULE`, `clone()`, `toJSON()`, `fromJSON()`.
+- Produces:
+  - `GlobalStore.setTag(value: unknown, key: string, val: unknown): void`
+  - `GlobalStore.getTagsFor(value: unknown): Record<string, unknown> | undefined`
+  - `GlobalStore.markRedacted(value: unknown): void`
+  - `GlobalStore.isRedacted(value: unknown): boolean`
+  - `GlobalStore.hasAnyTags(): boolean`
+  - `GlobalStore.REDACT_TAG` (readonly `"redact"`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/state/globalStore.tags.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { GlobalStore } from "./globalStore.js";
+
+describe("GlobalStore tags", () => {
+  it("keys primitive tags by value (all equal primitives share tags)", () => {
+    const gs = new GlobalStore();
+    gs.setTag("secret", "redact", true);
+    // A different string instance with the same value reads the same tags.
+    const other = ["sec", "ret"].join("");
+    expect(gs.getTagsFor(other)).toEqual({ redact: true });
+    expect(gs.getTagsFor("nope")).toBeUndefined();
+  });
+
+  it("keeps boolean, number, and string keys distinct", () => {
+    const gs = new GlobalStore();
+    gs.setTag(1, "a", 1);
+    gs.setTag(true, "b", 2);
+    expect(gs.getTagsFor(1)).toEqual({ a: 1 });
+    expect(gs.getTagsFor("1")).toBeUndefined();
+    expect(gs.getTagsFor(true)).toEqual({ b: 2 });
+    expect(gs.getTagsFor("true")).toBeUndefined();
+  });
+
+  it("keys object tags by reference (structurally-equal objects do not share)", () => {
+    const gs = new GlobalStore();
+    const o = { id: 1 };
+    gs.setTag(o, "redact", true);
+    expect(gs.getTagsFor(o)).toEqual({ redact: true });
+    expect(gs.getTagsFor({ id: 1 })).toBeUndefined();
+  });
+
+  it("merges multiple tags on the same value", () => {
+    const gs = new GlobalStore();
+    gs.setTag("k", "a", 1);
+    gs.setTag("k", "b", 2);
+    expect(gs.getTagsFor("k")).toEqual({ a: 1, b: 2 });
+  });
+
+  it("getTagsFor does not create the value Map (pure lookup never mutates)", () => {
+    const gs = new GlobalStore();
+    gs.getTagsFor("x");
+    // Nothing was set, so the __internal module slot must not exist yet —
+    // a read that created the backing Map would dirty every subsequent clone.
+    expect(gs.toJSON().store["__internal"]).toBeUndefined();
+  });
+
+  it("markRedacted / isRedacted own the redact tag", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("sk");
+    expect(gs.isRedacted("sk")).toBe(true);
+    expect(gs.isRedacted("other")).toBe(false);
+    // isRedacted checks === true, not mere presence.
+    gs.setTag("x", "redact", false);
+    expect(gs.isRedacted("x")).toBe(false);
+    // markRedacted writes the same key user code would via tag(x,"redact",true).
+    expect(gs.getTagsFor("sk")).toEqual({ redact: true });
+  });
+
+  it("hasAnyTags reflects primitive and object tags", () => {
+    const gs = new GlobalStore();
+    expect(gs.hasAnyTags()).toBe(false);
+    gs.setTag("p", "a", 1);
+    expect(gs.hasAnyTags()).toBe(true);
+  });
+
+  it("clone() keeps primitive tags but drops object tags", () => {
+    const gs = new GlobalStore();
+    const o = {};
+    gs.setTag("prim", "redact", true);
+    gs.setTag(o, "redact", true);
+    const c = gs.clone();
+    expect(c.getTagsFor("prim")).toEqual({ redact: true });
+    expect(c.getTagsFor(o)).toBeUndefined();
+    // hasAnyTags tracks the split: object-only presence resets on clone,
+    // primitive presence survives. (Pins the branch-local object contract.)
+    expect(c.hasAnyTags()).toBe(true); // primitive tag survived
+    const objOnly = new GlobalStore();
+    objOnly.setTag({}, "redact", true);
+    expect(objOnly.hasAnyTags()).toBe(true);
+    expect(objOnly.clone().hasAnyTags()).toBe(false); // object tag dropped
+  });
+
+  it("survives toJSON/fromJSON for primitive tags (interrupt durability)", () => {
+    const gs = new GlobalStore();
+    gs.setTag("prim", "redact", true);
+    const restored = GlobalStore.fromJSON(gs.toJSON());
+    expect(restored.getTagsFor("prim")).toEqual({ redact: true });
+    expect(restored.isRedacted("prim")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/state/globalStore.tags.test.ts`
+Expected: FAIL — `gs.setTag is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/runtime/state/globalStore.ts`, add fields and methods inside the `GlobalStore` class (place after the existing fields, e.g. just below `initializedModules`):
+
+```ts
+  // Object/array/function tags, keyed by reference. Deliberately a WeakMap so
+  // it is (a) excluded from toJSON serialization and (b) reset to empty on
+  // clone() (fromJSON constructs a fresh GlobalStore). Object identity does
+  // not survive the toJSON/fromJSON round-trip, so object tags are
+  // intentionally branch-local and do not cross fork/interrupt boundaries.
+  private objectTags: WeakMap<object, Record<string, unknown>> = new WeakMap();
+
+  // Tracks whether any object (reference) tag has been set, so hasAnyTags()
+  // can answer without enumerating the (non-enumerable) WeakMap. Not
+  // serialized and starts false on every fresh store, so it resets on
+  // clone()/fromJSON — matching the WeakMap, whose entries also reset.
+  private objectTagsPresent = false;
+
+  private static readonly VALUE_TAGS_KEY = "__valueTags";
+  static readonly REDACT_TAG = "redact";
+
+  private isRef(value: unknown): value is object {
+    return (
+      (typeof value === "object" && value !== null) ||
+      typeof value === "function"
+    );
+  }
+
+  // Primitive tags, keyed by value. Stored as a Map under the __internal
+  // module so it rides the existing toJSON/fromJSON/clone machinery. The
+  // MapReviver serializes entries as [key, value] pairs through JSON, which
+  // preserves primitive key *types* (1, "1", and true stay distinct).
+  private valueTagMap(): Map<unknown, Record<string, unknown>> {
+    let m = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    if (!(m instanceof Map)) {
+      m = new Map();
+      this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY, m);
+    }
+    return m as Map<unknown, Record<string, unknown>>;
+  }
+
+  // Resolve the tag record for a value. `create` controls whether a missing
+  // record (and its backing store slot) is allocated — reads pass false so a
+  // pure lookup never mutates state. Unifies the primitive (value Map) and
+  // object (WeakMap) paths so setTag/getTagsFor share one code path.
+  private tagsRecordFor(
+    value: unknown,
+    create: boolean,
+  ): Record<string, unknown> | undefined {
+    if (this.isRef(value)) {
+      let t = this.objectTags.get(value);
+      if (!t && create) {
+        t = {};
+        this.objectTags.set(value, t);
+        this.objectTagsPresent = true;
+      }
+      return t;
+    }
+    const m = create
+      ? this.valueTagMap()
+      : this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    if (!(m instanceof Map)) return undefined;
+    let t = m.get(value);
+    if (!t && create) {
+      t = {};
+      m.set(value, t);
+    }
+    return t;
+  }
+
+  setTag(value: unknown, key: string, val: unknown): void {
+    const tags = this.tagsRecordFor(value, true);
+    // create=true always yields a record; the guard is for the type checker.
+    if (tags) tags[key] = val;
+  }
+
+  getTagsFor(value: unknown): Record<string, unknown> | undefined {
+    return this.tagsRecordFor(value, false);
+  }
+
+  /**
+   * Mark a value for statelog redaction. Sole *writer* of the redact tag, so
+   * the tag's representation lives in exactly one place. Equivalent to the
+   * user-facing tag(value, "redact", true).
+   */
+  markRedacted(value: unknown): void {
+    this.setTag(value, GlobalStore.REDACT_TAG, true);
+  }
+
+  /**
+   * True when a value is marked redact:true. Sole *reader* of the redact tag
+   * (the statelog replacer calls this), so the walker never hard-codes the
+   * tag shape.
+   */
+  isRedacted(value: unknown): boolean {
+    return this.getTagsFor(value)?.[GlobalStore.REDACT_TAG] === true;
+  }
+
+  /**
+   * Cheap "are there any tags at all?" check so statelog can skip installing
+   * a redaction replacer entirely when nothing is tagged (the common case).
+   * The WeakMap can't report size, so object-tag presence is tracked by a
+   * boolean flag that resets on clone alongside the WeakMap.
+   */
+  hasAnyTags(): boolean {
+    if (this.objectTagsPresent) return true;
+    const m = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    return m instanceof Map && m.size > 0;
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/runtime/state/globalStore.tags.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Checkpoint (no commit)**
+
+Run the full file once more and confirm green. Per Global Constraints, do **not** `git commit`. Leave changes in the working tree.
+
+---
+
+### Task 2: `makeRedactReplacer` — the statelog redaction replacer
+
+A factory that builds a `JSON.stringify` replacer bound to a branch's `GlobalStore`. The replacer swaps any value marked `redact:true` for `"[REDACTED]"` and leaves everything else untouched. Implemented as a replacer (not a pre-copy deep-walk) so it rides statelog's single `JSON.stringify`, adds no second traversal, and preserves `Date`/`URL`/`toJSON`-bearing values. Kept standalone (own file) so `StatelogClient` imports only this, avoiding import cycles.
+
+**Files:**
+- Create: `lib/runtime/redactForStatelog.ts`
+- Test: `lib/runtime/redactForStatelog.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `GlobalStore.isRedacted` (Task 1); `GlobalStore` type only.
+- Produces:
+  - `REDACTED` (the `"[REDACTED]"` constant)
+  - `makeRedactReplacer(globals: GlobalStore): (this: unknown, key: string, value: unknown) => unknown`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/redactForStatelog.test.ts`. Tests exercise the replacer exactly as `post()` will — through `JSON.stringify` — so they cover the real mechanism, including native-type handling:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { GlobalStore } from "./state/globalStore.js";
+import { makeRedactReplacer } from "./redactForStatelog.js";
+
+// Serialize `body` the way StatelogClient.post does, then parse back so we
+// can assert on structure.
+function roundtrip(body: unknown, gs: GlobalStore): unknown {
+  return JSON.parse(JSON.stringify(body, makeRedactReplacer(gs)));
+}
+
+describe("makeRedactReplacer", () => {
+  it("redacts a tagged primitive leaf inside an object", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("sk-123");
+    const body = { url: "https://api.com", apiKey: "sk-123", n: 5 };
+    expect(roundtrip(body, gs)).toEqual({
+      url: "https://api.com",
+      apiKey: "[REDACTED]",
+      n: 5,
+    });
+  });
+
+  it("redacts a tagged object node without descending", () => {
+    const gs = new GlobalStore();
+    const creds = { user: "a", pass: "b" };
+    gs.markRedacted(creds);
+    expect(roundtrip({ creds, ok: true }, gs)).toEqual({
+      creds: "[REDACTED]",
+      ok: true,
+    });
+  });
+
+  it("walks arrays", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("secret");
+    expect(roundtrip({ items: ["a", "secret", "b"] }, gs)).toEqual({
+      items: ["a", "[REDACTED]", "b"],
+    });
+  });
+
+  it("preserves an untagged Date (native toJSON is not flattened)", () => {
+    // The critical regression guard: a naive Object.entries deep-walk turns a
+    // Date into {}. Install a replacer (via an unrelated tag so the path is
+    // live) and confirm the Date still serializes to its ISO string.
+    const gs = new GlobalStore();
+    gs.markRedacted("unrelated");
+    const when = new Date("2026-01-01T00:00:00.000Z");
+    expect(roundtrip({ when }, gs)).toEqual({ when: "2026-01-01T00:00:00.000Z" });
+  });
+
+  it("preserves an untagged value's custom toJSON output", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("unrelated");
+    const custom = { toJSON: () => "custom-serialized" };
+    expect(roundtrip({ v: custom }, gs)).toEqual({ v: "custom-serialized" });
+  });
+
+  it("redacts a tagged Date node (reference tag on a non-plain object)", () => {
+    const gs = new GlobalStore();
+    const when = new Date("2026-01-01T00:00:00.000Z");
+    gs.markRedacted(when);
+    expect(roundtrip({ when }, gs)).toEqual({ when: "[REDACTED]" });
+  });
+
+  it("does not redact a tag whose redact value is not true", () => {
+    const gs = new GlobalStore();
+    gs.setTag("x", "redact", false);
+    gs.setTag("y", "color", "blue");
+    expect(roundtrip({ a: "x", b: "y" }, gs)).toEqual({ a: "x", b: "y" });
+  });
+
+  it("redacts whole values only — an embedded substring is NOT scrubbed (v1)", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("sk-secret");
+    const body = { url: "https://api.com?key=sk-secret" };
+    // Locks the documented v1 boundary; must be updated deliberately if
+    // substring redaction is ever added.
+    expect(roundtrip(body, gs)).toEqual(body);
+  });
+
+  it("redacts nothing when the store has no tags", () => {
+    const gs = new GlobalStore();
+    expect(roundtrip({ apiKey: "secret" }, gs)).toEqual({ apiKey: "secret" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/redactForStatelog.test.ts`
+Expected: FAIL — cannot find module `./redactForStatelog.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/runtime/redactForStatelog.ts`:
+
+```ts
+import type { GlobalStore } from "./state/globalStore.js";
+
+export const REDACTED = "[REDACTED]";
+
+/**
+ * Build a `JSON.stringify` replacer bound to `globals` that swaps any value
+ * marked `redact: true` for "[REDACTED]" and returns everything else
+ * unchanged.
+ *
+ * Implemented as a replacer rather than a pre-copy deep-walk so it (a) runs
+ * inside the single JSON.stringify statelog already performs — no second
+ * traversal or deep copy — and (b) inherits JSON.stringify's native handling
+ * of Date/URL/toJSON-bearing values. A value with a toJSON reaches the
+ * replacer already converted to a primitive; `this[key]` still holds the
+ * original object, which is what the value/reference tag lookup needs. This
+ * mirrors `nativeTypeReplacer` (lib/runtime/revivers/index.ts).
+ *
+ * Cycles are left to JSON.stringify, which throws on them exactly as the
+ * statelog stringify does today — the replacer adds no cycle handling because
+ * a cyclic body could never have been serialized in the first place.
+ */
+export function makeRedactReplacer(
+  globals: GlobalStore,
+): (this: unknown, key: string, value: unknown) => unknown {
+  return function redactReplacer(
+    this: unknown,
+    key: string,
+    value: unknown,
+  ): unknown {
+    // Recover the raw, pre-toJSON value for the tag lookup.
+    let raw: unknown;
+    if (typeof value === "object" && value !== null) {
+      raw = value;
+    } else if (key === "") {
+      raw = value;
+    } else {
+      raw = (this as Record<string, unknown>)[key];
+    }
+    if (globals.isRedacted(raw)) return REDACTED;
+    return value;
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/runtime/redactForStatelog.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Checkpoint (no commit)**
+
+Run: `pnpm test:run lib/runtime/redactForStatelog.test.ts`
+Expected: PASS. Do not commit.
+
+---
+
+### Task 3: `std::tag` TS helpers
+
+The TS implementations behind the `std::tag` agency functions. They read the branch-local `GlobalStore` via the `__globals()` ALS accessor, so tags land on (and read from) the correct branch's store. `_redact` delegates to `GlobalStore.markRedacted` so the redact-tag shape stays owned by `GlobalStore`.
+
+**Files:**
+- Create: `lib/stdlib/tag.ts`
+- Test: `lib/stdlib/tag.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `__globals()` from `lib/runtime/asyncContext.js`; `GlobalStore.setTag/getTagsFor/markRedacted` (Task 1); `runInTestContext` for tests.
+- Produces:
+  - `_tag(value: unknown, key: string, val: unknown): void`
+  - `_getTags(value: unknown): Record<string, unknown>`
+  - `_redact(value: unknown): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/stdlib/tag.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { runInTestContext } from "../runtime/asyncContext.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+import { _tag, _getTags, _redact } from "./tag.js";
+
+function makeCtx() {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+      observability: true,
+    },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+}
+
+describe("std::tag TS helpers", () => {
+  it("tags and reads back a primitive by value", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      _tag("secret", "color", "blue");
+      expect(_getTags("secret")).toEqual({ color: "blue" });
+      expect(_getTags("other")).toEqual({});
+    });
+  });
+
+  it("tags an object by reference", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      const o = { id: 1 };
+      _tag(o, "source", "upload");
+      expect(_getTags(o)).toEqual({ source: "upload" });
+      expect(_getTags({ id: 1 })).toEqual({}); // distinct reference
+    });
+  });
+
+  it("redact() sets redact:true (via GlobalStore.markRedacted)", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      _redact("sk-1");
+      expect(_getTags("sk-1")).toEqual({ redact: true });
+      expect(execCtx.globals.isRedacted("sk-1")).toBe(true);
+    });
+  });
+
+  it("_getTags returns a copy, not the live store object", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      _tag("k", "a", 1);
+      const t = _getTags("k");
+      (t as Record<string, unknown>)["a"] = 999;
+      expect(_getTags("k")).toEqual({ a: 1 });
+    });
+  });
+
+  it("_tag is a no-op outside an Agency frame", () => {
+    expect(() => _tag("x", "a", 1)).not.toThrow();
+    expect(_getTags("x")).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/stdlib/tag.test.ts`
+Expected: FAIL — cannot find module `./tag.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/stdlib/tag.ts`:
+
+```ts
+import { __globals } from "../runtime/asyncContext.js";
+
+/**
+ * Attach a tag to a value. Primitives are keyed by value (all equal
+ * primitives share tags); objects by reference. No-op outside an Agency
+ * execution frame, matching the lenient stdlib convention.
+ */
+export function _tag(value: unknown, key: string, val: unknown): void {
+  const g = __globals();
+  if (!g) return;
+  g.setTag(value, key, val);
+}
+
+/** Return a shallow copy of a value's tags, or {} if none. */
+export function _getTags(value: unknown): Record<string, unknown> {
+  const t = __globals()?.getTagsFor(value);
+  return t ? { ...t } : {};
+}
+
+/** Mark a value so it is replaced with "[REDACTED]" in state logs. */
+export function _redact(value: unknown): void {
+  __globals()?.markRedacted(value);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/stdlib/tag.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Checkpoint (no commit)**
+
+Run: `pnpm test:run lib/stdlib/tag.test.ts`
+Expected: PASS. Do not commit.
+
+---
+
+### Task 4: Wire redaction into `StatelogClient.post`
+
+Install the redaction replacer at the single statelog chokepoint so all ~40 event types are covered, scoped to the `data` payload so envelope/infra fields can never be redacted. Gate on `hasAnyTags()` so tag-free programs (the common case) pay nothing. Integration-tested end-to-end via the `stdout` sink, including the native-type, envelope-immunity, and fork-durability paths.
+
+**Files:**
+- Modify: `lib/statelogClient.ts` (imports near top; `post()` body around line 1164)
+- Test: `lib/statelogClient.redaction.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `makeRedactReplacer` (Task 2); `__globals()` from `lib/runtime/asyncContext.js`; `GlobalStore.setTag/markRedacted/hasAnyTags/clone` (Task 1).
+- Produces: redaction applied to every event body inside `post()` before serialization. No new exported symbols.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/statelogClient.redaction.test.ts`:
+
+```ts
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { runInTestContext } from "./runtime/asyncContext.js";
+import { RuntimeContext } from "./runtime/state/context.js";
+import { ThreadStore } from "./runtime/state/threadStore.js";
+
+function makeStdoutCtx() {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "stdout",
+      projectId: "test-project",
+      debugMode: false,
+      observability: true,
+    },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+}
+
+function printed(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((c) => String(c[0])).join("\n");
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("StatelogClient redaction", () => {
+  it("replaces a redact-tagged primitive in a posted event with [REDACTED]", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      execCtx.globals.markRedacted("sk-secret");
+      await execCtx.statelogClient.post({ event: "toolCall", args: { apiKey: "sk-secret" } });
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("sk-secret");
+  });
+
+  it("leaves untagged values untouched", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await execCtx.statelogClient.post({ event: "toolCall", args: { city: "Mumbai" } });
+    });
+    expect(printed(spy)).toContain("Mumbai");
+  });
+
+  it("redacts a tagged object node end-to-end", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      const creds = { user: "alice", pass: "hunter2" };
+      execCtx.globals.markRedacted(creds);
+      await execCtx.statelogClient.post({ event: "toolCall", args: { creds } });
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("hunter2");
+  });
+
+  it("does not corrupt an untagged Date in the body (native-type guard)", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      // Redaction is live (a tag exists) but the Date is untagged: it must
+      // still serialize to its ISO string, not {}.
+      execCtx.globals.markRedacted("unrelated");
+      await execCtx.statelogClient.post({
+        event: "toolCall",
+        output: { when: new Date("2026-01-01T00:00:00.000Z") },
+      });
+    });
+    expect(printed(spy)).toContain("2026-01-01T00:00:00.000Z");
+  });
+
+  it("never redacts envelope fields even when a colliding value is tagged", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      // 1 === STATELOG_FORMAT_VERSION. A pathological value-tag on 1 must NOT
+      // touch the envelope's format_version (scoped-to-data redaction), but the
+      // same value inside the payload IS redacted.
+      execCtx.globals.markRedacted(1);
+      await execCtx.statelogClient.post({ event: "toolCall", args: { n: 1 } });
+    });
+    expect(printed(spy)).toContain('"format_version":1'); // infra field intact
+    expect(printed(spy)).toContain("[REDACTED]"); // payload value redacted
+  });
+
+  it("redaction survives a fork-style globals clone (durable primitive path)", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    // Tag on the parent store, then run post() against a CLONE of it — exactly
+    // what runInBranchAlsFrame does when entering a fork/parallel/race branch.
+    // This pins the headline claim: a primitive redact tag set before a fork is
+    // still honored inside the branch's post().
+    execCtx.globals.markRedacted("sk-fork");
+    execCtx.globals = execCtx.globals.clone();
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await execCtx.statelogClient.post({ event: "toolCall", args: { apiKey: "sk-fork" } });
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("sk-fork");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/statelogClient.redaction.test.ts`
+Expected: FAIL — output still contains `sk-secret` (redaction not wired yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/statelogClient.ts`, add imports near the other top-of-file imports:
+
+```ts
+import { makeRedactReplacer } from "./runtime/redactForStatelog.js";
+import { __globals } from "./runtime/asyncContext.js";
+```
+
+Then in `post()`, install the replacer on the existing `JSON.stringify`. Replace:
+
+```ts
+    const span = this.currentSpan;
+    const postBody = JSON.stringify({
+      format_version: STATELOG_FORMAT_VERSION,
+      trace_id: this.traceId,
+      project_id: this.projectId,
+      span_id: span?.spanId ?? null,
+      parent_span_id: span?.parentSpanId ?? null,
+      data: { ...body, timestamp: new Date().toISOString() },
+    });
+```
+
+with:
+
+```ts
+    const span = this.currentSpan;
+    // Single redaction chokepoint: every statelog event flows through post().
+    // Redaction is a JSON.stringify *replacer* scoped to the `data` payload
+    // ONLY. We stringify the envelope and the payload separately and splice
+    // them, so the replacer never runs over infra fields (format_version,
+    // trace_id, span ids). This keeps redaction single-pass (no extra deep
+    // copy) and preserves Date/URL/toJSON values, while making envelope fields
+    // structurally immune to a value-collision — e.g. a pathological
+    // `redact(1)` can't blank out `format_version: 1`. The replacer reads the
+    // caller's branch tag store via __globals(), synchronously before any
+    // detached (noWait) send, so it sees the correct branch. hasAnyTags() skips
+    // the replacer entirely when nothing is tagged, so tag-free programs pay
+    // nothing. Events posted outside an ALS frame (__globals() undefined) are
+    // not redacted — a documented boundary, not a secrecy guarantee.
+    const globals = __globals();
+    const replacer =
+      globals && globals.hasAnyTags() ? makeRedactReplacer(globals) : undefined;
+    const envelopeJson = JSON.stringify({
+      format_version: STATELOG_FORMAT_VERSION,
+      trace_id: this.traceId,
+      project_id: this.projectId,
+      span_id: span?.spanId ?? null,
+      parent_span_id: span?.parentSpanId ?? null,
+    });
+    const dataJson = JSON.stringify(
+      { ...body, timestamp: new Date().toISOString() },
+      replacer,
+    );
+    // Splice: drop the envelope's closing brace and append the data field. The
+    // envelope always carries format_version, so envelopeJson is never "{}" and
+    // the leading comma is always valid.
+    const postBody = `${envelopeJson.slice(0, -1)},"data":${dataJson}}`;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/statelogClient.redaction.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Guard against import cycles / regressions**
+
+Run the broader statelog + runtime unit suites to confirm no cycle or regression from the new imports.
+
+Run: `pnpm test:run lib/statelogClient.test.ts lib/statelog`
+Expected: PASS (no "Cannot access '...' before initialization" cycle errors).
+
+- [ ] **Step 6: Checkpoint (no commit)**
+
+Do not commit. Leave changes in the working tree.
+
+---
+
+### Task 5: `std::tag` Agency module + end-to-end execution tests
+
+Create the user-facing `.agency` module and prove it compiles and works end-to-end through the compiled CLI: tag/read a primitive by value, `redact` sets the redact tag, object tags are by reference, and a primitive tag is inherited by a `fork` branch (the durable path at the language level).
+
+**Files:**
+- Create: `stdlib/tag.agency`
+- Create: `tests/agency/tag.agency`
+- Create: `tests/agency/tag.test.json`
+
+**Interfaces:**
+- Consumes: `_tag`, `_getTags`, `_redact` from `agency-lang/stdlib-lib/tag.js` (Task 3; resolves via the `./stdlib-lib/*` → `./dist/lib/stdlib/*` export after `make`).
+- Produces: `std::tag` exporting `tag(value, key, val=true)`, `getTags(value)`, `redact(value)`.
+
+- [ ] **Step 1: Write the Agency module**
+
+Create `stdlib/tag.agency`:
+
+```ts
+/** @module Attach arbitrary tags to values and read them back anywhere in
+your program.
+
+Tags are stored in a side table, so nothing is attached to the value itself
+and TypeScript interop is unaffected. Two semantics, by value kind:
+
+- **Primitives** (string, number, boolean) are keyed by **value**: tagging one
+  copy of `"secret"` tags every equal `"secret"` in the current branch.
+- **Objects and arrays** are keyed by **reference**: tagging one object does
+  not tag a structurally-equal but distinct object.
+
+The built-in `redact` tag marks a value so it is replaced with `"[REDACTED]"`
+in state logs — useful for API keys and other secrets.
+
+  ```ts
+  import { redact } from "std::tag"
+
+  def callApi(apiKey: string) {
+    redact(apiKey)          // apiKey shows as "[REDACTED]" in state logs
+    return fetch("https://api.example.com", { headers: { key: apiKey } })
+  }
+  ```
+
+Note: object/array tags are branch-local — they do not survive `fork`/`race`/
+`parallel` branches or interrupt/resume. Primitive (value) tags survive both.
+*/
+
+import { _tag, _getTags, _redact } from "agency-lang/stdlib-lib/tag.js"
+
+export def tag(value: any, key: string, val: any = true) {
+  """Attach a tag to a value. Primitives are keyed by value; objects by
+  reference. `val` defaults to `true`."""
+  _tag(value, key, val)
+}
+
+export def getTags(value: any): any {
+  """Return all tags on a value as an object, or an empty object if none."""
+  return _getTags(value)
+}
+
+export def redact(value: any) {
+  """Mark a value so it is replaced with "[REDACTED]" in state logs. Shorthand
+  for tag(value, "redact", true)."""
+  _redact(value)
+}
+```
+
+> Note: the nested ```` ```ts ```` fence inside the `@module` docstring matches
+> the existing convention in `stdlib/thread.agency`, so `agency doc` handles it.
+
+- [ ] **Step 2: Build so the CLI picks up the new stdlib module**
+
+Run: `make`
+Expected: build succeeds; `dist/lib/stdlib/tag.js` and the stdlib copy of `tag.agency` exist. (`std::` modules resolve by file, so no manifest/allowlist needs updating.)
+
+If `std::tag` fails to resolve later, confirm `stdlib/tag.agency` was copied into the build output (that is `make`'s job) and that `dist/lib/stdlib/tag.js` exists.
+
+- [ ] **Step 3: Write the failing execution tests**
+
+Create `tests/agency/tag.agency`:
+
+```ts
+import { tag, getTags, redact } from "std::tag"
+
+node valueKeyed(): string {
+  const x = "hello"
+  tag(x, "color", "blue")
+  // Value-keyed: a second identical literal reads the same tags.
+  const t = getTags("hello")
+  return t["color"]
+}
+
+node redactSetsTag(): boolean {
+  const key = "sk-abc"
+  redact(key)
+  const t = getTags("sk-abc")
+  return t["redact"] == true
+}
+
+node objectByReference(): boolean {
+  const a = { id: 1 }
+  tag(a, "src", "upload")
+  // A distinct object with the same shape does NOT share tags.
+  const shared = getTags(a)["src"]
+  const b = { id: 1 }
+  const bTags = getTags(b)
+  // NB: Agency compiles `==` to strict `===`, and a missing object property is
+  // `undefined` (not `null`), so `bTags["src"] == null` would be false even
+  // when the tag is absent. Assert the tag did not leak by value instead.
+  return shared == "upload" && bTags["src"] != "upload"
+}
+
+node forkInheritsPrimitiveTag(): boolean {
+  // Primitive (value) tags are durable: a fork branch inherits them.
+  redact("sk-xyz")
+  const results = fork(["only"]) as item {
+    const t = getTags("sk-xyz")
+    return t["redact"] == true
+  }
+  return results[0]
+}
+```
+
+Create `tests/agency/tag.test.json`:
+
+```json
+{
+  "tests": [
+    { "nodeName": "valueKeyed", "input": "", "expectedOutput": "\"blue\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "redactSetsTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "objectByReference", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "forkInheritsPrimitiveTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}
+```
+
+> Redaction-through-statelog is asserted at the TS integration level (Task 4,
+> including the fork-clone durability case), which controls the statelog sink
+> directly. These compiled tests pin the language-level surface: value keying,
+> `redact` writing the tag, reference semantics, and fork inheritance of a
+> primitive tag. Object-tags-drop-on-clone is pinned by the Task 1 unit test.
+
+- [ ] **Step 4: Run the execution tests**
+
+Run: `pnpm run a test tests/agency/tag.agency 2>&1 | tee /tmp/tag-test.out`
+Expected: PASS — all four nodes. (Saving to a file per repo testing guidance so failures don't require a rerun.)
+
+- [ ] **Step 5: Checkpoint (no commit)**
+
+Do not commit. Leave changes in the working tree.
+
+---
+
+### Task 6: Guide documentation
+
+Add a user-facing guide page for tags and redaction, and regenerate the stdlib reference from the `tag.agency` docstrings.
+
+**Files:**
+- Create: `docs/site/guide/tags.md`
+- (Generated) stdlib reference for `std::tag` via `agency doc`
+
+**Interfaces:**
+- Consumes: the shipped `std::tag` module (Task 5).
+- Produces: documentation only; no code interfaces.
+
+- [ ] **Step 1: Write the guide page**
+
+Create `docs/site/guide/tags.md`:
+
+```markdown
+---
+name: Tags and Redaction
+description: Attach arbitrary tags to values with std::tag, and use the built-in redact tag to keep secrets like API keys out of state logs.
+---
+
+# Tags and Redaction
+
+The `std::tag` module lets you attach arbitrary tags to values and read them
+back anywhere in your program.
+
+```ts
+import { tag, getTags, redact } from "std::tag"
+
+tag(x, "source", "user-upload")   // attach a key/value tag
+tag(x, "reviewed")                // value defaults to true
+const tags = getTags(x)           // { source: "user-upload", reviewed: true }
+```
+
+## Value vs. reference semantics
+
+How a tag is stored depends on the kind of value:
+
+- **Primitives** (string, number, boolean) are keyed by **value**. Tagging one
+  copy of `"secret"` tags every equal `"secret"`. This is what makes redacting
+  an API key work no matter how the string was copied.
+- **Objects and arrays** are keyed by **reference**. Tagging one object does
+  *not* tag a structurally-equal but distinct object.
+
+> Object and array tags are branch-local: they do not survive `fork`, `race`,
+> or `parallel` branches, or an interrupt/resume. Primitive (value) tags
+> survive both.
+
+## Redaction
+
+The built-in `redact` tag marks a value so it is replaced with `"[REDACTED]"`
+in [state logs](/guide/observability). Use it for API keys and other secrets:
+
+```ts
+import { redact } from "std::tag"
+
+def callApi(apiKey: string) {
+  redact(apiKey)
+  return fetch("https://api.example.com", { headers: { key: apiKey } })
+}
+```
+
+`redact(x)` is shorthand for `tag(x, "redact", true)`.
+
+Three limits to know:
+
+- **Whole-value only.** A secret is redacted where it appears as a logged value
+  on its own. A secret concatenated into a larger logged string (for example a
+  URL query parameter) is *not* scrubbed — tag the exact string that gets
+  logged.
+- **State logs only.** Redaction governs what `std::statelog` records. It does
+  not affect `print()` or other direct output.
+- **Not a secrecy guarantee.** Redaction is best-effort scrubbing of state-log
+  events emitted while your program runs. It is not an information-flow or
+  security control — treat it as a way to keep secrets out of routine telemetry,
+  not as a guarantee a secret can never be observed.
+```
+
+- [ ] **Step 2: Regenerate the stdlib reference**
+
+Run: `pnpm run agency doc 2>&1 | tee /tmp/tag-doc.out` (or the repo's documented `agency doc` invocation per `docs/site/cli/doc.md`).
+Expected: a `docs/site/stdlib/tag.md` page is generated from the `tag.agency` docstrings. Confirm the nested ```` ```ts ```` example in the `@module` doc renders (matches the `thread.agency` precedent).
+
+- [ ] **Step 3: Verify the guide renders and links resolve**
+
+Confirm `docs/site/guide/tags.md` exists and its links (`/guide/observability`) match existing guide filenames.
+
+Run: `ls docs/site/guide/observability.md docs/site/guide/tags.md`
+Expected: both files listed.
+
+- [ ] **Step 4: Checkpoint (no commit)**
+
+Do not commit. Leave changes in the working tree.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two stores (primitive by value / object by reference) → Task 1.
+- Stored on `GlobalStore`, copy-on-branch, serializable → Task 1 (clone/toJSON tests).
+- Identity constraint (primitive durable, object branch-local) → Task 1 (`clone keeps primitive/drops object`, `toJSON survives primitive`, `hasAnyTags` reset-on-clone).
+- API `tag`/`getTags`/`redact` in `std::tag` module → Tasks 3 (TS) + 5 (Agency).
+- `redact` semantics owned in one place (no magic string spread across files) → Task 1 (`markRedacted`/`isRedacted`/`REDACT_TAG`), consumed by Task 2 replacer and Task 3 `_redact`.
+- Redaction at single `post()` chokepoint, as a replacer that preserves native types → Task 4; scoped to `data` so infra fields are immune → Task 4 (envelope/payload splice + envelope-immunity test); fast-path when untagged → Task 4 (`hasAnyTags` gate).
+- Whole-value-only, statelog-only, not-a-secrecy-guarantee → enforced/guarded by the replacer (Task 2 substring + redact:false tests) + documented (Task 6).
+- Testing bullets from spec:
+  - value-vs-reference → Task 1 + Task 3 (object helper) + Task 5 (`objectByReference`).
+  - redact through statelog → Task 4 (primitive + object node).
+  - **fork/interrupt durability for a primitive → now tested end-to-end**: Task 4 `fork-style globals clone` integration test (proves the branch's `post()` honors an inherited tag) + Task 5 `forkInheritsPrimitiveTag` compiled test. (This was the biggest gap in the prior draft.)
+  - object tags NOT surviving fork/interrupt → Task 1 `clone drops object tags` + `hasAnyTags` reset.
+  - native-type preservation (Date/toJSON) → Task 2 + Task 4 (regression guard for the replacer rework).
+  - embedded-substring NOT redacted (v1 boundary) → Task 2.
+  - `shared: true` propagation → a property of the existing GlobalStore pointer-share path; not re-tested here (documented as inherited behavior).
+- Docs → Task 6.
+- Non-goals (no boxing, no provenance, no substring) → respected; provenance untouched.
+
+**Review findings folded in (from `...-review.md`):**
+- Walker→replacer (AP-1 / Must-fix #1 / Should-fix #2): the deep-copy walker is replaced by `makeRedactReplacer`, fixing Date/native-type corruption, removing the unconditional deep copy, and reusing the serialization pass. Tests added for Date and custom-`toJSON`.
+- Redact-tag encapsulation (AP-2): `markRedacted`/`isRedacted`/`REDACT_TAG` on `GlobalStore`; the string `"redact"` lives in exactly one place.
+- `setTag` duplication (AP-3): unified through `tagsRecordFor(value, create)`.
+- Fast-path (Finding B): `hasAnyTags()` gate in `post()`.
+- ALS-frame boundary (Finding 4): documented in `post()` comment, Global Constraints, and the guide's "not a secrecy guarantee" note.
+- Test gaps: native-type, fork durability, compiled `redact`, substring boundary, `redact:false`, boolean-key distinctness, `getTagsFor` purity — all added.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code.
+
+**Type consistency:** `setTag`/`getTagsFor`/`markRedacted`/`isRedacted`/`hasAnyTags` used identically in Tasks 1–4. `_tag`/`_getTags`/`_redact` signatures match between Task 3 impl and Task 5 imports. `makeRedactReplacer(globals)` returns a `JSON.stringify` replacer used identically in Task 2 tests and Task 4.
+
+**Deferred / follow-ups (from spec, intentionally not in this plan):** substring redaction; `pii` and other special tags; low-entropy dev-mode warning; provenance (separate spec); a full compiled interrupt/resume redaction fixture (durability is covered by the Task 1 serialization unit test + the Task 4 clone integration test).

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md
@@ -257,6 +257,16 @@ Use Agency execution tests (`tests/agency/`) and agency-js tests
 
 ## Follow-ups
 
+- **Durable object tags (custom serialization)**: today object/array (reference)
+  tags are branch-local — they don't survive a `fork` clone or interrupt/resume,
+  because object identity dies in the `toJSON`/`fromJSON` round-trip and a
+  `WeakMap` can't be serialized. Storing tags *on* the object (e.g. a hidden
+  `__tags` property) does **not** fix this on its own: a non-enumerable property
+  is dropped by `JSON.stringify`, and an enumerable one leaks into user-visible
+  object shape and into the logs. Making object tags durable needs a custom
+  replacer/reviver pair that preserves a hidden `__tags` across the round-trip
+  (and re-hides it after redaction). Deferred to a follow-up PR (decided during
+  PR #447 review).
 - **Substring redaction**: scrub tagged secrets embedded in larger logged
   strings (thorough but O(secrets) per log; can mangle output).
 - **Additional special tags**: `pii`, etc., layered on the same mechanism.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md
@@ -1,0 +1,299 @@
+# Value Tags & Statelog Redaction — Design
+
+**Date:** 2026-07-07
+**Status:** Design (approved in brainstorm; pending written-spec review)
+**Author:** brainstormed with owner
+
+## Summary
+
+Add the ability to attach arbitrary **tags** to Agency values, and read them
+back anywhere in the program. Build one special tag — `redact` — on top of that
+mechanism: any value marked for redaction is replaced with the string
+`"[REDACTED]"` when it would otherwise be written to statelog.
+
+The immediate motivating use case: an **API key** passed into a `fetch` request
+should not appear in statelog. API keys are strings (primitives), which cannot
+carry attached metadata the way objects can — so the core of this design is a
+tag store that keys **primitives by value** and **objects/arrays by reference**.
+
+Provenance tracking (the `response.provenance` idea) is explicitly **out of
+scope** for this iteration. It is a separate, larger feature that builds on the
+same tag mechanism; see [Future Work](#future-work).
+
+## Goals
+
+- Let users attach tags to values: `tag(x, "key", val)` and read them with
+  `getTags(x)`.
+- Provide `redact(x)` sugar that marks a value so it never reaches statelog in
+  the clear.
+- Make redaction of **primitive secrets (API keys, tokens)** fully robust —
+  including across `fork`/`parallel`/`race` branches and interrupt/resume.
+- Reuse the existing per-branch, serializable state machinery (`GlobalStore`)
+  rather than inventing a parallel store.
+
+## Non-goals
+
+- **Provenance / taint propagation.** Tags do **not** automatically flow from
+  inputs to computed outputs. `const y = x + 1` does not copy `x`'s tags to `y`.
+- **Boxing primitives.** We never wrap primitives; TS/JS interop is unaffected.
+- **Substring redaction (v1).** Only whole-value matches are redacted. A secret
+  embedded inside a larger logged string (e.g. `"https://api.com?key=XYZ"`) is
+  **not** scrubbed in v1. See [Open questions / follow-ups](#follow-ups).
+- **Durable object tags across serialization boundaries.** Object (reference)
+  tags are branch-local and do not survive a `fork` boundary or interrupt/resume
+  (see [The identity constraint](#the-identity-constraint)).
+
+## Background: why primitives are the hard part
+
+Agency compiles to plain TypeScript/JS values. `const x = 1` is the number `1` —
+there is no object to hang metadata on, and all `1`s are indistinguishable. This
+is the same wall Clojure's metadata hits (its `with-meta` only works on reference
+types). Boxing primitives into wrapper objects was rejected: it forces unwrap
+logic on every arithmetic/comparison, triggers V8 deopts on numeric code, and
+breaks at the TS interop boundary (a boxed number handed to a plain
+`function f(n: number)` arrives as an object).
+
+The chosen alternative (owner's proposal): keep tags in **side tables**, and for
+primitives, **key by value** instead of by reference. Tagging the string
+`"secret-key"` tags *every* occurrence of that exact string. For a high-entropy
+secret this is correct and desirable — you want every copy redacted. (It is a
+footgun for low-entropy values like `0`/`true`/`"1"`, which we address with
+documentation, not enforcement.)
+
+## Design
+
+### Two tag stores
+
+| Store | Keyed by | Backing structure | Durable across branch/interrupt? |
+|---|---|---|---|
+| Primitive store | value (`string \| number \| boolean`) | `Map<primitive, Tags>` | **Yes** — serializes and clones cleanly |
+| Object store | object identity | `WeakMap<object, Tags>` | **No** — branch-local, ephemeral |
+
+`Tags` is a plain record: `Record<string, unknown>`. `tag(x, "redact", true)`
+sets `tags["redact"] = true`.
+
+`getTags(x)` dispatches on type: primitive → look up the value `Map`; object →
+look up the `WeakMap`. Returns `{}` when nothing is tagged. The split semantics
+are intentional and **must be documented loudly**: tagging one object does not
+tag a structurally-equal but distinct object, whereas tagging a primitive tags
+all equal primitives.
+
+### Where the stores live: `GlobalStore`
+
+The stores live on `GlobalStore` (`lib/runtime/state/globalStore.ts`), which is
+already the runtime's per-branch, serializable state container:
+
+- Held canonically on `ctx.globals`; read per-branch via the `__globals()` ALS
+  accessor.
+- Cloned per branch at fork time in `runInBranchAlsFrame`
+  (`lib/runtime/runBatch.ts`) via `parent.globals.clone()`; discarded at join.
+- Serialized for interrupts via `toJSON()`/`fromJSON()`, with branch snapshots
+  riding along on `BranchState.globalsJSON`.
+- Reserves an `__internal` module namespace for runtime bookkeeping (already
+  home to `__tokenStats`).
+
+**Decision: copy-on-branch, not merge-up-the-chain.** Each branch gets its own
+copy of the primitive store (following the existing GlobalStore clone), so a
+branch can set different tags on the same value without affecting siblings or
+the parent. We reuse GlobalStore's clone/serialize machinery rather than
+building a merge-at-lookup scheme, because (1) copy-on-branch is how every other
+per-branch value in the language already behaves, (2) the machinery is proven,
+and (3) merge-up-the-chain is a novel mechanism that is harder to serialize and
+whose only benefit — avoiding per-branch duplication — is a cost GlobalStore
+already accepts for globals.
+
+Implementation sketch:
+
+- **Primitive store**: stored under the `__internal` module (e.g. key
+  `__valueTags`) as `Map<primitive, Tags>` entries. `GlobalStore.toJSON()`/
+  `fromJSON()`/`clone()` already round-trip Maps correctly, so it inherits
+  serialization and per-branch cloning for free.
+- **Object store**: a `WeakMap<object, Tags>` field on `GlobalStore`, explicitly
+  **excluded** from `toJSON()` and reset (fresh empty) on `clone()`. See below
+  for why it cannot do otherwise.
+
+> House-rule note: the codebase prefers plain objects over `Map`. The primitive
+> store is a justified exception — it needs primitive keys with correct
+> type distinction (`1` vs `"1"` vs `true`), which only `Map` provides.
+
+### The identity constraint
+
+`GlobalStore.clone()` and interrupt save/restore both round-trip through
+`toJSON`/`fromJSON`. That **destroys object identity**: a cloned or restored
+object is a new reference. Consequences, which differ by store:
+
+- **Primitive (value) tags are fully durable.** `"secret-key"` is still
+  `"secret-key"` after any round-trip, so the value `Map` clones into branches
+  and survives interrupt/resume. **This is the API-key case, and it works end to
+  end.**
+- **Object (reference) tags are inherently branch-local and ephemeral.** A
+  `WeakMap` cannot be enumerated to serialize, and even if it could, the
+  post-round-trip object has a new identity that would not match. So object tags
+  work only *within a single branch, between interrupts*. A tagged object that
+  crosses a `fork` boundary or an interrupt/resume loses its tag.
+
+This is accepted, not fixed, in v1. It aligns with the feature: redaction's
+headline target (API keys, secret strings) is primitive and gets the durable
+path. Object redaction is a best-effort, branch-local bonus. (Provenance, which
+leans on object tagging, will have to confront identity preservation — another
+reason to defer it.)
+
+### Public API
+
+Placement (decided): a new `std::tag` module, imported like `guard` from
+`std::thread`. Chosen over auto-imported stdlib / builtins to avoid growing the
+no-import global namespace.
+
+```ts
+import { tag, getTags, redact } from "std::tag"
+
+// General tagging
+tag(x, "some key", "some val")   // tags["some key"] = "some val"
+tag(x, "some key")               // val defaults to true
+const t = getTags(x)             // Record<string, unknown>, {} if untagged
+
+// Redaction sugar
+redact(apiKey)                   // === tag(apiKey, "redact", true)
+```
+
+Signatures:
+
+- `tag(value: any, key: string, val: any = true): void`
+- `getTags(value: any): Record<string, unknown>`
+- `redact(value: any): void`
+
+`tag`/`redact` mutate the active branch's store (a side effect), returning
+nothing. They are usable inside nodes and functions; behavior in module
+top-level/global scope follows the same rule as other state-touching stdlib
+(no-op or error — to be finalized during implementation, matching the existing
+convention).
+
+### Redaction hook
+
+Every statelog event funnels through a single method, `StatelogClient.post(body)`
+(`lib/statelogClient.ts`), which does one `JSON.stringify` for all sinks (file,
+stdout, remote). That is the single chokepoint.
+
+At the top of `post()` — synchronously, in the caller's branch ALS context,
+before the `JSON.stringify` — run a `redactForStatelog(body)` walk:
+
+1. Deep-walk the `body` object.
+2. For each **primitive leaf**, check the value store; if it carries
+   `redact: true`, replace it with `"[REDACTED]"`.
+3. For each **object node**, check the object store; if tagged `redact: true`,
+   replace the whole node with `"[REDACTED]"` (do not descend).
+4. Leave everything else untouched.
+
+This single seam covers all ~40 event types (node enter/exit data, `toolCall`
+args/output, `promptCompletion` messages/completion, `followEdge` data, hooks,
+`evalValue`/`evalOutput`, `debug`/`diff`, etc.) without touching individual
+call sites.
+
+Precedent: `lib/runtime/prompt.ts` already has a redaction pass
+(`redactAttachments`) that shortens base64 blobs before logging; this is the
+same shape of concern, generalized to user-marked values.
+
+Reading the active stores inside the walk: use the ALS frame via
+`getRuntimeContext()`/`__globals()` (the established pattern for stdlib TS
+helpers). The walk runs synchronously within `post()` before any detached
+(`noWait`) network send, so it always reads the correct branch's stores.
+
+## Edge cases & decisions
+
+- **Whole-value only (v1).** Only a logged leaf whose value equals a tagged
+  primitive is redacted. `{ apiKey: "XYZ" }` → redacted; `"...key=XYZ..."` →
+  not redacted. Tag the exact string that gets logged. Substring scrubbing is a
+  documented follow-up.
+- **Low-entropy footgun.** Tagging `0`/`true`/`""`/`"1"` redacts every equal
+  value program-wide. Document that value-tagging is for high-entropy secrets;
+  optionally emit a dev-mode warning when redacting a short/low-entropy
+  primitive (nice-to-have, not required).
+- **`shared: true` branches.** These pointer-share the parent GlobalStore, so
+  tags set in the branch are visible to parent/siblings — consistent with how
+  `shared: true` already treats globals.
+- **Non-statelog logging.** This design only governs statelog. `print()` and
+  other direct output are unaffected — a redacted value printed with `print()`
+  shows in the clear (documented; redaction is a statelog concern, not a
+  general secrecy guarantee).
+- **Memory lifetime.** The primitive `Map` holds strong references to tagged
+  values for the life of the (per-branch) store, pinning them in memory. For a
+  bounded set of secrets this is fine. Broad use (many tagged values) would grow
+  unbounded — acceptable for redaction's use case; a scoping/eviction story is a
+  future concern tied to provenance.
+
+## Testing
+
+Use Agency execution tests (`tests/agency/`) and agency-js tests
+(`tests/agency-js/`) — no LLM calls required. Configure statelog to a
+`logFile`/`stdout` sink and assert on the emitted JSON.
+
+- `tag` + `getTags` round-trip for primitives (by value: a second identical
+  literal reads the same tags) and objects (by reference: a structurally-equal
+  distinct object reads `{}`).
+- `redact` on a string → `toolCall`/`evalValue` event shows `"[REDACTED]"` in
+  place of the value; untagged siblings unaffected.
+- Redaction survives a `fork` branch and an interrupt/resume for a **primitive**
+  (durable path).
+- Object tags are **not** expected to survive a fork/interrupt — assert the
+  documented branch-local behavior so the limitation is pinned by a test.
+- `shared: true` propagates tags to parent/siblings.
+- Whole-value vs. embedded-substring: assert embedded secret is **not** redacted
+  in v1 (locks the documented boundary).
+
+## Implementation surface (file map)
+
+- `lib/runtime/state/globalStore.ts` — add primitive `Map` under `__internal`
+  and object `WeakMap` field; extend `toJSON`/`fromJSON`/`clone` (Map in, WeakMap
+  excluded/reset).
+- `stdlib/tag.agency` (+ TS impl, e.g. `lib/stdlib/tag.ts`) — `tag`, `getTags`,
+  `redact`; read/write stores via `getRuntimeContext()`.
+- `lib/statelogClient.ts` — call `redactForStatelog(body)` at the top of
+  `post()`.
+- New `redactForStatelog` walker (co-located with statelog or in a small
+  runtime util) with unit tests.
+- Docs: a guide page (e.g. `docs/site/guide/tags.md` / redaction section) making
+  the value-vs-reference semantics and the statelog-only scope explicit; stdlib
+  reference via `agency doc` from `stdlib/tag.agency` docstrings.
+
+## Follow-ups
+
+- **Substring redaction**: scrub tagged secrets embedded in larger logged
+  strings (thorough but O(secrets) per log; can mangle output).
+- **Additional special tags**: `pii`, etc., layered on the same mechanism.
+- **Low-entropy dev-mode warning**.
+
+## Future work: provenance (separate spec)
+
+The eventual `response.provenance` capability — "could this user's data have
+been involved in generating this response?" — builds on this tag store but needs
+two things this spec deliberately omits:
+
+1. An **involvement model**. When `userData` (an object) is interpolated into a
+   prompt string, the object's identity is gone by the time `llm()` sees the
+   string, so value-lookup finds nothing. Automatic provenance needs
+   frame/thread-scoped accumulation (collect provenance-tagged values touched in
+   the current frame; stamp the response with the active set). This matches the
+   already-drafted **frame-scoped interrupt-lineage** model
+   (`docs/superpowers/specs/2026-07-07-interrupt-provenance-design.md`).
+2. A **write hook in `llm()` post-processing** (`lib/runtime/prompt.ts`, where
+   cost/token accounting and structured-output parsing already happen) to attach
+   the accumulated provenance to the returned value.
+
+Because provenance is best-effort (over-approximation is acceptable — better to
+say "maybe" than to miss), it avoids the strict implicit-flow requirements of
+security taint-tracking. It is nonetheless a materially larger feature and is
+intentionally deferred.
+
+## Prior art (for reference)
+
+- **Clojure `with-meta`/`meta`** — arbitrary metadata that doesn't affect
+  equality; reference-types only (same primitive limitation).
+- **Rust `secrecy`/`redact`/`secret-box`** — wrapper types whose Debug/log impl
+  prints `[REDACTED]`, with explicit `expose_secret()`. The redaction model.
+- **Perl taint mode / Ruby `$SAFE` (removed 3.0) / Ballerina `@tainted`** —
+  taint tracking; one-bit, explicit-flow-only, security-oriented. Cautionary
+  tale for the provenance follow-up (a trusted-but-leaky taint system is worse
+  than none).
+- **JIF / FlowCaml / LIO / Jeeves** — "correct" information-flow control
+  (label lattices + PC label for implicit flows); powerful but heavyweight —
+  out of scope.

--- a/packages/agency-lang/lib/runtime/redactForStatelog.test.ts
+++ b/packages/agency-lang/lib/runtime/redactForStatelog.test.ts
@@ -62,6 +62,16 @@ describe("makeRedactReplacer", () => {
     expect(roundtrip({ when }, gs)).toEqual({ when: "[REDACTED]" });
   });
 
+  it("redacts a tagged object whose toJSON returns an object (no leak)", () => {
+    // Regression: JSON.stringify runs toJSON BEFORE the replacer, so the
+    // replacer's `value` is the post-toJSON object, not the tagged one. The
+    // tag lookup must use the original (this[key]) or the secret leaks.
+    const gs = new GlobalStore();
+    const secret = { toJSON: () => ({ leaked: "sensitive" }) };
+    gs.markRedacted(secret);
+    expect(roundtrip({ secret }, gs)).toEqual({ secret: "[REDACTED]" });
+  });
+
   it("does not redact a tag whose redact value is not true", () => {
     const gs = new GlobalStore();
     gs.setTag("x", "redact", false);

--- a/packages/agency-lang/lib/runtime/redactForStatelog.test.ts
+++ b/packages/agency-lang/lib/runtime/redactForStatelog.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { GlobalStore } from "./state/globalStore.js";
+import { makeRedactReplacer } from "./redactForStatelog.js";
+
+// Serialize `body` the way StatelogClient.post does, then parse back so we
+// can assert on structure.
+function roundtrip(body: unknown, gs: GlobalStore): unknown {
+  return JSON.parse(JSON.stringify(body, makeRedactReplacer(gs)));
+}
+
+describe("makeRedactReplacer", () => {
+  it("redacts a tagged primitive leaf inside an object", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("sk-123");
+    const body = { url: "https://api.com", apiKey: "sk-123", n: 5 };
+    expect(roundtrip(body, gs)).toEqual({
+      url: "https://api.com",
+      apiKey: "[REDACTED]",
+      n: 5,
+    });
+  });
+
+  it("redacts a tagged object node without descending", () => {
+    const gs = new GlobalStore();
+    const creds = { user: "a", pass: "b" };
+    gs.markRedacted(creds);
+    expect(roundtrip({ creds, ok: true }, gs)).toEqual({
+      creds: "[REDACTED]",
+      ok: true,
+    });
+  });
+
+  it("walks arrays", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("secret");
+    expect(roundtrip({ items: ["a", "secret", "b"] }, gs)).toEqual({
+      items: ["a", "[REDACTED]", "b"],
+    });
+  });
+
+  it("preserves an untagged Date (native toJSON is not flattened)", () => {
+    // The critical regression guard: a naive Object.entries deep-walk turns a
+    // Date into {}. Install a replacer (via an unrelated tag so the path is
+    // live) and confirm the Date still serializes to its ISO string.
+    const gs = new GlobalStore();
+    gs.markRedacted("unrelated");
+    const when = new Date("2026-01-01T00:00:00.000Z");
+    expect(roundtrip({ when }, gs)).toEqual({ when: "2026-01-01T00:00:00.000Z" });
+  });
+
+  it("preserves an untagged value's custom toJSON output", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("unrelated");
+    const custom = { toJSON: () => "custom-serialized" };
+    expect(roundtrip({ v: custom }, gs)).toEqual({ v: "custom-serialized" });
+  });
+
+  it("redacts a tagged Date node (reference tag on a non-plain object)", () => {
+    const gs = new GlobalStore();
+    const when = new Date("2026-01-01T00:00:00.000Z");
+    gs.markRedacted(when);
+    expect(roundtrip({ when }, gs)).toEqual({ when: "[REDACTED]" });
+  });
+
+  it("does not redact a tag whose redact value is not true", () => {
+    const gs = new GlobalStore();
+    gs.setTag("x", "redact", false);
+    gs.setTag("y", "color", "blue");
+    expect(roundtrip({ a: "x", b: "y" }, gs)).toEqual({ a: "x", b: "y" });
+  });
+
+  it("redacts whole values only — an embedded substring is NOT scrubbed (v1)", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("sk-secret");
+    const body = { url: "https://api.com?key=sk-secret" };
+    // Locks the documented v1 boundary; must be updated deliberately if
+    // substring redaction is ever added.
+    expect(roundtrip(body, gs)).toEqual(body);
+  });
+
+  it("redacts nothing when the store has no tags", () => {
+    const gs = new GlobalStore();
+    expect(roundtrip({ apiKey: "secret" }, gs)).toEqual({ apiKey: "secret" });
+  });
+});

--- a/packages/agency-lang/lib/runtime/redactForStatelog.ts
+++ b/packages/agency-lang/lib/runtime/redactForStatelog.ts
@@ -27,15 +27,13 @@ export function makeRedactReplacer(
     key: string,
     value: unknown,
   ): unknown {
-    // Recover the raw, pre-toJSON value for the tag lookup.
-    let raw: unknown;
-    if (typeof value === "object" && value !== null) {
-      raw = value;
-    } else if (key === "") {
-      raw = value;
-    } else {
-      raw = (this as Record<string, unknown>)[key];
-    }
+    // Recover the raw, pre-toJSON value for the tag lookup. JSON.stringify
+    // applies toJSON() BEFORE calling the replacer, so `value` may already be
+    // transformed (e.g. a Date → ISO string, or a custom toJSON returning an
+    // object). `this[key]` still holds the original value the tag was set on,
+    // so always read from there for non-root keys. (Root is the wrapper's ""
+    // key, where this[""] === value anyway.)
+    const raw = key === "" ? value : (this as Record<string, unknown>)[key];
     if (globals.isRedacted(raw)) return REDACTED;
     return value;
   };

--- a/packages/agency-lang/lib/runtime/redactForStatelog.ts
+++ b/packages/agency-lang/lib/runtime/redactForStatelog.ts
@@ -1,0 +1,42 @@
+import type { GlobalStore } from "./state/globalStore.js";
+
+export const REDACTED = "[REDACTED]";
+
+/**
+ * Build a `JSON.stringify` replacer bound to `globals` that swaps any value
+ * marked `redact: true` for "[REDACTED]" and returns everything else
+ * unchanged.
+ *
+ * Implemented as a replacer rather than a pre-copy deep-walk so it (a) runs
+ * inside the single JSON.stringify statelog already performs — no second
+ * traversal or deep copy — and (b) inherits JSON.stringify's native handling
+ * of Date/URL/toJSON-bearing values. A value with a toJSON reaches the
+ * replacer already converted to a primitive; `this[key]` still holds the
+ * original object, which is what the value/reference tag lookup needs. This
+ * mirrors `nativeTypeReplacer` (lib/runtime/revivers/index.ts).
+ *
+ * Cycles are left to JSON.stringify, which throws on them exactly as the
+ * statelog stringify does today — the replacer adds no cycle handling because
+ * a cyclic body could never have been serialized in the first place.
+ */
+export function makeRedactReplacer(
+  globals: GlobalStore,
+): (this: unknown, key: string, value: unknown) => unknown {
+  return function redactReplacer(
+    this: unknown,
+    key: string,
+    value: unknown,
+  ): unknown {
+    // Recover the raw, pre-toJSON value for the tag lookup.
+    let raw: unknown;
+    if (typeof value === "object" && value !== null) {
+      raw = value;
+    } else if (key === "") {
+      raw = value;
+    } else {
+      raw = (this as Record<string, unknown>)[key];
+    }
+    if (globals.isRedacted(raw)) return REDACTED;
+    return value;
+  };
+}

--- a/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
@@ -87,4 +87,38 @@ describe("GlobalStore tags", () => {
     expect(restored.getTagsFor("prim")).toEqual({ redact: true });
     expect(restored.isRedacted("prim")).toBe(true);
   });
+
+  it("ignores bigint and symbol values (keeps serialization safe)", () => {
+    const gs = new GlobalStore();
+    gs.setTag(10n, "a", 1);
+    gs.setTag(Symbol("s"), "a", 1);
+    expect(gs.getTagsFor(10n)).toBeUndefined();
+    expect(gs.hasAnyTags()).toBe(false);
+    // The unsupported keys must not have created a Map that would throw here.
+    expect(() => gs.toJSON()).not.toThrow();
+  });
+
+  it("a __proto__ tag key does not pollute Object.prototype", () => {
+    const gs = new GlobalStore();
+    gs.setTag("v", "__proto__", { polluted: true });
+    expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
+    // It is stored as an own data property on the (null-proto) record.
+    expect(gs.getTagsFor("v")?.["__proto__"]).toEqual({ polluted: true });
+  });
+
+  it("removeTag deletes a single key; removeAllTags clears the value", () => {
+    const gs = new GlobalStore();
+    gs.setTag("k", "a", 1);
+    gs.setTag("k", "b", 2);
+    gs.removeTag("k", "a");
+    expect(gs.getTagsFor("k")).toEqual({ b: 2 });
+    gs.removeAllTags("k");
+    expect(gs.getTagsFor("k")).toBeUndefined();
+    expect(gs.hasAnyTags()).toBe(false);
+    // removeAllTags also works by reference for objects.
+    const o = {};
+    gs.setTag(o, "x", 1);
+    gs.removeAllTags(o);
+    expect(gs.getTagsFor(o)).toBeUndefined();
+  });
 });

--- a/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { GlobalStore } from "./globalStore.js";
+
+describe("GlobalStore tags", () => {
+  it("keys primitive tags by value (all equal primitives share tags)", () => {
+    const gs = new GlobalStore();
+    gs.setTag("secret", "redact", true);
+    // A different string instance with the same value reads the same tags.
+    const other = ["sec", "ret"].join("");
+    expect(gs.getTagsFor(other)).toEqual({ redact: true });
+    expect(gs.getTagsFor("nope")).toBeUndefined();
+  });
+
+  it("keeps boolean, number, and string keys distinct", () => {
+    const gs = new GlobalStore();
+    gs.setTag(1, "a", 1);
+    gs.setTag(true, "b", 2);
+    expect(gs.getTagsFor(1)).toEqual({ a: 1 });
+    expect(gs.getTagsFor("1")).toBeUndefined();
+    expect(gs.getTagsFor(true)).toEqual({ b: 2 });
+    expect(gs.getTagsFor("true")).toBeUndefined();
+  });
+
+  it("keys object tags by reference (structurally-equal objects do not share)", () => {
+    const gs = new GlobalStore();
+    const o = { id: 1 };
+    gs.setTag(o, "redact", true);
+    expect(gs.getTagsFor(o)).toEqual({ redact: true });
+    expect(gs.getTagsFor({ id: 1 })).toBeUndefined();
+  });
+
+  it("merges multiple tags on the same value", () => {
+    const gs = new GlobalStore();
+    gs.setTag("k", "a", 1);
+    gs.setTag("k", "b", 2);
+    expect(gs.getTagsFor("k")).toEqual({ a: 1, b: 2 });
+  });
+
+  it("getTagsFor does not create the value Map (pure lookup never mutates)", () => {
+    const gs = new GlobalStore();
+    gs.getTagsFor("x");
+    // Nothing was set, so the __internal module slot must not exist yet —
+    // a read that created the backing Map would dirty every subsequent clone.
+    expect(gs.toJSON().store["__internal"]).toBeUndefined();
+  });
+
+  it("markRedacted / isRedacted own the redact tag", () => {
+    const gs = new GlobalStore();
+    gs.markRedacted("sk");
+    expect(gs.isRedacted("sk")).toBe(true);
+    expect(gs.isRedacted("other")).toBe(false);
+    // isRedacted checks === true, not mere presence.
+    gs.setTag("x", "redact", false);
+    expect(gs.isRedacted("x")).toBe(false);
+    // markRedacted writes the same key user code would via tag(x,"redact",true).
+    expect(gs.getTagsFor("sk")).toEqual({ redact: true });
+  });
+
+  it("hasAnyTags reflects primitive and object tags", () => {
+    const gs = new GlobalStore();
+    expect(gs.hasAnyTags()).toBe(false);
+    gs.setTag("p", "a", 1);
+    expect(gs.hasAnyTags()).toBe(true);
+  });
+
+  it("clone() keeps primitive tags but drops object tags", () => {
+    const gs = new GlobalStore();
+    const o = {};
+    gs.setTag("prim", "redact", true);
+    gs.setTag(o, "redact", true);
+    const c = gs.clone();
+    expect(c.getTagsFor("prim")).toEqual({ redact: true });
+    expect(c.getTagsFor(o)).toBeUndefined();
+    // hasAnyTags tracks the split: object-only presence resets on clone,
+    // primitive presence survives. (Pins the branch-local object contract.)
+    expect(c.hasAnyTags()).toBe(true); // primitive tag survived
+    const objOnly = new GlobalStore();
+    objOnly.setTag({}, "redact", true);
+    expect(objOnly.hasAnyTags()).toBe(true);
+    expect(objOnly.clone().hasAnyTags()).toBe(false); // object tag dropped
+  });
+
+  it("survives toJSON/fromJSON for primitive tags (interrupt durability)", () => {
+    const gs = new GlobalStore();
+    gs.setTag("prim", "redact", true);
+    const restored = GlobalStore.fromJSON(gs.toJSON());
+    expect(restored.getTagsFor("prim")).toEqual({ redact: true });
+    expect(restored.isRedacted("prim")).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/globalStore.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.ts
@@ -32,56 +32,87 @@ export class GlobalStore {
     );
   }
 
+  // A value can carry tags if it is a reference (keyed by identity in the
+  // WeakMap) or a JSON-serializable primitive (keyed by value in the Map).
+  // bigint and symbol are excluded on purpose: a bigint Map key throws during
+  // MapReviver/JSON serialization (breaking clone() and interrupt save), and a
+  // symbol has no stable serializable identity. Tagging one is a silent no-op.
+  private isTaggable(value: unknown): boolean {
+    if (this.isRef(value)) return true;
+    const kind = typeof value;
+    return kind === "string" || kind === "number" || kind === "boolean";
+  }
+
   // Primitive tags, keyed by value. Stored as a Map under the __internal
   // module so it rides the existing toJSON/fromJSON/clone machinery. The
   // MapReviver serializes entries as [key, value] pairs through JSON, which
   // preserves primitive key *types* (1, "1", and true stay distinct).
   private valueTagMap(): Map<unknown, Record<string, unknown>> {
-    let m = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
-    if (!(m instanceof Map)) {
-      m = new Map();
-      this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY, m);
+    let map = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    if (!(map instanceof Map)) {
+      map = new Map();
+      this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY, map);
     }
-    return m as Map<unknown, Record<string, unknown>>;
+    return map as Map<unknown, Record<string, unknown>>;
   }
 
   // Resolve the tag record for a value. `create` controls whether a missing
   // record (and its backing store slot) is allocated — reads pass false so a
   // pure lookup never mutates state. Unifies the primitive (value Map) and
-  // object (WeakMap) paths so setTag/getTagsFor share one code path.
+  // object (WeakMap) paths so setTag/getTagsFor share one code path. Records
+  // are null-prototype so a user-controlled tag key like "__proto__" is stored
+  // as an own data property instead of mutating the prototype chain.
   private tagsRecordFor(
     value: unknown,
     create: boolean,
   ): Record<string, unknown> | undefined {
     if (this.isRef(value)) {
-      let t = this.objectTags.get(value);
-      if (!t && create) {
-        t = {};
-        this.objectTags.set(value, t);
+      let record = this.objectTags.get(value);
+      if (!record && create) {
+        record = Object.create(null) as Record<string, unknown>;
+        this.objectTags.set(value, record);
         this.objectTagsPresent = true;
       }
-      return t;
+      return record;
     }
-    const m = create
+    const map = create
       ? this.valueTagMap()
       : this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
-    if (!(m instanceof Map)) return undefined;
-    let t = m.get(value);
-    if (!t && create) {
-      t = {};
-      m.set(value, t);
+    if (!(map instanceof Map)) return undefined;
+    let record = map.get(value);
+    if (!record && create) {
+      record = Object.create(null) as Record<string, unknown>;
+      map.set(value, record);
     }
-    return t;
+    return record;
   }
 
   setTag(value: unknown, key: string, val: unknown): void {
-    const tags = this.tagsRecordFor(value, true);
+    // Silently ignore untaggable values (bigint/symbol) — see isTaggable.
+    if (!this.isTaggable(value)) return;
+    const record = this.tagsRecordFor(value, true);
     // create=true always yields a record; the guard is for the type checker.
-    if (tags) tags[key] = val;
+    if (record) record[key] = val;
   }
 
   getTagsFor(value: unknown): Record<string, unknown> | undefined {
     return this.tagsRecordFor(value, false);
+  }
+
+  /** Remove a single tag key from a value. No-op if the value has no tags. */
+  removeTag(value: unknown, key: string): void {
+    const record = this.getTagsFor(value);
+    if (record) delete record[key];
+  }
+
+  /** Remove every tag from a value. */
+  removeAllTags(value: unknown): void {
+    if (this.isRef(value)) {
+      this.objectTags.delete(value);
+      return;
+    }
+    const map = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    if (map instanceof Map) map.delete(value);
   }
 
   /**

--- a/packages/agency-lang/lib/runtime/state/globalStore.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.ts
@@ -9,6 +9,111 @@ export class GlobalStore {
   private store: Record<string, Record<string, any>> = {};
   private initializedModules: Set<string> = new Set();
 
+  // Object/array/function tags, keyed by reference. Deliberately a WeakMap so
+  // it is (a) excluded from toJSON serialization and (b) reset to empty on
+  // clone() (fromJSON constructs a fresh GlobalStore). Object identity does
+  // not survive the toJSON/fromJSON round-trip, so object tags are
+  // intentionally branch-local and do not cross fork/interrupt boundaries.
+  private objectTags: WeakMap<object, Record<string, unknown>> = new WeakMap();
+
+  // Tracks whether any object (reference) tag has been set, so hasAnyTags()
+  // can answer without enumerating the (non-enumerable) WeakMap. Not
+  // serialized and starts false on every fresh store, so it resets on
+  // clone()/fromJSON — matching the WeakMap, whose entries also reset.
+  private objectTagsPresent = false;
+
+  private static readonly VALUE_TAGS_KEY = "__valueTags";
+  static readonly REDACT_TAG = "redact";
+
+  private isRef(value: unknown): value is object {
+    return (
+      (typeof value === "object" && value !== null) ||
+      typeof value === "function"
+    );
+  }
+
+  // Primitive tags, keyed by value. Stored as a Map under the __internal
+  // module so it rides the existing toJSON/fromJSON/clone machinery. The
+  // MapReviver serializes entries as [key, value] pairs through JSON, which
+  // preserves primitive key *types* (1, "1", and true stay distinct).
+  private valueTagMap(): Map<unknown, Record<string, unknown>> {
+    let m = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    if (!(m instanceof Map)) {
+      m = new Map();
+      this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY, m);
+    }
+    return m as Map<unknown, Record<string, unknown>>;
+  }
+
+  // Resolve the tag record for a value. `create` controls whether a missing
+  // record (and its backing store slot) is allocated — reads pass false so a
+  // pure lookup never mutates state. Unifies the primitive (value Map) and
+  // object (WeakMap) paths so setTag/getTagsFor share one code path.
+  private tagsRecordFor(
+    value: unknown,
+    create: boolean,
+  ): Record<string, unknown> | undefined {
+    if (this.isRef(value)) {
+      let t = this.objectTags.get(value);
+      if (!t && create) {
+        t = {};
+        this.objectTags.set(value, t);
+        this.objectTagsPresent = true;
+      }
+      return t;
+    }
+    const m = create
+      ? this.valueTagMap()
+      : this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    if (!(m instanceof Map)) return undefined;
+    let t = m.get(value);
+    if (!t && create) {
+      t = {};
+      m.set(value, t);
+    }
+    return t;
+  }
+
+  setTag(value: unknown, key: string, val: unknown): void {
+    const tags = this.tagsRecordFor(value, true);
+    // create=true always yields a record; the guard is for the type checker.
+    if (tags) tags[key] = val;
+  }
+
+  getTagsFor(value: unknown): Record<string, unknown> | undefined {
+    return this.tagsRecordFor(value, false);
+  }
+
+  /**
+   * Mark a value for statelog redaction. Sole *writer* of the redact tag, so
+   * the tag's representation lives in exactly one place. Equivalent to the
+   * user-facing tag(value, "redact", true).
+   */
+  markRedacted(value: unknown): void {
+    this.setTag(value, GlobalStore.REDACT_TAG, true);
+  }
+
+  /**
+   * True when a value is marked redact:true. Sole *reader* of the redact tag
+   * (the statelog replacer calls this), so the walker never hard-codes the
+   * tag shape.
+   */
+  isRedacted(value: unknown): boolean {
+    return this.getTagsFor(value)?.[GlobalStore.REDACT_TAG] === true;
+  }
+
+  /**
+   * Cheap "are there any tags at all?" check so statelog can skip installing
+   * a redaction replacer entirely when nothing is tagged (the common case).
+   * The WeakMap can't report size, so object-tag presence is tracked by a
+   * boolean flag that resets on clone alongside the WeakMap.
+   */
+  hasAnyTags(): boolean {
+    if (this.objectTagsPresent) return true;
+    const m = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    return m instanceof Map && m.size > 0;
+  }
+
   get(moduleId: string, varName: string): any {
     return this.store[moduleId]?.[varName];
   }

--- a/packages/agency-lang/lib/statelogClient.redaction.test.ts
+++ b/packages/agency-lang/lib/statelogClient.redaction.test.ts
@@ -7,6 +7,7 @@ function makeStdoutCtx() {
   return new RuntimeContext({
     statelogConfig: {
       host: "stdout",
+      apiKey: "test-api-key",
       projectId: "test-project",
       debugMode: false,
       observability: true,
@@ -17,7 +18,7 @@ function makeStdoutCtx() {
 }
 
 function printed(spy: ReturnType<typeof vi.spyOn>): string {
-  return spy.mock.calls.map((c) => String(c[0])).join("\n");
+  return spy.mock.calls.map((c: unknown[]) => String(c[0])).join("\n");
 }
 
 afterEach(() => vi.restoreAllMocks());

--- a/packages/agency-lang/lib/statelogClient.redaction.test.ts
+++ b/packages/agency-lang/lib/statelogClient.redaction.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { runInTestContext } from "./runtime/asyncContext.js";
+import { RuntimeContext } from "./runtime/state/context.js";
+import { ThreadStore } from "./runtime/state/threadStore.js";
+
+function makeStdoutCtx() {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "stdout",
+      projectId: "test-project",
+      debugMode: false,
+      observability: true,
+    },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+}
+
+function printed(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((c) => String(c[0])).join("\n");
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("StatelogClient redaction", () => {
+  it("replaces a redact-tagged primitive in a posted event with [REDACTED]", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      execCtx.globals.markRedacted("sk-secret");
+      await execCtx.statelogClient.post({ event: "toolCall", args: { apiKey: "sk-secret" } });
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("sk-secret");
+  });
+
+  it("leaves untagged values untouched", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await execCtx.statelogClient.post({ event: "toolCall", args: { city: "Mumbai" } });
+    });
+    expect(printed(spy)).toContain("Mumbai");
+  });
+
+  it("redacts a tagged object node end-to-end", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      const creds = { user: "alice", pass: "hunter2" };
+      execCtx.globals.markRedacted(creds);
+      await execCtx.statelogClient.post({ event: "toolCall", args: { creds } });
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("hunter2");
+  });
+
+  it("does not corrupt an untagged Date in the body (native-type guard)", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      // Redaction is live (a tag exists) but the Date is untagged: it must
+      // still serialize to its ISO string, not {}.
+      execCtx.globals.markRedacted("unrelated");
+      await execCtx.statelogClient.post({
+        event: "toolCall",
+        output: { when: new Date("2026-01-01T00:00:00.000Z") },
+      });
+    });
+    expect(printed(spy)).toContain("2026-01-01T00:00:00.000Z");
+  });
+
+  it("never redacts envelope fields even when a colliding value is tagged", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      // 1 === STATELOG_FORMAT_VERSION. A pathological value-tag on 1 must NOT
+      // touch the envelope's format_version (scoped-to-data redaction), but the
+      // same value inside the payload IS redacted.
+      execCtx.globals.markRedacted(1);
+      await execCtx.statelogClient.post({ event: "toolCall", args: { n: 1 } });
+    });
+    expect(printed(spy)).toContain('"format_version":1'); // infra field intact
+    expect(printed(spy)).toContain("[REDACTED]"); // payload value redacted
+  });
+
+  it("redaction survives a fork-style globals clone (durable primitive path)", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    // Tag on the parent store, then run post() against a CLONE of it — exactly
+    // what runInBranchAlsFrame does when entering a fork/parallel/race branch.
+    // This pins the headline claim: a primitive redact tag set before a fork is
+    // still honored inside the branch's post().
+    execCtx.globals.markRedacted("sk-fork");
+    execCtx.globals = execCtx.globals.clone();
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await execCtx.statelogClient.post({ event: "toolCall", args: { apiKey: "sk-fork" } });
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("sk-fork");
+  });
+});

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1166,36 +1166,38 @@ export class StatelogClient {
 
     const span = this.currentSpan;
     // Single redaction chokepoint: every statelog event flows through post().
-    // Redaction is a JSON.stringify *replacer* scoped to the `data` payload
-    // ONLY. We stringify the envelope and the payload separately and splice
-    // them, so the replacer never runs over infra fields (format_version,
-    // trace_id, span ids). This keeps redaction single-pass (no extra deep
-    // copy) and preserves Date/URL/toJSON values, while making envelope fields
-    // structurally immune to a value-collision — e.g. a pathological
-    // `redact(1)` can't blank out `format_version: 1`. The replacer reads the
-    // caller's branch tag store via __globals(), synchronously before any
-    // detached (noWait) send, so it sees the correct branch. hasAnyTags() skips
-    // the replacer entirely when nothing is tagged, so tag-free programs pay
-    // nothing. Events posted outside an ALS frame (__globals() undefined) are
-    // not redacted — a documented boundary, not a secrecy guarantee.
+    // Redaction is a JSON.stringify *replacer* applied to the `data` payload
+    // ONLY, so it never touches infra fields (format_version, trace_id, span
+    // ids) — a pathological `redact(1)` can't blank out `format_version: 1`.
+    // We scope it by redacting `data` on its own (stringify with the replacer,
+    // then parse back), then serialize the whole envelope normally with the
+    // already-redacted payload. This preserves Date/URL/toJSON values (the
+    // replacer runs inside a real stringify) and keeps envelope handling as
+    // ordinary object construction — no string surgery.
+    //
+    // Reads the caller's branch tag store via __globals() (the lenient,
+    // returns-undefined accessor — post() can fire outside an ALS frame, so it
+    // must not throw like getRuntimeContext() would). hasAnyTags() skips the
+    // whole redaction pass when nothing is tagged, so the common case is one
+    // stringify, byte-identical to before. Events posted outside an ALS frame
+    // (__globals() undefined) are not redacted — a documented boundary, not a
+    // secrecy guarantee. See docs/dev/globalstore.md on per-branch isolation:
+    // __globals() returns the branch-local clone, so each branch redacts using
+    // its own tags.
     const globals = __globals();
-    const replacer =
-      globals && globals.hasAnyTags() ? makeRedactReplacer(globals) : undefined;
-    const envelopeJson = JSON.stringify({
+    const rawData = { ...body, timestamp: new Date().toISOString() };
+    const data =
+      globals && globals.hasAnyTags()
+        ? JSON.parse(JSON.stringify(rawData, makeRedactReplacer(globals)))
+        : rawData;
+    const postBody = JSON.stringify({
       format_version: STATELOG_FORMAT_VERSION,
       trace_id: this.traceId,
       project_id: this.projectId,
       span_id: span?.spanId ?? null,
       parent_span_id: span?.parentSpanId ?? null,
+      data,
     });
-    const dataJson = JSON.stringify(
-      { ...body, timestamp: new Date().toISOString() },
-      replacer,
-    );
-    // Splice: drop the envelope's closing brace and append the data field. The
-    // envelope always carries format_version, so envelopeJson is never "{}" and
-    // the leading comma is always valid.
-    const postBody = `${envelopeJson.slice(0, -1)},"data":${dataJson}}`;
 
     // File sink: append one JSON object per line. Done synchronously
     // so tests can read the file immediately after an awaited event.

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -4,6 +4,8 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { nanoid } from "nanoid";
 import { ModelName } from "smoltalk";
 import { JSONEdge } from "./types.js";
+import { makeRedactReplacer } from "./runtime/redactForStatelog.js";
+import { __globals } from "./runtime/asyncContext.js";
 
 // Bump this when the wire format changes in a way the viewer needs
 // to notice. The viewer rejects files with a higher version.
@@ -1163,14 +1165,37 @@ export class StatelogClient {
     }
 
     const span = this.currentSpan;
-    const postBody = JSON.stringify({
+    // Single redaction chokepoint: every statelog event flows through post().
+    // Redaction is a JSON.stringify *replacer* scoped to the `data` payload
+    // ONLY. We stringify the envelope and the payload separately and splice
+    // them, so the replacer never runs over infra fields (format_version,
+    // trace_id, span ids). This keeps redaction single-pass (no extra deep
+    // copy) and preserves Date/URL/toJSON values, while making envelope fields
+    // structurally immune to a value-collision — e.g. a pathological
+    // `redact(1)` can't blank out `format_version: 1`. The replacer reads the
+    // caller's branch tag store via __globals(), synchronously before any
+    // detached (noWait) send, so it sees the correct branch. hasAnyTags() skips
+    // the replacer entirely when nothing is tagged, so tag-free programs pay
+    // nothing. Events posted outside an ALS frame (__globals() undefined) are
+    // not redacted — a documented boundary, not a secrecy guarantee.
+    const globals = __globals();
+    const replacer =
+      globals && globals.hasAnyTags() ? makeRedactReplacer(globals) : undefined;
+    const envelopeJson = JSON.stringify({
       format_version: STATELOG_FORMAT_VERSION,
       trace_id: this.traceId,
       project_id: this.projectId,
       span_id: span?.spanId ?? null,
       parent_span_id: span?.parentSpanId ?? null,
-      data: { ...body, timestamp: new Date().toISOString() },
     });
+    const dataJson = JSON.stringify(
+      { ...body, timestamp: new Date().toISOString() },
+      replacer,
+    );
+    // Splice: drop the envelope's closing brace and append the data field. The
+    // envelope always carries format_version, so envelopeJson is never "{}" and
+    // the leading comma is always valid.
+    const postBody = `${envelopeJson.slice(0, -1)},"data":${dataJson}}`;
 
     // File sink: append one JSON object per line. Done synchronously
     // so tests can read the file immediately after an awaited event.

--- a/packages/agency-lang/lib/stdlib/tag.test.ts
+++ b/packages/agency-lang/lib/stdlib/tag.test.ts
@@ -2,7 +2,14 @@ import { describe, it, expect } from "vitest";
 import { runInTestContext } from "../runtime/asyncContext.js";
 import { RuntimeContext } from "../runtime/state/context.js";
 import { ThreadStore } from "../runtime/state/threadStore.js";
-import { _tag, _getTags, _redact } from "./tag.js";
+import {
+  _tag,
+  _setTags,
+  _getTags,
+  _redact,
+  _removeTag,
+  _removeAllTags,
+} from "./tag.js";
 
 function makeCtx() {
   return new RuntimeContext({
@@ -19,13 +26,24 @@ function makeCtx() {
 }
 
 describe("std::tag TS helpers", () => {
-  it("tags and reads back a primitive by value", async () => {
+  it("tags and reads back a primitive by value; _tag returns current tags", async () => {
     const ctx = makeCtx();
     const execCtx = await ctx.createExecutionContext("r1");
     await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
-      _tag("secret", "color", "blue");
+      expect(_tag("secret", "color", "blue")).toEqual({ color: "blue" });
       expect(_getTags("secret")).toEqual({ color: "blue" });
       expect(_getTags("other")).toEqual({});
+    });
+  });
+
+  it("setTags merges multiple tags; removeTag/removeAllTags return remaining", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      expect(_setTags("v", { a: 1, b: 2 })).toEqual({ a: 1, b: 2 });
+      expect(_removeTag("v", "a")).toEqual({ b: 2 });
+      expect(_removeAllTags("v")).toEqual({});
+      expect(_getTags("v")).toEqual({});
     });
   });
 
@@ -40,11 +58,11 @@ describe("std::tag TS helpers", () => {
     });
   });
 
-  it("redact() sets redact:true (via GlobalStore.markRedacted)", async () => {
+  it("redact() sets redact:true (via GlobalStore.markRedacted) and returns tags", async () => {
     const ctx = makeCtx();
     const execCtx = await ctx.createExecutionContext("r1");
     await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
-      _redact("sk-1");
+      expect(_redact("sk-1")).toEqual({ redact: true });
       expect(_getTags("sk-1")).toEqual({ redact: true });
       expect(execCtx.globals.isRedacted("sk-1")).toBe(true);
     });
@@ -61,8 +79,11 @@ describe("std::tag TS helpers", () => {
     });
   });
 
-  it("_tag is a no-op outside an Agency frame", () => {
-    expect(() => _tag("x", "a", 1)).not.toThrow();
-    expect(_getTags("x")).toEqual({});
+  it("throws outside an Agency frame (stdlib helpers require the active branch)", () => {
+    // These helpers use getRuntimeContext(), the documented strict accessor, so
+    // calling them with no active branch surfaces a clear error rather than
+    // silently writing into a discarded store.
+    expect(() => _tag("x", "a", 1)).toThrow();
+    expect(() => _getTags("x")).toThrow();
   });
 });

--- a/packages/agency-lang/lib/stdlib/tag.test.ts
+++ b/packages/agency-lang/lib/stdlib/tag.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { runInTestContext } from "../runtime/asyncContext.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+import { _tag, _getTags, _redact } from "./tag.js";
+
+function makeCtx() {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+      observability: true,
+    },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+}
+
+describe("std::tag TS helpers", () => {
+  it("tags and reads back a primitive by value", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      _tag("secret", "color", "blue");
+      expect(_getTags("secret")).toEqual({ color: "blue" });
+      expect(_getTags("other")).toEqual({});
+    });
+  });
+
+  it("tags an object by reference", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      const o = { id: 1 };
+      _tag(o, "source", "upload");
+      expect(_getTags(o)).toEqual({ source: "upload" });
+      expect(_getTags({ id: 1 })).toEqual({}); // distinct reference
+    });
+  });
+
+  it("redact() sets redact:true (via GlobalStore.markRedacted)", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      _redact("sk-1");
+      expect(_getTags("sk-1")).toEqual({ redact: true });
+      expect(execCtx.globals.isRedacted("sk-1")).toBe(true);
+    });
+  });
+
+  it("_getTags returns a copy, not the live store object", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      _tag("k", "a", 1);
+      const t = _getTags("k");
+      (t as Record<string, unknown>)["a"] = 999;
+      expect(_getTags("k")).toEqual({ a: 1 });
+    });
+  });
+
+  it("_tag is a no-op outside an Agency frame", () => {
+    expect(() => _tag("x", "a", 1)).not.toThrow();
+    expect(_getTags("x")).toEqual({});
+  });
+});

--- a/packages/agency-lang/lib/stdlib/tag.ts
+++ b/packages/agency-lang/lib/stdlib/tag.ts
@@ -1,0 +1,23 @@
+import { __globals } from "../runtime/asyncContext.js";
+
+/**
+ * Attach a tag to a value. Primitives are keyed by value (all equal
+ * primitives share tags); objects by reference. No-op outside an Agency
+ * execution frame, matching the lenient stdlib convention.
+ */
+export function _tag(value: unknown, key: string, val: unknown): void {
+  const g = __globals();
+  if (!g) return;
+  g.setTag(value, key, val);
+}
+
+/** Return a shallow copy of a value's tags, or {} if none. */
+export function _getTags(value: unknown): Record<string, unknown> {
+  const t = __globals()?.getTagsFor(value);
+  return t ? { ...t } : {};
+}
+
+/** Mark a value so it is replaced with "[REDACTED]" in state logs. */
+export function _redact(value: unknown): void {
+  __globals()?.markRedacted(value);
+}

--- a/packages/agency-lang/lib/stdlib/tag.ts
+++ b/packages/agency-lang/lib/stdlib/tag.ts
@@ -1,23 +1,63 @@
-import { __globals } from "../runtime/asyncContext.js";
+import { getRuntimeContext } from "../runtime/asyncContext.js";
+import type { GlobalStore } from "../runtime/state/globalStore.js";
+
+// Shallow copy of a value's tags, or {}. Shallow on purpose: a tag whose value
+// is itself an object is returned by reference (tag values are usually
+// primitives). Callers must not mutate nested tag values.
+function tagsCopy(globals: GlobalStore, value: unknown): Record<string, unknown> {
+  const record = globals.getTagsFor(value);
+  return record ? { ...record } : {};
+}
 
 /**
- * Attach a tag to a value. Primitives are keyed by value (all equal
- * primitives share tags); objects by reference. No-op outside an Agency
- * execution frame, matching the lenient stdlib convention.
+ * Attach a tag to a value and return the value's current tags. Primitives are
+ * keyed by value (all equal primitives share tags); objects by reference.
  */
-export function _tag(value: unknown, key: string, val: unknown): void {
-  const g = __globals();
-  if (!g) return;
-  g.setTag(value, key, val);
+export function _tag(
+  value: unknown,
+  key: string,
+  val: unknown,
+): Record<string, unknown> {
+  const { globals } = getRuntimeContext();
+  globals.setTag(value, key, val);
+  return tagsCopy(globals, value);
+}
+
+/**
+ * Attach every key/value in `tags` to `value`, then return its current tags.
+ */
+export function _setTags(
+  value: unknown,
+  tags: Record<string, unknown>,
+): Record<string, unknown> {
+  const { globals } = getRuntimeContext();
+  for (const key of Object.keys(tags)) globals.setTag(value, key, tags[key]);
+  return tagsCopy(globals, value);
 }
 
 /** Return a shallow copy of a value's tags, or {} if none. */
 export function _getTags(value: unknown): Record<string, unknown> {
-  const t = __globals()?.getTagsFor(value);
-  return t ? { ...t } : {};
+  const { globals } = getRuntimeContext();
+  return tagsCopy(globals, value);
 }
 
-/** Mark a value so it is replaced with "[REDACTED]" in state logs. */
-export function _redact(value: unknown): void {
-  __globals()?.markRedacted(value);
+/** Mark a value for statelog redaction and return its current tags. */
+export function _redact(value: unknown): Record<string, unknown> {
+  const { globals } = getRuntimeContext();
+  globals.markRedacted(value);
+  return tagsCopy(globals, value);
+}
+
+/** Remove a single tag from a value and return its remaining tags. */
+export function _removeTag(value: unknown, key: string): Record<string, unknown> {
+  const { globals } = getRuntimeContext();
+  globals.removeTag(value, key);
+  return tagsCopy(globals, value);
+}
+
+/** Remove all tags from a value and return the (now empty) tags. */
+export function _removeAllTags(value: unknown): Record<string, unknown> {
+  const { globals } = getRuntimeContext();
+  globals.removeAllTags(value);
+  return tagsCopy(globals, value);
 }

--- a/packages/agency-lang/stdlib/tag.agency
+++ b/packages/agency-lang/stdlib/tag.agency
@@ -25,21 +25,38 @@ Note: object/array tags are branch-local — they do not survive `fork`/`race`/
 `parallel` branches or interrupt/resume. Primitive (value) tags survive both.
 */
 
-import { _tag, _getTags, _redact } from "agency-lang/stdlib-lib/tag.js"
+import { _tag, _setTags, _getTags, _redact, _removeTag, _removeAllTags } from "agency-lang/stdlib-lib/tag.js"
 
-export def tag(value: any, key: string, val: any = true) {
+export def tag(value: any, key: string, val: any = true): any {
   """Attach a tag to a value. Primitives are keyed by value; objects by
-  reference. `val` defaults to `true`."""
-  _tag(value, key, val)
+  reference. `val` defaults to `true`. Returns the value's current tags."""
+  return _tag(value, key, val)
+}
+
+export def setTags(value: any, tags: any): any {
+  """Attach multiple tags at once from a `{ key: value }` object. Returns the
+  value's current tags."""
+  return _setTags(value, tags)
 }
 
 export def getTags(value: any): any {
-  """Return all tags on a value as an object, or an empty object if none."""
+  """Return all tags on a value as an object, or an empty object if none. The
+  result is a shallow copy; nested tag values are shared references."""
   return _getTags(value)
 }
 
-export def redact(value: any) {
+export def redact(value: any): any {
   """Mark a value so it is replaced with "[REDACTED]" in state logs. Shorthand
-  for tag(value, "redact", true)."""
-  _redact(value)
+  for tag(value, "redact", true). Returns the value's current tags."""
+  return _redact(value)
+}
+
+export def removeTag(value: any, key: string): any {
+  """Remove a single tag from a value. Returns the value's remaining tags."""
+  return _removeTag(value, key)
+}
+
+export def removeAllTags(value: any): any {
+  """Remove all tags from a value. Returns an empty object."""
+  return _removeAllTags(value)
 }

--- a/packages/agency-lang/stdlib/tag.agency
+++ b/packages/agency-lang/stdlib/tag.agency
@@ -1,0 +1,45 @@
+/** @module Attach arbitrary tags to values and read them back anywhere in
+your program.
+
+Tags are stored in a side table, so nothing is attached to the value itself
+and TypeScript interop is unaffected. Two semantics, by value kind:
+
+- **Primitives** (string, number, boolean) are keyed by **value**: tagging one
+  copy of `"secret"` tags every equal `"secret"` in the current branch.
+- **Objects and arrays** are keyed by **reference**: tagging one object does
+  not tag a structurally-equal but distinct object.
+
+The built-in `redact` tag marks a value so it is replaced with `"[REDACTED]"`
+in state logs — useful for API keys and other secrets.
+
+  ```ts
+  import { redact } from "std::tag"
+
+  def callApi(apiKey: string) {
+    redact(apiKey)          // apiKey shows as "[REDACTED]" in state logs
+    return fetch("https://api.example.com", { headers: { key: apiKey } })
+  }
+  ```
+
+Note: object/array tags are branch-local — they do not survive `fork`/`race`/
+`parallel` branches or interrupt/resume. Primitive (value) tags survive both.
+*/
+
+import { _tag, _getTags, _redact } from "agency-lang/stdlib-lib/tag.js"
+
+export def tag(value: any, key: string, val: any = true) {
+  """Attach a tag to a value. Primitives are keyed by value; objects by
+  reference. `val` defaults to `true`."""
+  _tag(value, key, val)
+}
+
+export def getTags(value: any): any {
+  """Return all tags on a value as an object, or an empty object if none."""
+  return _getTags(value)
+}
+
+export def redact(value: any) {
+  """Mark a value so it is replaced with "[REDACTED]" in state logs. Shorthand
+  for tag(value, "redact", true)."""
+  _redact(value)
+}

--- a/packages/agency-lang/tests/agency/tag.agency
+++ b/packages/agency-lang/tests/agency/tag.agency
@@ -1,4 +1,4 @@
-import { tag, getTags, redact } from "std::tag"
+import { tag, setTags, getTags, redact, removeTag, removeAllTags } from "std::tag"
 
 node valueKeyed(): string {
   const x = "hello"
@@ -26,6 +26,25 @@ node objectByReference(): boolean {
   // `undefined` (not `null`), so `bTags["src"] == null` would be false even
   // when the tag is absent. Assert the tag did not leak by value instead.
   return shared == "upload" && bTags["src"] != "upload"
+}
+
+node mutateTags(): boolean {
+  const x = "mkey"
+  setTags(x, { a: 1, b: 2 })
+  removeTag(x, "a")
+  const afterRemove = getTags("mkey")
+  // b survives, a is gone (missing key reads back as absent, not == 1).
+  const removedOne = afterRemove["b"] == 2 && afterRemove["a"] != 1
+  removeAllTags(x)
+  const cleared = getTags("mkey")
+  const removedAll = cleared["b"] != 2
+  return removedOne && removedAll
+}
+
+node tagReturnsCurrentTags(): boolean {
+  // tag() returns the value's current tags (LLM-tool confirmation).
+  const returned = tag("rkey", "phase", "final")
+  return returned["phase"] == "final"
 }
 
 node forkInheritsPrimitiveTag(): boolean {

--- a/packages/agency-lang/tests/agency/tag.agency
+++ b/packages/agency-lang/tests/agency/tag.agency
@@ -1,0 +1,39 @@
+import { tag, getTags, redact } from "std::tag"
+
+node valueKeyed(): string {
+  const x = "hello"
+  tag(x, "color", "blue")
+  // Value-keyed: a second identical literal reads the same tags.
+  const t = getTags("hello")
+  return t["color"]
+}
+
+node redactSetsTag(): boolean {
+  const key = "sk-abc"
+  redact(key)
+  const t = getTags("sk-abc")
+  return t["redact"] == true
+}
+
+node objectByReference(): boolean {
+  const a = { id: 1 }
+  tag(a, "src", "upload")
+  // A distinct object with the same shape does NOT share tags.
+  const shared = getTags(a)["src"]
+  const b = { id: 1 }
+  const bTags = getTags(b)
+  // NB: Agency compiles `==` to strict `===`, and a missing object property is
+  // `undefined` (not `null`), so `bTags["src"] == null` would be false even
+  // when the tag is absent. Assert the tag did not leak by value instead.
+  return shared == "upload" && bTags["src"] != "upload"
+}
+
+node forkInheritsPrimitiveTag(): boolean {
+  // Primitive (value) tags are durable: a fork branch inherits them.
+  redact("sk-xyz")
+  const results = fork(["only"]) as item {
+    const t = getTags("sk-xyz")
+    return t["redact"] == true
+  }
+  return results[0]
+}

--- a/packages/agency-lang/tests/agency/tag.test.json
+++ b/packages/agency-lang/tests/agency/tag.test.json
@@ -1,0 +1,8 @@
+{
+  "tests": [
+    { "nodeName": "valueKeyed", "input": "", "expectedOutput": "\"blue\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "redactSetsTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "objectByReference", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "forkInheritsPrimitiveTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/tag.test.json
+++ b/packages/agency-lang/tests/agency/tag.test.json
@@ -3,6 +3,8 @@
     { "nodeName": "valueKeyed", "input": "", "expectedOutput": "\"blue\"", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "redactSetsTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "objectByReference", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "mutateTags", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "tagReturnsCurrentTags", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "forkInheritsPrimitiveTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a `std::tag` module for attaching arbitrary tags to values, plus a built-in `redact` tag that keeps secrets (API keys, tokens) out of state logs. Motivating case: an API key passed into a `fetch` should never appear in statelog.

```ts
import { redact } from "std::tag"

def callApi(apiKey: string) {
  redact(apiKey)   // apiKey shows as "[REDACTED]" in state logs
  return fetch("https://api.example.com", { headers: { key: apiKey } })
}
```

## Design

- **Two tag stores on `GlobalStore`** (no boxing of values, so TS interop is untouched):
  - **Primitives** keyed by **value** (`Map` under `__internal`) — durable: clones into fork branches and survives interrupt/resume via the existing `MapReviver`.
  - **Objects/arrays** keyed by **reference** (`WeakMap`) — branch-local by design (object identity does not survive the `toJSON`/`fromJSON` round-trip), reset on `clone()`.
- **`redact` semantics owned by `GlobalStore`** (`markRedacted`/`isRedacted`/`REDACT_TAG`) so the tag shape lives in exactly one place.
- **Redaction at the single `StatelogClient.post()` chokepoint** as a `JSON.stringify` replacer, so it rides the one serialization pass, preserves `Date`/`URL`/`toJSON` values, and covers all ~40 event types at one seam. Gated on `hasAnyTags()` so tag-free programs pay nothing.
- **Scoped to the `data` payload only** (envelope and payload are stringified separately and spliced), so a value-collision can never corrupt infra fields like `format_version`.

## Limits (v1, documented)

- Whole-value redaction only — a secret embedded inside a larger logged string is not scrubbed.
- Statelog only — does not affect `print()`; not a general secrecy/information-flow guarantee.
- Primitives are keyed by value, so tagging a low-entropy value (e.g. `1`) redacts every occurrence — intended for high-entropy secrets.

Provenance tracking (`response.provenance`) is explicitly out of scope; the spec sketches it as future work on the same mechanism.

## Testing

- Unit: `GlobalStore` tag storage (value/reference keying, `1` vs `"1"` distinctness, clone/serialize durability, `hasAnyTags`); the redaction replacer (native-type preservation, object-node redaction, substring boundary); `std::tag` TS helpers.
- Integration: redaction end-to-end through `post()` via the stdout sink, including an untagged-`Date` guard, envelope-immunity, and a fork-style globals-clone durability test.
- Execution (`tests/agency/tag.agency`): value keying, `redact` writing the tag, object-by-reference, and a `fork` branch inheriting a primitive tag.
- Full `make` build (tsc) passes.

Design spec and plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
