### PR TITLE
Add std::data/tech/{yc,hackernews} connectors

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -275,6 +275,14 @@ export default defineConfig({
                   text: "data/people/littlesis",
                   link: "/stdlib/data/people/littlesis",
                 },
+                {
+                  text: "data/tech/yc",
+                  link: "/stdlib/data/tech/yc",
+                },
+                {
+                  text: "data/tech/hackernews",
+                  link: "/stdlib/data/tech/hackernews",
+                },
               ],
             },
             { text: "date", link: "/stdlib/date" },

--- a/packages/agency-lang/docs/site/stdlib/capabilities.md
+++ b/packages/agency-lang/docs/site/stdlib/capabilities.md
@@ -85,7 +85,7 @@ Anything that talks to the outside world over the network.
 
 ```ts
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews>
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L45))

--- a/packages/agency-lang/docs/site/stdlib/data/tech/hackernews.md
+++ b/packages/agency-lang/docs/site/stdlib/data/tech/hackernews.md
@@ -1,0 +1,208 @@
+---
+name: "hackernews"
+---
+
+# hackernews
+
+## Hacker News — front page, items, users, and search
+
+  Read [Hacker News](https://github.com/HackerNews/API) via its official Firebase API (ranked story
+  lists, items, and user profiles) and its [Algolia search](https://hn.algolia.com/api) index
+  (keyword full-text search). Use this connector to see what the tech community is discussing right
+  now (`hnStories`) or to find HN threads about a topic (`hnSearch`).
+
+  No API key required. `hnStories` fetches a list of item IDs and then one request per item to
+  hydrate it, so a large `limit` means many requests (it is capped at 100).
+
+  ### Usage
+
+  ```ts
+  import { hnStories, hnSearch } from "std::data/tech/hackernews"
+
+  node main() {
+    const front = hnStories("top", 10) catch []
+    for (s in front) {
+      print("${s.score}  ${s.title}  (${s.by})")
+    }
+    const hits = hnSearch("rust async", "recent") catch []
+    for (h in hits) { print(h.title) }
+  }
+  ```
+
+## Types
+
+### Story
+
+A Hacker News story (the hydrated list / search shape). `time` is a Unix timestamp.
+
+```ts
+/** A Hacker News story (the hydrated list / search shape). `time` is a Unix timestamp. */
+export type Story = {
+  id: number;
+  title: string;
+  url: string;
+  by: string;
+  score: number;
+  time: number;
+  descendants: number;
+  type: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L46))
+
+### Item
+
+A full Hacker News item — story, comment, job, or poll. `kids` are direct child comment ids.
+
+```ts
+/** A full Hacker News item — story, comment, job, or poll. `kids` are direct child comment ids. */
+export type Item = {
+  id: number;
+  type: string;
+  by: string;
+  time: number;
+  title: string;
+  url: string;
+  text: string;
+  score: number;
+  descendants: number;
+  parent?: number;
+  kids: number[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L58))
+
+### User
+
+A Hacker News user profile. `submitted` are the ids of items the user posted.
+
+```ts
+/** A Hacker News user profile. `submitted` are the ids of items the user posted. */
+export type User = {
+  id: string;
+  created: number;
+  karma: number;
+  about: string;
+  submitted: number[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L73))
+
+## Effects
+
+### std::hackernews
+
+```ts
+effect std::hackernews {
+  op: string;
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L30))
+
+## Functions
+
+### hnStories
+
+```ts
+hnStories(list: string, limit: number): Result<Story[]>
+```
+
+Fetch a Hacker News story list and hydrate the top items into full stories (title, url, author,
+  score, comment count). Fetches the id list plus one request per item, so a large limit means many
+  requests (capped at 100).
+
+  @param list - Which ranked list to read: "top", "new", "best", "ask", "show", or "job"
+  @param limit - How many stories to hydrate (capped at 100)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| list | `string` | "top" |
+| limit | `number` | 30 |
+
+**Returns:** `Result<Story[]>`
+
+**Throws:** `std::hackernews`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L283))
+
+### hnItem
+
+```ts
+hnItem(id: number): Result<Item>
+```
+
+Fetch one Hacker News item by id — a story, comment, job, or poll. Returns its text, author,
+  score, and the ids of its direct child comments. An unknown id returns a failure.
+
+  @param id - The Hacker News item id
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `number` |  |
+
+**Returns:** `Result<Item>`
+
+**Throws:** `std::hackernews`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L302))
+
+### hnUser
+
+```ts
+hnUser(username: string): Result<User>
+```
+
+Fetch a Hacker News user's public profile: karma, account age, about text, and submitted item
+  ids. An unknown username returns a failure.
+
+  @param username - The Hacker News username (case-sensitive)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| username | `string` |  |
+
+**Returns:** `Result<User>`
+
+**Throws:** `std::hackernews`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L314))
+
+### hnSearch
+
+```ts
+hnSearch(query: string, sort: string, tags: string, limit: number): Result<Story[]>
+```
+
+Search Hacker News stories by keyword via the Algolia index. Returns matching stories (title,
+  url, author, score, comment count), sorted by relevance or recency.
+
+  @param query - The search keywords
+  @param sort - Result ordering: "relevance" or "recent"
+  @param tags - Algolia tag filter, e.g. "story", "comment", "ask_hn", "show_hn"
+  @param limit - Maximum results (capped at 50)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| query | `string` |  |
+| sort | `string` | "relevance" |
+| tags | `string` | "story" |
+| limit | `number` | 20 |
+
+**Returns:** `Result<Story[]>`
+
+**Throws:** `std::hackernews`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/hackernews.agency#L326))

--- a/packages/agency-lang/docs/site/stdlib/data/tech/yc.md
+++ b/packages/agency-lang/docs/site/stdlib/data/tech/yc.md
@@ -1,0 +1,201 @@
+---
+name: "yc"
+---
+
+# yc
+
+## Y Combinator — the YC company directory
+
+  Query the [yc-oss](https://github.com/yc-oss/api) community dataset: every company Y Combinator
+  has funded, sliced by batch, industry, tag, or a curated list. Use this connector to track the
+  newest YC startups and what they do — batch, one-liner, industry, stage, team size, and status.
+
+  The data is static JSON refreshed daily, and there is no server-side search. Fetch a slice (a
+  batch, industry, or tag) and filter in Agency. `ycMeta` lists the available slugs, so an agent
+  can discover the newest batch before fetching it. No API key required.
+
+  ### Usage
+
+  ```ts
+  import { ycBatch } from "std::data/tech/yc"
+
+  node main() {
+    const companies = ycBatch("Winter 2025") catch []
+    for (c in companies) {
+      print("${c.name} — ${c.oneLiner} [${c.status}]")
+    }
+  }
+  ```
+
+## Types
+
+### Company
+
+A YC company — a curated subset of the yc-oss record. `launchedAt` is a Unix timestamp.
+
+```ts
+/** A YC company — a curated subset of the yc-oss record. `launchedAt` is a Unix timestamp. */
+export type Company = {
+  id: number;
+  name: string;
+  slug: string;
+  website: string;
+  oneLiner: string;
+  longDescription: string;
+  batch: string;
+  status: string;
+  stage: string;
+  teamSize: number;
+  industry: string;
+  subindustry: string;
+  tags: string[];
+  regions: string[];
+  allLocations: string;
+  launchedAt: number;
+  topCompany: boolean;
+  isHiring: boolean;
+  nonprofit: boolean;
+  url: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L38))
+
+### YcMeta
+
+The available slugs for discovery (from meta.json), so a caller can find the newest batch.
+
+```ts
+/** The available slugs for discovery (from meta.json), so a caller can find the newest batch. */
+export type YcMeta = {
+  lastUpdated: string;
+  batches: string[];
+  industries: string[];
+  tags: string[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L62))
+
+## Effects
+
+### std::yc
+
+```ts
+effect std::yc {
+  op: string;
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L29))
+
+## Functions
+
+### ycBatch
+
+```ts
+ycBatch(batch: string): Result<Company[]>
+```
+
+Fetch the YC companies in a batch. Returns each company's id, name, one-liner, batch, status,
+  stage, team size, industry, tags, and URL. An unknown batch returns a failure.
+
+  @param batch - The YC batch, e.g. "Winter 2025" or "winter-2025"
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| batch | `string` |  |
+
+**Returns:** `Result<Company[]>`
+
+**Throws:** `std::yc`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L191))
+
+### ycIndustry
+
+```ts
+ycIndustry(industry: string): Result<Company[]>
+```
+
+Fetch the YC companies in an industry. Returns each company's profile. An unknown industry
+  returns a failure.
+
+  @param industry - The industry, e.g. "fintech" or "Healthcare"
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| industry | `string` |  |
+
+**Returns:** `Result<Company[]>`
+
+**Throws:** `std::yc`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L203))
+
+### ycTag
+
+```ts
+ycTag(tag: string): Result<Company[]>
+```
+
+Fetch the YC companies with a tag. Returns each company's profile. An unknown tag returns a
+  failure.
+
+  @param tag - The tag, e.g. "ai" or "SaaS"
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| tag | `string` |  |
+
+**Returns:** `Result<Company[]>`
+
+**Throws:** `std::yc`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L215))
+
+### ycList
+
+```ts
+ycList(list: string): Result<Company[]>
+```
+
+Fetch a curated YC company list: "top", "all", "hiring", "nonprofit", "women-founded",
+  "black-founded", or "hispanic-latino-founded". "all" is large (~6 MB); prefer a batch, industry,
+  or tag slice when you can.
+
+  @param list - The curated list name
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| list | `string` | "top" |
+
+**Returns:** `Result<Company[]>`
+
+**Throws:** `std::yc`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L227))
+
+### ycMeta
+
+```ts
+ycMeta(): Result<YcMeta>
+```
+
+Fetch the YC directory metadata: the available batch, industry, and tag slugs plus the
+  last-updated timestamp. Use it to discover the newest batch slug before calling ycBatch.
+
+**Returns:** `Result<YcMeta>`
+
+**Throws:** `std::yc`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/tech/yc.agency#L245))

--- a/packages/agency-lang/stdlib/capabilities.agency
+++ b/packages/agency-lang/stdlib/capabilities.agency
@@ -42,7 +42,7 @@ export effectSet FileSystem = <FileRead, FileWrite>
 export effectSet Shell = <std::bash, std::exec, std::run>
 
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews>
 
 /** The std::data/finance connectors (news + macro + filings). Each also raises
     std::http::fetchJSON, which is covered by the broader Network set. */

--- a/packages/agency-lang/stdlib/capabilities.agency
+++ b/packages/agency-lang/stdlib/capabilities.agency
@@ -42,7 +42,7 @@ export effectSet FileSystem = <FileRead, FileWrite>
 export effectSet Shell = <std::bash, std::exec, std::run>
 
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc>
 
 /** The std::data/finance connectors (news + macro + filings). Each also raises
     std::http::fetchJSON, which is covered by the broader Network set. */

--- a/packages/agency-lang/stdlib/data/tech/hackernews.agency
+++ b/packages/agency-lang/stdlib/data/tech/hackernews.agency
@@ -1,0 +1,344 @@
+import { fetchJSON } from "std::http"
+
+/** @module
+  ## Hacker News — front page, items, users, and search
+
+  Read [Hacker News](https://github.com/HackerNews/API) via its official Firebase API (ranked story
+  lists, items, and user profiles) and its [Algolia search](https://hn.algolia.com/api) index
+  (keyword full-text search). Use this connector to see what the tech community is discussing right
+  now (`hnStories`) or to find HN threads about a topic (`hnSearch`).
+
+  No API key required. `hnStories` fetches a list of item IDs and then one request per item to
+  hydrate it, so a large `limit` means many requests (it is capped at 100).
+
+  ### Usage
+
+  ```ts
+  import { hnStories, hnSearch } from "std::data/tech/hackernews"
+
+  node main() {
+    const front = hnStories("top", 10) catch []
+    for (s in front) {
+      print("${s.score}  ${s.title}  (${s.by})")
+    }
+    const hits = hnSearch("rust async", "recent") catch []
+    for (h in hits) { print(h.title) }
+  }
+  ```
+*/
+
+effect std::hackernews { op: string, query: string }
+
+static const HN_BASE = "https://hacker-news.firebaseio.com/v0"
+static const HN_DOMAINS = ["hacker-news.firebaseio.com"]
+static const HN_ALGOLIA_BASE = "https://hn.algolia.com/api/v1"
+static const HN_ALGOLIA_DOMAINS = ["hn.algolia.com"]
+
+// Friendly list names, and the Firebase filename each maps to (parallel arrays).
+static const HN_LISTS = ["top", "new", "best", "ask", "show", "job"]
+static const HN_LIST_FILES = ["topstories", "newstories", "beststories", "askstories", "showstories", "jobstories"]
+
+// Friendly sort names, and the Algolia endpoint each maps to (parallel arrays).
+static const HN_SORTS = ["relevance", "recent"]
+static const HN_SORT_ENDPOINTS = ["search", "search_by_date"]
+
+/** A Hacker News story (the hydrated list / search shape). `time` is a Unix timestamp. */
+export type Story = {
+  id: number;
+  title: string;
+  url: string;
+  by: string;
+  score: number;
+  time: number;
+  descendants: number;
+  type: string
+}
+
+/** A full Hacker News item — story, comment, job, or poll. `kids` are direct child comment ids. */
+export type Item = {
+  id: number;
+  type: string;
+  by: string;
+  time: number;
+  title: string;
+  url: string;
+  text: string;
+  score: number;
+  descendants: number;
+  parent: number | null;
+  kids: number[]
+}
+
+/** A Hacker News user profile. `submitted` are the ids of items the user posted. */
+export type User = {
+  id: string;
+  created: number;
+  karma: number;
+  about: string;
+  submitted: number[]
+}
+
+/** Validate a friendly list name and map it to its Firebase filename. Unknown → failure. Pure. */
+safe def parseStoryList(list: string): Result<string> {
+  const idx = HN_LISTS.indexOf(list)
+  if (idx < 0) {
+    return failure("unknown list '${list}'; valid: ${HN_LISTS.join(", ")}")
+  }
+  return success(HN_LIST_FILES[idx])
+}
+
+/** Validate a friendly sort name and map it to its Algolia endpoint. Unknown → failure. Pure. */
+safe def parseSort(sort: string): Result<string> {
+  const idx = HN_SORTS.indexOf(sort)
+  if (idx < 0) {
+    return failure("unknown sort '${sort}'; valid: ${HN_SORTS.join(", ")}")
+  }
+  return success(HN_SORT_ENDPOINTS[idx])
+}
+
+/** Clamp n into [0, cap]. Pure. */
+safe def capLimit(n: number, cap: number): number {
+  if (n > cap) {
+    return cap
+  }
+  if (n < 0) {
+    return 0
+  }
+  return n
+}
+
+/** The first n ids (n clamped to ≥ 0; slice naturally clamps the high end). Pure/total. */
+safe def takeFirst(ids: number[], n: number): number[] {
+  if (n <= 0) {
+    return []
+  }
+  return ids.slice(0, n)
+}
+
+/** Build a Firebase story-list path (file already mapped by parseStoryList). Pure. */
+safe def buildStoryListPath(file: string): string {
+  return "/${file}.json"
+}
+
+/** Build a Firebase item path. Pure. */
+safe def buildItemPath(id: number): string {
+  return "/item/${id}.json"
+}
+
+/** Build a Firebase user path. Pure. */
+safe def buildUserPath(username: string): string {
+  return "/user/${encodeURIComponent(username)}.json"
+}
+
+/** Build an Algolia search path (endpoint already mapped by parseSort; limit clamped to 50). Pure. */
+safe def buildSearchPath(endpoint: string, query: string, tags: string, limit: number): string {
+  const q = encodeURIComponent(query)
+  const t = encodeURIComponent(tags)
+  const n = capLimit(limit, 50)
+  return "/${endpoint}?query=${q}&tags=${t}&hitsPerPage=${n}"
+}
+
+/** Reshape a Firebase item into a Story (front-page/list shape). Pure/total. */
+safe def parseStory(raw: any): Story {
+  const r: any = raw ?? {}
+  return {
+    id: r.id ?? 0,
+    title: r.title ?? "",
+    url: r.url ?? "",
+    by: r.by ?? "",
+    score: r.score ?? 0,
+    time: r.time ?? 0,
+    descendants: r.descendants ?? 0,
+    type: r.type ?? "story"
+  }
+}
+
+/** Reshape a Firebase item into the full Item (story/comment/job/poll). Pure/total. */
+safe def parseItem(raw: any): Item {
+  const r: any = raw ?? {}
+  return {
+    id: r.id ?? 0,
+    type: r.type ?? "",
+    by: r.by ?? "",
+    time: r.time ?? 0,
+    title: r.title ?? "",
+    url: r.url ?? "",
+    text: r.text ?? "",
+    score: r.score ?? 0,
+    descendants: r.descendants ?? 0,
+    parent: r.parent ?? null,
+    kids: r.kids ?? []
+  }
+}
+
+/** Reshape a Firebase user into a User. Pure/total. */
+safe def parseUser(raw: any): User {
+  const r: any = raw ?? {}
+  return {
+    id: r.id ?? "",
+    created: r.created ?? 0,
+    karma: r.karma ?? 0,
+    about: r.about ?? "",
+    submitted: r.submitted ?? []
+  }
+}
+
+/** Reshape an Algolia search body into Story[]. Hits map onto Story (objectID→id, author→by,
+    points→score, num_comments→descendants, created_at_i→time). Pure/total. */
+safe def parseAlgoliaHits(raw: any): Story[] {
+  const r: any = raw ?? {}
+  const hits = r.hits ?? []
+  return map(hits) as h {
+    const hit: any = h ?? {}
+    return {
+      id: Number(hit.objectID ?? hit.story_id ?? 0),
+      title: hit.title ?? "",
+      url: hit.url ?? "",
+      by: hit.author ?? "",
+      score: hit.points ?? 0,
+      time: hit.created_at_i ?? 0,
+      descendants: hit.num_comments ?? 0,
+      type: "story"
+    }
+  }
+}
+
+/** Shared failure message for a failed HN fetch. Pure. */
+safe def hnError(err: any): string {
+  return "Hacker News request failed (the API may be rate-limited): ${err.message ?? err}"
+}
+
+/** Turn a fetch Result into an Item Result; a null body (unknown id) → failure. Pure. */
+safe def itemFinalize(fetchResult: any): Result<Item> {
+  return match (fetchResult) {
+    success(body) => {
+      const b: any = body ?? null
+      if (b == null) {
+        return failure("Hacker News returned no item")
+      }
+      return success(parseItem(b))
+    }
+    failure(err) => failure(hnError(err))
+  }
+}
+
+/** Turn a fetch Result into a User Result; a null body (unknown user) → failure. Pure. */
+safe def userFinalize(fetchResult: any): Result<User> {
+  return match (fetchResult) {
+    success(body) => {
+      const b: any = body ?? null
+      if (b == null) {
+        return failure("Hacker News returned no user")
+      }
+      return success(parseUser(b))
+    }
+    failure(err) => failure(hnError(err))
+  }
+}
+
+/** Turn an Algolia fetch Result into a Story[] Result. Pure. */
+safe def searchFinalize(fetchResult: any): Result<Story[]> {
+  return match (fetchResult) {
+    success(body) => success(parseAlgoliaHits(body))
+    failure(err) => failure(hnError(err))
+  }
+}
+
+/** Fetch an HN path (Firebase or Algolia) and return the parsed-JSON Result. Raises
+    std::http::fetchJSON but approves it internally, so a plain caller sees only the connector's own
+    std::hackernews prompt while any OUTER fetch handler still receives (and can reject or propagate)
+    the fetch. allowedDomains is enforced inside fetchJSON regardless. Private. */
+safe def hnFetch(base: string, domains: string[], path: string): Result raises <std::http::fetchJSON> {
+  handle {
+    return fetchJSON(baseUrl: base, path: path, allowedDomains: domains)
+  } with (data) {
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+  }
+}
+
+/** Hydrate the first `limit` story ids into Story records via one item fetch each. Items that fail
+    to fetch are skipped. Private. */
+safe def hydrateStories(ids: number[], limit: number): Story[] raises <std::http::fetchJSON> {
+  let stories: Story[] = []
+  for (id in takeFirst(ids, limit)) {
+    const itemResult = hnFetch(HN_BASE, HN_DOMAINS, buildItemPath(id))
+    if (itemResult is success(body)) {
+      stories.push(parseStory(body))
+    }
+  }
+  return stories
+}
+
+/** Turn the id-list fetch Result into hydrated Story[] (matched here, in a helper taking `any`, so it
+    narrows correctly even though hnStories calls it after `return interrupt`). Private. */
+safe def storiesFromFetch(idsResult: any, limit: number): Result<Story[]> raises <std::http::fetchJSON> {
+  return match (idsResult) {
+    success(body) => success(hydrateStories(body ?? [], limit))
+    failure(err) => failure(hnError(err))
+  }
+}
+
+export safe def hnStories(list: string = "top", limit: number = 30): Result<Story[]> raises <std::hackernews, std::http::fetchJSON> {
+  """
+  Fetch a Hacker News story list and hydrate the top items into full stories (title, url, author,
+  score, comment count). Fetches the id list plus one request per item, so a large limit means many
+  requests (capped at 100).
+
+  @param list - Which ranked list to read: "top", "new", "best", "ask", "show", or "job"
+  @param limit - How many stories to hydrate (capped at 100)
+  """
+  const listResult = parseStoryList(list)
+  if (listResult is failure(msg)) {
+    return failure(msg)
+  }
+  const file = listResult.value
+  return interrupt std::hackernews("Fetch this Hacker News story list?", { op: "stories", query: list })
+  const idsResult = hnFetch(HN_BASE, HN_DOMAINS, buildStoryListPath(file))
+  return storiesFromFetch(idsResult, capLimit(limit, 100))
+}
+
+export safe def hnItem(id: number): Result<Item> raises <std::hackernews, std::http::fetchJSON> {
+  """
+  Fetch one Hacker News item by id — a story, comment, job, or poll. Returns its text, author,
+  score, and the ids of its direct child comments. An unknown id returns a failure.
+
+  @param id - The Hacker News item id
+  """
+  return interrupt std::hackernews("Fetch this Hacker News item?", { op: "item", query: "${id}" })
+  const result = hnFetch(HN_BASE, HN_DOMAINS, buildItemPath(id))
+  return itemFinalize(result)
+}
+
+export safe def hnUser(username: string): Result<User> raises <std::hackernews, std::http::fetchJSON> {
+  """
+  Fetch a Hacker News user's public profile: karma, account age, about text, and submitted item
+  ids. An unknown username returns a failure.
+
+  @param username - The Hacker News username (case-sensitive)
+  """
+  return interrupt std::hackernews("Fetch this Hacker News user?", { op: "user", query: username })
+  const result = hnFetch(HN_BASE, HN_DOMAINS, buildUserPath(username))
+  return userFinalize(result)
+}
+
+export safe def hnSearch(query: string, sort: string = "relevance", tags: string = "story", limit: number = 20): Result<Story[]> raises <std::hackernews, std::http::fetchJSON> {
+  """
+  Search Hacker News stories by keyword via the Algolia index. Returns matching stories (title,
+  url, author, score, comment count), sorted by relevance or recency.
+
+  @param query - The search keywords
+  @param sort - Result ordering: "relevance" or "recent"
+  @param tags - Algolia tag filter, e.g. "story", "comment", "ask_hn", "show_hn"
+  @param limit - Maximum results (capped at 50)
+  """
+  const sortResult = parseSort(sort)
+  if (sortResult is failure(msg)) {
+    return failure(msg)
+  }
+  const endpoint = sortResult.value
+  return interrupt std::hackernews("Search Hacker News for this query?", { op: "search", query: query })
+  const result = hnFetch(HN_ALGOLIA_BASE, HN_ALGOLIA_DOMAINS, buildSearchPath(endpoint, query, tags, limit))
+  return searchFinalize(result)
+}

--- a/packages/agency-lang/stdlib/data/tech/yc.agency
+++ b/packages/agency-lang/stdlib/data/tech/yc.agency
@@ -1,0 +1,253 @@
+import { fetchJSON } from "std::http"
+import { keys } from "std::object"
+
+/** @module
+  ## Y Combinator — the YC company directory
+
+  Query the [yc-oss](https://github.com/yc-oss/api) community dataset: every company Y Combinator
+  has funded, sliced by batch, industry, tag, or a curated list. Use this connector to track the
+  newest YC startups and what they do — batch, one-liner, industry, stage, team size, and status.
+
+  The data is static JSON refreshed daily, and there is no server-side search. Fetch a slice (a
+  batch, industry, or tag) and filter in Agency. `ycMeta` lists the available slugs, so an agent
+  can discover the newest batch before fetching it. No API key required.
+
+  ### Usage
+
+  ```ts
+  import { ycBatch } from "std::data/tech/yc"
+
+  node main() {
+    const companies = ycBatch("Winter 2025") catch []
+    for (c in companies) {
+      print("${c.name} — ${c.oneLiner} [${c.status}]")
+    }
+  }
+  ```
+*/
+
+effect std::yc { op: string, query: string }
+
+static const YC_BASE = "https://yc-oss.github.io/api"
+static const YC_DOMAINS = ["yc-oss.github.io"]
+
+// The curated company lists yc-oss serves at companies/<name>.json.
+static const YC_LISTS = ["top", "all", "hiring", "nonprofit", "women-founded", "black-founded", "hispanic-latino-founded"]
+
+/** A YC company — a curated subset of the yc-oss record. `launchedAt` is a Unix timestamp. */
+export type Company = {
+  id: number;
+  name: string;
+  slug: string;
+  website: string;
+  oneLiner: string;
+  longDescription: string;
+  batch: string;
+  status: string;
+  stage: string;
+  teamSize: number;
+  industry: string;
+  subindustry: string;
+  tags: string[];
+  regions: string[];
+  allLocations: string;
+  launchedAt: number;
+  topCompany: boolean;
+  isHiring: boolean;
+  nonprofit: boolean;
+  url: string
+}
+
+/** The available slugs for discovery (from meta.json), so a caller can find the newest batch. */
+export type YcMeta = {
+  lastUpdated: string;
+  batches: string[];
+  industries: string[];
+  tags: string[]
+}
+
+/** Normalize a human label to a yc-oss slug: lowercase, trim, spaces/underscores → hyphens.
+    So "Winter 2025" → "winter-2025". Pure. */
+safe def slugify(s: string): string {
+  return s.toLowerCase().trim().replaceAll(" ", "-").replaceAll("_", "-")
+}
+
+/** The curated-list names as a comma-separated string. Single source of truth for error messages. */
+safe def ycListsList(): string {
+  return YC_LISTS.join(", ")
+}
+
+/** Validate a curated-list name (lenient: slugified first). Unknown → failure listing valid names. */
+safe def parseListName(list: string): Result<string> {
+  const slug = slugify(list)
+  if (YC_LISTS.indexOf(slug) < 0) {
+    return failure("unknown list '${list}'; valid: ${ycListsList()}")
+  }
+  return success(slug)
+}
+
+/** Build the batch-slice path (caller slugifies). Pure. */
+safe def buildBatchPath(slug: string): string {
+  return "/batches/${slug}.json"
+}
+
+/** Build the industry-slice path. Pure. */
+safe def buildIndustryPath(slug: string): string {
+  return "/industries/${slug}.json"
+}
+
+/** Build the tag-slice path. Pure. */
+safe def buildTagPath(slug: string): string {
+  return "/tags/${slug}.json"
+}
+
+/** Build the curated-list path (name already validated by parseListName). Pure. */
+safe def buildListPath(name: string): string {
+  return "/companies/${name}.json"
+}
+
+/** Build the metadata path. Pure. */
+safe def buildMetaPath(): string {
+  return "/meta.json"
+}
+
+/** Reshape a yc-oss company array into Company[]. A slice body is a bare JSON array. Pure/total. */
+safe def parseCompanies(raw: any): Company[] {
+  const arr = raw ?? []
+  return map(arr) as c {
+    const co: any = c ?? {}
+    return {
+      id: co.id ?? 0,
+      name: co.name ?? "",
+      slug: co.slug ?? "",
+      website: co.website ?? "",
+      oneLiner: co.one_liner ?? "",
+      longDescription: co.long_description ?? "",
+      batch: co.batch ?? "",
+      status: co.status ?? "",
+      stage: co.stage ?? "",
+      teamSize: co.team_size ?? 0,
+      industry: co.industry ?? "",
+      subindustry: co.subindustry ?? "",
+      tags: co.tags ?? [],
+      regions: co.regions ?? [],
+      allLocations: co.all_locations ?? "",
+      launchedAt: co.launched_at ?? 0,
+      topCompany: co.top_company ?? false,
+      isHiring: co.isHiring ?? false,
+      nonprofit: co.nonprofit ?? false,
+      url: co.url ?? ""
+    }
+  }
+}
+
+/** Reshape meta.json into YcMeta. batches/industries/tags are slug-keyed objects → take the keys.
+    Pure/total. */
+safe def parseMeta(raw: any): YcMeta {
+  const r: any = raw ?? {}
+  return {
+    lastUpdated: r.last_updated ?? "",
+    batches: keys(r.batches ?? {}),
+    industries: keys(r.industries ?? {}),
+    tags: keys(r.tags ?? {})
+  }
+}
+
+/** Shared failure message for a failed YC fetch. Pure. */
+safe def ycError(err: any): string {
+  return "YC request failed (the data is static JSON on GitHub Pages; an unknown batch/industry/tag slug 404s): ${err.message ?? err}"
+}
+
+/** Turn a fetch Result into a Company[] Result. Pure — testable with mock Results. */
+safe def companiesFinalize(fetchResult: any): Result<Company[]> {
+  return match (fetchResult) {
+    success(body) => success(parseCompanies(body))
+    failure(err) => failure(ycError(err))
+  }
+}
+
+/** Turn a fetch Result into a YcMeta Result. Pure. */
+safe def metaFinalize(fetchResult: any): Result<YcMeta> {
+  return match (fetchResult) {
+    success(body) => success(parseMeta(body))
+    failure(err) => failure(ycError(err))
+  }
+}
+
+/** Fetch a YC path and return the parsed-JSON Result. Raises std::http::fetchJSON but approves it
+    internally, so a plain caller sees only the connector's own std::yc prompt while any OUTER fetch
+    handler still receives (and can reject or propagate) the fetch. allowedDomains is enforced inside
+    fetchJSON regardless. Private. */
+safe def ycFetch(path: string): Result raises <std::http::fetchJSON> {
+  handle {
+    return fetchJSON(baseUrl: YC_BASE, path: path, allowedDomains: YC_DOMAINS)
+  } with (data) {
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+  }
+}
+
+export safe def ycBatch(batch: string): Result<Company[]> raises <std::yc, std::http::fetchJSON> {
+  """
+  Fetch the YC companies in a batch. Returns each company's id, name, one-liner, batch, status,
+  stage, team size, industry, tags, and URL. An unknown batch returns a failure.
+
+  @param batch - The YC batch, e.g. "Winter 2025" or "winter-2025"
+  """
+  return interrupt std::yc("Fetch YC companies for this batch?", { op: "batch", query: batch })
+  const result = ycFetch(buildBatchPath(slugify(batch)))
+  return companiesFinalize(result)
+}
+
+export safe def ycIndustry(industry: string): Result<Company[]> raises <std::yc, std::http::fetchJSON> {
+  """
+  Fetch the YC companies in an industry. Returns each company's profile. An unknown industry
+  returns a failure.
+
+  @param industry - The industry, e.g. "fintech" or "Healthcare"
+  """
+  return interrupt std::yc("Fetch YC companies for this industry?", { op: "industry", query: industry })
+  const result = ycFetch(buildIndustryPath(slugify(industry)))
+  return companiesFinalize(result)
+}
+
+export safe def ycTag(tag: string): Result<Company[]> raises <std::yc, std::http::fetchJSON> {
+  """
+  Fetch the YC companies with a tag. Returns each company's profile. An unknown tag returns a
+  failure.
+
+  @param tag - The tag, e.g. "ai" or "SaaS"
+  """
+  return interrupt std::yc("Fetch YC companies for this tag?", { op: "tag", query: tag })
+  const result = ycFetch(buildTagPath(slugify(tag)))
+  return companiesFinalize(result)
+}
+
+export safe def ycList(list: string = "top"): Result<Company[]> raises <std::yc, std::http::fetchJSON> {
+  """
+  Fetch a curated YC company list: "top", "all", "hiring", "nonprofit", "women-founded",
+  "black-founded", or "hispanic-latino-founded". "all" is large (~6 MB); prefer a batch, industry,
+  or tag slice when you can.
+
+  @param list - The curated list name
+  """
+  const nameResult = parseListName(list)
+  if (nameResult is failure(msg)) {
+    return failure(msg)
+  }
+  const name = nameResult.value
+  return interrupt std::yc("Fetch this YC company list?", { op: "list", query: list })
+  const result = ycFetch(buildListPath(name))
+  return companiesFinalize(result)
+}
+
+export safe def ycMeta(): Result<YcMeta> raises <std::yc, std::http::fetchJSON> {
+  """
+  Fetch the YC directory metadata: the available batch, industry, and tag slugs plus the
+  last-updated timestamp. Use it to discover the newest batch slug before calling ycBatch.
+  """
+  return interrupt std::yc("Fetch the YC directory metadata?", { op: "meta", query: "" })
+  const result = ycFetch(buildMetaPath())
+  return metaFinalize(result)
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews-live/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews-live/agent.agency
@@ -1,0 +1,16 @@
+import { hnStories } from "std::data/tech/hackernews"
+
+node liveTop(): number {
+  handle {
+    const stories = hnStories("top", 3) catch []
+    return stories.length
+  } with (data) {
+    if (data.effect == "std::hackernews") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews-live/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews-live/fixture.json
@@ -1,0 +1,1 @@
+{ "skipped": true }

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews-live/test.js
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews-live/test.js
@@ -1,0 +1,11 @@
+import { liveTop } from "./agent.js";
+import { writeFileSync } from "node:fs";
+
+// Opt-in: only hits the live HN API when AGENCY_LIVE_TESTS is set. Exercises the hydration loop
+// (1 id-list fetch + up to 3 item fetches).
+if (!process.env.AGENCY_LIVE_TESTS) {
+  writeFileSync("__result.json", JSON.stringify({ skipped: true }, null, 2));
+} else {
+  const n = (await liveTop())?.data ?? -1;
+  writeFileSync("__result.json", JSON.stringify({ ok: n >= 1 }, null, 2));
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/agent.agency
@@ -1,0 +1,148 @@
+import test { parseStoryList, parseSort, capLimit, takeFirst, buildStoryListPath, buildItemPath, buildUserPath, buildSearchPath, parseStory, parseItem, parseUser, parseAlgoliaHits, itemFinalize, userFinalize, searchFinalize, hnError, hnStories, hnItem, hnSearch } from "std::data/tech/hackernews"
+import { Network } from "std::capabilities"
+
+// --- pure-function wrappers ---
+
+node tParseStoryList(list: string): any {
+  const r = parseStoryList(list)
+  if (r is failure(e)) {
+    return "FAIL: ${e}"
+  }
+  return r.value
+}
+
+node tParseSort(sort: string): any {
+  const r = parseSort(sort)
+  if (r is failure(e)) {
+    return "FAIL: ${e}"
+  }
+  return r.value
+}
+
+node tCapLimit(n: number, cap: number): number {
+  return capLimit(n, cap)
+}
+
+node tTakeFirst(ids: number[], n: number): any {
+  return takeFirst(ids, n)
+}
+
+node tStoryListPath(file: string): string {
+  return buildStoryListPath(file)
+}
+
+node tItemPath(id: number): string {
+  return buildItemPath(id)
+}
+
+node tUserPath(username: string): string {
+  return buildUserPath(username)
+}
+
+node tSearchPath(endpoint: string, query: string, tags: string, limit: number): string {
+  return buildSearchPath(endpoint, query, tags, limit)
+}
+
+node tParseStory(raw: any): any {
+  return parseStory(raw)
+}
+
+node tParseItem(raw: any): any {
+  return parseItem(raw)
+}
+
+node tParseUser(raw: any): any {
+  return parseUser(raw)
+}
+
+node tParseHits(raw: any): any {
+  return parseAlgoliaHits(raw)
+}
+
+node tParseHitsNull(): any {
+  return parseAlgoliaHits(null)
+}
+
+node tItemFinalizeNull(): string {
+  const r = itemFinalize(success(null))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tSearchFinalizeErr(): string {
+  const r = searchFinalize(failure("boom"))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tError(): string {
+  return hnError("boom")
+}
+
+// --- gating / capability ---
+
+// Compile-time capability assertion: hnStories raises std::hackernews + std::http::fetchJSON, so this
+// compiles only if BOTH are covered by Network. Never called at runtime.
+node netCheck() raises <Network> {
+  const r = hnStories("top", 1) catch []
+  return r.length
+}
+
+// Plain caller (no fetch handler): raises std::hackernews only.
+node callItem(id: number): any {
+  return hnItem(id)
+}
+
+// Governed caller: approve std::hackernews, PROPAGATE the fetch so std::http::fetchJSON surfaces with
+// its { baseUrl, path } — asserted offline, then rejected (no network).
+node callItemGoverned(id: number): any {
+  handle {
+    return hnItem(id)
+  } with (data) {
+    if (data.effect == "std::hackernews") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return propagate()
+    }
+  }
+}
+
+// Bad sort fails BEFORE the interrupt → a failure Result offline (no fetch, no interrupt).
+node callSearchBad(): string {
+  const r = hnSearch("rust", "bogus")
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS_OR_INTERRUPT"
+}
+
+// --- fetch-mocked end-to-end (see fetchMocks.json) ---
+// mockStories is the key one: it exercises the hydration loop — 1 id-list fetch + 1 item fetch per id.
+
+node mockStories(): any {
+  const r = hnStories("top", 2) with approve
+  return r catch "FAIL"
+}
+
+node mockItem(): any {
+  const r = hnItem(8863) with approve
+  return r catch "FAIL"
+}
+
+node mockItemNull(): string {
+  const r = hnItem(999) with approve
+  if (r is failure(e)) {
+    return "GOT_FAILURE"
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node mockSearch(): any {
+  const r = hnSearch("dropbox") with approve
+  return r catch "FAIL"
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/fetchMocks.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/fetchMocks.json
@@ -1,0 +1,7 @@
+[
+  { "url": "https://hacker-news.firebaseio.com/v0/topstories.json", "return": [8863, 8952] },
+  { "url": "https://hacker-news.firebaseio.com/v0/item/8863.json", "returnFile": "sample-item.json" },
+  { "url": "https://hacker-news.firebaseio.com/v0/item/8952.json", "return": { "id": 8952, "type": "story", "by": "pg", "time": 1175718200, "title": "Second story", "url": "http://example.com/2", "score": 50, "descendants": 10 } },
+  { "url": "https://hacker-news.firebaseio.com/v0/item/999.json", "return": null },
+  { "urlPattern": "hn\\.algolia\\.com/api/v1/search\\?query=dropbox", "returnFile": "sample-search.json" }
+]

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/fixture.json
@@ -1,0 +1,113 @@
+{
+  "listTop": "topstories",
+  "listJob": "jobstories",
+  "listBad": "FAIL: unknown list 'bogus'; valid: top, new, best, ask, show, job",
+  "sortRel": "search",
+  "sortRecent": "search_by_date",
+  "sortBad": "FAIL: unknown sort 'bogus'; valid: relevance, recent",
+  "capUnder": 30,
+  "capOver": 100,
+  "capNeg": 0,
+  "takeSome": [10, 20],
+  "takeOver": [10],
+  "takeZero": [],
+  "storyListPath": "/topstories.json",
+  "itemPath": "/item/8863.json",
+  "userPath": "/user/pg.json",
+  "searchPath": "/search?query=rust%20async&tags=story&hitsPerPage=20",
+  "searchPathClamped": "/search_by_date?query=ai&tags=story&hitsPerPage=50",
+  "story": {
+    "id": 8863,
+    "title": "My YC app: Dropbox - Throw away your USB drive",
+    "url": "http://www.getdropbox.com/u/2/screencast.html",
+    "by": "dhouston",
+    "score": 111,
+    "time": 1175714200,
+    "descendants": 71,
+    "type": "story"
+  },
+  "item": {
+    "id": 8863,
+    "type": "story",
+    "by": "dhouston",
+    "time": 1175714200,
+    "title": "My YC app: Dropbox - Throw away your USB drive",
+    "url": "http://www.getdropbox.com/u/2/screencast.html",
+    "text": "",
+    "score": 111,
+    "descendants": 71,
+    "parent": null,
+    "kids": [8952, 9224]
+  },
+  "user": {
+    "id": "pg",
+    "created": 1160418092,
+    "karma": 155111,
+    "about": "Bug fixer.",
+    "submitted": [1, 2, 3]
+  },
+  "hits": [
+    {
+      "id": 8863,
+      "title": "Dropbox",
+      "url": "http://getdropbox.com",
+      "by": "dhouston",
+      "score": 111,
+      "time": 1175714200,
+      "descendants": 71,
+      "type": "story"
+    }
+  ],
+  "hitsNull": [],
+  "itemFinalizeNull": "Hacker News returned no item",
+  "searchFinalizeErr": "Hacker News request failed (the API may be rate-limited): boom",
+  "errorMsg": "Hacker News request failed (the API may be rate-limited): boom",
+  "mockStories": [
+    {
+      "id": 8863,
+      "title": "My YC app: Dropbox - Throw away your USB drive",
+      "url": "http://www.getdropbox.com/u/2/screencast.html",
+      "by": "dhouston",
+      "score": 111,
+      "time": 1175714200,
+      "descendants": 71,
+      "type": "story"
+    },
+    {
+      "id": 8952,
+      "title": "Second story",
+      "url": "http://example.com/2",
+      "by": "pg",
+      "score": 50,
+      "time": 1175718200,
+      "descendants": 10,
+      "type": "story"
+    }
+  ],
+  "mockItem": {
+    "id": 8863,
+    "type": "story",
+    "by": "dhouston",
+    "time": 1175714200,
+    "title": "My YC app: Dropbox - Throw away your USB drive",
+    "url": "http://www.getdropbox.com/u/2/screencast.html",
+    "text": "",
+    "score": 111,
+    "descendants": 71,
+    "parent": null,
+    "kids": [8952, 9224]
+  },
+  "mockItemNull": "GOT_FAILURE",
+  "mockSearch": [
+    {
+      "id": 8863,
+      "title": "Dropbox",
+      "url": "http://getdropbox.com",
+      "by": "dhouston",
+      "score": 111,
+      "time": 1175714200,
+      "descendants": 71,
+      "type": "story"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/sample-item.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/sample-item.json
@@ -1,0 +1,11 @@
+{
+  "by": "dhouston",
+  "descendants": 71,
+  "id": 8863,
+  "kids": [8952, 9224],
+  "score": 111,
+  "time": 1175714200,
+  "title": "My YC app: Dropbox - Throw away your USB drive",
+  "type": "story",
+  "url": "http://www.getdropbox.com/u/2/screencast.html"
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/sample-search.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/sample-search.json
@@ -1,0 +1,15 @@
+{
+  "hits": [
+    {
+      "objectID": "8863",
+      "title": "Dropbox",
+      "url": "http://getdropbox.com",
+      "author": "dhouston",
+      "points": 111,
+      "num_comments": 71,
+      "created_at_i": 1175714200,
+      "story_id": 8863
+    }
+  ],
+  "nbHits": 1
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/sample-user.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/sample-user.json
@@ -1,0 +1,7 @@
+{
+  "id": "pg",
+  "created": 1160418092,
+  "karma": 155111,
+  "about": "Bug fixer.",
+  "submitted": [1, 2, 3]
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-hackernews/test.js
+++ b/packages/agency-lang/tests/agency-js/data-tech-hackernews/test.js
@@ -1,0 +1,78 @@
+import { tParseStoryList, tParseSort, tCapLimit, tTakeFirst, tStoryListPath, tItemPath, tUserPath, tSearchPath, tParseStory, tParseItem, tParseUser, tParseHits, tParseHitsNull, tItemFinalizeNull, tSearchFinalizeErr, tError, hasInterrupts, approve, reject, respondToInterrupts, callItem, callItemGoverned, callSearchBad, mockStories, mockItem, mockItemNull, mockSearch } from "./agent.js";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const unwrap = (r) => r?.data ?? r;
+const load = (f) => JSON.parse(readFileSync(new URL(f, import.meta.url), "utf8"));
+const sampleItem = load("./sample-item.json");
+const sampleUser = load("./sample-user.json");
+const sampleSearch = load("./sample-search.json");
+
+// --- interrupt / effect assertions (throw on mismatch) ---
+
+// (A) The domain interrupt gates the call: rejecting std::hackernews short-circuits with NO fetch.
+const i1 = await callItem(8863);
+if (!hasInterrupts(i1.data)) throw new Error("hnItem did not raise an interrupt");
+const iv = i1.data[0];
+if (iv.effect !== "std::hackernews") throw new Error("wrong effect: " + iv.effect);
+if (iv.data.op !== "item") throw new Error("wrong op discriminant: " + iv.data.op);
+if (iv.data.query !== "8863") throw new Error("wrong payload: " + iv.data.query);
+const rejected = await respondToInterrupts(i1.data, [reject()]);
+if (hasInterrupts(rejected.data)) throw new Error("rejecting std::hackernews must short-circuit before any fetch");
+
+// (B) Single-prompt ergonomics: a plain caller sees ONLY std::hackernews at the first hop.
+if (i1.data.filter((x) => x.effect && x.effect !== "std::hackernews").length > 0) {
+  throw new Error("plain caller must see only std::hackernews at the first hop");
+}
+
+// (C) Governance + offline URL wiring: propagate the fetch so std::http::fetchJSON surfaces with its
+// { baseUrl, path } (Firebase host + item path), asserted offline, then rejected (no network).
+const g1 = await callItemGoverned(8863);
+if (!hasInterrupts(g1.data)) throw new Error("governed caller should surface std::http::fetchJSON via propagate()");
+const gv = g1.data[0];
+if (gv.effect !== "std::http::fetchJSON") throw new Error("expected std::http::fetchJSON, got: " + gv.effect);
+if (gv.data.baseUrl !== "https://hacker-news.firebaseio.com/v0") throw new Error("wrong baseUrl: " + gv.data.baseUrl);
+if (gv.data.path !== "/item/8863.json") throw new Error("wrong path: " + gv.data.path);
+await respondToInterrupts(g1.data, [reject()]);
+
+// (D) Unknown-sort failure path, OFFLINE: bad sort validates to a failure Result with NO interrupt.
+const bad = await callSearchBad();
+if (hasInterrupts(bad.data)) throw new Error("bad sort must fail before raising std::hackernews (no interrupt)");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      listTop: unwrap(await tParseStoryList("top")),
+      listJob: unwrap(await tParseStoryList("job")),
+      listBad: unwrap(await tParseStoryList("bogus")),
+      sortRel: unwrap(await tParseSort("relevance")),
+      sortRecent: unwrap(await tParseSort("recent")),
+      sortBad: unwrap(await tParseSort("bogus")),
+      capUnder: unwrap(await tCapLimit(30, 100)),
+      capOver: unwrap(await tCapLimit(500, 100)),
+      capNeg: unwrap(await tCapLimit(-5, 100)),
+      takeSome: unwrap(await tTakeFirst([10, 20, 30, 40], 2)),
+      takeOver: unwrap(await tTakeFirst([10], 5)),
+      takeZero: unwrap(await tTakeFirst([10, 20], 0)),
+      storyListPath: unwrap(await tStoryListPath("topstories")),
+      itemPath: unwrap(await tItemPath(8863)),
+      userPath: unwrap(await tUserPath("pg")),
+      searchPath: unwrap(await tSearchPath("search", "rust async", "story", 20)),
+      searchPathClamped: unwrap(await tSearchPath("search_by_date", "ai", "story", 500)),
+      story: unwrap(await tParseStory(sampleItem)),
+      item: unwrap(await tParseItem(sampleItem)),
+      user: unwrap(await tParseUser(sampleUser)),
+      hits: unwrap(await tParseHits(sampleSearch)),
+      hitsNull: unwrap(await tParseHitsNull()),
+      itemFinalizeNull: unwrap(await tItemFinalizeNull()),
+      searchFinalizeErr: unwrap(await tSearchFinalizeErr()),
+      errorMsg: unwrap(await tError()),
+      mockStories: unwrap(await mockStories()),
+      mockItem: unwrap(await mockItem()),
+      mockItemNull: unwrap(await mockItemNull()),
+      mockSearch: unwrap(await mockSearch()),
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/data-tech-yc-live/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc-live/agent.agency
@@ -1,0 +1,16 @@
+import { ycBatch } from "std::data/tech/yc"
+
+node liveBatch(): number {
+  handle {
+    const companies = ycBatch("Winter 2012") catch []
+    return companies.length
+  } with (data) {
+    if (data.effect == "std::yc") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-yc-live/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc-live/fixture.json
@@ -1,0 +1,1 @@
+{ "skipped": true }

--- a/packages/agency-lang/tests/agency-js/data-tech-yc-live/test.js
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc-live/test.js
@@ -1,0 +1,10 @@
+import { liveBatch } from "./agent.js";
+import { writeFileSync } from "node:fs";
+
+// Opt-in: only hits the live yc-oss API when AGENCY_LIVE_TESTS is set.
+if (!process.env.AGENCY_LIVE_TESTS) {
+  writeFileSync("__result.json", JSON.stringify({ skipped: true }, null, 2));
+} else {
+  const n = (await liveBatch())?.data ?? -1;
+  writeFileSync("__result.json", JSON.stringify({ ok: n >= 1 }, null, 2));
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-yc/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc/agent.agency
@@ -1,0 +1,126 @@
+import test { slugify, parseListName, buildBatchPath, buildIndustryPath, buildTagPath, buildListPath, buildMetaPath, parseCompanies, parseMeta, companiesFinalize, metaFinalize, ycError, ycBatch, ycList, ycMeta } from "std::data/tech/yc"
+import { Network } from "std::capabilities"
+
+// --- pure-function wrappers ---
+
+node tSlugify(s: string): string {
+  return slugify(s)
+}
+
+node tParseListName(list: string): any {
+  const r = parseListName(list)
+  if (r is failure(e)) {
+    return "FAIL: ${e}"
+  }
+  return r.value
+}
+
+node tBatchPath(slug: string): string {
+  return buildBatchPath(slug)
+}
+
+node tIndustryPath(slug: string): string {
+  return buildIndustryPath(slug)
+}
+
+node tTagPath(slug: string): string {
+  return buildTagPath(slug)
+}
+
+node tListPath(name: string): string {
+  return buildListPath(name)
+}
+
+node tMetaPath(): string {
+  return buildMetaPath()
+}
+
+node tParseCompanies(raw: any): any {
+  return parseCompanies(raw)
+}
+
+node tParseNull(): any {
+  return parseCompanies(null)
+}
+
+node tParseMeta(raw: any): any {
+  return parseMeta(raw)
+}
+
+node tMetaFinalize(raw: any): any {
+  return metaFinalize(success(raw)) catch {}
+}
+
+node tCompaniesFinalizeErr(): string {
+  const r = companiesFinalize(failure("boom"))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tError(): string {
+  return ycError("boom")
+}
+
+// --- gating / capability ---
+
+// Compile-time capability assertion: ycBatch raises std::yc + std::http::fetchJSON, so this compiles
+// only if BOTH are covered by Network. Never called at runtime.
+node netCheck() raises <Network> {
+  const r = ycBatch("x") catch []
+  return r.length
+}
+
+// Plain caller: no fetch-level handler. Raises std::yc; approving it would resume into the
+// internally-approved fetch (a real network call), so tests only inspect/reject it.
+node callBatch(batch: string): any {
+  return ycBatch(batch)
+}
+
+// Governed caller: approve std::yc, then PROPAGATE the fetch. propagate() beats the connector's
+// internal approve(), so std::http::fetchJSON surfaces with its { baseUrl, path } — letting us assert
+// the built URL OFFLINE, then reject it so no network call happens.
+node callBatchGoverned(batch: string): any {
+  handle {
+    return ycBatch(batch)
+  } with (data) {
+    if (data.effect == "std::yc") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return propagate()
+    }
+  }
+}
+
+// Bad list name fails BEFORE the interrupt → a failure Result offline (no fetch, no interrupt).
+node callListBad(): string {
+  const r = ycList("bogus")
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS_OR_INTERRUPT"
+}
+
+// --- fetch-mocked end-to-end (see fetchMocks.json) ---
+// `with approve` approves std::yc (and the internal fetch), so the real fetch runs against the
+// fetchMocks.json entries — exercising the full validate→fetch→parse→finalize path.
+
+node mockBatch(): any {
+  const r = ycBatch("Winter 2012") with approve
+  return r catch "FAIL"
+}
+
+node mockMeta(): any {
+  const r = ycMeta() with approve
+  return r catch "FAIL"
+}
+
+node mockBatchBad(): string {
+  const r = ycBatch("Bogus Batch") with approve
+  if (r is failure(e)) {
+    return "GOT_FAILURE"
+  }
+  return "UNEXPECTED_SUCCESS"
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-yc/fetchMocks.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc/fetchMocks.json
@@ -1,0 +1,5 @@
+[
+  { "url": "https://yc-oss.github.io/api/batches/winter-2012.json", "returnFile": "sample-batch.json" },
+  { "url": "https://yc-oss.github.io/api/meta.json", "returnFile": "sample-meta.json" },
+  { "url": "https://yc-oss.github.io/api/batches/bogus-batch.json", "return": "Not Found", "status": 404 }
+]

--- a/packages/agency-lang/tests/agency-js/data-tech-yc/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc/fixture.json
@@ -1,0 +1,81 @@
+{
+  "slug1": "winter-2025",
+  "slug2": "b2b-saas",
+  "listOk": "top",
+  "listBad": "FAIL: unknown list 'bogus'; valid: top, all, hiring, nonprofit, women-founded, black-founded, hispanic-latino-founded",
+  "batchPath": "/batches/winter-2025.json",
+  "industryPath": "/industries/fintech.json",
+  "tagPath": "/tags/ai.json",
+  "listPath": "/companies/hiring.json",
+  "metaPath": "/meta.json",
+  "companies": [
+    {
+      "id": 271,
+      "name": "Airbnb",
+      "slug": "airbnb",
+      "website": "http://airbnb.com",
+      "oneLiner": "Book rooms with locals.",
+      "longDescription": "A marketplace for space.",
+      "batch": "Winter 2009",
+      "status": "Public",
+      "stage": "Public",
+      "teamSize": 6132,
+      "industry": "Consumer",
+      "subindustry": "Consumer -> Travel",
+      "tags": ["Marketplace", "Travel"],
+      "regions": ["United States of America"],
+      "allLocations": "San Francisco, CA, USA",
+      "launchedAt": 1234567890,
+      "topCompany": true,
+      "isHiring": false,
+      "nonprofit": false,
+      "url": "https://www.ycombinator.com/companies/airbnb"
+    }
+  ],
+  "parseNull": [],
+  "meta": {
+    "lastUpdated": "2026-07-07T02:09:17.762Z",
+    "batches": ["winter-2025", "spring-2025"],
+    "industries": ["fintech"],
+    "tags": ["ai"]
+  },
+  "metaFinalize": {
+    "lastUpdated": "2026-07-07T02:09:17.762Z",
+    "batches": ["winter-2025", "spring-2025"],
+    "industries": ["fintech"],
+    "tags": ["ai"]
+  },
+  "companiesFinalizeErr": "YC request failed (the data is static JSON on GitHub Pages; an unknown batch/industry/tag slug 404s): boom",
+  "errorMsg": "YC request failed (the data is static JSON on GitHub Pages; an unknown batch/industry/tag slug 404s): boom",
+  "mockBatch": [
+    {
+      "id": 271,
+      "name": "Airbnb",
+      "slug": "airbnb",
+      "website": "http://airbnb.com",
+      "oneLiner": "Book rooms with locals.",
+      "longDescription": "A marketplace for space.",
+      "batch": "Winter 2009",
+      "status": "Public",
+      "stage": "Public",
+      "teamSize": 6132,
+      "industry": "Consumer",
+      "subindustry": "Consumer -> Travel",
+      "tags": ["Marketplace", "Travel"],
+      "regions": ["United States of America"],
+      "allLocations": "San Francisco, CA, USA",
+      "launchedAt": 1234567890,
+      "topCompany": true,
+      "isHiring": false,
+      "nonprofit": false,
+      "url": "https://www.ycombinator.com/companies/airbnb"
+    }
+  ],
+  "mockMeta": {
+    "lastUpdated": "2026-07-07T02:09:17.762Z",
+    "batches": ["winter-2025", "spring-2025"],
+    "industries": ["fintech"],
+    "tags": ["ai"]
+  },
+  "mockBatchBad": "GOT_FAILURE"
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-yc/sample-batch.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc/sample-batch.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 271,
+    "name": "Airbnb",
+    "slug": "airbnb",
+    "former_names": [],
+    "small_logo_thumb_url": "https://logo.example/airbnb.png",
+    "website": "http://airbnb.com",
+    "all_locations": "San Francisco, CA, USA",
+    "long_description": "A marketplace for space.",
+    "one_liner": "Book rooms with locals.",
+    "team_size": 6132,
+    "highlight_women": false,
+    "industry": "Consumer",
+    "subindustry": "Consumer -> Travel",
+    "launched_at": 1234567890,
+    "tags": ["Marketplace", "Travel"],
+    "top_company": true,
+    "isHiring": false,
+    "nonprofit": false,
+    "batch": "Winter 2009",
+    "status": "Public",
+    "industries": ["Consumer", "Travel"],
+    "regions": ["United States of America"],
+    "stage": "Public",
+    "app_answers": null,
+    "url": "https://www.ycombinator.com/companies/airbnb",
+    "api": "https://yc-oss.github.io/api/companies/airbnb.json"
+  }
+]

--- a/packages/agency-lang/tests/agency-js/data-tech-yc/sample-meta.json
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc/sample-meta.json
@@ -1,0 +1,13 @@
+{
+  "last_updated": "2026-07-07T02:09:17.762Z",
+  "batches": {
+    "winter-2025": { "name": "Winter 2025", "count": 100, "api": "x" },
+    "spring-2025": { "name": "Spring 2025", "count": 90, "api": "x" }
+  },
+  "industries": {
+    "fintech": { "name": "Fintech", "count": 500, "api": "x" }
+  },
+  "tags": {
+    "ai": { "name": "AI", "count": 800, "api": "x" }
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-tech-yc/test.js
+++ b/packages/agency-lang/tests/agency-js/data-tech-yc/test.js
@@ -1,0 +1,67 @@
+import { tSlugify, tParseListName, tBatchPath, tIndustryPath, tTagPath, tListPath, tMetaPath, tParseCompanies, tParseNull, tParseMeta, tMetaFinalize, tCompaniesFinalizeErr, tError, hasInterrupts, approve, reject, respondToInterrupts, callBatch, callBatchGoverned, callListBad, mockBatch, mockMeta, mockBatchBad } from "./agent.js";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const unwrap = (r) => r?.data ?? r;
+const load = (f) => JSON.parse(readFileSync(new URL(f, import.meta.url), "utf8"));
+const sampleBatch = load("./sample-batch.json");
+const sampleMeta = load("./sample-meta.json");
+
+// --- interrupt / effect assertions (throw on mismatch) ---
+
+// (A) The domain interrupt gates the call: rejecting std::yc short-circuits with NO fetch.
+const i1 = await callBatch("Winter 2009");
+if (!hasInterrupts(i1.data)) throw new Error("ycBatch did not raise an interrupt");
+const iv = i1.data[0];
+if (iv.effect !== "std::yc") throw new Error("wrong effect: " + iv.effect);
+if (iv.data.op !== "batch") throw new Error("wrong op discriminant: " + iv.data.op);
+if (iv.data.query !== "Winter 2009") throw new Error("wrong payload: " + iv.data.query);
+const rejected = await respondToInterrupts(i1.data, [reject()]);
+if (hasInterrupts(rejected.data)) throw new Error("rejecting std::yc must short-circuit before any fetch");
+
+// (B) Single-prompt ergonomics: a plain caller sees ONLY std::yc at the first hop.
+if (i1.data.filter((x) => x.effect && x.effect !== "std::yc").length > 0) {
+  throw new Error("plain caller must see only std::yc at the first hop");
+}
+
+// (C) Governance + offline URL wiring: propagate the fetch so std::http::fetchJSON surfaces with its
+// { baseUrl, path }. Proves an outer handler still receives the fetch AND that the built URL (batch
+// slugified to "winter-2009") is correct — asserted offline, then rejected so no network call happens.
+const g1 = await callBatchGoverned("Winter 2009");
+if (!hasInterrupts(g1.data)) throw new Error("governed caller should surface std::http::fetchJSON via propagate()");
+const gv = g1.data[0];
+if (gv.effect !== "std::http::fetchJSON") throw new Error("expected std::http::fetchJSON, got: " + gv.effect);
+if (gv.data.baseUrl !== "https://yc-oss.github.io/api") throw new Error("wrong baseUrl: " + gv.data.baseUrl);
+if (gv.data.path !== "/batches/winter-2009.json") throw new Error("wrong path: " + gv.data.path);
+await respondToInterrupts(g1.data, [reject()]);
+
+// (D) Unknown-list failure path, OFFLINE: bad list validates to a failure Result with NO interrupt.
+const bad = await callListBad();
+if (hasInterrupts(bad.data)) throw new Error("bad list must fail before raising std::yc (no interrupt)");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      slug1: unwrap(await tSlugify("Winter 2025")),
+      slug2: unwrap(await tSlugify("  B2B SaaS ")),
+      listOk: unwrap(await tParseListName("Top")),
+      listBad: unwrap(await tParseListName("bogus")),
+      batchPath: unwrap(await tBatchPath("winter-2025")),
+      industryPath: unwrap(await tIndustryPath("fintech")),
+      tagPath: unwrap(await tTagPath("ai")),
+      listPath: unwrap(await tListPath("hiring")),
+      metaPath: unwrap(await tMetaPath()),
+      companies: unwrap(await tParseCompanies(sampleBatch)),
+      parseNull: unwrap(await tParseNull()),
+      meta: unwrap(await tParseMeta(sampleMeta)),
+      metaFinalize: unwrap(await tMetaFinalize(sampleMeta)),
+      companiesFinalizeErr: unwrap(await tCompaniesFinalizeErr()),
+      errorMsg: unwrap(await tError()),
+      mockBatch: unwrap(await mockBatch()),
+      mockMeta: unwrap(await mockMeta()),
+      mockBatchBad: unwrap(await mockBatchBad()),
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## What

Two new free, keyless stdlib connectors under `std::data/tech/`, following the connector recipe in `docs/dev/adding-connectors.md`:

- **`std::data/tech/yc`** — the [yc-oss](https://github.com/yc-oss/api) Y Combinator company directory. `ycBatch` / `ycIndustry` / `ycTag` / `ycList` (curated lists) return typed `Company[]`; `ycMeta` returns the available batch/industry/tag slugs for discovery. Static JSON, no server-side search.
- **`std::data/tech/hackernews`** — Hacker News over two hosts: the Firebase API (`hnStories` with hydrated `Story[]`, `hnItem`, `hnUser`) and the Algolia index (`hnSearch` keyword full-text search). `hnStories` fetches the id list, then hydrates the top N items via one shared fetch helper.

## Design

- **Option-B fetch gating:** each connector raises its own semantic effect (`std::yc` / `std::hackernews`) and calls `fetchJSON` inside a private helper that internally `approve()`s `std::http::fetchJSON`. A plain caller sees one prompt; the fetch effect still reaches outer governance handlers. Both effects are registered in the `Network` capability set.
- **Ergonomic types:** friendly string enums (validated before the interrupt), flat records, `Result` failures. Only the public functions and their return types are exported; every helper is a non-exported `safe def`, so the generated docs stay to the ~5 real tools per connector. Tests reach the helpers via `import test`.

## Testing (all offline unless noted)

Per connector, under `tests/agency-js/data-tech-*`:
- **Pure functions** — builders, parsers, finalizers, validators, against trimmed real captured bodies.
- **Interrupt gating** — reject short-circuits before fetch; a plain caller sees only the semantic effect; a `propagate()`d fetch surfaces `std::http::fetchJSON` with the exact `{ baseUrl, path }`; invalid enum input fails before the interrupt.
- **Fetch-mocked end-to-end** — the public functions run against a `fetchMocks.json`, asserting the fully-reshaped `Result` (a wrong built URL matches no mock → failure). Includes HN's `mockStories`, which drives the **full hydration loop** (id-list fetch + one item fetch per id) offline.
- **Opt-in live drift check** (`*-live/`, gated on `AGENCY_LIVE_TESTS`, skipped by default).

Docs are generated via `agency doc` (`docs/site/stdlib/data/tech/*`) with nav entries added.

Builds on the `std::http` non-2xx status fix (#455, already merged): `ycError`/`hnError` read `err.message` from the structured failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
