### PR TITLE
std::ui/layout: raw wraps by default, SGR-aware wrapping, shrink-to-fit ceiling

### DIFF
--- a/docs/superpowers/plans/2026-07-07-raw-wrapping.md
+++ b/docs/superpowers/plans/2026-07-07-raw-wrapping.md
@@ -1,0 +1,757 @@
+# `raw` Wrapping + SGR-aware Wrap + Shrink-to-fit Ceiling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `std::ui/layout`'s `raw` reflow to its container by default (with a `wrap: false` escape hatch), make wrapping preserve embedded ANSI cleanly (no style bleed into borders/padding), and make width-less containers shrink-to-fit-but-cap at the available width so content wraps instead of overflowing.
+
+**Architecture:** Three coordinated layers in `lib/stdlib/layout/` (TS render side) plus `stdlib/ui/layout.agency` (Agency data-construction side): (1) an SGR-aware `wrapText` that makes each emitted visual line self-contained; (2) an `availableWidth` ceiling threaded through the sizing context so content-driven leaves wrap at the terminal/parent width; (3) a `wrap` attribute on `raw` that reuses the same wrap/size machinery as `text` minus styling.
+
+**Tech Stack:** TypeScript (runtime/render), Agency (stdlib source), vitest (TS unit tests), Agency test framework (`tests/agency/layout/*.agency` + `.test.json`).
+
+**Design doc:** `docs/superpowers/specs/2026-07-07-raw-wrapping-design.md`
+
+## Global Constraints
+
+- **No dynamic imports** anywhere (repo rule).
+- Use **objects not maps**, **arrays not sets**, **types not interfaces** (repo rule).
+- After editing `stdlib/ui/layout.agency`, run **`make`** before running any Agency test (a plain `pnpm run build` does not rebuild the stdlib the CLI/tests load). Pure `lib/stdlib/layout/*.ts` changes are exercised by vitest directly and do **not** need `make`.
+- **`make fixtures` does NOT regenerate `tests/agency/layout/*.test.json`** — it only rewrites `tests/typescriptGenerator/` fixtures (`scripts/regenerate-fixtures.ts`, `fixturesDir = tests/typescriptGenerator`). Agency-layout fixtures are hand-edited from captured actual output.
+- The repo owner **reviews before committing**; treat each "Commit" step as "stage + request approval to commit" unless told otherwise.
+- v1 SGR state model is **sequence-accumulation**: `\x1b[0m` / `\x1b[m` clears the active run; any other `…m` SGR sequence accumulates. Partial attribute-off codes (`22`/`23`/`24`/`39`/`49`) and compound resets (`\x1b[0;31m`) are documented non-goals.
+- **`row` caps its children at the row's available width** (spec §3) — children stay shrink-to-fit (no `defaultWidth`) but get a wrap ceiling so a lone wide child wraps instead of overflowing. Horizontal width *distribution* among multiple row children is a non-goal.
+- **A leaf never gets `wrapWidth ≤ 0`** — when chrome ≥ available width the leaf degrades to overflow (visible), never to empty (`width <= 0` makes `wrapText` return `[]`).
+
+---
+
+## File Structure
+
+- `lib/stdlib/layout/ansi.ts` — add SGR state tracking + `reinjectSgr`; `wrapText` returns self-contained lines. (Task 1)
+- `lib/stdlib/layout/sizing.ts` — add optional `availableWidth` to `SizingContext`. (Task 2)
+- `lib/stdlib/layout/render.ts` — seed root `availableWidth` from the viewport. (Task 2)
+- `lib/stdlib/layout/box.ts` — pass child `availableWidth` (inner space). (Task 2)
+- `lib/stdlib/layout/axis.ts` — column and row pass a ceiling to children. (Task 2)
+- `lib/stdlib/layout/nodes.ts` — `wrapWidthFor` helper (ceiling + `≤0` guard); `sizeText`/`sizeRaw`; shared wrapped-block render helper. (Task 2 + Task 3)
+- `stdlib/ui/layout.agency` — `raw` gains `wrap`; `_addRaw`; docstrings + module doc. (Task 3)
+- `lib/stdlib/layout.test.ts` — TS unit tests for all of the above.
+- `tests/agency/layout/builders.test.json` — reconcile `raw` attrs fixture. (Task 3)
+- `tests/agency/layout/raw-wrap.agency` + `.test.json` — end-to-end integration. (Task 4)
+
+---
+
+## Task 1: SGR-aware `wrapText`
+
+Make each emitted visual line re-open the SGR state active at its start and close with `RESET` when a style is still open — so styling never bleeds across line boundaries (including literal `\n` boundaries, since the pass runs over the flattened segment list). `wrapSingleLine` and `breakLongToken` are unchanged; the fix is a post-pass over their output.
+
+**Files:**
+- Modify: `lib/stdlib/layout/ansi.ts` (the `wrapText` function ~line 19; add two helpers above it; `CSI` already exists at line 151)
+- Test: `lib/stdlib/layout.test.ts` (the `describe("wrapText", …)` block ~line 59)
+
+**Interfaces:**
+- Consumes: `RESET` (`ansi.ts:153`), `CSI` (`ansi.ts:151`), existing `wrapSingleLine`, `breakLongToken`.
+- Produces: `wrapText(content: string, width: number): string[]` — same signature, now emits self-contained ANSI lines. Consumed by Task 2/3 leaf renderers.
+
+- [ ] **Step 1: Update the one changed ANSI test + add the SGR-behavior tests**
+
+In `lib/stdlib/layout.test.ts`, **replace** the existing test at ~line 87 (`"breaks a long colored word …"`) — its expected output changes because each broken piece now self-closes — and **add** the tests below it. The word-boundary ANSI test at ~line 82 (`"keeps ANSI sequences attached …"`) stays as-is (its reset already falls inside the first segment, so its output is unchanged).
+
+```ts
+  test("breaks a long colored word at the column boundary, self-closing each line", () => {
+    expect(_internal.wrapText("\x1b[31mabcdefghij\x1b[0m", 4)).toEqual([
+      "\x1b[31mabcd\x1b[0m",
+      "\x1b[31mefgh\x1b[0m",
+      "\x1b[31mij\x1b[0m",
+    ]);
+  });
+
+  test("reopens the active style on each wrapped line and resets at its end", () => {
+    expect(_internal.wrapText("\x1b[2mAAAA BBBB CCCC\x1b[0m", 9)).toEqual([
+      "\x1b[2mAAAA BBBB\x1b[0m",
+      "\x1b[2mCCCC\x1b[0m",
+    ]);
+  });
+
+  test("accumulates stacked codes and reopens ALL of them on continuation lines", () => {
+    // No reset in the input: both fg (31) and bold (1) stay active and must
+    // both be reopened on every continuation line. Kills a keep-last-code bug.
+    expect(_internal.wrapText("\x1b[31m\x1b[1mred bold text here", 8)).toEqual([
+      "\x1b[31m\x1b[1mred bold\x1b[0m",
+      "\x1b[31m\x1b[1mtext\x1b[0m",
+      "\x1b[31m\x1b[1mhere\x1b[0m",
+    ]);
+  });
+
+  test("a full reset (\\x1b[0m and \\x1b[m) clears the carried style", () => {
+    expect(_internal.wrapText("\x1b[31mred one\x1b[0m two three", 7)).toEqual([
+      "\x1b[31mred one\x1b[0m",
+      "two",
+      "three",
+    ]);
+    // Empty-params reset `\x1b[m` also clears.
+    expect(_internal.wrapText("\x1b[31mfoo\x1b[m bar", 3)).toEqual([
+      "\x1b[31mfoo\x1b[m",
+      "bar",
+    ]);
+  });
+
+  test("carries style across a literal newline boundary too", () => {
+    // Style opened on one source line, reset two lines later: each emitted
+    // visual line is still self-contained. Guards the flatten-then-reinject
+    // ordering against a per-source-line refactor.
+    expect(_internal.wrapText("\x1b[31mfoo\nbar\x1b[0m", 10)).toEqual([
+      "\x1b[31mfoo\x1b[0m",
+      "\x1b[31mbar\x1b[0m",
+    ]);
+  });
+
+  test("non-SGR CSI (cursor/erase) passes through inline and is never reopened", () => {
+    // \x1b[2K is a CSI but not an SGR (ends in K). It must not enter the
+    // active-style state or be replayed on later lines.
+    expect(_internal.wrapText("\x1b[2Kfoo bar", 3)).toEqual([
+      "\x1b[2Kfoo",
+      "bar",
+    ]);
+  });
+
+  test("plain text and empty strings are unaffected by SGR handling", () => {
+    expect(_internal.wrapText("hello world", 5)).toEqual(["hello", "world"]);
+    expect(_internal.wrapText("hello  ", 10)).toEqual(["hello  "]);
+    expect(_internal.wrapText("", 5)).toEqual([""]);
+    expect(_internal.wrapText("hello", 0)).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run the tests — verify the new/updated ones fail**
+
+Run: `pnpm exec vitest run lib/stdlib/layout.test.ts -t wrapText`
+Expected: FAIL — the long-colored-word test and the new SGR tests fail; the plain-text test passes.
+
+- [ ] **Step 3: Implement SGR-aware `wrapText`**
+
+In `lib/stdlib/layout/ansi.ts`, add these helpers immediately above `export function wrapText` (~line 19), then change `wrapText`. Leave `wrapSingleLine` and `breakLongToken` untouched.
+
+```ts
+// Matches SGR sequences only (CSI … `m`), not other CSI like cursor/erase.
+const SGR_RE = /\x1b\[[\d;]*m/g;
+
+// Track the SGR run active since the last full reset. `\x1b[0m` / `\x1b[m`
+// clears it; any other SGR sequence accumulates. (v1: partial attribute-off
+// codes and compound resets like `\x1b[0;31m` are treated as accumulating —
+// see the layout design doc.)
+function updateActiveSgr(active: string, segment: string): string {
+  let result = active;
+  for (const match of segment.matchAll(SGR_RE)) {
+    const params = match[0].slice(CSI.length, -1);
+    result = params === "" || params === "0" ? "" : result + match[0];
+  }
+  return result;
+}
+
+// Make each wrapped segment self-contained: re-open the SGR state active at
+// its start and close with RESET when anything is still open at its end.
+// Each output is derived purely from its inputs so the order of statements
+// can't silently break it.
+function reinjectSgr(segments: string[]): string[] {
+  let active = "";
+  return segments.map((segment) => {
+    if (segment === "") return "";
+    const opened = active;
+    const closed = updateActiveSgr(opened, segment);
+    active = closed;
+    return opened + segment + (closed === "" ? "" : RESET);
+  });
+}
+```
+
+Change `wrapText`:
+
+```ts
+export function wrapText(content: string, width: number): string[] {
+  if (width <= 0) return [];
+  const segments = content.split("\n").flatMap((line) => wrapSingleLine(line, width));
+  return reinjectSgr(segments);
+}
+```
+
+- [ ] **Step 4: Run the tests — verify they pass**
+
+Run: `pnpm exec vitest run lib/stdlib/layout.test.ts -t wrapText`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/stdlib/layout/ansi.ts lib/stdlib/layout.test.ts
+git commit -m "feat(layout): SGR-aware wrapText so wrapped lines are self-contained"
+```
+
+---
+
+## Task 2: `availableWidth` shrink-to-fit ceiling
+
+Thread an available-width ceiling through the sizing context so a content-driven leaf (no imposed width) wraps at that ceiling instead of overflowing. Short content still passes through `wrapText` unchanged, preserving shrink-to-fit. A leaf never receives `wrapWidth ≤ 0`.
+
+**Files:**
+- Modify: `lib/stdlib/layout/sizing.ts:13-20` (`SizingContext`)
+- Modify: `lib/stdlib/layout/render.ts:108` (`resolveSizes` root context)
+- Modify: `lib/stdlib/layout/box.ts:39-47` (`sizeBox`)
+- Modify: `lib/stdlib/layout/axis.ts:147-161` (`sizeColumn`, `sizeRow`)
+- Modify: `lib/stdlib/layout/nodes.ts:151-157` (add `wrapWidthFor`, rewrite `sizeText`)
+- Test: `lib/stdlib/layout.test.ts` (the `describe("resolveSizes", …)` block)
+
+**Interfaces:**
+- Consumes: `wrapText` (Task 1), `resolveOwnWidth`, `innerWidthAfterChrome`, `nonNegativeInteger`, `BORDER_CELLS` (=2).
+- Produces: `SizingContext` gains `availableWidth?: number`. New `wrapWidthFor(node, ctx): number | undefined` returns the imposed-or-ceiling wrap width, or `undefined` when unbounded **or `≤ 0`**. Consumed by Task 3's `sizeRaw`.
+
+- [ ] **Step 1: Write/adjust failing sizing tests**
+
+Add these to `describe("resolveSizes", …)` in `lib/stdlib/layout.test.ts`:
+
+```ts
+  test("unsized box wraps content at the available width (shrink-to-fit ceiling)", () => {
+    // ceiling = viewport 40 − box chrome (2 border, 0 padding) = 38.
+    const tree = node("box", { padding: 0 }, [node("text", { content: "x" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 40, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBe(38);
+  });
+
+  test("unsized box ceiling subtracts padding on both sides", () => {
+    // chrome = 2 border + 2*2 padding = 6; ceiling = 40 − 6 = 34.
+    const tree = node("box", { padding: 2 }, [node("text", { content: "x" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 40, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBe(34);
+  });
+
+  test("nested unsized boxes subtract chrome at each level", () => {
+    const tree = node("box", { padding: 0 }, [
+      node("box", { padding: 0 }, [node("text", { content: "x" })]),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 40, rows: 24 });
+    // outer ceiling 40−2 = 38; inner ceiling 38−2 = 36.
+    expect(resolved.children[0].children[0].attrs.wrapWidth).toBe(36);
+  });
+
+  test("unsized column wraps its children at the available width", () => {
+    const tree = node("column", {}, [node("text", { content: "x" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 30, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBe(30);
+  });
+
+  test("never assigns wrapWidth ≤ 0 — content degrades to overflow, not to nothing", () => {
+    // chrome 2 + 2*20 = 42 > viewport 30 → ceiling clamps to 0 → no wrapWidth.
+    const tree = node("box", { padding: 20 }, [node("text", { content: "hello" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 30, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBeUndefined();
+  });
+```
+
+**Replace** the existing test at `lib/stdlib/layout.test.ts:127` (`"row does not give full width to every unsized child"`) — under the new cap rule its children get a wrap ceiling (not `undefined`). Its intent (children are not *filled*) is preserved because `defaultWidth` stays `undefined`; only the wrap ceiling is added:
+
+```ts
+  test("row caps unsized children at its width but does not fill them", () => {
+    const tree = node("row", { width: 20 }, [
+      node("text", { content: "first child is long" }),
+      node("text", { content: "second child is long" }),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    // Ceiling = row inner width (20, gap 0); children wrap at it but stay
+    // content-driven (no defaultWidth → not stretched to fill).
+    expect(resolved.children[0].attrs.wrapWidth).toBe(20);
+    expect(resolved.children[1].attrs.wrapWidth).toBe(20);
+  });
+```
+
+The existing sized tests at ~line 106 (box 30 → 28), ~line 187 (column 30 child → 30), and the `padding 1.9`/`gap -5` test at ~line 137 must still pass (they exercise the `own`-defined path, unchanged).
+
+- [ ] **Step 2: Run — verify the new/updated tests fail**
+
+Run: `pnpm exec vitest run lib/stdlib/layout.test.ts -t resolveSizes`
+Expected: FAIL — the ceiling tests fail (`wrapWidth` currently `undefined`); the row cap test fails (currently `undefined`).
+
+- [ ] **Step 3a: Add `availableWidth` to `SizingContext`**
+
+In `lib/stdlib/layout/sizing.ts`, extend the type (optional, so table/barchart contexts — which impose explicit cell widths — need no change):
+
+```ts
+export type SizingContext = {
+  // The width an unsized node should adopt (fill). Undefined when the parent
+  // does not impose a width on its children.
+  defaultWidth: number | undefined;
+  // The width that percentages and "full" compute against.
+  percentBasis: number | undefined;
+  // The max width content may occupy before it must wrap. A content-driven
+  // leaf with no imposed width wraps at this ceiling instead of overflowing.
+  // Optional: table cell contexts impose explicit widths and omit it.
+  availableWidth?: number | undefined;
+};
+```
+
+- [ ] **Step 3b: Seed the ceiling at the root**
+
+In `lib/stdlib/layout/render.ts`, `resolveSizes` (~line 108):
+
+```ts
+  return resolveNode(node, {
+    defaultWidth: undefined,
+    percentBasis: viewport.cols,
+    availableWidth: viewport.cols,
+  });
+```
+
+- [ ] **Step 3c: Pass the ceiling from `box`**
+
+In `lib/stdlib/layout/box.ts`, `sizeBox`. `available` collapses to a single `innerWidthAfterChrome` call (`own ?? ctx.availableWidth` is `inner`'s input either way):
+
+```ts
+function sizeBox(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const own = resolveOwnWidth(node, ctx);
+  const padding = nonNegativeInteger(node.attrs.padding);
+  const chrome = BORDER_CELLS + 2 * padding;
+  const inner = innerWidthAfterChrome(own, chrome);
+  const available = innerWidthAfterChrome(own ?? ctx.availableWidth, chrome);
+  return resolveContainer(node, own, {
+    defaultWidth: inner,
+    percentBasis: inner,
+    availableWidth: available,
+  });
+}
+```
+
+- [ ] **Step 3d: Pass the ceiling from `column` and `row`**
+
+In `lib/stdlib/layout/axis.ts`. Row keeps `defaultWidth: undefined` (children are not filled) but now passes a ceiling so a lone wide child wraps:
+
+```ts
+function sizeColumn(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const own = resolveOwnWidth(node, ctx);
+  return resolveContainer(node, own, {
+    defaultWidth: own,
+    percentBasis: own,
+    availableWidth: own ?? ctx.availableWidth,
+  });
+}
+
+function sizeRow(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const own = resolveOwnWidth(node, ctx);
+  const gap = nonNegativeInteger(node.attrs.gap);
+  const gapTotal = Math.max(0, node.children.length - 1) * gap;
+  const inner = innerWidthAfterChrome(own, gapTotal);
+  // Children stay content-driven (no defaultWidth → not filled), but are
+  // capped at the row's available width so a lone wide child wraps.
+  // Horizontal distribution among multiple children is a non-goal.
+  return resolveContainer(node, own, {
+    defaultWidth: undefined,
+    percentBasis: inner,
+    availableWidth: inner ?? ctx.availableWidth,
+  });
+}
+```
+
+- [ ] **Step 3e: Add `wrapWidthFor` and rewrite `sizeText`**
+
+In `lib/stdlib/layout/nodes.ts`, add the shared helper and use it (this is where the `≤ 0` guard lives — a single home shared with `sizeRaw` in Task 3):
+
+```ts
+// The wrap width a leaf should use: its imposed width if any, else the
+// available ceiling. Returns undefined when unbounded OR when the width is
+// ≤ 0 (chrome ≥ available), so the leaf degrades to overflow — never to
+// empty (wrapText returns [] for width ≤ 0).
+function wrapWidthFor(node: LayoutNode, ctx: SizingContext): number | undefined {
+  const own = resolveOwnWidth(node, ctx);
+  const width = own ?? ctx.availableWidth;
+  return width !== undefined && width > 0 ? width : undefined;
+}
+
+function sizeText(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  const width = wrapWidthFor(node, ctx);
+  if (width === undefined) return node;
+  return setAttr(node, "wrapWidth", width);
+}
+```
+
+- [ ] **Step 4: Run the resolveSizes tests — verify they pass**
+
+Run: `pnpm exec vitest run lib/stdlib/layout.test.ts -t resolveSizes`
+Expected: PASS — new ceiling + row-cap + `≤0` guard tests green; existing sized-path tests still green.
+
+- [ ] **Step 5: Run the whole layout unit suite — no regressions**
+
+Run: `pnpm exec vitest run lib/stdlib/layout.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/stdlib/layout/sizing.ts lib/stdlib/layout/render.ts lib/stdlib/layout/box.ts lib/stdlib/layout/axis.ts lib/stdlib/layout/nodes.ts lib/stdlib/layout.test.ts
+git commit -m "feat(layout): shrink-to-fit availableWidth ceiling with zero-width guard"
+```
+
+---
+
+## Task 3: `raw` gains `wrap` (Agency API + TS handler)
+
+Add a `wrap` parameter to `raw` (default `true`, appended last so positional `raw(content, align)` callers keep working), wire its sizing to `wrapWidthFor` (respecting `wrap: false`), and render `raw` like `text` but with no styling.
+
+**Files:**
+- Modify: `lib/stdlib/layout/nodes.ts` (`LEAF_RENDERERS.text` + `.raw` ~line 108-120; add `wrappedBlock`; add `sizeRaw`; `raw` handler ~line 164)
+- Modify: `stdlib/ui/layout.agency` (`raw` ~line 103-118, `_addRaw` ~line 224-232, module doc ~line 20)
+- Modify: `tests/agency/layout/builders.test.json:18` (raw attrs now include `wrap`)
+- Test: `lib/stdlib/layout.test.ts`
+
+**Interfaces:**
+- Consumes: `wrapWidthFor` (Task 2), SGR-aware `wrapText` (Task 1), `Block`, `pad`, `styled`, `styleOf`, `setAttr`.
+- Produces: `raw` node carries `attrs.wrap: boolean`; `raw.size` sets `wrapWidth` via `wrapWidthFor` unless `wrap === false`; `raw.render` wraps-or-splits without styling. Agency `raw(content, align = "start", wrap = true)`.
+
+- [ ] **Step 1: Write failing TS tests for raw sizing + render + align + no-bleed**
+
+Add a `describe("raw", …)` block to `lib/stdlib/layout.test.ts`:
+
+```ts
+describe("raw", () => {
+  test("wraps by default (gets a wrapWidth) but not when wrap:false", () => {
+    const wrapped = _internal.resolveSizes(
+      node("box", { width: 30 }, [node("raw", { content: "x", wrap: true })]),
+      { cols: 80, rows: 24 },
+    );
+    expect(wrapped.children[0].attrs.wrapWidth).toBe(28);
+
+    const preserved = _internal.resolveSizes(
+      node("box", { width: 30 }, [node("raw", { content: "x", wrap: false })]),
+      { cols: 80, rows: 24 },
+    );
+    expect(preserved.children[0].attrs.wrapWidth).toBeUndefined();
+  });
+
+  test("raw wraps content to the box exactly like text, adding no styling", () => {
+    const out = render(
+      node("box", { width: 12, padding: 1 }, [
+        node("raw", { content: "the quick brown fox" }),
+      ]),
+      { cols: 80, rows: 24 },
+    );
+    expect(out).toBe(
+      [
+        "╭──────────╮",
+        "│          │",
+        "│ the      │",
+        "│ quick    │",
+        "│ brown    │",
+        "│ fox      │",
+        "│          │",
+        "╰──────────╯",
+      ].join("\n"),
+    );
+  });
+
+  test("wrapped colored content survives AND never leaves an open SGR at a line boundary", () => {
+    const colored = "\x1b[31malpha beta gamma delta epsilon\x1b[0m";
+    const out = _render(
+      node("box", { width: 16, padding: 1 }, [node("raw", { content: colored })]),
+      true, 80, 24,
+    );
+    // Colors survive (kills a "strip all ANSI" render bug).
+    expect(out).toContain("\x1b[31m");
+    // No style bleeds past a line boundary → borders/padding stay uncolored.
+    // Independent re-implementation of the scan on purpose: a bug shared with
+    // updateActiveSgr would otherwise mask itself in this oracle.
+    const openAtEnd = (line: string): string => {
+      let active = "";
+      for (const match of line.matchAll(/\x1b\[[\d;]*m/g)) {
+        const params = match[0].slice(2, -1);
+        active = params === "" || params === "0" ? "" : active + match[0];
+      }
+      return active;
+    };
+    for (const line of out.split("\n")) expect(openAtEnd(line)).toBe("");
+  });
+
+  test("raw and text right-align short wrapped lines when align:end", () => {
+    const out = render(
+      node("box", { width: 10, padding: 0 }, [
+        node("raw", { content: "a\nbbbb", align: "end" }),
+      ]),
+      { cols: 80, rows: 24 },
+    );
+    // "a" is padded on the LEFT to line up under "bbbb" (right alignment).
+    expect(out).toContain("   a");
+  });
+});
+```
+
+- [ ] **Step 2: Run — verify they fail**
+
+Run: `pnpm exec vitest run lib/stdlib/layout.test.ts -t raw`
+Expected: FAIL — `raw` currently uses `passthrough` sizing and never wraps.
+
+- [ ] **Step 3a: Add the shared wrapped-block helper + rewrite both leaf renderers**
+
+In `lib/stdlib/layout/nodes.ts`, add the helper and use it in both leaves:
+
+```ts
+// Wrap (or split on newlines) then align-pad to a tidy rectangle. Shared by
+// `text` and `raw`; `text` additionally wraps the result in `styled`.
+function wrappedBlock(content: string, wrapWidth: number | undefined, align: Align): Block {
+  const lines = wrapWidth !== undefined ? wrapText(content, wrapWidth) : content.split("\n");
+  const block = Block.of(lines);
+  return pad(block, block.width, block.height, align, "start");
+}
+```
+
+```ts
+  text: (n) => {
+    const content   = asString(n.attrs.content);
+    const align     = (n.attrs.align as Align) ?? "start";
+    const wrapWidth = n.attrs.wrapWidth as number | undefined;
+    return styled(wrappedBlock(content, wrapWidth, align), styleOf(n.attrs));
+  },
+  raw: (n) => {
+    const content   = asString(n.attrs.content);
+    const align     = (n.attrs.align as Align) ?? "start";
+    const wrapWidth = n.attrs.wrapWidth as number | undefined;
+    // No `styled` wrapper: raw carries its own ANSI and must not have
+    // styling re-applied over it.
+    return wrappedBlock(content, wrapWidth, align);
+  },
+```
+
+Then delete `alignedTextBlock` if now unused — confirm first: `grep -rn alignedTextBlock lib/stdlib/layout/` (including `layout.ts` `_internal` and the test file). If any non-test caller remains, keep it.
+
+- [ ] **Step 3b: Add `sizeRaw` and update the `raw` handler**
+
+In `lib/stdlib/layout/nodes.ts`, add `sizeRaw` next to `sizeText` (reusing `wrapWidthFor`), and change the `raw` handler export (~line 164):
+
+```ts
+function sizeRaw(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  // wrap:false preserves exact layout (ASCII art / pre-rendered tables):
+  // no wrapWidth, so the renderer splits on newlines only.
+  if (node.attrs.wrap === false) return node;
+  const width = wrapWidthFor(node, ctx);
+  if (width === undefined) return node;
+  return setAttr(node, "wrapWidth", width);
+}
+```
+
+```ts
+export const raw: NodeHandler = { size: sizeRaw, render: LEAF_RENDERERS.raw };
+```
+
+- [ ] **Step 4: Run the raw TS tests — verify they pass**
+
+Run: `pnpm exec vitest run lib/stdlib/layout.test.ts -t raw`
+Expected: PASS.
+
+- [ ] **Step 5: Add `wrap` to the Agency `raw` constructor + builder + docs**
+
+In `stdlib/ui/layout.agency`, change `raw` (~line 103). `wrap` is appended **last** so positional `raw(content, "center")` keeps working:
+
+```
+/** A pre-styled string. Wraps to its container by default; pass `wrap: false`
+to preserve exact layout. Wrapping is ANSI-aware, so embedded color survives
+without bleeding into surrounding borders. */
+export safe def raw(content: string, align: Alignment = "start", wrap: boolean = true): LayoutNode {
+  """
+  A pre-styled string (may carry its own ANSI or newlines). Wraps to the
+  container width by default; pass wrap: false to render exactly as-is and
+  never reflow (ASCII art, pre-rendered tables).
+
+  @param content - Raw string content (may contain ANSI codes or newlines)
+  @param align - For multi-line content, how shorter lines align to the longest
+  @param wrap - Reflow to the container width (default true). false preserves the exact layout.
+  """
+  return {
+    type: "raw",
+    attrs: {
+      content: content,
+      align: align,
+      wrap: wrap
+    },
+    children: []
+  }
+}
+```
+
+Update `_addRaw` (~line 224):
+
+```
+def _addRaw(
+  kids: any[],
+  content: string,
+  align: Alignment = "start",
+  wrap: boolean = true,
+): LayoutNode {
+  const n = raw(content: content, align: align, wrap: wrap)
+  kids.push(n)
+  return n
+}
+```
+
+Update the module-doc line (~line 20) from:
+
+```
+  Containers (`box`, `row`, `column`) take a `width`: a number of columns,
+  `"50%"` of the parent, or `"full"` for the whole terminal. Text wraps to
+  fit; `raw` content never wraps.
+```
+
+to:
+
+```
+  Containers (`box`, `row`, `column`) take a `width`: a number of columns,
+  `"50%"` of the parent, or `"full"` for the whole terminal. Content wraps to
+  fit its container; pass `wrap: false` to `raw` to preserve exact layout
+  (ASCII art, pre-rendered tables). Unsized containers shrink to fit their
+  content but cap at the available width, wrapping anything longer.
+```
+
+- [ ] **Step 6: Reconcile the `raw` attrs fixture**
+
+`tests/agency/layout/builders.test.json:18` asserts the exact `raw` node attrs. Update its `expectedOutput` to append `wrap` (matching the `content, align, wrap` attrs order):
+
+```json
+      "expectedOutput": "{\"type\":\"raw\",\"attrs\":{\"content\":\"\\u001b[31mpre-styled\\u001b[0m\",\"align\":\"start\",\"wrap\":true},\"children\":[]}",
+```
+
+- [ ] **Step 7: Rebuild the stdlib and run the builders fixture**
+
+Run: `make`
+Then: `pnpm run agency test tests/agency/layout/builders.agency 2>&1 | tee /tmp/builders.out`
+Expected: PASS (the `raw` node now serializes with `"wrap":true`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/stdlib/layout/nodes.ts stdlib/ui/layout.agency lib/stdlib/layout.test.ts tests/agency/layout/builders.test.json
+git commit -m "feat(layout): raw gains wrap param, wraps to container by default"
+```
+
+---
+
+## Task 4: End-to-end integration + regression guard
+
+Prove the whole stack wires together from Agency source through render: `raw` wraps in a sized box, an unsized box caps + wraps at the viewport, colored content survives with clean borders, `wrap: false` forwards through the builder, and no existing layout fixture regressed.
+
+**Files:**
+- Create: `tests/agency/layout/raw-wrap.agency`
+- Create: `tests/agency/layout/raw-wrap.test.json`
+
+**Interfaces:**
+- Consumes: `box`, `raw`, `render` from `std::ui/layout` (Task 3).
+
+- [ ] **Step 1: Write the Agency integration test file**
+
+Create `tests/agency/layout/raw-wrap.agency`:
+
+```
+import { box, raw, render } from "std::ui/layout"
+
+// raw now wraps to the box exactly like text (default wrap: true).
+node testRawWrapsInBox(): string {
+  const panel = box(width: 12) as b {
+    b.raw("the quick brown fox")
+  }
+  return render(panel, color: false)
+}
+
+// Unsized box caps + wraps long content at the pinned viewport (headline fix).
+node testUnsizedBoxCapsAndWraps(): string {
+  const panel = box() as b {
+    b.text("the quick brown fox jumps over the lazy dog again")
+  }
+  return render(panel, color: false, cols: 16)
+}
+
+// Unsized box shrink-to-fits short content (does NOT blow up to full width).
+node testUnsizedBoxShrinkToFit(): string {
+  const panel = box() as b {
+    b.text("hi")
+  }
+  return render(panel, color: false, cols: 40)
+}
+
+// wrap: false forwards through the builder and preserves the exact node.
+node testRawWrapFalseNode(): LayoutNode {
+  return raw("ascii-art-line", wrap: false)
+}
+```
+
+- [ ] **Step 2: Capture actual output and author the fixture**
+
+`make fixtures` does NOT regenerate these — author `raw-wrap.test.json` by capturing. First build and run each node to see its real output:
+
+Run: `make && pnpm run agency run tests/agency/layout/raw-wrap.agency 2>&1 | tee /tmp/raw-wrap-capture.out`
+(Or run each node individually if `run` executes only `main`; use a temporary `main` that prints each, or rely on Step 3's test runner output.)
+
+`testRawWrapsInBox` is known exactly — Agency `box` defaults `padding: 1`, so a width-12 box has inner width 8, identical to the existing `testRenderWrap` fixture. Author the others from `/tmp/raw-wrap-capture.out`, verifying by eye that: the unsized-cap output is a box whose every line is ≤ 16 cols; the shrink-to-fit output is a small box (far narrower than 40); and the `wrap:false` node serializes with `"wrap":false`.
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "testRawWrapsInBox",
+      "input": "",
+      "expectedOutput": "\"╭──────────╮\\n│          │\\n│ the      │\\n│ quick    │\\n│ brown    │\\n│ fox      │\\n│          │\\n╰──────────╯\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "testUnsizedBoxCapsAndWraps",
+      "input": "",
+      "expectedOutput": "<PASTE captured string; verify every line ≤ 16 cols>",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "testUnsizedBoxShrinkToFit",
+      "input": "",
+      "expectedOutput": "<PASTE captured string; verify it is a small box, not 40 wide>",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "testRawWrapFalseNode",
+      "input": "",
+      "expectedOutput": "{\"type\":\"raw\",\"attrs\":{\"content\":\"ascii-art-line\",\"align\":\"start\",\"wrap\":false},\"children\":[]}",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `pnpm run agency test tests/agency/layout/raw-wrap.agency 2>&1 | tee /tmp/raw-wrap.out`
+Expected: PASS. If a render node fails, inspect `/tmp/raw-wrap.out`, confirm the actual output is correct wrapping (each line within the pinned `cols`), and correct the fixture string — do **not** change the code to match a wrong expectation.
+
+- [ ] **Step 4: Regression-check every layout fixture**
+
+Run each existing layout test and confirm none regressed from the ceiling/raw changes:
+
+Run: `for f in tests/agency/layout/*.agency; do echo "== $f =="; pnpm run agency test "$f"; done 2>&1 | tee /tmp/layout-all.out`
+Expected: all PASS. Any failure will be a fixture whose content is in an **unsized** container with a line longer than its viewport (now wrapped where it previously overflowed). For each: verify in `/tmp/layout-all.out` that the new output is correctly wrapped, then **hand-edit** that `.test.json`'s `expectedOutput` to the new string (`make fixtures` will NOT do this). Review with `git diff tests/agency/layout/` to confirm the change is only the expected wrapping.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/agency/layout/raw-wrap.agency tests/agency/layout/raw-wrap.test.json
+# plus any hand-edited fixtures reconciled in Step 4
+git commit -m "test(layout): end-to-end raw wrapping, ceiling, and fixture reconciliation"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Spec §1 (`raw` gains `wrap`, default true, no self-styling) → Task 3.
+- Spec §2 (SGR-aware `wrapText`; self-contained at *every* boundary incl. `\n`; `breakLongToken` participates) → Task 1 (`reinjectSgr` over the flattened list; tests: long-colored-word, dim, stacked-codes, newline-carried, non-SGR-CSI, `\x1b[m`).
+- Spec §3 (`availableWidth` ceiling: root, box, column, **row cap**) → Task 2 (Steps 3a–3d). Row cap is now implemented per spec (was reversed in the prior draft; corrected).
+- Spec §4 (leaf sizing/render; `own ?? availableWidth`; `wrap:false`; shared helper) → Task 2 (`wrapWidthFor`, `sizeText`) + Task 3 (`wrappedBlock`, `sizeRaw`).
+- Spec §5 examples → Task 3 render tests + Task 4 execution tests.
+- Back-compat: only long-line-in-bounded/ceilinged content changes → Task 1 Step 1 (updates the one affected unit test), Task 2 Step 1 (replaces `:127`), Task 3 Step 6 (`builders.test.json`), Task 4 Step 4 (fixture sweep). The `wrapWidth ≤ 0` guard additionally fixes a pre-existing bug where a too-narrow sized box (`width: 3, padding: 1`) rendered its text as nothing — now it overflows visibly.
+- Testing plan: every listed case has a concrete test — self-contained lines (T1), full-reset clears (T1), **stacked codes reopened (T1, real two-code input)**, plain unchanged (T1), raw wraps / `wrap:false` preserves (T3.1, T4), unsized shrink-to-fit + cap (T2 sizing + T4 execution), colored content clean borders **and survival** (T3.3), **align when wrapping (T3.4)**, nested ceiling (T2), zero-width guard (T2).
+- Non-goals honored: Style-parser, row horizontal distribution, compound-reset handling, #453 — all left out with code comments where relevant.
+
+**Placeholder scan:** the only intentional placeholders are the two Task 4 fixture strings that must be captured from real output (`make fixtures` can't generate them); every other step has concrete code and exact commands.
+
+**Type consistency:** `SizingContext.availableWidth?: number | undefined` is read by `sizeBox`/`sizeColumn`/`sizeRow`/`wrapWidthFor` and written at root/box/column/row (table cell contexts deliberately omit it — the field is optional for exactly that reason). `wrapWidthFor(node, ctx): number | undefined` is the single source of the ceiling + `≤0` guard, used by both `sizeText` and `sizeRaw`. `wrappedBlock(content, wrapWidth, align)` matches both leaf call sites. `updateActiveSgr`/`reinjectSgr` are file-local to `ansi.ts`; the Task 3 `openAtEnd` test oracle re-implements the scan on purpose (commented). Agency `raw(content, align, wrap = true)` param order matches attrs order and the `builders.test.json` fixture.
+
+---
+
+**Note:** Per your instruction, nothing here has been committed — this plan document is written to disk only. The spec (`2026-07-07-raw-wrapping-design.md`) is being amended in parallel for the four items where the plan now intentionally goes beyond it: `availableWidth` optional, the every-boundary self-contained guarantee, the `raw(content, align, wrap)` signature, and the `wrapWidth ≤ 0` guard.

--- a/docs/superpowers/specs/2026-07-07-raw-wrapping-design.md
+++ b/docs/superpowers/specs/2026-07-07-raw-wrapping-design.md
@@ -1,0 +1,300 @@
+# Design: `raw` wrapping, SGR-aware wrap, and shrink-to-fit width ceiling
+
+**Date:** 2026-07-07
+**Status:** Approved (design) — ready for implementation plan
+**Module:** `std::ui/layout` (`stdlib/ui/layout.agency` + `lib/stdlib/layout/*`)
+
+## Problem
+
+Putting pre-colored, long-line content inside a `box` currently produces a
+shredded box with no visible styling. The trigger case:
+
+```
+node main() {
+  const res = diff(file1 catch "", file2 catch "", color: true)  // long lines + ANSI
+  const panel = box(title: "Hello", padding: 1) as b {
+    b.raw(res)
+  }
+  print(render(panel))
+}
+```
+
+Three independent defects combine here:
+
+1. **`raw` never wraps.** Its sizing handler is `passthrough` (`lib/stdlib/layout/nodes.ts:164`),
+   so it never receives a `wrapWidth`; the ~280-column diff line is emitted intact.
+2. **A width-less box does not bound its content.** `resolveSizes` seeds the root
+   with `defaultWidth: undefined` (`render.ts:108`), so an unsized box stays
+   content-driven and grows to the longest line. That line overflows the terminal,
+   which then hard-wraps every row and scatters the borders.
+3. **Wrapping is not SGR-aware.** Even when content *does* wrap (via `text`), the
+   opening SGR lands on the first visual row and the `\x1b[0m` only on the last;
+   the middle rows carry no codes, so inside a box the **borders and padding of the
+   wrapped rows inherit the color/dim** (they render while the SGR is still open).
+
+(A fourth, separate defect — `render`'s default `color: "auto"` stripping ANSI even
+in an interactive terminal — is tracked in issue #453 and is **out of scope** here.)
+
+This design fixes 1–3 so the naive snippet above "just works": `raw` wraps to the
+box, the box bounds itself to the terminal, and the diff's colors render cleanly
+without bleeding into the frame.
+
+## Goals
+
+- `raw` reflows to its container by default, while never applying styling of its
+  own (embedded ANSI passes through untouched).
+- An explicit escape hatch (`wrap: false`) preserves exact layout for ASCII art and
+  pre-rendered tables.
+- Width-less containers shrink to fit their content but **cap at the available
+  width**, wrapping anything longer instead of overflowing.
+- Wrapped ANSI content is styled per visual line, so container chrome
+  (borders/padding) is never tinted.
+
+## Non-goals
+
+- **Full SGR parser.** v1 tracks styling by sequence-accumulation (below), which is
+  correct for set-then-full-reset content (what `std::syntax` and typical
+  highlighters emit). Handling partial attribute-off codes (`22`/`23`/`24`/`39`/`49`)
+  and compound resets (`\x1b[0;31m`, which v1 accumulates rather than treating the
+  leading `0` as a clear — replay stays visually correct but `activeSeq` grows on
+  streaming input) without a full reset is a documented limitation and a follow-up.
+- **Horizontal width distribution in `row`.** Splitting a horizontal budget among
+  several side-by-side children is a real sizing problem left for a follow-up. v1
+  only caps each row child at the row's available width so a lone wide child wraps
+  instead of overflowing infinitely.
+- **The `color: "auto"` TTY bug** (issue #453).
+- **A clip strategy for over-wide `wrap: false` content.** It still overflows by
+  definition; documented, not clipped.
+
+## Design
+
+### 1. `raw` gains a `wrap` parameter
+
+`stdlib/ui/layout.agency`:
+
+```
+export safe def raw(content: string, align: Alignment = "start", wrap: boolean = true): LayoutNode
+```
+
+`wrap` is appended **last** (after the existing `align`) so positional callers of
+the old `raw(content, align)` signature keep working; the escape hatch reads
+naturally as a named argument (`raw(content, wrap: false)`).
+
+- `wrap: true` (default) — reflow to the container's inner width; apply no styling.
+- `wrap: false` — render exactly as-is, never reflow (today's behavior).
+
+The `wrap` value is stored in `attrs`. Mirror the parameter through the builder
+helper `_addRaw` (`layout.agency`) so `b.raw(content, wrap: false)` works inside a
+block. Update the `raw` docstring and the module-doc lines that currently say
+*"raw content never wraps"* and warn that nested ANSI *"won't re-apply styling after
+those sequences reset"* — both become inaccurate once wrapping is SGR-aware.
+
+### 2. SGR-aware `wrapText` (`lib/stdlib/layout/ansi.ts`)
+
+`wrapText` already measures width correctly (`visualWidth` ignores CSI). The change:
+make **every emitted visual line self-contained** — it re-opens whatever SGR state
+was active at that point and closes with `RESET` when anything is open. This holds
+at *every* line boundary, including a literal `\n` in the content (the pass runs
+over the flattened segment list, so a style opened on one source line and reset on
+a later one still never bleeds). Then `pad` and `beside` add spaces and border
+chars *after* a `RESET`, so the frame stays uncolored.
+
+**State model (v1 — sequence accumulation):** while walking the original line,
+maintain `activeSeq`, the run of SGR sequences seen since the last full reset:
+
+- On `\x1b[0m` / `\x1b[m` (full reset): set `activeSeq = ""` (the reset stays inline).
+- On any other SGR sequence (CSI ending in `m`): append it to `activeSeq`.
+- Non-SGR CSI (cursor moves, etc.) passes through inline and does not affect state.
+
+At each wrap boundary:
+
+- If `activeSeq` is non-empty at the segment end, append `RESET` to close the segment.
+- Prefix the next segment with the current `activeSeq` to re-open the state.
+
+Worked example (dim text, wraps after `BBBB`):
+
+```
+in : "\x1b[2mAAAA BBBB CCCC\x1b[0m"
+out: ["\x1b[2mAAAA BBBB\x1b[0m",   // closes the open dim
+      "\x1b[2mCCCC\x1b[0m"]        // reopens dim, then closes
+```
+
+Notes:
+
+- Plain (non-ANSI) content produces no state and is byte-identical to today.
+- `breakLongToken` (the mid-token break path for tokens longer than `width`) must
+  participate in the same state tracking so a color that opens inside an over-long
+  token is reopened on continuation lines.
+- Later-wins is fine: stacked colors (`\x1b[31m\x1b[32m` with no reset between)
+  reopen both; the terminal applies the last.
+
+**Beneficiary:** `text` already calls `wrapText`, so text-with-embedded-ANSI gets
+the clean-per-line behavior for free; no change to the `text` handler is required
+for this part.
+
+### 3. Shrink-to-fit with an available-width ceiling (`sizing.ts` + containers)
+
+Add a third field to `SizingContext`:
+
+```
+type SizingContext = {
+  defaultWidth:    number | undefined;   // width an unsized child adopts (fill)
+  percentBasis:    number | undefined;   // basis for "%"/"full"
+  availableWidth?: number | undefined;   // NEW: ceiling a content-driven child wraps at
+};
+```
+
+- `defaultWidth` is unchanged: it makes unsized children **fill** a sized parent.
+- `availableWidth` is the **max width content may occupy before it must wrap**. It
+  is **optional**: the root and every container (`box`/`column`/`row`) set it, but
+  table-cell contexts impose explicit cell widths (so `own` is always defined there
+  and the ceiling is never consulted) and deliberately omit it — which is why the
+  field is optional rather than required, so `table.ts`/barchart need no change.
+
+**Root** (`render.ts` `resolveSizes`): `availableWidth: viewport.cols` (alongside the
+existing `defaultWidth: undefined, percentBasis: viewport.cols`).
+
+**Per container**, the child context's `availableWidth` is that container's own
+available inner space:
+
+- **box** (`box.ts` `sizeBox`): chrome is `BORDER_CELLS + 2*padding` (`BORDER_CELLS = 2`).
+  `childAvailable = innerWidthAfterChrome(own ?? ctx.availableWidth, chrome)` — when
+  `own` is defined this is the box's own inner width; when unsized it is the parent
+  ceiling minus this box's chrome. (One expression: `own ?? ctx.availableWidth`
+  collapses both cases.)
+- **column** (`axis.ts` `sizeColumn`): children fill the column width, so
+  `childAvailable = own ?? ctx.availableWidth`.
+- **row** (`axis.ts` `sizeRow`): `childAvailable = inner ?? ctx.availableWidth`
+  (`inner = own − gapTotal`). Children keep `defaultWidth: undefined` (they are not
+  *filled*) but get a wrap ceiling, so a lone wide child wraps instead of
+  overflowing. Per-child horizontal *distribution* is a non-goal.
+
+Only leaves consume `availableWidth`; containers pass an adjusted ceiling down.
+
+### 4. Leaf sizing/render (`nodes.ts`)
+
+**`sizeText`** and the wrapping branch of `raw.size` resolve their wrap width as
+"imposed width, else the ceiling" via a shared `wrapWidthFor` helper. The helper
+also **guards against `wrapWidth ≤ 0`**: when chrome ≥ available width (e.g. an
+unsized `box(padding: 20)` on a narrow terminal, reachable with no explicit widths
+anywhere) the ceiling clamps to `0`; without the guard the leaf would get
+`wrapWidth: 0` and `wrapText` returns `[]`, rendering the content as **nothing**.
+Returning `undefined` instead degrades to overflow (visible). This also fixes the
+pre-existing imposed-width variant (a `box(width: 3, padding: 1)` vanishes its text
+today).
+
+```
+function wrapWidthFor(node, ctx) {
+  const own = resolveOwnWidth(node, ctx);          // imposed width or defaultWidth
+  const width = own ?? ctx.availableWidth;         // fall back to the ceiling
+  return width !== undefined && width > 0 ? width : undefined;
+}
+// sizeText:  const w = wrapWidthFor(node, ctx); return w === undefined ? node : setAttr(node, "wrapWidth", w);
+// sizeRaw:   if (node.attrs.wrap === false) return node; then the same as sizeText.
+```
+
+- If a parent imposes a width (e.g. a sized box → `defaultWidth = inner`), `own` is
+  defined and behavior is unchanged (fill + wrap at that width).
+- If the parent is content-driven, `own` is undefined and the leaf now wraps at the
+  ceiling. Short lines pass through `wrapText` unchanged (`visualWidth <= width`), so
+  **shrink-to-fit is preserved**; only over-long lines wrap.
+
+**`raw` handler** becomes conditional on `wrap`:
+
+- `raw.size`: when `attrs.wrap !== false`, use the same wrap-width logic as
+  `sizeText`; when `attrs.wrap === false`, `passthrough` (no `wrapWidth`; content is
+  preserved and may overflow — the explicit opt-out).
+- `raw.render`: if `wrapWidth` is set, `wrapText(content, wrapWidth)`; else
+  `content.split("\n")`. Then align-pad **without** a `styled()` wrapper (raw carries
+  no style attrs). This is `text`'s renderer minus styling; factor the shared
+  "wrap-or-split + align-pad" into one helper reused by both leaves.
+
+### 5. Resulting behavior
+
+```
+// naive case — now works with no width, no wrap flag:
+box(title: "Hello", padding: 1) as b { b.raw(coloredDiff) }
+//   raw wraps (default) → box caps at terminal → clean colored box
+//   (still needs color: true until #453 is fixed)
+
+// shrink-to-fit preserved:
+box(title: "Status") as b { b.text("OK") }        // small box, hugs "OK"
+
+// explicit full-width panel (unchanged):
+box(width: "full") as b { b.text(longLine) }      // fills terminal, wraps
+
+// preserve exact layout (ASCII art / pre-rendered table):
+box(width: 40) as b { b.raw(asciiDiagram, wrap: false) }
+```
+
+## Backward compatibility / migration
+
+- **Rendering that changes:** `raw` with lines longer than the available width
+  inside a container previously overflowed; it now wraps. Width-less containers with
+  *short* content are unchanged (shrink-to-fit). Anyone whose layout-sensitive art
+  relied on overflow-in-a-box adds `wrap: false`. This is expected to be rare and is
+  called out in the module docs.
+- **Byte-level `wrapText` change:** SGR-aware wrapping adds `RESET`/re-open sequences
+  around wrapped ANSI lines. Any unit test asserting exact `wrapText` output on
+  ANSI input is updated; plain-text output is unchanged.
+- **`wrapWidth ≤ 0` guard is a strict improvement:** a too-narrow *sized* box
+  (`box(width: 3, padding: 1)`) previously rendered its text as nothing; it now
+  overflows visibly. No caller relied on the vanish behavior.
+
+## Testing plan
+
+Unit (`lib/stdlib/layout.test.ts` — the single layout unit-test file):
+
+- Each emitted line is self-contained: reopens the active style, closes with `RESET`.
+- Full reset (`\x1b[0m` and empty-params `\x1b[m`) clears state; a color after a
+  reset does not carry the pre-reset style.
+- **Stacked codes** with no intervening reset are **all** reopened (real two-code
+  input, e.g. `\x1b[31m\x1b[1m…`, not a single code).
+- Style carries across a **literal `\n`** boundary (self-contained at every boundary).
+- **Non-SGR CSI** (e.g. `\x1b[2K`) passes through inline and is never reopened.
+- Plain content is byte-identical to the pre-change output.
+- Width measurement still ignores escape codes; `breakLongToken` preserves state
+  across continuation lines.
+- Sizing: unsized box/column wrap children at the ceiling; **row caps** children at
+  its width (not `undefined`); nested boxes subtract chrome at each level; the
+  `wrapWidth ≤ 0` guard leaves content unwrapped (present) rather than empty.
+
+Render-level (TS `render`/`_render`, deterministic — no hand-computed ANSI):
+
+- Colored content in a box **survives** (`toContain("\x1b[…")`) **and** leaves no open
+  SGR at any line boundary (borders untinted) — an independent-oracle property test.
+- `align: "end"` right-aligns short wrapped lines.
+
+Layout execution tests (`tests/agency/layout/`, `render(color: false, cols: N)`):
+
+- `raw` wraps by default inside a sized box (exact, equals the `text` output).
+- Width-less box shrink-to-fits short content but caps + wraps a long line.
+- `raw(wrap: false)` forwards through the builder (exact node attrs).
+
+Run `make` after editing the `.agency` stdlib source. **`make fixtures` does not
+regenerate `tests/agency/layout/*.test.json`** (it only rewrites
+`tests/typescriptGenerator/`); these fixtures are hand-authored from captured output.
+
+## Follow-ups
+
+- **Style-based SGR parser** — decode SGR params into the existing `Style`
+  (`fg/bg/bold/dim/italic/underline`), honoring off-codes and 256/24-bit color, and
+  re-emit minimal SGR per line. Replaces v1 accumulation; needed only for third-party
+  ANSI that uses partial attribute-off codes. Requires extending `sgr()` to emit the
+  full SGR space.
+- **`row` horizontal width distribution** — real budget-splitting among side-by-side
+  children.
+- **Issue #453** — `render` `"auto"` color detection under the `agency` CLI runner.
+
+## Code touch-points
+
+- `stdlib/ui/layout.agency` — `raw` signature + `wrap` attr, `_addRaw`, docstrings,
+  module doc.
+- `lib/stdlib/layout/ansi.ts` — SGR-aware `wrapText` / `wrapSingleLine` /
+  `breakLongToken`.
+- `lib/stdlib/layout/sizing.ts` — `availableWidth` on `SizingContext`;
+  `resolveContainer` threading.
+- `lib/stdlib/layout/render.ts` — root `availableWidth = viewport.cols`.
+- `lib/stdlib/layout/box.ts`, `axis.ts` — per-container child `availableWidth`.
+- `lib/stdlib/layout/nodes.ts` — `sizeText`/`raw` wrap-width fallback; conditional
+  `raw` sizing; shared wrap-or-split render helper.

--- a/packages/agency-lang/docs/site/stdlib/ui/layout.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/layout.md
@@ -19,8 +19,10 @@ Build terminal output as a tree of boxes, rows, and columns, then render
   ```
 
   Containers (`box`, `row`, `column`) take a `width`: a number of columns,
-  `"50%"` of the parent, or `"full"` for the whole terminal. Text wraps to
-  fit; `raw` content never wraps.
+  `"50%"` of the parent, or `"full"` for the whole terminal. Content wraps to
+  fit its container; pass `wrap: false` to `raw` to preserve exact layout
+  (ASCII art, pre-rendered tables). Unsized containers shrink to fit their
+  content but cap at the available width, wrapping anything longer.
 
   For live, redrawing UIs with input handling, use `std::ui` instead.
 
@@ -43,7 +45,7 @@ export type LayoutNode = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L31))
 
 ### LayoutBuilder
 
@@ -69,7 +71,7 @@ export type LayoutBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L42))
 
 ### Alignment
 
@@ -77,7 +79,7 @@ export type LayoutBuilder = {
 export type Alignment = "start" | "center" | "end"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L53))
 
 ### BorderStyle
 
@@ -85,7 +87,7 @@ export type Alignment = "start" | "center" | "end"
 export type BorderStyle = "rounded" | "heavy" | "double" | "light"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L55))
 
 ### Width
 
@@ -93,7 +95,7 @@ export type BorderStyle = "rounded" | "heavy" | "double" | "light"
 export type Width = number | "full" | string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L57))
 
 ## Functions
 
@@ -129,21 +131,25 @@ A styled run of text. Newlines split it into multiple lines.
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L65))
 
 ### raw
 
 ```ts
-raw(content: string, align: Alignment): LayoutNode
+raw(content: string, align: Alignment, wrap: boolean): LayoutNode
 ```
 
-A pre-styled string, rendered as-is and never wrapped. Use it for ASCII art or strings that already carry their own styling.
+A pre-styled string (may carry its own ANSI or newlines). Wraps to the
+  container width by default; pass wrap: false to render exactly as-is and
+  never reflow (ASCII art, pre-rendered tables).
 
   @param content - Raw string content (may contain ANSI codes or newlines)
   @param align - For multi-line content, how shorter lines align to the longest
+  @param wrap - Reflow to the container width (default true). false preserves the exact layout.
 
-If the string carries its own ANSI sequences, nesting it inside a
-styled `text` or `box` won't re-apply styling after those sequences reset.
+Wraps to its container by default; pass `wrap: false` to preserve exact
+layout. Wrapping is ANSI-aware, so embedded color survives without bleeding
+into surrounding borders.
 
 **Parameters:**
 
@@ -151,10 +157,11 @@ styled `text` or `box` won't re-apply styling after those sequences reset.
 |---|---|---|
 | content | `string` |  |
 | align | [Alignment](#alignment) | "start" |
+| wrap | `boolean` | true |
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L106))
 
 ### space
 
@@ -174,7 +181,7 @@ Blank space. Inside a row it adds columns; inside a column, rows.
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L127))
 
 ### hline
 
@@ -202,7 +209,7 @@ A horizontal rule. Inside a column, leave length at 0 to span the column's width
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L142))
 
 ### vline
 
@@ -230,7 +237,7 @@ A vertical rule. Inside a row, leave length at 0 to span the row's height.
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L171))
 
 ### row
 
@@ -258,7 +265,7 @@ A horizontal container. Children render left to right.
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L336))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L344))
 
 ### column
 
@@ -286,7 +293,7 @@ A vertical container. Children render top to bottom.
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L375))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L383))
 
 ### box
 
@@ -320,7 +327,7 @@ A bordered panel. Multiple children stack vertically inside it.
 
 **Returns:** [LayoutNode](#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L414))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L422))
 
 ### render
 
@@ -346,4 +353,4 @@ Render a layout tree to a styled, multi-line string ready to print.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L462))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/layout.agency#L470))

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -828,9 +828,11 @@ describe("box renderer", () => {
     expect(lines).toContain("│the quick brown   │");
     expect(lines).toContain("│fox jumps         │");
   });
-  test("fixed-width box leaves raw content unwrapped", () => {
+  test("fixed-width box leaves raw content unwrapped when wrap:false", () => {
+    // raw wraps to the box by default now; wrap:false preserves the exact,
+    // unwrapped line (ASCII art / pre-rendered content).
     const tree = node("box", { width: 10 }, [
-      node("raw", { content: "ABCDEFGHIJKLMNOP" }),
+      node("raw", { content: "ABCDEFGHIJKLMNOP", wrap: false }),
     ]);
     const lines = render(tree, { cols: 80, rows: 24 }).split("\n");
     expect(_internal.visualWidth(lines[0])).toBe(10);
@@ -1586,5 +1588,75 @@ describe("table — _validateTable", () => {
     expect(v.header[0].type).toBe("text");
     expect(v.header[0].attrs.content).toBe("A");
     expect((v.body[0][0].attrs as { bold: boolean }).bold).toBe(true);
+  });
+});
+
+describe("raw", () => {
+  test("wraps by default (gets a wrapWidth) but not when wrap:false", () => {
+    const wrapped = _internal.resolveSizes(
+      node("box", { width: 30 }, [node("raw", { content: "x", wrap: true })]),
+      { cols: 80, rows: 24 },
+    );
+    expect(wrapped.children[0].attrs.wrapWidth).toBe(28);
+
+    const preserved = _internal.resolveSizes(
+      node("box", { width: 30 }, [node("raw", { content: "x", wrap: false })]),
+      { cols: 80, rows: 24 },
+    );
+    expect(preserved.children[0].attrs.wrapWidth).toBeUndefined();
+  });
+
+  test("raw wraps content to the box exactly like text, adding no styling", () => {
+    const out = render(
+      node("box", { width: 12, padding: 1 }, [
+        node("raw", { content: "the quick brown fox" }),
+      ]),
+      { cols: 80, rows: 24 },
+    );
+    expect(out).toBe(
+      [
+        "╭──────────╮",
+        "│          │",
+        "│ the      │",
+        "│ quick    │",
+        "│ brown    │",
+        "│ fox      │",
+        "│          │",
+        "╰──────────╯",
+      ].join("\n"),
+    );
+  });
+
+  test("wrapped colored content survives AND never leaves an open SGR at a line boundary", () => {
+    const colored = "\x1b[31malpha beta gamma delta epsilon\x1b[0m";
+    const out = _render(
+      node("box", { width: 16, padding: 1 }, [node("raw", { content: colored })]),
+      true, 80, 24,
+    );
+    // Colors survive (kills a "strip all ANSI" render bug).
+    expect(out).toContain("\x1b[31m");
+    // No style bleeds past a line boundary -> borders/padding stay uncolored.
+    // Independent re-implementation of the scan on purpose: a bug shared with
+    // updateActiveSgr would otherwise mask itself in this oracle.
+    const openAtEnd = (line: string): string => {
+      let active = "";
+      for (const match of line.matchAll(/\x1b\[[\d;]*m/g)) {
+        const params = match[0].slice(2, -1);
+        active = params === "" || params === "0" ? "" : active + match[0];
+      }
+      return active;
+    };
+    for (const line of out.split("\n")) expect(openAtEnd(line)).toBe("");
+  });
+
+  test("raw right-aligns short wrapped lines when align:end", () => {
+    const out = render(
+      node("box", { width: 10, padding: 0 }, [
+        node("raw", { content: "a\nbbbb", align: "end" }),
+      ]),
+      { cols: 80, rows: 24 },
+    );
+    // "a" is padded on the LEFT to line up under "bbbb" (right alignment).
+    expect(out).toContain("   a");
   });
 });

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -84,15 +84,67 @@ describe("wrapText", () => {
       .toEqual(["\x1b[31mhello\x1b[0m", "world"]);
   });
 
-  test("breaks a long colored word at the column boundary while keeping CSI escapes intact", () => {
-    // The break must happen at a visual-cell boundary (width=4), not
-    // mid-escape. Both pieces of the broken token must keep the
-    // CSI bytes that landed inside their span.
+  test("breaks a long colored word at the column boundary, self-closing each line", () => {
     expect(_internal.wrapText("\x1b[31mabcdefghij\x1b[0m", 4)).toEqual([
-      "\x1b[31mabcd",
-      "efgh",
-      "ij\x1b[0m",
+      "\x1b[31mabcd\x1b[0m",
+      "\x1b[31mefgh\x1b[0m",
+      "\x1b[31mij\x1b[0m",
     ]);
+  });
+
+  test("reopens the active style on each wrapped line and resets at its end", () => {
+    expect(_internal.wrapText("\x1b[2mAAAA BBBB CCCC\x1b[0m", 9)).toEqual([
+      "\x1b[2mAAAA BBBB\x1b[0m",
+      "\x1b[2mCCCC\x1b[0m",
+    ]);
+  });
+
+  test("accumulates stacked codes and reopens ALL of them on continuation lines", () => {
+    // No reset in the input: both fg (31) and bold (1) stay active and must
+    // both be reopened on every continuation line. Kills a keep-last-code bug.
+    expect(_internal.wrapText("\x1b[31m\x1b[1mred bold text here", 8)).toEqual([
+      "\x1b[31m\x1b[1mred bold\x1b[0m",
+      "\x1b[31m\x1b[1mtext\x1b[0m",
+      "\x1b[31m\x1b[1mhere\x1b[0m",
+    ]);
+  });
+
+  test("a full reset (\\x1b[0m and \\x1b[m) clears the carried style", () => {
+    expect(_internal.wrapText("\x1b[31mred one\x1b[0m two three", 7)).toEqual([
+      "\x1b[31mred one\x1b[0m",
+      "two",
+      "three",
+    ]);
+    // Empty-params reset `\x1b[m` also clears.
+    expect(_internal.wrapText("\x1b[31mfoo\x1b[m bar", 3)).toEqual([
+      "\x1b[31mfoo\x1b[m",
+      "bar",
+    ]);
+  });
+
+  test("carries style across a literal newline boundary too", () => {
+    // Style opened on one source line, reset two lines later: each emitted
+    // visual line is still self-contained.
+    expect(_internal.wrapText("\x1b[31mfoo\nbar\x1b[0m", 10)).toEqual([
+      "\x1b[31mfoo\x1b[0m",
+      "\x1b[31mbar\x1b[0m",
+    ]);
+  });
+
+  test("non-SGR CSI (cursor/erase) passes through inline and is never reopened", () => {
+    // \x1b[2K is a CSI but not an SGR (ends in K). It must not enter the
+    // active-style state or be replayed on later lines.
+    expect(_internal.wrapText("\x1b[2Kfoo bar", 3)).toEqual([
+      "\x1b[2Kfoo",
+      "bar",
+    ]);
+  });
+
+  test("plain text and empty strings are unaffected by SGR handling", () => {
+    expect(_internal.wrapText("hello world", 5)).toEqual(["hello", "world"]);
+    expect(_internal.wrapText("hello  ", 10)).toEqual(["hello  "]);
+    expect(_internal.wrapText("", 5)).toEqual([""]);
+    expect(_internal.wrapText("hello", 0)).toEqual([]);
   });
 });
 

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -140,6 +140,18 @@ describe("wrapText", () => {
     ]);
   });
 
+  test("a blank line inside an active style span is self-contained", () => {
+    // The empty middle line reopens+resets the carried style (never dropped)
+    // and the style still continues on the next line.
+    expect(_internal.wrapText("\x1b[31mfoo\n\nbar\x1b[0m", 10)).toEqual([
+      "\x1b[31mfoo\x1b[0m",
+      "\x1b[31m\x1b[0m",
+      "\x1b[31mbar\x1b[0m",
+    ]);
+    // With no active style, a blank line stays truly empty.
+    expect(_internal.wrapText("foo\n\nbar", 10)).toEqual(["foo", "", "bar"]);
+  });
+
   test("plain text and empty strings are unaffected by SGR handling", () => {
     expect(_internal.wrapText("hello world", 5)).toEqual(["hello", "world"]);
     expect(_internal.wrapText("hello  ", 10)).toEqual(["hello  "]);

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -152,6 +152,24 @@ describe("wrapText", () => {
     expect(_internal.wrapText("foo\n\nbar", 10)).toEqual(["foo", "", "bar"]);
   });
 
+  test("reopens a 24-bit / multi-param SGR code on continuation lines", () => {
+    // The real codes the renderer emits (sgr() -> \x1b[38;2;r;g;bm) carry
+    // semicolons; they must be treated as one SGR unit and fully reopened.
+    expect(_internal.wrapText("\x1b[38;2;1;2;3mfoo bar baz", 7)).toEqual([
+      "\x1b[38;2;1;2;3mfoo bar\x1b[0m",
+      "\x1b[38;2;1;2;3mbaz\x1b[0m",
+    ]);
+  });
+
+  test("after a reset, only the new color is reopened on the next line", () => {
+    // red closes, green opens, then wrap: the second line reopens green only
+    // (not the reset-away red). Exercises clear-then-accumulate.
+    expect(_internal.wrapText("\x1b[31mred\x1b[0m \x1b[32mgreen text", 9)).toEqual([
+      "\x1b[31mred\x1b[0m \x1b[32mgreen\x1b[0m",
+      "\x1b[32mtext\x1b[0m",
+    ]);
+  });
+
   test("plain text and empty strings are unaffected by SGR handling", () => {
     expect(_internal.wrapText("hello world", 5)).toEqual(["hello", "world"]);
     expect(_internal.wrapText("hello  ", 10)).toEqual(["hello  "]);
@@ -198,6 +216,17 @@ describe("resolveSizes", () => {
     // content-driven (no defaultWidth → not stretched to fill).
     expect(resolved.children[0].attrs.wrapWidth).toBe(20);
     expect(resolved.children[1].attrs.wrapWidth).toBe(20);
+  });
+
+  test("row subtracts gap from the ceiling it caps children at", () => {
+    const tree = node("row", { width: 20, gap: 2 }, [
+      node("text", { content: "a" }),
+      node("text", { content: "b" }),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    // inner = 20 − (2 children − 1) * gap 2 = 18.
+    expect(resolved.children[0].attrs.wrapWidth).toBe(18);
+    expect(resolved.children[1].attrs.wrapWidth).toBe(18);
   });
 
   test("unsized box wraps content at the available width (shrink-to-fit ceiling)", () => {
@@ -1618,6 +1647,14 @@ describe("raw", () => {
     expect(preserved.children[0].attrs.wrapWidth).toBeUndefined();
   });
 
+  test("raw also degrades to no wrapWidth when the ceiling clamps to 0", () => {
+    // sizeRaw shares wrapWidthFor's ≤0 guard: over-padded unsized box → the
+    // raw content stays present (overflow), not annotated to wrap at 0.
+    const tree = node("box", { padding: 20 }, [node("raw", { content: "hello" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 30, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBeUndefined();
+  });
+
   test("raw wraps content to the box exactly like text, adding no styling", () => {
     const out = render(
       node("box", { width: 12, padding: 1 }, [
@@ -1659,6 +1696,17 @@ describe("raw", () => {
       return active;
     };
     for (const line of out.split("\n")) expect(openAtEnd(line)).toBe("");
+
+    // Background colors must also reset before the border/padding, so the
+    // frame never inherits the bg on wrapped rows.
+    const bg = _render(
+      node("box", { width: 16, padding: 1 }, [
+        node("raw", { content: "\x1b[41malpha beta gamma delta epsilon\x1b[0m" }),
+      ]),
+      true, 80, 24,
+    );
+    expect(bg).toContain("\x1b[41m");
+    for (const line of bg.split("\n")) expect(openAtEnd(line)).toBe("");
   });
 
   test("raw right-aligns short wrapped lines when align:end", () => {

--- a/packages/agency-lang/lib/stdlib/layout.test.ts
+++ b/packages/agency-lang/lib/stdlib/layout.test.ts
@@ -176,14 +176,52 @@ describe("resolveSizes", () => {
     expect(row.children.map((child) => child.attrs.resolvedWidth)).toEqual([20, 20]);
   });
 
-  test("row does not give full width to every unsized child", () => {
+  test("row caps unsized children at its width but does not fill them", () => {
     const tree = node("row", { width: 20 }, [
       node("text", { content: "first child is long" }),
       node("text", { content: "second child is long" }),
     ]);
     const resolved = _internal.resolveSizes(tree, { cols: 80, rows: 24 });
+    // Ceiling = row inner width (20, gap 0); children wrap at it but stay
+    // content-driven (no defaultWidth → not stretched to fill).
+    expect(resolved.children[0].attrs.wrapWidth).toBe(20);
+    expect(resolved.children[1].attrs.wrapWidth).toBe(20);
+  });
+
+  test("unsized box wraps content at the available width (shrink-to-fit ceiling)", () => {
+    // ceiling = viewport 40 − box chrome (2 border, 0 padding) = 38.
+    const tree = node("box", { padding: 0 }, [node("text", { content: "x" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 40, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBe(38);
+  });
+
+  test("unsized box ceiling subtracts padding on both sides", () => {
+    // chrome = 2 border + 2*2 padding = 6; ceiling = 40 − 6 = 34.
+    const tree = node("box", { padding: 2 }, [node("text", { content: "x" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 40, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBe(34);
+  });
+
+  test("nested unsized boxes subtract chrome at each level", () => {
+    const tree = node("box", { padding: 0 }, [
+      node("box", { padding: 0 }, [node("text", { content: "x" })]),
+    ]);
+    const resolved = _internal.resolveSizes(tree, { cols: 40, rows: 24 });
+    // outer ceiling 40−2 = 38; inner ceiling 38−2 = 36.
+    expect(resolved.children[0].children[0].attrs.wrapWidth).toBe(36);
+  });
+
+  test("unsized column wraps its children at the available width", () => {
+    const tree = node("column", {}, [node("text", { content: "x" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 30, rows: 24 });
+    expect(resolved.children[0].attrs.wrapWidth).toBe(30);
+  });
+
+  test("never assigns wrapWidth ≤ 0 — content degrades to overflow, not to nothing", () => {
+    // chrome 2 + 2*20 = 42 > viewport 30 → ceiling clamps to 0 → no wrapWidth.
+    const tree = node("box", { padding: 20 }, [node("text", { content: "hello" })]);
+    const resolved = _internal.resolveSizes(tree, { cols: 30, rows: 24 });
     expect(resolved.children[0].attrs.wrapWidth).toBeUndefined();
-    expect(resolved.children[1].attrs.wrapWidth).toBeUndefined();
   });
 
   test("uses clamped integer padding and gap when resolving child width", () => {

--- a/packages/agency-lang/lib/stdlib/layout/ansi.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.ts
@@ -16,9 +16,41 @@ export function stripAnsi(s: string): string {
   return s.replace(CSI_RE, "");
 }
 
+// Matches SGR sequences only (CSI … `m`), not other CSI like cursor/erase.
+const SGR_RE = /\x1b\[[\d;]*m/g;
+
+// Track the SGR run active since the last full reset. `\x1b[0m` / `\x1b[m`
+// clears it; any other SGR sequence accumulates. (v1: partial attribute-off
+// codes and compound resets like `\x1b[0;31m` are treated as accumulating —
+// see the layout design doc.)
+function updateActiveSgr(active: string, segment: string): string {
+  let result = active;
+  for (const match of segment.matchAll(SGR_RE)) {
+    const params = match[0].slice(CSI.length, -1);
+    result = params === "" || params === "0" ? "" : result + match[0];
+  }
+  return result;
+}
+
+// Make each wrapped segment self-contained: re-open the SGR state active at
+// its start and close with RESET when anything is still open at its end.
+// Each output is derived purely from its inputs so statement order can't
+// silently break it.
+function reinjectSgr(segments: string[]): string[] {
+  let active = "";
+  return segments.map((segment) => {
+    if (segment === "") return "";
+    const opened = active;
+    const closed = updateActiveSgr(opened, segment);
+    active = closed;
+    return opened + segment + (closed === "" ? "" : RESET);
+  });
+}
+
 export function wrapText(content: string, width: number): string[] {
   if (width <= 0) return [];
-  return content.split("\n").flatMap((line) => wrapSingleLine(line, width));
+  const segments = content.split("\n").flatMap((line) => wrapSingleLine(line, width));
+  return reinjectSgr(segments);
 }
 
 function wrapSingleLine(line: string, width: number): string[] {

--- a/packages/agency-lang/lib/stdlib/layout/ansi.ts
+++ b/packages/agency-lang/lib/stdlib/layout/ansi.ts
@@ -35,15 +35,18 @@ function updateActiveSgr(active: string, segment: string): string {
 // Make each wrapped segment self-contained: re-open the SGR state active at
 // its start and close with RESET when anything is still open at its end.
 // Each output is derived purely from its inputs so statement order can't
-// silently break it.
+// silently break it. A blank line inside an active style span is still made
+// self-contained (`<open><RESET>`) rather than special-cased to "" — this
+// keeps the invariant uniform (only a few zero-width bytes) so a style is
+// never dropped mid-span; when no style is active a blank line stays "".
 function reinjectSgr(segments: string[]): string[] {
   let active = "";
   return segments.map((segment) => {
-    if (segment === "") return "";
     const opened = active;
     const closed = updateActiveSgr(opened, segment);
     active = closed;
-    return opened + segment + (closed === "" ? "" : RESET);
+    const suffix = closed === "" ? "" : RESET;
+    return opened + segment + suffix;
   });
 }
 

--- a/packages/agency-lang/lib/stdlib/layout/axis.ts
+++ b/packages/agency-lang/lib/stdlib/layout/axis.ts
@@ -147,7 +147,11 @@ export function composeColumn(node: LayoutNode): Block { return composeAxis(node
 function sizeColumn(node: LayoutNode, ctx: SizingContext): LayoutNode {
   const own = resolveOwnWidth(node, ctx);
   // Columns stack vertically; horizontal width is shared with every child.
-  return resolveContainer(node, own, { defaultWidth: own, percentBasis: own });
+  return resolveContainer(node, own, {
+    defaultWidth: own,
+    percentBasis: own,
+    availableWidth: own ?? ctx.availableWidth,
+  });
 }
 
 function sizeRow(node: LayoutNode, ctx: SizingContext): LayoutNode {
@@ -155,9 +159,14 @@ function sizeRow(node: LayoutNode, ctx: SizingContext): LayoutNode {
   const gap = nonNegativeInteger(node.attrs.gap);
   const gapTotal = Math.max(0, node.children.length - 1) * gap;
   const inner = innerWidthAfterChrome(own, gapTotal);
-  // Row children stay natural width unless they declare their own
-  // width; percentages compute against the row's inner space.
-  return resolveContainer(node, own, { defaultWidth: undefined, percentBasis: inner });
+  // Row children stay natural width (no defaultWidth → not filled), but are
+  // capped at the row's available width so a lone wide child wraps instead
+  // of overflowing. Per-child horizontal distribution is a non-goal.
+  return resolveContainer(node, own, {
+    defaultWidth: undefined,
+    percentBasis: inner,
+    availableWidth: inner ?? ctx.availableWidth,
+  });
 }
 
 export const row:    NodeHandler = { size: sizeRow,    render: composeRow };

--- a/packages/agency-lang/lib/stdlib/layout/box.ts
+++ b/packages/agency-lang/lib/stdlib/layout/box.ts
@@ -39,11 +39,19 @@ export function composeBox(node: LayoutNode): Block {
 function sizeBox(node: LayoutNode, ctx: SizingContext): LayoutNode {
   const own = resolveOwnWidth(node, ctx);
   const padding = nonNegativeInteger(node.attrs.padding);
-  const inner = innerWidthAfterChrome(own, BORDER_CELLS + 2 * padding);
+  const chrome = BORDER_CELLS + 2 * padding;
+  const inner = innerWidthAfterChrome(own, chrome);
   // Box children either occupy the inner width directly (single child)
   // or are wrapped in an implicit column, which itself fills the inner
-  // width. Either way, children fill.
-  return resolveContainer(node, own, { defaultWidth: inner, percentBasis: inner });
+  // width. Either way, children fill. When unsized, the wrap ceiling is
+  // the parent ceiling minus this box's chrome (`own ?? ctx.availableWidth`
+  // collapses both the sized and unsized cases).
+  const available = innerWidthAfterChrome(own ?? ctx.availableWidth, chrome);
+  return resolveContainer(node, own, {
+    defaultWidth: inner,
+    percentBasis: inner,
+    availableWidth: available,
+  });
 }
 
 export const box: NodeHandler = { size: sizeBox, render: composeBox };

--- a/packages/agency-lang/lib/stdlib/layout/nodes.ts
+++ b/packages/agency-lang/lib/stdlib/layout/nodes.ts
@@ -148,12 +148,22 @@ export const LEAF_RENDERERS: Record<
   },
 };
 
-function sizeText(node: LayoutNode, ctx: SizingContext): LayoutNode {
-  // Text doesn't track a resolvedWidth; instead it gets a wrapWidth so
-  // its content wraps to the inline space the parent allocated.
+// The wrap width a leaf should use: its imposed width if any, else the
+// available ceiling. Returns undefined when unbounded OR when the width is
+// ≤ 0 (chrome ≥ available), so the leaf degrades to overflow — never to
+// empty (wrapText returns [] for width ≤ 0).
+function wrapWidthFor(node: LayoutNode, ctx: SizingContext): number | undefined {
   const own = resolveOwnWidth(node, ctx);
-  if (own === undefined) return node;
-  return setAttr(node, "wrapWidth", own);
+  const width = own ?? ctx.availableWidth;
+  return width !== undefined && width > 0 ? width : undefined;
+}
+
+function sizeText(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  // Text doesn't track a resolvedWidth; instead it gets a wrapWidth so its
+  // content wraps to the inline space the parent allocated (or the ceiling).
+  const width = wrapWidthFor(node, ctx);
+  if (width === undefined) return node;
+  return setAttr(node, "wrapWidth", width);
 }
 
 function passthrough(node: LayoutNode, _ctx: SizingContext): LayoutNode {

--- a/packages/agency-lang/lib/stdlib/layout/nodes.ts
+++ b/packages/agency-lang/lib/stdlib/layout/nodes.ts
@@ -80,8 +80,11 @@ export function styleOf(attrs: Record<string, unknown>): Style {
 // (width = own width). The block is always returned as a tidy
 // rectangle (every line padded to the same width) so downstream
 // `beside` / `above` composition is well-behaved.
-export function alignedTextBlock(content: string, align: Align): Block {
-  const block = Block.of(content);
+// Wrap (or split on newlines) then align-pad to a tidy rectangle. Shared by
+// `text` and `raw`; `text` additionally wraps the result in `styled`.
+function wrappedBlock(content: string, wrapWidth: number | undefined, align: Align): Block {
+  const lines = wrapWidth !== undefined ? wrapText(content, wrapWidth) : content.split("\n");
+  const block = Block.of(lines);
   return pad(block, block.width, block.height, align, "start");
 }
 
@@ -109,14 +112,15 @@ export const LEAF_RENDERERS: Record<
     const content   = asString(n.attrs.content);
     const align     = (n.attrs.align as Align) ?? "start";
     const wrapWidth = n.attrs.wrapWidth as number | undefined;
-    const lines = wrapWidth !== undefined ? wrapText(content, wrapWidth) : content.split("\n");
-    const block = Block.of(lines);
-    return styled(pad(block, block.width, block.height, align, "start"), styleOf(n.attrs));
+    return styled(wrappedBlock(content, wrapWidth, align), styleOf(n.attrs));
   },
   raw: (n) => {
-    const content = asString(n.attrs.content);
-    const align   = (n.attrs.align as Align) ?? "start";
-    return alignedTextBlock(content, align);
+    const content   = asString(n.attrs.content);
+    const align     = (n.attrs.align as Align) ?? "start";
+    const wrapWidth = n.attrs.wrapWidth as number | undefined;
+    // No `styled` wrapper: raw carries its own ANSI and must not have
+    // styling re-applied over it.
+    return wrappedBlock(content, wrapWidth, align);
   },
   space: (_n) => {
     throw new Error(
@@ -166,12 +170,21 @@ function sizeText(node: LayoutNode, ctx: SizingContext): LayoutNode {
   return setAttr(node, "wrapWidth", width);
 }
 
+function sizeRaw(node: LayoutNode, ctx: SizingContext): LayoutNode {
+  // wrap:false preserves exact layout (ASCII art / pre-rendered tables):
+  // no wrapWidth, so the renderer splits on newlines only.
+  if (node.attrs.wrap === false) return node;
+  const width = wrapWidthFor(node, ctx);
+  if (width === undefined) return node;
+  return setAttr(node, "wrapWidth", width);
+}
+
 function passthrough(node: LayoutNode, _ctx: SizingContext): LayoutNode {
   return node;
 }
 
 export const text:  NodeHandler = { size: sizeText,    render: LEAF_RENDERERS.text };
-export const raw:   NodeHandler = { size: passthrough, render: LEAF_RENDERERS.raw };
+export const raw:   NodeHandler = { size: sizeRaw,     render: LEAF_RENDERERS.raw };
 export const space: NodeHandler = { size: passthrough, render: LEAF_RENDERERS.space };
 export const hline: NodeHandler = { size: passthrough, render: LEAF_RENDERERS.hline };
 export const vline: NodeHandler = { size: passthrough, render: LEAF_RENDERERS.vline };

--- a/packages/agency-lang/lib/stdlib/layout/render.ts
+++ b/packages/agency-lang/lib/stdlib/layout/render.ts
@@ -105,7 +105,11 @@ export function resolveSizes(node: LayoutNode, viewport: Viewport): LayoutNode {
   // percent basis (so `width: "full"` / `width: "100%"` at the root mean
   // "fill the terminal columns") but does not impose a default width
   // (so unsized roots stay content-driven).
-  return resolveNode(node, { defaultWidth: undefined, percentBasis: viewport.cols });
+  return resolveNode(node, {
+    defaultWidth: undefined,
+    percentBasis: viewport.cols,
+    availableWidth: viewport.cols,
+  });
 }
 
 export function resolveNode(node: LayoutNode, ctx: SizingContext): LayoutNode {

--- a/packages/agency-lang/lib/stdlib/layout/sizing.ts
+++ b/packages/agency-lang/lib/stdlib/layout/sizing.ts
@@ -17,6 +17,10 @@ export type SizingContext = {
   // The width that percentages and "full" compute against. Undefined
   // when no enclosing ancestor has a resolved width.
   percentBasis: number | undefined;
+  // The max width content may occupy before it must wrap. A content-driven
+  // leaf with no imposed width wraps at this ceiling instead of overflowing.
+  // Optional: table cell contexts impose explicit widths and omit it.
+  availableWidth?: number | undefined;
 };
 
 // One node type's two behaviors, paired. `size` is phase 1 (resolve

--- a/packages/agency-lang/stdlib/ui/layout.agency
+++ b/packages/agency-lang/stdlib/ui/layout.agency
@@ -16,8 +16,10 @@ import { _render } from "agency-lang/stdlib-lib/layout.js"
   ```
 
   Containers (`box`, `row`, `column`) take a `width`: a number of columns,
-  `"50%"` of the parent, or `"full"` for the whole terminal. Text wraps to
-  fit; `raw` content never wraps.
+  `"50%"` of the parent, or `"full"` for the whole terminal. Content wraps to
+  fit its container; pass `wrap: false` to `raw` to preserve exact layout
+  (ASCII art, pre-rendered tables). Unsized containers shrink to fit their
+  content but cap at the available width, wrapping anything longer.
 
   For live, redrawing UIs with input handling, use `std::ui` instead.
 */
@@ -98,20 +100,25 @@ export safe def text(
   }
 }
 
-/** If the string carries its own ANSI sequences, nesting it inside a
-styled `text` or `box` won't re-apply styling after those sequences reset. */
-export safe def raw(content: string, align: Alignment = "start"): LayoutNode {
+/** Wraps to its container by default; pass `wrap: false` to preserve exact
+layout. Wrapping is ANSI-aware, so embedded color survives without bleeding
+into surrounding borders. */
+export safe def raw(content: string, align: Alignment = "start", wrap: boolean = true): LayoutNode {
   """
-  A pre-styled string, rendered as-is and never wrapped. Use it for ASCII art or strings that already carry their own styling.
+  A pre-styled string (may carry its own ANSI or newlines). Wraps to the
+  container width by default; pass wrap: false to render exactly as-is and
+  never reflow (ASCII art, pre-rendered tables).
 
   @param content - Raw string content (may contain ANSI codes or newlines)
   @param align - For multi-line content, how shorter lines align to the longest
+  @param wrap - Reflow to the container width (default true). false preserves the exact layout.
   """
   return {
     type: "raw",
     attrs: {
       content: content,
-      align: align
+      align: align,
+      wrap: wrap
     },
     children: []
   }
@@ -225,8 +232,9 @@ def _addRaw(
   kids: any[],
   content: string,
   align: Alignment = "start",
+  wrap: boolean = true,
 ): LayoutNode {
-  const n = raw(content: content, align: align)
+  const n = raw(content: content, align: align, wrap: wrap)
   kids.push(n)
   return n
 }

--- a/packages/agency-lang/tests/agency/layout/builders.test.json
+++ b/packages/agency-lang/tests/agency/layout/builders.test.json
@@ -15,7 +15,7 @@
     {
       "nodeName": "testRaw",
       "input": "",
-      "expectedOutput": "{\"type\":\"raw\",\"attrs\":{\"content\":\"\\u001b[31mpre-styled\\u001b[0m\",\"align\":\"start\"},\"children\":[]}",
+      "expectedOutput": "{\"type\":\"raw\",\"attrs\":{\"content\":\"\\u001b[31mpre-styled\\u001b[0m\",\"align\":\"start\",\"wrap\":true},\"children\":[]}",
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {

--- a/packages/agency-lang/tests/agency/layout/raw-wrap.agency
+++ b/packages/agency-lang/tests/agency/layout/raw-wrap.agency
@@ -1,0 +1,30 @@
+import { box, raw, render } from "std::ui/layout"
+
+// raw now wraps to the box exactly like text (default wrap: true).
+node testRawWrapsInBox(): string {
+  const panel = box(width: 12) as b {
+    b.raw("the quick brown fox")
+  }
+  return render(panel, color: false)
+}
+
+// Unsized box caps + wraps long content at the pinned viewport (headline fix).
+node testUnsizedBoxCapsAndWraps(): string {
+  const panel = box() as b {
+    b.text("the quick brown fox jumps over the lazy dog again")
+  }
+  return render(panel, color: false, cols: 16)
+}
+
+// Unsized box shrink-to-fits short content (does NOT blow up to full width).
+node testUnsizedBoxShrinkToFit(): string {
+  const panel = box() as b {
+    b.text("hi")
+  }
+  return render(panel, color: false, cols: 40)
+}
+
+// wrap: false forwards through the builder and preserves the exact node.
+node testRawWrapFalseNode() {
+  return raw("ascii-art-line", wrap: false)
+}

--- a/packages/agency-lang/tests/agency/layout/raw-wrap.test.json
+++ b/packages/agency-lang/tests/agency/layout/raw-wrap.test.json
@@ -1,0 +1,44 @@
+{
+  "tests": [
+    {
+      "nodeName": "testRawWrapsInBox",
+      "input": "",
+      "expectedOutput": "\"╭──────────╮\\n│          │\\n│ the      │\\n│ quick    │\\n│ brown    │\\n│ fox      │\\n│          │\\n╰──────────╯\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "testUnsizedBoxCapsAndWraps",
+      "input": "",
+      "expectedOutput": "\"╭──────────────╮\\n│              │\\n│ the quick    │\\n│ brown fox    │\\n│ jumps over   │\\n│ the lazy dog │\\n│ again        │\\n│              │\\n╰──────────────╯\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "testUnsizedBoxShrinkToFit",
+      "input": "",
+      "expectedOutput": "\"╭────╮\\n│    │\\n│ hi │\\n│    │\\n╰────╯\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "testRawWrapFalseNode",
+      "input": "",
+      "expectedOutput": "{\"type\":\"raw\",\"attrs\":{\"content\":\"ascii-art-line\",\"align\":\"start\",\"wrap\":false},\"children\":[]}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

Putting pre-colored, long-line content (e.g. a `std::syntax::diff(..., color: true)`) inside a `box` produced a shredded frame with no visible styling. Three independent `std::ui/layout` defects combined:

1. **`raw` never wrapped** — its sizing handler was `passthrough`, so a long line was emitted intact and overflowed the frame.
2. **Width-less containers didn't bound content** — an unsized box grew to the longest line, which overflowed the terminal and got hard-wrapped into garbage.
3. **Wrapping wasn't SGR-aware** — the opening ANSI landed on the first visual row and the reset only on the last, so container borders/padding on wrapped rows inherited the color/dim.

This PR fixes all three so the naive "colored string in a box" case just works.

## Changes

- **SGR-aware `wrapText`** (`ansi.ts`): every emitted visual line is now self-contained — it re-opens the SGR state active at its start and closes with `RESET` when a style is still open. Holds at every boundary, including literal `\n`. v1 tracks styling by sequence-accumulation (correct for the set-then-full-reset content `std::syntax`/highlighters emit); partial attribute-off codes and compound resets are documented follow-ups. `text` benefits for free (shared code path).
- **Shrink-to-fit `availableWidth` ceiling** (`sizing.ts`/`render.ts`/`box.ts`/`axis.ts`/`nodes.ts`): a content-driven leaf with no imposed width now wraps at the terminal/parent width instead of overflowing; short content still shrink-fits. Threaded root → box → column → row. `row` caps its children at the row width (they wrap but are not filled); per-child horizontal distribution stays a non-goal. A shared `wrapWidthFor` helper guards against `wrapWidth <= 0` (chrome >= available) so content degrades to overflow, never to empty — this also fixes a pre-existing bug where a too-narrow sized box vanished its text.
- **`raw` gains `wrap`** (`layout.agency` + `nodes.ts`): `raw(content, align, wrap = true)` reflows to its container like `text` (applying no styling of its own), sharing `wrapWidthFor` and a new `wrappedBlock` helper. `wrap: false` preserves the exact, unwrapped layout for ASCII art / pre-rendered tables. `wrap` is appended last so positional `raw(content, align)` callers keep working.

## Verified

- 200 layout unit tests (`lib/stdlib/layout.test.ts`), `tsc --noEmit` clean, structural linter clean.
- All 12 layout Agency fixtures pass (no unsized-container regressions); new `raw-wrap.agency` exercises the full Agency→render path (sized-box wrap, unsized cap+wrap, shrink-to-fit, `wrap: false` through the builder).
- End-to-end: a real colored multi-line string in an unsized box wraps, keeps its colors, and leaves 0 open SGR at any line boundary (borders untinted).

## Scoping notes / follow-ups

- **Table cells are intentionally unchanged.** `table.ts` already short-circuits `raw` cells to literal, so raw-in-a-table-cell stays literal (not wrapped). Whether raw should wrap to the column width like `text` cells is left as an open question rather than silently changed here.
- Not addressed (separate/deferred): the `render()` `color: "auto"` detection bug under the CLI runner (#453); a full `Style`-based SGR parser; `row` horizontal width distribution.

Design + plan committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
