### PR TITLE
Speed up CI: parse cache, test-runner precompile, split workflow jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,14 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        # Don't write GITHUB_TOKEN into .git/config: no step does
+        # authenticated git operations afterward (the coverage comment
+        # authenticates via github-script's injected client), and these
+        # jobs execute PR-controlled code — the agency tests compile and
+        # run programs from the PR — which could otherwise read the
+        # persisted token.
+        persist-credentials: false
 
     - name: Set up pnpm
       uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -116,6 +124,14 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        # Don't write GITHUB_TOKEN into .git/config: no step does
+        # authenticated git operations afterward (the coverage comment
+        # authenticates via github-script's injected client), and these
+        # jobs execute PR-controlled code — the agency tests compile and
+        # run programs from the PR — which could otherwise read the
+        # persisted token.
+        persist-credentials: false
 
     - name: Set up pnpm
       uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -217,6 +233,8 @@ jobs:
       TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,24 +12,13 @@ on:
 permissions:
   contents: read
 
+# The test suites are split across two parallel jobs (`build` and
+# `agency-tests`) to cut wall-clock time. Each job is self-contained — it
+# runs its own `pnpm install && make` (~2 min) rather than sharing a build
+# artifact, which would serialize the jobs and cost about as much in
+# upload/download as it saves.
 jobs:
   build:
-    # `pull-requests: write` is required so the coverage reporter can post
-    # a sticky comment on PRs.
-    #
-    # Security notes:
-    #   * This workflow uses `pull_request`, NOT `pull_request_target`. PRs
-    #     from forks therefore receive a read-only `GITHUB_TOKEN` regardless
-    #     of the `permissions:` block, so a fork cannot abuse this scope.
-    #   * For same-repo PRs the author already has push access, so the
-    #     incremental risk of granting comment-write to that PR's workflow
-    #     run is minimal.
-    #   * The post step is wrapped with `continue-on-error: true` so that a
-    #     missing/restricted token never fails the build.
-    permissions:
-      contents: read
-      pull-requests: write
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -90,6 +79,57 @@ jobs:
         CI: "true"
       run: node tests/integration/stdlib-sandbox/run.mjs
       timeout-minutes: 10
+    - name: Built-in agent tests
+      working-directory: packages/agency-lang
+      env:
+        AGENCY_USE_TEST_LLM_PROVIDER: "1"
+      # Smoke tests for the agents bundled under lib/agents/ (deterministic
+      # LLM provider, no API key). Catches wiring regressions like duplicate
+      # tool names that only surface when an agent actually issues an LLM
+      # call. Lives in this job (not agency-tests) for load balance — it
+      # collects no coverage, so it has no coupling to the coverage steps.
+      run: pnpm run test:agents
+
+  agency-tests:
+    # `pull-requests: write` is required so the coverage reporter can post
+    # a sticky comment on PRs.
+    #
+    # Security notes:
+    #   * This workflow uses `pull_request`, NOT `pull_request_target`. PRs
+    #     from forks therefore receive a read-only `GITHUB_TOKEN` regardless
+    #     of the `permissions:` block, so a fork cannot abuse this scope.
+    #   * For same-repo PRs the author already has push access, so the
+    #     incremental risk of granting comment-write to that PR's workflow
+    #     run is minimal.
+    #   * The post step is wrapped with `continue-on-error: true` so that a
+    #     missing/restricted token never fails the build.
+    permissions:
+      contents: read
+      pull-requests: write
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x, 23.x]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Set up pnpm
+      uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      with:
+        version: 9
+        run_install: false
+
+    - name: Set up Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+    - run: pnpm install
+    - run: make
     - name: Agency execution tests
       working-directory: packages/agency-lang
       env:
@@ -113,14 +153,6 @@ jobs:
         else
           pnpm run test:agency-js
         fi
-    - name: Built-in agent tests
-      working-directory: packages/agency-lang
-      env:
-        AGENCY_USE_TEST_LLM_PROVIDER: "1"
-      # Smoke tests for the agents bundled under lib/agents/ (deterministic
-      # LLM provider, no API key). Catches wiring regressions like duplicate
-      # tool names that only surface when an agent actually issues an LLM call.
-      run: pnpm run test:agents
     - name: Generate stdlib coverage report
       if: matrix.node-version == '22.x' && always() && !cancelled()
       working-directory: packages/agency-lang

--- a/docs/superpowers/specs/2026-07-07-ci-compile-caching-design-review.md
+++ b/docs/superpowers/specs/2026-07-07-ci-compile-caching-design-review.md
@@ -1,0 +1,109 @@
+# Review: CI Compile Caching + Job Split — Design
+
+Date: 2026-07-07
+Spec: `2026-07-07-ci-compile-caching-design.md`
+Verdict: **Sound and well-grounded.** Every factual claim checked against the code is
+accurate except one (coverage accumulation, finding 4). Two real gaps in Fix 2
+(findings 1 and 2) and one one-line omission (finding 3) should be folded into the
+spec before implementation. Fixes 1 and 3 are ready as written modulo small
+corrections.
+
+## Claims verified true
+
+- `lib/cli/commands.ts:177-235`: `compiledFiles` + `currentClosure` exist and
+  `ensureCompiledClosure` clears them exactly as described (rebuild whenever the
+  entry isn't covered by the current closure).
+- `preferCompiled` is already plumbed through both `ExecuteNodeAsyncArgs` and
+  `RunAgencyNodeArgs` (`lib/cli/util.ts:229,263,301`) and reuses the sibling `.js`.
+- `SymbolTable.build`'s `visit()` (`lib/symbolTable.ts:147`) and
+  `buildCompiledClosure` (`lib/compiler/compileClosure.ts:255-257`) both re-read
+  and re-parse from disk with no caching.
+- The AST-mutation concern justifying `structuredClone` is real: `compile()` →
+  `resolveImports`/`resolveReExports`, pattern lowering, and typechecker
+  annotation all mutate the AST in place. The planned clone-isolation unit test
+  will also catch a `DataCloneError` if the AST ever holds non-cloneable values.
+- `testTs()` already compiles once per dir with the local-config merge
+  (`lib/cli/test.ts:1009-1015`), and `runTestFile` does the same merge
+  (`lib/cli/test.ts:730-733`).
+- The CI job split maps cleanly onto the actual steps in
+  `.github/workflows/test.yml`; the permissions change and the
+  push-to-main/22.x-only conditional moves are all correct.
+
+## Findings
+
+### 1. Fix 2's "staleness impossible by construction" has an unguarded config dimension
+
+Compiled output is config-dependent — the generator bakes config into emitted
+code (`lib/backends/typescriptBuilder.ts:348` `configDefaults`, `:3848`
+`buildSmoltalkDefaults`). Sibling `.js` is a single slot per module, so if a
+module were reachable from two entries whose merged configs differ (a
+local-`agency.json` dir importing a shared helper, or a base-config test
+importing into such a dir), precompile is last-writer-wins and `preferCompiled`
+runs the wrong config's code. Today's per-case recompile rewrites the closure
+with the correct config just before each spawn, so this is a genuine semantic
+change.
+
+Checked all 16 local-config dirs under `tests/`: none currently imports outside
+its own directory, so this is latent, not live — but nothing enforces it.
+
+**Recommendation:** the precompile pass should assert the invariant — any module
+reachable from entries with differing merged configs → fail loudly, or exclude
+those files from `preferCompiled` (fall back to per-case compile for them).
+
+### 2. Precompile will thrash the closure unless it uses the existing union-closure path
+
+"Precompile each unique source exactly once" via per-file `compile()` calls hits
+`ensureCompiledClosure`'s covers-check on nearly every file → ~870 closure
+rebuilds (each one an import-tree walk + init-topsort analysis; the parse cache
+makes them cheaper but not free).
+
+The codebase already owns the solution: `compile()` on a directory builds ONE
+union closure covering all entries (`lib/cli/commands.ts:282-317`), added
+precisely to avoid this thrash.
+
+**Recommendation:** group precompile entries by merged config — one union
+closure for all base-config files, plus one directory compile per local-config
+dir. Note this also weakens the out-of-scope rejection of "union-closure
+priming": the thrash argument applies to interleaved per-case compiles, not to
+a sequential, config-grouped precompile phase.
+
+### 3. Fix 2 omits `allowTestImports`
+
+The runner passes `allowTestImports: true` on every per-case compile today
+(`lib/cli/test.ts:586`), and the flag is documented as inert on the
+`preferCompiled` branch (`lib/cli/util.ts:264-266`) — so ALL
+`import test { … }` enforcement moves to the precompile pass. If precompile
+doesn't pass the flag, every test using test-only imports fails to compile.
+One line, but it's a correctness requirement the spec should state.
+
+### 4. Fix 3 misstates coverage accumulation
+
+`test:agents` is `test lib/agents -p 12` with **no** `--coverage`/`--accumulate`
+(`packages/agency-lang/package.json:12`); coverage accumulates across the
+agency (`--coverage`) and agency-js (`--coverage --accumulate`) steps only. The
+grouping still works, but the stated reason for pinning the agents step to
+`agency-tests` is wrong — that step is actually free to move to whichever job
+balances better, which matters since load-balancing is the whole point of
+Fix 3.
+
+### 5. Fix 1's open question about config-dependent parsing resolves cleanly
+
+The only `AgencyConfig` field the parse path reads is `tarsecTraceHost`
+(`lib/parser.ts:186`, debug tracing) — the cache needs no config in its key,
+just a bypass when tracing is on. Two adjacent nits:
+
+- `parseAgency` has a fourth param `lower` (the format path passes
+  `lower: false`) — pin the cache to `lower: true` or add it to the key before
+  any "opportunistic migration" touches the formatter.
+- Key on `mtimeMs` (ideally + size): second-granularity `mtime` can miss rapid
+  edits in watch mode, which is exactly the correctness story the spec leans on.
+
+### 6. Minor
+
+- `compile()` itself parses the entry a third time per compile
+  (`lib/cli/commands.ts:348`) — same mechanism, worth switching in the same
+  change rather than "opportunistically".
+- Cache successful parses only; the parser's module-global error state
+  (`getErrorMessage`, rightmost failure) is populated per-parse. Confirmed
+  nothing reads parse-global state (`getInputStr`/template offset) after a
+  successful parse, so cache hits skipping those side effects are safe.

--- a/docs/superpowers/specs/2026-07-07-ci-compile-caching-design.md
+++ b/docs/superpowers/specs/2026-07-07-ci-compile-caching-design.md
@@ -1,0 +1,155 @@
+# CI Compile Caching + Job Split — Design
+
+Date: 2026-07-07
+Status: Approved
+
+## Problem
+
+CI wall-clock for the `build (22.x)` job grew from ~14 min (2026-07-01) to ~24 min
+(2026-07-07). Root-cause analysis of run 28549258023 (fast) vs 28902551402 (slow):
+
+1. **Every Agency compile got ~60% slower** (avg 211ms → 341ms on identical
+   files; identical-file compile total 133s → 218s). Driver: stdlib growth —
+   `stdlib/index.agency` (auto-imported into every program) grew 301 → 519
+   lines when the std::array functions moved into it (`cce04f10`), plus new
+   modules (std::git, std::data/finance, littlesis, std::tag). Neither
+   `buildCompiledClosure` nor `SymbolTable.build` caches parses: each compile
+   re-reads and re-parses the full stdlib prelude chain from disk. Measured
+   locally: a trivial 8-line test file compiles in ~135ms, of which ~55ms is
+   `buildCompiledClosure` and ~37ms is `SymbolTable.build`.
+
+2. **The test runner compiles once per test *case*, not per file.** Each
+   `executeNodeAsync` → `runAgencyNode` → `compile()`. The per-session cache in
+   `lib/cli/commands.ts` (`compiledFiles` + `currentClosure`) is cleared by
+   `ensureCompiledClosure` whenever the entry file is not covered by the
+   current closure — and with `-p 12` interleaving test files, it almost never
+   is. Result: ~1750 compiles per CI run for ~870 unique files; the
+   agency-agent module tree (~15 modules, `agent.agency` alone 1.3–1.8s)
+   recompiles for every one of ~120 agent test cases (612 → 1181 compiles in
+   the "Built-in agent tests" step after the attachments/imageTool/gitPolicy
+   test additions).
+
+3. All test suites run sequentially inside one job.
+
+## Fix 1: Parse cache
+
+New module `lib/parseCache.ts` exporting `parseAgencyFileCached(absPath,
+config, applyTemplate)`:
+
+- Process-wide cache keyed by `(absolute path, mtime, applyTemplate)`.
+- Key on `mtimeMs` + file size (not second-granularity `mtime`, which can miss
+  rapid successive edits in watch mode). Stdlib files never change mid-run so
+  they hit ~always.
+- **Returns a `structuredClone` of the cached AST.** Downstream code mutates
+  ASTs in place (`compile()` rewrites `node.modulePath`; the typechecker
+  annotates nodes), so sharing one object across consumers would corrupt
+  state. Cloning costs a few ms vs ~30ms+ for a re-parse. If a later audit
+  proves consumers read-only, the clone can be dropped.
+- Config is NOT part of the key: the only `AgencyConfig` field the parse path
+  reads is `tarsecTraceHost` (`lib/parser.ts:186`, debug tracing). The cache
+  bypasses (no read, no store) when `tarsecTraceHost` is set.
+- The cache is pinned to `lower: true` parses (`parseAgency`'s fourth param;
+  the formatter passes `lower: false`). If the formatter ever migrates, `lower`
+  joins the key.
+- Cache successful parses only. The parser's module-global error state
+  (rightmost-failure tracking) is per-parse; confirmed nothing reads
+  parse-global state after a successful parse, so hits skipping those side
+  effects are safe.
+- Consumers switched in this change: `buildCompiledClosure`,
+  `SymbolTable.build`'s `visit()`, and `compile()`'s own entry parse
+  (`lib/cli/commands.ts:348` — the same file's third parse per compile).
+  Other parse-from-disk sites can migrate opportunistically.
+
+This speeds up every compile everywhere: the test runner, vitest unit tests
+(which compile in-process), `agency run`, and the coverage report step.
+
+## Fix 2: Compile-once in the test runner
+
+In `test()` (`lib/cli/test.ts`, used by both `tests/agency` and `lib/agents`
+suites):
+
+- Before any test case runs, precompile each unique `.agency` source exactly
+  once, **grouped by merged config**: one union-closure compile over all
+  base-config files (the same union path directory `compile()` already uses,
+  `lib/cli/commands.ts:282-317` — per-file `compile()` calls would rebuild the
+  closure ~870 times via `ensureCompiledClosure`'s covers-check), plus one
+  compile per local-`agency.json` dir with its merged config (same merge
+  `runTestFile` does today). The union path needs a small exported entry point
+  in `commands.ts` (e.g. `compileMany(config, files, options)`), since the
+  existing union logic is reachable only via the directory branch.
+- The precompile pass passes `allowTestImports: true` — the per-case compiles
+  it replaces pass it today (`lib/cli/test.ts:586`), and the flag is inert on
+  the `preferCompiled` branch, so ALL `import test { … }` enforcement lives in
+  the precompile pass. Omitting it would break every test using test-only
+  imports.
+- **Cross-config invariant, asserted loudly:** compiled output is
+  config-dependent (the generator bakes config into emitted code —
+  `lib/backends/typescriptBuilder.ts:322,348,3848`), and a sibling `.js` is a
+  single slot per module. If any module is reachable from two entries whose
+  merged configs differ, precompile fails with an error naming the module and
+  the conflicting entry dirs. Verified none of the 16 local-config dirs under
+  `tests/` currently imports outside its own directory, so the assert is
+  enforcement, not a behavior change. (Graceful fallback — excluding
+  conflicting files from `preferCompiled` — was rejected: interleaved per-case
+  compiles would rewrite shared siblings mid-run, reintroducing the overwrite
+  race this fix removes.)
+- Every `executeNodeAsync` call then passes the already-implemented
+  `preferCompiled: true`, so `runAgencyNode` reuses the sibling `.js` instead
+  of recompiling. Staleness is impossible by construction — the runner
+  compiled the sibling in the same run.
+- Compile failures during precompile keep today's behavior (parse errors in
+  `compile()` exit the process; other errors fail that file's tests).
+- `testTs()` (agency-js) already compiles once per dir; it inherits the Fix 1
+  speedup unchanged.
+
+Expected effect: ~1750 → ~870 compiles per CI run; the agent tree compiles
+once instead of ~120 times; each remaining compile is itself several times
+faster via Fix 1.
+
+## Fix 3: CI job split
+
+Split the single `build` job in `.github/workflows/test.yml` into two
+self-contained jobs, each doing its own `pnpm install && make` (~2 min; no
+artifact plumbing — chosen over artifact sharing, which adds a serial
+dependency and upload/download costs that eat the savings):
+
+- **`build`** (matrix 22.x/23.x): checkout, install, make, docs, vitest,
+  tarball/bundler/CLI integration, main-only CLI, statelog, sandbox, and the
+  **built-in agent tests** (`test:agents` runs with no `--coverage` flag, so it
+  has no coupling to the coverage steps and lands here for load balance).
+  Existing 22.x-only step conditionals unchanged.
+- **`agency-tests`** (matrix 22.x/23.x): checkout, install, make, agency
+  execution tests, agency-js tests, stdlib coverage report + PR comment,
+  github stdlib smoke test. Agency + agency-js stay together because coverage
+  accumulates across those two steps (`--coverage` then
+  `--coverage --accumulate`). Existing 22-vs-23 and push-to-main conditionals
+  move with their steps.
+- `integration-credentials` job unchanged.
+- Permissions: `pull-requests: write` (coverage comment) moves to
+  `agency-tests`; `build` drops to `contents: read`.
+
+## Verification
+
+- Unit tests for the parse cache: hit, mtimeMs+size invalidation,
+  applyTemplate keying, tarsecTraceHost bypass, clone isolation (mutating a
+  returned AST must not affect the next read).
+- Unit test for the cross-config assert: two synthetic entries with differing
+  configs sharing a module must fail precompile with the named module.
+- `pnpm run test:agents` locally — the worst offender; expect a large drop.
+- A slice of `tests/agency`, plus one local-config dir
+  (`tests/agency-js/debugger/...`) to prove the config-merge path.
+- Fixture/generator suites (`pnpm test:run`, `make fixtures` diff-clean) to
+  prove compiled output is byte-identical.
+- Compare CI wall-clock on the PR. Expected: 22.x leg ~24 min → two parallel
+  jobs of roughly 7–9 min each.
+
+## Out of scope
+
+- Persistent (cross-process/disk) compile caching.
+- Reducing the stdlib prelude itself.
+
+Note: an earlier draft rejected union-closure use in the runner on thrash
+grounds. That argument applies to *interleaved per-case* compiles, not to the
+sequential, config-grouped precompile phase Fix 2 now specifies — the union
+closure is exactly right there and is what the directory-compile path already
+does.

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -32,6 +32,7 @@ import {
   type ImportStrategy,
 } from "../importStrategy.js";
 import { parseAgency, replaceBlankLines } from "../parser.js";
+import { parseAgencyFileCached } from "../parseCache.js";
 import { fileURLToPath, pathToFileURL } from "url";
 import {
   classifyInstall,
@@ -187,6 +188,45 @@ export function resetCompilationCache(): void {
 }
 
 /**
+ * Compile a set of entry files under ONE union closure, like the
+ * directory branch of `compile()` does. Callers with many entry points
+ * (the test runner's precompile pass) use this instead of per-file
+ * `compile()` calls, which would rebuild the closure once per entry via
+ * `ensureCompiledClosure`'s covers-check.
+ *
+ * Unlike the CLI directory branch, closure errors THROW
+ * (`CompileClosureError`) instead of exiting, so programmatic callers
+ * can attach context. Parse/typecheck failures inside per-file
+ * `compile()` keep their existing exit behavior.
+ *
+ * `options.closure` lets a caller that already built the union closure
+ * (e.g. to run analyses over `closure.programs`) hand it in rather than
+ * paying for a rebuild. It MUST cover every file in `files`, otherwise
+ * `ensureCompiledClosure` clears the session cache mid-loop and the
+ * one-compile-per-module guarantee is lost.
+ */
+export function compileMany(
+  config: AgencyConfig,
+  files: string[],
+  options?: {
+    closure?: CompiledClosure;
+    quiet?: boolean;
+    allowTestImports?: boolean;
+  },
+): void {
+  const absFiles = files.map((f) => path.resolve(f));
+  if (absFiles.length === 0) return;
+  currentClosure = options?.closure ?? buildCompiledClosure(absFiles, config);
+  compiledFiles.clear();
+  for (const file of absFiles) {
+    compile(config, file, undefined, {
+      quiet: options?.quiet,
+      allowTestImports: options?.allowTestImports,
+    });
+  }
+}
+
+/**
  * Build the import-closure analysis once per compile session — at the
  * outermost call, before any recursive per-file compile() runs. The
  * recursive children reuse the cached closure to get per-module init
@@ -255,6 +295,26 @@ function runTypecheck(
   } else {
     console.warn(formatErrors(errors, "warning"));
   }
+}
+
+// Cached-parse counterpart of `parse()`: same exit-on-failure contract the
+// CLI pipeline expects, but reads through the process-wide parse cache.
+function parseFileOrExit(
+  absPath: string,
+  config: AgencyConfig,
+  applyTemplate: boolean,
+  contents: string,
+): AgencyProgram {
+  const parseResult = parseAgencyFileCached(absPath, config, applyTemplate);
+  if (!parseResult.success) {
+    if (parseResult.message) {
+      console.error(`Failed to parse Agency program: ${parseResult.message}`);
+    } else {
+      console.error("Failed to parse Agency program.", contents.slice(0, 400));
+    }
+    process.exit(1);
+  }
+  return parseResult.result;
 }
 
 export function compile(
@@ -345,7 +405,7 @@ export function compile(
 
   const contents = readFile(inputFile);
   const applyTemplate = !isNonTemplatedStdlib(absoluteInputFile);
-  const parsedProgram = parse(contents, config, applyTemplate);
+  const parsedProgram = parseFileOrExit(absoluteInputFile, config, applyTemplate, contents);
 
   const symbolTableStartTime = performance.now();
   const symbolTable =

--- a/packages/agency-lang/lib/cli/precompile.test.ts
+++ b/packages/agency-lang/lib/cli/precompile.test.ts
@@ -110,6 +110,30 @@ describe("groupTestSources", () => {
     expect(groups[0].files).toEqual([path.join(root, "live/main.agency")]);
   });
 
+  test("configKey is key-order independent", () => {
+    // Same config content, different key order in the two agency.json
+    // files. JSON.stringify would produce different strings; the group
+    // keys must still match so the dirs are config-compatible.
+    const root = writeTree({
+      a: {
+        "main.agency": TRIVIAL,
+        "main.test.json": TEST_JSON,
+        "agency.json": '{"verbose": true, "observability": false}',
+      },
+      b: {
+        "main.agency": TRIVIAL,
+        "main.test.json": TEST_JSON,
+        "agency.json": '{"observability": false, "verbose": true}',
+      },
+    });
+    const groups = groupTestSources({}, [
+      path.join(root, "a/main.test.json"),
+      path.join(root, "b/main.test.json"),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].configKey).toBe(groups[1].configKey);
+  });
+
   test("test files without a sibling .agency are excluded", () => {
     const root = writeTree({
       orphan: { "main.test.json": TEST_JSON },

--- a/packages/agency-lang/lib/cli/precompile.test.ts
+++ b/packages/agency-lang/lib/cli/precompile.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  findCrossConfigConflicts,
+  groupTestSources,
+  precompileTestSources,
+} from "./precompile.js";
+
+const TRIVIAL = 'node main() {\n  return "ok"\n}\n';
+const HELPER = 'export def helper(): string {\n  return "shared"\n}\n';
+const IMPORTS_HELPER =
+  'import { helper } from "../shared/helper.agency"\n\nnode main() {\n  return helper()\n}\n';
+
+// Lay out a temp tree of test dirs. Spec: { "dirName": { files..., } }
+function writeTree(spec: Record<string, Record<string, string>>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agency-precompile-"));
+  for (const [dir, files] of Object.entries(spec)) {
+    const dirPath = path.join(root, dir);
+    fs.mkdirSync(dirPath, { recursive: true });
+    for (const [name, contents] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dirPath, name), contents);
+    }
+  }
+  return root;
+}
+
+const TEST_JSON = JSON.stringify({ tests: [] });
+
+describe("findCrossConfigConflicts", () => {
+  test("no conflict when groups with the same config share a module", () => {
+    const conflicts = findCrossConfigConflicts([
+      { label: "a", configKey: "{}", modules: ["/shared.agency"] },
+      { label: "b", configKey: "{}", modules: ["/shared.agency"] },
+    ]);
+    expect(conflicts).toEqual([]);
+  });
+
+  test("conflict when groups with differing configs share a module", () => {
+    const conflicts = findCrossConfigConflicts([
+      { label: "a", configKey: "{}", modules: ["/shared.agency", "/a.agency"] },
+      { label: "b", configKey: '{"verbose":true}', modules: ["/shared.agency"] },
+    ]);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].module).toBe("/shared.agency");
+    expect(conflicts[0].labels.sort()).toEqual(["a", "b"]);
+  });
+
+  test("no conflict when differing-config groups touch disjoint modules", () => {
+    const conflicts = findCrossConfigConflicts([
+      { label: "a", configKey: "{}", modules: ["/a.agency"] },
+      { label: "b", configKey: '{"verbose":true}', modules: ["/b.agency"] },
+    ]);
+    expect(conflicts).toEqual([]);
+  });
+});
+
+describe("groupTestSources", () => {
+  test("files without a local agency.json land in one base group", () => {
+    const root = writeTree({
+      one: { "main.agency": TRIVIAL, "main.test.json": TEST_JSON },
+      two: { "main.agency": TRIVIAL, "main.test.json": TEST_JSON },
+    });
+    const groups = groupTestSources({}, [
+      path.join(root, "one/main.test.json"),
+      path.join(root, "two/main.test.json"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].files.sort()).toEqual([
+      path.join(root, "one/main.agency"),
+      path.join(root, "two/main.agency"),
+    ]);
+  });
+
+  test("a dir with a local agency.json becomes its own group with merged config", () => {
+    const root = writeTree({
+      plain: { "main.agency": TRIVIAL, "main.test.json": TEST_JSON },
+      custom: {
+        "main.agency": TRIVIAL,
+        "main.test.json": TEST_JSON,
+        "agency.json": JSON.stringify({ verbose: true }),
+      },
+    });
+    const groups = groupTestSources({ observability: true }, [
+      path.join(root, "plain/main.test.json"),
+      path.join(root, "custom/main.test.json"),
+    ]);
+    expect(groups).toHaveLength(2);
+    const custom = groups.find((g) => g.label.includes("custom"))!;
+    expect(custom.config.verbose).toBe(true);
+    expect(custom.config.observability).toBe(true);
+    const base = groups.find((g) => !g.label.includes("custom"))!;
+    expect(base.configKey).not.toBe(custom.configKey);
+  });
+
+  test("file-level skipped test files are excluded", () => {
+    const root = writeTree({
+      live: { "main.agency": TRIVIAL, "main.test.json": TEST_JSON },
+      dead: {
+        "main.agency": "this does not even parse {{{",
+        "main.test.json": JSON.stringify({ skip: true, tests: [] }),
+      },
+    });
+    const groups = groupTestSources({}, [
+      path.join(root, "live/main.test.json"),
+      path.join(root, "dead/main.test.json"),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].files).toEqual([path.join(root, "live/main.agency")]);
+  });
+
+  test("test files without a sibling .agency are excluded", () => {
+    const root = writeTree({
+      orphan: { "main.test.json": TEST_JSON },
+    });
+    const groups = groupTestSources({}, [
+      path.join(root, "orphan/main.test.json"),
+    ]);
+    expect(groups).toEqual([]);
+  });
+});
+
+describe("precompileTestSources", () => {
+  test("compiles every entry and shared imports once, leaving .js siblings", () => {
+    const root = writeTree({
+      shared: { "helper.agency": HELPER },
+      one: { "main.agency": IMPORTS_HELPER, "main.test.json": TEST_JSON },
+      two: { "main.agency": IMPORTS_HELPER, "main.test.json": TEST_JSON },
+    });
+    precompileTestSources({}, [
+      path.join(root, "one/main.test.json"),
+      path.join(root, "two/main.test.json"),
+    ]);
+    expect(fs.existsSync(path.join(root, "one/main.js"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "two/main.js"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "shared/helper.js"))).toBe(true);
+  });
+
+  test("throws when a module is reachable from entries with differing configs", () => {
+    const root = writeTree({
+      shared: { "helper.agency": HELPER },
+      plain: { "main.agency": IMPORTS_HELPER, "main.test.json": TEST_JSON },
+      custom: {
+        "main.agency": IMPORTS_HELPER,
+        "main.test.json": TEST_JSON,
+        "agency.json": JSON.stringify({ verbose: true }),
+      },
+    });
+    expect(() =>
+      precompileTestSources({}, [
+        path.join(root, "plain/main.test.json"),
+        path.join(root, "custom/main.test.json"),
+      ]),
+    ).toThrow(/helper\.agency/);
+  });
+
+  test("compiles test-only imports (allowTestImports)", () => {
+    const root = writeTree({
+      mod: { "lib.agency": 'def secret(): string {\n  return "s"\n}\n' },
+      t: {
+        "main.agency":
+          'import test { secret } from "../mod/lib.agency"\n\nnode main() {\n  return secret()\n}\n',
+        "main.test.json": TEST_JSON,
+      },
+    });
+    precompileTestSources({}, [path.join(root, "t/main.test.json")]);
+    expect(fs.existsSync(path.join(root, "t/main.js"))).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/cli/precompile.ts
+++ b/packages/agency-lang/lib/cli/precompile.ts
@@ -60,7 +60,9 @@ export function groupTestSources(
   baseConfig: AgencyConfig,
   testJsonFiles: string[],
 ): PrecompileGroup[] {
-  const groups: Record<string, PrecompileGroup> = {};
+  // Null-prototype: keyed by dir paths (see lib/optimize/registry.ts for the
+  // house pattern on string-keyed registries).
+  const groups: Record<string, PrecompileGroup> = Object.create(null);
   for (const testJsonFile of testJsonFiles) {
     const sourceFile = path
       .resolve(testJsonFile)
@@ -80,6 +82,11 @@ export function groupTestSources(
     const group = (groups[label] ??= {
       label,
       config,
+      // JSON.stringify is order-stable here: every config passes through
+      // AgencyConfigSchema.safeParse (loadConfigSafe), and zod rebuilds the
+      // object in SCHEMA shape order, not input order — so semantically
+      // identical configs always serialize identically. Guarded by the
+      // "configKey is key-order independent" test.
       configKey: JSON.stringify(config),
       files: [],
     });
@@ -91,7 +98,9 @@ export function groupTestSources(
 export function findCrossConfigConflicts(
   groups: { label: string; configKey: string; modules: string[] }[],
 ): { module: string; labels: string[] }[] {
-  const touchedBy: Record<string, { configKey: string; label: string }[]> = {};
+  // Null-prototype: keyed by absolute module paths.
+  const touchedBy: Record<string, { configKey: string; label: string }[]> =
+    Object.create(null);
   for (const group of groups) {
     for (const module of group.modules) {
       (touchedBy[module] ??= []).push({

--- a/packages/agency-lang/lib/cli/precompile.ts
+++ b/packages/agency-lang/lib/cli/precompile.ts
@@ -1,0 +1,154 @@
+/**
+ * Precompile pass for the Agency test runner.
+ *
+ * Historically each test CASE recompiled its `.agency` source (and the
+ * source's whole import tree) via `executeNodeAsync` → `compile()` — with
+ * `-p 12` interleaving entries, the per-session closure cache thrashed and
+ * CI ran ~1750 compiles for ~870 unique files. This pass compiles every
+ * unique source exactly once, up front; the runner then executes test cases
+ * with `preferCompiled: true`, which reuses the sibling `.js`.
+ *
+ * Config grouping: compiled output is config-dependent (the generator bakes
+ * config defaults into emitted code), and a test dir may carry a local
+ * `agency.json` that `runTestFile` merges over the base config. Sources are
+ * therefore grouped by merged config — one union-closure compile for all
+ * base-config files, plus one per local-config dir.
+ *
+ * Cross-config invariant: a sibling `.js` is a single slot per module, so a
+ * module reachable from two groups whose configs differ would be
+ * last-writer-wins. That is asserted here and fails loudly (no test dir
+ * does this today). A graceful fallback (per-case compiles for conflicting
+ * files) was rejected: interleaved recompiles rewrite shared siblings
+ * mid-run, which is exactly the race this pass removes.
+ */
+import fs from "fs";
+import path from "path";
+import { AgencyConfig } from "../config.js";
+import { loadConfig, compileMany } from "./commands.js";
+import {
+  buildCompiledClosure,
+  CompileClosureError,
+  type CompiledClosure,
+} from "../compiler/compileClosure.js";
+
+const BASE_GROUP_LABEL = "<base config>";
+
+export type PrecompileGroup = {
+  /** Base-config marker or the local-`agency.json` dir, for error messages. */
+  label: string;
+  config: AgencyConfig;
+  /** Canonical serialization of `config`; groups conflict only when keys differ. */
+  configKey: string;
+  /** Absolute `.agency` entry paths. */
+  files: string[];
+};
+
+// File-level skip mirror of runTestFile's check: a `skip: true` (or
+// `skipOnCI: true` under CI) .test.json never runs, so its source must not
+// be precompiled either — it may intentionally not compile. Malformed
+// .test.json is treated as live; the runner will surface the real error.
+function isFileLevelSkipped(testJsonFile: string): boolean {
+  try {
+    const tests = JSON.parse(fs.readFileSync(testJsonFile, "utf-8"));
+    return tests.skip === true || (tests.skipOnCI === true && !!process.env.CI);
+  } catch {
+    return false;
+  }
+}
+
+export function groupTestSources(
+  baseConfig: AgencyConfig,
+  testJsonFiles: string[],
+): PrecompileGroup[] {
+  const groups: Record<string, PrecompileGroup> = {};
+  for (const testJsonFile of testJsonFiles) {
+    const sourceFile = path
+      .resolve(testJsonFile)
+      .replace(/\.test\.json$/, ".agency");
+    if (!fs.existsSync(sourceFile)) continue;
+    if (isFileLevelSkipped(testJsonFile)) continue;
+
+    const dir = path.dirname(sourceFile);
+    const localConfigPath = path.join(dir, "agency.json");
+    let label = BASE_GROUP_LABEL;
+    let config = baseConfig;
+    if (fs.existsSync(localConfigPath)) {
+      label = dir;
+      config = { ...baseConfig, ...loadConfig(localConfigPath) };
+    }
+
+    const group = (groups[label] ??= {
+      label,
+      config,
+      configKey: JSON.stringify(config),
+      files: [],
+    });
+    if (!group.files.includes(sourceFile)) group.files.push(sourceFile);
+  }
+  return Object.values(groups);
+}
+
+export function findCrossConfigConflicts(
+  groups: { label: string; configKey: string; modules: string[] }[],
+): { module: string; labels: string[] }[] {
+  const touchedBy: Record<string, { configKey: string; label: string }[]> = {};
+  for (const group of groups) {
+    for (const module of group.modules) {
+      (touchedBy[module] ??= []).push({
+        configKey: group.configKey,
+        label: group.label,
+      });
+    }
+  }
+  const conflicts: { module: string; labels: string[] }[] = [];
+  for (const [module, touches] of Object.entries(touchedBy)) {
+    const distinctKeys = touches
+      .map((t) => t.configKey)
+      .filter((key, i, all) => all.indexOf(key) === i);
+    if (distinctKeys.length > 1) {
+      conflicts.push({ module, labels: touches.map((t) => t.label) });
+    }
+  }
+  return conflicts;
+}
+
+export function precompileTestSources(
+  baseConfig: AgencyConfig,
+  testJsonFiles: string[],
+  options?: { quiet?: boolean },
+): void {
+  const groups = groupTestSources(baseConfig, testJsonFiles);
+  const withClosures: { group: PrecompileGroup; closure: CompiledClosure }[] =
+    groups.map((group) => ({
+      group,
+      closure: buildCompiledClosure(group.files, group.config),
+    }));
+
+  const conflicts = findCrossConfigConflicts(
+    withClosures.map(({ group, closure }) => ({
+      label: group.label,
+      configKey: group.configKey,
+      modules: Object.keys(closure.programs),
+    })),
+  );
+  if (conflicts.length > 0) {
+    const lines = conflicts.map(
+      (c) =>
+        `  ${c.module}\n    reachable from: ${c.labels.join(", ")}`,
+    );
+    throw new CompileClosureError(
+      "Test sources with differing configs share modules. A module's " +
+        "compiled .js is a single slot, so this would be last-writer-wins. " +
+        "Move the shared module or align the configs:\n" +
+        lines.join("\n"),
+    );
+  }
+
+  for (const { group, closure } of withClosures) {
+    compileMany(group.config, group.files, {
+      closure,
+      quiet: options?.quiet,
+      allowTestImports: true,
+    });
+  }
+}

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -20,6 +20,8 @@ import { formatDiff } from "@/utils/diff.js";
 import { AgencyConfig } from "@/config.js";
 import path from "path";
 import { compile, loadConfig } from "./commands.js";
+import { precompileTestSources } from "./precompile.js";
+import { CompileClosureError } from "../compiler/compileClosure.js";
 import type { LLMMock, ScopedLLMMocks } from "../runtime/deterministicClient.js";
 import type { FetchMock } from "../runtime/fetchMock.js";
 import { resolveFetchMocks, writeFetchMocksTempFile } from "./fetchMockResolve.js";
@@ -584,6 +586,10 @@ async function runSingleTest(
       hasArgs,
       argsString: testCase.input,
       allowTestImports: true,
+      // The precompile pass in test() already compiled this source (with
+      // allowTestImports enforcement); reuse the sibling .js instead of
+      // recompiling for every test case.
+      preferCompiled: true,
       interruptHandlers: testCase.interruptHandlers,
       timeoutMs,
       signal,
@@ -892,6 +898,21 @@ export async function test(
   const testFiles: string[] = [];
   for (const inputPath of inputPaths) {
     testFiles.push(...collectTestFiles(inputPath));
+  }
+
+  // Compile every unique source exactly once, up front (grouped by merged
+  // config). Test cases then run with `preferCompiled: true` and reuse the
+  // sibling `.js` instead of recompiling per case. Parse/typecheck failures
+  // exit here, matching the old per-case compile behavior (those compiles
+  // ran in this process and exited too).
+  try {
+    precompileTestSources(config, testFiles);
+  } catch (e) {
+    if (e instanceof CompileClosureError) {
+      console.error(color.red(e.message));
+      process.exit(1);
+    }
+    throw e;
   }
 
   const suite = createSuiteContext(testFiles);

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -20,7 +20,7 @@ import * as fs from "fs";
 import * as path from "path";
 import type { AgencyProgram, AgencyNode } from "../types.js";
 import { AgencyConfig } from "../config.js";
-import { parseAgency } from "../parser.js";
+import { parseAgencyFileCached } from "../parseCache.js";
 import { SymbolTable } from "../symbolTable.js";
 import { resolveReExports } from "../preprocessors/resolveReExports.js";
 import {
@@ -252,9 +252,8 @@ function loadModule(
       `Error: Input file '${moduleId}' not found`,
     );
   }
-  const source = fs.readFileSync(moduleId, "utf-8");
   const applyTemplate = !isNonTemplatedStdlib(moduleId);
-  const result = parseAgency(source, config, applyTemplate);
+  const result = parseAgencyFileCached(moduleId, config, applyTemplate);
   if (!result.success) {
     throw new CompileClosureError(
       `Failed to parse ${moduleId}: ${result.message ?? "unknown parse error"}`,

--- a/packages/agency-lang/lib/parseCache.test.ts
+++ b/packages/agency-lang/lib/parseCache.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { parseAgencyFileCached, _internal } from "./parseCache.js";
+
+function writeTempAgencyFile(contents: string): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-parsecache-"));
+  const tmpFile = path.join(tmpDir, "main.agency");
+  fs.writeFileSync(tmpFile, contents);
+  return tmpFile;
+}
+
+const VALID_PROGRAM = 'node main() {\n  return "hello"\n}\n';
+const VALID_PROGRAM_B = 'node main() {\n  return "world"\n}\n';
+
+describe("parseAgencyFileCached", () => {
+  beforeEach(() => {
+    _internal.clear();
+  });
+
+  test("parses a file and returns the program", () => {
+    const file = writeTempAgencyFile(VALID_PROGRAM);
+    const result = parseAgencyFileCached(file, {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.nodes.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("second parse of an unchanged file is a cache hit", () => {
+    const file = writeTempAgencyFile(VALID_PROGRAM);
+    parseAgencyFileCached(file, {});
+    const before = { ..._internal.stats };
+    const second = parseAgencyFileCached(file, {});
+    expect(second.success).toBe(true);
+    expect(_internal.stats.hits).toBe(before.hits + 1);
+    expect(_internal.stats.misses).toBe(before.misses);
+  });
+
+  test("mutating a returned program does not affect subsequent reads", () => {
+    const file = writeTempAgencyFile(VALID_PROGRAM);
+    const first = parseAgencyFileCached(file, {});
+    expect(first.success).toBe(true);
+    if (first.success) {
+      first.result.nodes.length = 0;
+      (first.result as any).poisoned = true;
+    }
+    const second = parseAgencyFileCached(file, {});
+    expect(second.success).toBe(true);
+    if (second.success) {
+      expect(second.result.nodes.length).toBeGreaterThan(0);
+      expect((second.result as any).poisoned).toBeUndefined();
+    }
+  });
+
+  test("changed content (different size) invalidates the entry", () => {
+    const file = writeTempAgencyFile(VALID_PROGRAM);
+    parseAgencyFileCached(file, {});
+    fs.writeFileSync(file, 'node main() {\n  return "hello again, longer"\n}\n');
+    const result = parseAgencyFileCached(file, {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(JSON.stringify(result.result)).toContain("hello again, longer");
+    }
+    expect(_internal.stats.hits).toBe(0);
+  });
+
+  test("same-size content change with a newer mtime invalidates the entry", () => {
+    // VALID_PROGRAM and VALID_PROGRAM_B are the same byte length, so only
+    // mtimeMs distinguishes the versions.
+    expect(VALID_PROGRAM.length).toBe(VALID_PROGRAM_B.length);
+    const file = writeTempAgencyFile(VALID_PROGRAM);
+    parseAgencyFileCached(file, {});
+    fs.writeFileSync(file, VALID_PROGRAM_B);
+    // Force an mtime strictly newer than the first write, in case the
+    // filesystem's timestamp granularity is coarse.
+    const future = new Date(Date.now() + 5000);
+    fs.utimesSync(file, future, future);
+    const result = parseAgencyFileCached(file, {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(JSON.stringify(result.result)).toContain("world");
+    }
+    expect(_internal.stats.hits).toBe(0);
+  });
+
+  test("applyTemplate is part of the cache key", () => {
+    const file = writeTempAgencyFile(VALID_PROGRAM);
+    const templated = parseAgencyFileCached(file, {}, true);
+    const raw = parseAgencyFileCached(file, {}, false);
+    expect(templated.success).toBe(true);
+    expect(raw.success).toBe(true);
+    // Distinct keys: the second call must not have hit the first's entry.
+    expect(_internal.stats.hits).toBe(0);
+    expect(_internal.stats.misses).toBe(2);
+  });
+
+  test("bypasses the cache entirely when tarsecTraceHost is set", () => {
+    const file = writeTempAgencyFile(VALID_PROGRAM);
+    const traced = parseAgencyFileCached(file, { tarsecTraceHost: true } as any);
+    expect(traced.success).toBe(true);
+    expect(_internal.stats.hits).toBe(0);
+    expect(_internal.stats.misses).toBe(0);
+    // The traced parse must not have stored an entry either.
+    parseAgencyFileCached(file, {});
+    expect(_internal.stats.hits).toBe(0);
+    expect(_internal.stats.misses).toBe(1);
+  });
+
+  test("failed parses are not cached", () => {
+    const file = writeTempAgencyFile("node main( {{{ nope");
+    const first = parseAgencyFileCached(file, {});
+    expect(first.success).toBe(false);
+    const second = parseAgencyFileCached(file, {});
+    expect(second.success).toBe(false);
+    expect(_internal.stats.hits).toBe(0);
+    expect(_internal.stats.misses).toBe(2);
+  });
+
+  test("missing file returns a failure instead of throwing", () => {
+    const result = parseAgencyFileCached("/nonexistent/nope.agency", {});
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/parseCache.ts
+++ b/packages/agency-lang/lib/parseCache.ts
@@ -16,6 +16,12 @@ import { AgencyProgram } from "./types.js";
  *  - Keyed by absolute path; an entry is valid only while the file's
  *    `mtimeMs` AND `size` both match (size guards against same-mtime edits
  *    on filesystems with coarse timestamp granularity).
+ *    Residual risk, accepted: an edit that keeps the byte count identical
+ *    AND lands within the same filesystem timestamp granule serves a stale
+ *    AST. Impossible mid-CI (files don't change during a run) but real for
+ *    long-lived processes (watch mode, `agency serve`, a future REPL). If
+ *    it ever bites, switch the validity check to a content hash — still far
+ *    cheaper than a re-parse.
  *  - `applyTemplate` is part of the key: the same file parses to different
  *    programs with and without the CLI template prelude.
  *  - Returns a `structuredClone` of the cached program on every read —

--- a/packages/agency-lang/lib/parseCache.ts
+++ b/packages/agency-lang/lib/parseCache.ts
@@ -1,0 +1,100 @@
+import fs from "fs";
+import { parseAgency, ParseAgencyResult } from "./parser.js";
+import { AgencyConfig } from "./config.js";
+import { isNonTemplatedStdlib } from "./importPaths.js";
+import { AgencyProgram } from "./types.js";
+
+/**
+ * Process-wide cache of successful `.agency` file parses.
+ *
+ * Motivation: neither `buildCompiledClosure` nor `SymbolTable.build` cached
+ * parses, so every compile re-read and re-parsed the full auto-imported
+ * stdlib prelude chain from disk (~90ms of a ~135ms trivial-file compile).
+ * The test runner compiles hundreds of files per run, all sharing that chain.
+ *
+ * Correctness properties:
+ *  - Keyed by absolute path; an entry is valid only while the file's
+ *    `mtimeMs` AND `size` both match (size guards against same-mtime edits
+ *    on filesystems with coarse timestamp granularity).
+ *  - `applyTemplate` is part of the key: the same file parses to different
+ *    programs with and without the CLI template prelude.
+ *  - Returns a `structuredClone` of the cached program on every read —
+ *    downstream passes mutate ASTs in place (import-path rewriting,
+ *    typechecker annotation), so callers must never share one object.
+ *  - Only successful parses are cached. Failures re-parse every time; the
+ *    parser's module-global rightmost-failure state is per-parse and callers
+ *    may read it after a failure.
+ *  - Bypassed entirely (no read, no store) when `config.tarsecTraceHost` is
+ *    set: tracing is the one config field the parse path reads, and a traced
+ *    parse must actually run.
+ *  - Pinned to `lower: true` parses. The formatter's `lower: false` path must
+ *    not use this cache without adding `lower` to the key.
+ */
+type ParseCacheEntry = {
+  mtimeMs: number;
+  size: number;
+  program: AgencyProgram;
+};
+
+const cache: Record<string, ParseCacheEntry> = {};
+
+const stats = { hits: 0, misses: 0 };
+
+export const _internal = {
+  stats,
+  clear: () => {
+    for (const key of Object.keys(cache)) {
+      delete cache[key];
+    }
+    stats.hits = 0;
+    stats.misses = 0;
+  },
+};
+
+export function parseAgencyFileCached(
+  absPath: string,
+  config: AgencyConfig = {},
+  applyTemplate: boolean = !isNonTemplatedStdlib(absPath),
+): ParseAgencyResult {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(absPath);
+  } catch (e) {
+    return {
+      success: false,
+      message: `Input file '${absPath}' not found`,
+      rest: "",
+    };
+  }
+
+  const bypass = !!config.tarsecTraceHost;
+  const key = `${applyTemplate ? "t" : "r"}:${absPath}`;
+
+  if (!bypass) {
+    const entry = cache[key];
+    if (entry && entry.mtimeMs === stat.mtimeMs && entry.size === stat.size) {
+      stats.hits++;
+      return {
+        success: true,
+        result: structuredClone(entry.program),
+        rest: "",
+      };
+    }
+  }
+
+  const contents = fs.readFileSync(absPath, "utf-8");
+  const result = parseAgency(contents, config, applyTemplate);
+  if (bypass) return result;
+
+  stats.misses++;
+  if (result.success) {
+    cache[key] = {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      // Clone on store as well as on read: the caller receives `result`
+      // and may mutate it, which must not poison the cached copy.
+      program: structuredClone(result.result),
+    };
+  }
+  return result;
+}

--- a/packages/agency-lang/lib/parseCache.ts
+++ b/packages/agency-lang/lib/parseCache.ts
@@ -36,7 +36,9 @@ type ParseCacheEntry = {
   program: AgencyProgram;
 };
 
-const cache: Record<string, ParseCacheEntry> = {};
+// Null-prototype: keyed by (prefixed) file paths, matching the repo's other
+// string-keyed registries (e.g. lib/optimize/registry.ts).
+const cache: Record<string, ParseCacheEntry> = Object.create(null);
 
 const stats = { hits: 0, misses: 0 };
 

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -183,6 +183,12 @@ export function _parseAgency(
   // Clear memo caches so loc info derived from `setInputStr` in a previous
   // parse (which may have used a different source) doesn't leak through.
   resetMemos();
+  // CAUTION (parse cache): `tarsecTraceHost` is currently the ONLY config
+  // field the parse path reads, and lib/parseCache.ts relies on that — its
+  // cache key deliberately excludes config (tracing is handled via a full
+  // cache bypass). If you add any config-driven parse behavior here (e.g. a
+  // syntax feature flag), you MUST add that field to the parseCache key, or
+  // the cache will silently serve one config's AST to another.
   if (config.tarsecTraceHost) {
     setTraceHost("http://localhost:1465");
     setTraceId(nanoid());

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { parseAgency } from "./parser.js";
+import { parseAgencyFileCached } from "./parseCache.js";
 import type { AgencyConfig } from "./config.js";
 import type {
   AgencyNode,
@@ -144,9 +144,8 @@ export class SymbolTable {
         console.log(`[SymbolTable] Processing ${absPath}`);
       }
 
-      const contents = fs.readFileSync(absPath, "utf-8");
-      const parseResult = parseAgency(
-        contents,
+      const parseResult = parseAgencyFileCached(
+        absPath,
         config,
         !isNonTemplatedStdlib(absPath),
       );


### PR DESCRIPTION
## Why

CI wall-clock grew from ~14 min (7/1) to ~24 min (7/7). Root cause analysis (comparing runs 28549258023 vs 28902551402) found two mechanisms, both compounding with normal test-suite growth:

1. **Every compile re-parsed the whole auto-imported stdlib prelude chain.** Neither `buildCompiledClosure` nor `SymbolTable.build` cached parses, so as `stdlib/index.agency` grew 301 → 519 lines (std::array absorbed into the prelude) plus new stdlib modules, identical files got ~60% slower to compile (avg 211ms → 341ms).
2. **The test runner compiled once per test case, not per file.** `ensureCompiledClosure` clears the per-session cache whenever the entry is not covered by the current closure — with `-p 12` interleaving entries it never is. CI ran ~1750 compiles for ~870 unique files; the agency-agent module tree recompiled for every one of ~120 agent test cases.

## What

- **`lib/parseCache.ts`** — process-wide parse cache keyed by (path, mtimeMs, size, applyTemplate). Returns `structuredClone` on every read because downstream passes mutate ASTs in place. Successful parses only; bypassed under `tarsecTraceHost`. Consumers: `buildCompiledClosure`, `SymbolTable.build`, and `compile()` entry parse. Warm-cache compile of a trivial file: 121ms → 28ms.
- **`lib/cli/precompile.ts`** — the test runner compiles each unique source exactly once up front, grouped by merged config (local `agency.json` dirs get their own group), under one union closure per group (new `commands.compileMany`). Asserts loudly if a module is reachable from groups with differing configs (a sibling `.js` is a single slot; verified no test dir does this today). Test cases then run with `preferCompiled: true`.
- **`.github/workflows/test.yml`** — split into two self-contained parallel jobs: `build` (vitest, integration, sandbox, + agent tests) and `agency-tests` (agency + agency-js + coverage + smoke test). Each runs its own `pnpm install && make`; `pull-requests: write` moves to `agency-tests` with the coverage comment.

## Measured

| Check | Result |
|---|---|
| Agents suite (local) | 2m50s / 1109 compiles → **60s / 32 compiles** |
| Full vitest | 7419 passed |
| `make fixtures` | zero diff (compiled output byte-identical) |
| agency + agency-js slices incl. local-config dirs | all green |

Design doc: `docs/superpowers/specs/2026-07-07-ci-compile-caching-design.md` (reviewed; all 6 review findings folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
