### PR TITLE
typechecker: fix two scope-visibility holes hiding type errors

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -538,7 +538,7 @@ flushPolicy()
  * `std::write` via `with approve` (you opted in by installing the
  * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L480))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L485))
 
 ### _handler
 
@@ -559,7 +559,7 @@ _handler(intr: any): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L698))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L705))
 
 ### cliPolicyHandler
 
@@ -631,4 +631,4 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L821))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L828))

--- a/packages/agency-lang/lib/typeChecker/scope.test.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.test.ts
@@ -65,4 +65,19 @@ describe("Scope", () => {
     expect(child.isConst("c")).toBe(true);
   });
 
+  it("treats '__proto__' as an ordinary variable name", () => {
+    // With a plain `{}` backing map, `vars["__proto__"] = <object>` would
+    // invoke the prototype setter instead of storing a binding — the binding
+    // is lost and the map's prototype is mutated.
+    const scope = new Scope("function:foo");
+    const objType: VariableType = {
+      type: "objectType",
+      fields: [],
+    } as unknown as VariableType;
+    scope.declare("__proto__", objType, true);
+    expect(scope.lookup("__proto__")).toEqual(objType);
+    expect(scope.isConst("__proto__")).toBe(true);
+    // Unrelated lookups are unaffected by the declaration.
+    expect(scope.lookup("toString")).toBeUndefined();
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/scope.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.ts
@@ -5,8 +5,11 @@ export type ScopeType = VariableType | "any";
 export class Scope {
   readonly key: string;
   readonly parent?: Scope;
-  private readonly vars: Record<string, ScopeType> = {};
-  private readonly consts: Record<string, boolean> = {};
+  // Null-prototype dictionaries: variable names are user-controlled, and on
+  // a plain `{}` assigning the key "__proto__" invokes the prototype setter
+  // (losing the binding and mutating the map) instead of storing an entry.
+  private readonly vars: Record<string, ScopeType> = Object.create(null);
+  private readonly consts: Record<string, boolean> = Object.create(null);
   private readonly isFunctionBoundary: boolean;
 
   constructor(key: string, parent?: Scope, isFunctionBoundary: boolean = false) {

--- a/packages/agency-lang/lib/typeChecker/scope.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.ts
@@ -7,10 +7,12 @@ export class Scope {
   readonly parent?: Scope;
   private readonly vars: Record<string, ScopeType> = {};
   private readonly consts: Record<string, boolean> = {};
+  private readonly isFunctionBoundary: boolean;
 
-  constructor(key: string, parent?: Scope) {
+  constructor(key: string, parent?: Scope, isFunctionBoundary: boolean = false) {
     this.key = key;
     this.parent = parent;
+    this.isFunctionBoundary = isFunctionBoundary;
   }
 
   /**
@@ -46,6 +48,20 @@ export class Scope {
     return this.parent?.lookup(name);
   }
 
+  /**
+   * Like `lookup`, but stops at the enclosing function boundary instead of
+   * walking into outer (module-level) scopes. Used to decide whether a
+   * `let`/`const` statement redeclares an existing local or shadows an
+   * outer binding with a fresh one.
+   */
+  lookupInFunction(name: string): ScopeType | undefined {
+    if (Object.prototype.hasOwnProperty.call(this.vars, name)) {
+      return this.vars[name];
+    }
+    if (!this.parent || this.isFunctionBoundary) return undefined;
+    return this.parent.lookupInFunction(name);
+  }
+
   isConst(name: string): boolean {
     // Own-property check — `name in this.vars` walks the prototype chain.
     if (Object.prototype.hasOwnProperty.call(this.vars, name)) {
@@ -63,7 +79,9 @@ export class Scope {
   }
 
   private functionScope(): Scope {
-    if (!this.parent) return this;
+    // A function-boundary scope is a declaration target even when it chains
+    // to the module scope for lookups — locals must not leak into it.
+    if (!this.parent || this.isFunctionBoundary) return this;
     return this.parent.functionScope();
   }
 }

--- a/packages/agency-lang/lib/typeChecker/scopeVisibility.test.ts
+++ b/packages/agency-lang/lib/typeChecker/scopeVisibility.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+function check(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(
+    parsed.result,
+    { typechecker: { undefinedFunctions: "silent" } },
+    info,
+  ).errors.map((e) => e.message);
+}
+
+describe("with-modifier declarations are visible to the scope builder", () => {
+  it("infers the type of a `const x = f() with approve` declaration", () => {
+    const errs = check(`
+def getNum(): number { return 5 }
+def wantsString(s: string): string { return s }
+def main() {
+  const f = getNum() with approve
+  wantsString(f)
+}
+`);
+    expect(
+      errs.some((e) =>
+        e.includes(
+          "Argument type 'number' is not assignable to parameter type 'string'",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag a correctly-typed `with approve` declaration", () => {
+    const errs = check(`
+def getStr(): string { return "x" }
+def wantsString(s: string): string { return s }
+def main() {
+  const f = getStr() with approve
+  wantsString(f)
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("tracks const-ness through a with modifier", () => {
+    const errs = check(`
+def getNum(): number { return 5 }
+def main() {
+  const f = getNum() with approve
+  f = 6
+}
+`);
+    expect(
+      errs.some((e) => e.includes("Cannot reassign to constant 'f'")),
+    ).toBe(true);
+  });
+});
+
+describe("module-level bindings are visible inside function and node scopes", () => {
+  it("flags a top-level const used at the wrong type inside a def", () => {
+    const errs = check(`
+const f = 5
+def main() {
+  const x: string = f
+}
+`);
+    expect(
+      errs.some((e) =>
+        e.includes("Type 'number' is not assignable to type 'string'"),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags a top-level const passed as a wrongly-typed argument inside a node", () => {
+    const errs = check(`
+def wantsString(s: string): string { return s }
+const f = 5
+node main() {
+  const r = wantsString(f)
+}
+`);
+    expect(
+      errs.some((e) =>
+        e.includes(
+          "Argument type 'number' is not assignable to parameter type 'string'",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags the combined case: top-level `with approve` declaration misused in a node", () => {
+    const errs = check(`
+def getNum(): number { return 5 }
+def wantsString(s: string): string { return s }
+const f = getNum() with approve
+node main() {
+  const r = wantsString(f)
+}
+`);
+    expect(
+      errs.some((e) =>
+        e.includes(
+          "Argument type 'number' is not assignable to parameter type 'string'",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags reassignment of a top-level const inside a def", () => {
+    const errs = check(`
+const f = 5
+def main() {
+  f = 6
+}
+`);
+    expect(
+      errs.some((e) => e.includes("Cannot reassign to constant 'f'")),
+    ).toBe(true);
+  });
+
+  it("lets a parameter shadow a top-level binding", () => {
+    const errs = check(`
+const f = 5
+def main(f: string) {
+  const x: string = f
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("lets a local declaration shadow a top-level binding", () => {
+    const errs = check(`
+const f = 5
+def main() {
+  const f = "local"
+  const x: string = f
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("does not leak locals from one function into another", () => {
+    const errs = check(`
+def a() {
+  const g = "str"
+}
+def b() {
+  const x: number = g
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("allows iterating a typed-`any` value in a for loop", () => {
+    // Surfaced by the with-modifier fix: an `is success(v)` binder over a
+    // bare `Result` binds `v` as typed `any`, which the for-loop iterable
+    // check rejected even though the string "any" is accepted.
+    const errs = check(`
+def f(x: any) {
+  for (e in x) {
+    print(e)
+  }
+}
+`);
+    expect(errs.filter((e) => e.includes("For-loop iterable"))).toEqual([]);
+  });
+
+  it("does not leak locals from a function into the top level", () => {
+    const errs = check(`
+def a() {
+  const g = "str"
+}
+const x: number = g
+`);
+    expect(errs).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -19,7 +19,7 @@ import { ScopeInfo, TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
 import type { FlowNode } from "./flow.js";
 import { formatTypeHint } from "../utils/formatType.js";
-import { checkType, getBlockSlot } from "./utils.js";
+import { checkType, getBlockSlot, isAnyType } from "./utils.js";
 import { checkMatchExprYields } from "./matchExprTypes.js";
 import { NUMBER_T } from "./primitives.js";
 import { recordLikeKeyValue } from "./recordLike.js";
@@ -45,7 +45,7 @@ export function buildScopes(ctx: TypeCheckerContext): ScopeInfo[] {
     ...Object.values(ctx.functionDefs),
     ...Object.values(ctx.nodeDefs),
   ]) {
-    scopes.push(buildDefScope(def, ctx));
+    scopes.push(buildDefScope(def, topLevelScope, ctx));
   }
 
   return scopes;
@@ -53,6 +53,7 @@ export function buildScopes(ctx: TypeCheckerContext): ScopeInfo[] {
 
 function buildDefScope(
   def: FunctionDefinition | GraphNodeDefinition,
+  topLevelScope: Scope,
   ctx: TypeCheckerContext,
 ): ScopeInfo {
   const name = def.type === "function" ? def.functionName : def.nodeName;
@@ -60,7 +61,10 @@ function buildDefScope(
     def.type === "function"
       ? scopeKey(functionScope(def.functionName))
       : scopeKey(nodeScope(def.nodeName));
-  const scope = new Scope(sk);
+  // Chain to the module scope so top-level bindings are visible inside the
+  // def (lookup only — the boundary flag keeps declarations local, and the
+  // top-level scope is fully walked before any def scope is built).
+  const scope = new Scope(sk, topLevelScope, true);
   for (const param of def.parameters) {
     scope.declare(param.name, param.typeHint ?? "any");
   }
@@ -119,7 +123,14 @@ export function declareVariable(
   }
 
   const newType = node.typeHint;
-  const existingType = scope.lookup(node.variableName);
+  // A `let`/`const` statement declares a fresh binding: only a match within
+  // the current function counts as "existing" (redeclaration); an outer
+  // module-level binding of the same name is shadowed, not redeclared. Bare
+  // reassignment (`x = 5`) targets whatever binding is visible, including
+  // module-level ones.
+  const existingType = node.declKind
+    ? scope.lookupInFunction(node.variableName)
+    : scope.lookup(node.variableName);
   const isConst = node.declKind === "const";
 
   if (newType) {
@@ -366,8 +377,15 @@ export function walkScopeBody(
   ctx: TypeCheckerContext,
 ): void {
   for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
-    checkConstMutations(node, scope, ctx);
+    const raw = nodes[i];
+    checkConstMutations(raw, scope, ctx);
+    // A `stmt with handler` modifier wraps the statement it applies to;
+    // unwrap it so a declaration inside (`const f = read(...) with approve`)
+    // still reaches declareVariable. Unwrap rather than recurse:
+    // checkConstMutations already descends into the wrapped statement via
+    // expressionChildren, so a recursive walkScopeBody call would report
+    // const mutations twice.
+    const node = raw.type === "withModifier" ? raw.statement : raw;
     switch (node.type) {
       case "assignment":
         declareVariable(node, scope, ctx);
@@ -393,9 +411,14 @@ export function walkScopeBody(
         // synthesis agree on an object literal's value type. Object literals
         // synthesize to `objectType`, not `Record`, so without this they'd be
         // wrongly rejected as non-iterable.
+        // Typed `any` (an explicit `: any` annotation, or an `is success(v)`
+        // binder over a bare `Result`) is as unknowable as the "any" string —
+        // treat both as "could be any iterable" rather than rejecting.
         const recordLike =
-          iterableType === "any" ? undefined : recordLikeKeyValue(iterableType);
-        if (iterableType === "any") {
+          iterableType === "any" || isAnyType(iterableType)
+            ? undefined
+            : recordLikeKeyValue(iterableType);
+        if (iterableType === "any" || isAnyType(iterableType)) {
           itemType = "any";
           // Iterable kind is unknown, so the second var could be either an
           // index or a value — leave it as `any` rather than assume a number.

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -460,9 +460,14 @@ def maybeFlush() {
   if (_pendingSave) {
     // flip FIRST
     _pendingSave = false
-    _internalIo = true
-    writePolicyFile(globalCliPolicyOpts.file, _policy, []) with approve
-    _internalIo = false
+    // `_pendingSave` is only set after a decision is recorded, which also
+    // sets `_policy` — but if that invariant ever breaks, skip the write
+    // rather than clobber the policy file with `null`.
+    if (_policy != null) {
+      _internalIo = true
+      writePolicyFile(globalCliPolicyOpts.file, _policy, []) with approve
+      _internalIo = false
+    }
   }
 }
 
@@ -480,9 +485,11 @@ def maybeFlush() {
 export def flushPolicy() {
   if (_pendingSave) {
     _pendingSave = false
-    _internalIo = true
-    writePolicyFile(globalCliPolicyOpts.file, _policy, []) with approve
-    _internalIo = false
+    if (_policy != null) {
+      _internalIo = true
+      writePolicyFile(globalCliPolicyOpts.file, _policy, []) with approve
+      _internalIo = false
+    }
   }
 }
 

--- a/packages/agency-lang/tests/agency-js/policy-autoapprove-existing-file/agent.agency
+++ b/packages/agency-lang/tests/agency-js/policy-autoapprove-existing-file/agent.agency
@@ -1,4 +1,4 @@
-import { cliPolicyHandler, setPolicy, ScopedRuleFields } from "std::policy"
+import { cliPolicyHandler, setPolicy, Policy, ScopedRuleFields } from "std::policy"
 
 // Regression: when the on-disk policy file EXISTS and approves a kind,
 // cliPolicyHandler must auto-approve it without prompting. Previously the
@@ -13,7 +13,7 @@ const FIELDS: ScopedRuleFields = {
   "std::read": [{ field: "dir", matchSubpaths: true }],
 }
 
-const POLICY = {
+const POLICY: Policy = {
   "std::read": [{ action: "approve" }],
 }
 

--- a/packages/agency-lang/tests/agency/stdlib/glob-malformed.agency
+++ b/packages/agency-lang/tests/agency/stdlib/glob-malformed.agency
@@ -2,8 +2,12 @@ import { glob } from "std::shell"
 
 node main() {
   let result = glob("{ts", "glob-fixtures") with approve
+  let hasError = false
+  if (isFailure(result)) {
+    hasError = result.error != null
+  }
   return {
     ok: isSuccess(result),
-    hasError: result.error != null
+    hasError: hasError
   }
 }

--- a/packages/agency-lang/tests/agency/subprocess/lock-cross-process.agency
+++ b/packages/agency-lang/tests/agency/subprocess/lock-cross-process.agency
@@ -11,7 +11,7 @@ import { withLock } from "std::concurrency"
 node main() {
   withLock("resource") as {
     const before = read("agency-withlock-cross-process.txt", "/tmp") with approve
-    if (before.value == "parent") {
+    if ((before catch "") == "parent") {
       write("agency-withlock-cross-process.txt", "overlap", "/tmp") with approve
     } else {
       write("agency-withlock-cross-process.txt", "child", "/tmp") with approve

--- a/packages/agency-lang/tests/agency/subprocess/lock-cross-process.agency
+++ b/packages/agency-lang/tests/agency/subprocess/lock-cross-process.agency
@@ -43,5 +43,5 @@ node main() {
   }
 
   const final = read(filename, "/tmp") with approve
-  return final.value
+  return final catch "read failed"
 }


### PR DESCRIPTION
## Summary

Passing a `Result`-typed module-level variable into a `string` parameter was not flagged by the type checker:

```agency
import { diff } from "std::syntax"
const file1 = read("testfile") with approve
const file2 = read("testfile2") with approve

node main() {
  const res = diff(file1, file2, color: true)  // no error, should be two
}
```

Two independent holes made `file1`/`file2` silently type as `any`:

### Hole 1: `with` modifier statements were skipped during scope building

`const f = read(...) with approve` parses as a `withModifier` node wrapping the assignment, and `walkScopeBody` had no case for it — the binding was never declared or inferred, even inside a node body. Fixed by unwrapping the modifier at the top of the walk loop (unwrap rather than recurse: `checkConstMutations` already descends into the wrapped statement via `expressionChildren`, so recursing would double-report const mutations).

### Hole 2: module-level bindings were invisible inside def/node scopes

`buildDefScope` created each def scope with no parent, so top-level consts resolved to nothing and synthesized as `any` (there was even a comment in `declareVariable` acknowledging this). Fixed by chaining def scopes to the fully-built top-level scope. Two guards keep the chaining sound:

- A new `isFunctionBoundary` flag on `Scope`: `declare()` targets the nearest function scope by walking to the root, so without the flag every function-local declaration would leak into the module scope. The boundary stops both `functionScope()` and shadowing lookups.
- `declareVariable` now distinguishes declarations from reassignments: a `let`/`const` only counts as a redeclaration if the name exists **within the current function** (`Scope.lookupInFunction`); an outer module-level binding of the same name is shadowed. Bare reassignment (`x = 5`) still targets whatever is visible, so reassigning a top-level `const` from inside a def is now correctly rejected.

### Fallout fixed along the way

- **For-loop false positive**: iterables typed as `any` (e.g. the `is success(v)` binder over a bare `Result`, or an explicit `: any` param) were rejected with `For-loop iterable must be an array or Record, got 'any'`. Pre-existing on main; the withModifier fix surfaced two more instances. Typed `any` is now treated like the `"any"` string. This clears nine pre-existing instances of the error across `tests/agency` on main.
- **Genuine latent bug in `stdlib/policy.agency`**: `maybeFlush`/`flushPolicy` passed `_policy` (`Policy | null`) to `writePolicyFile(path, policy: Policy, ...)`, relying on the implicit "`_pendingSave` implies `_policy` loaded" invariant. The write is now guarded so a broken invariant can't serialize `null` into the policy file (flip-flag-first pattern preserved).
- **Three test programs** the now-visible types correctly flag: `glob-malformed` (unguarded `.error`), `lock-cross-process` (unguarded `.value`, now `catch`-guarded), `policy-autoapprove-existing-file` (top-level object literal widened `"approve"` to `string`; now annotated `: Policy`).

## Measured blast radius

- Full unit suite: **7354 passed** (includes the stdlib + fixtures typecheck integration tests).
- Batch typecheck of all **871** `tests/agency` + `tests/agency-js` programs, diffed against main: **13 diagnostics removed, 0 added**. Removed: 4 spurious `Function 'X' is not defined` warnings on module-level bindings (`partial-application-global`, `preapprove-global`) + 9 for-loop-over-`any` false positives (`attach-to-reply`, `threads-registry/*`, `ls-recursive-cap`).
- The original repro now reports `Argument type 'Result' is not assignable to parameter type 'string' in call to 'diff'.`

## Notes

- `inferReturnTypeFor` still builds an unparented def scope, so a function whose return value references a module-level binding infers `any` (degrades softly, no false positives). Left as a follow-up.
- Not included: `make` regenerates `tests/debugger/*.ts` with the `installFetchMock` preamble from 0334cf5e ("fetch mocks for the agency test framework") — those checked-in generated fixtures weren't regenerated in that commit. Left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
