### PR TITLE
Incremental agency builds: content-hash manifest + freshness policy (Stage A, PR 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ Pipeline and architecture:
 - `docs/dev/validation-annotations.md` — `@validate(...)` and `@jsonSchema(...)` internals: tag merging, `__agency_descriptor` contract, descriptor tree, runtime walker
 - `docs/dev/async-context.md` — `agencyStore` AsyncLocalStorage frame and `getRuntimeContext()` pattern for stdlib TS helpers
 - `docs/dev/local-models.md` — Local-model support: provider, name resolution, catalog refresh, and SHA-256 download verification
+- `docs/dev/incremental-builds.md` — The build manifest: schema, invalidation fields, the ManifestTracker policy object, --force
 
 Other references:
 - `docs/misc/TESTING.md` — Full testing guide (unit tests, fixtures, execution tests, agency-js tests)

--- a/packages/agency-lang/docs/dev/incremental-builds.md
+++ b/packages/agency-lang/docs/dev/incremental-builds.md
@@ -1,0 +1,67 @@
+# Incremental builds
+
+The compiler skips recompiling `.agency` files whose inputs have not
+changed. The record of those inputs is the **build manifest**:
+`.agency-build/manifest.json` at the project root (the nearest directory
+with an `agency.json`; without one, each compiled file's own directory —
+so an agency.json-less multi-directory project grows one `.agency-build/`
+per directory). The manifest is gitignored, wiped by `make clean`, and
+written atomically (temp file + rename), so concurrent compiles get
+last-writer-wins and never a torn file.
+
+## The entry schema
+
+Each compiled module gets one entry. Every field is an input that shapes
+the compiled output; a mismatch on any field forces a recompile, so a bug
+in a field can only cause an unnecessary rebuild, never a stale skip.
+
+| Field | Why it exists |
+|---|---|
+| `sourceHash` | The module's own bytes. Also the soundness anchor: imports are part of the source, so an unchanged `sourceHash` implies the recorded `deps` list is still the module's true deps. |
+| `deps` + `depsHash` | Transitive agency imports (paths + one hash over their contents, built by `computeDepsHash` — the single shared construction). Freshness also requires every recorded dep to have a manifest entry whose OUTPUT exists: a skip never recurses into deps, so a deleted dep `.js` would otherwise ship a broken import. |
+| `stdlibHash` | One hash over all stdlib sources. The closure walker excludes `std::` imports, so `depsHash` cannot see stdlib edits — yet stdlib content genuinely shapes output (`resolveReExports` bakes resolved stdlib paths in). Any stdlib edit rebuilds the world. |
+| `hasPkgImports` | Modules whose import subtree touches `pkg::` are NEVER skipped: package content shapes emitted imports and is invisible to the manifest. Detection shares the closure walker's edge extraction (`programHasPkgImport`), covering plain imports, node imports, and re-exports. |
+| `compilerStamp` | Content hash of the compiled compiler (`dist/lib` excluding `runtime/` — generated text does not depend on runtime internals — and `agents/`, which are the agency compiler's own output; including them would make every build invalidate the next). Content, not mtimes: `tsc-alias` rewrites the whole outDir every build. |
+| `configKey` | Compiled output bakes config in. Canonical because configs pass through zod (schema shape order). |
+| `outputPath` | Where the `.js` landed; a missing output is stale. |
+
+## Freshness modes and the tracker
+
+Policy is interpreted in exactly one place: `createManifestTracker`
+(`lib/compiler/manifestTracker.ts`). Session call sites are unconditional —
+if you find yourself comparing `freshness === "..."` elsewhere, extend the
+tracker instead.
+
+- `incremental` (default for all disk compiles): consult and record.
+- `always` (internal only): the shared no-op tracker — no reads, no
+  writes, no manifest file. Forced for `allowTestImports` (the test
+  runner; `configKey` cannot see that flag), `--ts` mode (different
+  artifact), and any compile with a caller-supplied `importStrategy`
+  (RunStrategy — the run/coverage paths — rewrites emitted import
+  specifiers and transpiles sibling `.ts` deps, none of which the key can
+  see).
+- `force` (`agency compile --force`): reads disabled, writes on —
+  recompile everything and rewrite the manifest.
+
+## Skip granularity
+
+A fully-clean entry set takes the fast path in `BuildSession.compile`:
+no closure walk, no parsing at all. A closure with any dirty member pays
+closure-level parse + analysis, and its clean members skip typecheck,
+codegen, and emit (their per-module check sits before the closure build in
+`compileEntry`). Skipped modules also skip their typecheck warnings —
+`make clean` or `--force` restores full output.
+
+## What never touches the manifest
+
+`std::agency` (all its compile/run functions are in-memory `compileSource`
+calls — sandboxed agent code can neither read nor poison the manifest),
+the LSP (it never calls `compile()`), the test runner's precompile, and
+run/coverage paths (via the `importStrategy` rule above).
+
+## Recovery
+
+`agency compile --force` rebuilds everything and rewrites the manifest.
+`make clean` deletes the manifest with all outputs; a from-scratch build
+is byte-identical to an incremental build that found nothing to skip
+(verified by the cold-vs-warm hash gate in the Stage A PR 2 verification).

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -190,7 +190,7 @@ export function compileMany(
     allowTestImports?: boolean;
   },
 ): void {
-  getDefaultSession().compileMany(config, files, options);
+  getDefaultSession().compile(config, { entries: files, ...options });
 }
 
 /**
@@ -204,7 +204,11 @@ export function compile(
   _outputFile?: string,
   options?: CompileOptions,
 ): string | null {
-  return getDefaultSession().compile(config, inputFile, _outputFile, options);
+  return getDefaultSession().compile(config, {
+    entries: [inputFile],
+    outputFile: _outputFile,
+    ...options,
+  });
 }
 
 export async function format(

--- a/packages/agency-lang/lib/compiler/buildManifest.test.ts
+++ b/packages/agency-lang/lib/compiler/buildManifest.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import {
+  hashBytes,
+  hashFile,
+  computeDepsHash,
+  loadManifest,
+  saveManifest,
+  computeStdlibHash,
+  computeCompilerStamp,
+  isEntryFresh,
+  manifestDirFor,
+  MANIFEST_DIR_NAME,
+  type BuildManifest,
+  type FreshnessContext,
+} from "./buildManifest.js";
+
+function tmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "agency-manifest-"));
+}
+
+// A fresh two-entry manifest (main imports dep) + matching on-disk state;
+// each test perturbs ONE dimension.
+function freshFixture(): { dir: string; manifest: BuildManifest; ctx: FreshnessContext } {
+  const dir = tmp();
+  fs.writeFileSync(path.join(dir, "main.agency"), "node main() {\n  return 1\n}\n");
+  fs.writeFileSync(path.join(dir, "dep.agency"), 'export def d(): number {\n  return 2\n}\n');
+  fs.writeFileSync(path.join(dir, "main.js"), "// compiled");
+  fs.writeFileSync(path.join(dir, "dep.js"), "// compiled dep");
+  const depHash = hashFile(path.join(dir, "dep.agency"))!;
+  const shared = {
+    stdlibHash: "STDLIB",
+    hasPkgImports: false,
+    configKey: "{}",
+    compilerStamp: "COMPILER",
+  };
+  const manifest: BuildManifest = {
+    version: 1,
+    entries: {
+      "main.agency": {
+        ...shared,
+        sourceHash: hashFile(path.join(dir, "main.agency"))!,
+        deps: ["dep.agency"],
+        depsHash: computeDepsHash([depHash]),
+        outputPath: "main.js",
+      },
+      "dep.agency": {
+        ...shared,
+        sourceHash: depHash,
+        deps: [],
+        depsHash: computeDepsHash([]),
+        outputPath: "dep.js",
+      },
+    },
+  };
+  const ctx: FreshnessContext = {
+    manifestDir: dir,
+    stdlibHash: "STDLIB",
+    compilerStamp: "COMPILER",
+    configKey: "{}",
+  };
+  return { dir, manifest, ctx };
+}
+
+describe("manifest IO", () => {
+  test("loadManifest returns empty for missing, corrupt, and wrong-version files", () => {
+    const dir = tmp();
+    expect(loadManifest(dir).entries).toEqual({});
+    fs.mkdirSync(path.join(dir, MANIFEST_DIR_NAME), { recursive: true });
+    fs.writeFileSync(path.join(dir, MANIFEST_DIR_NAME, "manifest.json"), "{not json");
+    expect(loadManifest(dir).entries).toEqual({});
+    fs.writeFileSync(
+      path.join(dir, MANIFEST_DIR_NAME, "manifest.json"),
+      JSON.stringify({ version: 99, entries: { x: {} } }),
+    );
+    expect(loadManifest(dir).entries).toEqual({});
+  });
+
+  test("saveManifest round-trips atomically and leaves no tmp file", () => {
+    const dir = tmp();
+    const manifest: BuildManifest = { version: 1, entries: {} };
+    saveManifest(dir, manifest);
+    expect(loadManifest(dir)).toEqual(manifest);
+    expect(fs.readdirSync(path.join(dir, MANIFEST_DIR_NAME))).toEqual(["manifest.json"]);
+  });
+
+  test("manifestDirFor falls back to the file dir without an agency.json", () => {
+    const dir = tmp();
+    fs.writeFileSync(path.join(dir, "x.agency"), "");
+    expect(manifestDirFor(path.join(dir, "x.agency"))).toBe(dir);
+  });
+});
+
+describe("hashing", () => {
+  test("hashFile returns null for missing files and a stable hex hash otherwise", () => {
+    const dir = tmp();
+    expect(hashFile(path.join(dir, "nope"))).toBeNull();
+    fs.writeFileSync(path.join(dir, "a"), "hello");
+    expect(hashFile(path.join(dir, "a"))).toBe(hashBytes("hello"));
+    expect(hashFile(path.join(dir, "a"))).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("computeDepsHash is order-sensitive and deterministic", () => {
+    expect(computeDepsHash(["a", "b"])).toBe(computeDepsHash(["a", "b"]));
+    expect(computeDepsHash(["a", "b"])).not.toBe(computeDepsHash(["b", "a"]));
+    expect(computeDepsHash([])).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("computeStdlibHash changes when any stdlib source changes and ignores non-agency files", () => {
+    const dir = tmp();
+    fs.mkdirSync(path.join(dir, "sub"));
+    fs.writeFileSync(path.join(dir, "a.agency"), "one");
+    fs.writeFileSync(path.join(dir, "sub", "b.agency"), "two");
+    fs.writeFileSync(path.join(dir, "a.js"), "ignored");
+    const before = computeStdlibHash(dir);
+    fs.writeFileSync(path.join(dir, "a.js"), "still ignored, changed");
+    expect(computeStdlibHash(dir)).toBe(before);
+    fs.writeFileSync(path.join(dir, "sub", "b.agency"), "two!");
+    expect(computeStdlibHash(dir)).not.toBe(before);
+  });
+
+  test("computeCompilerStamp excludes runtime/ and agents/ and keys on content", () => {
+    const dir = tmp();
+    fs.mkdirSync(path.join(dir, "backends"));
+    fs.mkdirSync(path.join(dir, "runtime"));
+    fs.mkdirSync(path.join(dir, "agents"));
+    fs.writeFileSync(path.join(dir, "backends", "gen.js"), "v1");
+    fs.writeFileSync(path.join(dir, "runtime", "r.js"), "r1");
+    fs.writeFileSync(path.join(dir, "agents", "a.js"), "a1");
+    const before = computeCompilerStamp(dir);
+    fs.writeFileSync(path.join(dir, "runtime", "r.js"), "r2");
+    fs.writeFileSync(path.join(dir, "agents", "a.js"), "a2");
+    expect(computeCompilerStamp(dir)).toBe(before);
+    fs.writeFileSync(path.join(dir, "backends", "gen.js"), "v2");
+    expect(computeCompilerStamp(dir)).not.toBe(before);
+  });
+});
+
+describe("isEntryFresh — each field is load-bearing", () => {
+  test("fresh when everything matches", () => {
+    const { manifest, ctx } = freshFixture();
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(true);
+  });
+
+  test("no entry → stale", () => {
+    const { manifest, ctx } = freshFixture();
+    delete manifest.entries["main.agency"];
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("source edit → stale", () => {
+    const { dir, manifest, ctx } = freshFixture();
+    fs.writeFileSync(path.join(dir, "main.agency"), "node main() {\n  return 2\n}\n");
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("dep content edit → stale", () => {
+    const { dir, manifest, ctx } = freshFixture();
+    fs.writeFileSync(path.join(dir, "dep.agency"), 'export def d(): number {\n  return 3\n}\n');
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("missing dep file → stale", () => {
+    const { dir, manifest, ctx } = freshFixture();
+    fs.unlinkSync(path.join(dir, "dep.agency"));
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("missing dep OUTPUT → stale (a skip never visits deps)", () => {
+    const { dir, manifest, ctx } = freshFixture();
+    fs.unlinkSync(path.join(dir, "dep.js"));
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("missing dep ENTRY → stale", () => {
+    const { manifest, ctx } = freshFixture();
+    delete manifest.entries["dep.agency"];
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("stdlibHash mismatch → stale", () => {
+    const { manifest, ctx } = freshFixture();
+    expect(isEntryFresh("main.agency", manifest, { ...ctx, stdlibHash: "OTHER" })).toBe(false);
+  });
+
+  test("compilerStamp mismatch → stale", () => {
+    const { manifest, ctx } = freshFixture();
+    expect(isEntryFresh("main.agency", manifest, { ...ctx, compilerStamp: "OTHER" })).toBe(false);
+  });
+
+  test("configKey mismatch → stale", () => {
+    const { manifest, ctx } = freshFixture();
+    expect(isEntryFresh("main.agency", manifest, { ...ctx, configKey: '{"verbose":true}' })).toBe(false);
+  });
+
+  test("hasPkgImports → never fresh", () => {
+    const { manifest, ctx } = freshFixture();
+    manifest.entries["main.agency"].hasPkgImports = true;
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+
+  test("missing own output → stale", () => {
+    const { dir, manifest, ctx } = freshFixture();
+    fs.unlinkSync(path.join(dir, "main.js"));
+    expect(isEntryFresh("main.agency", manifest, ctx)).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/compiler/buildManifest.test.ts
+++ b/packages/agency-lang/lib/compiler/buildManifest.test.ts
@@ -91,6 +91,14 @@ describe("manifest IO", () => {
     fs.writeFileSync(path.join(dir, "x.agency"), "");
     expect(manifestDirFor(path.join(dir, "x.agency"))).toBe(dir);
   });
+
+  test("manifestDirFor anchors DIRECTORY entries at the directory itself, not its parent", () => {
+    const parent = tmp();
+    const projectDir = path.join(parent, "someProject");
+    fs.mkdirSync(projectDir);
+    fs.writeFileSync(path.join(projectDir, "x.agency"), "");
+    expect(manifestDirFor(projectDir)).toBe(projectDir);
+  });
 });
 
 describe("hashing", () => {

--- a/packages/agency-lang/lib/compiler/buildManifest.ts
+++ b/packages/agency-lang/lib/compiler/buildManifest.ts
@@ -1,0 +1,224 @@
+/**
+ * The incremental-build manifest: content-hash records that let a
+ * BuildSession skip recompiling unchanged modules WITHOUT parsing anything.
+ *
+ * Leaf module by design (PR #466 review): imports only node built-ins and
+ * config.js. It must never import from lib/cli/ — the commands →
+ * buildSession → cli/util → commands cycle stays at three edges. That
+ * leaf-ness is also why walkFiles below deliberately duplicates the
+ * spirit of lib/cli/util.ts findRecursively: importing it would add the
+ * fourth cycle edge. Reuse traded for isolation, on purpose.
+ *
+ * Invalidation fields (spec "The manifest"): each can only over-rebuild.
+ *  - sourceHash: the module's own bytes. Unchanged source ⇒ unchanged
+ *    import list ⇒ the recorded `deps` are still the true deps (the
+ *    load-bearing soundness invariant — imports are part of the source).
+ *  - deps + depsHash: recorded transitive agency imports, re-hashed from
+ *    the recorded paths at check time via computeDepsHash — the ONE
+ *    construction both writer and checker share. Missing dep = stale.
+ *    Freshness ALSO requires every recorded dep to have a manifest entry
+ *    whose OUTPUT exists: a skip never recurses into deps, so a deleted
+ *    dep .js would otherwise survive the skip and ship a broken import.
+ *  - stdlibHash: the closure walker EXCLUDES std:: imports, so no depsHash
+ *    can see a stdlib edit — yet stdlib content genuinely shapes emitted
+ *    output (resolveReExports bakes resolved stdlib paths in). Any stdlib
+ *    edit rebuilds the world.
+ *  - hasPkgImports: pkg:: imports are likewise closure-invisible and shape
+ *    emitted imports; modules touching pkg:: are NEVER skipped.
+ *  - compilerStamp: content hash of the compiled compiler (dist/lib minus
+ *    runtime/ and agents/). runtime/ because generated TEXT does not
+ *    depend on runtime internals; agents/ because those are the agency
+ *    compiler's OWN OUTPUT — including them would make every build
+ *    invalidate the next (self-invalidation loop). Content, not mtimes:
+ *    tsc-alias rewrites the whole outDir every build.
+ *  - configKey: compiled output bakes config in.
+ *
+ * The MANIFEST decides whether to compile; parseCache remains an
+ * intra-process memo consulted only once compilation is already happening.
+ */
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import { findProjectRoot } from "@/config.js";
+
+export type ManifestEntry = {
+  sourceHash: string;
+  /** Transitive agency-import paths, manifest-dir-relative, sorted. */
+  deps: string[];
+  depsHash: string;
+  stdlibHash: string;
+  hasPkgImports: boolean;
+  configKey: string;
+  compilerStamp: string;
+  /** Manifest-dir-relative output path. */
+  outputPath: string;
+};
+
+export type BuildManifest = {
+  version: 1;
+  /** Keyed by manifest-dir-relative module path. */
+  entries: Record<string, ManifestEntry>;
+};
+
+export const MANIFEST_DIR_NAME = ".agency-build";
+const MANIFEST_FILE = "manifest.json";
+
+export function manifestDirFor(entryFile: string): string {
+  const root = findProjectRoot(path.dirname(path.resolve(entryFile)));
+  return root ?? path.dirname(path.resolve(entryFile));
+}
+
+function emptyManifest(): BuildManifest {
+  return { version: 1, entries: Object.create(null) };
+}
+
+export function loadManifest(manifestDir: string): BuildManifest {
+  const file = path.join(manifestDir, MANIFEST_DIR_NAME, MANIFEST_FILE);
+  if (!fs.existsSync(file)) {
+    return emptyManifest();
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    if (parsed?.version !== 1 || typeof parsed.entries !== "object" || parsed.entries === null) {
+      return emptyManifest();
+    }
+    return { version: 1, entries: Object.assign(Object.create(null), parsed.entries) };
+  } catch (e) {
+    // A corrupt manifest only costs a full rebuild; log for traceability.
+    console.warn(`agency: ignoring corrupt build manifest at ${file}: ${e}`);
+    return emptyManifest();
+  }
+}
+
+export function saveManifest(manifestDir: string, manifest: BuildManifest): void {
+  const dir = path.join(manifestDir, MANIFEST_DIR_NAME);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, MANIFEST_FILE);
+  // Atomic write: concurrent compiles get last-writer-wins, never a torn file.
+  const tmpFile = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpFile, JSON.stringify(manifest, null, 2));
+  fs.renameSync(tmpFile, file);
+}
+
+export function hashBytes(data: string | Buffer): string {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+export function hashFile(absPath: string): string | null {
+  if (!fs.existsSync(absPath)) {
+    return null;
+  }
+  return hashBytes(fs.readFileSync(absPath));
+}
+
+/** THE construction of depsHash. Writer (manifestTracker) and checker
+ *  (isEntryFresh) both call this; never inline the expression. */
+export function computeDepsHash(depHashes: string[]): string {
+  return hashBytes(JSON.stringify(depHashes));
+}
+
+// Deliberate near-duplicate of lib/cli/util.ts findRecursively — see the
+// module doc comment (leaf-ness beats reuse here).
+function walkFiles(dir: string, extension: string, skipDirs: string[]): string[] {
+  const out: string[] = [];
+  const walk = (current: string) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const child = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (!skipDirs.includes(entry.name)) {
+          walk(child);
+        }
+      } else if (child.endsWith(extension)) {
+        out.push(child);
+      }
+    }
+  };
+  if (fs.existsSync(dir)) {
+    walk(dir);
+  }
+  return out.sort();
+}
+
+// NUL separators between path and content and between files: without a
+// delimiter, path/content boundaries are ambiguous in principle.
+function hashTree(dir: string, extension: string, skipDirs: string[]): string {
+  const hash = crypto.createHash("sha256");
+  for (const file of walkFiles(dir, extension, skipDirs)) {
+    hash.update(path.relative(dir, file));
+    hash.update("\0");
+    hash.update(fs.readFileSync(file));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+export function computeStdlibHash(stdlibDir: string): string {
+  return hashTree(stdlibDir, ".agency", []);
+}
+
+export function computeCompilerStamp(distLibDir: string): string {
+  return hashTree(distLibDir, ".js", ["runtime", "agents"]);
+}
+
+export type FreshnessContext = {
+  manifestDir: string;
+  stdlibHash: string;
+  compilerStamp: string;
+  configKey: string;
+};
+
+/**
+ * The skip algorithm, from the manifest alone — no parsing:
+ * 1. sourceHash matches (⇒ recorded deps are still the true deps);
+ * 2. every recorded dep source exists and the recomputed depsHash matches;
+ * 3. every recorded dep has a manifest entry whose OUTPUT exists — a skip
+ *    never recurses into deps, so a deleted dep .js would otherwise
+ *    survive the skip and ship a broken import;
+ * 4. stdlibHash / compilerStamp / configKey match; hasPkgImports is false;
+ * 5. the module's own recorded output exists.
+ */
+export function isEntryFresh(
+  moduleRel: string,
+  manifest: BuildManifest,
+  ctx: FreshnessContext,
+): boolean {
+  const entry = manifest.entries[moduleRel];
+  if (!entry) {
+    return false;
+  }
+  if (entry.hasPkgImports) {
+    return false;
+  }
+  if (entry.stdlibHash !== ctx.stdlibHash) {
+    return false;
+  }
+  if (entry.compilerStamp !== ctx.compilerStamp) {
+    return false;
+  }
+  if (entry.configKey !== ctx.configKey) {
+    return false;
+  }
+  const sourceHash = hashFile(path.join(ctx.manifestDir, moduleRel));
+  if (sourceHash === null || sourceHash !== entry.sourceHash) {
+    return false;
+  }
+  const depHashes: string[] = [];
+  for (const dep of entry.deps) {
+    const depHash = hashFile(path.join(ctx.manifestDir, dep));
+    if (depHash === null) {
+      return false;
+    }
+    depHashes.push(depHash);
+    const depEntry = manifest.entries[dep];
+    if (!depEntry) {
+      return false;
+    }
+    if (!fs.existsSync(path.join(ctx.manifestDir, depEntry.outputPath))) {
+      return false;
+    }
+  }
+  if (computeDepsHash(depHashes) !== entry.depsHash) {
+    return false;
+  }
+  return fs.existsSync(path.join(ctx.manifestDir, entry.outputPath));
+}

--- a/packages/agency-lang/lib/compiler/buildManifest.ts
+++ b/packages/agency-lang/lib/compiler/buildManifest.ts
@@ -64,8 +64,15 @@ export const MANIFEST_DIR_NAME = ".agency-build";
 const MANIFEST_FILE = "manifest.json";
 
 export function manifestDirFor(entryFile: string): string {
-  const root = findProjectRoot(path.dirname(path.resolve(entryFile)));
-  return root ?? path.dirname(path.resolve(entryFile));
+  // Entries can be files OR directories (`agency compile someDir`): a
+  // directory anchors the search (and the fallback) at itself, not its
+  // parent — otherwise `.agency-build/` would pollute a sibling-containing
+  // parent dir in agency.json-less projects.
+  const abs = path.resolve(entryFile);
+  const startDir =
+    fs.existsSync(abs) && fs.statSync(abs).isDirectory() ? abs : path.dirname(abs);
+  const root = findProjectRoot(startDir);
+  return root ?? startDir;
 }
 
 function emptyManifest(): BuildManifest {
@@ -115,6 +122,14 @@ export function hashFile(absPath: string): string | null {
  *  (isEntryFresh) both call this; never inline the expression. */
 export function computeDepsHash(depHashes: string[]): string {
   return hashBytes(JSON.stringify(depHashes));
+}
+
+/** Canonical config identity. JSON.stringify is order-stable here because
+ *  every config passes through AgencyConfigSchema.safeParse (loadConfigSafe
+ *  returns result.data), and zod rebuilds objects in SCHEMA shape order —
+ *  guarded by the key-order test in lib/cli/precompile.test.ts. */
+export function deriveConfigKey(config: unknown): string {
+  return JSON.stringify(config);
 }
 
 // Deliberate near-duplicate of lib/cli/util.ts findRecursively — see the
@@ -177,13 +192,30 @@ export type FreshnessContext = {
  * 4. stdlibHash / compilerStamp / configKey match; hasPkgImports is false;
  * 5. the module's own recorded output exists.
  */
+// A valid-but-malformed manifest (manual edit, older schema) must cost a
+// rebuild, never a crash — validate the runtime shape of every field the
+// checker touches before trusting it.
+function entryHasValidShape(entry: ManifestEntry): boolean {
+  return (
+    typeof entry.sourceHash === "string" &&
+    Array.isArray(entry.deps) &&
+    entry.deps.every((d) => typeof d === "string") &&
+    typeof entry.depsHash === "string" &&
+    typeof entry.stdlibHash === "string" &&
+    typeof entry.hasPkgImports === "boolean" &&
+    typeof entry.configKey === "string" &&
+    typeof entry.compilerStamp === "string" &&
+    typeof entry.outputPath === "string"
+  );
+}
+
 export function isEntryFresh(
   moduleRel: string,
   manifest: BuildManifest,
   ctx: FreshnessContext,
 ): boolean {
   const entry = manifest.entries[moduleRel];
-  if (!entry) {
+  if (!entry || !entryHasValidShape(entry)) {
     return false;
   }
   if (entry.hasPkgImports) {
@@ -210,7 +242,7 @@ export function isEntryFresh(
     }
     depHashes.push(depHash);
     const depEntry = manifest.entries[dep];
-    if (!depEntry) {
+    if (!depEntry || typeof depEntry.outputPath !== "string") {
       return false;
     }
     if (!fs.existsSync(path.join(ctx.manifestDir, depEntry.outputPath))) {

--- a/packages/agency-lang/lib/compiler/buildSession.test.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.test.ts
@@ -4,6 +4,8 @@ import os from "os";
 import path from "path";
 import { createBuildSession, findCrossConfigConflicts } from "./buildSession.js";
 import { loadManifest, MANIFEST_DIR_NAME } from "./buildManifest.js";
+import { _internal as parseCacheInternal } from "../parseCache.js";
+import { RunStrategy } from "../importStrategy.js";
 import { CompileClosureError } from "./compileClosure.js";
 import { compile, resetCompilationCache } from "../cli/commands.js";
 
@@ -58,20 +60,28 @@ describe("createBuildSession", () => {
     expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBe(stamped);
   });
 
-  test("sessions are isolated: a fresh session recompiles", () => {
+  test("sessions are isolated: a fresh session recompiles (manifest removed)", () => {
+    // The dedupe set is SESSION state; the manifest is durable and would
+    // legitimately let a fresh session skip. Remove it so re-emission is
+    // the isolation observable again.
     const dir = writeTempDir({ "main.agency": TRIVIAL });
     const entry = path.join(dir, "main.agency");
-    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    const first = createBuildSession();
+    first.compile({}, { entries: [entry], quiet: true });
+    fs.rmSync(path.join(dir, MANIFEST_DIR_NAME), { recursive: true, force: true });
     const stamped = backdate(path.join(dir, "main.js"));
+    first.compile({}, { entries: [entry], quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBe(stamped); // same session: deduped
     createBuildSession().compile({}, { entries: [entry], quiet: true });
-    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped); // fresh session: re-emits
   });
 
-  test("reset() drops the dedupe state", () => {
+  test("reset() drops the dedupe state (manifest removed)", () => {
     const dir = writeTempDir({ "main.agency": TRIVIAL });
     const entry = path.join(dir, "main.agency");
     const session = createBuildSession();
     session.compile({}, { entries: [entry], quiet: true });
+    fs.rmSync(path.join(dir, MANIFEST_DIR_NAME), { recursive: true, force: true });
     const stamped = backdate(path.join(dir, "main.js"));
     session.reset();
     session.compile({}, { entries: [entry], quiet: true });
@@ -245,6 +255,7 @@ describe("commands.ts delegates", () => {
     const stamped = backdate(path.join(dir, "main.js"));
     compile({}, entry, undefined, { quiet: true });
     expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBe(stamped); // deduped
+    fs.rmSync(path.join(dir, MANIFEST_DIR_NAME), { recursive: true, force: true });
     resetCompilationCache();
     compile({}, entry, undefined, { quiet: true });
     expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
@@ -280,5 +291,101 @@ describe("manifest write path", () => {
     const dir = writeTempDir({ "main.agency": TRIVIAL });
     createBuildSession().compile({}, { entries: [path.join(dir, "main.agency")], quiet: true, ts: true });
     expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
+  });
+});
+
+describe("manifest read path (incremental skip)", () => {
+  test("second compile skips: no emit, no parse (fully-clean fast path)", () => {
+    const dir = writeTempDir({ "helper.agency": HELPER, "main.agency": IMPORTS_HELPER });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    parseCacheInternal.clear();
+    const before = { ...parseCacheInternal.stats };
+    const out = createBuildSession().compile({}, { entries: [entry], quiet: true });
+    expect(out).toBe(path.join(dir, "main.js"));
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBe(stamped);
+    expect(parseCacheInternal.stats.misses).toBe(before.misses);
+    expect(parseCacheInternal.stats.hits).toBe(before.hits);
+  });
+
+  test("editing a dep recompiles the dependent", () => {
+    const dir = writeTempDir({ "helper.agency": HELPER, "main.agency": IMPORTS_HELPER });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    fs.writeFileSync(path.join(dir, "helper.agency"), HELPER.replace("shared", "changed"));
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+  });
+
+  test("deleting a DEP output recompiles the entry", () => {
+    const dir = writeTempDir({ "helper.agency": HELPER, "main.agency": IMPORTS_HELPER });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    fs.unlinkSync(path.join(dir, "helper.js"));
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    expect(fs.existsSync(path.join(dir, "helper.js"))).toBe(true); // re-emitted
+  });
+
+  test("a caller-supplied importStrategy is never skip-eligible in either direction", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    createBuildSession().compile({}, {
+      entries: [entry],
+      quiet: true,
+      importStrategy: new RunStrategy(),
+    });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+    fs.rmSync(path.join(dir, MANIFEST_DIR_NAME), { recursive: true, force: true });
+    createBuildSession().compile({}, { entries: [entry], quiet: true, importStrategy: new RunStrategy() });
+    const runStamped = backdate(path.join(dir, "main.js"));
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(runStamped);
+  });
+
+  test("deleting the output recompiles", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    fs.unlinkSync(path.join(dir, "main.js"));
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    expect(fs.existsSync(path.join(dir, "main.js"))).toBe(true);
+  });
+
+  test("freshness force recompiles and rewrites the manifest", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    const stamped = backdate(path.join(dir, "main.js"));
+    createBuildSession().compile({}, { entries: [entry], quiet: true, freshness: "force" });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+    expect(loadManifest(dir).entries["main.agency"]).toBeDefined();
+  });
+
+  test("mixed closure: dirty member recompiles, clean sibling skips emit", () => {
+    const dir = writeTempDir({
+      "helper.agency": HELPER,
+      "a.agency": IMPORTS_HELPER,
+      "b.agency": TRIVIAL,
+    });
+    const entries = [path.join(dir, "a.agency"), path.join(dir, "b.agency")];
+    createBuildSession().compile({}, { entries, quiet: true });
+    const bStamped = backdate(path.join(dir, "b.js"));
+    fs.writeFileSync(path.join(dir, "a.agency"), IMPORTS_HELPER + "\n// touched\n");
+    createBuildSession().compile({}, { entries, quiet: true });
+    expect(fs.statSync(path.join(dir, "b.js")).mtimeMs).toBe(bStamped);
+  });
+
+  test("directory entry: fully-clean directory skips with zero parses", () => {
+    const dir = writeTempDir({ "helper.agency": HELPER, "a.agency": IMPORTS_HELPER });
+    createBuildSession().compile({}, { entries: [dir], quiet: true });
+    parseCacheInternal.clear();
+    const before = { ...parseCacheInternal.stats };
+    createBuildSession().compile({}, { entries: [dir], quiet: true });
+    expect(parseCacheInternal.stats.misses).toBe(before.misses);
+    expect(parseCacheInternal.stats.hits).toBe(before.hits);
   });
 });

--- a/packages/agency-lang/lib/compiler/buildSession.test.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.test.ts
@@ -110,13 +110,19 @@ describe("createBuildSession", () => {
     expect(emitCount(spy, "helper.agency")).toBe(1);
   });
 
-  test("compileMany throws CompileClosureError for programmatic callers", () => {
+  test("multi-entry compile throws CompileClosureError for programmatic callers", () => {
+    // The throw contract belongs to the union-closure path (2+ entries);
+    // a single entry keeps the legacy exit-on-closure-error behavior.
     const dir = writeTempDir({
+      "ok.agency": TRIVIAL,
       "main.agency":
         'import { gone } from "./missing.agency"\n\nnode main() {\n  return gone()\n}\n',
     });
     expect(() =>
-      createBuildSession().compile({}, { entries: [path.join(dir, "main.agency")], quiet: true }),
+      createBuildSession().compile({}, {
+        entries: [path.join(dir, "ok.agency"), path.join(dir, "main.agency")],
+        quiet: true,
+      }),
     ).toThrow(CompileClosureError);
   });
 

--- a/packages/agency-lang/lib/compiler/buildSession.test.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.test.ts
@@ -6,6 +6,7 @@ import { createBuildSession, findCrossConfigConflicts } from "./buildSession.js"
 import { loadManifest, MANIFEST_DIR_NAME } from "./buildManifest.js";
 import { _internal as parseCacheInternal } from "../parseCache.js";
 import { RunStrategy } from "../importStrategy.js";
+import { SymbolTable } from "../symbolTable.js";
 import { CompileClosureError } from "./compileClosure.js";
 import { compile, resetCompilationCache } from "../cli/commands.js";
 
@@ -387,5 +388,46 @@ describe("manifest read path (incremental skip)", () => {
     createBuildSession().compile({}, { entries: [dir], quiet: true });
     expect(parseCacheInternal.stats.misses).toBe(before.misses);
     expect(parseCacheInternal.stats.hits).toBe(before.hits);
+  });
+});
+
+describe("review hardening (PR #468)", () => {
+  test("serve-style compile (threaded symbolTable, no closure) records NO manifest entry", () => {
+    // lib/cli/serve.ts compiles with a top-level symbolTable and no
+    // closure; deps are unknowable there, and recording deps: [] would
+    // poison the manifest into stale skips that outlive serve.
+    const dir = writeTempDir({ "helper.agency": HELPER, "main.agency": IMPORTS_HELPER });
+    const entry = path.join(dir, "main.agency");
+    const symbolTable = SymbolTable.build(entry, {});
+    createBuildSession().compile({}, { entries: [entry], quiet: true, symbolTable });
+    expect(loadManifest(dir).entries["main.agency"]).toBeUndefined();
+  });
+
+  test("serve-then-edit-dep-then-plain-compile re-emits (no poisoned skip)", () => {
+    const dir = writeTempDir({ "helper.agency": HELPER, "main.agency": IMPORTS_HELPER });
+    const entry = path.join(dir, "main.agency");
+    const symbolTable = SymbolTable.build(entry, {});
+    createBuildSession().compile({}, { entries: [entry], quiet: true, symbolTable });
+    fs.writeFileSync(path.join(dir, "helper.agency"), HELPER.replace("shared", "changed"));
+    const stamped = backdate(path.join(dir, "main.js"));
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
+    expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+  });
+
+  test("an explicit outputFile always writes, even against a fresh entry", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    const entry = path.join(dir, "main.agency");
+    createBuildSession().compile({}, { entries: [entry], quiet: true }); // fresh entry recorded
+    const requested = path.join(dir, "custom-out.js");
+    const out = createBuildSession().compile({}, { entries: [entry], quiet: true, outputFile: requested });
+    expect(out).toBe(requested);
+    expect(fs.existsSync(requested)).toBe(true); // must exist — never a skipped phantom path
+  });
+
+  test("fast path returns null for a fresh single-DIRECTORY entry", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    createBuildSession().compile({}, { entries: [dir], quiet: true });
+    const out = createBuildSession().compile({}, { entries: [dir], quiet: true });
+    expect(out).toBeNull(); // matches the compile path directory contract
   });
 });

--- a/packages/agency-lang/lib/compiler/buildSession.test.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.test.ts
@@ -42,7 +42,7 @@ describe("createBuildSession", () => {
   test("compiles a single file and returns the output path", () => {
     const dir = writeTempDir({ "main.agency": TRIVIAL });
     const session = createBuildSession();
-    const out = session.compile({}, path.join(dir, "main.agency"), undefined, { quiet: true });
+    const out = session.compile({}, { entries: [path.join(dir, "main.agency")], quiet: true });
     expect(out).toBe(path.join(dir, "main.js"));
     expect(fs.existsSync(out!)).toBe(true);
   });
@@ -51,18 +51,18 @@ describe("createBuildSession", () => {
     const dir = writeTempDir({ "main.agency": TRIVIAL });
     const session = createBuildSession();
     const entry = path.join(dir, "main.agency");
-    session.compile({}, entry, undefined, { quiet: true });
+    session.compile({}, { entries: [entry], quiet: true });
     const stamped = backdate(path.join(dir, "main.js"));
-    session.compile({}, entry, undefined, { quiet: true });
+    session.compile({}, { entries: [entry], quiet: true });
     expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBe(stamped);
   });
 
   test("sessions are isolated: a fresh session recompiles", () => {
     const dir = writeTempDir({ "main.agency": TRIVIAL });
     const entry = path.join(dir, "main.agency");
-    createBuildSession().compile({}, entry, undefined, { quiet: true });
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
     const stamped = backdate(path.join(dir, "main.js"));
-    createBuildSession().compile({}, entry, undefined, { quiet: true });
+    createBuildSession().compile({}, { entries: [entry], quiet: true });
     expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
   });
 
@@ -70,10 +70,10 @@ describe("createBuildSession", () => {
     const dir = writeTempDir({ "main.agency": TRIVIAL });
     const entry = path.join(dir, "main.agency");
     const session = createBuildSession();
-    session.compile({}, entry, undefined, { quiet: true });
+    session.compile({}, { entries: [entry], quiet: true });
     const stamped = backdate(path.join(dir, "main.js"));
     session.reset();
-    session.compile({}, entry, undefined, { quiet: true });
+    session.compile({}, { entries: [entry], quiet: true });
     expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
   });
 
@@ -84,10 +84,9 @@ describe("createBuildSession", () => {
       "b.agency": IMPORTS_HELPER,
     });
     const spy = vi.spyOn(console, "log");
-    createBuildSession().compileMany({}, [
-      path.join(dir, "a.agency"),
-      path.join(dir, "b.agency"),
-    ]);
+    createBuildSession().compile({}, {
+      entries: [path.join(dir, "a.agency"), path.join(dir, "b.agency")],
+    });
     for (const out of ["a.js", "b.js", "helper.js"]) {
       expect(fs.existsSync(path.join(dir, out))).toBe(true);
     }
@@ -103,7 +102,7 @@ describe("createBuildSession", () => {
       "b.agency": IMPORTS_HELPER,
     });
     const spy = vi.spyOn(console, "log");
-    const result = createBuildSession().compile({}, dir);
+    const result = createBuildSession().compile({}, { entries: [dir] });
     expect(result).toBeNull();
     for (const out of ["a.js", "b.js", "helper.js"]) {
       expect(fs.existsSync(path.join(dir, out))).toBe(true);
@@ -117,7 +116,7 @@ describe("createBuildSession", () => {
         'import { gone } from "./missing.agency"\n\nnode main() {\n  return gone()\n}\n',
     });
     expect(() =>
-      createBuildSession().compileMany({}, [path.join(dir, "main.agency")], { quiet: true }),
+      createBuildSession().compile({}, { entries: [path.join(dir, "main.agency")], quiet: true }),
     ).toThrow(CompileClosureError);
   });
 
@@ -128,10 +127,10 @@ describe("createBuildSession", () => {
         'import test { secret } from "./lib.agency"\n\nnode main() {\n  return secret()\n}\n',
     });
     const files = [path.join(dir, "main.agency")];
-    expect(() => createBuildSession().compileMany({}, files, { quiet: true })).toThrow(
+    expect(() => createBuildSession().compile({}, { entries: files, quiet: true })).toThrow(
       /only allowed under the test harness/,
     );
-    createBuildSession().compileMany({}, files, { quiet: true, allowTestImports: true });
+    createBuildSession().compile({}, { entries: files, quiet: true, allowTestImports: true });
     expect(fs.existsSync(path.join(dir, "main.js"))).toBe(true);
   });
 
@@ -145,16 +144,37 @@ describe("createBuildSession", () => {
     const previousCwd = process.cwd();
     try {
       process.chdir(dir);
-      const out = createBuildSession().compile({ outDir }, "main.agency", undefined, {
-        quiet: true,
-      });
+      const out = createBuildSession().compile({ outDir }, { entries: ["main.agency"], quiet: true });
       expect(out).toBe(path.join(outDir, "main.js"));
       expect(fs.existsSync(out!)).toBe(true);
     } finally {
       process.chdir(previousCwd);
     }
   });
+
+  test("single entry returns the output path; multiple entries return null", () => {
+    const dir = writeTempDir({ "a.agency": TRIVIAL, "b.agency": TRIVIAL });
+    const single = createBuildSession().compile({}, { entries: [path.join(dir, "a.agency")], quiet: true });
+    expect(single).toBe(path.join(dir, "a.js"));
+    const multi = createBuildSession().compile(
+      {},
+      { entries: [path.join(dir, "a.agency"), path.join(dir, "b.agency")], quiet: true },
+    );
+    expect(multi).toBeNull();
+  });
+
+  test("outputFile with multiple entries throws", () => {
+    const dir = writeTempDir({ "a.agency": TRIVIAL, "b.agency": TRIVIAL });
+    expect(() =>
+      createBuildSession().compile({}, {
+        entries: [path.join(dir, "a.agency"), path.join(dir, "b.agency")],
+        outputFile: path.join(dir, "out.js"),
+        quiet: true,
+      }),
+    ).toThrow(/outputFile/);
+  });
 });
+
 
 describe("findCrossConfigConflicts", () => {
   test("no conflict when groups with the same config share a module", () => {

--- a/packages/agency-lang/lib/compiler/buildSession.test.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.test.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import os from "os";
 import path from "path";
 import { createBuildSession, findCrossConfigConflicts } from "./buildSession.js";
+import { loadManifest, MANIFEST_DIR_NAME } from "./buildManifest.js";
 import { CompileClosureError } from "./compileClosure.js";
 import { compile, resetCompilationCache } from "../cli/commands.js";
 
@@ -247,5 +248,37 @@ describe("commands.ts delegates", () => {
     resetCompilationCache();
     compile({}, entry, undefined, { quiet: true });
     expect(fs.statSync(path.join(dir, "main.js")).mtimeMs).toBeGreaterThan(stamped);
+  });
+});
+
+describe("manifest write path", () => {
+  test("compiling records an entry per emitted module with recorded deps", () => {
+    const dir = writeTempDir({ "helper.agency": HELPER, "main.agency": IMPORTS_HELPER });
+    createBuildSession().compile({}, { entries: [path.join(dir, "main.agency")], quiet: true });
+    const manifest = loadManifest(dir);
+    expect(manifest.entries["main.agency"].deps).toEqual(["helper.agency"]);
+    expect(manifest.entries["main.agency"].outputPath).toBe("main.js");
+    expect(manifest.entries["main.agency"].hasPkgImports).toBe(false);
+    expect(manifest.entries["helper.agency"].deps).toEqual([]);
+  });
+
+  test("allowTestImports sessions write no manifest", () => {
+    const dir = writeTempDir({
+      "lib.agency": 'def secret(): string {\n  return "s"\n}\n',
+      "main.agency":
+        'import test { secret } from "./lib.agency"\n\nnode main() {\n  return secret()\n}\n',
+    });
+    createBuildSession().compile({}, {
+      entries: [path.join(dir, "main.agency")],
+      quiet: true,
+      allowTestImports: true,
+    });
+    expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
+  });
+
+  test("--ts mode writes no manifest", () => {
+    const dir = writeTempDir({ "main.agency": TRIVIAL });
+    createBuildSession().compile({}, { entries: [path.join(dir, "main.agency")], quiet: true, ts: true });
+    expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -25,10 +25,18 @@ import { buildCompilationUnit, CompilationUnit } from "@/compilationUnit.js";
 import { SymbolTable } from "@/symbolTable.js";
 import { formatErrors, typeCheck } from "@/typeChecker/index.js";
 import {
+  agencyImportTargets,
   buildCompiledClosure,
   CompileClosureError,
+  programHasPkgImport,
   type CompiledClosure,
 } from "@/compiler/compileClosure.js";
+import {
+  createManifestTracker,
+  NOOP_TRACKER,
+  type Freshness,
+  type ManifestTracker,
+} from "./manifestTracker.js";
 import { transformSync } from "esbuild";
 import * as fs from "fs";
 import * as path from "path";
@@ -53,6 +61,11 @@ export type CompileOptions = {
    *  test runner / analysis paths — kept off AgencyConfig so agent source
    *  cannot enable it. */
   allowTestImports?: boolean;
+  /** Skip policy. "incremental" (default) consults and records the
+   *  manifest; "force" recompiles everything but rewrites it (--force);
+   *  "always" is internal (allowTestImports / --ts / caller-supplied
+   *  importStrategy) and touches nothing. */
+  freshness?: Freshness;
 };
 
 export type CompileRequest = {
@@ -78,6 +91,19 @@ export type CompileGroup = {
   files: string[];
 };
 
+// The only place freshness OVERRIDES live; the policy MEANING lives in
+// the tracker factory. A caller-supplied importStrategy shapes emitted
+// bytes (RunStrategy rewrites .ts import specifiers and transpiles
+// sibling .ts deps on disk — run/runAgencyNode/coverage paths), and the
+// manifest key cannot see it — same disease configKey/hasPkgImports
+// prevent, so it forces "always".
+function resolveFreshness(options?: CompileOptions): Freshness {
+  if (options?.allowTestImports || options?.ts || options?.importStrategy) {
+    return "always";
+  }
+  return options?.freshness ?? "incremental";
+}
+
 export function createBuildSession(): BuildSession {
   return new BuildSession();
 }
@@ -87,6 +113,9 @@ export class BuildSession {
   // Cached `CompiledClosure` for this session. Built once at the outermost
   // compile call and reused by every per-file emit.
   private currentClosure: CompiledClosure | null = null;
+  // Per-operation manifest policy object; NOOP outside operations and for
+  // "always" sessions, so every call site is an unconditional one-liner.
+  private tracker: ManifestTracker = NOOP_TRACKER;
 
   /**
    * The one public compile entry point: callers declare WHAT to build
@@ -103,11 +132,29 @@ export class BuildSession {
     if (outputFile !== undefined && entries.length !== 1) {
       throw new Error("outputFile is only valid with a single file entry");
     }
-    if (entries.length === 1) {
-      return this.compileEntry(config, entries[0], outputFile, options);
+    if (entries.length === 0) {
+      return null;
     }
-    this.compileManyImpl(config, entries, options);
-    return null;
+    this.tracker = createManifestTracker(
+      config,
+      entries[0],
+      resolveFreshness(options),
+      deriveConfigKey(config),
+    );
+    try {
+      if (entries.length === 1) {
+        return this.compileEntry(config, entries[0], outputFile, options);
+      }
+      this.compileManyImpl(config, entries, options);
+      return null;
+    } finally {
+      // Modules emitted before a later failure are legitimately fresh, so
+      // flushing in finally is correct. Caveat: most compile failures are
+      // process.exit(1), which bypasses finally — the flush is simply
+      // lost, which only over-rebuilds next time. Safe.
+      this.tracker.flush();
+      this.tracker = NOOP_TRACKER;
+    }
   }
 
   /** Compile config-heterogeneous groups (one union closure each), after
@@ -117,7 +164,7 @@ export class BuildSession {
    *  Throws `CompileClosureError` naming the module and group labels. */
   compileGroups(
     groups: CompileGroup[],
-    options?: { quiet?: boolean; allowTestImports?: boolean },
+    options?: { quiet?: boolean; allowTestImports?: boolean; freshness?: Freshness },
   ): void {
     const withClosures = groups.map((group) => ({
       group,
@@ -146,17 +193,32 @@ export class BuildSession {
     }
 
     for (const { group, closure } of withClosures) {
-      this.compileManyImpl(group.config, group.files, {
-        closure,
-        quiet: options?.quiet,
-        allowTestImports: options?.allowTestImports,
-      });
+      // Each group gets its own tracker (per-group config identity); the
+      // test runner passes allowTestImports, which resolves to "always"
+      // and the NOOP tracker — no manifest IO, structurally.
+      this.tracker = createManifestTracker(
+        group.config,
+        group.files[0],
+        resolveFreshness(options),
+        deriveConfigKey(group.config),
+      );
+      try {
+        this.compileManyImpl(group.config, group.files, {
+          closure,
+          quiet: options?.quiet,
+          allowTestImports: options?.allowTestImports,
+        });
+      } finally {
+        this.tracker.flush();
+        this.tracker = NOOP_TRACKER;
+      }
     }
   }
 
   /** Drop all cached state (watch-mode rebuild boundary). */
   reset(): void {
     this.setClosure(null);
+    this.tracker = NOOP_TRACKER;
   }
 
   // `compiledFiles` entries are only meaningful under the current closure,
@@ -166,6 +228,28 @@ export class BuildSession {
   private setClosure(closure: CompiledClosure | null): void {
     this.currentClosure = closure;
     this.compiledFiles.clear();
+  }
+
+  /** BFS over the closure import graph. Stdlib entries have no closure —
+   *  their deps are [] by construction (stdlibHash covers them). */
+  private transitiveDeps(absModule: string): string[] {
+    const programs = this.currentClosure?.programs;
+    if (!programs || !programs[absModule]) {
+      return [];
+    }
+    const seen = [absModule];
+    for (let i = 0; i < seen.length; i++) {
+      const program = programs[seen[i]];
+      if (!program) {
+        continue;
+      }
+      for (const target of agencyImportTargets(program, seen[i])) {
+        if (!seen.includes(target)) {
+          seen.push(target);
+        }
+      }
+    }
+    return seen.slice(1);
   }
 
   /**
@@ -428,6 +512,13 @@ export class BuildSession {
       fs.writeFileSync(outputFile, result.code, "utf-8");
       const esbuildEndTime = performance.now();
       logTime({ label: `Transformed code for ${absoluteInputFile} with esbuild`, start: esbuildStartTime, end: esbuildEndTime, verbose });
+      const transitiveDeps = this.transitiveDeps(absoluteInputFile);
+      this.tracker.record(
+        absoluteInputFile,
+        path.resolve(outputFile),
+        transitiveDeps,
+        subtreeHasPkgImport(this.currentClosure, absoluteInputFile, transitiveDeps),
+      );
     }
     const compileEndTime = performance.now();
     const timeTaken = `${(compileEndTime - compileStartTime).toFixed(2)}ms`
@@ -528,4 +619,21 @@ function logTime({ label, start, end, verbose }: { label: string, start: number,
   if (verbose) {
     console.log(`${label} in ${(end - start).toFixed(2)}ms`);
   }
+}
+
+/** pkg:: imports are invisible to the closure and depsHash; a module whose
+ *  subtree touches pkg:: is never skipped (spec). Edge detection is shared
+ *  with the closure walker via programHasPkgImport. */
+function subtreeHasPkgImport(
+  closure: CompiledClosure | null,
+  absModule: string,
+  transitiveDeps: string[],
+): boolean {
+  for (const modulePath of [absModule, ...transitiveDeps]) {
+    const program = closure?.programs[modulePath];
+    if (program && programHasPkgImport(program)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -142,6 +142,19 @@ export class BuildSession {
       deriveConfigKey(config),
     );
     try {
+      // Fully-clean fast path: every requested module fresh per the
+      // manifest alone — no closure walk, no parsing. Directories expand
+      // with the same walker the compile path uses.
+      const allFiles = expandEntries(entries);
+      if (this.tracker.allFresh(allFiles)) {
+        for (const file of allFiles) {
+          this.compiledFiles.add(file);
+        }
+        if (!options.quiet) {
+          console.log(`${allFiles.length} file(s) up to date`);
+        }
+        return allFiles.length === 1 ? this.tracker.outputFor(allFiles[0]) : null;
+      }
       if (entries.length === 1) {
         return this.compileEntry(config, entries[0], outputFile, options);
       }
@@ -388,8 +401,6 @@ export class BuildSession {
     const compileStartTime = performance.now();
     const absoluteInputFile = path.resolve(inputFile);
 
-    this.ensureCompiledClosure(absoluteInputFile, config, !!options?.symbolTable, verbose);
-
     const ext = options?.ts ? ".ts" : ".js";
     // Anchor the replacement to the extension so that an absolute path
     // containing ".agency" as a substring in a parent directory (e.g.
@@ -409,6 +420,21 @@ export class BuildSession {
       return outputFile;
     }
 
+    // Incremental skip — BEFORE the closure build, so a fresh module pays
+    // no parse, no analysis, no typecheck, no recursion into imports (its
+    // depsHash covers the whole subtree), no emit. The NOOP tracker makes
+    // this constant-false for "always" sessions. Deliberately NOT added to
+    // compiledFiles here: ensureCompiledClosure below may clear that set,
+    // and repeat visits are absorbed by this same check.
+    if (this.tracker.isFresh(absoluteInputFile)) {
+      return outputFile;
+    }
+
+    this.ensureCompiledClosure(absoluteInputFile, config, !!options?.symbolTable, verbose);
+
+    // Added AFTER ensureCompiledClosure: setClosure clears the dedupe set
+    // when the closure changes, so an earlier add would be wiped moments
+    // later (this ordering predates the manifest and must be preserved).
     this.compiledFiles.add(absoluteInputFile);
 
     const contents = readFile(inputFile);
@@ -636,4 +662,21 @@ function subtreeHasPkgImport(
     }
   }
   return false;
+}
+
+/** Expand request entries to absolute FILE paths: directories via the same
+ *  walker the compile path uses, files as-is. Fast-path support only —
+ *  the compile dispatch itself keeps its dir handling untouched. */
+function expandEntries(entries: string[]): string[] {
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (fs.existsSync(entry) && fs.statSync(entry).isDirectory()) {
+      for (const found of findRecursively(entry)) {
+        files.push(path.resolve(found.path));
+      }
+    } else {
+      files.push(path.resolve(entry));
+    }
+  }
+  return files;
 }

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -37,6 +37,7 @@ import {
   type Freshness,
   type ManifestTracker,
 } from "./manifestTracker.js";
+import { deriveConfigKey } from "./buildManifest.js";
 import { transformSync } from "esbuild";
 import * as fs from "fs";
 import * as path from "path";
@@ -97,8 +98,20 @@ export type CompileGroup = {
 // sibling .ts deps on disk — run/runAgencyNode/coverage paths), and the
 // manifest key cannot see it — same disease configKey/hasPkgImports
 // prevent, so it forces "always".
-function resolveFreshness(options?: CompileOptions): Freshness {
-  if (options?.allowTestImports || options?.ts || options?.importStrategy) {
+function resolveFreshness(
+  options?: CompileOptions & { outputFile?: string },
+): Freshness {
+  // An explicit outputFile also forces "always": a fresh entry only knows
+  // the RECORDED output path, so a skip could return the requested path
+  // without ever writing it. Unreachable today (the only outputFile caller
+  // also passes RunStrategy) but both are public surface — same precedent
+  // as --ts: different artifact, not manifest-tracked.
+  if (
+    options?.allowTestImports ||
+    options?.ts ||
+    options?.importStrategy ||
+    options?.outputFile !== undefined
+  ) {
     return "always";
   }
   return options?.freshness ?? "incremental";
@@ -135,17 +148,12 @@ export class BuildSession {
     if (entries.length === 0) {
       return null;
     }
-    this.tracker = createManifestTracker(
-      config,
-      entries[0],
-      resolveFreshness(options),
-      deriveConfigKey(config),
-    );
+    this.tracker = createManifestTracker(config, entries[0], resolveFreshness(request));
     try {
       // Fully-clean fast path: every requested module fresh per the
       // manifest alone — no closure walk, no parsing. Directories expand
       // with the same walker the compile path uses.
-      const allFiles = expandEntries(entries);
+      const { files: allFiles, hasDirectory } = expandEntries(entries);
       if (this.tracker.allFresh(allFiles)) {
         for (const file of allFiles) {
           this.compiledFiles.add(file);
@@ -153,7 +161,12 @@ export class BuildSession {
         if (!options.quiet) {
           console.log(`${allFiles.length} file(s) up to date`);
         }
-        return allFiles.length === 1 ? this.tracker.outputFor(allFiles[0]) : null;
+        // Match the compile path contract: directory entries return null
+        // even when the directory holds exactly one file.
+        if (allFiles.length === 1 && !hasDirectory) {
+          return this.tracker.outputFor(allFiles[0]);
+        }
+        return null;
       }
       if (entries.length === 1) {
         return this.compileEntry(config, entries[0], outputFile, options);
@@ -209,12 +222,7 @@ export class BuildSession {
       // Each group gets its own tracker (per-group config identity); the
       // test runner passes allowTestImports, which resolves to "always"
       // and the NOOP tracker — no manifest IO, structurally.
-      this.tracker = createManifestTracker(
-        group.config,
-        group.files[0],
-        resolveFreshness(options),
-        deriveConfigKey(group.config),
-      );
+      this.tracker = createManifestTracker(group.config, group.files[0], resolveFreshness(options));
       try {
         this.compileManyImpl(group.config, group.files, {
           closure,
@@ -538,13 +546,25 @@ export class BuildSession {
       fs.writeFileSync(outputFile, result.code, "utf-8");
       const esbuildEndTime = performance.now();
       logTime({ label: `Transformed code for ${absoluteInputFile} with esbuild`, start: esbuildStartTime, end: esbuildEndTime, verbose });
-      const transitiveDeps = this.transitiveDeps(absoluteInputFile);
-      this.tracker.record(
-        absoluteInputFile,
-        path.resolve(outputFile),
-        transitiveDeps,
-        subtreeHasPkgImport(this.currentClosure, absoluteInputFile, transitiveDeps),
-      );
+      // Record ONLY when the module's deps are knowable: covered by the
+      // session closure, or a stdlib module (compiled closure-free by
+      // design; deps [] is correct because stdlibHash covers all of
+      // stdlib). A module compiled with a caller-threaded symbolTable and
+      // no closure (agency serve) has REAL imports the session cannot see
+      // — recording deps: [] would poison the manifest with an entry that
+      // skips despite edited imports.
+      const isStdlibModule = absoluteInputFile.startsWith(getStdlibDir() + path.sep);
+      const depsKnowable =
+        isStdlibModule || this.currentClosure?.programs[absoluteInputFile] !== undefined;
+      if (depsKnowable) {
+        const transitiveDeps = this.transitiveDeps(absoluteInputFile);
+        this.tracker.record(
+          absoluteInputFile,
+          path.resolve(outputFile),
+          transitiveDeps,
+          subtreeHasPkgImport(this.currentClosure, absoluteInputFile, transitiveDeps),
+        );
+      }
     }
     const compileEndTime = performance.now();
     const timeTaken = `${(compileEndTime - compileStartTime).toFixed(2)}ms`
@@ -562,14 +582,6 @@ export function readFile(inputFile: string): string {
   }
 
   return fs.readFileSync(inputFile, "utf-8");
-}
-
-// Canonical config identity. JSON.stringify is order-stable here because
-// every config passes through AgencyConfigSchema.safeParse (loadConfigSafe
-// returns result.data), and zod rebuilds objects in SCHEMA shape order —
-// guarded by the key-order test in lib/cli/precompile.test.ts.
-function deriveConfigKey(config: AgencyConfig): string {
-  return JSON.stringify(config);
 }
 
 export function findCrossConfigConflicts(
@@ -667,10 +679,12 @@ function subtreeHasPkgImport(
 /** Expand request entries to absolute FILE paths: directories via the same
  *  walker the compile path uses, files as-is. Fast-path support only —
  *  the compile dispatch itself keeps its dir handling untouched. */
-function expandEntries(entries: string[]): string[] {
+function expandEntries(entries: string[]): { files: string[]; hasDirectory: boolean } {
   const files: string[] = [];
+  let hasDirectory = false;
   for (const entry of entries) {
     if (fs.existsSync(entry) && fs.statSync(entry).isDirectory()) {
+      hasDirectory = true;
       for (const found of findRecursively(entry)) {
         files.push(path.resolve(found.path));
       }
@@ -678,5 +692,5 @@ function expandEntries(entries: string[]): string[] {
       files.push(path.resolve(entry));
     }
   }
-  return files;
+  return { files, hasDirectory };
 }

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -55,6 +55,14 @@ export type CompileOptions = {
   allowTestImports?: boolean;
 };
 
+export type CompileRequest = {
+  /** Files or directories. One entry = the legacy per-entry path
+   *  (covers-check closure, stdlib carve-out); many = one union closure. */
+  entries: string[];
+  /** Single non-directory entry only: explicit output path. */
+  outputFile?: string;
+} & CompileOptions;
+
 /**
  * A set of entry files sharing one effective config. The canonical config
  * key is NOT part of this type: it is the session's own integrity
@@ -80,28 +88,26 @@ export class BuildSession {
   // compile call and reused by every per-file emit.
   private currentClosure: CompiledClosure | null = null;
 
-  /** Compile a file or directory entry: recursive imports, per-session
-   *  dedupe. Returns the output path (null for directories). */
-  compile(
-    config: AgencyConfig,
-    inputFile: string,
-    outputFile?: string,
-    options?: CompileOptions,
-  ): string | null {
-    return this.compileEntry(config, inputFile, outputFile, options);
-  }
-
-  /** Compile a set of entry files under ONE union closure, like the
-   *  directory branch of `compile()`. Closure errors THROW
-   *  (`CompileClosureError`) so programmatic callers can attach context;
-   *  parse/typecheck failures inside per-file compiles keep their exit
-   *  behavior. */
-  compileMany(
-    config: AgencyConfig,
-    files: string[],
-    options?: { quiet?: boolean; allowTestImports?: boolean },
-  ): void {
-    this.compileManyImpl(config, files, options);
+  /**
+   * The one public compile entry point: callers declare WHAT to build
+   * (entries + options); the session decides how. A single entry keeps the
+   * legacy per-entry closure semantics (covers-check reuse, stdlib
+   * carve-out); multiple entries compile under ONE union closure, where
+   * closure errors THROW (`CompileClosureError`) so programmatic callers
+   * can attach context. Parse/typecheck failures inside per-file compiles
+   * keep their exit behavior. Returns the output path for a single
+   * non-directory entry, null otherwise.
+   */
+  compile(config: AgencyConfig, request: CompileRequest): string | null {
+    const { entries, outputFile, ...options } = request;
+    if (outputFile !== undefined && entries.length !== 1) {
+      throw new Error("outputFile is only valid with a single file entry");
+    }
+    if (entries.length === 1) {
+      return this.compileEntry(config, entries[0], outputFile, options);
+    }
+    this.compileManyImpl(config, entries, options);
+    return null;
   }
 
   /** Compile config-heterogeneous groups (one union closure each), after
@@ -171,20 +177,20 @@ export class BuildSession {
   private compileManyImpl(
     config: AgencyConfig,
     files: string[],
-    options?: {
+    options?: CompileOptions & {
+      /** Prebuilt union closure (compileGroups handoff). MUST cover every
+       *  file, or the covers-check clears the session cache mid-loop. */
       closure?: CompiledClosure;
-      quiet?: boolean;
-      allowTestImports?: boolean;
     },
   ): void {
     const absFiles = files.map((f) => path.resolve(f));
-    if (absFiles.length === 0) return;
-    this.setClosure(options?.closure ?? buildCompiledClosure(absFiles, config));
+    if (absFiles.length === 0) {
+      return;
+    }
+    const { closure, ...compileOptions } = options ?? {};
+    this.setClosure(closure ?? buildCompiledClosure(absFiles, config));
     for (const file of absFiles) {
-      this.compileEntry(config, file, undefined, {
-        quiet: options?.quiet,
-        allowTestImports: options?.allowTestImports,
-      });
+      this.compileEntry(config, file, undefined, compileOptions);
     }
   }
 

--- a/packages/agency-lang/lib/compiler/compileClosure.test.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, test, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import {
   buildCompiledClosure,
   CompileClosureError,
+  programHasPkgImport,
 } from "./compileClosure.js";
+import { parseAgency } from "../parser.js";
 
 let dir: string;
 
@@ -174,5 +176,35 @@ describe("buildCompiledClosure", () => {
     // localOrder still doesn't include bare slots — codegen emits them
     // inline via the section assembler.
     expect(c.plans[mainPath]!.global.localOrder).toEqual([]);
+  });
+});
+
+describe("programHasPkgImport", () => {
+  function parse(source: string) {
+    const result = parseAgency(source, {}, false);
+    if (!result.success) {
+      throw new Error("fixture parse failed");
+    }
+    return result.result;
+  }
+
+  test("detects a plain pkg import", () => {
+    expect(programHasPkgImport(parse('import { x } from "pkg::toolbox"\n'))).toBe(true);
+  });
+
+  test("detects a pkg node import", () => {
+    expect(programHasPkgImport(parse('import node { main } from "pkg::toolbox"\n'))).toBe(true);
+  });
+
+  test("detects a pkg re-export", () => {
+    expect(programHasPkgImport(parse('export { x } from "pkg::toolbox"\n'))).toBe(true);
+  });
+
+  test("false for stdlib and local imports", () => {
+    expect(
+      programHasPkgImport(
+        parse('import { map } from "std::index"\nimport { y } from "./local.agency"\n'),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -265,7 +265,7 @@ function loadModule(
   };
 }
 
-function agencyImportTargets(
+export function agencyImportTargets(
   program: AgencyProgram,
   moduleId: string,
 ): string[] {
@@ -285,6 +285,24 @@ function agencyImportTarget(node: AgencyNode): string | null {
   if (node.type === "importNodeStatement") return node.agencyFile;
   if (node.type === "exportFromStatement") return node.modulePath;
   return null;
+}
+
+/**
+ * True when the program has any pkg:: import edge. Routed through the
+ * SAME extraction as the closure walker (agencyImportTarget), which
+ * recognizes importStatement, importNodeStatement, AND
+ * exportFromStatement — a hand-rolled importStatement-only scan would let
+ * `export { x } from "pkg::…"` escape the incremental-build never-skip.
+ * One source of truth for "what is an import edge".
+ */
+export function programHasPkgImport(program: AgencyProgram): boolean {
+  for (const node of program.nodes) {
+    const target = agencyImportTarget(node);
+    if (target !== null && isPkgImport(target)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/agency-lang/lib/compiler/manifestTracker.test.ts
+++ b/packages/agency-lang/lib/compiler/manifestTracker.test.ts
@@ -15,7 +15,7 @@ function tmp(): string {
 describe("createManifestTracker policy resolution", () => {
   test("always → NOOP: no reads, no writes, no manifest file", () => {
     const dir = tmp();
-    const tracker = createManifestTracker({}, path.join(dir, "main.agency"), "always", "{}");
+    const tracker = createManifestTracker({}, path.join(dir, "main.agency"), "always");
     expect(tracker).toBe(NOOP_TRACKER);
     tracker.record(path.join(dir, "main.agency"), path.join(dir, "main.js"), [], false);
     tracker.flush();
@@ -25,11 +25,11 @@ describe("createManifestTracker policy resolution", () => {
   test("incremental: record + flush round-trips through isFresh and outputFor", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
-    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    const writer = createManifestTracker({}, entry, "incremental");
     expect(writer.isFresh(entry)).toBe(false); // nothing recorded yet
     writer.record(entry, path.join(dir, "main.js"), [], false);
     writer.flush();
-    const reader = createManifestTracker({}, entry, "incremental", "{}");
+    const reader = createManifestTracker({}, entry, "incremental");
     expect(reader.isFresh(entry)).toBe(true);
     expect(reader.allFresh([entry])).toBe(true);
     expect(reader.outputFor(entry)).toBe(path.join(dir, "main.js"));
@@ -38,10 +38,10 @@ describe("createManifestTracker policy resolution", () => {
   test("force: reads disabled, writes enabled", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
-    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    const writer = createManifestTracker({}, entry, "incremental");
     writer.record(entry, path.join(dir, "main.js"), [], false);
     writer.flush();
-    const forced = createManifestTracker({}, entry, "force", "{}");
+    const forced = createManifestTracker({}, entry, "force");
     expect(forced.isFresh(entry)).toBe(false);
     forced.record(entry, path.join(dir, "main.js"), [], false);
     forced.flush();
@@ -51,26 +51,57 @@ describe("createManifestTracker policy resolution", () => {
   test("configKey mismatch across trackers → stale", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
-    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    const writer = createManifestTracker({}, entry, "incremental");
     writer.record(entry, path.join(dir, "main.js"), [], false);
     writer.flush();
-    const other = createManifestTracker({}, entry, "incremental", '{"verbose":true}');
+    const other = createManifestTracker({ verbose: true }, entry, "incremental");
     expect(other.isFresh(entry)).toBe(false);
   });
 
   test("hasPkgImports recorded true → never fresh", () => {
     const dir = tmp();
     const entry = path.join(dir, "main.agency");
-    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    const writer = createManifestTracker({}, entry, "incremental");
     writer.record(entry, path.join(dir, "main.js"), [], true);
     writer.flush();
-    const reader = createManifestTracker({}, entry, "incremental", "{}");
+    const reader = createManifestTracker({}, entry, "incremental");
     expect(reader.isFresh(entry)).toBe(false);
   });
 
   test("flush without records writes nothing", () => {
     const dir = tmp();
-    createManifestTracker({}, path.join(dir, "main.agency"), "incremental", "{}").flush();
+    createManifestTracker({}, path.join(dir, "main.agency"), "incremental").flush();
     expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
+  });
+});
+
+describe("malformed manifest resilience", () => {
+  test("outputFor returns null for a non-string outputPath", () => {
+    const dir = tmp();
+    const entry = path.join(dir, "main.agency");
+    const writer = createManifestTracker({}, entry, "incremental");
+    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.flush();
+    const file = path.join(dir, MANIFEST_DIR_NAME, "manifest.json");
+    const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
+    raw.entries["main.agency"].outputPath = 42;
+    fs.writeFileSync(file, JSON.stringify(raw));
+    const reader = createManifestTracker({}, entry, "incremental");
+    expect(reader.outputFor(entry)).toBeNull();
+    expect(reader.isFresh(entry)).toBe(false); // shape guard: stale, not a throw
+  });
+
+  test("non-array deps is stale, not a crash", () => {
+    const dir = tmp();
+    const entry = path.join(dir, "main.agency");
+    const writer = createManifestTracker({}, entry, "incremental");
+    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.flush();
+    const file = path.join(dir, MANIFEST_DIR_NAME, "manifest.json");
+    const raw = JSON.parse(fs.readFileSync(file, "utf-8"));
+    raw.entries["main.agency"].deps = "not-an-array";
+    fs.writeFileSync(file, JSON.stringify(raw));
+    const reader = createManifestTracker({}, entry, "incremental");
+    expect(reader.isFresh(entry)).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/compiler/manifestTracker.test.ts
+++ b/packages/agency-lang/lib/compiler/manifestTracker.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createManifestTracker, NOOP_TRACKER } from "./manifestTracker.js";
+import { loadManifest, MANIFEST_DIR_NAME } from "./buildManifest.js";
+
+function tmp(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-tracker-"));
+  fs.writeFileSync(path.join(dir, "main.agency"), "node main() {\n  return 1\n}\n");
+  fs.writeFileSync(path.join(dir, "main.js"), "// out");
+  return dir;
+}
+
+describe("createManifestTracker policy resolution", () => {
+  test("always → NOOP: no reads, no writes, no manifest file", () => {
+    const dir = tmp();
+    const tracker = createManifestTracker({}, path.join(dir, "main.agency"), "always", "{}");
+    expect(tracker).toBe(NOOP_TRACKER);
+    tracker.record(path.join(dir, "main.agency"), path.join(dir, "main.js"), [], false);
+    tracker.flush();
+    expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
+  });
+
+  test("incremental: record + flush round-trips through isFresh and outputFor", () => {
+    const dir = tmp();
+    const entry = path.join(dir, "main.agency");
+    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    expect(writer.isFresh(entry)).toBe(false); // nothing recorded yet
+    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.flush();
+    const reader = createManifestTracker({}, entry, "incremental", "{}");
+    expect(reader.isFresh(entry)).toBe(true);
+    expect(reader.allFresh([entry])).toBe(true);
+    expect(reader.outputFor(entry)).toBe(path.join(dir, "main.js"));
+  });
+
+  test("force: reads disabled, writes enabled", () => {
+    const dir = tmp();
+    const entry = path.join(dir, "main.agency");
+    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.flush();
+    const forced = createManifestTracker({}, entry, "force", "{}");
+    expect(forced.isFresh(entry)).toBe(false);
+    forced.record(entry, path.join(dir, "main.js"), [], false);
+    forced.flush();
+    expect(loadManifest(dir).entries["main.agency"]).toBeDefined();
+  });
+
+  test("configKey mismatch across trackers → stale", () => {
+    const dir = tmp();
+    const entry = path.join(dir, "main.agency");
+    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    writer.record(entry, path.join(dir, "main.js"), [], false);
+    writer.flush();
+    const other = createManifestTracker({}, entry, "incremental", '{"verbose":true}');
+    expect(other.isFresh(entry)).toBe(false);
+  });
+
+  test("hasPkgImports recorded true → never fresh", () => {
+    const dir = tmp();
+    const entry = path.join(dir, "main.agency");
+    const writer = createManifestTracker({}, entry, "incremental", "{}");
+    writer.record(entry, path.join(dir, "main.js"), [], true);
+    writer.flush();
+    const reader = createManifestTracker({}, entry, "incremental", "{}");
+    expect(reader.isFresh(entry)).toBe(false);
+  });
+
+  test("flush without records writes nothing", () => {
+    const dir = tmp();
+    createManifestTracker({}, path.join(dir, "main.agency"), "incremental", "{}").flush();
+    expect(fs.existsSync(path.join(dir, MANIFEST_DIR_NAME))).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/compiler/manifestTracker.ts
+++ b/packages/agency-lang/lib/compiler/manifestTracker.ts
@@ -15,6 +15,7 @@ import {
   computeCompilerStamp,
   computeDepsHash,
   computeStdlibHash,
+  deriveConfigKey,
   hashFile,
   isEntryFresh,
   loadManifest,
@@ -98,7 +99,9 @@ class RealManifestTracker implements ManifestTracker {
   outputFor(absModule: string): string | null {
     const rel = path.relative(this.manifestDir, absModule);
     const entry = this.manifest.entries[rel];
-    if (!entry) {
+    // Malformed manifests are recoverable everywhere else; a non-string
+    // outputPath (manual edit, older schema) must not throw here either.
+    if (!entry || typeof entry.outputPath !== "string") {
       return null;
     }
     return path.join(this.manifestDir, entry.outputPath);
@@ -132,15 +135,27 @@ class RealManifestTracker implements ManifestTracker {
 /** Policy is resolved HERE, once:
  *  "always" → the shared NOOP tracker (no state, no IO, isFresh always false)
  *  "force"  → real tracker with reads disabled, writes on
- *  "incremental" → real tracker, reads + writes on. */
+ *  "incremental" → real tracker, reads + writes on.
+ *  The tracker derives the config key itself — it owns every other piece
+ *  of freshness identity, and a caller-supplied key could mismatch the
+ *  config.
+ *
+ *  Perf note: each real tracker recomputes computeStdlibHash + the
+ *  compiler stamp + loadManifest; the warm-make path constructs one per
+ *  CLI input (~6). Fine today (warm make 2.5s) — if this ever regresses,
+ *  memoize PER SESSION, not module-level (watch mode can outlive a stdlib
+ *  edit). */
 export function createManifestTracker(
-  _config: AgencyConfig,
+  config: AgencyConfig,
   entryFile: string,
   freshness: Freshness,
-  configKey: string,
 ): ManifestTracker {
   if (freshness === "always") {
     return NOOP_TRACKER;
   }
-  return new RealManifestTracker(manifestDirFor(entryFile), freshness === "incremental", configKey);
+  return new RealManifestTracker(
+    manifestDirFor(entryFile),
+    freshness === "incremental",
+    deriveConfigKey(config),
+  );
 }

--- a/packages/agency-lang/lib/compiler/manifestTracker.ts
+++ b/packages/agency-lang/lib/compiler/manifestTracker.ts
@@ -1,0 +1,146 @@
+/**
+ * The single interpreter of freshness policy: it is resolved HERE, once
+ * per operation — call sites in the session are unconditional one-liners,
+ * and a no-op tracker absorbs the "always" case so no `freshness === ...`
+ * comparison exists outside this factory.
+ *
+ * Division of labor: the SESSION owns the closure (so it computes deps
+ * and hasPkgImports); the TRACKER owns policy, hashing, and storage.
+ */
+import * as path from "path";
+import { AgencyConfig } from "@/config.js";
+import { getStdlibDir } from "@/importPaths.js";
+import { fileURLToPath } from "url";
+import {
+  computeCompilerStamp,
+  computeDepsHash,
+  computeStdlibHash,
+  hashFile,
+  isEntryFresh,
+  loadManifest,
+  manifestDirFor,
+  saveManifest,
+  type BuildManifest,
+  type FreshnessContext,
+} from "./buildManifest.js";
+
+/** "incremental" consults and records the manifest; "force" recompiles
+ *  everything but rewrites it (--force); "always" is internal
+ *  (allowTestImports / --ts / caller-supplied importStrategy) and touches
+ *  nothing. */
+export type Freshness = "incremental" | "always" | "force";
+
+export type ManifestTracker = {
+  /** False unless policy allows reads AND the entry passes isEntryFresh. */
+  isFresh(absModule: string): boolean;
+  allFresh(absModules: string[]): boolean;
+  /** The recorded output path for a module (fast-path return value). */
+  outputFor(absModule: string): string | null;
+  /** No-op unless policy allows writes. deps/hasPkgImports supplied by the
+   *  session (it owns the closure); the tracker owns hashing and storage. */
+  record(absModule: string, absOutput: string, deps: string[], hasPkgImports: boolean): void;
+  /** Persist (atomic). No-op unless something was recorded. */
+  flush(): void;
+};
+
+export const NOOP_TRACKER: ManifestTracker = {
+  isFresh: () => false,
+  allFresh: () => false,
+  outputFor: () => null,
+  record: () => {},
+  flush: () => {},
+};
+
+class RealManifestTracker implements ManifestTracker {
+  private manifest: BuildManifest;
+  private ctx: FreshnessContext;
+  private dirty = false;
+
+  constructor(
+    private manifestDir: string,
+    private readsEnabled: boolean,
+    configKey: string,
+  ) {
+    this.manifest = loadManifest(manifestDir);
+    // The compiled compiler lives at dist/lib relative to this module
+    // (dist/lib/compiler/manifestTracker.js) — works for repo dev and
+    // installed packages alike. KNOWN + load-bearing-consistent: under
+    // vitest this module runs from lib/, so distLib resolves to the source
+    // tree with ~no .js — writer and checker agree on that (empty-ish)
+    // stamp, so tests are sound. Do not "fix" one side of this.
+    const distLib = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+    this.ctx = {
+      manifestDir,
+      stdlibHash: computeStdlibHash(getStdlibDir()),
+      compilerStamp: computeCompilerStamp(distLib),
+      configKey,
+    };
+  }
+
+  isFresh(absModule: string): boolean {
+    if (!this.readsEnabled) {
+      return false;
+    }
+    const rel = path.relative(this.manifestDir, absModule);
+    // Whole manifest, not one entry: freshness includes dep entries and
+    // dep OUTPUTS — a skip never recurses into deps, so a deleted dep .js
+    // would otherwise survive the skip and ship a broken import.
+    return isEntryFresh(rel, this.manifest, this.ctx);
+  }
+
+  allFresh(absModules: string[]): boolean {
+    if (absModules.length === 0) {
+      return false;
+    }
+    return absModules.every((m) => this.isFresh(m));
+  }
+
+  outputFor(absModule: string): string | null {
+    const rel = path.relative(this.manifestDir, absModule);
+    const entry = this.manifest.entries[rel];
+    if (!entry) {
+      return null;
+    }
+    return path.join(this.manifestDir, entry.outputPath);
+  }
+
+  record(absModule: string, absOutput: string, deps: string[], hasPkgImports: boolean): void {
+    const relDeps = deps.map((d) => path.relative(this.manifestDir, d)).sort();
+    const depHashes = relDeps.map((d) => hashFile(path.join(this.manifestDir, d)) ?? "");
+    this.manifest.entries[path.relative(this.manifestDir, absModule)] = {
+      sourceHash: hashFile(absModule) ?? "",
+      deps: relDeps,
+      depsHash: computeDepsHash(depHashes),
+      stdlibHash: this.ctx.stdlibHash,
+      hasPkgImports,
+      configKey: this.ctx.configKey,
+      compilerStamp: this.ctx.compilerStamp,
+      outputPath: path.relative(this.manifestDir, absOutput),
+    };
+    this.dirty = true;
+  }
+
+  flush(): void {
+    if (!this.dirty) {
+      return;
+    }
+    saveManifest(this.manifestDir, this.manifest);
+    this.dirty = false;
+  }
+}
+
+/** Policy is resolved HERE, once:
+ *  "always" → the shared NOOP tracker (no state, no IO, isFresh always false)
+ *  "force"  → real tracker with reads disabled, writes on
+ *  "incremental" → real tracker, reads + writes on. */
+export function createManifestTracker(
+  _config: AgencyConfig,
+  entryFile: string,
+  freshness: Freshness,
+  configKey: string,
+): ManifestTracker {
+  if (freshness === "always") {
+    return NOOP_TRACKER;
+  }
+  return new RealManifestTracker(manifestDirFor(entryFile), freshness === "incremental", configKey);
+}

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -113,7 +113,7 @@ fixtures:
 # includes the doc generator) changed. `make clean` wipes .agency-build
 # and forces regeneration.
 doc:
-	@STAMP=$$(node ./scripts/stdlib-stamp.mjs); \
+	@STAMP=$$(node ./dist/scripts/stdlib-stamp.js); \
 	if [ -f .agency-build/doc.stamp ] && [ "$$(cat .agency-build/doc.stamp)" = "$$STAMP" ]; then \
 	  echo "stdlib docs up to date"; \
 	else \

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -14,15 +14,13 @@ TSC_ALIAS := ./node_modules/.bin/tsc-alias
 AGENT_DIRS := review policy agency-agent eval optimize
 AGENT_PATHS := $(addprefix dist/lib/agents/,$(AGENT_DIRS))
 
-# Stage agent sources into dist. Wipe-then-copy, NOT overlay: with dist
-# persisting across builds, an overlay would keep outputs of agent sources
-# that were deleted from lib/agents. Safe to wipe: lib/agents contains no
-# .ts, so tsc emits nothing under dist/lib/agents — everything there is
-# agency-compiled from the sources this recipe just copied.
+# Sync-style staging (scripts/stage-agents.mjs): copies sources over,
+# deletes orphans (a removed foo.agency takes its foo.js), and never
+# deletes a compiled output whose source survives — the old rm -rf
+# recipe wiped every compiled agent .js and made incremental agent
+# skips impossible.
 define stage-agent-sources
-	mkdir -p dist/lib
-	rm -rf dist/lib/agents
-	cp -r lib/agents dist/lib
+	node ./scripts/stage-agents.mjs lib/agents dist/lib/agents
 endef
 
 # Stage the doc markdown the agents read at runtime. rm before cp -r:
@@ -111,8 +109,17 @@ fixtures:
 	pnpm run templates && pnpm run build
 	node dist/scripts/regenerate-fixtures.js
 
+# Regenerate stdlib docs only when stdlib content OR the compiler (which
+# includes the doc generator) changed. `make clean` wipes .agency-build
+# and forces regeneration.
 doc:
-	rm -rf docs/site/stdlib/ && node ./dist/scripts/agency.js doc stdlib -o docs/site/stdlib/
+	@STAMP=$$(node ./scripts/stdlib-stamp.mjs); \
+	if [ -f .agency-build/doc.stamp ] && [ "$$(cat .agency-build/doc.stamp)" = "$$STAMP" ]; then \
+	  echo "stdlib docs up to date"; \
+	else \
+	  rm -rf docs/site/stdlib/ && node ./dist/scripts/agency.js doc stdlib -o docs/site/stdlib/ && \
+	  mkdir -p .agency-build && echo "$$STAMP" > .agency-build/doc.stamp; \
+	fi
 
 # Documentable packages: each has an index.agency that `agency doc` reads.
 # (brave-search / tui / examples have no library source, so they're skipped.)

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -164,6 +164,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .description("Compile .agency file(s) or directory(s) to JavaScript")
     .argument("<inputs...>", "Paths to .agency input files or directories")
     .option("--ts", "Output .ts files with // @no-check header")
+    .option("--force", "Recompile everything, ignoring the incremental-build manifest")
     .option("-w, --watch", "Watch for changes and recompile")
     .option("--strict", "Fail on any fatal type error (typechecker.strict)")
     .option(
@@ -181,6 +182,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
         inputs: string[],
         opts: {
           ts?: boolean;
+          force?: boolean;
           watch?: boolean;
           strict?: boolean;
           maxToolCallRounds?: number;
@@ -200,7 +202,10 @@ export function createProgram(deps: CliDependencies = {}): Command {
           });
         } else {
           for (const input of inputs) {
-            compile(config, input, undefined, { ts: opts.ts });
+            compile(config, input, undefined, {
+              ts: opts.ts,
+              freshness: opts.force ? "force" : undefined,
+            });
           }
           // If installed globally, the user will hit ERR_MODULE_NOT_FOUND
           // if they try to `node` the output directly. Steer them toward

--- a/packages/agency-lang/scripts/stage-agents.d.mts
+++ b/packages/agency-lang/scripts/stage-agents.d.mts
@@ -1,0 +1,4 @@
+export function syncAgents(
+  srcDir: string,
+  destDir: string,
+): { copied: number; deleted: string[] };

--- a/packages/agency-lang/scripts/stage-agents.mjs
+++ b/packages/agency-lang/scripts/stage-agents.mjs
@@ -60,8 +60,10 @@ export function syncAgents(srcDir, destDir) {
   return { copied, deleted };
 }
 
+// path.resolve for robustness even though node absolutizes argv[1] for
+// direct invocations — free hardening against exotic launchers.
 const invokedDirectly =
-  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+  process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
 if (invokedDirectly) {
   const [src, dest] = process.argv.slice(2);
   if (!src || !dest) {

--- a/packages/agency-lang/scripts/stage-agents.mjs
+++ b/packages/agency-lang/scripts/stage-agents.mjs
@@ -1,0 +1,73 @@
+// Sync-style agent staging (spec "Agent staging"). Replaces the old
+// `rm -rf dist/lib/agents && cp -r` recipe, which deleted every compiled
+// agent output on every make and made incremental agent skips impossible.
+// Rules:
+//   1. copy every file from src over dest (overwrite);
+//   2. delete dest files whose source counterpart is gone — a deleted
+//      foo.agency takes its compiled foo.js with it;
+//   3. never touch dest/docs/ (owned by the stage-agent-docs recipe) and
+//      never delete a compiled .js whose .agency source survives.
+// Orphan safety is double-covered: this sync deletes orphans, and publish
+// still routes through `make clean`.
+//
+// The tree walk deliberately duplicates lib/cli/util.ts findRecursively:
+// this script must run on bare node BEFORE dist exists (make agents can
+// run right after make clean), so it cannot import compiled code.
+import fs from "fs";
+import path from "path";
+import { pathToFileURL } from "url";
+
+function walk(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const child = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(child, out);
+    } else {
+      out.push(child);
+    }
+  }
+  return out;
+}
+
+export function syncAgents(srcDir, destDir) {
+  fs.mkdirSync(destDir, { recursive: true });
+  let copied = 0;
+  for (const srcFile of walk(srcDir)) {
+    const rel = path.relative(srcDir, srcFile);
+    const destFile = path.join(destDir, rel);
+    fs.mkdirSync(path.dirname(destFile), { recursive: true });
+    fs.copyFileSync(srcFile, destFile);
+    copied++;
+  }
+  const deleted = [];
+  for (const destFile of walk(destDir)) {
+    const rel = path.relative(destDir, destFile);
+    if (rel === "docs" || rel.startsWith(`docs${path.sep}`)) {
+      continue;
+    }
+    if (fs.existsSync(path.join(srcDir, rel))) {
+      continue;
+    }
+    if (rel.endsWith(".js")) {
+      const agencySibling = rel.replace(/\.js$/, ".agency");
+      if (fs.existsSync(path.join(srcDir, agencySibling))) {
+        continue; // live compiled output
+      }
+    }
+    fs.unlinkSync(destFile);
+    deleted.push(rel);
+  }
+  return { copied, deleted };
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  const [src, dest] = process.argv.slice(2);
+  if (!src || !dest) {
+    console.error("usage: node stage-agents.mjs <srcDir> <destDir>");
+    process.exit(1);
+  }
+  const { copied, deleted } = syncAgents(src, dest);
+  console.log(`staged agents: ${copied} copied, ${deleted.length} orphans removed`);
+}

--- a/packages/agency-lang/scripts/stage-agents.test.ts
+++ b/packages/agency-lang/scripts/stage-agents.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { syncAgents } from "./stage-agents.mjs";
+
+function tree(spec: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "agency-stage-"));
+  for (const [rel, contents] of Object.entries(spec)) {
+    const target = path.join(root, rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, contents);
+  }
+  return root;
+}
+
+describe("syncAgents", () => {
+  test("copies sources over and preserves live compiled outputs", () => {
+    const src = tree({ "review/agent.agency": "src-v2" });
+    const dest = tree({
+      "review/agent.agency": "src-v1",
+      "review/agent.js": "compiled",
+    });
+    syncAgents(src, dest);
+    expect(fs.readFileSync(path.join(dest, "review/agent.agency"), "utf-8")).toBe("src-v2");
+    expect(fs.existsSync(path.join(dest, "review/agent.js"))).toBe(true);
+  });
+
+  test("deletes orphaned sources AND their compiled siblings", () => {
+    const src = tree({ "review/keep.agency": "k" });
+    const dest = tree({
+      "review/keep.agency": "k",
+      "review/gone.agency": "old-source",
+      "review/gone.js": "old-output",
+    });
+    const { deleted } = syncAgents(src, dest);
+    expect(fs.existsSync(path.join(dest, "review/gone.agency"))).toBe(false);
+    expect(fs.existsSync(path.join(dest, "review/gone.js"))).toBe(false);
+    expect(deleted.sort()).toEqual(["review/gone.agency", "review/gone.js"]);
+  });
+
+  test("never touches the docs/ subtree", () => {
+    const src = tree({ "review/agent.agency": "a" });
+    const dest = tree({ "docs/guide/x.md": "doc" });
+    syncAgents(src, dest);
+    expect(fs.existsSync(path.join(dest, "docs/guide/x.md"))).toBe(true);
+  });
+
+  test("creates dest when missing", () => {
+    const src = tree({ "review/agent.agency": "a" });
+    const dest = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "agency-stage-")), "not-yet");
+    syncAgents(src, dest);
+    expect(fs.readFileSync(path.join(dest, "review/agent.agency"), "utf-8")).toBe("a");
+  });
+});

--- a/packages/agency-lang/scripts/stdlib-stamp.mjs
+++ b/packages/agency-lang/scripts/stdlib-stamp.mjs
@@ -1,0 +1,19 @@
+// Prints the doc stamp: stdlib content hash COMBINED with the compiler
+// stamp. docs/site/stdlib/ is tracked and ships; its output depends on
+// the doc generator too, which lives inside the compilerStamp scope —
+// stdlibHash alone would leave tracked docs stale after a generator edit
+// until some unrelated stdlib change. Imports the canonical
+// implementations from dist (no duplication) — requires a built dist,
+// which `make all` guarantees (build runs before doc).
+import {
+  computeStdlibHash,
+  computeCompilerStamp,
+  hashBytes,
+} from "../dist/lib/compiler/buildManifest.js";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const stdlibHash = computeStdlibHash(path.join(packageRoot, "stdlib"));
+const compilerStamp = computeCompilerStamp(path.join(packageRoot, "dist", "lib"));
+console.log(hashBytes(stdlibHash + compilerStamp));

--- a/packages/agency-lang/scripts/stdlib-stamp.ts
+++ b/packages/agency-lang/scripts/stdlib-stamp.ts
@@ -9,6 +9,7 @@
 // runs from `make doc`, which `make all` sequences after `make build`, so
 // a built dist is guaranteed). Contrast scripts/stage-agents.mjs, which
 // must run on bare node before dist exists and therefore stays plain .mjs.
+import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import {
@@ -17,8 +18,19 @@ import {
   hashBytes,
 } from "@/compiler/buildManifest.js";
 
-// dist/scripts/stdlib-stamp.js → package root is one level up.
-const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const stdlibHash = computeStdlibHash(path.join(packageRoot, "stdlib"));
-const compilerStamp = computeCompilerStamp(path.join(packageRoot, "dist", "lib"));
+// This file executes as dist/scripts/stdlib-stamp.js → the package root
+// is TWO levels up (the .mjs predecessor lived at scripts/, one level up
+// — that off-by-one shipped a constant stamp once; hence the loud guards
+// below instead of hashTree's silent empty hash for missing dirs).
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const stdlibDir = path.join(packageRoot, "stdlib");
+const distLib = path.join(packageRoot, "dist", "lib");
+for (const required of [stdlibDir, distLib]) {
+  if (!fs.existsSync(required)) {
+    console.error(`stdlib-stamp: expected directory missing: ${required}`);
+    process.exit(1);
+  }
+}
+const stdlibHash = computeStdlibHash(stdlibDir);
+const compilerStamp = computeCompilerStamp(distLib);
 console.log(hashBytes(stdlibHash + compilerStamp));

--- a/packages/agency-lang/scripts/stdlib-stamp.ts
+++ b/packages/agency-lang/scripts/stdlib-stamp.ts
@@ -2,17 +2,22 @@
 // stamp. docs/site/stdlib/ is tracked and ships; its output depends on
 // the doc generator too, which lives inside the compilerStamp scope —
 // stdlibHash alone would leave tracked docs stale after a generator edit
-// until some unrelated stdlib change. Imports the canonical
-// implementations from dist (no duplication) — requires a built dist,
-// which `make all` guarantees (build runs before doc).
+// until some unrelated stdlib change.
+//
+// Written in TypeScript and compiled to dist/scripts/stdlib-stamp.js like
+// every other script (this is NOT part of the compile bootstrap — it only
+// runs from `make doc`, which `make all` sequences after `make build`, so
+// a built dist is guaranteed). Contrast scripts/stage-agents.mjs, which
+// must run on bare node before dist exists and therefore stays plain .mjs.
+import * as path from "path";
+import { fileURLToPath } from "url";
 import {
   computeStdlibHash,
   computeCompilerStamp,
   hashBytes,
-} from "../dist/lib/compiler/buildManifest.js";
-import path from "path";
-import { fileURLToPath } from "url";
+} from "@/compiler/buildManifest.js";
 
+// dist/scripts/stdlib-stamp.js → package root is one level up.
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const stdlibHash = computeStdlibHash(path.join(packageRoot, "stdlib"));
 const compilerStamp = computeCompilerStamp(path.join(packageRoot, "dist", "lib"));


### PR DESCRIPTION
## What

Stage A, PR 2 of the incremental-builds work (spec: `docs/superpowers/specs/2026-07-08-incremental-builds-design.md`; plan: `docs/superpowers/plans/2026-07-09-incremental-manifest.md`, both review-hardened): the content-hash **build manifest**. The compiler now skips recompiling `.agency` files whose inputs are unchanged, with correctness carried by conservative invalidation fields that can only over-rebuild:

- `lib/compiler/buildManifest.ts` (leaf module, no new import-cycle edge): manifest types, atomic IO, hashing, the shared `computeDepsHash`, and `isEntryFresh` — freshness of a module requires its source, every recorded transitive dep (source AND compiled output AND manifest entry), `stdlibHash`, `compilerStamp`, `configKey`, and its own output to all check out.
- `lib/compiler/manifestTracker.ts`: freshness policy is interpreted in exactly ONE place — the tracker factory. "always" (test runner, `--ts`, any caller-supplied importStrategy — the run/coverage paths, whose RunStrategy shapes emitted bytes) gets a shared no-op tracker; `--force` gets reads-off/writes-on. Session call sites are unconditional one-liners.
- `BuildSession` public interface collapses to one entries-based `compile(config, { entries, ... })` with the fully-clean fast path in the single dispatch: a clean entry set performs zero parses (proven by parse-cache-stats tests).
- `agency compile --force` is the escape hatch; `make clean` remains the full reset.
- `make` integration: agent staging becomes a sync script (`scripts/stage-agents.mjs`) that stops deleting compiled agent outputs (the old `rm -rf` made agent skips impossible), and `make doc` gets a stamp keyed on stdlibHash + compilerStamp so doc-generator edits regenerate tracked docs.
- Dev doc: `docs/dev/incremental-builds.md` (linked from CLAUDE.md).

## Measured (M-series laptop)

| Scenario | Result |
|---|---|
| warm `make`, no changes | **2.5s** (was 6.9s; 16.8s before Stage C) — all 96 modules skip, zero parses |
| cold (`make clean && make`) | 11.9s |
| touch one agent `.agency` | recompiles exactly 1 file |
| touch any stdlib file | rebuilds the world (96) via `stdlibHash` — required: `resolveReExports` bakes stdlib paths into output |
| edit `lib/runtime/*.ts` | zero agency recompiles (stamp exclusion) |
| real codegen edit | rebuilds all 96 AND regenerates docs |
| whitespace-only compiler edit | zero rebuilds (content-hash stamp sees identical emitted `.js`) |
| `touch stdlib/*.agency` (mtime churn) | zero rebuilds |

**Purity gate**: after the full edit matrix, the incremental tree is hash-identical to a from-scratch `make clean && make` across all 96 compiled files — a skipped module's bytes never depend on which closure it was originally compiled under.

## Verification

Full vitest (7537), lint, fixtures diff-clean, 74-file agency execution slice, agents suite, and the boundary proofs: the test runner leaves no manifest entries for test sources; strategy compiles never skip in either direction; `export { x } from "pkg::…"` modules are never skipped (detection shares the closure walker across all three import-edge node types).

## Found during execution (pre-existing, not fixed here)

The built-in agent settings tests (`lib/agents/agency-agent/tests/settings.agency`) read and write the REAL `~/.agency-agent/settings.json` — every local `test:agents` run clobbers the user's actual settings, and under `-p 12` the shared file races (one such race failed a run of this verification; the suite passes in isolation and on rerun). Needs a sandboxed settings path — issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
