### PR TITLE
Add std::data/wikidata connector

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -283,6 +283,10 @@ export default defineConfig({
                   text: "data/tech/hackernews",
                   link: "/stdlib/data/tech/hackernews",
                 },
+                {
+                  text: "data/wikidata",
+                  link: "/stdlib/data/wikidata",
+                },
               ],
             },
             { text: "date", link: "/stdlib/date" },

--- a/packages/agency-lang/docs/site/stdlib/capabilities.md
+++ b/packages/agency-lang/docs/site/stdlib/capabilities.md
@@ -85,7 +85,7 @@ Anything that talks to the outside world over the network.
 
 ```ts
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews, std::wikidata>
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L45))

--- a/packages/agency-lang/docs/site/stdlib/data/wikidata.md
+++ b/packages/agency-lang/docs/site/stdlib/data/wikidata.md
@@ -91,8 +91,9 @@ effect std::wikidata {
 wikidataSearch(name: string, limit: number): Result<Entity[]>
 ```
 
-Search Wikidata for entities by name. Returns matches with QID, label, description, and URL; use a
-  returned id with wikidataEntity or wikidataQuery. Empty result set returns an empty list.
+Search Wikidata for entities by name. Returns matches with QID, label, description, and URL. The
+  QID identifies the entity for a follow-up entity fetch or SPARQL query. Empty result set returns an
+  empty list.
 
   @param name - The person, organization, place, or thing to search for
   @param limit - Maximum number of matches to return (default 5)
@@ -132,7 +133,7 @@ Fetch one Wikidata entity by its QID. Returns the English label, description, al
 
 **Throws:** `std::wikidata`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L244))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L245))
 
 ### wikidataQuery
 
@@ -156,4 +157,4 @@ Run a SPARQL query against the Wikidata Query Service and return rows (each a ma
 
 **Throws:** `std::wikidata`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L257))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L258))

--- a/packages/agency-lang/docs/site/stdlib/data/wikidata.md
+++ b/packages/agency-lang/docs/site/stdlib/data/wikidata.md
@@ -1,0 +1,159 @@
+---
+name: "wikidata"
+---
+
+# wikidata
+
+## Wikidata — the open knowledge graph
+
+  Query [Wikidata](https://www.wikidata.org), the free structured database behind Wikipedia:
+  resolve a name to an entity, read an entity's facts, or run a raw SPARQL query over the graph.
+  Use it for broad entity research — people, organizations, places, works, and their typed
+  relationships — complementing the power-network focus of `std::data/people/littlesis`.
+
+  Recipe: `wikidataSearch` a name to get a QID, then `wikidataEntity(qid)` for its facts, or
+  `wikidataQuery` for graph traversal. Entity claims and SPARQL results reference other entities by
+  QID (e.g. "Q5"); resolve those with another search/entity call, or ask SPARQL for labels with
+  `SERVICE wikibase:label`. No API key required (WDQS is rate-limited and wants a descriptive
+  User-Agent — set WIKIDATA_USER_AGENT to override the default).
+
+  ### Usage
+
+  ```ts
+  import { wikidataSearch, wikidataEntity } from "std::data/wikidata"
+
+  node main() {
+    const hits = wikidataSearch("Ada Lovelace") catch []
+    if (hits.length > 0) {
+      const e = wikidataEntity(hits[0].id) catch { id: "", label: "", description: "", aliases: [], claims: {} }
+      print("${e.label}: ${e.description}")
+    }
+  }
+  ```
+
+## Types
+
+### Entity
+
+A Wikidata entity from a name search. `id` is the QID (e.g. "Q42").
+
+```ts
+/** A Wikidata entity from a name search. `id` is the QID (e.g. "Q42"). */
+export type Entity = {
+  id: string;
+  label: string;
+  description: string;
+  url: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L46))
+
+### EntityDetail
+
+One entity's facts. `claims` maps a property id (e.g. "P31") to its values; a value is a QID for
+    entity-valued claims, or the literal's string form otherwise. Resolve QIDs with another
+    search/entity call.
+
+```ts
+/** One entity's facts. `claims` maps a property id (e.g. "P31") to its values; a value is a QID for
+    entity-valued claims, or the literal's string form otherwise. Resolve QIDs with another
+    search/entity call. */
+export type EntityDetail = {
+  id: string;
+  label: string;
+  description: string;
+  aliases: string[];
+  claims: Record<string, string[]>
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L56))
+
+## Effects
+
+### std::wikidata
+
+```ts
+effect std::wikidata {
+  op: string;
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L34))
+
+## Functions
+
+### wikidataSearch
+
+```ts
+wikidataSearch(name: string, limit: number): Result<Entity[]>
+```
+
+Search Wikidata for entities by name. Returns matches with QID, label, description, and URL; use a
+  returned id with wikidataEntity or wikidataQuery. Empty result set returns an empty list.
+
+  @param name - The person, organization, place, or thing to search for
+  @param limit - Maximum number of matches to return (default 5)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+| limit | `number` | 5 |
+
+**Returns:** `Result<Entity[]>`
+
+**Throws:** `std::wikidata`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L231))
+
+### wikidataEntity
+
+```ts
+wikidataEntity(qid: string): Result<EntityDetail>
+```
+
+Fetch one Wikidata entity by its QID. Returns the English label, description, aliases, and claims
+  (property id to values; entity-valued claims are QIDs to resolve separately). Unknown QID returns
+  a failure.
+
+  @param qid - The Wikidata entity id, e.g. "Q42"
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| qid | `string` |  |
+
+**Returns:** `Result<EntityDetail>`
+
+**Throws:** `std::wikidata`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L244))
+
+### wikidataQuery
+
+```ts
+wikidataQuery(sparql: string): Result<Record<string, string>[]>
+```
+
+Run a SPARQL query against the Wikidata Query Service and return rows (each a map of the SELECTed
+  variable names to string values). Prefixes wd:/wdt:/rdfs: and SERVICE wikibase:label are available.
+  Example: SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5 . SERVICE wikibase:label { bd:serviceParam wikibase:language "en" } } LIMIT 10
+
+  @param sparql - The SPARQL query text
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| sparql | `string` |  |
+
+**Returns:** `Result<Record<string, string>[]>`
+
+**Throws:** `std::wikidata`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/wikidata.agency#L257))

--- a/packages/agency-lang/stdlib/capabilities.agency
+++ b/packages/agency-lang/stdlib/capabilities.agency
@@ -42,7 +42,7 @@ export effectSet FileSystem = <FileRead, FileWrite>
 export effectSet Shell = <std::bash, std::exec, std::run>
 
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews, std::wikidata>
 
 /** The std::data/finance connectors (news + macro + filings). Each also raises
     std::http::fetchJSON, which is covered by the broader Network set. */

--- a/packages/agency-lang/stdlib/data/wikidata.agency
+++ b/packages/agency-lang/stdlib/data/wikidata.agency
@@ -1,0 +1,268 @@
+import { fetchJSON } from "std::http"
+import { env } from "std::system"
+import { mapValues, values } from "std::object"
+
+/** @module
+  ## Wikidata — the open knowledge graph
+
+  Query [Wikidata](https://www.wikidata.org), the free structured database behind Wikipedia:
+  resolve a name to an entity, read an entity's facts, or run a raw SPARQL query over the graph.
+  Use it for broad entity research — people, organizations, places, works, and their typed
+  relationships — complementing the power-network focus of `std::data/people/littlesis`.
+
+  Recipe: `wikidataSearch` a name to get a QID, then `wikidataEntity(qid)` for its facts, or
+  `wikidataQuery` for graph traversal. Entity claims and SPARQL results reference other entities by
+  QID (e.g. "Q5"); resolve those with another search/entity call, or ask SPARQL for labels with
+  `SERVICE wikibase:label`. No API key required (WDQS is rate-limited and wants a descriptive
+  User-Agent — set WIKIDATA_USER_AGENT to override the default).
+
+  ### Usage
+
+  ```ts
+  import { wikidataSearch, wikidataEntity } from "std::data/wikidata"
+
+  node main() {
+    const hits = wikidataSearch("Ada Lovelace") catch []
+    if (hits.length > 0) {
+      const e = wikidataEntity(hits[0].id) catch { id: "", label: "", description: "", aliases: [], claims: {} }
+      print("${e.label}: ${e.description}")
+    }
+  }
+  ```
+*/
+
+effect std::wikidata { op: string, query: string }
+
+static const WD_BASE = "https://www.wikidata.org"
+static const WD_DOMAINS = ["www.wikidata.org"]
+static const WDQS_BASE = "https://query.wikidata.org"
+static const WDQS_DOMAINS = ["query.wikidata.org"]
+
+// WDQS requires a descriptive User-Agent. Read once per run (env), like edgar's SEC_USER_AGENT.
+const wikidataUserAgent = env("WIKIDATA_USER_AGENT") ?? "agency-lang (https://agency-lang.com)"
+const WD_HEADERS = { "User-Agent": wikidataUserAgent }
+
+/** A Wikidata entity from a name search. `id` is the QID (e.g. "Q42"). */
+export type Entity = {
+  id: string;
+  label: string;
+  description: string;
+  url: string
+}
+
+/** One entity's facts. `claims` maps a property id (e.g. "P31") to its values; a value is a QID for
+    entity-valued claims, or the literal's string form otherwise. Resolve QIDs with another
+    search/entity call. */
+export type EntityDetail = {
+  id: string;
+  label: string;
+  description: string;
+  aliases: string[];
+  claims: Record<string, string[]>
+}
+
+/** Build the entity-search path (wbsearchentities). Pure. */
+safe def buildSearchPath(name: string, limit: number): string {
+  const q = encodeURIComponent(name)
+  return "/w/api.php?action=wbsearchentities&search=${q}&language=en&format=json&limit=${limit}"
+}
+
+/** Build the entity-data path. Pure. */
+safe def buildEntityPath(qid: string): string {
+  return "/wiki/Special:EntityData/${encodeURIComponent(qid)}.json"
+}
+
+/** Build the SPARQL path. Pure. */
+safe def buildQueryPath(sparql: string): string {
+  const q = encodeURIComponent(sparql)
+  return "/sparql?query=${q}&format=json"
+}
+
+/** Reshape a wbsearchentities body into Entity[]. Pure/total. */
+safe def parseSearch(raw: any): Entity[] {
+  const r: any = raw ?? {}
+  const results = r.search ?? []
+  return map(results) as s {
+    const e: any = s ?? {}
+    return {
+      id: e.id ?? "",
+      label: e.label ?? "",
+      description: e.description ?? "",
+      url: e.concepturi ?? ""
+    }
+  }
+}
+
+/** Reduce a claim's mainsnak to a string by datavalue type. A novalue/somevalue snak → "".
+    Pure/total. */
+safe def parseClaimValue(mainsnak: any): string {
+  const snak: any = mainsnak ?? {}
+  if ((snak.snaktype ?? "") != "value") {
+    return ""
+  }
+  const dv: any = snak.datavalue ?? {}
+  const t = dv.type ?? ""
+  const v: any = dv.value ?? null
+  if (t == "wikibase-entityid") {
+    return v.id ?? ""
+  }
+  if (t == "string") {
+    return v ?? ""
+  }
+  if (t == "monolingualtext") {
+    return v.text ?? ""
+  }
+  if (t == "time") {
+    return v.time ?? ""
+  }
+  if (t == "quantity") {
+    return v.amount ?? ""
+  }
+  if (t == "globecoordinate") {
+    return "${v.latitude ?? 0},${v.longitude ?? 0}"
+  }
+  return ""
+}
+
+/** Map a property's statements to a list of stringified claim values. Pure/total. */
+safe def parseClaimList(statements: any): string[] {
+  const arr = statements ?? []
+  return map(arr) as s {
+    const st: any = s ?? {}
+    return parseClaimValue(st.mainsnak ?? {})
+  }
+}
+
+/** Reshape the claims object (PID → statements) into PID → string[]. Pure/total. */
+safe def parseClaims(claims: any): Record<string, string[]> {
+  const c: any = claims ?? {}
+  return mapValues(c) as (statements, pid) {
+    return parseClaimList(statements)
+  }
+}
+
+/** Reshape an EntityData body into EntityDetail. `qid` is the fallback id. Pure/total. */
+safe def parseEntity(raw: any, qid: string): EntityDetail {
+  const r: any = raw ?? {}
+  const ents: any[] = values(r.entities ?? {})
+  const ent: any = ents[0] ?? {}
+  const labels: any = ent.labels ?? {}
+  const descriptions: any = ent.descriptions ?? {}
+  const aliasesObj: any = ent.aliases ?? {}
+  const enLabel: any = labels.en ?? {}
+  const enDesc: any = descriptions.en ?? {}
+  const enAliases: any[] = aliasesObj.en ?? []
+  return {
+    id: ent.id ?? qid,
+    label: enLabel.value ?? "",
+    description: enDesc.value ?? "",
+    aliases: map(enAliases) as a {
+      const al: any = a ?? {}
+      return al.value ?? ""
+    },
+    claims: parseClaims(ent.claims ?? {})
+  }
+}
+
+/** Reshape a SPARQL body into rows (variable → value string). Pure/total. */
+safe def parseBindings(raw: any): Record<string, string>[] {
+  const r: any = raw ?? {}
+  const res: any = r.results ?? {}
+  const bindings = res.bindings ?? []
+  return map(bindings) as b {
+    const binding: any = b ?? {}
+    return mapValues(binding) as (cell, varName) {
+      const c: any = cell ?? {}
+      return c.value ?? ""
+    }
+  }
+}
+
+/** Shared failure message for a failed Wikidata fetch. Pure. */
+safe def wikidataError(err: any): string {
+  return "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): ${err.message ?? err}"
+}
+
+/** Turn a fetch Result into an Entity[] Result. Pure. */
+safe def searchFinalize(fetchResult: any): Result<Entity[]> {
+  return match (fetchResult) {
+    success(body) => success(parseSearch(body))
+    failure(err) => failure(wikidataError(err))
+  }
+}
+
+/** Turn a fetch Result into an EntityDetail Result; empty entities (unknown QID) → failure. Pure. */
+safe def entityFinalize(fetchResult: any, qid: string): Result<EntityDetail> {
+  return match (fetchResult) {
+    success(body) => {
+      const b: any = body ?? {}
+      const ents: any[] = values(b.entities ?? {})
+      if (ents.length == 0) {
+        return failure("Wikidata returned no entity for ${qid}")
+      }
+      return success(parseEntity(b, qid))
+    }
+    failure(err) => failure(wikidataError(err))
+  }
+}
+
+/** Turn a SPARQL fetch Result into a rows Result. Pure. */
+safe def queryFinalize(fetchResult: any): Result<Record<string, string>[]> {
+  return match (fetchResult) {
+    success(body) => success(parseBindings(body))
+    failure(err) => failure(wikidataError(err))
+  }
+}
+
+/** Fetch a Wikidata path (either host) with the User-Agent header, returning the parsed-JSON Result.
+    Raises std::http::fetchJSON but approves it internally, so a plain caller sees only the connector's
+    own std::wikidata prompt while any OUTER fetch handler still receives (and can reject or propagate)
+    the fetch. allowedDomains is enforced inside fetchJSON regardless. Private. */
+safe def wikidataFetch(base: string, domains: string[], path: string): Result raises <std::http::fetchJSON> {
+  handle {
+    return fetchJSON(baseUrl: base, path: path, headers: WD_HEADERS, allowedDomains: domains)
+  } with (data) {
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+  }
+}
+
+export safe def wikidataSearch(name: string, limit: number = 5): Result<Entity[]> raises <std::wikidata, std::http::fetchJSON> {
+  """
+  Search Wikidata for entities by name. Returns matches with QID, label, description, and URL; use a
+  returned id with wikidataEntity or wikidataQuery. Empty result set returns an empty list.
+
+  @param name - The person, organization, place, or thing to search for
+  @param limit - Maximum number of matches to return (default 5)
+  """
+  return interrupt std::wikidata("Search Wikidata for this name?", { op: "search", query: name })
+  const result = wikidataFetch(WD_BASE, WD_DOMAINS, buildSearchPath(name, limit))
+  return searchFinalize(result)
+}
+
+export safe def wikidataEntity(qid: string): Result<EntityDetail> raises <std::wikidata, std::http::fetchJSON> {
+  """
+  Fetch one Wikidata entity by its QID. Returns the English label, description, aliases, and claims
+  (property id to values; entity-valued claims are QIDs to resolve separately). Unknown QID returns
+  a failure.
+
+  @param qid - The Wikidata entity id, e.g. "Q42"
+  """
+  return interrupt std::wikidata("Fetch this Wikidata entity?", { op: "entity", query: qid })
+  const result = wikidataFetch(WD_BASE, WD_DOMAINS, buildEntityPath(qid))
+  return entityFinalize(result, qid)
+}
+
+export safe def wikidataQuery(sparql: string): Result<Record<string, string>[]> raises <std::wikidata, std::http::fetchJSON> {
+  """
+  Run a SPARQL query against the Wikidata Query Service and return rows (each a map of the SELECTed
+  variable names to string values). Prefixes wd:/wdt:/rdfs: and SERVICE wikibase:label are available.
+  Example: SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5 . SERVICE wikibase:label { bd:serviceParam wikibase:language "en" } } LIMIT 10
+
+  @param sparql - The SPARQL query text
+  """
+  return interrupt std::wikidata("Run this SPARQL query against Wikidata?", { op: "query", query: sparql })
+  const result = wikidataFetch(WDQS_BASE, WDQS_DOMAINS, buildQueryPath(sparql))
+  return queryFinalize(result)
+}

--- a/packages/agency-lang/stdlib/data/wikidata.agency
+++ b/packages/agency-lang/stdlib/data/wikidata.agency
@@ -178,9 +178,9 @@ safe def parseBindings(raw: any): Record<string, string>[] {
   }
 }
 
-/** Shared failure message for a failed Wikidata fetch. Pure. */
+/** Shared failure message for a failed Wikidata fetch (either host). Pure. */
 safe def wikidataError(err: any): string {
-  return "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): ${err.message ?? err}"
+  return "Wikidata request failed (the API is rate-limited and expects a descriptive User-Agent): ${err.message ?? err}"
 }
 
 /** Turn a fetch Result into an Entity[] Result. Pure. */
@@ -230,8 +230,9 @@ safe def wikidataFetch(base: string, domains: string[], path: string): Result ra
 
 export safe def wikidataSearch(name: string, limit: number = 5): Result<Entity[]> raises <std::wikidata, std::http::fetchJSON> {
   """
-  Search Wikidata for entities by name. Returns matches with QID, label, description, and URL; use a
-  returned id with wikidataEntity or wikidataQuery. Empty result set returns an empty list.
+  Search Wikidata for entities by name. Returns matches with QID, label, description, and URL. The
+  QID identifies the entity for a follow-up entity fetch or SPARQL query. Empty result set returns an
+  empty list.
 
   @param name - The person, organization, place, or thing to search for
   @param limit - Maximum number of matches to return (default 5)

--- a/packages/agency-lang/tests/agency-js/data-wikidata-live/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-wikidata-live/agent.agency
@@ -1,0 +1,16 @@
+import { wikidataSearch } from "std::data/wikidata"
+
+node liveSearch(): number {
+  handle {
+    const hits = wikidataSearch("Ada Lovelace") catch []
+    return hits.length
+  } with (data) {
+    if (data.effect == "std::wikidata") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-wikidata-live/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-wikidata-live/fixture.json
@@ -1,0 +1,1 @@
+{ "skipped": true }

--- a/packages/agency-lang/tests/agency-js/data-wikidata-live/test.js
+++ b/packages/agency-lang/tests/agency-js/data-wikidata-live/test.js
@@ -1,0 +1,10 @@
+import { liveSearch } from "./agent.js";
+import { writeFileSync } from "node:fs";
+
+// Opt-in: only hits the live Wikidata API when AGENCY_LIVE_TESTS is set.
+if (!process.env.AGENCY_LIVE_TESTS) {
+  writeFileSync("__result.json", JSON.stringify({ skipped: true }, null, 2));
+} else {
+  const n = (await liveSearch())?.data ?? -1;
+  writeFileSync("__result.json", JSON.stringify({ ok: n >= 1 }, null, 2));
+}

--- a/packages/agency-lang/tests/agency-js/data-wikidata/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/agent.agency
@@ -1,0 +1,118 @@
+import test { buildSearchPath, buildEntityPath, buildQueryPath, parseSearch, parseClaimValue, parseClaims, parseEntity, parseBindings, wikidataError, searchFinalize, entityFinalize, queryFinalize, wikidataSearch, wikidataEntity, wikidataQuery } from "std::data/wikidata"
+import { Network } from "std::capabilities"
+
+// --- pure-function wrappers ---
+
+node tSearchPath(name: string, limit: number): string {
+  return buildSearchPath(name, limit)
+}
+
+node tEntityPath(qid: string): string {
+  return buildEntityPath(qid)
+}
+
+node tQueryPath(sparql: string): string {
+  return buildQueryPath(sparql)
+}
+
+node tParseSearch(raw: any): any {
+  return parseSearch(raw)
+}
+
+node tParseSearchNull(): any {
+  return parseSearch(null)
+}
+
+node tParseClaimValue(snak: any): string {
+  return parseClaimValue(snak)
+}
+
+node tParseEntity(raw: any): any {
+  return parseEntity(raw, "Q42")
+}
+
+node tParseBindings(raw: any): any {
+  return parseBindings(raw)
+}
+
+node tEntityFinalizeUnknown(): string {
+  const r = entityFinalize(success({ entities: {} }), "Q999")
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tSearchFinalizeErr(): string {
+  const r = searchFinalize(failure("boom"))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tQueryFinalizeErr(): string {
+  const r = queryFinalize(failure("boom"))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tError(): string {
+  return wikidataError("boom")
+}
+
+// --- gating / capability ---
+
+// Compile-time capability assertion: wikidataSearch raises std::wikidata + std::http::fetchJSON, so
+// this compiles only if BOTH are covered by Network. Never called at runtime.
+node netCheck() raises <Network> {
+  const r = wikidataSearch("x") catch []
+  return r.length
+}
+
+// Plain caller: no fetch-level handler. Raises std::wikidata; tests only inspect/reject it.
+node callSearch(name: string): any {
+  return wikidataSearch(name)
+}
+
+// Governed caller: approve std::wikidata, PROPAGATE the fetch so std::http::fetchJSON surfaces with
+// its { baseUrl, path } — asserted offline, then rejected (no network).
+node callSearchGoverned(name: string): any {
+  handle {
+    return wikidataSearch(name)
+  } with (data) {
+    if (data.effect == "std::wikidata") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return propagate()
+    }
+  }
+}
+
+// --- fetch-mocked end-to-end (see fetchMocks.json); `with approve` lets the mocked fetch run ---
+
+node mockSearch(): any {
+  const r = wikidataSearch("Andreessen Horowitz") with approve
+  return r catch "FAIL"
+}
+
+node mockEntity(): any {
+  const r = wikidataEntity("Q42") with approve
+  return r catch "FAIL"
+}
+
+node mockEntityUnknown(): string {
+  const r = wikidataEntity("Q999999999") with approve
+  if (r is failure(e)) {
+    return "GOT_FAILURE"
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node mockQuery(): any {
+  const r = wikidataQuery("SELECT ?item ?itemLabel WHERE { ?item wdt:P31 wd:Q5 } LIMIT 1") with approve
+  return r catch "FAIL"
+}

--- a/packages/agency-lang/tests/agency-js/data-wikidata/fetchMocks.json
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/fetchMocks.json
@@ -1,0 +1,6 @@
+[
+  { "urlPattern": "www\\.wikidata\\.org/w/api\\.php.*wbsearchentities", "returnFile": "sample-search.json" },
+  { "url": "https://www.wikidata.org/wiki/Special:EntityData/Q42.json", "returnFile": "sample-entity.json" },
+  { "url": "https://www.wikidata.org/wiki/Special:EntityData/Q999999999.json", "return": { "entities": {} } },
+  { "urlPattern": "query\\.wikidata\\.org/sparql", "returnFile": "sample-sparql.json" }
+]

--- a/packages/agency-lang/tests/agency-js/data-wikidata/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/fixture.json
@@ -1,0 +1,52 @@
+{
+  "searchPath": "/w/api.php?action=wbsearchentities&search=Andreessen%20Horowitz&language=en&format=json&limit=5",
+  "entityPath": "/wiki/Special:EntityData/Q42.json",
+  "queryPath": "/sparql?query=SELECT%20%3Fx%20WHERE%20%7B%20%3Fx%20wdt%3AP31%20wd%3AQ5%20%7D%20LIMIT%201&format=json",
+  "search": [
+    { "id": "Q4034010", "label": "Andreessen Horowitz", "description": "American venture capital firm", "url": "http://www.wikidata.org/entity/Q4034010" }
+  ],
+  "searchNull": [],
+  "cvEntity": "Q5",
+  "cvString": "hello",
+  "cvMono": "Bonjour",
+  "cvTime": "+1952-03-11T00:00:00Z",
+  "cvQuantity": "+1.96",
+  "cvCoord": "51.5,-0.1",
+  "cvNovalue": "",
+  "entity": {
+    "id": "Q42",
+    "label": "Douglas Adams",
+    "description": "English writer and humorist",
+    "aliases": ["Douglas Noel Adams"],
+    "claims": {
+      "P31": ["Q5"],
+      "P569": ["+1952-03-11T00:00:00Z"],
+      "P856": ["http://www.douglasadams.com/"]
+    }
+  },
+  "bindings": [
+    { "item": "http://www.wikidata.org/entity/Q5", "itemLabel": "human" }
+  ],
+  "entityFinalizeUnknown": "Wikidata returned no entity for Q999",
+  "searchFinalizeErr": "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): boom",
+  "queryFinalizeErr": "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): boom",
+  "errorMsg": "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): boom",
+  "mockSearch": [
+    { "id": "Q4034010", "label": "Andreessen Horowitz", "description": "American venture capital firm", "url": "http://www.wikidata.org/entity/Q4034010" }
+  ],
+  "mockEntity": {
+    "id": "Q42",
+    "label": "Douglas Adams",
+    "description": "English writer and humorist",
+    "aliases": ["Douglas Noel Adams"],
+    "claims": {
+      "P31": ["Q5"],
+      "P569": ["+1952-03-11T00:00:00Z"],
+      "P856": ["http://www.douglasadams.com/"]
+    }
+  },
+  "mockEntityUnknown": "GOT_FAILURE",
+  "mockQuery": [
+    { "item": "http://www.wikidata.org/entity/Q5", "itemLabel": "human" }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/data-wikidata/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/fixture.json
@@ -28,9 +28,9 @@
     { "item": "http://www.wikidata.org/entity/Q5", "itemLabel": "human" }
   ],
   "entityFinalizeUnknown": "Wikidata returned no entity for Q999",
-  "searchFinalizeErr": "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): boom",
-  "queryFinalizeErr": "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): boom",
-  "errorMsg": "Wikidata request failed (WDQS rate-limits and requires a descriptive User-Agent): boom",
+  "searchFinalizeErr": "Wikidata request failed (the API is rate-limited and expects a descriptive User-Agent): boom",
+  "queryFinalizeErr": "Wikidata request failed (the API is rate-limited and expects a descriptive User-Agent): boom",
+  "errorMsg": "Wikidata request failed (the API is rate-limited and expects a descriptive User-Agent): boom",
   "mockSearch": [
     { "id": "Q4034010", "label": "Andreessen Horowitz", "description": "American venture capital firm", "url": "http://www.wikidata.org/entity/Q4034010" }
   ],

--- a/packages/agency-lang/tests/agency-js/data-wikidata/sample-entity.json
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/sample-entity.json
@@ -1,0 +1,15 @@
+{
+  "entities": {
+    "Q42": {
+      "id": "Q42",
+      "labels": { "en": { "language": "en", "value": "Douglas Adams" } },
+      "descriptions": { "en": { "language": "en", "value": "English writer and humorist" } },
+      "aliases": { "en": [ { "language": "en", "value": "Douglas Noel Adams" } ] },
+      "claims": {
+        "P31": [ { "mainsnak": { "snaktype": "value", "property": "P31", "datavalue": { "value": { "entity-type": "item", "numeric-id": 5, "id": "Q5" }, "type": "wikibase-entityid" }, "datatype": "wikibase-item" } } ],
+        "P569": [ { "mainsnak": { "snaktype": "value", "property": "P569", "datavalue": { "value": { "time": "+1952-03-11T00:00:00Z", "precision": 11 }, "type": "time" }, "datatype": "time" } } ],
+        "P856": [ { "mainsnak": { "snaktype": "value", "property": "P856", "datavalue": { "value": "http://www.douglasadams.com/", "type": "string" }, "datatype": "url" } } ]
+      }
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-wikidata/sample-search.json
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/sample-search.json
@@ -1,0 +1,16 @@
+{
+  "searchinfo": { "search": "Andreessen Horowitz" },
+  "search": [
+    {
+      "id": "Q4034010",
+      "title": "Q4034010",
+      "pageid": 3844709,
+      "concepturi": "http://www.wikidata.org/entity/Q4034010",
+      "url": "//www.wikidata.org/wiki/Q4034010",
+      "label": "Andreessen Horowitz",
+      "description": "American venture capital firm",
+      "match": { "type": "label", "language": "en", "text": "Andreessen Horowitz" }
+    }
+  ],
+  "success": 1
+}

--- a/packages/agency-lang/tests/agency-js/data-wikidata/sample-sparql.json
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/sample-sparql.json
@@ -1,0 +1,8 @@
+{
+  "head": { "vars": ["item", "itemLabel"] },
+  "results": {
+    "bindings": [
+      { "item": { "type": "uri", "value": "http://www.wikidata.org/entity/Q5" }, "itemLabel": { "xml:lang": "en", "type": "literal", "value": "human" } }
+    ]
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-wikidata/test.js
+++ b/packages/agency-lang/tests/agency-js/data-wikidata/test.js
@@ -1,0 +1,76 @@
+import { tSearchPath, tEntityPath, tQueryPath, tParseSearch, tParseSearchNull, tParseClaimValue, tParseEntity, tParseBindings, tEntityFinalizeUnknown, tSearchFinalizeErr, tQueryFinalizeErr, tError, hasInterrupts, approve, reject, respondToInterrupts, callSearch, callSearchGoverned, mockSearch, mockEntity, mockEntityUnknown, mockQuery } from "./agent.js";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const unwrap = (r) => r?.data ?? r;
+const load = (f) => JSON.parse(readFileSync(new URL(f, import.meta.url), "utf8"));
+const sampleSearch = load("./sample-search.json");
+const sampleEntity = load("./sample-entity.json");
+const sampleSparql = load("./sample-sparql.json");
+
+// snaks exercising each parseClaimValue datatype branch
+const snakEntity = { snaktype: "value", datavalue: { value: { id: "Q5" }, type: "wikibase-entityid" } };
+const snakString = { snaktype: "value", datavalue: { value: "hello", type: "string" } };
+const snakMono = { snaktype: "value", datavalue: { value: { text: "Bonjour", language: "fr" }, type: "monolingualtext" } };
+const snakTime = { snaktype: "value", datavalue: { value: { time: "+1952-03-11T00:00:00Z" }, type: "time" } };
+const snakQuantity = { snaktype: "value", datavalue: { value: { amount: "+1.96" }, type: "quantity" } };
+const snakCoord = { snaktype: "value", datavalue: { value: { latitude: 51.5, longitude: -0.1 }, type: "globecoordinate" } };
+const snakNovalue = { snaktype: "novalue", property: "P40" };
+
+// --- interrupt / effect assertions (throw on mismatch) ---
+
+// (A) The domain interrupt gates the call: rejecting std::wikidata short-circuits with NO fetch.
+const i1 = await callSearch("Andreessen Horowitz");
+if (!hasInterrupts(i1.data)) throw new Error("wikidataSearch did not raise an interrupt");
+const iv = i1.data[0];
+if (iv.effect !== "std::wikidata") throw new Error("wrong effect: " + iv.effect);
+if (iv.data.op !== "search") throw new Error("wrong op discriminant: " + iv.data.op);
+if (iv.data.query !== "Andreessen Horowitz") throw new Error("wrong payload: " + iv.data.query);
+const rejected = await respondToInterrupts(i1.data, [reject()]);
+if (hasInterrupts(rejected.data)) throw new Error("rejecting std::wikidata must short-circuit before any fetch");
+
+// (B) Single-prompt ergonomics: a plain caller sees ONLY std::wikidata at the first hop.
+if (i1.data.filter((x) => x.effect && x.effect !== "std::wikidata").length > 0) {
+  throw new Error("plain caller must see only std::wikidata at the first hop");
+}
+
+// (C) Governance + offline URL wiring: propagate the fetch so std::http::fetchJSON surfaces with its
+// { baseUrl, path }, asserted offline, then rejected (no network).
+const g1 = await callSearchGoverned("Andreessen Horowitz");
+if (!hasInterrupts(g1.data)) throw new Error("governed caller should surface std::http::fetchJSON via propagate()");
+const gv = g1.data[0];
+if (gv.effect !== "std::http::fetchJSON") throw new Error("expected std::http::fetchJSON, got: " + gv.effect);
+if (gv.data.baseUrl !== "https://www.wikidata.org") throw new Error("wrong baseUrl: " + gv.data.baseUrl);
+if (gv.data.path !== "/w/api.php?action=wbsearchentities&search=Andreessen%20Horowitz&language=en&format=json&limit=5") throw new Error("wrong path: " + gv.data.path);
+await respondToInterrupts(g1.data, [reject()]);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      searchPath: unwrap(await tSearchPath("Andreessen Horowitz", 5)),
+      entityPath: unwrap(await tEntityPath("Q42")),
+      queryPath: unwrap(await tQueryPath("SELECT ?x WHERE { ?x wdt:P31 wd:Q5 } LIMIT 1")),
+      search: unwrap(await tParseSearch(sampleSearch)),
+      searchNull: unwrap(await tParseSearchNull()),
+      cvEntity: unwrap(await tParseClaimValue(snakEntity)),
+      cvString: unwrap(await tParseClaimValue(snakString)),
+      cvMono: unwrap(await tParseClaimValue(snakMono)),
+      cvTime: unwrap(await tParseClaimValue(snakTime)),
+      cvQuantity: unwrap(await tParseClaimValue(snakQuantity)),
+      cvCoord: unwrap(await tParseClaimValue(snakCoord)),
+      cvNovalue: unwrap(await tParseClaimValue(snakNovalue)),
+      entity: unwrap(await tParseEntity(sampleEntity)),
+      bindings: unwrap(await tParseBindings(sampleSparql)),
+      entityFinalizeUnknown: unwrap(await tEntityFinalizeUnknown()),
+      searchFinalizeErr: unwrap(await tSearchFinalizeErr()),
+      queryFinalizeErr: unwrap(await tQueryFinalizeErr()),
+      errorMsg: unwrap(await tError()),
+      mockSearch: unwrap(await mockSearch()),
+      mockEntity: unwrap(await mockEntity()),
+      mockEntityUnknown: unwrap(await mockEntityUnknown()),
+      mockQuery: unwrap(await mockQuery()),
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## What

`std::data/wikidata` — a free, keyless connector over the Wikidata knowledge graph, complementing the power-network focus of `std::data/people/littlesis` with broad entity coverage.

| Function | Returns | Purpose |
|---|---|---|
| `wikidataSearch(name, limit=5)` | `Entity[]` | Resolve a name to entities (`wbsearchentities`) — the entry point (you need a QID for the rest). |
| `wikidataEntity(qid)` | `EntityDetail` | One entity's label/description/aliases + flattened claims (`Special:EntityData`). |
| `wikidataQuery(sparql)` | `Record<string,string>[]` | Raw SPARQL over the graph (WDQS); bindings flattened to `{var: value}` rows. |

## Design

- Two GET/JSON hosts (`www.wikidata.org`, `query.wikidata.org`), one Option-B `wikidataFetch` helper: raises `std::http::fetchJSON` but approves it internally, so a plain caller sees one `std::wikidata` prompt while an outer governance handler still receives the fetch. `allowedDomains` pins each host; `std::wikidata` is added to `Network`.
- WDQS requires a descriptive User-Agent → sent via header from `WIKIDATA_USER_AGENT` (defaulting like EDGAR's `SEC_USER_AGENT`).
- Claims flatten to `Record<PID, string[]>` via `parseClaimValue` (entity-ref → QID, string, monolingualtext → text, time, quantity → amount, globecoordinate → "lat,lon", novalue → ""). QID-valued claims stay opaque until resolved via another search/entity call or a SPARQL `SERVICE wikibase:label` — a documented quirk (like LittleSis's "edges carry IDs").
- Only the three public functions + `Entity`/`EntityDetail` are exported; every helper is a non-exported `safe def` (tests use `import test`). Placed flat at `std::data/wikidata` (a knowledge graph is cross-cutting, not a single domain).

## Testing (offline unless noted)

`tests/agency-js/data-wikidata/`:
- **Pure functions** — builders, `parseSearch`/`parseEntity`/`parseBindings`/`parseClaims`, and `parseClaimValue` with one case per datatype (entity-ref, string, monolingualtext, time, quantity, globecoordinate, novalue).
- **Interrupt gating** — reject short-circuits before fetch; a plain caller sees only `std::wikidata`; a `propagate()`d fetch surfaces `std::http::fetchJSON` with the exact `{ baseUrl, path }`.
- **Fetch-mocked end-to-end** — all three functions run against a `fetchMocks.json`, plus an unknown-QID → failure.
- **Opt-in live drift check** (`-live/`, gated on `AGENCY_LIVE_TESTS`, skipped by default).

Regression: littlesis / yc / hackernews still pass (the `Network` change is clean). Shapes grounded on the live APIs (SPARQL bindings, `wbsearchentities`, a real `Special:EntityData/Q42.json` claim).

## Follow-ups (not in this PR)

Two sibling connectors were scoped but deferred: **USASpending** needs POST-with-body support in `std::http` (its search endpoints are POST); **OPM** serves its workforce data as Parquet (not JSON), so it's blocked until Agency can read Parquet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
