### PR TITLE
Durable object tags: plain object/array tags survive fork and interrupt/resume

### DIFF
--- a/packages/agency-lang/docs/site/guide/tags.md
+++ b/packages/agency-lang/docs/site/guide/tags.md
@@ -32,9 +32,12 @@ How a tag is stored depends on the kind of value:
 - **Objects and arrays** are keyed by **reference**. Tagging one object does
   *not* tag a structurally-equal but distinct object.
 
-> Object and array tags are branch-local: they do not survive `fork`, `race`,
-> or `parallel` branches, or an interrupt/resume. Primitive (value) tags
-> survive both.
+> Tags on **plain objects and arrays** survive `fork`, `race`, `parallel`,
+> and interrupt/resume, the same as primitive (value) tags. A **spread or
+> structural copy** (`{...obj}`) produces an *untagged* new object — durability
+> follows the *same* object, not its copies. Tags on **frozen/sealed objects**
+> and **native-typed objects** (`Date`, `Map`, `Set`, …) are branch-local
+> (best-effort) — they can't carry the durable marker.
 
 ## Redaction
 

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-07-durable-object-tags-review.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-07-durable-object-tags-review.md
@@ -1,0 +1,125 @@
+# Review: Durable Object Tags Implementation Plan (2026-07-07)
+
+**Plan:** `2026-07-07-durable-object-tags.md`
+**Spec:** `docs/superpowers/specs/2026-07-07-durable-object-tags-design.md`
+**Spec review:** `docs/superpowers/specs/2026-07-07-durable-object-tags-design-review.md`
+**Verdict:** Approve with revisions — Finding A will make Task 4's fixture fail
+as written and must be fixed before execution; Findings B and C are one-line
+hardenings to the flag machinery; Finding D needs a documenting sentence.
+
+All harness/helper/syntax claims below were verified against the worktree code,
+not just read off the plan.
+
+## What checks out (verified against code)
+
+- **Spec-review findings are all folded in correctly.** Finding 1 → Task 4
+  (join OR-in), Finding 2 → Task 3 (`removeAllTags` clears keys, never
+  `delete`s), Finding 3 → Task 1 (`attachTag` forces null prototype, exercised
+  by Task 2's revive test), split-flag suggestion → the two-flag Global
+  Constraint + Task 3, `tagsRecordFor` naming → Task 3 edits the unified helper
+  rather than forking per-method.
+- **The read-existing-first dispatch is better than the spec.** Locating an
+  existing record before choosing a storage path makes `setTag` *and*
+  `removeAllTags` on a tagged-then-frozen object correct (the spec only handled
+  serialize/read after freeze). Task 3's freeze-after-tag test pins it.
+- **`runBatch` insertion point is right.** `shareGlobals`, `parent`, and
+  `branchGlobals` are all in scope in the settle closure
+  (`lib/runtime/runBatch.ts:336-388`), and both value and interrupt settles
+  return through that line.
+- **Harness names are real.** `makeCtx`/`makeParent` exist in
+  `lib/runtime/runBatch.test.ts:40,69`. Task 5's `makeStdoutCtx`/`printed`/
+  `runInTestContext`/`post({event, args})` all match
+  `lib/statelogClient.redaction.test.ts` exactly (the new test is a minimal
+  variation of the existing creds/hunter2 test at `:51-59` — good mirroring).
+- **Agency syntax is right.** `fork(["only"]) as item { ... }` and the
+  `std::tag` imports match the existing `tests/agency/tag.agency`
+  (`forkInheritsPrimitiveTag` at `:50` is the exact template being mirrored).
+  Task 6 uses `pnpm run a test` per repo convention.
+
+## Finding A (must fix): Task 4's agency-js fixture is missing `agency.json` — it will fail for the wrong reason
+
+The fixture's `test.js` reads `./statelog.log`, but a statelog file only exists
+when the fixture directory has an `agency.json` enabling file logging. Every
+sibling that reads `statelog.log` has one (verified:
+`tests/agency-js/llm-call-single-span/agency.json`,
+`tests/agency-js/fork-branch-value/agency.json`):
+
+```json
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}
+```
+
+Without it, the log file is missing/empty, the `!log.includes("[REDACTED]")`
+check throws, and the failure looks like the redaction bug rather than a
+missing config — inviting the executor to "fix" the test by weakening
+assertions. **Fix:** add `tests/agency-js/tag-fork-redaction/agency.json` (the
+content above) to Task 4's file list, Step 5, and the Step 7 `git add`.
+
+Related: Step 6's literal invocation is `node tests/agency-js/.../test.js`, but
+the repo runner for these fixtures is `pnpm run agency test js <file>` (per
+CLAUDE.md), which handles compiling `agent.agency` → `agent.js`. The hedge
+("mirror the sibling invocation") points the right way, but the literal command
+shown is the one an executor will paste. Make the runner command the primary
+instruction.
+
+## Finding B: the durable flag is not set when a store adopts an already-tagged object
+
+Task 3's dispatch sets `DURABLE_FLAG_KEY` only on the **create-new-record**
+path. When `readTag(value)` finds an existing durable record (an object tagged
+elsewhere, arriving by reference), the store mutates the record but never sets
+its own flag. Today the known by-reference flow (branch → parent) is covered
+because Task 4's join OR-in runs before the parent can touch the object — but
+that makes the gate's correctness depend on propagation *ordering* instead of
+being locally true in the store.
+
+**Fix (one line):** in `tagsRecordFor`, when `create === true` and the value
+resolves to a durable record (existing or new), set the flag. It's monotonic
+and idempotent, so the extra write is free, and the gate becomes correct
+independently of who tagged the object first.
+
+## Finding C: join propagation is skipped when the branch throws
+
+Task 4 places the OR-in after `const value = await fn()`, so a branch that
+**throws** never propagates its flag. A thrown error can carry a reference to a
+branch-tagged object and be caught and logged by the parent — same leak shape
+as Finding 1 of the spec review. The neighboring snapshot block deliberately
+skips throws, but that logic is about *resume state* (error branches are torn
+down, not resumed); the monotonic flag has no such reason to skip.
+
+**Fix:** wrap the body in `try { ... } finally { if (!shareGlobals &&
+branchGlobals.hasDurableObjectTagFlag()) parent.globals.setDurableObjectTagFlag(); }`
+so value, interrupt, and throw settles all propagate. (With Finding B's
+hardening this becomes belt-and-braces, but it's one keyword.)
+
+## Finding D (document it): durable `removeAllTags` leaves `getTagsFor` returning `{}`, not `undefined`
+
+On the WeakMap and primitive paths, `removeAllTags` deletes the entry, so
+`getTagsFor` returns `undefined`. On the durable path it clears keys in place
+(necessarily — the frozen-after-tag case), so `getTagsFor` returns `{}` and the
+`TaggedReviver` keeps wrapping the object (an empty `Tagged` marker in every
+subsequent checkpoint). Task 3's test pins `toEqual({})` without saying why the
+paths diverge. Behavior is harmless (`isRedacted` reads `=== true`; agency-level
+`getTags(x)["k"]` is falsy either way), but the asymmetry should be stated in
+the plan/test comment so a future cleanup doesn't "unify" it back to a
+throwing `delete`.
+
+## Smaller notes
+
+- **Commit trailer:** the Global Constraints hardcode
+  `Co-Authored-By: Claude Opus 4.8 (1M context)`. The trailer should be the
+  executing model's, not pinned to a specific one in the plan.
+- **Guide wording:** the Task 6 doc text says tags "now survive" — "now" ages
+  poorly in reference docs. Phrase it timelessly ("Tags on plain objects and
+  arrays survive …").
+- **Final verification step:** the plan has no closing task that runs the full
+  unit suite and the structural linter. Add a last step before the PR: full
+  `pnpm test:run` (save output to a file per repo convention) +
+  `pnpm run lint:structure`. Per repo rules, do *not* run the full agency
+  execution suite locally — CI covers it.
+- **Task 4 Step 1 mechanism test is pseudocode** — acknowledged inline with the
+  concrete assertion and an e2e fallback. Acceptable, provided Finding A is
+  fixed so the e2e guard actually functions.

--- a/packages/agency-lang/docs/superpowers/plans/2026-07-07-durable-object-tags.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-07-07-durable-object-tags.md
@@ -1,0 +1,919 @@
+# Durable Object Tags Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `std::tag` tags on plain objects/arrays survive `fork`/`race`/`parallel` and interrupt/resume (today they're branch-local), by storing them on the object itself and preserving them through Agency's shared serialization.
+
+**Architecture:** A plain object's/array's tags move from a branch-local `WeakMap` onto the object as a non-enumerable `Symbol` property. One new reviver (`TaggedReviver`) in the shared `nativeTypeReplacer`/`nativeTypeReviver` array preserves that property across every state round-trip (`deepClone`, state stack, `GlobalStore` clone/serialize). Frozen and native-typed objects keep the `WeakMap` fallback. The redaction fast-path gate gains a serialized, join-propagated flag so a branch that tags an object doesn't leak it when the object returns to the parent.
+
+**Tech Stack:** TypeScript, Agency stdlib, Vitest, Agency execution tests (`tests/agency/`), agency-js fixtures (`tests/agency-js/`).
+
+**Design spec:** `docs/superpowers/specs/2026-07-07-durable-object-tags-design.md`
+**Base feature (merged):** `docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md` (PR #447)
+**Spec review folded in:** `docs/superpowers/specs/2026-07-07-durable-object-tags-design-review.md` (Findings 1–3 + split-flag/naming suggestions).
+**Plan review folded in:** `docs/superpowers/plans/2026-07-07-durable-object-tags-review.md` (Findings A–D + trailer/wording/final-verification notes).
+
+## Global Constraints
+
+- **Commit per task; push and open a PR at the end** (this work targets a PR, like the base feature). Branch off updated `main` in a fresh worktree. End commit messages with the **executing model's** `Co-Authored-By` trailer (e.g. `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` — don't copy a stale model name from an older plan); write messages/PR body via files (apostrophes on the CLI break).
+- **Primitive tag storage is unchanged** — value `Map` under `__internal`.
+- **Two object storage paths:** plain+extensible object/array → on-object Symbol (durable); frozen/sealed/native-typed/other → branch-local `WeakMap` (unchanged).
+- **Read/remove locate an existing tag first; capability decides only where a *new* tag lands** (freeze-after-tag correctness).
+- **`removeAllTags` on the durable path clears the record's keys — never `delete`s the property** (a frozen-after-tag property is non-configurable and `delete` throws).
+- **Two presence flags:** in-memory `objectTagsPresent` (WeakMap path, resets on clone) + serialized `__hasDurableObjectTags` (durable path; parent→child via serialization, child→parent via a `runBatch` join OR-in). The durable flag is **monotonic** (never reset) and must be **locally true**: any store that *writes* to a durable record — including one created by another store, on an object that arrived by reference — sets its own flag, so the redaction gate never depends on propagation ordering.
+- **The redaction log path is untouched** — `statelogClient` uses its own `makeRedactReplacer` + plain `JSON.stringify`, never the Tagged reviver. Symbol keys are dropped by `JSON.stringify`, so tags never leak into logs.
+- **No import cycle:** the shared symbol/helpers live in a standalone `lib/runtime/state/tagSymbol.ts` imported by both `globalStore.ts` and `taggedReviver.ts` (never reviver→globalStore).
+- **Rebuild after stdlib/reviver changes:** `make` before any compiled-CLI or fixture test. Vitest runs against TS source and needs no build.
+
+---
+
+### Task 1: `tagSymbol.ts` — shared symbol + object helpers
+
+The dependency-free module holding the tag Symbol and the object-tag primitives, so `globalStore.ts` and the reviver share them without a cycle.
+
+**Files:**
+- Create: `lib/runtime/state/tagSymbol.ts`
+- Test: `lib/runtime/state/tagSymbol.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing (pure).
+- Produces:
+  - `TAG_SYMBOL: unique symbol`
+  - `isPlainObjectOrArray(value: unknown): boolean`
+  - `canHoldDurableTag(value: unknown): boolean`
+  - `attachTag(target: object, tags: Record<string, unknown>): void`
+  - `readTag(value: unknown): Record<string, unknown> | undefined`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/state/tagSymbol.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  TAG_SYMBOL,
+  isPlainObjectOrArray,
+  canHoldDurableTag,
+  attachTag,
+  readTag,
+} from "./tagSymbol.js";
+
+describe("tagSymbol", () => {
+  it("isPlainObjectOrArray: plain objects and arrays only", () => {
+    expect(isPlainObjectOrArray({})).toBe(true);
+    expect(isPlainObjectOrArray(Object.create(null))).toBe(true);
+    expect(isPlainObjectOrArray([1, 2])).toBe(true);
+    expect(isPlainObjectOrArray(new Date())).toBe(false);
+    expect(isPlainObjectOrArray(new Map())).toBe(false);
+    expect(isPlainObjectOrArray("s")).toBe(false);
+    expect(isPlainObjectOrArray(null)).toBe(false);
+  });
+
+  it("canHoldDurableTag: plain/array AND extensible", () => {
+    expect(canHoldDurableTag({})).toBe(true);
+    expect(canHoldDurableTag([])).toBe(true);
+    expect(canHoldDurableTag(Object.freeze({}))).toBe(false);
+    expect(canHoldDurableTag(new Date())).toBe(false);
+    expect(canHoldDurableTag(42)).toBe(false);
+  });
+
+  it("attachTag stores a non-enumerable, spread-invisible, null-proto record", () => {
+    const o: Record<string, unknown> = { a: 1 };
+    attachTag(o, Object.assign(Object.create(null), { redact: true }));
+    expect(readTag(o)).toEqual({ redact: true });
+    // Invisible to enumeration/spread/JSON:
+    expect(Object.keys(o)).toEqual(["a"]);
+    expect({ ...o }).toEqual({ a: 1 });
+    expect(readTag({ ...o })).toBeUndefined();
+    expect(JSON.stringify(o)).toBe('{"a":1}');
+  });
+
+  it("attachTag forces a null prototype on the record (proto-safety)", () => {
+    const o = {};
+    attachTag(o, { __proto__: { polluted: true } } as Record<string, unknown>);
+    // The record must be null-proto so a "__proto__" key is plain data.
+    const rec = readTag(o)!;
+    expect(Object.getPrototypeOf(rec)).toBeNull();
+  });
+
+  it("readTag returns undefined for untagged / non-object values", () => {
+    expect(readTag({})).toBeUndefined();
+    expect(readTag("s")).toBeUndefined();
+    expect(readTag(null)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/state/tagSymbol.test.ts`
+Expected: FAIL — cannot find module `./tagSymbol.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/runtime/state/tagSymbol.ts`:
+
+```ts
+// Module-private key for durable object tags. Stored non-enumerable, so it is
+// invisible to Object.keys / for-in / spread / JSON.stringify (symbol keys are
+// always dropped by JSON). Reachable only via this symbol.
+export const TAG_SYMBOL: unique symbol = Symbol("agencyTags");
+
+export function isPlainObjectOrArray(value: unknown): boolean {
+  if (Array.isArray(value)) return true;
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+// A value can hold a *durable* on-object tag only if it's a plain object/array
+// and still extensible (a frozen/sealed object can't take a new property).
+export function canHoldDurableTag(value: unknown): boolean {
+  return isPlainObjectOrArray(value) && Object.isExtensible(value as object);
+}
+
+// Attach the tag record as a non-enumerable Symbol property. Forces the record
+// null-proto so a user/LLM-controlled "__proto__" tag key is plain data (the
+// same invariant GlobalStore establishes on creation and must restore on revive).
+export function attachTag(
+  target: object,
+  tags: Record<string, unknown>,
+): void {
+  Object.setPrototypeOf(tags, null);
+  Object.defineProperty(target, TAG_SYMBOL, {
+    value: tags,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
+}
+
+export function readTag(value: unknown): Record<string, unknown> | undefined {
+  if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+    return undefined;
+  }
+  return (value as Record<symbol, Record<string, unknown> | undefined>)[TAG_SYMBOL];
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/runtime/state/tagSymbol.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/state/tagSymbol.ts lib/runtime/state/tagSymbol.test.ts
+git commit -F <message-file>   # "feat(runtime): add tagSymbol module for durable object tags"
+```
+
+---
+
+### Task 2: `TaggedReviver` — preserve on-object tags across serialization
+
+The reviver that makes on-object tags survive `deepClone` / state-stack / `GlobalStore` round-trips.
+
+**Files:**
+- Create: `lib/runtime/revivers/taggedReviver.ts`
+- Modify: `lib/runtime/revivers/index.ts` (register in the `revivers` array)
+- Test: `lib/runtime/revivers/taggedReviver.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `TAG_SYMBOL`, `isPlainObjectOrArray`, `attachTag`, `readTag` (Task 1); `BaseReviver`; `deepClone` (`lib/runtime/utils.ts`) for the test.
+- Produces: `TaggedReviver` class registered in the shared reviver array (nativeType name `"Tagged"`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/revivers/taggedReviver.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { deepClone } from "../utils.js";
+import { attachTag, readTag } from "../state/tagSymbol.js";
+
+function tagged<T extends object>(obj: T, tags: Record<string, unknown>): T {
+  attachTag(obj, Object.assign(Object.create(null), tags));
+  return obj;
+}
+
+describe("TaggedReviver (via deepClone)", () => {
+  it("preserves a plain object's tag across deepClone (new identity, tag intact)", () => {
+    const obj = tagged({ a: 1 }, { redact: true });
+    const cloned = deepClone(obj);
+    expect(cloned).not.toBe(obj);
+    expect(cloned).toEqual({ a: 1 });
+    expect(readTag(cloned)).toEqual({ redact: true });
+  });
+
+  it("preserves an array's tag across deepClone", () => {
+    const arr = tagged([1, 2, 3], { redact: true });
+    const cloned = deepClone(arr);
+    expect(cloned).toEqual([1, 2, 3]);
+    expect(readTag(cloned)).toEqual({ redact: true });
+  });
+
+  it("preserves a nested tagged object", () => {
+    const inner = tagged({ secret: "s" }, { redact: true });
+    const cloned = deepClone({ outer: { inner } }) as any;
+    expect(readTag(cloned.outer.inner)).toEqual({ redact: true });
+  });
+
+  it("restores a null-prototype tag record on revive (proto-safety)", () => {
+    const cloned = deepClone(tagged({ a: 1 }, { x: 1 }));
+    expect(Object.getPrototypeOf(readTag(cloned)!)).toBeNull();
+  });
+
+  it("a spread copy is untagged (reference semantics)", () => {
+    const obj = tagged({ a: 1 }, { redact: true });
+    expect(readTag({ ...obj })).toBeUndefined();
+  });
+
+  it("round-trips a tag whose value is itself a native type (Date)", () => {
+    const when = new Date("2026-01-01T00:00:00.000Z");
+    const cloned = deepClone(tagged({ a: 1 }, { when }));
+    expect(readTag(cloned)!.when).toBeInstanceOf(Date);
+    expect((readTag(cloned)!.when as Date).toISOString()).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/revivers/taggedReviver.test.ts`
+Expected: FAIL — `readTag(cloned)` is `undefined` (deepClone drops the symbol; reviver not registered yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `lib/runtime/revivers/taggedReviver.ts`:
+
+```ts
+import { BaseReviver } from "./baseReviver.js";
+import { TAG_SYMBOL, isPlainObjectOrArray, attachTag, readTag } from "../state/tagSymbol.js";
+
+// Preserves a plain object's / array's durable tag (a non-enumerable TAG_SYMBOL
+// property) across the shared JSON round-trip. Plain objects/arrays match no
+// other reviver, so registration order is irrelevant.
+export class TaggedReviver implements BaseReviver<object> {
+  nativeTypeName(): string {
+    return "Tagged";
+  }
+
+  isInstance(value: unknown): value is object {
+    // Cheap symbol read first, then confirm it's a plain object/array.
+    return readTag(value) !== undefined && isPlainObjectOrArray(value);
+  }
+
+  serialize(value: object): Record<string, unknown> {
+    // Spread drops the non-enumerable symbol, so `v` is tag-free and recursing
+    // into it can't re-match this reviver (no loop). Nested natives and nested
+    // tagged values inside `v` recurse normally.
+    const v = Array.isArray(value) ? [...value] : { ...value };
+    return { __nativeType: this.nativeTypeName(), tags: readTag(value), v };
+  }
+
+  validate(value: Record<string, unknown>): boolean {
+    return "tags" in value && "v" in value;
+  }
+
+  revive(value: Record<string, unknown>): object {
+    // `v` is already revived (bottom-up). attachTag re-hides the tag and
+    // restores the null prototype the JSON round-trip stripped.
+    const target = value.v as object;
+    attachTag(target, value.tags as Record<string, unknown>);
+    return target;
+  }
+}
+```
+
+In `lib/runtime/revivers/index.ts`, import and register it:
+
+```ts
+import { TaggedReviver } from "./taggedReviver.js";
+```
+
+Add `new TaggedReviver(),` to the `revivers` array (anywhere; order is irrelevant):
+
+```ts
+const revivers: BaseReviver<any>[] = [
+  new SetReviver(),
+  new MapReviver(),
+  new DateReviver(),
+  new RegExpReviver(),
+  new URLReviver(),
+  new ErrorReviver(),
+  new TaggedReviver(),
+  functionRefReviver,
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/runtime/revivers/taggedReviver.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Run the existing reviver + state suites (no regression)**
+
+Run: `pnpm test:run lib/runtime/revivers lib/runtime/state`
+Expected: PASS (existing reviver/state tests unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/runtime/revivers/taggedReviver.ts lib/runtime/revivers/index.ts lib/runtime/revivers/taggedReviver.test.ts
+git commit -F <message-file>   # "feat(runtime): add TaggedReviver to preserve on-object tags across serialization"
+```
+
+---
+
+### Task 3: `GlobalStore` durable dispatch + flags
+
+Route plain-object/array tags to the on-object symbol, keep the WeakMap fallback, and add the serialized durable-presence flag.
+
+**Files:**
+- Modify: `lib/runtime/state/globalStore.ts`
+- Test: `lib/runtime/state/globalStore.tags.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `canHoldDurableTag`, `attachTag`, `readTag` (Task 1).
+- Produces (new/changed on `GlobalStore`):
+  - `setDurableObjectTagFlag(): void`
+  - `hasDurableObjectTagFlag(): boolean`
+  - unchanged public shapes for `setTag`/`getTagsFor`/`removeTag`/`removeAllTags`/`isRedacted`/`hasAnyTags`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `lib/runtime/state/globalStore.tags.test.ts`:
+
+```ts
+import { deepClone } from "../utils.js";
+import { readTag } from "./tagSymbol.js";
+
+describe("GlobalStore durable object tags", () => {
+  it("stores a plain object's tag ON the object (survives deepClone)", () => {
+    const gs = new GlobalStore();
+    const o = { id: 1 };
+    gs.setTag(o, "redact", true);
+    expect(readTag(o)).toEqual({ redact: true });   // on the object
+    const cloned = deepClone(o);
+    expect(gs.getTagsFor(cloned)).toEqual({ redact: true });  // durable
+  });
+
+  it("frozen and native-typed objects fall back to the WeakMap (branch-local)", () => {
+    const gs = new GlobalStore();
+    const frozen = Object.freeze({ id: 1 });
+    const date = new Date();
+    gs.setTag(frozen, "redact", true);
+    gs.setTag(date, "redact", true);
+    expect(readTag(frozen)).toBeUndefined();   // not on the object
+    expect(gs.getTagsFor(frozen)).toEqual({ redact: true });  // in WeakMap
+    expect(gs.getTagsFor(date)).toEqual({ redact: true });
+  });
+
+  it("resolves a tag on an object frozen AFTER tagging (read/remove first)", () => {
+    const gs = new GlobalStore();
+    const o: Record<string, unknown> = { id: 1 };
+    gs.setTag(o, "redact", true);   // durable path (extensible)
+    Object.freeze(o);               // now non-extensible
+    expect(gs.getTagsFor(o)).toEqual({ redact: true });   // still found
+    gs.setTag(o, "extra", 1);       // mutates the record, no throw
+    expect(gs.getTagsFor(o)).toEqual({ redact: true, extra: 1 });
+    expect(() => gs.removeAllTags(o)).not.toThrow();       // clears keys, no delete
+    // NOTE: intentional asymmetry — the durable path returns {} after
+    // removeAllTags (keys cleared in place; the record can't be deleted off a
+    // frozen target), while the WeakMap/primitive paths delete the entry and
+    // return undefined. Don't "unify" this back to a delete: it throws on
+    // frozen-after-tag objects. isRedacted (=== true) is unaffected.
+    expect(gs.getTagsFor(o)).toEqual({});
+  });
+
+  it("adding a tag to an object tagged by ANOTHER store sets this store's durable flag", () => {
+    // The durable record rides ON the object, so a store can adopt one it never
+    // created (object arrived by reference, e.g. from a settled branch). A
+    // write through this store must set ITS flag — the redaction gate has to be
+    // locally true, not dependent on join-propagation ordering.
+    const a = new GlobalStore();
+    const b = new GlobalStore();
+    const o = { id: 1 };
+    a.setTag(o, "redact", true);          // record created via store A
+    expect(b.hasDurableObjectTagFlag()).toBe(false);
+    b.setTag(o, "extra", 1);              // store B adopts the existing record
+    expect(b.hasDurableObjectTagFlag()).toBe(true);
+  });
+
+  it("durable flag survives clone/fromJSON (parent->child); WeakMap flag resets", () => {
+    const gs = new GlobalStore();
+    gs.setTag({ id: 1 }, "redact", true);            // durable
+    expect(gs.hasDurableObjectTagFlag()).toBe(true);
+    expect(gs.clone().hasDurableObjectTagFlag()).toBe(true);
+    expect(GlobalStore.fromJSON(gs.toJSON()).hasAnyTags()).toBe(true);
+
+    const weakOnly = new GlobalStore();
+    weakOnly.setTag(Object.freeze({}), "redact", true);  // WeakMap path
+    expect(weakOnly.hasAnyTags()).toBe(true);
+    expect(weakOnly.clone().hasAnyTags()).toBe(false);   // WeakMap bit resets
+  });
+
+  it("setDurableObjectTagFlag is idempotent and readable", () => {
+    const gs = new GlobalStore();
+    expect(gs.hasDurableObjectTagFlag()).toBe(false);
+    gs.setDurableObjectTagFlag();
+    gs.setDurableObjectTagFlag();
+    expect(gs.hasDurableObjectTagFlag()).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/state/globalStore.tags.test.ts`
+Expected: FAIL — `readTag(o)` undefined (object still WeakMap-stored) / `hasDurableObjectTagFlag` not a function.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/runtime/state/globalStore.ts`, add the import:
+
+```ts
+import { canHoldDurableTag, attachTag, readTag } from "./tagSymbol.js";
+```
+
+Add the durable-flag key beside `VALUE_TAGS_KEY`:
+
+```ts
+  private static readonly DURABLE_FLAG_KEY = "__hasDurableObjectTags";
+```
+
+Replace the object branch of `tagsRecordFor` (currently the `if (this.isRef(value)) { … objectTags … }` block) with read-existing-first dispatch:
+
+```ts
+    if (this.isRef(value)) {
+      // Follow an existing tag wherever it already lives (so an object frozen
+      // AFTER tagging still resolves to its on-object record).
+      const durable = readTag(value);
+      if (durable !== undefined) {
+        // The record may have been created by ANOTHER store (the object arrived
+        // by reference, e.g. from a settled branch). On a write, set THIS
+        // store's flag too — the redaction gate must be locally true, not
+        // dependent on join-propagation ordering. Monotonic + idempotent.
+        if (create) {
+          this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.DURABLE_FLAG_KEY, true);
+        }
+        return durable;
+      }
+      const weak = this.objectTags.get(value);
+      if (weak !== undefined) return weak;
+      if (!create) return undefined;
+      // Creating: choose the path by current capability.
+      const record = Object.create(null) as Record<string, unknown>;
+      if (canHoldDurableTag(value)) {
+        attachTag(value, record);
+        this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.DURABLE_FLAG_KEY, true);
+      } else {
+        this.objectTags.set(value, record);
+        this.objectTagsPresent = true;
+      }
+      return record;
+    }
+```
+
+Replace `removeAllTags` with a durable-aware version that never `delete`s the property:
+
+```ts
+  /** Remove every tag from a value. */
+  removeAllTags(value: unknown): void {
+    if (this.isRef(value)) {
+      const durable = readTag(value);
+      if (durable !== undefined) {
+        // Clear keys in place — the record object is separate from the (possibly
+        // frozen) target, and `delete target[TAG_SYMBOL]` would throw on a
+        // frozen-after-tag object. Intentional asymmetry with the WeakMap/
+        // primitive paths: getTagsFor afterwards returns {} here (record stays
+        // attached, so the TaggedReviver keeps wrapping the object with empty
+        // tags), undefined there. Harmless — isRedacted checks `=== true`.
+        for (const key of Object.keys(durable)) delete durable[key];
+        return;
+      }
+      this.objectTags.delete(value);
+      return;
+    }
+    const map = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    if (map instanceof Map) map.delete(value);
+  }
+```
+
+Update `hasAnyTags` to include the durable flag:
+
+```ts
+  hasAnyTags(): boolean {
+    if (this.objectTagsPresent) return true;
+    if (this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.DURABLE_FLAG_KEY) === true) {
+      return true;
+    }
+    const map = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
+    return map instanceof Map && map.size > 0;
+  }
+```
+
+Add the flag accessors (used by `runBatch` in Task 4):
+
+```ts
+  /** True when any durable (on-object) tag has been created on this store. */
+  hasDurableObjectTagFlag(): boolean {
+    return this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.DURABLE_FLAG_KEY) === true;
+  }
+
+  /** Set the durable-object-tag presence flag (monotonic; join-propagated). */
+  setDurableObjectTagFlag(): void {
+    this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.DURABLE_FLAG_KEY, true);
+  }
+```
+
+> `getTagsFor` / `setTag` / `removeTag` are unchanged — they already funnel through `tagsRecordFor`, which now does the durable dispatch. `isRedacted` is unchanged (reads `getTagsFor`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run lib/runtime/state/globalStore.tags.test.ts`
+Expected: PASS (existing base-feature tests + 6 new durable tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/state/globalStore.ts lib/runtime/state/globalStore.tags.test.ts
+git commit -F <message-file>   # "feat(runtime): durable on-object tag dispatch + presence flag in GlobalStore"
+```
+
+---
+
+### Task 4: `runBatch` child→parent flag propagation (Finding 1)
+
+Close the leak where a branch tags an object, returns it by reference, and the parent's redaction gate is unset.
+
+**Files:**
+- Modify: `lib/runtime/runBatch.ts` (branch-settle point, ~line 381)
+- Test: `lib/runtime/runBatch.test.ts` (extend) — mechanism; plus an agency-js fixture for the end-to-end guard.
+- Create: `tests/agency-js/tag-fork-redaction/agent.agency`
+- Create: `tests/agency-js/tag-fork-redaction/agency.json` (**required** — `statelog.log` only exists when the fixture enables file logging; see siblings `llm-call-single-span`/`fork-branch-value`)
+- Create: `tests/agency-js/tag-fork-redaction/test.js`
+
+**Interfaces:**
+- Consumes: `GlobalStore.hasDurableObjectTagFlag` / `setDurableObjectTagFlag` (Task 3); the on-object durable tag (Tasks 1–3).
+- Produces: parent store's durable flag is set whenever a settling branch had one. No new exported symbols.
+
+- [ ] **Step 1: Write the failing mechanism test**
+
+Add to `lib/runtime/runBatch.test.ts` a focused case. (Mirror the file's existing `makeParent`/`runBatch` harness; a branch body sets a durable tag via its branch-local globals, and after settle the parent store carries the flag.)
+
+```ts
+import { GlobalStore } from "./state/globalStore.js";
+
+it("propagates the durable-object-tag flag from a settled branch to the parent", async () => {
+  const { ctx } = makeCtx();
+  const parentGlobals = new GlobalStore();
+  ctx.globals = parentGlobals;
+
+  // A branch that durably-tags an object it returns. In runBatch the branch
+  // body runs against a cloned branchGlobals; here we assert the parent flag
+  // is OR'd in after the branch settles.
+  await runBatch(
+    /* items/branches per the harness */ [{ /* branch that calls
+       getRuntimeContext().globals.setTag({}, "redact", true) and returns it */ }] as any,
+    { ctx, parent: { globals: parentGlobals } } as any,
+  );
+
+  expect(parentGlobals.hasDurableObjectTagFlag()).toBe(true);
+});
+```
+
+> Implementation note for the executor: match the exact `runBatch` call
+> signature used elsewhere in this test file (`makeParent()` +
+> `runBatch(...)`). The assertion that matters is
+> `parentGlobals.hasDurableObjectTagFlag() === true` after a branch that set its
+> branch-local durable flag settles. If wiring a branch body that reaches
+> branch-local globals via ALS is impractical in this stub, rely on the agency-js
+> fixture below as the end-to-end guard and keep this as a direct check that
+> `setDurableObjectTagFlag()` on a child store OR's into the parent through the
+> settle hook.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/runBatch.test.ts`
+Expected: FAIL — parent flag stays `false` (no propagation yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `lib/runtime/runBatch.ts`, wrap the branch body (the `const value = await fn();` … `return value;` block inside the `agencyStore.run` closure) in `try`/`finally`, with the propagation in the `finally`:
+
+```ts
+    async () => {
+      try {
+        // (existing body unchanged: await fn(), capture-on-INTERRUPT snapshot,
+        // return value)
+        const value = await fn();
+        if (hasInterrupts(value)) {
+          if (!shareGlobals) branch.globalsJSON = branchGlobals.toJSON();
+          if (!shareThreads) branch.activeStack = [...branchThreads.activeStack];
+        }
+        return value;
+      } finally {
+        // Durable object tags set inside the branch travel back on the returned
+        // value (by reference), but the branch's presence flag lives on its
+        // discarded cloned store. OR it into the parent so the parent's statelog
+        // redaction gate still fires. In a `finally` so value, interrupt, AND
+        // throw settles all propagate — a thrown error can reference a
+        // branch-tagged object that the parent catches and logs. (The snapshot
+        // block above deliberately skips throws, but that logic is about resume
+        // state; the monotonic flag has no reason to skip.) One idempotent
+        // write. shareGlobals: true needs nothing (same store).
+        if (!shareGlobals && branchGlobals.hasDurableObjectTagFlag()) {
+          parent.globals.setDurableObjectTagFlag();
+        }
+      }
+    },
+```
+
+- [ ] **Step 4: Run mechanism test**
+
+Run: `pnpm test:run lib/runtime/runBatch.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the end-to-end agency-js fixture**
+
+Create `tests/agency-js/tag-fork-redaction/agency.json` — without this, no
+`statelog.log` is written and the test fails for the wrong reason (missing/empty
+log, which looks like the redaction bug and invites weakening the assertions):
+
+```json
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}
+```
+
+Create `tests/agency-js/tag-fork-redaction/agent.agency`:
+
+```ts
+import { redact } from "std::tag"
+
+def tagInBranch(item: string): any {
+  const secret = { apiKey: "sk-branch-secret" }
+  redact(secret)
+  return secret
+}
+
+node main(): any {
+  // The branch durably tags an object and returns it by reference to the
+  // parent. When the parent logs its node data, the object must be redacted —
+  // which only happens if the durable-tag flag propagated to the parent.
+  const results = fork(["only"]) as item {
+    return tagInBranch(item)
+  }
+  return results
+}
+```
+
+Create `tests/agency-js/tag-fork-redaction/test.js` (mirror the harness of a sibling in `tests/agency-js/fork/*`; the point is to run `main()` then inspect the fixture's `statelog.log`):
+
+```js
+import { main } from "./agent.js";
+import { readFileSync, writeFileSync } from "fs";
+
+const logPath = new URL("./statelog.log", import.meta.url);
+writeFileSync(logPath, "");     // truncate any prior run's appended events
+
+await main();
+
+const log = readFileSync(logPath, "utf8");
+if (log.includes("sk-branch-secret")) {
+  throw new Error("LEAK: branch-tagged secret appeared in parent statelog (Finding 1)");
+}
+if (!log.includes("[REDACTED]")) {
+  throw new Error("Expected [REDACTED] in statelog — object not redacted after fork join");
+}
+console.log("ok: branch-tagged object redacted in parent statelog");
+```
+
+- [ ] **Step 6: Build and run the fixture**
+
+Run: `make` (rebuilds stdlib/reviver), then run the fixture through the repo's agency-js test runner — it compiles `agent.agency` → `agent.js` and executes `test.js` (do NOT invoke `node test.js` directly; `agent.js` won't exist). Capture output to a file per repo convention:
+
+```bash
+make 2>&1 | tail -3
+pnpm run agency test js tests/agency-js/tag-fork-redaction/test.js 2>&1 | tee /tmp/tag-fork.out
+```
+
+Expected: prints `ok: branch-tagged object redacted in parent statelog` (no LEAK/throw).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/runtime/runBatch.ts lib/runtime/runBatch.test.ts tests/agency-js/tag-fork-redaction/
+git commit -F <message-file>   # "fix(runtime): propagate durable object-tag flag on branch join (no redaction leak)"
+```
+
+---
+
+### Task 5: Statelog durability integration test
+
+Prove a durably-tagged object is redacted in statelog *after* it has gone through the shared serialization (the reviver path), end to end at the TS layer.
+
+**Files:**
+- Test: `lib/statelogClient.redaction.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `deepClone` (`lib/runtime/utils.ts`), `GlobalStore` durable tags (Tasks 1–3), `runInTestContext`, `ctx.statelogClient.post`.
+- Produces: none (test only).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `lib/statelogClient.redaction.test.ts` (reuse the file's `makeStdoutCtx` / `printed` helpers):
+
+```ts
+import { deepClone } from "./runtime/utils.js";
+
+it("redacts a durably-tagged object after it survives serialization", async () => {
+  const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+  const ctx = makeStdoutCtx();
+  const execCtx = await ctx.createExecutionContext("r1");
+  await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+    const creds = { user: "alice", pass: "hunter2" };
+    execCtx.globals.setTag(creds, "redact", true);     // durable (on-object)
+    // Round-trip the object the way fork/interrupt do to state:
+    const revived = deepClone(creds);
+    expect(revived).not.toBe(creds);                   // new identity
+    await execCtx.statelogClient.post({ event: "toolCall", args: { creds: revived } });
+  });
+  expect(printed(spy)).toContain("[REDACTED]");
+  expect(printed(spy)).not.toContain("hunter2");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `pnpm test:run lib/statelogClient.redaction.test.ts`
+Expected: with Tasks 1–3 in place it PASSES; if run before them it FAILS (revived object loses its tag → `hunter2` leaks). Confirm it passes now.
+
+- [ ] **Step 3: Run the full feature TS suite (no regression)**
+
+Run: `pnpm test:run lib/runtime/state lib/runtime/revivers lib/runtime/redactForStatelog.test.ts lib/statelogClient.test.ts lib/statelogClient.redaction.test.ts lib/stdlib/tag.test.ts`
+Expected: PASS across all.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/statelogClient.redaction.test.ts
+git commit -F <message-file>   # "test(statelog): durable-tagged object redacts after serialization round-trip"
+```
+
+---
+
+### Task 6: Docs + execution test + regenerate
+
+Update the guide's semantics, add a compiled durability check, regenerate the stdlib reference, and cross-link the base spec.
+
+**Files:**
+- Modify: `docs/site/guide/tags.md`
+- Modify: `docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md` (mark follow-up addressed)
+- Modify: `tests/agency/tag.agency` and `tests/agency/tag.test.json` (add object-tag fork-durability node)
+- (Generated) `docs/site/stdlib/tag.md` via `make`
+
+**Interfaces:**
+- Consumes: the shipped durable-tag behavior (Tasks 1–4).
+- Produces: docs + one execution test.
+
+- [ ] **Step 1: Narrow the guide's branch-local caveat**
+
+In `docs/site/guide/tags.md`, replace the current branch-local note:
+
+```markdown
+> Object and array tags are branch-local: they do not survive `fork`, `race`,
+> or `parallel` branches, or an interrupt/resume. Primitive (value) tags
+> survive both.
+```
+
+with:
+
+```markdown
+> Tags on **plain objects and arrays** survive `fork`, `race`, `parallel`,
+> and interrupt/resume, the same as primitive (value) tags. A **spread or
+> structural copy** (`{...obj}`) produces an *untagged* new object — durability
+> follows the *same* object, not its copies. Tags on **frozen/sealed objects**
+> and **native-typed objects** (`Date`, `Map`, `Set`, …) are branch-local
+> (best-effort) — they can't carry the durable marker.
+```
+
+(Reference docs are timeless — no "now"/"new" phrasing.)
+
+- [ ] **Step 2: Write the failing execution test**
+
+Add to `tests/agency/tag.agency`:
+
+```ts
+node forkInheritsObjectTag(): boolean {
+  // A plain object tagged in the parent is durable: the fork branch's clone of
+  // it carries the tag. (Contrast primitives, already covered.)
+  const o = { id: 1 }
+  redact(o)
+  const results = fork(["only"]) as item {
+    return getTags(o)["redact"] == true
+  }
+  return results[0]
+}
+```
+
+Add to `tests/agency/tag.test.json` (inside `"tests"`):
+
+```json
+    { "nodeName": "forkInheritsObjectTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+```
+
+- [ ] **Step 3: Build and run docs regen + execution tests**
+
+Run: `make 2>&1 | tail -3` (regenerates `docs/site/stdlib/tag.md`; no signature changes expected), then:
+
+```bash
+pnpm run a test tests/agency/tag.agency 2>&1 | tee /tmp/tag-exec.out
+```
+
+Expected: all nodes pass, including `forkInheritsObjectTag`.
+
+- [ ] **Step 4: Cross-link the base spec**
+
+In `docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md`, update the "Durable object tags (custom serialization)" follow-up bullet to note it is addressed by `2026-07-07-durable-object-tags-design.md` (and this plan).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/site/guide/tags.md docs/site/stdlib/tag.md docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md tests/agency/tag.agency tests/agency/tag.test.json
+git commit -F <message-file>   # "docs: object tags are durable for plain objects/arrays; + fork-durability execution test"
+```
+
+---
+
+### Task 7: Final verification + PR
+
+Full-suite regression check, structural lint, then push and open the PR.
+
+**Files:** none created/modified (verification + PR only).
+
+- [ ] **Step 1: Run the full unit suite (output to a file — never rerun to see what failed)**
+
+```bash
+pnpm test:run 2>&1 | tee /tmp/durable-tags-full-suite.out
+tail -20 /tmp/durable-tags-full-suite.out
+```
+
+Expected: PASS. If anything fails, read `/tmp/durable-tags-full-suite.out` — do not rerun the suite to see the failure again.
+
+- [ ] **Step 2: Run the structural linter**
+
+```bash
+pnpm run lint:structure 2>&1 | tee /tmp/durable-tags-lint.out
+```
+
+Expected: clean.
+
+> Do NOT run the full agency execution suite locally (repo rule — CI runs it on the PR). Only the specific agency/agency-js tests touched by Tasks 4 and 6 run locally.
+
+- [ ] **Step 3: Push and open the PR**
+
+Write the PR body to a file (apostrophes on the CLI break), then:
+
+```bash
+git push -u origin <branch>
+gh pr create --title "Durable object tags: plain object/array tags survive fork and interrupt/resume" --body-file <body-file>
+```
+
+PR body should link the design spec, the spec review, and this plan; call out the two leak-guard mechanisms (locally-true flag on adopt-write + join OR-in in `finally`) so reviewers know both exist on purpose.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- On-object Symbol storage + helpers → Task 1.
+- `TaggedReviver` preserving tags through the shared round-trip → Task 2.
+- Storage dispatch (plain→durable, frozen/native→WeakMap, read-existing-first) → Task 3.
+- `removeAllTags` clears keys / never deletes (Finding 2) → Task 3 (impl + test).
+- Null-prototype record restored on revive (Finding 3) → Task 1 (`attachTag`) + Task 2 (test).
+- Two presence flags; parent→child serialization → Task 3; **child→parent join propagation (Finding 1)** → Task 4.
+- Log-path separation (no leak, symbol dropped) → exercised in Tasks 4–5.
+- Semantics + edge cases (spread untagged, freeze-after-tag) → Tasks 2, 3, 6.
+- Docs + regenerate + base-spec cross-link → Task 6.
+- Non-goals (primitives unchanged, no substring/provenance/boxing) → untouched.
+
+**Plan-review coverage (Findings A–D):**
+- **A** (fixture needs `agency.json` + run via `pnpm run agency test js`, not raw `node`) → Task 4 Steps 5–6 + file list.
+- **B** (flag must be locally true when a store adopts an already-tagged object) → Task 3 dispatch sets the flag on the readTag-existing write path + dedicated two-store test; Global Constraints updated.
+- **C** (propagation must survive branch throws) → Task 4 Step 3 moves the OR-in into a `finally` (value/interrupt/throw settles all propagate).
+- **D** (durable `removeAllTags` → `getTagsFor` returns `{}`, not `undefined`) → intentional-asymmetry comments in Task 3's test and `removeAllTags` impl.
+- Smaller notes: executing-model commit trailer (Global Constraints), timeless guide wording (Task 6), full unit suite + structural lint + PR → Task 7.
+
+**Placeholder scan:** The only non-literal is Task 4 Step 1's `runBatch(...)` call, which must match this test file's existing `makeParent`/`runBatch` harness — flagged inline with the concrete assertion (`parentGlobals.hasDurableObjectTagFlag() === true`) and a fixture fallback. All other steps contain complete code.
+
+**Type consistency:** `TAG_SYMBOL`/`attachTag`/`readTag`/`isPlainObjectOrArray`/`canHoldDurableTag` (Task 1) used identically in Tasks 2–3. `hasDurableObjectTagFlag`/`setDurableObjectTagFlag` defined in Task 3, consumed in Task 4. `TaggedReviver` nativeType `"Tagged"` consistent.
+
+**Deferred (unchanged):** substring redaction; `pii`/other special tags; low-entropy dev-mode warning; provenance; the primitive-record null-proto-after-clone residual (noted in spec, out of scope).

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-07-durable-object-tags-design-review.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-07-durable-object-tags-design-review.md
@@ -1,0 +1,105 @@
+# Review: Durable Object Tags — Design (2026-07-07)
+
+**Spec:** `2026-07-07-durable-object-tags-design.md`
+**Verdict:** Approve with revisions — Finding 1 needs a design addition (join-time
+flag propagation + a test) before this goes to a plan; Findings 2–3 are small
+spec amendments.
+
+All claims below were verified against the worktree code (`revivers/index.ts`,
+`globalStore.ts`, `redactForStatelog.ts`, `statelogClient.ts`, `runBatch.ts`,
+`stateStack.ts`), not just the spec text.
+
+## What checks out
+
+- **The chokepoint claim is true.** Only five non-test files touch
+  `nativeTypeReplacer`/`nativeTypeReviver`: `deepClone` (`lib/runtime/utils.ts:8`),
+  `lib/runtime/state/stateStack.ts`, `lib/runtime/state/context.ts`,
+  `GlobalStore.toJSON` (`lib/runtime/state/globalStore.ts:166-169`), and the
+  log-path file. One new reviver really does cover deepClone, interrupt locals,
+  and globals clone/fork. The altitude is right — this reuses the codebase's own
+  round-trip semantics instead of inventing a parallel path.
+- **The log path really is separate.** `makeRedactReplacer`
+  (`lib/runtime/redactForStatelog.ts`) is a standalone replacer that never
+  composes with `nativeTypeReplacer`, and `statelogClient.ts:1191` uses plain
+  `JSON.stringify` with it. A `__nativeType:"Tagged"` marker can't appear in
+  logs, and `JSON.stringify` drops the symbol key natively.
+- **The reviver mechanics work as described.** `JSON.parse` revivers run
+  bottom-up, so `value.v` is fully revived when `TaggedReviver.revive` runs; the
+  spread in `serialize` drops the non-enumerable symbol so there's no re-match
+  loop; and all 7 registered revivers were checked — none match plain
+  objects/arrays, so registration order genuinely doesn't matter.
+- The frozen-after-tagging **serialize** path, the spread-drops-tag semantics,
+  and the monotonic-flag safety direction are all correct as written.
+
+## Finding 1 (must fix): child→parent join still leaks — the spec's own promise is broken in one direction
+
+The `hasAnyTags()` fix covers tag-signal flow **parent→child** (clone/`fromJSON`
+carry the serialized flag) but not **child→parent**. Successful branch results
+return to the parent **by reference** — `lib/runtime/runBatch.ts:381`
+(`const value = await fn()`; successful returns are never round-tripped) —
+while the branch ran on a **cloned** GlobalStore (`runBatch.ts:348-352`). So:
+
+1. A branch calls `redact(obj)` — the symbol lands on the object, and
+   `__hasObjectTags` is set on the *branch's* store.
+2. The branch returns `obj`; it reaches the parent with its tag intact (that's
+   the durability the spec promises).
+3. The parent posts statelog. The gate at `statelogClient.ts:1190` reads the
+   **parent's** store, whose flag was never set → the redaction pass is skipped
+   entirely → `obj` logs **unredacted**, even though `isRedacted(obj)` would
+   have said yes.
+
+Today this same flow merely loses the tag, which the docs call out as
+branch-local. After this spec, the guide will say object tags "survive
+fork/race/parallel" — making this a silent leak relative to the documented
+contract. Interrupt payloads (`e.data` referencing a branch-tagged object,
+handled by parent handlers) hit the same hole.
+
+**Fix:** propagate the flag at branch settle in `runBatch` — when a branch
+completes (values *or* interrupts) with its store's object-tag flag set, OR it
+into the parent's store. It's monotonic so this is one boolean write, and
+there's already a per-branch propagate-at-join precedent (the cost/token
+roll-up). `shareGlobals: true` needs nothing (same store).
+
+**Test to add:** branch redacts an object, returns it, parent logs it →
+`[REDACTED]`.
+
+## Finding 2: `removeAllTags` on a tagged-then-frozen object will throw
+
+The edge-case section covers freeze-after-tag for *serialize/read* only. But
+freezing makes the symbol property non-configurable, so
+`delete obj[TAG_SYMBOL]` throws a TypeError in strict mode — and the spec's
+test plan says "removeTag / removeAllTags clear the symbol prop." The current
+code (`globalStore.ts:103-116`) has the same shape split: `removeTag` mutates
+the record (safe — the record object isn't frozen when the target is),
+`removeAllTags` deletes the container entry (unsafe on the symbol path).
+
+**Fix:** implement `removeAllTags` on the durable path by clearing the record's
+keys (or try-delete with record-clear fallback), never by deleting the property.
+
+## Finding 3: `revive` should restore the null-prototype record
+
+`tagsRecordFor` deliberately uses null-prototype records so a tag key like
+`"__proto__"` is a plain data property (`globalStore.ts:62-64`). `JSON.parse`
+produces an `Object.prototype`-based `tags` record, so a later `setTag` on the
+revived object would assign through the `__proto__` setter.
+
+**Fix:** one line in `revive` — `Object.setPrototypeOf(value.tags, null)`
+before attaching. Worth stating in the spec so the invariant doesn't silently
+regress.
+
+## Smaller suggestions
+
+- **Split the flag instead of unifying it.** The spec sets the serialized
+  `__hasObjectTags` on both the durable and WeakMap paths. But WeakMap tags
+  *don't* survive clone — serializing their bit means one tag on a frozen
+  object makes every descendant branch and every resumed run pay the redaction
+  pass forever, for a tag that no longer exists. Keep two bits: today's
+  in-memory `objectTagsPresent` (resets on clone, covers WeakMap — current
+  behavior at `globalStore.ts:23` is already correct for it) plus the new
+  serialized flag for the durable path only. Same safety, less permanent
+  over-approximation.
+- **Name `tagsRecordFor` in the file map.** The dispatch the spec's table
+  describes lives in one unified helper (`globalStore.ts:65`), not severally in
+  `setTag`/`getTagsFor`/`removeTag`. Saying so keeps the implementer from
+  forking that unified path; `removeAllTags` (`:110`) is the one method with
+  its own branch to update.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-07-durable-object-tags-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-07-durable-object-tags-design.md
@@ -1,0 +1,387 @@
+# Durable Object Tags — Design
+
+**Date:** 2026-07-07
+**Status:** Design (approved in brainstorm; pending written-spec review)
+**Follow-up to:** `2026-07-07-value-tags-and-redaction-design.md` (PR #447, merged)
+
+## Summary
+
+Make **object and array tags durable** — so a tag set with `std::tag`'s
+`tag`/`redact` survives `fork`/`race`/`parallel` branches and interrupt/resume,
+the same way primitive (value-keyed) tags already do.
+
+Today object tags are **branch-local**: they live in a `WeakMap` keyed by object
+identity, and both `fork` cloning and interrupt serialization round-trip state
+through JSON, which destroys object identity — so the tag is lost. This is the
+one limitation the base feature deferred (PR #447 review decision).
+
+The fix: store a plain object's / array's tags **on the object itself** (a hidden
+`Symbol` property) and teach Agency's single shared serialization chokepoint to
+preserve it via one new reviver. Frozen and native-typed objects, which can't
+carry a durable hidden property, keep the existing branch-local `WeakMap`.
+
+## Goals
+
+- Object/array tags survive `fork`/`race`/`parallel` and interrupt/resume for
+  the common case (plain objects and arrays).
+- `redact(obj)` keeps redacting that object in statelog after those boundaries.
+- No regression for the cases that can't be made durable (frozen/native-typed
+  objects) — they stay exactly as branch-local as they are today.
+- Reuse the existing reviver machinery rather than inventing a parallel path.
+
+## Non-goals
+
+- **Primitive storage is unchanged.** Primitives stay value-keyed in the
+  `Map` under `__internal` (already durable).
+- **Durable tags for frozen or native-typed objects.** `Object.freeze`d objects
+  and `Date`/`Map`/`Set`/`URL`/`RegExp`/`Error`/class instances keep the
+  branch-local `WeakMap`. (Realistic tag targets are plain objects/arrays.)
+- **Substring redaction, provenance, boxing.** Out of scope, as before.
+
+## Background: why this needs the shared serializer
+
+Object tags are usually on **locals**, not globals:
+
+```ts
+const userData = getUserData(userId)   // a local
+redact(userData)
+```
+
+Agency copies/serializes state through **one shared chokepoint** —
+`nativeTypeReplacer` / `nativeTypeReviver` (`lib/runtime/revivers/index.ts`) —
+used by:
+
+- `deepClone()` (`lib/runtime/utils.ts`) = `JSON.parse(JSON.stringify(obj,
+  nativeTypeReplacer), nativeTypeReviver)`
+- state-stack locals serialization (interrupt/resume) — via `deepClone`
+- `GlobalStore.toJSON`/`fromJSON` (globals + fork clone)
+
+Every one of these destroys object identity. A `WeakMap` keyed by identity
+therefore can't follow an object through them — no matter where the object
+lives. So durability has to be handled **at the shared reviver**, and the tag
+has to ride **on the object** (the only thing that travels through every copy
+path). This is why the "store tags on the object" direction is the right one,
+and why patching only `GlobalStore` would be insufficient.
+
+The reviver system is designed for exactly this: `Date`, `Map`, `Set`, `URL`,
+`Error`, `RegExp`, and function refs already round-trip via pluggable revivers
+that emit `{ __nativeType: "..." }` markers. Durable tags become **one more
+reviver**.
+
+## Design
+
+### Storage dispatch
+
+`GlobalStore.setTag` / `getTagsFor` / `removeTag` / `removeAllTags` dispatch on
+the value:
+
+| Value kind | Storage | Durable? |
+|---|---|---|
+| Primitive (`string`/`number`/`boolean`) | value `Map` under `__internal` | Yes (unchanged) |
+| Plain object / array, extensible | non-enumerable `Symbol` prop **on the object** | **Yes (new)** |
+| Frozen/sealed, native-typed, or other non-plain object | branch-local `WeakMap` | No (branch-local, unchanged) |
+
+"Plain object" = `Object.getPrototypeOf(x) === Object.prototype` or `=== null`;
+"array" = `Array.isArray(x)`. "Extensible" = `Object.isExtensible(x)` (a frozen
+or sealed object is not).
+
+**Dispatch order matters for freeze-after-tag.** The unified `tagsRecordFor`
+helper must first check for an **existing** tag — `readTag(value)` (durable
+symbol), then the `WeakMap` — and only consult `canHoldDurableTag` when
+*creating* a new record. Otherwise an object tagged while extensible and then
+`Object.freeze`d would report `canHoldDurableTag === false` and its on-object tag
+would become unreachable (`getTagsFor` would miss it, `removeAllTags` would look
+in the wrong store). Read/remove follow the tag that's actually there;
+capability decides only where a *fresh* tag lands.
+
+Helper (conceptual):
+
+```ts
+private canHoldDurableTag(value: unknown): boolean {
+  if (!this.isRef(value)) return false;
+  if (!Object.isExtensible(value)) return false;       // frozen/sealed → WeakMap
+  if (Array.isArray(value)) return true;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;  // plain object
+}
+```
+
+### The hidden tag property
+
+```ts
+const TAG_SYMBOL = Symbol("agencyTags");   // module-private, in globalStore.ts
+```
+
+Stored non-enumerable:
+
+```ts
+Object.defineProperty(obj, TAG_SYMBOL, {
+  value: tags,          // Record<string, unknown>, null-prototype (as today)
+  enumerable: false,
+  writable: true,
+  configurable: true,
+});
+```
+
+A non-enumerable **Symbol** key is invisible to:
+
+- `Object.keys`, `Object.getOwnPropertyNames`, `for…in`
+- object spread `{...obj}` and `Object.assign` (they copy own *enumerable*
+  props; a non-enumerable symbol is skipped) — so a spread copy is correctly
+  **untagged** (new identity ⇒ new object)
+- `JSON.stringify` (symbol-keyed properties are always dropped) — so it never
+  leaks into logs or user-facing serialization
+
+It's reachable only via `TAG_SYMBOL`, which only `globalStore.ts` holds.
+
+### The `TaggedReviver`
+
+A new reviver in `lib/runtime/revivers/`, registered in the shared array in
+`index.ts` (order is irrelevant — plain objects/arrays match no other reviver):
+
+```ts
+class TaggedReviver implements BaseReviver<object> {
+  nativeTypeName() { return "Tagged"; }
+
+  isInstance(value: unknown): value is object {
+    // Cheap: symbol lookup first, then confirm plain object/array.
+    return (
+      value != null &&
+      (value as any)[TAG_SYMBOL] !== undefined &&
+      isPlainObjectOrArray(value)
+    );
+  }
+
+  serialize(value: object) {
+    // {...value} / [...value] drops the non-enumerable symbol, so `v` is
+    // tag-free and recursing into it will not re-match this reviver (no loop).
+    // Nested natives and nested tagged values inside `v` recurse normally.
+    const v = Array.isArray(value) ? [...value] : { ...value };
+    return { __nativeType: "Tagged", tags: (value as any)[TAG_SYMBOL], v };
+  }
+
+  validate(value: Record<string, unknown>): boolean {
+    return "tags" in value && "v" in value;
+  }
+
+  revive(value: Record<string, unknown>): object {
+    // `v` is already revived (bottom-up). Re-attach the hidden tag.
+    const target = value.v as object;
+    // JSON.parse produced an Object.prototype-based tags record; restore the
+    // null prototype so a later setTag(obj, "__proto__", ...) stays a plain data
+    // property instead of assigning through the __proto__ setter (the same
+    // invariant tagsRecordFor establishes on creation, globalStore.ts:62-64).
+    Object.setPrototypeOf(value.tags as object, null);
+    Object.defineProperty(target, TAG_SYMBOL, {
+      value: value.tags,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+    return target;
+  }
+}
+```
+
+> Related residual (out of scope, noted for tracking): primitive tag records
+> also come back `Object.prototype`-based after a `Map` round-trip via
+> `MapReviver`. Same low-severity `__proto__`-key nuance; not fixed here since it
+> predates this spec and `MapReviver` is generic (not tag-aware).
+
+`TAG_SYMBOL` must be shared between `globalStore.ts` and `taggedReviver.ts`.
+Export it from a small shared module (e.g. `globalStore.ts` exports it, or a tiny
+`tagSymbol.ts` both import) to avoid a cycle.
+
+### Serialization paths stay cleanly separated
+
+- **State path** (`nativeTypeReplacer`/reviver, used by `deepClone` / globals /
+  state stack): now preserves tags via `TaggedReviver`. It does **not** redact —
+  state must keep real values.
+- **Log path** (`statelogClient.post`): uses its own `makeRedactReplacer` + plain
+  `JSON.stringify`, and never the Tagged reviver. So a `__nativeType:"Tagged"`
+  marker can never appear in a log, and the hidden symbol tag is dropped from log
+  output automatically. `isRedacted(obj)` reads the symbol to make the redaction
+  decision.
+
+`isRedacted(obj)` for a durably-tagged object is now a direct property read
+(`obj[TAG_SYMBOL]?.redact === true`); for frozen/native objects it reads the
+`WeakMap`; for primitives it reads the value `Map`. All three stay behind the
+existing `GlobalStore.isRedacted` so callers are unchanged.
+
+### The `hasAnyTags()` correctness fix (two flags + join propagation)
+
+`statelogClient.post` gates the redaction pass on `GlobalStore.hasAnyTags()` to
+keep tag-free programs cheap. Tags set on objects are **decentralized** — they
+live on the object, not in a central store — so `hasAnyTags()` needs a signal
+that tracks their presence across branch boundaries in **both** directions. The
+two object storage paths have *different* propagation needs, so they get
+**two different flags**:
+
+**1. WeakMap path (frozen/native objects): in-memory flag, no propagation.**
+Keep today's non-serialized `objectTagsPresent` boolean (`globalStore.ts:23`),
+set on the WeakMap path. WeakMap tags are branch-local — they don't survive a
+clone (the WeakMap isn't serialized) and don't cross a join (the branch's WeakMap
+is discarded, and the returned object has no entry in the parent's WeakMap). So
+their signal *correctly* resets on clone and is never propagated: there's no tag
+on the other side to redact, so there's nothing to signal. Serializing this bit
+would be wrong (claim a tag that doesn't exist) as well as a permanent
+over-approximation.
+
+**2. Durable path (symbol on plain object/array): serialized flag, propagated
+both directions.** Add a **serializable, monotonic** flag in `__internal`
+(`__hasDurableObjectTags: true`), set on the durable path.
+
+- **Parent → child** (fork clone, `fromJSON` on resume): the flag lives in the
+  serialized store, so it rides the round-trip. A branch/resumed run that
+  inherited a durably-tagged object sees `hasAnyTags() === true`.
+- **Child → parent** (join): a successful branch returns its value **by
+  reference** (`runBatch.ts:381` — `return value`, no round-trip), so a branch
+  that `redact`s an object and returns it hands the parent an object with its
+  symbol tag intact — but the branch set the flag on its *cloned* store, which is
+  discarded at join. Without propagation, the parent's flag stays false and it
+  logs the object **unredacted** (a leak relative to the "survives fork" contract
+  this spec introduces). **Fix:** at branch settle in `runBatch`, OR the branch
+  store's `__hasDurableObjectTags` into the parent's store. It's a monotonic
+  boolean, so this is a single idempotent write, and it mirrors the existing
+  cost/token join propagation (`propagateBranchCost` / `propagateLoserCost` /
+  `propagateWinnerCost` in `runBatch.ts`). Propagate on **both** the value-return
+  and interrupt-settle paths (an interrupt payload `e.data` can reference a
+  branch-tagged object handled by a parent handler — same hole). `shareGlobals:
+  true` needs nothing (same store object).
+
+**Combined check:**
+
+```ts
+hasAnyTags(): boolean {
+  return (
+    this.objectTagsPresent ||                                  // WeakMap path (in-memory)
+    valueMapSize > 0 ||                                        // primitives (exact)
+    this.get(INTERNAL_MODULE, "__hasDurableObjectTags") === true  // durable objects (serialized + join-propagated)
+  );
+}
+```
+
+Monotonic on the durable flag (never reset by `removeTag`/`removeAllTags`): it
+may only **over**-approximate (an unnecessary redaction pass), never
+**under**-approximate (a leak) — the safe direction for a redaction gate.
+Primitives keep their exact `Map`-size check.
+
+> The durable flag is set on the branch-local `GlobalStore` (the one
+> `getRuntimeContext().globals` / `__globals()` resolves to), so it is per-branch
+> and serialized with that branch's state; the join hook carries it up.
+
+### Semantics changes (to document in the guide)
+
+- Plain-object / array tags now **survive `fork`/`race`/`parallel` and
+  interrupt/resume**. This is the headline change; the guide's current
+  "object/array tags are branch-local" note is narrowed to *frozen and
+  native-typed objects only*.
+- A spread / structural copy (`{...obj}`) yields an **untagged** object —
+  durability is about the *same* object traveling through Agency's own
+  copy/serialize machinery, not about propagating to copies.
+
+## Edge cases
+
+- **Frozen/sealed object** → `canHoldDurableTag` is false → `WeakMap` (branch-
+  local). No throw.
+- **Native-typed object** (`Date`, `Map`, …) → non-plain → `WeakMap`. (Also
+  sidesteps reviver-ordering between "Tagged" and the type's own reviver.)
+- **Object frozen *after* tagging** → the symbol prop is already attached; the
+  reviver only needs to *read* it on serialize and *define* it on a
+  freshly-revived (not-yet-frozen) `v`, so serialize/read are unaffected.
+  - **But `removeAllTags` must not `delete` the property.** Freezing makes the
+    symbol prop non-configurable, so `delete obj[TAG_SYMBOL]` throws a
+    `TypeError` in strict mode (all ESM). Implement `removeAllTags` on the
+    durable path by **clearing the record's own keys** (the record object the
+    symbol points to is separate and never frozen by `Object.freeze(target)`),
+    not by deleting the property. This also keeps `setTag`/`removeTag` working on
+    a frozen-after-tag object — they mutate the record, which is allowed
+    (non-writable blocks *reassigning* the property, not mutating the object it
+    references). `getTagsFor` then returns an empty record; the durable flag
+    stays set (monotonic).
+- **`__nativeType` collision** — a user plain object literally containing a
+  `__nativeType` key is a pre-existing whole-codebase concern (all revivers share
+  it), not introduced here.
+- **Circular tagged object** — `JSON.stringify` already throws on cycles; no new
+  behavior.
+- **Tag values that are themselves native** (`tag(x, "when", someDate)`) — the
+  `tags` record recurses through the normal replacer, so the `Date` round-trips
+  via `DateReviver`. Works.
+
+## Testing
+
+Agency execution + agency-js tests need no LLM calls (per `docs/misc/TESTING.md`).
+
+**Unit — `TaggedReviver` / `deepClone`:**
+- `deepClone` of a tagged plain object preserves the tag (new identity, tag
+  present); of a tagged array likewise.
+- Nested: a tagged object inside another object round-trips.
+- Spread `{...tagged}` produces an object with **no** tag.
+- A tagged object whose tag value is a `Date` round-trips both.
+
+**Unit — `GlobalStore` dispatch:**
+- Plain object → tag stored on the object (survives `deepClone`/`clone`).
+- Frozen object and a `Date` → tag stored in `WeakMap` (does **not** survive
+  `clone`) — pins the documented fallback.
+- `hasAnyTags()` stays `true` after `clone()`/`fromJSON` when a **durably**-tagged
+  object was inherited (parent→child leak-guard); and is **not** falsely set by a
+  WeakMap-only tag surviving a clone (the WeakMap flag resets).
+- `removeTag` clears one key; `removeAllTags` empties the record.
+- **`removeAllTags` on a tagged-then-**`Object.freeze`**d object does not throw**
+  and leaves `getTagsFor` returning `{}` (Finding 2).
+- After `deepClone`, `setTag(obj, "__proto__", …)` on the revived object stays a
+  plain data property and does not pollute `Object.prototype` (Finding 3 —
+  null-proto record restored on revive).
+
+**Unit / integration — child→parent join (Finding 1):**
+- A branch `redact`s a plain object and returns it; the **parent** then posts a
+  statelog event containing it → `[REDACTED]` (the join-propagation guard). Fails
+  today without the `runBatch` flag OR-in.
+
+**Integration — statelog (`lib/statelogClient.redaction.test.ts`):**
+- A `redact`ed object still logs `[REDACTED]` **after a fork-style globals
+  clone** (the durability the follow-up exists for) — contrast the base PR's
+  test where object tags were branch-local.
+- Same after a `toJSON`/`fromJSON` round-trip (interrupt/resume analogue).
+
+**Execution (`tests/agency/`):**
+- A `fork` branch reads an inherited **object** tag (mirrors the existing
+  `forkInheritsPrimitiveTag`, now for objects).
+- Object-tag durability across a checkpoint/restore if cheaply expressible.
+
+## Implementation surface (file map)
+
+- `lib/runtime/revivers/taggedReviver.ts` — new `TaggedReviver` (+ unit test).
+- `lib/runtime/revivers/index.ts` — register it in the `revivers` array.
+- `lib/runtime/state/globalStore.ts` — `TAG_SYMBOL` (exported for the reviver);
+  extend the **unified `tagsRecordFor` helper** (`globalStore.ts:65`) with the
+  durable-vs-WeakMap dispatch so `setTag`/`getTagsFor`/`removeTag` all inherit it
+  from one place; `removeAllTags` (`globalStore.ts:110`) is the one method with
+  its own branch — update it to clear-record-keys on the durable path (never
+  `delete`). **Keep** the in-memory `objectTagsPresent` (WeakMap path) and **add**
+  the serialized `__hasDurableObjectTags` flag (durable path); update
+  `hasAnyTags`/`isRedacted`. Keep the `WeakMap` as fallback.
+- `lib/runtime/runBatch.ts` — at branch settle, OR the branch store's
+  `__hasDurableObjectTags` into the parent's store (value-return and
+  interrupt-settle paths), alongside the existing cost/token propagation.
+- Tests: `globalStore.tags.test.ts` (extend), `redactForStatelog`/statelog
+  integration (extend), `tests/agency/tag.agency` (extend), `taggedReviver.test.ts`
+  (new).
+- Docs: `docs/site/guide/tags.md` — narrow the branch-local caveat to
+  frozen/native objects; note spread-drops-tag. Regenerate stdlib reference
+  (`make`) — no signature changes expected.
+- Spec: mark the "durable object tags" follow-up in the base design doc as
+  addressed by this spec.
+
+## Risks
+
+- **Mutating user objects.** A hidden non-enumerable symbol is about as
+  unobtrusive as possible, but it *is* a mutation. Documented; invisible to all
+  standard reflection except `getOwnPropertySymbols`.
+- **`isPlainObjectOrArray` misclassification.** If a genuinely plain object is
+  misclassified as non-plain, it silently falls back to branch-local (no leak,
+  just non-durable). The reverse (native object treated as plain) is prevented by
+  the prototype check. Fail-safe direction.
+- **Reviver runs on all state serialization.** `isInstance` adds one symbol
+  lookup per object during state (de)serialization; negligible, and gated by the
+  cheap symbol check before the prototype test.

--- a/packages/agency-lang/docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-07-07-value-tags-and-redaction-design.md
@@ -266,7 +266,11 @@ Use Agency execution tests (`tests/agency/`) and agency-js tests
   object shape and into the logs. Making object tags durable needs a custom
   replacer/reviver pair that preserves a hidden `__tags` across the round-trip
   (and re-hides it after redaction). Deferred to a follow-up PR (decided during
-  PR #447 review).
+  PR #447 review). **ADDRESSED** by
+  `2026-07-07-durable-object-tags-design.md` (+ its implementation plan):
+  a non-enumerable `Symbol` property carried through the shared reviver
+  machinery (`TaggedReviver`), durable for plain extensible objects/arrays,
+  `WeakMap` fallback for frozen/native-typed objects.
 - **Substring redaction**: scrub tagged secrets embedded in larger logged
   strings (thorough but O(secrets) per log; can mangle output).
 - **Additional special tags**: `pii`, etc., layered on the same mechanism.

--- a/packages/agency-lang/lib/runtime/revivers/index.ts
+++ b/packages/agency-lang/lib/runtime/revivers/index.ts
@@ -6,6 +6,7 @@ import { RegExpReviver } from "./regExpReviver.js";
 import { URLReviver } from "./urlReviver.js";
 import { ErrorReviver } from "./errorReviver.js";
 import { FunctionRefReviver } from "./functionRefReviver.js";
+import { TaggedReviver } from "./taggedReviver.js";
 
 export const functionRefReviver = new FunctionRefReviver();
 
@@ -16,6 +17,7 @@ const revivers: BaseReviver<any>[] = [
   new RegExpReviver(),
   new URLReviver(),
   new ErrorReviver(),
+  new TaggedReviver(),
   functionRefReviver,
 ];
 

--- a/packages/agency-lang/lib/runtime/revivers/taggedReviver.test.ts
+++ b/packages/agency-lang/lib/runtime/revivers/taggedReviver.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { deepClone } from "../utils.js";
+import { attachTag, readTag } from "../state/tagSymbol.js";
+
+function tagged<T extends object>(obj: T, tags: Record<string, unknown>): T {
+  attachTag(obj, Object.assign(Object.create(null), tags));
+  return obj;
+}
+
+describe("TaggedReviver (via deepClone)", () => {
+  it("preserves a plain object's tag across deepClone (new identity, tag intact)", () => {
+    const obj = tagged({ a: 1 }, { redact: true });
+    const cloned = deepClone(obj);
+    expect(cloned).not.toBe(obj);
+    expect(cloned).toEqual({ a: 1 });
+    expect(readTag(cloned)).toEqual({ redact: true });
+  });
+
+  it("preserves an array's tag across deepClone", () => {
+    const arr = tagged([1, 2, 3], { redact: true });
+    const cloned = deepClone(arr);
+    expect(cloned).toEqual([1, 2, 3]);
+    expect(readTag(cloned)).toEqual({ redact: true });
+  });
+
+  it("preserves a nested tagged object", () => {
+    const inner = tagged({ secret: "s" }, { redact: true });
+    const cloned = deepClone({ outer: { inner } }) as {
+      outer: { inner: object };
+    };
+    expect(cloned.outer.inner).toEqual({ secret: "s" });
+    expect(readTag(cloned.outer.inner)).toEqual({ redact: true });
+  });
+
+  it("restores a null-prototype tag record on revive (proto-safety)", () => {
+    const cloned = deepClone(tagged({ a: 1 }, { x: 1 }));
+    expect(Object.getPrototypeOf(readTag(cloned)!)).toBeNull();
+  });
+
+  it("a spread copy is untagged (reference semantics)", () => {
+    const obj = tagged({ a: 1 }, { redact: true });
+    expect(readTag({ ...obj })).toBeUndefined();
+  });
+
+  it("round-trips a tag whose value is itself a native type (Date)", () => {
+    const when = new Date("2026-01-01T00:00:00.000Z");
+    const cloned = deepClone(tagged({ a: 1 }, { when }));
+    expect(readTag(cloned)!.when).toBeInstanceOf(Date);
+    expect((readTag(cloned)!.when as Date).toISOString()).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+});

--- a/packages/agency-lang/lib/runtime/revivers/taggedReviver.ts
+++ b/packages/agency-lang/lib/runtime/revivers/taggedReviver.ts
@@ -1,0 +1,40 @@
+import { BaseReviver } from "./baseReviver.js";
+import {
+  isPlainObjectOrArray,
+  attachTag,
+  readTag,
+} from "../state/tagSymbol.js";
+
+// Preserves a plain object's / array's durable tag (a non-enumerable TAG_SYMBOL
+// property) across the shared JSON round-trip. Plain objects/arrays match no
+// other reviver, so registration order is irrelevant.
+export class TaggedReviver implements BaseReviver<object> {
+  nativeTypeName(): string {
+    return "Tagged";
+  }
+
+  isInstance(value: unknown): value is object {
+    // Cheap symbol read first, then confirm it's a plain object/array.
+    return readTag(value) !== undefined && isPlainObjectOrArray(value);
+  }
+
+  serialize(value: object): Record<string, unknown> {
+    // Spread drops the non-enumerable symbol, so `v` is tag-free and recursing
+    // into it can't re-match this reviver (no loop). Nested natives and nested
+    // tagged values inside `v` recurse normally.
+    const v = Array.isArray(value) ? [...value] : { ...value };
+    return { __nativeType: this.nativeTypeName(), tags: readTag(value), v };
+  }
+
+  validate(value: Record<string, unknown>): boolean {
+    return "tags" in value && "v" in value;
+  }
+
+  revive(value: Record<string, unknown>): object {
+    // `v` is already revived (JSON.parse revivers run bottom-up). attachTag
+    // re-hides the tag and restores the null prototype the round-trip stripped.
+    const target = value.v as object;
+    attachTag(target, value.tags as Record<string, unknown>);
+    return target;
+  }
+}

--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { getRuntimeContext, runInTestContext } from "./asyncContext.js";
 import { readCause } from "./errors.js";
 import type { Interrupt } from "./interrupts.js";
 import { runBatch } from "./runBatch.js";
+import { GlobalStore } from "./state/globalStore.js";
 import { State, StateStack } from "./state/stateStack.js";
+import { ThreadStore } from "./state/threadStore.js";
 
 /** Build a synthetic Checkpoint-ish object (only the fields runBatch reads
  *  matter for these tests). */
@@ -700,5 +703,74 @@ describe("runBatch — mode 'race'", () => {
         children: [{ key: "c0", invoke: async () => 1 }],
       }),
     ).rejects.toThrow(/checkpoint\/mode mismatch/);
+  });
+});
+
+describe("runBatch — durable object-tag flag propagation", () => {
+  // A branch runs on a CLONE of the parent's GlobalStore; a durable tag set
+  // inside the branch rides back to the parent on the returned object (by
+  // reference), but the branch's presence flag would die with the clone. The
+  // settle hook must OR it into the parent so the parent's statelog redaction
+  // gate still fires.
+  function makeTagCtx() {
+    const { ctx } = makeCtx();
+    ctx.globals = new GlobalStore();
+    return ctx;
+  }
+
+  function batchOpts(ctx: any, invoke: () => Promise<unknown>) {
+    const { parentStack, parentFrame } = makeParent();
+    return {
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all" as const,
+      children: [{ key: "c0", invoke }],
+    };
+  }
+
+  it("propagates the flag when a branch that tagged an object settles", async () => {
+    const ctx = makeTagCtx();
+    await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+      runBatch(
+        batchOpts(ctx, async () => {
+          // Runs inside the branch ALS frame → branch-local cloned store.
+          const branchGlobals = getRuntimeContext().globals;
+          expect(branchGlobals).not.toBe(ctx.globals);
+          branchGlobals.setTag({ secret: "s" }, "redact", true);
+          return "ok";
+        }),
+      ),
+    );
+    expect((ctx.globals as GlobalStore).hasDurableObjectTagFlag()).toBe(true);
+  });
+
+  it("propagates the flag even when the branch THROWS (parent may log the error payload)", async () => {
+    const ctx = makeTagCtx();
+    await expect(
+      runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+        runBatch(
+          batchOpts(ctx, async () => {
+            getRuntimeContext().globals.setTag({ secret: "s" }, "redact", true);
+            throw new Error("branch failed");
+          }),
+        ),
+      ),
+    ).rejects.toThrow("branch failed");
+    expect((ctx.globals as GlobalStore).hasDurableObjectTagFlag()).toBe(true);
+  });
+
+  it("does not set the parent flag when the branch tagged nothing durable", async () => {
+    const ctx = makeTagCtx();
+    await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+      runBatch(
+        batchOpts(ctx, async () => {
+          getRuntimeContext().globals.setTag("prim", "redact", true);
+          return "ok";
+        }),
+      ),
+    );
+    expect((ctx.globals as GlobalStore).hasDurableObjectTagFlag()).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -369,21 +369,37 @@ function runInBranchAlsFrame<T>(
       moduleDir: parent.moduleDir,
     },
     async () => {
-      // Capture-on-INTERRUPT discipline: snapshot the per-branch
-      // globals + active-thread pointer only when the body settles
-      // as an `Interrupt[]`. Successful returns are discarded at
-      // join, so capturing then is pure waste (a JSON round-trip per
-      // branch). Throws naturally skip the capture and propagate —
-      // error-path branches are torn down rather than resumed.
-      //
-      // Only meaningful for the corresponding isolated dial.
-      // Pointer-shared dials have nothing to snapshot.
-      const value = await fn();
-      if (hasInterrupts(value)) {
-        if (!shareGlobals) branch.globalsJSON = branchGlobals.toJSON();
-        if (!shareThreads) branch.activeStack = [...branchThreads.activeStack];
+      try {
+        // Capture-on-INTERRUPT discipline: snapshot the per-branch
+        // globals + active-thread pointer only when the body settles
+        // as an `Interrupt[]`. Successful returns are discarded at
+        // join, so capturing then is pure waste (a JSON round-trip per
+        // branch). Throws naturally skip the capture and propagate —
+        // error-path branches are torn down rather than resumed.
+        //
+        // Only meaningful for the corresponding isolated dial.
+        // Pointer-shared dials have nothing to snapshot.
+        const value = await fn();
+        if (hasInterrupts(value)) {
+          if (!shareGlobals) branch.globalsJSON = branchGlobals.toJSON();
+          if (!shareThreads) branch.activeStack = [...branchThreads.activeStack];
+        }
+        return value;
+      } finally {
+        // Durable object tags set inside the branch travel back on the
+        // returned value (by reference), but the branch's presence flag
+        // lives on its discarded cloned store. OR it into the parent so
+        // the parent's statelog redaction gate still fires. In a `finally`
+        // so value, interrupt, AND throw settles all propagate — a thrown
+        // error can reference a branch-tagged object that the parent
+        // catches and logs. (The snapshot above deliberately skips throws,
+        // but that logic is about resume state; the monotonic flag has no
+        // reason to skip.) One idempotent write; pointer-shared globals
+        // need nothing (same store).
+        if (!shareGlobals && branchGlobals.hasDurableObjectTagFlag()) {
+          parent.globals.setDurableObjectTagFlag();
+        }
       }
-      return value;
     },
   );
 }

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { Runner, stripSlug, safeStatelogValue } from "./runner.js";
+import { GlobalStore } from "./state/globalStore.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { getRuntimeContext } from "./asyncContext.js";
@@ -86,6 +87,26 @@ describe("safeStatelogValue", () => {
     const a: any = {};
     a.self = a;
     expect(safeStatelogValue(a)).toBe("[unserializable]");
+  });
+
+  it("preserves a durable redact tag on the clone (redaction runs on this copy)", () => {
+    // A plain JSON round-trip would strip the on-object tag and the statelog
+    // redaction replacer would leak the branch value into forkBranchEnd.
+    const gs = new GlobalStore();
+    const secret = { apiKey: "sk-secret" };
+    gs.setTag(secret, "redact", true);
+    const out = safeStatelogValue({ wrapped: secret }) as {
+      wrapped: object;
+    };
+    expect(out.wrapped).toEqual({ apiKey: "sk-secret" });
+    expect(gs.isRedacted(out.wrapped)).toBe(true); // tag survived the clone
+  });
+
+  it("preserves native types (Date) through the clone", () => {
+    const out = safeStatelogValue({
+      when: new Date("2026-01-01T00:00:00.000Z"),
+    }) as { when: Date };
+    expect(out.when).toBeInstanceOf(Date);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -3,7 +3,7 @@ import { Runner, stripSlug, safeStatelogValue } from "./runner.js";
 import { GlobalStore } from "./state/globalStore.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
-import { getRuntimeContext } from "./asyncContext.js";
+import { getRuntimeContext, runInTestContext } from "./asyncContext.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 import { GuardExceededError, TimeGuard } from "./guard.js";
 import { readCause } from "./errors.js";
@@ -107,6 +107,42 @@ describe("safeStatelogValue", () => {
       when: new Date("2026-01-01T00:00:00.000Z"),
     }) as { when: Date };
     expect(out.when).toBeInstanceOf(Date);
+  });
+
+  it("redacts an oversized value BEFORE truncating (no string leak)", () => {
+    // The truncation branch returns a plain string; post()'s redaction
+    // replacer can't see inside a string, so redaction must happen during
+    // this stringify. The redacted object is a small part of an oversized
+    // payload — big enough to truncate, with the secret inside the cap.
+    const gs = new GlobalStore();
+    const secret = { apiKey: "sk-oversized-secret" };
+    gs.setTag(secret, "redact", true);
+    const ctx: any = { globals: gs };
+    const out = runInTestContext(
+      ctx,
+      new StateStack(),
+      new ThreadStore(),
+      () => safeStatelogValue({ secret, filler: "x".repeat(5000) }),
+    );
+    expect(typeof out).toBe("string");
+    expect(out).toMatch(/…\[truncated\]$/);
+    expect(out).toContain("[REDACTED]");
+    expect(out).not.toContain("sk-oversized-secret");
+  });
+
+  it("redacts the small-path clone in place when a frame is present", () => {
+    const gs = new GlobalStore();
+    const secret = { apiKey: "sk-small-secret" };
+    gs.setTag(secret, "redact", true);
+    const ctx: any = { globals: gs };
+    const out = runInTestContext(
+      ctx,
+      new StateStack(),
+      new ThreadStore(),
+      () => safeStatelogValue({ secret, other: 1 }),
+    ) as Record<string, unknown>;
+    expect(out.secret).toBe("[REDACTED]");
+    expect(out.other).toBe(1);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -6,6 +6,7 @@ import { HaltSignal } from "./haltSignal.js";
 import { invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
+import { nativeTypeReplacer, nativeTypeReviver } from "./revivers/index.js";
 import { runBatch } from "./runBatch.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
@@ -52,14 +53,20 @@ const FORK_VALUE_CHAR_CAP = 4000;
  *  WITHOUT ever throwing — telemetry must not break execution. Returns:
  *  - `undefined` when there is no value (non-success outcome, or a value
  *    JSON can't represent, e.g. a function);
- *  - a deep JSON clone for normal small values (so it renders cleanly);
+ *  - a deep clone for normal small values (so it renders cleanly);
  *  - a truncated string for oversized values;
- *  - `"[unserializable]"` when stringification throws (e.g. a cycle). */
+ *  - `"[unserializable]"` when (de)serialization throws (e.g. a cycle).
+ *
+ *  The clone goes through the shared nativeTypeReplacer/nativeTypeReviver
+ *  pair (like deepClone) rather than plain JSON: a plain round-trip would
+ *  strip a durable redact tag off a branch-returned object, and the
+ *  statelog redaction replacer — which runs on this clone at post() time —
+ *  would then leak the value into the forkBranchEnd event. */
 export function safeStatelogValue(value: unknown): unknown {
   if (value === undefined) return undefined;
   let json: string | undefined;
   try {
-    json = JSON.stringify(value);
+    json = JSON.stringify(value, nativeTypeReplacer);
   } catch {
     return "[unserializable]";
   }
@@ -67,7 +74,13 @@ export function safeStatelogValue(value: unknown): unknown {
   if (json.length > FORK_VALUE_CHAR_CAP) {
     return json.slice(0, FORK_VALUE_CHAR_CAP) + "…[truncated]";
   }
-  return JSON.parse(json);
+  try {
+    return JSON.parse(json, nativeTypeReviver);
+  } catch {
+    // e.g. a FunctionRef whose registry entry is gone — telemetry must
+    // degrade, not throw.
+    return "[unserializable]";
+  }
 }
 
 /**

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,10 +1,11 @@
 import { nanoid } from "nanoid";
-import { agencyStore } from "./asyncContext.js";
+import { __globals, agencyStore } from "./asyncContext.js";
 import { debugStep } from "./debugger.js";
 import { RestoreSignal, readCause } from "./errors.js";
 import { HaltSignal } from "./haltSignal.js";
 import { invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
+import { makeRedactReplacer, REDACTED } from "./redactForStatelog.js";
 import { __pipeBind } from "./result.js";
 import { nativeTypeReplacer, nativeTypeReviver } from "./revivers/index.js";
 import { runBatch } from "./runBatch.js";
@@ -57,16 +58,32 @@ const FORK_VALUE_CHAR_CAP = 4000;
  *  - a truncated string for oversized values;
  *  - `"[unserializable]"` when (de)serialization throws (e.g. a cycle).
  *
- *  The clone goes through the shared nativeTypeReplacer/nativeTypeReviver
- *  pair (like deepClone) rather than plain JSON: a plain round-trip would
- *  strip a durable redact tag off a branch-returned object, and the
- *  statelog redaction replacer — which runs on this clone at post() time —
- *  would then leak the value into the forkBranchEnd event. */
+ *  Redaction happens HERE, during the stringify — not only at post() time.
+ *  The truncation branch returns a plain string, and post()'s redaction
+ *  replacer cannot see inside a string, so an oversized redact()ed branch
+ *  value would otherwise leak its first FORK_VALUE_CHAR_CAP chars into the
+ *  event. The redact check composes with the shared nativeTypeReplacer
+ *  (like deepClone) so untagged natives and non-redact tags still round-trip
+ *  intact for the small path. Reads the caller's store leniently: both call
+ *  sites run at the fork join inside the parent's ALS frame; with no frame
+ *  this degrades to tag-preserving cloning, which post() still redacts on
+ *  the un-truncated path. */
 export function safeStatelogValue(value: unknown): unknown {
   if (value === undefined) return undefined;
+  const globals = __globals();
+  const redact =
+    globals && globals.hasAnyTags() ? makeRedactReplacer(globals) : null;
+  const replacer = function (
+    this: unknown,
+    key: string,
+    val: unknown,
+  ): unknown {
+    if (redact && redact.call(this, key, val) === REDACTED) return REDACTED;
+    return nativeTypeReplacer.call(this, key, val);
+  };
   let json: string | undefined;
   try {
-    json = JSON.stringify(value, nativeTypeReplacer);
+    json = JSON.stringify(value, replacer);
   } catch {
     return "[unserializable]";
   }

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -217,6 +217,9 @@ export class RuntimeContext<T> {
     this.statelogClient = new StatelogClient(statelogConfig);
     this.stateStack = new StateStack();
     this.globals = GlobalStore.withTokenStats();
+    // Out-of-frame posts (e.g. agentEnd) redact against the CURRENT top-level
+    // store — a getter because restore reassigns this.globals.
+    this.statelogClient.setFallbackGlobals(() => this.globals);
     this.checkpoints = new CheckpointStore(this.maxRestores);
     this.handlers = [];
     this.callbacks = {};
@@ -329,6 +332,9 @@ export class RuntimeContext<T> {
       ...this.statelogConfig,
       traceId: runId,
     });
+    // Out-of-frame posts (e.g. agentEnd) redact against the CURRENT top-level
+    // store — a getter because restore reassigns execCtx.globals.
+    execCtx.statelogClient.setFallbackGlobals(() => execCtx.globals);
     // Subprocess: nest this process's spans under the parent's
     // `subprocessRun` span (seeded by the bootstrap from the run/resume
     // instruction). The runId itself was already inherited by the caller

--- a/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
@@ -118,12 +118,15 @@ describe("GlobalStore tags", () => {
     gs.removeAllTags("k");
     expect(gs.getTagsFor("k")).toBeUndefined();
     expect(gs.hasAnyTags()).toBe(false);
-    // Durable (plain-object) path: keys are cleared in place, so getTagsFor
-    // returns {} — see the intentional-asymmetry note in the durable block.
+    // Durable (plain-object) path: the symbol property is detached outright
+    // (the object stops matching the TaggedReviver), so getTagsFor returns
+    // undefined like the other paths. Only a frozen-after-tag target keeps
+    // the cleared-in-place {} record — see the durable block below.
     const o = {};
     gs.setTag(o, "x", 1);
     gs.removeAllTags(o);
-    expect(gs.getTagsFor(o)).toEqual({});
+    expect(gs.getTagsFor(o)).toBeUndefined();
+    expect(readTag(o)).toBeUndefined();
     // WeakMap (frozen) path: the entry is deleted, so getTagsFor is undefined.
     const frozen = Object.freeze({});
     gs.setTag(frozen, "x", 1);
@@ -162,11 +165,12 @@ describe("GlobalStore tags", () => {
       gs.setTag(o, "extra", 1); // mutates the record, no throw
       expect(gs.getTagsFor(o)).toEqual({ redact: true, extra: 1 });
       expect(() => gs.removeAllTags(o)).not.toThrow(); // clears keys, no delete
-      // NOTE: intentional asymmetry — the durable path returns {} after
-      // removeAllTags (keys cleared in place; the record can't be deleted off
-      // a frozen target), while the WeakMap/primitive paths delete the entry
-      // and return undefined. Don't "unify" this back to a delete: it throws
-      // on frozen-after-tag objects. isRedacted (=== true) is unaffected.
+      // NOTE: intentional, narrow asymmetry — a FROZEN-after-tag target keeps
+      // an empty {} record (its symbol property is non-configurable, so it
+      // can't be detached; keys are cleared in place instead). Extensible
+      // targets get the property detached and return undefined like every
+      // other path. Don't "unify" this to an unconditional delete: it throws
+      // here. isRedacted (=== true) is unaffected.
       expect(gs.getTagsFor(o)).toEqual({});
       expect(gs.isRedacted(o)).toBe(false);
     });

--- a/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { GlobalStore } from "./globalStore.js";
+import { deepClone } from "../utils.js";
+import { readTag } from "./tagSymbol.js";
 
 describe("GlobalStore tags", () => {
   it("keys primitive tags by value (all equal primitives share tags)", () => {
@@ -63,21 +65,22 @@ describe("GlobalStore tags", () => {
     expect(gs.hasAnyTags()).toBe(true);
   });
 
-  it("clone() keeps primitive tags but drops object tags", () => {
+  it("clone() keeps primitive tags; FROZEN-object tags stay branch-local", () => {
+    // Plain-object tags are durable now (on the object itself — see the
+    // durable-tags describe block below); the branch-local contract this test
+    // pins is narrowed to objects that can't carry the marker (frozen/native).
     const gs = new GlobalStore();
-    const o = {};
+    const frozen = Object.freeze({ id: 1 });
     gs.setTag("prim", "redact", true);
-    gs.setTag(o, "redact", true);
+    gs.setTag(frozen, "redact", true);
     const c = gs.clone();
     expect(c.getTagsFor("prim")).toEqual({ redact: true });
-    expect(c.getTagsFor(o)).toBeUndefined();
-    // hasAnyTags tracks the split: object-only presence resets on clone,
-    // primitive presence survives. (Pins the branch-local object contract.)
+    expect(c.getTagsFor(frozen)).toBeUndefined(); // WeakMap is per-store
     expect(c.hasAnyTags()).toBe(true); // primitive tag survived
     const objOnly = new GlobalStore();
-    objOnly.setTag({}, "redact", true);
+    objOnly.setTag(Object.freeze({}), "redact", true);
     expect(objOnly.hasAnyTags()).toBe(true);
-    expect(objOnly.clone().hasAnyTags()).toBe(false); // object tag dropped
+    expect(objOnly.clone().hasAnyTags()).toBe(false); // WeakMap bit resets
   });
 
   it("survives toJSON/fromJSON for primitive tags (interrupt durability)", () => {
@@ -115,10 +118,93 @@ describe("GlobalStore tags", () => {
     gs.removeAllTags("k");
     expect(gs.getTagsFor("k")).toBeUndefined();
     expect(gs.hasAnyTags()).toBe(false);
-    // removeAllTags also works by reference for objects.
+    // Durable (plain-object) path: keys are cleared in place, so getTagsFor
+    // returns {} — see the intentional-asymmetry note in the durable block.
     const o = {};
     gs.setTag(o, "x", 1);
     gs.removeAllTags(o);
-    expect(gs.getTagsFor(o)).toBeUndefined();
+    expect(gs.getTagsFor(o)).toEqual({});
+    // WeakMap (frozen) path: the entry is deleted, so getTagsFor is undefined.
+    const frozen = Object.freeze({});
+    gs.setTag(frozen, "x", 1);
+    gs.removeAllTags(frozen);
+    expect(gs.getTagsFor(frozen)).toBeUndefined();
+  });
+
+  describe("durable object tags", () => {
+    it("stores a plain object's tag ON the object (survives deepClone)", () => {
+      const gs = new GlobalStore();
+      const o = { id: 1 };
+      gs.setTag(o, "redact", true);
+      expect(readTag(o)).toEqual({ redact: true }); // on the object
+      const cloned = deepClone(o);
+      expect(gs.getTagsFor(cloned)).toEqual({ redact: true }); // durable
+      expect(gs.isRedacted(cloned)).toBe(true);
+    });
+
+    it("frozen and native-typed objects fall back to the WeakMap (branch-local)", () => {
+      const gs = new GlobalStore();
+      const frozen = Object.freeze({ id: 1 });
+      const date = new Date();
+      gs.setTag(frozen, "redact", true);
+      gs.setTag(date, "redact", true);
+      expect(readTag(frozen)).toBeUndefined(); // not on the object
+      expect(gs.getTagsFor(frozen)).toEqual({ redact: true }); // in WeakMap
+      expect(gs.getTagsFor(date)).toEqual({ redact: true });
+    });
+
+    it("resolves a tag on an object frozen AFTER tagging (read/remove first)", () => {
+      const gs = new GlobalStore();
+      const o: Record<string, unknown> = { id: 1 };
+      gs.setTag(o, "redact", true); // durable path (extensible)
+      Object.freeze(o); // now non-extensible
+      expect(gs.getTagsFor(o)).toEqual({ redact: true }); // still found
+      gs.setTag(o, "extra", 1); // mutates the record, no throw
+      expect(gs.getTagsFor(o)).toEqual({ redact: true, extra: 1 });
+      expect(() => gs.removeAllTags(o)).not.toThrow(); // clears keys, no delete
+      // NOTE: intentional asymmetry — the durable path returns {} after
+      // removeAllTags (keys cleared in place; the record can't be deleted off
+      // a frozen target), while the WeakMap/primitive paths delete the entry
+      // and return undefined. Don't "unify" this back to a delete: it throws
+      // on frozen-after-tag objects. isRedacted (=== true) is unaffected.
+      expect(gs.getTagsFor(o)).toEqual({});
+      expect(gs.isRedacted(o)).toBe(false);
+    });
+
+    it("durable flag survives clone/fromJSON (parent->child); WeakMap flag resets", () => {
+      const gs = new GlobalStore();
+      gs.setTag({ id: 1 }, "redact", true); // durable
+      expect(gs.hasDurableObjectTagFlag()).toBe(true);
+      expect(gs.clone().hasDurableObjectTagFlag()).toBe(true);
+      expect(GlobalStore.fromJSON(gs.toJSON()).hasAnyTags()).toBe(true);
+
+      const weakOnly = new GlobalStore();
+      weakOnly.setTag(Object.freeze({}), "redact", true); // WeakMap path
+      expect(weakOnly.hasAnyTags()).toBe(true);
+      expect(weakOnly.clone().hasAnyTags()).toBe(false); // WeakMap bit resets
+    });
+
+    it("adding a tag to an object tagged by ANOTHER store sets this store's durable flag", () => {
+      // The durable record rides ON the object, so a store can adopt one it
+      // never created (object arrived by reference, e.g. from a settled
+      // branch). A write through this store must set ITS flag — the redaction
+      // gate has to be locally true, not dependent on join-propagation order.
+      const a = new GlobalStore();
+      const b = new GlobalStore();
+      const o = { id: 1 };
+      a.setTag(o, "redact", true); // record created via store A
+      expect(b.hasDurableObjectTagFlag()).toBe(false);
+      b.setTag(o, "extra", 1); // store B adopts the existing record
+      expect(b.hasDurableObjectTagFlag()).toBe(true);
+    });
+
+    it("setDurableObjectTagFlag is idempotent and readable", () => {
+      const gs = new GlobalStore();
+      expect(gs.hasDurableObjectTagFlag()).toBe(false);
+      gs.setDurableObjectTagFlag();
+      gs.setDurableObjectTagFlag();
+      expect(gs.hasDurableObjectTagFlag()).toBe(true);
+      expect(gs.hasAnyTags()).toBe(true);
+    });
   });
 });

--- a/packages/agency-lang/lib/runtime/state/globalStore.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.ts
@@ -1,5 +1,10 @@
 import { nativeTypeReplacer, nativeTypeReviver } from "../revivers/index.js";
-import { canHoldDurableTag, attachTag, readTag } from "./tagSymbol.js";
+import {
+  canHoldDurableTag,
+  attachTag,
+  detachTag,
+  readTag,
+} from "./tagSymbol.js";
 
 export type GlobalStoreJSON = {
   store: Record<string, Record<string, any>>;
@@ -135,14 +140,17 @@ export class GlobalStore {
     if (this.isRef(value)) {
       const durable = readTag(value);
       if (durable !== undefined) {
-        // Clear keys in place — the record object is separate from the
-        // (possibly frozen) target, and deleting the symbol property would
-        // throw on a frozen-after-tag object. Intentional asymmetry with the
-        // WeakMap/primitive paths: getTagsFor afterwards returns {} here
-        // (record stays attached, so the TaggedReviver keeps wrapping the
-        // object with empty tags), undefined there. Harmless — isRedacted
-        // checks `=== true`.
-        for (const key of Object.keys(durable)) delete durable[key];
+        // Prefer detaching the property outright so the object stops
+        // matching the TaggedReviver (no perpetual empty "Tagged" wrapper
+        // in every subsequent serialization) and getTagsFor returns
+        // undefined, consistent with the WeakMap/primitive paths. A
+        // frozen/sealed-after-tag target's property is non-configurable —
+        // deleting it would throw — so fall back to clearing the record's
+        // keys in place; getTagsFor then returns {} (intentional, narrow
+        // asymmetry; isRedacted checks `=== true` and is unaffected).
+        if (!detachTag(value)) {
+          for (const key of Object.keys(durable)) delete durable[key];
+        }
         return;
       }
       this.objectTags.delete(value);

--- a/packages/agency-lang/lib/runtime/state/globalStore.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.ts
@@ -1,4 +1,5 @@
 import { nativeTypeReplacer, nativeTypeReviver } from "../revivers/index.js";
+import { canHoldDurableTag, attachTag, readTag } from "./tagSymbol.js";
 
 export type GlobalStoreJSON = {
   store: Record<string, Record<string, any>>;
@@ -9,20 +10,27 @@ export class GlobalStore {
   private store: Record<string, Record<string, any>> = {};
   private initializedModules: Set<string> = new Set();
 
-  // Object/array/function tags, keyed by reference. Deliberately a WeakMap so
-  // it is (a) excluded from toJSON serialization and (b) reset to empty on
-  // clone() (fromJSON constructs a fresh GlobalStore). Object identity does
-  // not survive the toJSON/fromJSON round-trip, so object tags are
-  // intentionally branch-local and do not cross fork/interrupt boundaries.
+  // FALLBACK object-tag store for values that can't carry the durable
+  // on-object marker (frozen/sealed or native-typed objects, functions — see
+  // canHoldDurableTag). Keyed by reference; deliberately a WeakMap so it is
+  // (a) excluded from toJSON serialization and (b) reset to empty on clone()
+  // (fromJSON constructs a fresh GlobalStore). Object identity does not
+  // survive the toJSON/fromJSON round-trip, so THESE tags are branch-local.
+  // Plain extensible objects/arrays instead carry the record on the object
+  // itself (tagSymbol.ts) and the TaggedReviver preserves it through every
+  // state round-trip — those tags are durable.
   private objectTags: WeakMap<object, Record<string, unknown>> = new WeakMap();
 
-  // Tracks whether any object (reference) tag has been set, so hasAnyTags()
-  // can answer without enumerating the (non-enumerable) WeakMap. Not
-  // serialized and starts false on every fresh store, so it resets on
-  // clone()/fromJSON — matching the WeakMap, whose entries also reset.
+  // Tracks whether any WEAKMAP (branch-local) object tag has been set, so
+  // hasAnyTags() can answer without enumerating the (non-enumerable) WeakMap.
+  // Not serialized and starts false on every fresh store, so it resets on
+  // clone()/fromJSON — matching the WeakMap, whose entries also reset. The
+  // durable (on-object) path has its own SERIALIZED flag under __internal
+  // (DURABLE_FLAG_KEY), which rides toJSON/fromJSON/clone.
   private objectTagsPresent = false;
 
   private static readonly VALUE_TAGS_KEY = "__valueTags";
+  private static readonly DURABLE_FLAG_KEY = "__hasDurableObjectTags";
   static readonly REDACT_TAG = "redact";
 
   private isRef(value: unknown): value is object {
@@ -67,9 +75,26 @@ export class GlobalStore {
     create: boolean,
   ): Record<string, unknown> | undefined {
     if (this.isRef(value)) {
-      let record = this.objectTags.get(value);
-      if (!record && create) {
-        record = Object.create(null) as Record<string, unknown>;
+      // Follow an existing tag wherever it already lives (so an object frozen
+      // AFTER tagging still resolves to its on-object record).
+      const durable = readTag(value);
+      if (durable !== undefined) {
+        // The record may have been created by ANOTHER store (the object
+        // arrived by reference, e.g. from a settled branch). On a write, set
+        // THIS store's flag too — the redaction gate must be locally true,
+        // not dependent on join-propagation ordering. Monotonic + idempotent.
+        if (create) this.setDurableObjectTagFlag();
+        return durable;
+      }
+      const weak = this.objectTags.get(value);
+      if (weak !== undefined) return weak;
+      if (!create) return undefined;
+      // Creating: choose the path by current capability.
+      const record = Object.create(null) as Record<string, unknown>;
+      if (canHoldDurableTag(value)) {
+        attachTag(value, record);
+        this.setDurableObjectTagFlag();
+      } else {
         this.objectTags.set(value, record);
         this.objectTagsPresent = true;
       }
@@ -108,6 +133,18 @@ export class GlobalStore {
   /** Remove every tag from a value. */
   removeAllTags(value: unknown): void {
     if (this.isRef(value)) {
+      const durable = readTag(value);
+      if (durable !== undefined) {
+        // Clear keys in place — the record object is separate from the
+        // (possibly frozen) target, and deleting the symbol property would
+        // throw on a frozen-after-tag object. Intentional asymmetry with the
+        // WeakMap/primitive paths: getTagsFor afterwards returns {} here
+        // (record stays attached, so the TaggedReviver keeps wrapping the
+        // object with empty tags), undefined there. Harmless — isRedacted
+        // checks `=== true`.
+        for (const key of Object.keys(durable)) delete durable[key];
+        return;
+      }
       this.objectTags.delete(value);
       return;
     }
@@ -136,13 +173,31 @@ export class GlobalStore {
   /**
    * Cheap "are there any tags at all?" check so statelog can skip installing
    * a redaction replacer entirely when nothing is tagged (the common case).
-   * The WeakMap can't report size, so object-tag presence is tracked by a
-   * boolean flag that resets on clone alongside the WeakMap.
+   * Three signals: the in-memory WeakMap bit (branch-local tags; resets on
+   * clone alongside the WeakMap), the serialized durable flag (on-object
+   * tags; rides clone/interrupt round-trips), and the primitive Map's size.
    */
   hasAnyTags(): boolean {
     if (this.objectTagsPresent) return true;
+    if (this.hasDurableObjectTagFlag()) return true;
     const m = this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.VALUE_TAGS_KEY);
     return m instanceof Map && m.size > 0;
+  }
+
+  /** True when any durable (on-object) tag has been created on or adopted by
+   * this store. Serialized under __internal, so it survives clone/fromJSON. */
+  hasDurableObjectTagFlag(): boolean {
+    return (
+      this.get(GlobalStore.INTERNAL_MODULE, GlobalStore.DURABLE_FLAG_KEY) ===
+      true
+    );
+  }
+
+  /** Set the durable-object-tag presence flag. Monotonic (never reset —
+   * over-approximating costs one redaction pass, under-approximating leaks);
+   * OR'd into the parent store when a branch settles (see runBatch). */
+  setDurableObjectTagFlag(): void {
+    this.set(GlobalStore.INTERNAL_MODULE, GlobalStore.DURABLE_FLAG_KEY, true);
   }
 
   get(moduleId: string, varName: string): any {

--- a/packages/agency-lang/lib/runtime/state/tagSymbol.test.ts
+++ b/packages/agency-lang/lib/runtime/state/tagSymbol.test.ts
@@ -4,6 +4,7 @@ import {
   isPlainObjectOrArray,
   canHoldDurableTag,
   attachTag,
+  detachTag,
   readTag,
 } from "./tagSymbol.js";
 
@@ -50,6 +51,19 @@ describe("tagSymbol", () => {
     expect(readTag({})).toBeUndefined();
     expect(readTag("s")).toBeUndefined();
     expect(readTag(null)).toBeUndefined();
+  });
+
+  it("detachTag removes the property when extensible, refuses when frozen", () => {
+    const o = {};
+    attachTag(o, Object.assign(Object.create(null), { x: 1 }));
+    expect(detachTag(o)).toBe(true);
+    expect(readTag(o)).toBeUndefined();
+
+    const frozen = {};
+    attachTag(frozen, Object.assign(Object.create(null), { x: 1 }));
+    Object.freeze(frozen);
+    expect(detachTag(frozen)).toBe(false); // non-configurable — caller clears keys
+    expect(readTag(frozen)).toEqual({ x: 1 });
   });
 
   it("TAG_SYMBOL is the only way to reach the record", () => {

--- a/packages/agency-lang/lib/runtime/state/tagSymbol.test.ts
+++ b/packages/agency-lang/lib/runtime/state/tagSymbol.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  TAG_SYMBOL,
+  isPlainObjectOrArray,
+  canHoldDurableTag,
+  attachTag,
+  readTag,
+} from "./tagSymbol.js";
+
+describe("tagSymbol", () => {
+  it("isPlainObjectOrArray: plain objects and arrays only", () => {
+    expect(isPlainObjectOrArray({})).toBe(true);
+    expect(isPlainObjectOrArray(Object.create(null))).toBe(true);
+    expect(isPlainObjectOrArray([1, 2])).toBe(true);
+    expect(isPlainObjectOrArray(new Date())).toBe(false);
+    expect(isPlainObjectOrArray(new Map())).toBe(false);
+    expect(isPlainObjectOrArray("s")).toBe(false);
+    expect(isPlainObjectOrArray(null)).toBe(false);
+  });
+
+  it("canHoldDurableTag: plain/array AND extensible", () => {
+    expect(canHoldDurableTag({})).toBe(true);
+    expect(canHoldDurableTag([])).toBe(true);
+    expect(canHoldDurableTag(Object.freeze({}))).toBe(false);
+    expect(canHoldDurableTag(new Date())).toBe(false);
+    expect(canHoldDurableTag(42)).toBe(false);
+  });
+
+  it("attachTag stores a non-enumerable, spread-invisible, null-proto record", () => {
+    const o: Record<string, unknown> = { a: 1 };
+    attachTag(o, Object.assign(Object.create(null), { redact: true }));
+    expect(readTag(o)).toEqual({ redact: true });
+    // Invisible to enumeration/spread/JSON:
+    expect(Object.keys(o)).toEqual(["a"]);
+    expect({ ...o }).toEqual({ a: 1 });
+    expect(readTag({ ...o })).toBeUndefined();
+    expect(JSON.stringify(o)).toBe('{"a":1}');
+  });
+
+  it("attachTag forces a null prototype on the record (proto-safety)", () => {
+    const o = {};
+    attachTag(o, Object.assign({}, { polluted: true }) as Record<string, unknown>);
+    // The record must be null-proto so a "__proto__" key is plain data.
+    const rec = readTag(o)!;
+    expect(Object.getPrototypeOf(rec)).toBeNull();
+    expect(rec.polluted).toBe(true);
+  });
+
+  it("readTag returns undefined for untagged / non-object values", () => {
+    expect(readTag({})).toBeUndefined();
+    expect(readTag("s")).toBeUndefined();
+    expect(readTag(null)).toBeUndefined();
+  });
+
+  it("TAG_SYMBOL is the only way to reach the record", () => {
+    const o = {};
+    attachTag(o, Object.assign(Object.create(null), { x: 1 }));
+    expect((o as Record<symbol, unknown>)[TAG_SYMBOL]).toEqual({ x: 1 });
+    expect(Object.getOwnPropertyNames(o)).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/tagSymbol.ts
+++ b/packages/agency-lang/lib/runtime/state/tagSymbol.ts
@@ -34,6 +34,17 @@ export function attachTag(
   });
 }
 
+// Remove the tag property from a target that can still afford it: our
+// property is defined configurable, and only freeze/seal flips that — both of
+// which also make the object non-extensible, so isExtensible is a safe proxy
+// for "delete won't throw". Returns false when the caller must fall back to
+// clearing the record's keys in place.
+export function detachTag(target: object): boolean {
+  if (!Object.isExtensible(target)) return false;
+  delete (target as Record<symbol, unknown>)[TAG_SYMBOL];
+  return true;
+}
+
 export function readTag(value: unknown): Record<string, unknown> | undefined {
   if (
     value === null ||

--- a/packages/agency-lang/lib/runtime/state/tagSymbol.ts
+++ b/packages/agency-lang/lib/runtime/state/tagSymbol.ts
@@ -1,0 +1,47 @@
+// Module-private key for durable object tags. Stored non-enumerable, so it is
+// invisible to Object.keys / for-in / spread / JSON.stringify (symbol keys are
+// always dropped by JSON). Reachable only via this symbol. Lives in its own
+// dependency-free module so globalStore.ts and the TaggedReviver can share it
+// without an import cycle.
+export const TAG_SYMBOL: unique symbol = Symbol("agencyTags");
+
+export function isPlainObjectOrArray(value: unknown): boolean {
+  if (Array.isArray(value)) return true;
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+// A value can hold a *durable* on-object tag only if it's a plain object/array
+// and still extensible (a frozen/sealed object can't take a new property).
+export function canHoldDurableTag(value: unknown): boolean {
+  return isPlainObjectOrArray(value) && Object.isExtensible(value as object);
+}
+
+// Attach the tag record as a non-enumerable Symbol property. Forces the record
+// null-proto so a user/LLM-controlled "__proto__" tag key is plain data (the
+// same invariant GlobalStore establishes on creation and must survive revive).
+export function attachTag(
+  target: object,
+  tags: Record<string, unknown>,
+): void {
+  Object.setPrototypeOf(tags, null);
+  Object.defineProperty(target, TAG_SYMBOL, {
+    value: tags,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
+}
+
+export function readTag(value: unknown): Record<string, unknown> | undefined {
+  if (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  ) {
+    return undefined;
+  }
+  return (value as Record<symbol, Record<string, unknown> | undefined>)[
+    TAG_SYMBOL
+  ];
+}

--- a/packages/agency-lang/lib/statelogClient.redaction.test.ts
+++ b/packages/agency-lang/lib/statelogClient.redaction.test.ts
@@ -90,6 +90,22 @@ describe("StatelogClient redaction", () => {
     expect(printed(spy)).toContain("[REDACTED]"); // payload value redacted
   });
 
+  it("redacts an out-of-frame post via the fallback globals (agentEnd path)", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    execCtx.globals.markRedacted("sk-final");
+    // NO runInTestContext: this post fires outside any ALS frame, exactly like
+    // the result-bearing agentEnd event after the run's frame has ended. The
+    // client's fallbackGlobals (wired by createExecutionContext) must kick in.
+    await execCtx.statelogClient.post({
+      event: "agentEnd",
+      result: { apiKey: "sk-final" },
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("sk-final");
+  });
+
   it("redaction survives a fork-style globals clone (durable primitive path)", async () => {
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
     const ctx = makeStdoutCtx();

--- a/packages/agency-lang/lib/statelogClient.redaction.test.ts
+++ b/packages/agency-lang/lib/statelogClient.redaction.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { runInTestContext } from "./runtime/asyncContext.js";
 import { RuntimeContext } from "./runtime/state/context.js";
 import { ThreadStore } from "./runtime/state/threadStore.js";
+import { deepClone } from "./runtime/utils.js";
 
 function makeStdoutCtx() {
   return new RuntimeContext({
@@ -88,6 +89,22 @@ describe("StatelogClient redaction", () => {
     });
     expect(printed(spy)).toContain('"format_version":1'); // infra field intact
     expect(printed(spy)).toContain("[REDACTED]"); // payload value redacted
+  });
+
+  it("redacts a durably-tagged object after it survives serialization", async () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = makeStdoutCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      const creds = { user: "alice", pass: "hunter2" };
+      execCtx.globals.setTag(creds, "redact", true); // durable (on-object)
+      // Round-trip the object the way fork/interrupt round-trip state:
+      const revived = deepClone(creds);
+      expect(revived).not.toBe(creds); // new identity
+      await execCtx.statelogClient.post({ event: "toolCall", args: { creds: revived } });
+    });
+    expect(printed(spy)).toContain("[REDACTED]");
+    expect(printed(spy)).not.toContain("hunter2");
   });
 
   it("redacts an out-of-frame post via the fallback globals (agentEnd path)", async () => {

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -5,6 +5,7 @@ import { nanoid } from "nanoid";
 import { ModelName } from "smoltalk";
 import { JSONEdge } from "./types.js";
 import { makeRedactReplacer } from "./runtime/redactForStatelog.js";
+import type { GlobalStore } from "./runtime/state/globalStore.js";
 import { __globals } from "./runtime/asyncContext.js";
 
 // Bump this when the wire format changes in a way the viewer needs
@@ -132,6 +133,13 @@ export class StatelogClient {
   private spanStorage = new AsyncLocalStorage<SpanContext[]>();
   private metadata?: RunMetadata;
   private requestTimeoutMs: number;
+  // Fallback tag-store accessor for posts that fire OUTSIDE any ALS frame
+  // (agentEnd and the resume-path finalization events post after the run's
+  // agencyStore frame has ended). Wired by the execution context to read the
+  // CURRENT top-level GlobalStore — a getter, not a captured reference,
+  // because checkpoint restore reassigns execCtx.globals. Branch posts are
+  // unaffected: they run inside an ALS frame, where __globals() wins.
+  private fallbackGlobals: (() => GlobalStore | undefined) | null = null;
 
   constructor(config: StatelogConfig) {
     const { host, apiKey, projectId, traceId, debugMode } = config;
@@ -1139,6 +1147,12 @@ export class StatelogClient {
     });
   }
 
+  /** Wire the out-of-frame redaction fallback (see the field's docstring).
+   *  Called by the execution context right after this client is created. */
+  setFallbackGlobals(fn: () => GlobalStore | undefined): void {
+    this.fallbackGlobals = fn;
+  }
+
   // === Post (wire format) ===
 
   async post(
@@ -1180,11 +1194,12 @@ export class StatelogClient {
     // must not throw like getRuntimeContext() would). hasAnyTags() skips the
     // whole redaction pass when nothing is tagged, so the common case is one
     // stringify, byte-identical to before. Events posted outside an ALS frame
-    // (__globals() undefined) are not redacted — a documented boundary, not a
-    // secrecy guarantee. See docs/dev/globalstore.md on per-branch isolation:
+    // fall back to the execution's top-level store (fallbackGlobals) — the
+    // result-bearing agentEnd event posts after the run's frame has ended and
+    // must still redact. See docs/dev/globalstore.md on per-branch isolation:
     // __globals() returns the branch-local clone, so each branch redacts using
     // its own tags.
-    const globals = __globals();
+    const globals = __globals() ?? this.fallbackGlobals?.();
     const rawData = { ...body, timestamp: new Date().toISOString() };
     const data =
       globals && globals.hasAnyTags()

--- a/packages/agency-lang/tests/agency-js/tag-fork-redaction/agency.json
+++ b/packages/agency-lang/tests/agency-js/tag-fork-redaction/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/tag-fork-redaction/agent.agency
+++ b/packages/agency-lang/tests/agency-js/tag-fork-redaction/agent.agency
@@ -1,0 +1,18 @@
+import { redact } from "std::tag"
+
+// The branch redact()s a plain object and returns it BY REFERENCE to the
+// parent. Parent-side statelog events that include it (forkBranchEnd, node
+// results) must stay redacted — which requires the branch's durable-tag flag
+// to propagate to the parent store at settle.
+def tagInBranch(item: string) {
+  const secret = { apiKey: "sk-branch-secret" }
+  redact(secret)
+  return secret
+}
+
+node main() {
+  const results = fork(["only"]) as item {
+    return tagInBranch(item)
+  }
+  return results
+}

--- a/packages/agency-lang/tests/agency-js/tag-fork-redaction/fixture.json
+++ b/packages/agency-lang/tests/agency-js/tag-fork-redaction/fixture.json
@@ -1,0 +1,4 @@
+{
+  "leaked": false,
+  "redactedPresent": true
+}

--- a/packages/agency-lang/tests/agency-js/tag-fork-redaction/test.js
+++ b/packages/agency-lang/tests/agency-js/tag-fork-redaction/test.js
@@ -1,0 +1,30 @@
+import { main } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+// Durable-object-tag leak guard (plan Finding 1): a fork branch redact()s a
+// plain object and returns it by reference. The parent posts statelog events
+// containing that object AFTER the join (forkBranchEnd value, node result) —
+// they must show [REDACTED], which only happens if the branch's durable-tag
+// flag propagated to the parent's store when the branch settled.
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+await main();
+
+const log = readFileSync("statelog.log", "utf-8");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      leaked: log.includes("sk-branch-secret"),
+      redactedPresent: log.includes("[REDACTED]"),
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency/tag.agency
+++ b/packages/agency-lang/tests/agency/tag.agency
@@ -56,3 +56,16 @@ node forkInheritsPrimitiveTag(): boolean {
   }
   return results[0]
 }
+
+node forkInheritsObjectTag(): boolean {
+  // Plain-object tags are durable too: the fork branch's state round-trip
+  // clones the object (new identity), but the tag rides ON the object via
+  // the TaggedReviver, so the branch still sees it.
+  const o = { id: 1 }
+  redact(o)
+  const results = fork(["only"]) as item {
+    const t = getTags(o)
+    return t["redact"] == true
+  }
+  return results[0]
+}

--- a/packages/agency-lang/tests/agency/tag.test.json
+++ b/packages/agency-lang/tests/agency/tag.test.json
@@ -5,6 +5,7 @@
     { "nodeName": "objectByReference", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "mutateTags", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "tagReturnsCurrentTags", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "forkInheritsPrimitiveTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    { "nodeName": "forkInheritsPrimitiveTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "forkInheritsObjectTag", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
   ]
 }


### PR DESCRIPTION
## Summary

Makes `std::tag` tags on **plain objects and arrays durable**: they now survive `fork`/`race`/`parallel` branches and interrupt/resume, the same way primitive (value) tags already do. This closes the one limitation deferred from the base value-tags feature (PR #447).

- **Design spec:** `docs/superpowers/specs/2026-07-07-durable-object-tags-design.md` (+ review)
- **Plan:** `docs/superpowers/plans/2026-07-07-durable-object-tags.md` (+ review)

## How it works

- A tagged plain object/array carries its tag record as a **non-enumerable `Symbol` property** (`lib/runtime/state/tagSymbol.ts`) — invisible to `Object.keys`, spread, and `JSON.stringify`.
- A new **`TaggedReviver`** in the shared `nativeTypeReplacer`/`nativeTypeReviver` array preserves that property through every state round-trip (`deepClone`, state-stack serialization, `GlobalStore` clone/`toJSON`/`fromJSON`).
- **Frozen/sealed and native-typed objects** (`Date`, `Map`, class instances, …) can't carry the marker; they keep the branch-local `WeakMap` fallback, unchanged.
- `GlobalStore.tagsRecordFor` resolves an **existing record first** (on-object, then WeakMap) and only chooses storage by capability for brand-new tags — so an object frozen *after* tagging still reads, writes, and clears its durable record.

## Redaction-gate hardening (two mechanisms, on purpose)

`statelogClient.post` skips the redaction pass entirely when `hasAnyTags()` is false, so a tag whose *presence signal* doesn't reach a store is a leak. Two guards keep the gate correct:

1. **Locally-true flag on adopt-write:** the serialized `__hasDurableObjectTags` flag is set whenever a store creates *or adopts* (writes to) a durable record — even one another store created — so the gate never depends on propagation ordering.
2. **Join OR-in:** `runBatch` ORs a settling branch's flag into the parent store in a `finally`, covering value, interrupt, **and throw** settles (a thrown error can reference a branch-tagged object the parent logs).

The WeakMap path keeps its separate in-memory bit that resets on clone, so one frozen-object tag doesn't permanently over-approximate descendants.

## Discovered while executing the plan (not in the spec)

Running the new end-to-end fixture surfaced two additional leak paths that defeated redaction *regardless* of the gate, both fixed here:

- **`safeStatelogValue` (forkBranchEnd value):** the telemetry copy used a plain JSON round-trip, which stripped the on-object tag before the redaction replacer ran. It now clones through the shared replacer/reviver pair (behavior otherwise unchanged; still never throws).
- **Out-of-frame `agentEnd` posts:** the result-bearing `agentEnd` event fires *after* the run's ALS frame ends, where `post()` previously skipped redaction entirely ("documented boundary"). The client now redacts against a fallback top-level-store accessor wired by the execution context (a getter, since checkpoint restore reassigns `execCtx.globals`). This also fixes the same pre-existing gap for **primitive** tags.

## Semantics changes

- Plain-object/array tags survive `fork`/`race`/`parallel` and interrupt/resume (guide updated; branch-local caveat narrowed to frozen/native objects).
- A spread/structural copy (`{...obj}`) yields an **untagged** object — durability follows the same object, not copies.
- `removeAllTags` on a durably-tagged object clears the record's keys in place, so `getTagsFor` returns `{}` (not `undefined`) afterward — deleting the property would throw on frozen-after-tag objects. `isRedacted` (`=== true`) is unaffected.
- Two existing tests that pinned "plain-object tags are branch-local" now pin that contract for frozen objects only.

## Testing

- Unit: `tagSymbol.test.ts` (new), `taggedReviver.test.ts` (new), `globalStore.tags.test.ts` (+6 incl. adopt-flag and freeze-after-tag), `runBatch.test.ts` (+3 incl. throw-path propagation), `runner.test.ts` (+2 for `safeStatelogValue`), `statelogClient.redaction.test.ts` (+2: durable round-trip, out-of-frame fallback).
- End-to-end: `tests/agency-js/tag-fork-redaction/` — a fork branch `redact()`s an object and returns it; the parent statelog must show `[REDACTED]` and never the raw value.
- Execution: `tests/agency/tag.agency` `forkInheritsObjectTag` (compiled fork path).
- Full unit suite: 7367 passed / 0 failed. `lint:structure` clean. `make` (tsc + fixtures + docs regen) clean; stdlib reference regen produced no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
