### PR TITLE
BuildSession: consolidate compile pipeline behind one declarative module (Stage A, PR 1)

### DIFF
--- a/docs/superpowers/specs/2026-07-08-incremental-builds-design.md
+++ b/docs/superpowers/specs/2026-07-08-incremental-builds-design.md
@@ -1,0 +1,364 @@
+# Incremental Builds — Design
+
+Date: 2026-07-08
+Status: Stage C merged (PR #463). Stage A design closed 2026-07-08 (second
+brainstorm); ready for planning.
+
+## Problem
+
+Full `make` costs 16.8s locally (~50s CI) and every second of it is paid on
+every run, including no-change rebuilds. Measured split: tsc 7.0s (42%),
+agency compiles 4.6s (27%), pnpm/node process overhead + copies ~4.7s (28%),
+tsc-alias/templates/doc ~1.4s. Agency compile cost grows linearly with the
+stdlib and bundled agents (both growing fast); the CPU profile shows no
+redundant work left *inside* a compile after PR #457 — parse-once + AST walks
++ emit is the irreducible per-file cost — so further speedup must come from
+not compiling unchanged files at all.
+
+Primary target (owner decision): **local `make` iteration**. CI keeps clean
+builds; no `actions/cache` plumbing.
+
+## Constraints discovered in research
+
+- `package.json` `files` ships `./dist` AND `./stdlib/**/*.js` wholesale. A
+  stale output orphaned by a deleted/renamed source would ship in the npm
+  tarball. Publish/pack must therefore always route through a clean build
+  (owner decision: incremental is the dev default, clean for publish).
+- mtimes are unreliable staleness tokens across `make` runs: `make agents`
+  does an unconditional `cp -r lib/agents dist/lib` (fresh mtimes every run)
+  and `git checkout` churns mtimes wholesale. Content hashes are required.
+- Compiled agency output is config-dependent (generator bakes config in) and
+  compiler-dependent (a codegen change must invalidate every compiled
+  `.agency`).
+- tsc `--incremental` measured on this repo: cold 6.9s, no-change 1.9s,
+  one-file-change 1.5s.
+- Stdlib outputs are gitignored `.js` siblings inside `stdlib/`; agent
+  outputs live inside the `dist/lib/agents` copy. Two output roots.
+
+## Stage C — tsc incremental + process consolidation (land first)
+
+Goal: no-change `make` ≈ 5–6s. No new invalidation machinery.
+
+1. **tsc incremental.** Enable `incremental` in tsconfig.json with
+   `tsBuildInfoFile` at `.agency-build/tsc.tsbuildinfo` — NOT inside `dist/`,
+   which ships wholesale in the npm tarball (`files: ["./dist", ...]`), and a
+   clean build regenerates the buildinfo right before pack. `.agency-build/`
+   is the same gitignored scratch dir Stage A's manifest uses; `make clean`
+   wipes it. Remove `rm -rf dist/` from the default `build` target. Keep
+   `tsc-alias` paired immediately after every `tsc` (a bare `tsc` leaves
+   broken `@/` aliases in dist — verified the hard way during research).
+2. **`make clean` + clean publish.** New `clean` target: `rm -rf dist/` plus
+   delete gitignored `stdlib/**/*.js` siblings (both are shipped in the
+   tarball). `make publish` gains a hard dependency on a from-clean rebuild.
+   CI needs no change (fresh checkouts are always clean).
+3. **Process consolidation.** The `compile` CLI is ALREADY variadic
+   (`scripts/agency.ts:151`, `.argument("<inputs...>")`) — the delta is
+   Makefile-only. Replace the five per-agent-dir `pnpm run agency compile`
+   invocations AND the separate stdlib invocation with ONE direct
+   `node ./dist/scripts/agency.js compile stdlib/ <5 agent dirs>` call in the
+   default build path (keeping `stdlib`/`agents` as thin aliases for
+   selective use). One process means the stdlib prelude parses once, warm,
+   for all 94 files — this is the load-bearing lever for the Stage C target,
+   since agency compiles are otherwise still full builds. Drop `pnpm run`
+   wrappers (pure startup overhead) in favor of direct `node` everywhere in
+   the Makefile. Note: the existing variadic action calls `compile()` per
+   input (independent closure per entry), not the union-closure path — fine
+   for these self-contained roots; Stage A's session unifies it.
+4. Unchanged in this stage: the agents staging copy (NOTE, corrected by the
+   second design review: as shipped, `stage-agent-sources` does
+   `rm -rf dist/lib/agents` before copying — it deletes the compiled agent
+   OUTPUTS every build, not just mtimes. Stage A must replace it; see the
+   agent-staging decision in Stage A), `make fixtures`, `make doc`, CI
+   workflow.
+
+Verification: time `make` — the ~5–6s warm target is an ESTIMATE whose
+load-bearing assumption (one warm process collapses the agency share) must
+be measured first; if single-process compile of stdlib+agents doesn't get
+agency under ~2.5s, say so and re-scope. Also: `make clean && make` (expect
+today's ~17s), fixture regeneration diff-clean, and an orphan test on the
+publish path (create+compile a scratch .ts/.agency, delete source, run the
+publish-path build, assert the orphan output is absent from the tarball
+file list via `npm pack --dry-run`).
+
+## Stage A — build sessions + content-hash manifest (follow-up)
+
+Goal (corrected by the second design review — the original "1.5–2s" did
+not close arithmetically): **agency compile share of a no-change `make`
+drops to ≈0.2–0.3s**, constant as stdlib/agents grow. Total warm `make`
+lands ≈3s: the non-agency floor is tsc-incremental 1.9s + tsc-alias 0.5s +
+templates 0.3s + copies. In scope as a cheap adjacent win: `make doc` (0.6s,
+re-parses all of stdlib every run) gets a stamp — `.agency-build/doc.stamp`
+holding the stdlibHash; the recipe skips regeneration when the stamp
+matches. With it, warm `make` ≈ 2.5s. Secondary goal, unchanged: the
+caching/compile machinery consolidated behind one declarative interface
+(per docs/dev/anti-patterns.md "imperative code everywhere" / "leaky
+abstractions" feedback on PR #457's layout).
+
+### Rollout decisions (owner, 2026-07-08)
+
+- **Two PRs.** PR 1 is pure consolidation: buildSession absorbs the
+  existing machinery with freshness pinned to "always" — provably
+  byte-identical, zero behavior change. PR 2 adds the manifest and the
+  freshness policy on the clean interface. Each is independently
+  revertable.
+- **Incremental is the DEFAULT and ONLY public mode for disk compiles.**
+  No `--incremental` flag. Rationale: tsc keeps incremental opt-in
+  because of a huge legacy base, because tsc is one tool inside pipelines
+  it does not own, and because opt-in shifts under-invalidation risk onto
+  the user — none of which applies to agency (tiny user base, owns its
+  output convention; note tsc's own `--build` mode, where it owns the
+  graph, is effectively always-incremental). There is no second build
+  path to maintain: a full build IS the incremental path with an empty
+  manifest, so "always" costs one `if` at the skip decision, not a
+  parallel pipeline.
+- **`--force` is the escape hatch** on `agency compile`: ignore the
+  manifest, compile everything, rewrite the manifest fresh. Covers
+  "I do not trust the cache" without hand-deleting files. (`make clean`
+  remains the in-repo full reset.)
+- **`freshness: "always"` survives as an INTERNAL policy only** — the
+  test runner's precompile requires it (allowTestImports sessions never
+  touch the manifest), and the in-memory path has no freshness dimension
+  at all.
+- Consequences accepted: user projects grow a gitignored-by-convention
+  `.agency-build/` dir; manifest writes are atomic (write temp + rename)
+  with last-writer-wins so concurrent compiles cannot corrupt it; a
+  staleness bug would reach users as stale `.js`, mitigated by the
+  conservative invalidation fields (each can only over-rebuild) plus
+  `--force`. Orphaned sibling `.js` from deleted sources is a
+  pre-existing property of sibling outputs, not new.
+
+### Boundary constraints (verified against code, 2026-07-08)
+
+- **std::agency is out of the manifest's world entirely.** Every function
+  on that module (compile, run, runFile, typecheck, …) routes through
+  `compileSource` (`lib/stdlib/agency.ts` → `lib/compiler/compile.ts`) —
+  even `runFile` reads the file itself and passes a string
+  (`_compileFile`). In-memory, sandboxed, no `.js` outputs → nothing to
+  skip, nothing to go stale, and sandboxed agent code can neither read
+  nor poison the build cache.
+- **Refactor contract for the above:** `compileSource` calls
+  `buildCompiledClosure` directly (both callers are named in
+  compileClosure.ts's header). `buildCompiledClosure` therefore STAYS a
+  pure exported function; the buildSession wraps it as the disk-pipeline
+  consumer and must not swallow it.
+- **The LSP is untouched by the manifest.** Diagnostics parse editor
+  buffers as strings with `lower: false` (`lib/lsp/diagnostics.ts:88`) —
+  the parse cache is file-keyed and lower:true-pinned, so buffer parses
+  bypass it. Cross-file symbol builds (`lib/lsp/server.ts:74`,
+  `SymbolTable.build` from disk) already read through the #457 parse
+  cache; mtime+size keying is what makes that safe in a long-lived
+  server. The LSP never calls `compile()`, so manifest, compilerStamp
+  hashing, and `--force` never execute in the LSP process. Pre-existing
+  and unchanged: cross-file symbols reflect other files' on-disk state,
+  not unsaved buffers.
+
+### The interface (the "what")
+
+One module — `lib/compiler/buildSession.ts` — becomes the single entry point
+for multi-file compilation:
+
+```ts
+// As built in PR 1 (transitional — mirrors the legacy call sites so the
+// consolidation stays byte-identical):
+const session = createBuildSession();
+session.compile(config, entry, outputFile?, options?);   // file or dir, per-entry closure
+session.compileMany(config, files, options?);             // one union closure
+session.compileGroups(groups, options?);                  // multi-config + single-slot assert
+// config is per-call: cache state is config-agnostic while grouped
+// compiles carry per-group configs — which per-module configKey needs in
+// PR 2. configKey is derived INSIDE the session (integrity mechanism, not
+// caller input); the prebuilt-closure handoff is internal-only.
+
+// Destination (PR 2, with the manifest): compile/compileMany collapse into
+// ONE entries-based method — a single entry is a degenerate union — and
+// the closure strategy becomes the session's decision, not the caller's:
+//   session.compile(config, { entries: string[], freshness?, allowTestImports? })
+// freshness defaults "incremental" for disk compiles; "always" stays
+// internal-only (test runner). --force maps to a forced-"always" that
+// rewrites the manifest.
+```
+
+Callers declare entries + config (+ freshness, from PR 2). The session owns
+the "how", ALL of it: parse cache, union closure, config grouping and the
+cross-config assert, per-session compile dedupe, and (new) manifest-driven
+staleness. Consumers after the refactor:
+
+- CLI `compile` command (dirs and multi-path): a session with
+  `freshness: "always"` initially; `"incremental"` once the manifest lands.
+- Test-runner precompile (`precompile.ts`): shrinks to an adapter that
+  builds the config groups and calls the session.
+- `commands.ts`: `compileMany` folds into the session; `ensureCompiledClosure`
+  + `compiledFiles` + `currentClosure` module-globals become session state.
+- `parseCache.ts`: becomes internal to the session (module stays, but its
+  only importers are the session and tests).
+
+Success criterion for the refactor: "how does compilation caching work" has
+a one-file answer, and no compile-path module-global state remains in
+`commands.ts`.
+
+### The manifest (the "how" of incremental)
+
+`.agency-build/manifest.json` at the package root (gitignored; wiped by
+`make clean`). Per compiled module:
+
+- `sourceHash` — sha256 of the module's source bytes (content, not mtime —
+  survives `cp -r` and `git checkout`).
+- `deps` — the module's transitive agency-import paths (package-root-relative)
+  as recorded at the compile that wrote the entry. This field exists so the
+  skip check can run FROM THE MANIFEST ALONE, without a closure walk — the
+  closure walk parses every file, which would make "skipped modules skip
+  parse" impossible (second review, blocking finding #2). Soundness
+  invariant, load-bearing: import statements are part of the source, so an
+  unchanged `sourceHash` implies an unchanged import list, which implies the
+  recorded `deps` are still the module's true deps. A refactor that breaks
+  this implication (e.g. imports resolved through some source-external
+  state) must add that state to the key.
+- `hasPkgImports` — true when the module's recorded closure contains any
+  `pkg::` import. Such modules are NEVER skipped. The closure walker
+  excludes pkg imports exactly as it excludes stdlib
+  (`compileClosure.ts`: `isStdlibImport(target) || isPkgImport(target) →
+  continue`), and package content genuinely shapes emitted output (import
+  classification per docs/dev/pkg-imports.md) — so an `npm update` could
+  otherwise strand stale user `.js` with every manifest field matching.
+  Never-skip is the smallest sound rule; a real `pkgHash` (hash of resolved
+  package `.agency` sources) can replace it if pkg usage grows.
+- `depsHash` — hash over the sorted `sourceHash`es of the module's transitive
+  agency imports, VERIFIED at check time by re-hashing the recorded `deps`
+  paths (not by rebuilding the closure). CRITICAL CAVEAT
+  (design review finding #1): the closure walker EXCLUDES stdlib and pkg
+  imports (`compileClosure.ts`: `isStdlibImport(target) → continue`), so
+  `depsHash` alone can never see a stdlib edit — and recompiled stdlib `.js`
+  siblings live in `stdlib/`, not `dist/lib/`, so `compilerStamp` misses them
+  too. Without the next field, "touch `stdlib/index.agency`" would skip every
+  user module — a stale-output bug.
+- `stdlibHash` — hash over the contents of all `stdlib/**/*.agency` sources,
+  one value per session, a separate manifest field precisely because the
+  closure will never carry it. This is not merely conservative: user-module
+  codegen genuinely depends on stdlib content — `resolveReExports` resolves
+  user imports through stdlib re-export declarations into concrete module
+  paths in the emitted `.js`, so moving a function between stdlib modules
+  changes downstream output (this happened in practice in the `cce04f10`
+  stdlib reorganization). A stdlib edit therefore rebuilds the world, by
+  deliberate decision.
+- `configKey` — PR #457's canonical config serialization.
+- `compilerStamp` — one value per session: hash over the CONTENT of compiled
+  compiler files. mtime-based stamping is settled as unworkable (review
+  finding #2): `tsc-alias` reprocesses the entire outDir on every build, so
+  mtimes churn every `make`. Scope: `dist/lib/**/*.js` EXCLUDING
+  `dist/lib/runtime/` and `dist/lib/agents/` — generated code's TEXT does not
+  depend on runtime internals (it imports runtime symbols by name at
+  execution time; any rename that would change emitted references requires a
+  codegen edit, which is inside the stamp), and runtime is where the most
+  common non-codegen edits land. Exclusion-list design is fail-safe: a new
+  compiler dir is included by default. NAMED LIMIT: an edit to any other
+  `.ts` file still invalidates all agency output, so Stage A's incrementality
+  pays off in agency-only and runtime-only iteration loops, not in
+  compiler-hacking loops. That is the accepted trade for a stamp that can
+  never under-invalidate.
+- `outputPath` — where the `.js` landed, so staleness can also verify the
+  output still exists.
+
+Skip algorithm (runs from the manifest alone, no parsing):
+
+1. Hash M's source bytes; compare `sourceHash`.
+2. If it matches, the recorded `deps` are still valid (soundness invariant
+   above). Hash each recorded dep's current source bytes; recompute and
+   compare `depsHash`. A missing dep file = dirty.
+3. Compare `stdlibHash`, `compilerStamp`, `configKey`; check `outputPath`
+   exists; check `hasPkgImports` is false.
+4. All pass → skip M entirely. Any miss → M compiles.
+
+Skip granularity, stated precisely (second review, finding #2): a FULLY
+CLEAN closure skips everything — no parse, no symbol table, no init
+analysis, no typecheck, no codegen. A closure with ANY dirty member pays
+closure-level parse + symbol table + init analysis (that machinery is
+closure-granular by design), and its clean members skip only typecheck +
+codegen. So "recompile" and "reparse" diverge on partially-dirty closures;
+tests must assert the right one. Skipped modules also skip their typecheck
+warnings (same trade tsc makes; `make clean` restores full output).
+
+Freshness-oracle layering (second review, finding #6): the MANIFEST decides
+whether to compile; `parseCache` is an intra-process memo consulted only
+once compilation is already happening. Its `mtimeMs+size` key can in theory
+serve a stale AST that content hashing would have caught — accepted as-is
+(APFS sub-ms mtimes + the size guard make it astronomically unlikely). Do
+not "unify" the two caches in the other direction.
+
+### Residual risks, named
+
+- The manifest is dev-only by construction (publish path is clean-built), so
+  a manifest bug can produce a confusing local state but can never ship
+  stale code. `make clean` is always the escape hatch.
+- Hashing every source file per build costs ~1–2ms/file (sha256 of ~12k
+  lines total) — noise next to the 1s+ it replaces.
+- `import test { … }` modules are local files and DO participate in
+  closures, so `deps`/`depsHash` cover them. `pkg::` imports do NOT (the
+  walker skips them) — covered by the `hasPkgImports` never-skip rule above.
+  (The first draft of this bullet claimed pkg imports were in the closure;
+  the second review showed that is false — `compileClosure.ts` skips them
+  like stdlib.)
+- `allowTestImports` is deliberately NOT on `AgencyConfig`, so `configKey`
+  cannot distinguish a test-import compile from a normal one. Rule: sessions
+  with `allowTestImports: true` (the test runner's precompile) NEITHER read
+  NOR write the manifest — they stay `freshness: "always"`. If precompile is
+  ever flipped to incremental, `allowTestImports` must join the manifest key
+  first.
+- `.gitignore`: DONE in Stage C — the root `.gitignore` carries an explicit
+  `.agency-build/` entry. No Stage A task needed. (User projects get
+  `.agency-build/` by convention only; see Consequences accepted.)
+
+### Agent staging (decision — second review, blocking finding #1)
+
+Stage C's `stage-agent-sources` recipe does `rm -rf dist/lib/agents` before
+copying, which deletes every compiled agent output on every `make` — under
+the skip rule (`outputPath` must exist) no agent file would EVER skip, and
+the "constant as agents grow" goal would be unreachable. The wipe exists
+for orphan safety (an overlay copy would keep outputs of deleted sources),
+so the fix is a replacement, not a removal.
+
+Decision: **sync-style staging** via a small script (`scripts/stage-agents.mjs`
+or equivalent), replacing the `rm -rf` + `cp -r` recipe:
+
+1. Copy every file from `lib/agents` over `dist/lib/agents` (overwrite).
+2. Delete from `dist/lib/agents` any file whose source counterpart no
+   longer exists in `lib/agents` — and for a deleted `foo.agency`, also
+   delete its compiled `foo.js` sibling.
+3. Never touch compiled `.js` whose `.agency` source survives, and never
+   touch `docs/` (owned by `stage-agent-docs`).
+
+Orphan safety is preserved twice over: the sync deletes orphans itself, and
+publish still routes through `make clean`. Alternatives rejected: letting
+the manifest/session own staging (heavier, blurs the session's boundary
+into Makefile concerns); accepting always-rebuild agents (contradicts the
+stated goal).
+
+Verification: unit tests on the staleness rule (each field's mismatch
+triggers rebuild — including `stdlibHash` and a recorded-dep content change
+via `deps`; missing dep file, missing output, and `hasPkgImports: true`
+each trigger rebuild); a no-parse proof for the clean case (fully clean
+closure → zero `parseAgency` calls, assert via parse-cache stats or a spy);
+end-to-end: warm `make` twice → second run skips ALL 94 modules INCLUDING
+the five agent dirs (this is the acceptance test for the sync-staging
+decision — the old recipe made agent skips impossible); touch any stdlib
+file → all agency modules recompile (`stdlibHash`) AND `make doc`
+regenerates (doc.stamp); no stdlib change → `make doc` skips; touch a
+non-stdlib `.agency` → its closure re-parses, only dirty members re-codegen
+(assert recompile vs reparse per the granularity statement); delete an
+agent `.agency` from `lib/agents` → sync staging removes its dist copy and
+compiled sibling; edit `lib/backends/typescriptBuilder.ts` + rebuild → all
+recompile (stamp); edit `lib/runtime/*.ts` + rebuild → ZERO agency
+recompiles (stamp exclusion); `cp -r` and branch-switch churn → zero
+spurious rebuilds (content hashes unchanged); fixtures diff-clean;
+test-runner behavior unchanged (its precompile stays `freshness: "always"`
+and never touches the manifest — flipping it to incremental is a separate,
+later decision gated on adding `allowTestImports` to the manifest key).
+
+## Out of scope
+
+- CI incrementality via `actions/cache`.
+- Micro-optimizations found in profiling (tarsec's always-on `trace()`
+  wrapper ~116ms, `getAllVariablesInBody` 306ms) — each worth ~0.1–0.3s;
+  candidates for separate small PRs.
+- Watch-mode / daemonized compiles.
+- Orphan-tracking deletion (rejected in favor of clean-for-publish: simpler,
+  and a manifest bug then can't affect a tarball).

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -1,45 +1,27 @@
 import { generateAgency } from "@/backends/agencyGenerator.js";
 import { AgencyConfig, loadConfigSafe } from "@/config.js";
-import { AgencyProgram, generateTypeScript } from "@/index.js";
-import { initPlanForModule } from "@/backends/typescriptGenerator.js";
-import { resolveImports } from "@/preprocessors/importResolver.js";
-import { resolveReExports } from "@/preprocessors/resolveReExports.js";
-import { liftCallbackBlocks } from "@/preprocessors/liftCallbacks.js";
-import { buildCompilationUnit, CompilationUnit } from "@/compilationUnit.js";
-import { SymbolTable } from "@/symbolTable.js";
-import { formatErrors, typeCheck } from "@/typeChecker/index.js";
-import {
-  buildCompiledClosure,
-  CompileClosureError,
-  type CompiledClosure,
-} from "@/compiler/compileClosure.js";
+import { AgencyProgram } from "@/index.js";
+import { CompileClosureError } from "@/compiler/compileClosure.js";
 import { spawn } from "child_process";
-import { transformSync } from "esbuild";
 import * as fs from "fs";
 import { createRequire } from "module";
 import * as path from "path";
 
-import {
-  getStdlibDir,
-  isNonTemplatedStdlib,
-  isPkgImport,
-  isStdlibImport,
-  resolveAgencyImportPath,
-} from "../importPaths.js";
-import {
-  CompileStrategy,
-  RunStrategy,
-  type ImportStrategy,
-} from "../importStrategy.js";
+import { RunStrategy } from "../importStrategy.js";
 import { parseAgency, replaceBlankLines } from "../parser.js";
-import { parseAgencyFileCached } from "../parseCache.js";
 import { fileURLToPath, pathToFileURL } from "url";
 import {
   classifyInstall,
   installDirFromUrl,
   type InstallKind,
 } from "./installLocation.js";
-import { findRecursively, getImports } from "./util.js";
+import { findRecursively } from "./util.js";
+import {
+  createBuildSession,
+  readFile,
+  type BuildSession,
+  type CompileOptions,
+} from "../compiler/buildSession.js";
 
 // Returns the file:// URL of the ESM loader-register shim shipped with the
 // agency-lang package. Passing this to `node --import=<url>` causes Node to
@@ -166,351 +148,64 @@ export function parse(
   return parseResult.result;
 }
 
-export function readFile(inputFile: string): string {
-  if (!fs.existsSync(inputFile)) {
-    console.error(`Error: Input file '${inputFile}' not found`);
-    process.exit(1);
-  }
+export { readFile };
 
-  return fs.readFileSync(inputFile, "utf-8");
+// The default session backing the legacy module-level entry points
+// (compile/compileMany/resetCompilationCache). Deliberately the ONLY
+// compile-pipeline state left in this file: CLI processes are
+// single-session by nature, and watch mode resets it between rebuilds.
+// All pipeline logic lives in lib/compiler/buildSession.ts.
+//
+// Created LAZILY, not at module top level: `agency pack` bundles compiled
+// programs whose import chain reaches this module for small helpers
+// (readFile, loadConfig). An eager createBuildSession() call is a
+// top-level side effect that defeats esbuild tree-shaking and drags the
+// entire codegen subtree into every packed artifact (~16k extra lines,
+// caught by pack.test.ts).
+let defaultSession: BuildSession | null = null;
+
+function getDefaultSession(): BuildSession {
+  return (defaultSession ??= createBuildSession());
 }
 
-const compiledFiles: Set<string> = new Set();
-// Cached `CompiledClosure` for the current compile session. Built once
-// at the outermost `compile()` call (when no per-file recursion is in
-// progress) and reused by every per-file emit. Cleared by
-// `resetCompilationCache()`.
-let currentClosure: CompiledClosure | null = null;
-
 export function resetCompilationCache(): void {
-  compiledFiles.clear();
-  currentClosure = null;
+  defaultSession = null;
 }
 
 /**
  * Compile a set of entry files under ONE union closure, like the
  * directory branch of `compile()` does. Callers with many entry points
  * (the test runner's precompile pass) use this instead of per-file
- * `compile()` calls, which would rebuild the closure once per entry via
- * `ensureCompiledClosure`'s covers-check.
+ * `compile()` calls, which would rebuild the closure once per entry.
  *
  * Unlike the CLI directory branch, closure errors THROW
  * (`CompileClosureError`) instead of exiting, so programmatic callers
  * can attach context. Parse/typecheck failures inside per-file
  * `compile()` keep their existing exit behavior.
- *
- * `options.closure` lets a caller that already built the union closure
- * (e.g. to run analyses over `closure.programs`) hand it in rather than
- * paying for a rebuild. It MUST cover every file in `files`, otherwise
- * `ensureCompiledClosure` clears the session cache mid-loop and the
- * one-compile-per-module guarantee is lost.
  */
 export function compileMany(
   config: AgencyConfig,
   files: string[],
   options?: {
-    closure?: CompiledClosure;
     quiet?: boolean;
     allowTestImports?: boolean;
   },
 ): void {
-  const absFiles = files.map((f) => path.resolve(f));
-  if (absFiles.length === 0) return;
-  currentClosure = options?.closure ?? buildCompiledClosure(absFiles, config);
-  compiledFiles.clear();
-  for (const file of absFiles) {
-    compile(config, file, undefined, {
-      quiet: options?.quiet,
-      allowTestImports: options?.allowTestImports,
-    });
-  }
+  getDefaultSession().compileMany(config, files, options);
 }
 
 /**
- * Build the import-closure analysis once per compile session — at the
- * outermost call, before any recursive per-file compile() runs. The
- * recursive children reuse the cached closure to get per-module init
- * plans without re-parsing.
- *
- * "Outermost call" = no `options.symbolTable` (passed by recursive
- * children). When the outermost call's entry file changes (e.g. the
- * `agency test` runner iterates several .test.json fixtures in one
- * process), the cached closure no longer covers the new entry's
- * imports so we rebuild and drop the stale `compiledFiles` set.
- * Without that drop, downstream codegen would look up plans for
- * modules that aren't in the closure and emit an empty init plan.
- *
- * Stdlib files compile under their own entry (e.g., when a user runs
- * `agency compile std/...`) but most user code reaches them via
- * `import "std::..."`, which the closure walker intentionally skips.
- * Avoid building a closure rooted at a stdlib file — its imports are
- * structured differently and we don't need the analysis there.
+ * Compile an .agency file (or directory of them) to JavaScript. Thin
+ * delegate over the default BuildSession — all pipeline logic and caching
+ * state live in lib/compiler/buildSession.ts.
  */
-function ensureCompiledClosure(
-  absoluteInputFile: string,
-  config: AgencyConfig,
-  hasSymbolTable: boolean,
-  verbose: boolean,
-): void {
-  const isOutermostCall = !hasSymbolTable;
-  const isStdlibEntry = absoluteInputFile.startsWith(getStdlibDir() + path.sep);
-  const closureCoversEntry =
-    currentClosure?.programs[absoluteInputFile] !== undefined;
-  if (!isOutermostCall || isStdlibEntry || closureCoversEntry) return;
-
-  currentClosure = null;
-  compiledFiles.clear();
-  try {
-    const ccStartTime = performance.now();
-    currentClosure = buildCompiledClosure(absoluteInputFile, config);
-    const ccEndTime = performance.now();
-    logTime({ label: "Built compile closure", start: ccStartTime, end: ccEndTime, verbose });
-  } catch (e) {
-    if (e instanceof CompileClosureError) {
-      console.error(e.message);
-      process.exit(1);
-    }
-    throw e;
-  }
-}
-
-function runTypecheck(
-  liftedProgram: AgencyProgram,
-  config: AgencyConfig,
-  info: CompilationUnit,
-  absoluteInputFile: string,
-  verbose: boolean,
-): void {
-  const tc = config.typechecker;
-  if (!tc?.enabled && !tc?.strict) return;
-  const tcStartTime = performance.now();
-  const { errors } = typeCheck(liftedProgram, config, info);
-  const tcEndTime = performance.now();
-  logTime({ label: `Type checked ${absoluteInputFile}`, start: tcStartTime, end: tcEndTime, verbose });
-  if (errors.length === 0) return;
-  if (tc?.strict) {
-    console.error(formatErrors(errors));
-    const hasFatal = errors.some((e) => (e.severity ?? "error") === "error");
-    if (hasFatal) process.exit(1);
-  } else {
-    console.warn(formatErrors(errors, "warning"));
-  }
-}
-
-// Cached-parse counterpart of `parse()`: same exit-on-failure contract the
-// CLI pipeline expects, but reads through the process-wide parse cache.
-function parseFileOrExit(
-  absPath: string,
-  config: AgencyConfig,
-  applyTemplate: boolean,
-  contents: string,
-): AgencyProgram {
-  const parseResult = parseAgencyFileCached(absPath, config, applyTemplate);
-  if (!parseResult.success) {
-    if (parseResult.message) {
-      console.error(`Failed to parse Agency program: ${parseResult.message}`);
-    } else {
-      console.error("Failed to parse Agency program.", contents.slice(0, 400));
-    }
-    process.exit(1);
-  }
-  return parseResult.result;
-}
-
 export function compile(
   config: AgencyConfig,
   inputFile: string,
   _outputFile?: string,
-  options?: {
-    ts?: boolean;
-    symbolTable?: SymbolTable;
-    importStrategy?: ImportStrategy;
-    /** Suppress the per-file `input → output (in Nms)` progress line. */
-    quiet?: boolean;
-    /** Test-harness only. Honors `import test { … }`. Never set outside the
-     *  test runner / analysis paths — kept off AgencyConfig so agent source
-     *  cannot enable it. */
-    allowTestImports?: boolean;
-  },
+  options?: CompileOptions,
 ): string | null {
-  if (!fs.existsSync(inputFile)) {
-    console.error(`Error: Input file '${inputFile}' not found`);
-    process.exit(1);
-  }
-  const stats = fs.statSync(inputFile);
-  const verbose = config.verbose ?? false;
-  if (stats.isDirectory()) {
-    const files = [...findRecursively(inputFile)].map((f) => f.path);
-    // A directory is many entry points — every .agency file under it. To
-    // avoid recompiling shared dependencies once per entry, build ONE
-    // import closure covering all of them up front and reuse it for every
-    // file. Without this, each sibling entry the previous closure didn't
-    // cover would clear the per-session cache (see ensureCompiledClosure)
-    // and recompile shared deps once per entry. Skipped for:
-    //   - recursive child calls (a symbolTable was threaded in) — those
-    //     aren't real top-level directory compiles; and
-    //   - stdlib dirs, which intentionally compile without a closure (the
-    //     same carve-out ensureCompiledClosure makes for stdlib entries).
-    const absDir = path.resolve(inputFile);
-    const isStdlibDir =
-      absDir === getStdlibDir() || absDir.startsWith(getStdlibDir() + path.sep);
-    if (!options?.symbolTable && !isStdlibDir && files.length > 0) {
-      try {
-        currentClosure = buildCompiledClosure(
-          files.map((f) => path.resolve(f)),
-          config,
-        );
-        // The fresh union closure supersedes anything cached for a prior
-        // entry; drop the per-file set so codegen reruns under it.
-        compiledFiles.clear();
-      } catch (e) {
-        if (e instanceof CompileClosureError) {
-          console.error(e.message);
-          process.exit(1);
-        }
-        throw e;
-      }
-    }
-    for (const file of files) {
-      compile(config, file, undefined, options);
-    }
-    return null;
-  }
-
-  const compileStartTime = performance.now();
-  const absoluteInputFile = path.resolve(inputFile);
-
-  ensureCompiledClosure(absoluteInputFile, config, !!options?.symbolTable, verbose);
-
-  const ext = options?.ts ? ".ts" : ".js";
-  // Anchor the replacement to the extension so that an absolute path
-  // containing ".agency" as a substring in a parent directory (e.g.
-  // "/Users/me/dev/worksy.agency-init/src/agent.agency") does not get
-  // the first match clobbered. See issue #48.
-  let outputFile = _outputFile || inputFile.replace(/\.agency$/, ext);
-  if (config.outDir && !_outputFile) {
-    const outputDir = path.resolve(config.outDir);
-
-    if (!fs.existsSync(outputDir)) {
-      fs.mkdirSync(outputDir, { recursive: true });
-    }
-
-    outputFile = path.join(outputDir, outputFile);
-  }
-  if (compiledFiles.has(absoluteInputFile)) {
-    return outputFile;
-  }
-
-  compiledFiles.add(absoluteInputFile);
-
-  const contents = readFile(inputFile);
-  const applyTemplate = !isNonTemplatedStdlib(absoluteInputFile);
-  const parsedProgram = parseFileOrExit(absoluteInputFile, config, applyTemplate, contents);
-
-  const symbolTableStartTime = performance.now();
-  const symbolTable =
-    options?.symbolTable ?? SymbolTable.build(absoluteInputFile, config);
-
-  const symbolTableEndTime = performance.now();
-  logTime({ label: `Built symbol table for ${absoluteInputFile}`, start: symbolTableStartTime, end: symbolTableEndTime, verbose });
-
-  const compilationUnitStartTime = performance.now();
-  const reExportedProgram = resolveReExports(
-    parsedProgram,
-    symbolTable,
-    absoluteInputFile,
-  );
-  const resolvedProgram = resolveImports(reExportedProgram, symbolTable, absoluteInputFile, {
-    allowTestImports: options?.allowTestImports ?? false,
-  });
-  // Lift `callback("onX") { ... }` block bodies to top-level defs.
-  // Must run BEFORE buildCompilationUnit and typecheck so the lifted defs
-  // appear in functionDefinitions and get their bodies typechecked.
-  const liftedProgram = liftCallbackBlocks(resolvedProgram);
-  const info = buildCompilationUnit(
-    liftedProgram,
-    symbolTable,
-    absoluteInputFile,
-    contents,
-  );
-  const compilationUnitEndTime = performance.now();
-  logTime({ label: `Built compilation unit for ${absoluteInputFile}`, start: compilationUnitStartTime, end: compilationUnitEndTime, verbose });
-
-  runTypecheck(liftedProgram, config, info, absoluteInputFile, verbose);
-
-  const imports = getImports(resolvedProgram);
-
-  for (const importPath of imports) {
-    if (isStdlibImport(importPath) || isPkgImport(importPath)) continue;
-
-    const absPath = resolveAgencyImportPath(importPath, absoluteInputFile);
-    compile(config, absPath, undefined, { ...options, symbolTable });
-  }
-
-  // Rewrite import paths in the AST using the import strategy
-  const strategy =
-    options?.importStrategy ?? new CompileStrategy({ targetExt: ".js" });
-  const nonAgencyImports: string[] = [];
-
-  liftedProgram.nodes.forEach((node) => {
-    if (node.type !== "importStatement") return;
-    if (isStdlibImport(node.modulePath) || isPkgImport(node.modulePath)) return;
-
-    node.modulePath = strategy.rewriteImport(
-      node.modulePath,
-      absoluteInputFile,
-    );
-
-    if (!node.modulePath.endsWith(".agency")) {
-      nonAgencyImports.push(node.modulePath);
-    }
-  });
-
-  try {
-    strategy.prepareDependencies(nonAgencyImports, absoluteInputFile);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  }
-
-  const moduleId = path.relative(process.cwd(), absoluteInputFile);
-  const absoluteOutputFile = path.resolve(outputFile);
-  // Per-module init plan view — derived from the cached closure if we
-  // built one. Modules not in the closure (e.g., out-of-tree stdlib
-  // compiles) fall through to the legacy path with no plan.
-  const initPlan = currentClosure
-    ? initPlanForModule(currentClosure, absoluteInputFile)
-    : undefined;
-  const codegenStartTime = performance.now();
-  const generatedCode = generateTypeScript(
-    liftedProgram,
-    config,
-    info,
-    moduleId,
-    absoluteOutputFile,
-    initPlan,
-  );
-  const codegenEndTime = performance.now();
-  logTime({ label: `Generated code for ${absoluteInputFile}`, start: codegenStartTime, end: codegenEndTime, verbose });
-  if (options?.ts) {
-    fs.writeFileSync(outputFile, "// @ts-nocheck\n" + generatedCode, "utf-8");
-  } else {
-    const esbuildStartTime = performance.now();
-    const result = transformSync(generatedCode, {
-      loader: "ts",
-      format: "esm",
-      supported: { "top-level-await": true },
-    });
-    fs.writeFileSync(outputFile, result.code, "utf-8");
-    const esbuildEndTime = performance.now();
-    logTime({ label: `Transformed code for ${absoluteInputFile} with esbuild`, start: esbuildStartTime, end: esbuildEndTime, verbose });
-  }
-  const compileEndTime = performance.now();
-  const timeTaken = `${(compileEndTime - compileStartTime).toFixed(2)}ms`
-  if (!options?.quiet) {
-    console.log(`${inputFile} → ${outputFile} (in ${timeTaken})`);
-  }
-  return outputFile;
+  return getDefaultSession().compile(config, inputFile, _outputFile, options);
 }
 
 export async function format(
@@ -591,10 +286,4 @@ export function run(
       process.exit(code || 1);
     }
   });
-}
-
-function logTime({ label, start, end, verbose }: { label: string, start: number, end: number, verbose: boolean }): void {
-  if (verbose) {
-    console.log(`${label} in ${(end - start).toFixed(2)}ms`);
-  }
 }

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -1,7 +1,6 @@
 import { generateAgency } from "@/backends/agencyGenerator.js";
 import { AgencyConfig, loadConfigSafe } from "@/config.js";
 import { AgencyProgram } from "@/index.js";
-import { CompileClosureError } from "@/compiler/compileClosure.js";
 import { spawn } from "child_process";
 import * as fs from "fs";
 import { createRequire } from "module";

--- a/packages/agency-lang/lib/cli/precompile.test.ts
+++ b/packages/agency-lang/lib/cli/precompile.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, test } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import {
-  findCrossConfigConflicts,
-  groupTestSources,
-  precompileTestSources,
-} from "./precompile.js";
+import { groupTestSources, precompileTestSources } from "./precompile.js";
 
 const TRIVIAL = 'node main() {\n  return "ok"\n}\n';
 const HELPER = 'export def helper(): string {\n  return "shared"\n}\n';
@@ -27,34 +23,6 @@ function writeTree(spec: Record<string, Record<string, string>>): string {
 }
 
 const TEST_JSON = JSON.stringify({ tests: [] });
-
-describe("findCrossConfigConflicts", () => {
-  test("no conflict when groups with the same config share a module", () => {
-    const conflicts = findCrossConfigConflicts([
-      { label: "a", configKey: "{}", modules: ["/shared.agency"] },
-      { label: "b", configKey: "{}", modules: ["/shared.agency"] },
-    ]);
-    expect(conflicts).toEqual([]);
-  });
-
-  test("conflict when groups with differing configs share a module", () => {
-    const conflicts = findCrossConfigConflicts([
-      { label: "a", configKey: "{}", modules: ["/shared.agency", "/a.agency"] },
-      { label: "b", configKey: '{"verbose":true}', modules: ["/shared.agency"] },
-    ]);
-    expect(conflicts).toHaveLength(1);
-    expect(conflicts[0].module).toBe("/shared.agency");
-    expect(conflicts[0].labels.sort()).toEqual(["a", "b"]);
-  });
-
-  test("no conflict when differing-config groups touch disjoint modules", () => {
-    const conflicts = findCrossConfigConflicts([
-      { label: "a", configKey: "{}", modules: ["/a.agency"] },
-      { label: "b", configKey: '{"verbose":true}', modules: ["/b.agency"] },
-    ]);
-    expect(conflicts).toEqual([]);
-  });
-});
 
 describe("groupTestSources", () => {
   test("files without a local agency.json land in one base group", () => {
@@ -91,7 +59,7 @@ describe("groupTestSources", () => {
     expect(custom.config.verbose).toBe(true);
     expect(custom.config.observability).toBe(true);
     const base = groups.find((g) => !g.label.includes("custom"))!;
-    expect(base.configKey).not.toBe(custom.configKey);
+    expect(base.config).not.toEqual(custom.config);
   });
 
   test("file-level skipped test files are excluded", () => {
@@ -110,28 +78,32 @@ describe("groupTestSources", () => {
     expect(groups[0].files).toEqual([path.join(root, "live/main.agency")]);
   });
 
-  test("configKey is key-order independent", () => {
-    // Same config content, different key order in the two agency.json
-    // files. JSON.stringify would produce different strings; the group
-    // keys must still match so the dirs are config-compatible.
+  test("key-order-different but equal local configs are compatible (zod-normalized keys)", () => {
+    // Two dirs whose agency.json files have the same content in different
+    // key order, sharing an imported module. The session derives config
+    // keys via JSON.stringify, which is only order-stable because
+    // loadConfig routes through zod (schema shape order). If that
+    // normalization ever breaks, the keys diverge and the shared module
+    // trips the cross-config assert — this test is the tripwire.
     const root = writeTree({
+      shared: { "helper.agency": HELPER },
       a: {
-        "main.agency": TRIVIAL,
+        "main.agency": IMPORTS_HELPER,
         "main.test.json": TEST_JSON,
-        "agency.json": '{"verbose": true, "observability": false}',
+        "agency.json": '{"verbose": false, "observability": true}',
       },
       b: {
-        "main.agency": TRIVIAL,
+        "main.agency": IMPORTS_HELPER,
         "main.test.json": TEST_JSON,
-        "agency.json": '{"observability": false, "verbose": true}',
+        "agency.json": '{"observability": true, "verbose": false}',
       },
     });
-    const groups = groupTestSources({}, [
-      path.join(root, "a/main.test.json"),
-      path.join(root, "b/main.test.json"),
-    ]);
-    expect(groups).toHaveLength(2);
-    expect(groups[0].configKey).toBe(groups[1].configKey);
+    expect(() =>
+      precompileTestSources({}, [
+        path.join(root, "a/main.test.json"),
+        path.join(root, "b/main.test.json"),
+      ], { quiet: true }),
+    ).not.toThrow();
   });
 
   test("test files without a sibling .agency are excluded", () => {

--- a/packages/agency-lang/lib/cli/precompile.ts
+++ b/packages/agency-lang/lib/cli/precompile.ts
@@ -1,5 +1,6 @@
 /**
- * Precompile pass for the Agency test runner.
+ * Precompile pass for the Agency test runner — a thin adapter over
+ * BuildSession.compileGroups.
  *
  * Historically each test CASE recompiled its `.agency` source (and the
  * source's whole import tree) via `executeNodeAsync` → `compile()` — with
@@ -8,40 +9,25 @@
  * unique source exactly once, up front; the runner then executes test cases
  * with `preferCompiled: true`, which reuses the sibling `.js`.
  *
- * Config grouping: compiled output is config-dependent (the generator bakes
- * config defaults into emitted code), and a test dir may carry a local
- * `agency.json` that `runTestFile` merges over the base config. Sources are
- * therefore grouped by merged config — one union-closure compile for all
- * base-config files, plus one per local-config dir.
- *
- * Cross-config invariant: a sibling `.js` is a single slot per module, so a
- * module reachable from two groups whose configs differ would be
- * last-writer-wins. That is asserted here and fails loudly (no test dir
- * does this today). A graceful fallback (per-case compiles for conflicting
- * files) was rejected: interleaved recompiles rewrite shared siblings
- * mid-run, which is exactly the race this pass removes.
+ * What lives HERE is only what is test-runner-specific: mapping `.test.json`
+ * files to sibling sources, honoring file-level skip/skipOnCI, and merging a
+ * dir-local `agency.json` over the base config. The config grouping
+ * contract, the cross-config single-slot assert, and the per-group compile
+ * loop live in lib/compiler/buildSession.ts.
  */
 import fs from "fs";
 import path from "path";
 import { AgencyConfig } from "../config.js";
-import { loadConfig, compileMany } from "./commands.js";
+import { loadConfig } from "./commands.js";
 import {
-  buildCompiledClosure,
-  CompileClosureError,
-  type CompiledClosure,
-} from "../compiler/compileClosure.js";
+  createBuildSession,
+  type CompileGroup,
+} from "../compiler/buildSession.js";
 
 const BASE_GROUP_LABEL = "<base config>";
 
-export type PrecompileGroup = {
-  /** Base-config marker or the local-`agency.json` dir, for error messages. */
-  label: string;
-  config: AgencyConfig;
-  /** Canonical serialization of `config`; groups conflict only when keys differ. */
-  configKey: string;
-  /** Absolute `.agency` entry paths. */
-  files: string[];
-};
+// Back-compat name for existing importers (precompile.test.ts).
+export type { CompileGroup as PrecompileGroup };
 
 // File-level skip mirror of runTestFile's check: a `skip: true` (or
 // `skipOnCI: true` under CI) .test.json never runs, so its source must not
@@ -59,10 +45,10 @@ function isFileLevelSkipped(testJsonFile: string): boolean {
 export function groupTestSources(
   baseConfig: AgencyConfig,
   testJsonFiles: string[],
-): PrecompileGroup[] {
+): CompileGroup[] {
   // Null-prototype: keyed by dir paths (see lib/optimize/registry.ts for the
   // house pattern on string-keyed registries).
-  const groups: Record<string, PrecompileGroup> = Object.create(null);
+  const groups: Record<string, CompileGroup> = Object.create(null);
   for (const testJsonFile of testJsonFiles) {
     const sourceFile = path
       .resolve(testJsonFile)
@@ -82,43 +68,11 @@ export function groupTestSources(
     const group = (groups[label] ??= {
       label,
       config,
-      // JSON.stringify is order-stable here: every config passes through
-      // AgencyConfigSchema.safeParse (loadConfigSafe), and zod rebuilds the
-      // object in SCHEMA shape order, not input order — so semantically
-      // identical configs always serialize identically. Guarded by the
-      // "configKey is key-order independent" test.
-      configKey: JSON.stringify(config),
       files: [],
     });
     if (!group.files.includes(sourceFile)) group.files.push(sourceFile);
   }
   return Object.values(groups);
-}
-
-export function findCrossConfigConflicts(
-  groups: { label: string; configKey: string; modules: string[] }[],
-): { module: string; labels: string[] }[] {
-  // Null-prototype: keyed by absolute module paths.
-  const touchedBy: Record<string, { configKey: string; label: string }[]> =
-    Object.create(null);
-  for (const group of groups) {
-    for (const module of group.modules) {
-      (touchedBy[module] ??= []).push({
-        configKey: group.configKey,
-        label: group.label,
-      });
-    }
-  }
-  const conflicts: { module: string; labels: string[] }[] = [];
-  for (const [module, touches] of Object.entries(touchedBy)) {
-    const distinctKeys = touches
-      .map((t) => t.configKey)
-      .filter((key, i, all) => all.indexOf(key) === i);
-    if (distinctKeys.length > 1) {
-      conflicts.push({ module, labels: touches.map((t) => t.label) });
-    }
-  }
-  return conflicts;
 }
 
 export function precompileTestSources(
@@ -127,37 +81,13 @@ export function precompileTestSources(
   options?: { quiet?: boolean },
 ): void {
   const groups = groupTestSources(baseConfig, testJsonFiles);
-  const withClosures: { group: PrecompileGroup; closure: CompiledClosure }[] =
-    groups.map((group) => ({
-      group,
-      closure: buildCompiledClosure(group.files, group.config),
-    }));
-
-  const conflicts = findCrossConfigConflicts(
-    withClosures.map(({ group, closure }) => ({
-      label: group.label,
-      configKey: group.configKey,
-      modules: Object.keys(closure.programs),
-    })),
-  );
-  if (conflicts.length > 0) {
-    const lines = conflicts.map(
-      (c) =>
-        `  ${c.module}\n    reachable from: ${c.labels.join(", ")}`,
-    );
-    throw new CompileClosureError(
-      "Test sources with differing configs share modules. A module's " +
-        "compiled .js is a single slot, so this would be last-writer-wins. " +
-        "Move the shared module or align the configs:\n" +
-        lines.join("\n"),
-    );
-  }
-
-  for (const { group, closure } of withClosures) {
-    compileMany(group.config, group.files, {
-      closure,
-      quiet: options?.quiet,
-      allowTestImports: true,
-    });
-  }
+  // Fresh session per precompile — a declared delta from the old shared
+  // module globals: the default session no longer inherits precompile's
+  // last-group closure/dedupe state. Safe because test cases run with
+  // `preferCompiled: true` and never re-enter compile(); the old inherited
+  // state was itself a latent staleness hazard.
+  createBuildSession().compileGroups(groups, {
+    quiet: options?.quiet,
+    allowTestImports: true,
+  });
 }

--- a/packages/agency-lang/lib/compiler/buildSession.test.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.test.ts
@@ -128,7 +128,9 @@ describe("createBuildSession", () => {
         'import test { secret } from "./lib.agency"\n\nnode main() {\n  return secret()\n}\n',
     });
     const files = [path.join(dir, "main.agency")];
-    expect(() => createBuildSession().compileMany({}, files, { quiet: true })).toThrow();
+    expect(() => createBuildSession().compileMany({}, files, { quiet: true })).toThrow(
+      /only allowed under the test harness/,
+    );
     createBuildSession().compileMany({}, files, { quiet: true, allowTestImports: true });
     expect(fs.existsSync(path.join(dir, "main.js"))).toBe(true);
   });

--- a/packages/agency-lang/lib/compiler/buildSession.test.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createBuildSession, findCrossConfigConflicts } from "./buildSession.js";
+import { CompileClosureError } from "./compileClosure.js";
+import { compile, resetCompilationCache } from "../cli/commands.js";
+
+const TRIVIAL = 'node main() {\n  return "ok"\n}\n';
+const HELPER = 'export def helper(): string {\n  return "shared"\n}\n';
+const IMPORTS_HELPER =
+  'import { helper } from "./helper.agency"\n\nnode main() {\n  return helper()\n}\n';
+
+function writeTempDir(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-buildsession-"));
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), contents);
+  }
+  return dir;
+}
+
+// Back-date a file so any re-emit measurably moves its mtime, independent
+// of filesystem timestamp granularity vs compile duration.
+const BACKDATE = new Date("2020-01-01T00:00:00Z");
+function backdate(file: string): number {
+  fs.utimesSync(file, BACKDATE, BACKDATE);
+  return fs.statSync(file).mtimeMs;
+}
+
+// Count progress lines ("<input> → <output> (in Nms)") for a source file.
+function emitCount(spy: ReturnType<typeof vi.spyOn>, sourceName: string): number {
+  return spy.mock.calls.filter(
+    (args: unknown[]) => typeof args[0] === "string" && args[0].includes(`${sourceName} → `),
+  ).length;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createBuildSession", () => {
+  test("compiles a single file and returns the output path", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const session = createBuildSession();
+    const out = session.compile({}, path.join(dir, "main.agency"), undefined, { quiet: true });
+    expect(out).toBe(path.join(dir, "main.js"));
+    expect(fs.existsSync(out!)).toBe(true);
+  });
+
+  test("dedupes within a session: second compile of the same entry is a no-op", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const session = createBuildSession();
+    const entry = path.join(dir, "main.agency");
+    session.compile({}, entry, undefined, { quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    session.compile({}, entry, undefined, { quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBe(stamped);
+  });
+
+  test("sessions are isolated: a fresh session recompiles", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, entry, undefined, { quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    createBuildSession().compile({}, entry, undefined, { quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+  });
+
+  test("reset() drops the dedupe state", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const entry = path.join(dir, "main.agency");
+    const session = createBuildSession();
+    session.compile({}, entry, undefined, { quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    session.reset();
+    session.compile({}, entry, undefined, { quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+  });
+
+  test("compileMany compiles the shared import exactly once (union closure)", () => {
+    const dir = writeTempDir({
+      "helper.agency": HELPER,
+      "a.agency": IMPORTS_HELPER,
+      "b.agency": IMPORTS_HELPER,
+    });
+    const spy = vi.spyOn(console, "log");
+    createBuildSession().compileMany({}, [
+      path.join(dir, "a.agency"),
+      path.join(dir, "b.agency"),
+    ]);
+    for (const out of ["a.js", "b.js", "helper.js"]) {
+      expect(fs.existsSync(path.join(dir, out))).toBe(true);
+    }
+    // The property under test: helper compiles ONCE. A closure-per-entry
+    // regression compiles it twice and still leaves all files existing.
+    expect(emitCount(spy, "helper.agency")).toBe(1);
+  });
+
+  test("directory entries compile every member with one union closure", () => {
+    const dir = writeTempDir({
+      "helper.agency": HELPER,
+      "a.agency": IMPORTS_HELPER,
+      "b.agency": IMPORTS_HELPER,
+    });
+    const spy = vi.spyOn(console, "log");
+    const result = createBuildSession().compile({}, dir);
+    expect(result).toBeNull();
+    for (const out of ["a.js", "b.js", "helper.js"]) {
+      expect(fs.existsSync(path.join(dir, out))).toBe(true);
+    }
+    expect(emitCount(spy, "helper.agency")).toBe(1);
+  });
+
+  test("compileMany throws CompileClosureError for programmatic callers", () => {
+    const dir = writeTempDir({
+      "main.agency":
+        'import { gone } from "./missing.agency"\n\nnode main() {\n  return gone()\n}\n',
+    });
+    expect(() =>
+      createBuildSession().compileMany({}, [path.join(dir, "main.agency")], { quiet: true }),
+    ).toThrow(CompileClosureError);
+  });
+
+  test("allowTestImports gates import test compilation", () => {
+    const dir = writeTempDir({
+      "lib.agency": 'def secret(): string {\n  return "s"\n}\n',
+      "main.agency":
+        'import test { secret } from "./lib.agency"\n\nnode main() {\n  return secret()\n}\n',
+    });
+    const files = [path.join(dir, "main.agency")];
+    expect(() => createBuildSession().compileMany({}, files, { quiet: true })).toThrow();
+    createBuildSession().compileMany({}, files, { quiet: true, allowTestImports: true });
+    expect(fs.existsSync(path.join(dir, "main.js"))).toBe(true);
+  });
+
+  test("outDir routes output into the configured directory", () => {
+    // The outDir branch joins outDir with the INPUT-derived path, so it is
+    // designed for CWD-relative inputs (`agency compile main.agency` with
+    // an outDir config). Exercise it the way the CLI does: chdir into the
+    // project dir and pass a bare relative path.
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const outDir = path.join(dir, "built");
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(dir);
+      const out = createBuildSession().compile({ outDir }, "main.agency", undefined, {
+        quiet: true,
+      });
+      expect(out).toBe(path.join(outDir, "main.js"));
+      expect(fs.existsSync(out!)).toBe(true);
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+});
+
+describe("findCrossConfigConflicts", () => {
+  test("no conflict when groups with the same config share a module", () => {
+    const conflicts = findCrossConfigConflicts([
+      { label: "a", configKey: "{}", modules: ["/shared.agency"] },
+      { label: "b", configKey: "{}", modules: ["/shared.agency"] },
+    ]);
+    expect(conflicts).toEqual([]);
+  });
+
+  test("conflict when groups with differing configs share a module", () => {
+    const conflicts = findCrossConfigConflicts([
+      { label: "a", configKey: "{}", modules: ["/shared.agency", "/a.agency"] },
+      { label: "b", configKey: '{"verbose":true}', modules: ["/shared.agency"] },
+    ]);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0].module).toBe("/shared.agency");
+    expect(conflicts[0].labels.sort()).toEqual(["a", "b"]);
+  });
+
+  test("no conflict when differing-config groups touch disjoint modules", () => {
+    const conflicts = findCrossConfigConflicts([
+      { label: "a", configKey: "{}", modules: ["/a.agency"] },
+      { label: "b", configKey: '{"verbose":true}', modules: ["/b.agency"] },
+    ]);
+    expect(conflicts).toEqual([]);
+  });
+});
+
+describe("compileGroups", () => {
+  test("asserts loudly when differing configs share a module", () => {
+    const dir = writeTempDir({
+      "helper.agency": HELPER,
+      "a.agency": IMPORTS_HELPER,
+      "b.agency": IMPORTS_HELPER,
+    });
+    const groups = [
+      { label: "a", config: {}, files: [path.join(dir, "a.agency")] },
+      { label: "b", config: { verbose: false }, files: [path.join(dir, "b.agency")] },
+    ];
+    expect(() =>
+      createBuildSession().compileGroups(groups, { quiet: true }),
+    ).toThrow(/helper\.agency/);
+  });
+
+  test("compiles compatible groups", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const groups = [
+      { label: "<base config>", config: {}, files: [path.join(dir, "main.agency")] },
+    ];
+    createBuildSession().compileGroups(groups, { quiet: true });
+    expect(fs.existsSync(path.join(dir, "main.js"))).toBe(true);
+  });
+});
+
+describe("commands.ts delegates", () => {
+  test("module-level compile + resetCompilationCache re-emits", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const entry = path.join(dir, "main.agency");
+    compile({}, entry, undefined, { quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    compile({}, entry, undefined, { quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBe(stamped); // deduped
+    resetCompilationCache();
+    compile({}, entry, undefined, { quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+  });
+});

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -1,0 +1,541 @@
+/**
+ * The single owner of compile-pipeline caching and orchestration.
+ *
+ * Before this module, "how does compilation caching work" required reading
+ * four places: parseCache.ts (parse memo), commands.ts (three module
+ * globals + compileMany + ensureCompiledClosure), precompile.ts (config
+ * grouping + cross-config assert), and the directory branch of compile().
+ * A BuildSession now owns all of that state and logic; commands.ts keeps
+ * thin delegates for its existing exports.
+ *
+ * Contract (spec "Boundary constraints"): buildCompiledClosure remains a
+ * pure exported function — compileSource (lib/compiler/compile.ts) calls
+ * it directly for in-memory sandbox compiles and must not be affected.
+ *
+ * PR 2 adds `freshness`/the manifest here. Until then every compile is a
+ * full compile (the historical behavior).
+ */
+import { AgencyConfig } from "@/config.js";
+import { AgencyProgram, generateTypeScript } from "@/index.js";
+import { initPlanForModule } from "@/backends/typescriptGenerator.js";
+import { resolveImports } from "@/preprocessors/importResolver.js";
+import { resolveReExports } from "@/preprocessors/resolveReExports.js";
+import { liftCallbackBlocks } from "@/preprocessors/liftCallbacks.js";
+import { buildCompilationUnit, CompilationUnit } from "@/compilationUnit.js";
+import { SymbolTable } from "@/symbolTable.js";
+import { formatErrors, typeCheck } from "@/typeChecker/index.js";
+import {
+  buildCompiledClosure,
+  CompileClosureError,
+  type CompiledClosure,
+} from "@/compiler/compileClosure.js";
+import { transformSync } from "esbuild";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  getStdlibDir,
+  isNonTemplatedStdlib,
+  isPkgImport,
+  isStdlibImport,
+  resolveAgencyImportPath,
+} from "@/importPaths.js";
+import { CompileStrategy, type ImportStrategy } from "@/importStrategy.js";
+import { parseAgencyFileCached } from "@/parseCache.js";
+import { findRecursively, getImports } from "@/cli/util.js";
+
+export type CompileOptions = {
+  ts?: boolean;
+  symbolTable?: SymbolTable;
+  importStrategy?: ImportStrategy;
+  /** Suppress the per-file `input → output (in Nms)` progress line. */
+  quiet?: boolean;
+  /** Test-harness only. Honors `import test { … }`. Never set outside the
+   *  test runner / analysis paths — kept off AgencyConfig so agent source
+   *  cannot enable it. */
+  allowTestImports?: boolean;
+};
+
+/**
+ * A set of entry files sharing one effective config. The canonical config
+ * key is NOT part of this type: it is the session's own integrity
+ * mechanism (the cross-config assert compares it, and PR 2 makes it a
+ * manifest field), so the session derives it — a caller-supplied key that
+ * canonicalized differently would silently weaken the assert.
+ */
+export type CompileGroup = {
+  /** Base-config marker or the local-`agency.json` dir, for error messages. */
+  label: string;
+  config: AgencyConfig;
+  /** Absolute `.agency` entry paths. */
+  files: string[];
+};
+
+export type BuildSession = {
+  /** Compile a file or directory entry: recursive imports, per-session
+   *  dedupe. Returns the output path (null for directories). */
+  compile(
+    config: AgencyConfig,
+    inputFile: string,
+    outputFile?: string,
+    options?: CompileOptions,
+  ): string | null;
+  /** Compile a set of entry files under ONE union closure, like the
+   *  directory branch of `compile()`. Closure errors THROW
+   *  (`CompileClosureError`) so programmatic callers can attach context;
+   *  parse/typecheck failures inside per-file compiles keep their exit
+   *  behavior. */
+  compileMany(
+    config: AgencyConfig,
+    files: string[],
+    options?: { quiet?: boolean; allowTestImports?: boolean },
+  ): void;
+  /** Compile config-heterogeneous groups (one union closure each), after
+   *  asserting no module is reachable from groups whose configs differ —
+   *  compiled output is config-dependent and a sibling `.js` is a single
+   *  slot per module, so a shared module would be last-writer-wins.
+   *  Throws `CompileClosureError` naming the module and group labels. */
+  compileGroups(
+    groups: CompileGroup[],
+    options?: { quiet?: boolean; allowTestImports?: boolean },
+  ): void;
+  /** Drop all cached state (watch-mode rebuild boundary). */
+  reset(): void;
+};
+
+type SessionState = {
+  compiledFiles: Set<string>;
+  // Cached `CompiledClosure` for this session. Built once at the outermost
+  // compile call and reused by every per-file emit.
+  currentClosure: CompiledClosure | null;
+};
+
+// `compiledFiles` entries are only meaningful under the current closure,
+// so replacing the closure MUST clear the set. Previously that pairing was
+// enforced by hand at three separate call sites; this makes it structural
+// (and protects the additional writers PR 2 introduces).
+function setClosure(state: SessionState, closure: CompiledClosure | null): void {
+  state.currentClosure = closure;
+  state.compiledFiles.clear();
+}
+
+export function createBuildSession(): BuildSession {
+  const state: SessionState = {
+    compiledFiles: new Set(),
+    currentClosure: null,
+  };
+  return {
+    compile: (config, inputFile, outputFile, options) =>
+      compileEntry(state, config, inputFile, outputFile, options),
+    compileMany: (config, files, options) =>
+      compileManyImpl(state, config, files, options),
+    compileGroups: (groups, options) =>
+      compileGroupsImpl(state, groups, options),
+    reset: () => setClosure(state, null),
+  };
+}
+
+// Canonical config identity. JSON.stringify is order-stable here because
+// every config passes through AgencyConfigSchema.safeParse (loadConfigSafe
+// returns result.data), and zod rebuilds objects in SCHEMA shape order —
+// guarded by the key-order test in lib/cli/precompile.test.ts.
+function deriveConfigKey(config: AgencyConfig): string {
+  return JSON.stringify(config);
+}
+
+export function findCrossConfigConflicts(
+  groups: { label: string; configKey: string; modules: string[] }[],
+): { module: string; labels: string[] }[] {
+  // Null-prototype: keyed by absolute module paths.
+  const touchedBy: Record<string, { configKey: string; label: string }[]> =
+    Object.create(null);
+  for (const group of groups) {
+    for (const module of group.modules) {
+      (touchedBy[module] ??= []).push({
+        configKey: group.configKey,
+        label: group.label,
+      });
+    }
+  }
+  const conflicts: { module: string; labels: string[] }[] = [];
+  for (const [module, touches] of Object.entries(touchedBy)) {
+    const distinctKeys = touches
+      .map((t) => t.configKey)
+      .filter((key, i, all) => all.indexOf(key) === i);
+    if (distinctKeys.length > 1) {
+      conflicts.push({ module, labels: touches.map((t) => t.label) });
+    }
+  }
+  return conflicts;
+}
+
+function compileGroupsImpl(
+  state: SessionState,
+  groups: CompileGroup[],
+  options?: { quiet?: boolean; allowTestImports?: boolean },
+): void {
+  const withClosures = groups.map((group) => ({
+    group,
+    configKey: deriveConfigKey(group.config),
+    closure: buildCompiledClosure(group.files, group.config),
+  }));
+
+  const conflicts = findCrossConfigConflicts(
+    withClosures.map(({ group, configKey, closure }) => ({
+      label: group.label,
+      configKey,
+      modules: Object.keys(closure.programs),
+    })),
+  );
+  if (conflicts.length > 0) {
+    const lines = conflicts.map(
+      (c) =>
+        `  ${c.module}\n    reachable from: ${c.labels.join(", ")}`,
+    );
+    throw new CompileClosureError(
+      "Test sources with differing configs share modules. A module's " +
+        "compiled .js is a single slot, so this would be last-writer-wins. " +
+        "Move the shared module or align the configs:\n" +
+        lines.join("\n"),
+    );
+  }
+
+  for (const { group, closure } of withClosures) {
+    compileManyImpl(state, group.config, group.files, {
+      closure,
+      quiet: options?.quiet,
+      allowTestImports: options?.allowTestImports,
+    });
+  }
+}
+
+export function readFile(inputFile: string): string {
+  if (!fs.existsSync(inputFile)) {
+    console.error(`Error: Input file '${inputFile}' not found`);
+    process.exit(1);
+  }
+
+  return fs.readFileSync(inputFile, "utf-8");
+}
+
+/**
+ * Internal signature keeps the prebuilt-closure handoff (`options.closure`)
+ * used by compileGroups; the public `BuildSession.compileMany` type omits
+ * it — the closure MUST cover every file, a cache-coherence contract no
+ * external caller should have to carry.
+ */
+function compileManyImpl(
+  state: SessionState,
+  config: AgencyConfig,
+  files: string[],
+  options?: {
+    closure?: CompiledClosure;
+    quiet?: boolean;
+    allowTestImports?: boolean;
+  },
+): void {
+  const absFiles = files.map((f) => path.resolve(f));
+  if (absFiles.length === 0) return;
+  setClosure(state, options?.closure ?? buildCompiledClosure(absFiles, config));
+  for (const file of absFiles) {
+    compileEntry(state, config, file, undefined, {
+      quiet: options?.quiet,
+      allowTestImports: options?.allowTestImports,
+    });
+  }
+}
+
+/**
+ * Build the import-closure analysis once per compile session — at the
+ * outermost call, before any recursive per-file compile runs. The
+ * recursive children reuse the cached closure to get per-module init
+ * plans without re-parsing.
+ *
+ * "Outermost call" = no `options.symbolTable` (passed by recursive
+ * children). When the outermost call's entry file changes (e.g. the
+ * `agency test` runner iterates several .test.json fixtures in one
+ * process), the cached closure no longer covers the new entry's
+ * imports so we rebuild and drop the stale `compiledFiles` set.
+ * Without that drop, downstream codegen would look up plans for
+ * modules that aren't in the closure and emit an empty init plan.
+ *
+ * Stdlib files compile under their own entry (e.g., when a user runs
+ * `agency compile std/...`) but most user code reaches them via
+ * `import "std::..."`, which the closure walker intentionally skips.
+ * Avoid building a closure rooted at a stdlib file — its imports are
+ * structured differently and we don't need the analysis there.
+ */
+function ensureCompiledClosure(
+  state: SessionState,
+  absoluteInputFile: string,
+  config: AgencyConfig,
+  hasSymbolTable: boolean,
+  verbose: boolean,
+): void {
+  const isOutermostCall = !hasSymbolTable;
+  const isStdlibEntry = absoluteInputFile.startsWith(getStdlibDir() + path.sep);
+  const closureCoversEntry =
+    state.currentClosure?.programs[absoluteInputFile] !== undefined;
+  if (!isOutermostCall || isStdlibEntry || closureCoversEntry) return;
+
+  setClosure(state, null);
+  try {
+    const ccStartTime = performance.now();
+    setClosure(state, buildCompiledClosure(absoluteInputFile, config));
+    const ccEndTime = performance.now();
+    logTime({ label: "Built compile closure", start: ccStartTime, end: ccEndTime, verbose });
+  } catch (e) {
+    if (e instanceof CompileClosureError) {
+      console.error(e.message);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+function runTypecheck(
+  liftedProgram: AgencyProgram,
+  config: AgencyConfig,
+  info: CompilationUnit,
+  absoluteInputFile: string,
+  verbose: boolean,
+): void {
+  const tc = config.typechecker;
+  if (!tc?.enabled && !tc?.strict) return;
+  const tcStartTime = performance.now();
+  const { errors } = typeCheck(liftedProgram, config, info);
+  const tcEndTime = performance.now();
+  logTime({ label: `Type checked ${absoluteInputFile}`, start: tcStartTime, end: tcEndTime, verbose });
+  if (errors.length === 0) return;
+  if (tc?.strict) {
+    console.error(formatErrors(errors));
+    const hasFatal = errors.some((e) => (e.severity ?? "error") === "error");
+    if (hasFatal) process.exit(1);
+  } else {
+    console.warn(formatErrors(errors, "warning"));
+  }
+}
+
+// Cached-parse counterpart of `parse()`: same exit-on-failure contract the
+// CLI pipeline expects, but reads through the process-wide parse cache.
+function parseFileOrExit(
+  absPath: string,
+  config: AgencyConfig,
+  applyTemplate: boolean,
+  contents: string,
+): AgencyProgram {
+  const parseResult = parseAgencyFileCached(absPath, config, applyTemplate);
+  if (!parseResult.success) {
+    if (parseResult.message) {
+      console.error(`Failed to parse Agency program: ${parseResult.message}`);
+    } else {
+      console.error("Failed to parse Agency program.", contents.slice(0, 400));
+    }
+    process.exit(1);
+  }
+  return parseResult.result;
+}
+
+// A directory is many entry points — every .agency file under it. To
+// avoid recompiling shared dependencies once per entry, build ONE
+// import closure covering all of them up front and reuse it for every
+// file. Without this, each sibling entry the previous closure didn't
+// cover would clear the per-session cache (see ensureCompiledClosure)
+// and recompile shared deps once per entry. Skipped for:
+//   - recursive child calls (a symbolTable was threaded in) — those
+//     aren't real top-level directory compiles; and
+//   - stdlib dirs, which intentionally compile without a closure (the
+//     same carve-out ensureCompiledClosure makes for stdlib entries).
+function compileDirectory(
+  state: SessionState,
+  config: AgencyConfig,
+  inputFile: string,
+  options?: CompileOptions,
+): null {
+  const files = [...findRecursively(inputFile)].map((f) => f.path);
+  const absDir = path.resolve(inputFile);
+  const isStdlibDir =
+    absDir === getStdlibDir() || absDir.startsWith(getStdlibDir() + path.sep);
+  if (!options?.symbolTable && !isStdlibDir && files.length > 0) {
+    try {
+      // The fresh union closure supersedes anything cached for a prior
+      // entry (setClosure drops the per-file set so codegen reruns under
+      // the new closure).
+      setClosure(
+        state,
+        buildCompiledClosure(
+          files.map((f) => path.resolve(f)),
+          config,
+        ),
+      );
+    } catch (e) {
+      if (e instanceof CompileClosureError) {
+        console.error(e.message);
+        process.exit(1);
+      }
+      throw e;
+    }
+  }
+  for (const file of files) {
+    compileEntry(state, config, file, undefined, options);
+  }
+  return null;
+}
+
+function compileEntry(
+  state: SessionState,
+  config: AgencyConfig,
+  inputFile: string,
+  _outputFile?: string,
+  options?: CompileOptions,
+): string | null {
+  if (!fs.existsSync(inputFile)) {
+    console.error(`Error: Input file '${inputFile}' not found`);
+    process.exit(1);
+  }
+  const stats = fs.statSync(inputFile);
+  const verbose = config.verbose ?? false;
+  if (stats.isDirectory()) {
+    return compileDirectory(state, config, inputFile, options);
+  }
+
+  const compileStartTime = performance.now();
+  const absoluteInputFile = path.resolve(inputFile);
+
+  ensureCompiledClosure(state, absoluteInputFile, config, !!options?.symbolTable, verbose);
+
+  const ext = options?.ts ? ".ts" : ".js";
+  // Anchor the replacement to the extension so that an absolute path
+  // containing ".agency" as a substring in a parent directory (e.g.
+  // "/Users/me/dev/worksy.agency-init/src/agent.agency") does not get
+  // the first match clobbered. See issue #48.
+  let outputFile = _outputFile || inputFile.replace(/\.agency$/, ext);
+  if (config.outDir && !_outputFile) {
+    const outputDir = path.resolve(config.outDir);
+
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    outputFile = path.join(outputDir, outputFile);
+  }
+  if (state.compiledFiles.has(absoluteInputFile)) {
+    return outputFile;
+  }
+
+  state.compiledFiles.add(absoluteInputFile);
+
+  const contents = readFile(inputFile);
+  const applyTemplate = !isNonTemplatedStdlib(absoluteInputFile);
+  const parsedProgram = parseFileOrExit(absoluteInputFile, config, applyTemplate, contents);
+
+  const symbolTableStartTime = performance.now();
+  const symbolTable =
+    options?.symbolTable ?? SymbolTable.build(absoluteInputFile, config);
+
+  const symbolTableEndTime = performance.now();
+  logTime({ label: `Built symbol table for ${absoluteInputFile}`, start: symbolTableStartTime, end: symbolTableEndTime, verbose });
+
+  const compilationUnitStartTime = performance.now();
+  const reExportedProgram = resolveReExports(
+    parsedProgram,
+    symbolTable,
+    absoluteInputFile,
+  );
+  const resolvedProgram = resolveImports(reExportedProgram, symbolTable, absoluteInputFile, {
+    allowTestImports: options?.allowTestImports ?? false,
+  });
+  // Lift `callback("onX") { ... }` block bodies to top-level defs.
+  // Must run BEFORE buildCompilationUnit and typecheck so the lifted defs
+  // appear in functionDefinitions and get their bodies typechecked.
+  const liftedProgram = liftCallbackBlocks(resolvedProgram);
+  const info = buildCompilationUnit(
+    liftedProgram,
+    symbolTable,
+    absoluteInputFile,
+    contents,
+  );
+  const compilationUnitEndTime = performance.now();
+  logTime({ label: `Built compilation unit for ${absoluteInputFile}`, start: compilationUnitStartTime, end: compilationUnitEndTime, verbose });
+
+  runTypecheck(liftedProgram, config, info, absoluteInputFile, verbose);
+
+  const imports = getImports(resolvedProgram);
+
+  for (const importPath of imports) {
+    if (isStdlibImport(importPath) || isPkgImport(importPath)) continue;
+
+    const absPath = resolveAgencyImportPath(importPath, absoluteInputFile);
+    compileEntry(state, config, absPath, undefined, { ...options, symbolTable });
+  }
+
+  // Rewrite import paths in the AST using the import strategy
+  const strategy =
+    options?.importStrategy ?? new CompileStrategy({ targetExt: ".js" });
+  const nonAgencyImports: string[] = [];
+
+  liftedProgram.nodes.forEach((node) => {
+    if (node.type !== "importStatement") return;
+    if (isStdlibImport(node.modulePath) || isPkgImport(node.modulePath)) return;
+
+    node.modulePath = strategy.rewriteImport(
+      node.modulePath,
+      absoluteInputFile,
+    );
+
+    if (!node.modulePath.endsWith(".agency")) {
+      nonAgencyImports.push(node.modulePath);
+    }
+  });
+
+  try {
+    strategy.prepareDependencies(nonAgencyImports, absoluteInputFile);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  const moduleId = path.relative(process.cwd(), absoluteInputFile);
+  const absoluteOutputFile = path.resolve(outputFile);
+  // Per-module init plan view — derived from the cached closure if we
+  // built one. Modules not in the closure (e.g., out-of-tree stdlib
+  // compiles) fall through to the legacy path with no plan.
+  const initPlan = state.currentClosure
+    ? initPlanForModule(state.currentClosure, absoluteInputFile)
+    : undefined;
+  const codegenStartTime = performance.now();
+  const generatedCode = generateTypeScript(
+    liftedProgram,
+    config,
+    info,
+    moduleId,
+    absoluteOutputFile,
+    initPlan,
+  );
+  const codegenEndTime = performance.now();
+  logTime({ label: `Generated code for ${absoluteInputFile}`, start: codegenStartTime, end: codegenEndTime, verbose });
+  if (options?.ts) {
+    fs.writeFileSync(outputFile, "// @ts-nocheck\n" + generatedCode, "utf-8");
+  } else {
+    const esbuildStartTime = performance.now();
+    const result = transformSync(generatedCode, {
+      loader: "ts",
+      format: "esm",
+      supported: { "top-level-await": true },
+    });
+    fs.writeFileSync(outputFile, result.code, "utf-8");
+    const esbuildEndTime = performance.now();
+    logTime({ label: `Transformed code for ${absoluteInputFile} with esbuild`, start: esbuildStartTime, end: esbuildEndTime, verbose });
+  }
+  const compileEndTime = performance.now();
+  const timeTaken = `${(compileEndTime - compileStartTime).toFixed(2)}ms`
+  if (!options?.quiet) {
+    console.log(`${inputFile} → ${outputFile} (in ${timeTaken})`);
+  }
+  return outputFile;
+}
+
+function logTime({ label, start, end, verbose }: { label: string, start: number, end: number, verbose: boolean }): void {
+  if (verbose) {
+    console.log(`${label} in ${(end - start).toFixed(2)}ms`);
+  }
+}

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -70,7 +70,16 @@ export type CompileGroup = {
   files: string[];
 };
 
-export type BuildSession = {
+export function createBuildSession(): BuildSession {
+  return new BuildSession();
+}
+
+export class BuildSession {
+  private compiledFiles: Set<string> = new Set();
+  // Cached `CompiledClosure` for this session. Built once at the outermost
+  // compile call and reused by every per-file emit.
+  private currentClosure: CompiledClosure | null = null;
+
   /** Compile a file or directory entry: recursive imports, per-session
    *  dedupe. Returns the output path (null for directories). */
   compile(
@@ -78,7 +87,10 @@ export type BuildSession = {
     inputFile: string,
     outputFile?: string,
     options?: CompileOptions,
-  ): string | null;
+  ): string | null {
+    return this.compileEntry(config, inputFile, outputFile, options);
+  }
+
   /** Compile a set of entry files under ONE union closure, like the
    *  directory branch of `compile()`. Closure errors THROW
    *  (`CompileClosureError`) so programmatic callers can attach context;
@@ -88,7 +100,10 @@ export type BuildSession = {
     config: AgencyConfig,
     files: string[],
     options?: { quiet?: boolean; allowTestImports?: boolean },
-  ): void;
+  ): void {
+    this.compileManyImpl(config, files, options);
+  }
+
   /** Compile config-heterogeneous groups (one union closure each), after
    *  asserting no module is reachable from groups whose configs differ —
    *  compiled output is config-dependent and a sibling `.js` is a single
@@ -97,41 +112,333 @@ export type BuildSession = {
   compileGroups(
     groups: CompileGroup[],
     options?: { quiet?: boolean; allowTestImports?: boolean },
-  ): void;
+  ): void {
+    const withClosures = groups.map((group) => ({
+      group,
+      configKey: deriveConfigKey(group.config),
+      closure: buildCompiledClosure(group.files, group.config),
+    }));
+
+    const conflicts = findCrossConfigConflicts(
+      withClosures.map(({ group, configKey, closure }) => ({
+        label: group.label,
+        configKey,
+        modules: Object.keys(closure.programs),
+      })),
+    );
+    if (conflicts.length > 0) {
+      const lines = conflicts.map(
+        (c) =>
+          `  ${c.module}\n    reachable from: ${c.labels.join(", ")}`,
+      );
+      throw new CompileClosureError(
+        "Test sources with differing configs share modules. A module's " +
+          "compiled .js is a single slot, so this would be last-writer-wins. " +
+          "Move the shared module or align the configs:\n" +
+          lines.join("\n"),
+      );
+    }
+
+    for (const { group, closure } of withClosures) {
+      this.compileManyImpl(group.config, group.files, {
+        closure,
+        quiet: options?.quiet,
+        allowTestImports: options?.allowTestImports,
+      });
+    }
+  }
+
   /** Drop all cached state (watch-mode rebuild boundary). */
-  reset(): void;
-};
+  reset(): void {
+    this.setClosure(null);
+  }
 
-type SessionState = {
-  compiledFiles: Set<string>;
-  // Cached `CompiledClosure` for this session. Built once at the outermost
-  // compile call and reused by every per-file emit.
-  currentClosure: CompiledClosure | null;
-};
+  // `compiledFiles` entries are only meaningful under the current closure,
+  // so replacing the closure MUST clear the set. Previously that pairing
+  // was enforced by hand at three separate call sites; this makes it
+  // structural (and protects the additional writers PR 2 introduces).
+  private setClosure(closure: CompiledClosure | null): void {
+    this.currentClosure = closure;
+    this.compiledFiles.clear();
+  }
 
-// `compiledFiles` entries are only meaningful under the current closure,
-// so replacing the closure MUST clear the set. Previously that pairing was
-// enforced by hand at three separate call sites; this makes it structural
-// (and protects the additional writers PR 2 introduces).
-function setClosure(state: SessionState, closure: CompiledClosure | null): void {
-  state.currentClosure = closure;
-  state.compiledFiles.clear();
+  /**
+   * Internal variant of compileMany keeping the prebuilt-closure handoff
+   * (`options.closure`) used by compileGroups; the public method omits it —
+   * the closure MUST cover every file, a cache-coherence contract no
+   * external caller should have to carry.
+   */
+  private compileManyImpl(
+    config: AgencyConfig,
+    files: string[],
+    options?: {
+      closure?: CompiledClosure;
+      quiet?: boolean;
+      allowTestImports?: boolean;
+    },
+  ): void {
+    const absFiles = files.map((f) => path.resolve(f));
+    if (absFiles.length === 0) return;
+    this.setClosure(options?.closure ?? buildCompiledClosure(absFiles, config));
+    for (const file of absFiles) {
+      this.compileEntry(config, file, undefined, {
+        quiet: options?.quiet,
+        allowTestImports: options?.allowTestImports,
+      });
+    }
+  }
+
+  /**
+   * Build the import-closure analysis once per compile session — at the
+   * outermost call, before any recursive per-file compile runs. The
+   * recursive children reuse the cached closure to get per-module init
+   * plans without re-parsing.
+   *
+   * "Outermost call" = no `options.symbolTable` (passed by recursive
+   * children). When the outermost call's entry file changes (e.g. the
+   * `agency test` runner iterates several .test.json fixtures in one
+   * process), the cached closure no longer covers the new entry's
+   * imports so we rebuild and drop the stale `compiledFiles` set.
+   * Without that drop, downstream codegen would look up plans for
+   * modules that aren't in the closure and emit an empty init plan.
+   *
+   * Stdlib files compile under their own entry (e.g., when a user runs
+   * `agency compile std/...`) but most user code reaches them via
+   * `import "std::..."`, which the closure walker intentionally skips.
+   * Avoid building a closure rooted at a stdlib file — its imports are
+   * structured differently and we don't need the analysis there.
+   */
+  private ensureCompiledClosure(
+    absoluteInputFile: string,
+    config: AgencyConfig,
+    hasSymbolTable: boolean,
+    verbose: boolean,
+  ): void {
+    const isOutermostCall = !hasSymbolTable;
+    const isStdlibEntry = absoluteInputFile.startsWith(getStdlibDir() + path.sep);
+    const closureCoversEntry =
+      this.currentClosure?.programs[absoluteInputFile] !== undefined;
+    if (!isOutermostCall || isStdlibEntry || closureCoversEntry) return;
+
+    this.setClosure(null);
+    try {
+      const ccStartTime = performance.now();
+      this.setClosure(buildCompiledClosure(absoluteInputFile, config));
+      const ccEndTime = performance.now();
+      logTime({ label: "Built compile closure", start: ccStartTime, end: ccEndTime, verbose });
+    } catch (e) {
+      if (e instanceof CompileClosureError) {
+        console.error(e.message);
+        process.exit(1);
+      }
+      throw e;
+    }
+  }
+
+  // A directory is many entry points — every .agency file under it. To
+  // avoid recompiling shared dependencies once per entry, build ONE
+  // import closure covering all of them up front and reuse it for every
+  // file. Without this, each sibling entry the previous closure didn't
+  // cover would clear the per-session cache (see ensureCompiledClosure)
+  // and recompile shared deps once per entry. Skipped for:
+  //   - recursive child calls (a symbolTable was threaded in) — those
+  //     aren't real top-level directory compiles; and
+  //   - stdlib dirs, which intentionally compile without a closure (the
+  //     same carve-out ensureCompiledClosure makes for stdlib entries).
+  private compileDirectory(
+    config: AgencyConfig,
+    inputFile: string,
+    options?: CompileOptions,
+  ): null {
+    const files = [...findRecursively(inputFile)].map((f) => f.path);
+    const absDir = path.resolve(inputFile);
+    const isStdlibDir =
+      absDir === getStdlibDir() || absDir.startsWith(getStdlibDir() + path.sep);
+    if (!options?.symbolTable && !isStdlibDir && files.length > 0) {
+      try {
+        // The fresh union closure supersedes anything cached for a prior
+        // entry (setClosure drops the per-file set so codegen reruns under
+        // the new closure).
+        this.setClosure(
+          buildCompiledClosure(
+            files.map((f) => path.resolve(f)),
+            config,
+          ),
+        );
+      } catch (e) {
+        if (e instanceof CompileClosureError) {
+          console.error(e.message);
+          process.exit(1);
+        }
+        throw e;
+      }
+    }
+    for (const file of files) {
+      this.compileEntry(config, file, undefined, options);
+    }
+    return null;
+  }
+
+  private compileEntry(
+    config: AgencyConfig,
+    inputFile: string,
+    _outputFile?: string,
+    options?: CompileOptions,
+  ): string | null {
+    if (!fs.existsSync(inputFile)) {
+      console.error(`Error: Input file '${inputFile}' not found`);
+      process.exit(1);
+    }
+    const stats = fs.statSync(inputFile);
+    const verbose = config.verbose ?? false;
+    if (stats.isDirectory()) {
+      return this.compileDirectory(config, inputFile, options);
+    }
+
+    const compileStartTime = performance.now();
+    const absoluteInputFile = path.resolve(inputFile);
+
+    this.ensureCompiledClosure(absoluteInputFile, config, !!options?.symbolTable, verbose);
+
+    const ext = options?.ts ? ".ts" : ".js";
+    // Anchor the replacement to the extension so that an absolute path
+    // containing ".agency" as a substring in a parent directory (e.g.
+    // "/Users/me/dev/worksy.agency-init/src/agent.agency") does not get
+    // the first match clobbered. See issue #48.
+    let outputFile = _outputFile || inputFile.replace(/\.agency$/, ext);
+    if (config.outDir && !_outputFile) {
+      const outputDir = path.resolve(config.outDir);
+
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+
+      outputFile = path.join(outputDir, outputFile);
+    }
+    if (this.compiledFiles.has(absoluteInputFile)) {
+      return outputFile;
+    }
+
+    this.compiledFiles.add(absoluteInputFile);
+
+    const contents = readFile(inputFile);
+    const applyTemplate = !isNonTemplatedStdlib(absoluteInputFile);
+    const parsedProgram = parseFileOrExit(absoluteInputFile, config, applyTemplate, contents);
+
+    const symbolTableStartTime = performance.now();
+    const symbolTable =
+      options?.symbolTable ?? SymbolTable.build(absoluteInputFile, config);
+
+    const symbolTableEndTime = performance.now();
+    logTime({ label: `Built symbol table for ${absoluteInputFile}`, start: symbolTableStartTime, end: symbolTableEndTime, verbose });
+
+    const compilationUnitStartTime = performance.now();
+    const reExportedProgram = resolveReExports(
+      parsedProgram,
+      symbolTable,
+      absoluteInputFile,
+    );
+    const resolvedProgram = resolveImports(reExportedProgram, symbolTable, absoluteInputFile, {
+      allowTestImports: options?.allowTestImports ?? false,
+    });
+    // Lift `callback("onX") { ... }` block bodies to top-level defs.
+    // Must run BEFORE buildCompilationUnit and typecheck so the lifted defs
+    // appear in functionDefinitions and get their bodies typechecked.
+    const liftedProgram = liftCallbackBlocks(resolvedProgram);
+    const info = buildCompilationUnit(
+      liftedProgram,
+      symbolTable,
+      absoluteInputFile,
+      contents,
+    );
+    const compilationUnitEndTime = performance.now();
+    logTime({ label: `Built compilation unit for ${absoluteInputFile}`, start: compilationUnitStartTime, end: compilationUnitEndTime, verbose });
+
+    runTypecheck(liftedProgram, config, info, absoluteInputFile, verbose);
+
+    const imports = getImports(resolvedProgram);
+
+    for (const importPath of imports) {
+      if (isStdlibImport(importPath) || isPkgImport(importPath)) continue;
+
+      const absPath = resolveAgencyImportPath(importPath, absoluteInputFile);
+      this.compileEntry(config, absPath, undefined, { ...options, symbolTable });
+    }
+
+    // Rewrite import paths in the AST using the import strategy
+    const strategy =
+      options?.importStrategy ?? new CompileStrategy({ targetExt: ".js" });
+    const nonAgencyImports: string[] = [];
+
+    liftedProgram.nodes.forEach((node) => {
+      if (node.type !== "importStatement") return;
+      if (isStdlibImport(node.modulePath) || isPkgImport(node.modulePath)) return;
+
+      node.modulePath = strategy.rewriteImport(
+        node.modulePath,
+        absoluteInputFile,
+      );
+
+      if (!node.modulePath.endsWith(".agency")) {
+        nonAgencyImports.push(node.modulePath);
+      }
+    });
+
+    try {
+      strategy.prepareDependencies(nonAgencyImports, absoluteInputFile);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+
+    const moduleId = path.relative(process.cwd(), absoluteInputFile);
+    const absoluteOutputFile = path.resolve(outputFile);
+    // Per-module init plan view — derived from the cached closure if we
+    // built one. Modules not in the closure (e.g., out-of-tree stdlib
+    // compiles) fall through to the legacy path with no plan.
+    const initPlan = this.currentClosure
+      ? initPlanForModule(this.currentClosure, absoluteInputFile)
+      : undefined;
+    const codegenStartTime = performance.now();
+    const generatedCode = generateTypeScript(
+      liftedProgram,
+      config,
+      info,
+      moduleId,
+      absoluteOutputFile,
+      initPlan,
+    );
+    const codegenEndTime = performance.now();
+    logTime({ label: `Generated code for ${absoluteInputFile}`, start: codegenStartTime, end: codegenEndTime, verbose });
+    if (options?.ts) {
+      fs.writeFileSync(outputFile, "// @ts-nocheck\n" + generatedCode, "utf-8");
+    } else {
+      const esbuildStartTime = performance.now();
+      const result = transformSync(generatedCode, {
+        loader: "ts",
+        format: "esm",
+        supported: { "top-level-await": true },
+      });
+      fs.writeFileSync(outputFile, result.code, "utf-8");
+      const esbuildEndTime = performance.now();
+      logTime({ label: `Transformed code for ${absoluteInputFile} with esbuild`, start: esbuildStartTime, end: esbuildEndTime, verbose });
+    }
+    const compileEndTime = performance.now();
+    const timeTaken = `${(compileEndTime - compileStartTime).toFixed(2)}ms`
+    if (!options?.quiet) {
+      console.log(`${inputFile} → ${outputFile} (in ${timeTaken})`);
+    }
+    return outputFile;
+  }
 }
 
-export function createBuildSession(): BuildSession {
-  const state: SessionState = {
-    compiledFiles: new Set(),
-    currentClosure: null,
-  };
-  return {
-    compile: (config, inputFile, outputFile, options) =>
-      compileEntry(state, config, inputFile, outputFile, options),
-    compileMany: (config, files, options) =>
-      compileManyImpl(state, config, files, options),
-    compileGroups: (groups, options) =>
-      compileGroupsImpl(state, groups, options),
-    reset: () => setClosure(state, null),
-  };
+export function readFile(inputFile: string): string {
+  if (!fs.existsSync(inputFile)) {
+    console.error(`Error: Input file '${inputFile}' not found`);
+    process.exit(1);
+  }
+
+  return fs.readFileSync(inputFile, "utf-8");
 }
 
 // Canonical config identity. JSON.stringify is order-stable here because
@@ -168,128 +475,24 @@ export function findCrossConfigConflicts(
   return conflicts;
 }
 
-function compileGroupsImpl(
-  state: SessionState,
-  groups: CompileGroup[],
-  options?: { quiet?: boolean; allowTestImports?: boolean },
-): void {
-  const withClosures = groups.map((group) => ({
-    group,
-    configKey: deriveConfigKey(group.config),
-    closure: buildCompiledClosure(group.files, group.config),
-  }));
-
-  const conflicts = findCrossConfigConflicts(
-    withClosures.map(({ group, configKey, closure }) => ({
-      label: group.label,
-      configKey,
-      modules: Object.keys(closure.programs),
-    })),
-  );
-  if (conflicts.length > 0) {
-    const lines = conflicts.map(
-      (c) =>
-        `  ${c.module}\n    reachable from: ${c.labels.join(", ")}`,
-    );
-    throw new CompileClosureError(
-      "Test sources with differing configs share modules. A module's " +
-        "compiled .js is a single slot, so this would be last-writer-wins. " +
-        "Move the shared module or align the configs:\n" +
-        lines.join("\n"),
-    );
-  }
-
-  for (const { group, closure } of withClosures) {
-    compileManyImpl(state, group.config, group.files, {
-      closure,
-      quiet: options?.quiet,
-      allowTestImports: options?.allowTestImports,
-    });
-  }
-}
-
-export function readFile(inputFile: string): string {
-  if (!fs.existsSync(inputFile)) {
-    console.error(`Error: Input file '${inputFile}' not found`);
+// Cached-parse counterpart of `parse()`: same exit-on-failure contract the
+// CLI pipeline expects, but reads through the process-wide parse cache.
+function parseFileOrExit(
+  absPath: string,
+  config: AgencyConfig,
+  applyTemplate: boolean,
+  contents: string,
+): AgencyProgram {
+  const parseResult = parseAgencyFileCached(absPath, config, applyTemplate);
+  if (!parseResult.success) {
+    if (parseResult.message) {
+      console.error(`Failed to parse Agency program: ${parseResult.message}`);
+    } else {
+      console.error("Failed to parse Agency program.", contents.slice(0, 400));
+    }
     process.exit(1);
   }
-
-  return fs.readFileSync(inputFile, "utf-8");
-}
-
-/**
- * Internal signature keeps the prebuilt-closure handoff (`options.closure`)
- * used by compileGroups; the public `BuildSession.compileMany` type omits
- * it — the closure MUST cover every file, a cache-coherence contract no
- * external caller should have to carry.
- */
-function compileManyImpl(
-  state: SessionState,
-  config: AgencyConfig,
-  files: string[],
-  options?: {
-    closure?: CompiledClosure;
-    quiet?: boolean;
-    allowTestImports?: boolean;
-  },
-): void {
-  const absFiles = files.map((f) => path.resolve(f));
-  if (absFiles.length === 0) return;
-  setClosure(state, options?.closure ?? buildCompiledClosure(absFiles, config));
-  for (const file of absFiles) {
-    compileEntry(state, config, file, undefined, {
-      quiet: options?.quiet,
-      allowTestImports: options?.allowTestImports,
-    });
-  }
-}
-
-/**
- * Build the import-closure analysis once per compile session — at the
- * outermost call, before any recursive per-file compile runs. The
- * recursive children reuse the cached closure to get per-module init
- * plans without re-parsing.
- *
- * "Outermost call" = no `options.symbolTable` (passed by recursive
- * children). When the outermost call's entry file changes (e.g. the
- * `agency test` runner iterates several .test.json fixtures in one
- * process), the cached closure no longer covers the new entry's
- * imports so we rebuild and drop the stale `compiledFiles` set.
- * Without that drop, downstream codegen would look up plans for
- * modules that aren't in the closure and emit an empty init plan.
- *
- * Stdlib files compile under their own entry (e.g., when a user runs
- * `agency compile std/...`) but most user code reaches them via
- * `import "std::..."`, which the closure walker intentionally skips.
- * Avoid building a closure rooted at a stdlib file — its imports are
- * structured differently and we don't need the analysis there.
- */
-function ensureCompiledClosure(
-  state: SessionState,
-  absoluteInputFile: string,
-  config: AgencyConfig,
-  hasSymbolTable: boolean,
-  verbose: boolean,
-): void {
-  const isOutermostCall = !hasSymbolTable;
-  const isStdlibEntry = absoluteInputFile.startsWith(getStdlibDir() + path.sep);
-  const closureCoversEntry =
-    state.currentClosure?.programs[absoluteInputFile] !== undefined;
-  if (!isOutermostCall || isStdlibEntry || closureCoversEntry) return;
-
-  setClosure(state, null);
-  try {
-    const ccStartTime = performance.now();
-    setClosure(state, buildCompiledClosure(absoluteInputFile, config));
-    const ccEndTime = performance.now();
-    logTime({ label: "Built compile closure", start: ccStartTime, end: ccEndTime, verbose });
-  } catch (e) {
-    if (e instanceof CompileClosureError) {
-      console.error(e.message);
-      process.exit(1);
-    }
-    throw e;
-  }
+  return parseResult.result;
 }
 
 function runTypecheck(
@@ -313,225 +516,6 @@ function runTypecheck(
   } else {
     console.warn(formatErrors(errors, "warning"));
   }
-}
-
-// Cached-parse counterpart of `parse()`: same exit-on-failure contract the
-// CLI pipeline expects, but reads through the process-wide parse cache.
-function parseFileOrExit(
-  absPath: string,
-  config: AgencyConfig,
-  applyTemplate: boolean,
-  contents: string,
-): AgencyProgram {
-  const parseResult = parseAgencyFileCached(absPath, config, applyTemplate);
-  if (!parseResult.success) {
-    if (parseResult.message) {
-      console.error(`Failed to parse Agency program: ${parseResult.message}`);
-    } else {
-      console.error("Failed to parse Agency program.", contents.slice(0, 400));
-    }
-    process.exit(1);
-  }
-  return parseResult.result;
-}
-
-// A directory is many entry points — every .agency file under it. To
-// avoid recompiling shared dependencies once per entry, build ONE
-// import closure covering all of them up front and reuse it for every
-// file. Without this, each sibling entry the previous closure didn't
-// cover would clear the per-session cache (see ensureCompiledClosure)
-// and recompile shared deps once per entry. Skipped for:
-//   - recursive child calls (a symbolTable was threaded in) — those
-//     aren't real top-level directory compiles; and
-//   - stdlib dirs, which intentionally compile without a closure (the
-//     same carve-out ensureCompiledClosure makes for stdlib entries).
-function compileDirectory(
-  state: SessionState,
-  config: AgencyConfig,
-  inputFile: string,
-  options?: CompileOptions,
-): null {
-  const files = [...findRecursively(inputFile)].map((f) => f.path);
-  const absDir = path.resolve(inputFile);
-  const isStdlibDir =
-    absDir === getStdlibDir() || absDir.startsWith(getStdlibDir() + path.sep);
-  if (!options?.symbolTable && !isStdlibDir && files.length > 0) {
-    try {
-      // The fresh union closure supersedes anything cached for a prior
-      // entry (setClosure drops the per-file set so codegen reruns under
-      // the new closure).
-      setClosure(
-        state,
-        buildCompiledClosure(
-          files.map((f) => path.resolve(f)),
-          config,
-        ),
-      );
-    } catch (e) {
-      if (e instanceof CompileClosureError) {
-        console.error(e.message);
-        process.exit(1);
-      }
-      throw e;
-    }
-  }
-  for (const file of files) {
-    compileEntry(state, config, file, undefined, options);
-  }
-  return null;
-}
-
-function compileEntry(
-  state: SessionState,
-  config: AgencyConfig,
-  inputFile: string,
-  _outputFile?: string,
-  options?: CompileOptions,
-): string | null {
-  if (!fs.existsSync(inputFile)) {
-    console.error(`Error: Input file '${inputFile}' not found`);
-    process.exit(1);
-  }
-  const stats = fs.statSync(inputFile);
-  const verbose = config.verbose ?? false;
-  if (stats.isDirectory()) {
-    return compileDirectory(state, config, inputFile, options);
-  }
-
-  const compileStartTime = performance.now();
-  const absoluteInputFile = path.resolve(inputFile);
-
-  ensureCompiledClosure(state, absoluteInputFile, config, !!options?.symbolTable, verbose);
-
-  const ext = options?.ts ? ".ts" : ".js";
-  // Anchor the replacement to the extension so that an absolute path
-  // containing ".agency" as a substring in a parent directory (e.g.
-  // "/Users/me/dev/worksy.agency-init/src/agent.agency") does not get
-  // the first match clobbered. See issue #48.
-  let outputFile = _outputFile || inputFile.replace(/\.agency$/, ext);
-  if (config.outDir && !_outputFile) {
-    const outputDir = path.resolve(config.outDir);
-
-    if (!fs.existsSync(outputDir)) {
-      fs.mkdirSync(outputDir, { recursive: true });
-    }
-
-    outputFile = path.join(outputDir, outputFile);
-  }
-  if (state.compiledFiles.has(absoluteInputFile)) {
-    return outputFile;
-  }
-
-  state.compiledFiles.add(absoluteInputFile);
-
-  const contents = readFile(inputFile);
-  const applyTemplate = !isNonTemplatedStdlib(absoluteInputFile);
-  const parsedProgram = parseFileOrExit(absoluteInputFile, config, applyTemplate, contents);
-
-  const symbolTableStartTime = performance.now();
-  const symbolTable =
-    options?.symbolTable ?? SymbolTable.build(absoluteInputFile, config);
-
-  const symbolTableEndTime = performance.now();
-  logTime({ label: `Built symbol table for ${absoluteInputFile}`, start: symbolTableStartTime, end: symbolTableEndTime, verbose });
-
-  const compilationUnitStartTime = performance.now();
-  const reExportedProgram = resolveReExports(
-    parsedProgram,
-    symbolTable,
-    absoluteInputFile,
-  );
-  const resolvedProgram = resolveImports(reExportedProgram, symbolTable, absoluteInputFile, {
-    allowTestImports: options?.allowTestImports ?? false,
-  });
-  // Lift `callback("onX") { ... }` block bodies to top-level defs.
-  // Must run BEFORE buildCompilationUnit and typecheck so the lifted defs
-  // appear in functionDefinitions and get their bodies typechecked.
-  const liftedProgram = liftCallbackBlocks(resolvedProgram);
-  const info = buildCompilationUnit(
-    liftedProgram,
-    symbolTable,
-    absoluteInputFile,
-    contents,
-  );
-  const compilationUnitEndTime = performance.now();
-  logTime({ label: `Built compilation unit for ${absoluteInputFile}`, start: compilationUnitStartTime, end: compilationUnitEndTime, verbose });
-
-  runTypecheck(liftedProgram, config, info, absoluteInputFile, verbose);
-
-  const imports = getImports(resolvedProgram);
-
-  for (const importPath of imports) {
-    if (isStdlibImport(importPath) || isPkgImport(importPath)) continue;
-
-    const absPath = resolveAgencyImportPath(importPath, absoluteInputFile);
-    compileEntry(state, config, absPath, undefined, { ...options, symbolTable });
-  }
-
-  // Rewrite import paths in the AST using the import strategy
-  const strategy =
-    options?.importStrategy ?? new CompileStrategy({ targetExt: ".js" });
-  const nonAgencyImports: string[] = [];
-
-  liftedProgram.nodes.forEach((node) => {
-    if (node.type !== "importStatement") return;
-    if (isStdlibImport(node.modulePath) || isPkgImport(node.modulePath)) return;
-
-    node.modulePath = strategy.rewriteImport(
-      node.modulePath,
-      absoluteInputFile,
-    );
-
-    if (!node.modulePath.endsWith(".agency")) {
-      nonAgencyImports.push(node.modulePath);
-    }
-  });
-
-  try {
-    strategy.prepareDependencies(nonAgencyImports, absoluteInputFile);
-  } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  }
-
-  const moduleId = path.relative(process.cwd(), absoluteInputFile);
-  const absoluteOutputFile = path.resolve(outputFile);
-  // Per-module init plan view — derived from the cached closure if we
-  // built one. Modules not in the closure (e.g., out-of-tree stdlib
-  // compiles) fall through to the legacy path with no plan.
-  const initPlan = state.currentClosure
-    ? initPlanForModule(state.currentClosure, absoluteInputFile)
-    : undefined;
-  const codegenStartTime = performance.now();
-  const generatedCode = generateTypeScript(
-    liftedProgram,
-    config,
-    info,
-    moduleId,
-    absoluteOutputFile,
-    initPlan,
-  );
-  const codegenEndTime = performance.now();
-  logTime({ label: `Generated code for ${absoluteInputFile}`, start: codegenStartTime, end: codegenEndTime, verbose });
-  if (options?.ts) {
-    fs.writeFileSync(outputFile, "// @ts-nocheck\n" + generatedCode, "utf-8");
-  } else {
-    const esbuildStartTime = performance.now();
-    const result = transformSync(generatedCode, {
-      loader: "ts",
-      format: "esm",
-      supported: { "top-level-await": true },
-    });
-    fs.writeFileSync(outputFile, result.code, "utf-8");
-    const esbuildEndTime = performance.now();
-    logTime({ label: `Transformed code for ${absoluteInputFile} with esbuild`, start: esbuildStartTime, end: esbuildEndTime, verbose });
-  }
-  const compileEndTime = performance.now();
-  const timeTaken = `${(compileEndTime - compileStartTime).toFixed(2)}ms`
-  if (!options?.quiet) {
-    console.log(`${inputFile} → ${outputFile} (in ${timeTaken})`);
-  }
-  return outputFile;
 }
 
 function logTime({ label, start, end, verbose }: { label: string, start: number, end: number, verbose: boolean }): void {


### PR DESCRIPTION
## What

Stage A, PR 1 of the incremental-builds work (spec now committed at `docs/superpowers/specs/2026-07-08-incremental-builds-design.md`; plan at `docs/superpowers/plans/2026-07-08-buildsession-consolidation.md`, both review-hardened): a **pure consolidation with byte-identical outputs**. `lib/compiler/buildSession.ts` becomes the single owner of compile-pipeline caching and orchestration:

- The `commands.ts` module globals (`compiledFiles`, `currentClosure`), `ensureCompiledClosure`, the directory union-closure branch, and `compileMany` move into a `BuildSession` object (verbatim move; state threaded via a `SessionState` param).
- The cross-config machinery moves in from `precompile.ts`: `CompileGroup`, the single-slot conflict assert, and — new — `configKey` derivation happens INSIDE the session (an integrity mechanism, not caller input). `precompile.ts` shrinks to a test-runner adapter on a fresh session.
- `commands.ts` keeps thin delegates (`compile`/`compileMany`/`resetCompilationCache`) over one lazy `defaultSession`, so every caller (watch mode, runAgencyNode, coverage, tests) is untouched.
- One allowed shape change: a private `setClosure()` pairs every closure replacement with the dedupe-set clear — previously a convention repeated at three sites, structural before PR 2 adds more writers.

PR 2 adds the content-hash manifest and `freshness` policy on this interface.

## Found during execution

- **Tree-shaking trap:** an eager top-level `createBuildSession()` in `commands.ts` dragged the whole codegen subtree (~16k lines) into every `agency pack` artifact — packed programs import `commands.js` for small helpers, and the call was an unshakeable side effect. Caught by `pack.test.ts`; fixed with lazy initialization. Main was safe only because its module globals were inert literals.
- **Pre-existing, not fixed here:** `tests/debugger/loop-test.ts` (a tracked fixture) is stale against current codegen — `lib/debugger/driver.test.ts`'s beforeAll rewrites it to the newer lazy-iterable loop form on pristine main too. It will show as a dirty file after any full local vitest run. Worth a follow-up: regenerate and commit it, or untrack it.

## Verification

- **Byte-identity vs main:** all 94 compiled stdlib + agent `.js` files hash-identical to a baseline built from untouched main before any change; `make fixtures` diff-clean.
- Full vitest: 7481 passed (includes 24 new buildSession/delegate tests: session isolation, dedupe, reset, union-closure emit-counts, directory entries, throw contract, allowTestImports gating, outDir, cross-config assert, zod key-order tripwire).
- Runtime slices: 74 agency execution test files (incl. the local-config memory dir through `compileGroups`), agency-js debugger dir, full agents suite (48s — exercises the fresh-session precompile delta at scale).
- Watch-mode smoke: initial compile + rebuild-after-edit through the `resetCompilationCache` delegate.
- Declared behavior delta (reviewed): precompile uses a fresh session, so the default session no longer inherits its leftover closure — safe because test cases run `preferCompiled`; the old inherited state was a latent staleness hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
