### PR TITLE
Tags: interrupt/resume durability tests (audit follow-up to #451)

### DIFF
--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -761,6 +761,24 @@ describe("runBatch — durable object-tag flag propagation", () => {
     expect((ctx.globals as GlobalStore).hasDurableObjectTagFlag()).toBe(true);
   });
 
+  it("propagates the flag when the branch settles as INTERRUPTS (payload may reference a tagged object)", async () => {
+    const ctx = makeTagCtx();
+    const result = await runInTestContext(
+      ctx,
+      new StateStack(),
+      new ThreadStore(),
+      () =>
+        runBatch(
+          batchOpts(ctx, async () => {
+            getRuntimeContext().globals.setTag({ secret: "s" }, "redact", true);
+            return [fakeInterrupt("t", 9)];
+          }),
+        ),
+    );
+    expect(result.kind).toBe("interrupts");
+    expect((ctx.globals as GlobalStore).hasDurableObjectTagFlag()).toBe(true);
+  });
+
   it("does not set the parent flag when the branch tagged nothing durable", async () => {
     const ctx = makeTagCtx();
     await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>

--- a/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
+++ b/packages/agency-lang/lib/runtime/state/globalStore.tags.test.ts
@@ -188,6 +188,23 @@ describe("GlobalStore tags", () => {
       expect(weakOnly.clone().hasAnyTags()).toBe(false); // WeakMap bit resets
     });
 
+    it("a tagged object stored IN a global survives toJSON/fromJSON with its tag", () => {
+      // Distinct from deepClone-ing the object directly: here the Tagged
+      // wrapper is embedded inside the serialized STORE (the path a tagged
+      // global takes through clone() and interrupt save/restore).
+      const gs = new GlobalStore();
+      const creds = { user: "alice", pass: "hunter2" };
+      gs.setTag(creds, "redact", true);
+      gs.set("m", "creds", creds);
+      const restored = GlobalStore.fromJSON(gs.toJSON());
+      const revived = restored.get("m", "creds");
+      expect(revived).not.toBe(creds); // new identity
+      expect(revived).toEqual(creds);
+      expect(restored.getTagsFor(revived)).toEqual({ redact: true });
+      expect(restored.isRedacted(revived)).toBe(true);
+      expect(restored.hasAnyTags()).toBe(true); // gate flag rode along
+    });
+
     it("adding a tag to an object tagged by ANOTHER store sets this store's durable flag", () => {
       // The durable record rides ON the object, so a store can adopt one it
       // never created (object arrived by reference, e.g. from a settled

--- a/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/agency.json
+++ b/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/agent.agency
+++ b/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/agent.agency
@@ -1,0 +1,13 @@
+import { redact } from "std::tag"
+
+// The node redact()s a plain object BEFORE interrupting. Resume revives both
+// the object (from the checkpoint's serialized state stack) and the globals
+// store (carrying the durable-tag gate flag) from JSON. Every post-resume
+// statelog event that includes the object — node result, agentEnd — must
+// still show [REDACTED].
+node main() {
+  const secret = { apiKey: "sk-resume-secret" }
+  redact(secret)
+  const check = interrupt("Do you approve?")
+  return secret
+}

--- a/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/fixture.json
+++ b/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/fixture.json
@@ -1,0 +1,5 @@
+{
+  "leaked": false,
+  "redactedPresent": true,
+  "valueIntact": true
+}

--- a/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/test.js
+++ b/packages/agency-lang/tests/agency-js/tag-interrupt-redaction/test.js
@@ -1,0 +1,39 @@
+import { main, hasInterrupts, approve, respondToInterrupts } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+// Redaction must survive a REAL interrupt/resume: the checkpoint serializes
+// the state stack (destroying the tagged object's identity) and the globals
+// store (carrying the durable-tag gate flag); resume revives both from JSON.
+// The resumed run returns the object, so post-resume statelog events
+// (node result, agentEnd) leak unless the revived copy still carries its tag
+// AND the revived store still trips the hasAnyTags() gate.
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const result = await main();
+
+if (!hasInterrupts(result.data)) {
+  throw new Error("Expected an interrupt");
+}
+
+const finalResult = await respondToInterrupts(result.data, [approve()]);
+
+const log = readFileSync("statelog.log", "utf-8");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      leaked: log.includes("sk-resume-secret"),
+      redactedPresent: log.includes("[REDACTED]"),
+      // The RETURN VALUE keeps the real data — redaction is statelog-only.
+      valueIntact: finalResult.data?.apiKey === "sk-resume-secret",
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency/tag-interrupt.agency
+++ b/packages/agency-lang/tests/agency/tag-interrupt.agency
@@ -1,0 +1,36 @@
+import { redact, getTags } from "std::tag"
+
+// Interrupt/resume is the real serialization boundary for tags: the
+// checkpoint stores stateStack.toJSON() + globals.toJSON() at interrupt time,
+// and resume revives BOTH from JSON — object identity is destroyed, exactly
+// like the date-interrupt fixture pins for Date. These nodes prove tags ride
+// that round-trip (fork alone does NOT prove it: a fork branch reads the
+// parent's live locals by reference on the happy path).
+
+def confirm() {
+  return interrupt("confirm")
+}
+
+node objectTagSurvivesResume(): boolean {
+  const o = { id: 1 }
+  redact(o)
+  const r = confirm()
+  // After resume, o is a REVIVED copy (new identity). The tag must be on it.
+  const t = getTags(o)
+  return t["redact"] == true
+}
+
+node arrayTagSurvivesResume(): boolean {
+  const arr = [1, 2, 3]
+  redact(arr)
+  const r = confirm()
+  const t = getTags(arr)
+  return t["redact"] == true
+}
+
+node primitiveTagSurvivesResume(): boolean {
+  redact("sk-resume-secret")
+  const r = confirm()
+  const t = getTags("sk-resume-secret")
+  return t["redact"] == true
+}

--- a/packages/agency-lang/tests/agency/tag-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/tag-interrupt.test.json
@@ -1,0 +1,28 @@
+{
+  "tests": [
+    {
+      "nodeName": "objectTagSurvivesResume",
+      "description": "Durable object tag survives the interrupt/resume serialization round-trip",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve", "expectedMessage": "confirm" }]
+    },
+    {
+      "nodeName": "arrayTagSurvivesResume",
+      "description": "Durable array tag survives the interrupt/resume serialization round-trip",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve", "expectedMessage": "confirm" }]
+    },
+    {
+      "nodeName": "primitiveTagSurvivesResume",
+      "description": "Primitive (value) tag survives the interrupt/resume serialization round-trip",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve", "expectedMessage": "confirm" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/tag.agency
+++ b/packages/agency-lang/tests/agency/tag.agency
@@ -58,9 +58,11 @@ node forkInheritsPrimitiveTag(): boolean {
 }
 
 node forkInheritsObjectTag(): boolean {
-  // Plain-object tags are durable too: the fork branch's state round-trip
-  // clones the object (new identity), but the tag rides ON the object via
-  // the TaggedReviver, so the branch still sees it.
+  // Pins ON-OBJECT tag storage: the fork branch reads the parent's live `o`
+  // by reference (no serialization on the happy path), but through a CLONED
+  // GlobalStore — the old per-store WeakMap would miss here. Serialization
+  // durability itself is pinned by tag-interrupt.agency, where resume revives
+  // the object from checkpoint JSON.
   const o = { id: 1 }
   redact(o)
   const results = fork(["only"]) as item {


### PR DESCRIPTION
## Summary

Follow-up to #451. An audit of that PR's tests found the headline claim — tags survive **interrupt/resume** — had no test driving the real resume machinery, and one test comment overclaimed what it covered. This PR closes those gaps with tests only (no product code changes).

## What the audit found

- **No interrupt/resume test existed.** The closest coverage was unit-level `deepClone`/`toJSON` round-trips — same chokepoint, but not the real path (checkpoint serialization → `respondToInterrupts` → state restore).
- **`forkInheritsObjectTag` doesn't test serialization.** The compiled fork block reads the parent's live `o` **by reference** (verified in generated output) — no round-trip on the happy path. It genuinely pins on-object storage vs. the old per-store WeakMap (it fails on pre-#451 code), but its comment claimed a "state round-trip clones the object," which is wrong. Comment corrected.
- **Two smaller unit gaps:** the interrupt-settle arm of the `runBatch` flag propagation `finally` was untested (only value/throw settles were), and no test covered a tagged object embedded **inside** the serialized GlobalStore (a tagged global), as opposed to `deepClone`-ing the object directly.

## New tests

- **`tests/agency/tag-interrupt.agency`** — object, array, and primitive tags survive an externally-resolved interrupt (the `date-interrupt` pattern: the checkpoint stores `stateStack.toJSON()` + `globals.toJSON()`, resume revives both from JSON, destroying identity).
- **`tests/agency-js/tag-interrupt-redaction/`** — end-to-end statelog guard: a `redact()`ed object returned *after* resume must log `[REDACTED]` (revived tag + revived gate flag + out-of-frame `agentEnd` fallback in one path), while the actual return value keeps the real data (redaction is statelog-only).
- **`runBatch.test.ts`** — interrupt-settle flag propagation.
- **`globalStore.tags.test.ts`** — tagged object stored in a global survives `toJSON`/`fromJSON` with tag + gate flag.

## Vacuousness check

Verified the new tests are load-bearing by temporarily unregistering the `TaggedReviver` and rebuilding: `objectTagSurvivesResume` and `arrayTagSurvivesResume` **fail** (primitive node still passes — it rides the value Map, as expected), and the `tag-interrupt-redaction` fixture **fails with `leaked: true`**. Registration restored; all pass again.

## Verification

Full unit suite 7389 passed / 0 failed; `lint:structure` clean; `tag-interrupt` 3/3, `tag.agency` 7/7, both agency-js tag fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
