### PR TITLE
Incremental builds Stage C: tsc incremental, make clean, single-process agency compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 **/dist/*
 **/node_modules/*
 .*
+# Explicit (also matched by the .* rule above): the incremental-build
+# scratch dir — tsc buildinfo now, Stage A manifest later. Kept explicit
+# so the intent survives if the broad dot-rule is ever narrowed.
+.agency-build/
 **/index.mts
 **/__evaluate.*
 **/__judge*

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -1,41 +1,98 @@
-.PHONY: all test stdlib agents doc packages-doc refresh-action-pins build
+.PHONY: all test stdlib agents doc packages-doc refresh-action-pins build clean publish compile-agency
+
+# Resolve tsc/tsc-alias from the workspace, not from whatever happens to
+# be global. Historically `make build` was only ever reached via
+# `pnpm run build`, which put node_modules/.bin on PATH; `all` now invokes
+# it directly ($(MAKE) build), so the Makefile must point at the tools
+# itself. Explicit paths (not a PATH export) because Apple's GNU make 3.81
+# does not reliably apply an exported PATH to its exec fast path. Also
+# pins tool versions to the repo lockfile.
+TSC := ./node_modules/.bin/tsc
+TSC_ALIAS := ./node_modules/.bin/tsc-alias
+
+# The bundled agent dirs. Adding an agent = add it here, nowhere else.
+AGENT_DIRS := review policy agency-agent eval optimize
+AGENT_PATHS := $(addprefix dist/lib/agents/,$(AGENT_DIRS))
+
+# Stage agent sources into dist. Wipe-then-copy, NOT overlay: with dist
+# persisting across builds, an overlay would keep outputs of agent sources
+# that were deleted from lib/agents. Safe to wipe: lib/agents contains no
+# .ts, so tsc emits nothing under dist/lib/agents — everything there is
+# agency-compiled from the sources this recipe just copied.
+define stage-agent-sources
+	rm -rf dist/lib/agents
+	cp -r lib/agents dist/lib
+endef
+
+# Stage the doc markdown the agents read at runtime. rm before cp -r:
+# copying onto an existing dir NESTS (guide/guide) — that artifact exists
+# in pre-Stage-C tarballs; these copies must be idempotent.
+define stage-agent-docs
+	mkdir -p dist/lib/agents/docs
+	rm -rf dist/lib/agents/docs/guide dist/lib/agents/docs/cli
+	cp -r docs/site/guide dist/lib/agents/docs/guide
+	cp -r docs/site/cli dist/lib/agents/docs/cli
+endef
 
 all:
-	pnpm run templates && pnpm run build && $(MAKE) stdlib && $(MAKE) agents && $(MAKE) doc
+	pnpm run templates && $(MAKE) build && $(MAKE) compile-agency && $(MAKE) doc
 
 # Build the dist/ tree. Invoked by `pnpm run build`. Kept here (rather
 # than as a chain in package.json) so the steps remain readable and easy
 # to extend without inflating the package.json scripts section.
 build:
-	rm -rf dist/
-	tsc
-	tsc-alias
+	# Incremental: dist/ is NOT wiped here (use `make clean` for a full
+	# reset; publish always goes through clean). Because the buildinfo
+	# lives OUTSIDE dist/ (it must not ship in the tarball), dist and its
+	# incremental state no longer share a lifetime: if dist/ was deleted
+	# by hand but the buildinfo survived, tsc would consider everything
+	# up-to-date, emit nothing, and leave an empty dist. Drop the stale
+	# buildinfo in that case.
+	@if [ ! -d dist/lib ]; then rm -f .agency-build/tsc.tsbuildinfo; fi
+	$(TSC)
+	$(TSC_ALIAS)
 	mkdir -p dist/lib/cli/runShim
 	cp lib/cli/runShim/*.mjs dist/lib/cli/runShim/
 	mkdir -p dist/lib/stdlib/providers
 	cp lib/stdlib/providers/*.mjs dist/lib/stdlib/providers/
-	mkdir -p dist/lib/agents/docs
-	cp -r docs/site/guide dist/lib/agents/docs/guide
-	cp -r docs/site/cli dist/lib/agents/docs/cli
 
+# Full reset: compiled TS, incremental scratch state, and the gitignored
+# stdlib .js siblings. Both dist/ AND stdlib/**/*.js ship in the npm
+# tarball, so publish MUST come through here to guarantee no orphaned
+# output (from a deleted/renamed source) can ship. Safe: stdlib contains
+# no .ts and no tracked/.mjs .js — every stdlib .js is agency-generated.
+clean:
+	rm -rf dist/ .agency-build/
+	find stdlib -name '*.js' -type f -delete
+
+# ONE compiler process for stdlib + all agent dirs: node boot and the
+# compiler import are paid once, and the process-wide parse cache means
+# the stdlib prelude (imported by every one of the 94 files) is parsed
+# once instead of once per invocation. This is the load-bearing lever for
+# the Stage C warm-make target.
+compile-agency:
+	$(stage-agent-sources)
+	node ./dist/scripts/agency.js compile stdlib/ $(AGENT_PATHS)
+	$(stage-agent-docs)
+
+# Selective-use aliases (same recipes, one root set each).
 stdlib:
-	pnpm run agency compile stdlib/
+	node ./dist/scripts/agency.js compile stdlib/
 
 agents:
-	cp -r lib/agents dist/lib && \
-	pnpm run agency compile dist/lib/agents/review/ && \
-	pnpm run agency compile dist/lib/agents/policy/ && \
-	pnpm run agency compile dist/lib/agents/agency-agent/ && \
-	pnpm run agency compile dist/lib/agents/eval/ && \
-	pnpm run agency compile dist/lib/agents/optimize/ && \
-	mkdir -p dist/lib/agents/docs
-	cp -r docs/site/guide dist/lib/agents/docs/guide
-	cp -r docs/site/cli dist/lib/agents/docs/cli
+	$(stage-agent-sources)
+	node ./dist/scripts/agency.js compile $(AGENT_PATHS)
+	$(stage-agent-docs)
 
 test:
 	pnpm run test
 
+# Publish = clean rebuild, no tests (CI gates merges; publishing is not a
+# test run — deliberate). Note `make all` regenerates docs/site/stdlib/,
+# so publish can leave tracked doc files modified in the working tree.
 publish:
+	$(MAKE) clean
+	$(MAKE) all
 	pnpm publish --no-git-checks
 
 fixtures:
@@ -43,7 +100,7 @@ fixtures:
 	node dist/scripts/regenerate-fixtures.js
 
 doc:
-	rm -rf docs/site/stdlib/ && pnpm run agency doc stdlib -o docs/site/stdlib/
+	rm -rf docs/site/stdlib/ && node ./dist/scripts/agency.js doc stdlib -o docs/site/stdlib/
 
 # Documentable packages: each has an index.agency that `agency doc` reads.
 # (brave-search / tui / examples have no library source, so they're skipped.)

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -20,6 +20,7 @@ AGENT_PATHS := $(addprefix dist/lib/agents/,$(AGENT_DIRS))
 # .ts, so tsc emits nothing under dist/lib/agents — everything there is
 # agency-compiled from the sources this recipe just copied.
 define stage-agent-sources
+	mkdir -p dist/lib
 	rm -rf dist/lib/agents
 	cp -r lib/agents dist/lib
 endef
@@ -40,20 +41,31 @@ all:
 # Build the dist/ tree. Invoked by `pnpm run build`. Kept here (rather
 # than as a chain in package.json) so the steps remain readable and easy
 # to extend without inflating the package.json scripts section.
+#
+# Incremental: dist/ is NOT wiped here (use `make clean` for a full
+# reset; publish always goes through clean). Because the buildinfo lives
+# OUTSIDE dist/ (it must not ship in the tarball), dist and its
+# incremental state no longer share a lifetime: if dist/ was deleted by
+# hand but the buildinfo survived, tsc would consider everything
+# up-to-date, emit nothing, and leave an empty dist. The recipe's first
+# line drops the stale buildinfo in that case. It keys on dist/lib as a
+# heuristic for "dist meaningfully exists" — a PARTIAL hand-deletion that
+# leaves dist/lib (e.g. rm -rf dist/scripts) is not covered; `make clean`
+# is the recovery for any surgically damaged dist.
+#
+# The .mjs copies are wipe-then-copy so an .mjs deleted from lib/ cannot
+# linger (and later ship) in dist. The wipe targets *.mjs ONLY: these
+# dist dirs also hold tsc-emitted .js/.d.ts, which incremental tsc would
+# NOT re-emit if deleted behind its back.
 build:
-	# Incremental: dist/ is NOT wiped here (use `make clean` for a full
-	# reset; publish always goes through clean). Because the buildinfo
-	# lives OUTSIDE dist/ (it must not ship in the tarball), dist and its
-	# incremental state no longer share a lifetime: if dist/ was deleted
-	# by hand but the buildinfo survived, tsc would consider everything
-	# up-to-date, emit nothing, and leave an empty dist. Drop the stale
-	# buildinfo in that case.
 	@if [ ! -d dist/lib ]; then rm -f .agency-build/tsc.tsbuildinfo; fi
 	$(TSC)
 	$(TSC_ALIAS)
 	mkdir -p dist/lib/cli/runShim
+	rm -f dist/lib/cli/runShim/*.mjs
 	cp lib/cli/runShim/*.mjs dist/lib/cli/runShim/
 	mkdir -p dist/lib/stdlib/providers
+	rm -f dist/lib/stdlib/providers/*.mjs
 	cp lib/stdlib/providers/*.mjs dist/lib/stdlib/providers/
 
 # Full reset: compiled TS, incremental scratch state, and the gitignored

--- a/packages/agency-lang/tsconfig.json
+++ b/packages/agency-lang/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
     /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    "incremental": true /* Speeds up rebuilds; buildinfo lives in .agency-build/ (gitignored, wiped by `make clean`) so it can never ship in the npm tarball, which packs ./dist wholesale. */,
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    "tsBuildInfoFile": "./.agency-build/tsc.tsbuildinfo",
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */


### PR DESCRIPTION
## What

Stage C of the incremental-builds work (spec: `docs/superpowers/specs/2026-07-08-incremental-builds-design.md`; plan: `docs/superpowers/plans/2026-07-08-incremental-builds-stage-c.md`, both reviewed). Local-`make` iteration speedup with no new invalidation machinery:

- **tsc incremental**: flag enabled, buildinfo at `.agency-build/tsc.tsbuildinfo` — deliberately outside `dist/`, which ships wholesale in the npm tarball. Measured tsc: cold 6.9s → no-change 1.9s.
- **`make clean` + clean publish**: the default build no longer wipes `dist/`; `make clean` resets dist, scratch state, AND the `stdlib/**/*.js` siblings (also tarball-shipped), and `make publish` routes through it — an orphaned output from a deleted/renamed source can never ship. Publish deliberately runs no tests (CI gates merges) and may leave regenerated `docs/site/stdlib/` modified.
- **Single-process agency compile**: stdlib + all five agent dirs compile in ONE `node` invocation (the `compile` CLI was already variadic) — node boot and compiler import paid once, stdlib prelude parsed once via the parse cache from #457. Agent staging is factored into `AGENT_DIRS` + canned recipes.
- **Fixes riding along**: the pre-existing nested `dist/lib/agents/docs/guide/guide` artifact (repeated `cp -r` onto an existing dir) no longer ships in tarballs; and `tsc`/`tsc-alias` now resolve from `./node_modules/.bin` explicitly — bare `tsc` in the Makefile silently used whatever global install existed whenever make was not invoked through pnpm.

## Measured (M-series laptop)

| Scenario | Before | After |
|---|---|---|
| warm `make`, no changes | 16.8s | **6.9s** |
| one `.ts` edit | 16.8s | 7.0s |
| one `.agency` edit | 16.8s | 7.2s |
| cold (`make clean && make`) | 16.8s | 12.0s |

The plan's stretch target was 5–6s warm; the residual ~3.9s is irreducible per-file agency compile work (94 files, parse-once + walk + emit), which Stage A (content-hash manifest, skip unchanged files) addresses. Flagged per the plan's spec gate rather than silently shipped.

## Verification

- Stale-buildinfo guard exercised: hand-deleted `dist/` + surviving buildinfo rebuilds a full dist.
- `make agents` standalone, `.js`-sibling walker over all six roots, no `guide/guide` nesting.
- Incremental-vs-clean equivalence: post-edit-matrix clean rebuild, then `make fixtures` — byte-identical (`git status -- tests` clean).
- Orphan test: scratch stdlib module compiled, source deleted, publish-path rebuild → orphan gone.
- Runtime smoke: 72 execution-test files over `tests/agency/blocks` + `tests/agency/stdlib` pass against the consolidated-compiled stdlib.
- `npm pack --dry-run`: no buildinfo, no nested docs.
- CI unaffected: CI calls bare `make` (= `all`), behavior-equivalent, always cold on fresh checkouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
