### PR TITLE
Sandbox the agent home in tests via AGENCY_AGENT_HOME (fixes #469)

### DIFF
--- a/packages/agency-lang/docs/site/cli/agent.md
+++ b/packages/agency-lang/docs/site/cli/agent.md
@@ -14,3 +14,19 @@ agency agent
 Launches the Agency language assistant agent — an LLM agent that knows about Agency's syntax, standard library, and idioms. You can ask it to write Agency code, explain language features, debug an error, or walk through a piece of code with you.
 
 This is a convenient way to get help with Agency without leaving your terminal.
+
+## The agent home directory
+
+The agent keeps its state — `settings.json`, `policy.json`, and conversation history — in `~/.agency-agent`. You can point it at a different directory:
+
+```
+agency agent --agent-home /path/to/dir
+```
+
+or with the `AGENCY_AGENT_HOME` environment variable:
+
+```
+AGENCY_AGENT_HOME=/path/to/dir agency agent
+```
+
+The flag wins when both are set. An empty value is treated as unset. This is useful for keeping separate agent profiles (say, different policies or model settings per project), and for sandboxing: the test harness uses it to give every test its own throwaway agent home so runs never touch your real `~/.agency-agent`.

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -1607,6 +1607,10 @@ node main() {
         optional: true,
         description: "Approval policy for this run: a built-in name (minimal, recommended, with-writes, approve-all) or a path to a policy JSON file. with-writes auto-approves file writes and git changes scoped to the current directory and its children; approve-all approves EVERY interrupt with no scoping (sandbox use only). Overrides the saved policy without persisting it. Pass --policy with no value to list the built-in policies."
       },
+      "agent-home": {
+        type: "string",
+        description: "Directory to use instead of ~/.agency-agent for settings, policy, and history (equivalent to the AGENCY_AGENT_HOME env var; the flag wins when both are set)"
+      },
       local: {
         type: "string",
         optional: true,
@@ -1638,11 +1642,14 @@ node main() {
   },
   )
 
-  // NOTE: --trace / --log-file are declared here only for --help and so
-  // parseArgs accepts them. runBundledAgent extracts them from the forwarded
-  // args and passes them to this process as the AGENCY_CONFIG_OVERRIDES env
-  // var, read when the RuntimeContext is constructed — before this main() runs.
-  // Do not re-handle them here.
+  // NOTE: --trace / --log-file / --agent-home are declared here only for
+  // --help and so parseArgs accepts them. runBundledAgent extracts them from
+  // the forwarded args and passes them to this process via env vars
+  // (AGENCY_CONFIG_OVERRIDES for the first two, AGENCY_AGENT_HOME for the
+  // last), read before this main() runs — the RuntimeContext consumes the
+  // config overrides at construction, and lib/config.agency derives the
+  // settings/policy/history paths from the agent home in its static-const
+  // initializers. Do not re-handle them here.
 
   if (args.flags.debug) {
     AGENT_DEBUG = true

--- a/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
@@ -6,13 +6,25 @@ import { env } from "std::system"
 export static const agentNames = ["code", "research"]
 export static const POLICY_FILE = "policy.json"
 export static const HISTORY_FILE = "history"
-// AGENCY_AGENT_HOME redirects the WHOLE agent home (settings, policy,
-// history all derive from POLICY_DIR). The test harness sets it to a
-// per-test sandbox dir so tests can never clobber the real
-// ~/.agency-agent (issue #469: the settings tests deleted/corrupted the
-// developer file on every local run, and the shared file raced under
-// the parallel runner).
-export static const POLICY_DIR = env("AGENCY_AGENT_HOME") ?? path.join(os.homedir(), ".agency-agent")
+// AGENCY_AGENT_HOME (or its flag form, `agency agent --agent-home`,
+// which the CLI launcher injects into this process's env) redirects the
+// WHOLE agent home: settings, policy, and history all derive from
+// POLICY_DIR. The test harness sets it to a per-test sandbox dir so
+// tests can never clobber the real ~/.agency-agent (issue #469: the
+// settings tests deleted/corrupted the developer file on every local
+// run, and the shared file raced under the parallel runner).
+//
+// An empty override counts as unset: env() returns "" for a
+// set-but-empty var, and without the guard every derived path would
+// silently become cwd-relative (a stray `settings.json` written into —
+// or read from — whatever directory the agent runs in).
+def resolveAgentHome(override: string | null): string {
+  if (override == null || override == "") {
+    return path.join(os.homedir(), ".agency-agent")
+  }
+  return override
+}
+export static const POLICY_DIR = resolveAgentHome(env("AGENCY_AGENT_HOME"))
 export static const POLICY_PATH = path.join(POLICY_DIR, POLICY_FILE)
 // A --policy built-in is materialized here (not to POLICY_PATH) so a
 // one-off override never clobbers the user's saved policy, and a

--- a/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
@@ -1,11 +1,18 @@
 import {
   ScopedRuleFields
  } from "std::policy"
+import { env } from "std::system"
 
 export static const agentNames = ["code", "research"]
 export static const POLICY_FILE = "policy.json"
 export static const HISTORY_FILE = "history"
-export static const POLICY_DIR = path.join(os.homedir(), ".agency-agent")
+// AGENCY_AGENT_HOME redirects the WHOLE agent home (settings, policy,
+// history all derive from POLICY_DIR). The test harness sets it to a
+// per-test sandbox dir so tests can never clobber the real
+// ~/.agency-agent (issue #469: the settings tests deleted/corrupted the
+// developer file on every local run, and the shared file raced under
+// the parallel runner).
+export static const POLICY_DIR = env("AGENCY_AGENT_HOME") ?? path.join(os.homedir(), ".agency-agent")
 export static const POLICY_PATH = path.join(POLICY_DIR, POLICY_FILE)
 // A --policy built-in is materialized here (not to POLICY_PATH) so a
 // one-off override never clobbers the user's saved policy, and a

--- a/packages/agency-lang/lib/cli/runBundledAgent.test.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.test.ts
@@ -8,7 +8,12 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 import { CONFIG_OVERRIDES_ENV } from "@/config.js";
-import { agentConfigOverride, runBundledAgent } from "./runBundledAgent.js";
+import * as path from "path";
+import {
+  agentConfigOverride,
+  agentHomeOverride,
+  runBundledAgent,
+} from "./runBundledAgent.js";
 
 describe("agentConfigOverride", () => {
   it("--trace <file> → traceFile", () => {
@@ -71,9 +76,31 @@ describe("agentConfigOverride", () => {
   });
 });
 
+describe("agentHomeOverride", () => {
+  it("--agent-home <dir> → absolute path, space and attached forms", () => {
+    expect(agentHomeOverride(["--agent-home", "/x/home"])).toBe("/x/home");
+    expect(agentHomeOverride(["--agent-home=/x/home"])).toBe("/x/home");
+  });
+  it("resolves a relative dir against cwd", () => {
+    expect(agentHomeOverride(["--agent-home", "rel"])).toBe(
+      path.resolve("rel"),
+    );
+  });
+  it("bare --agent-home (or one followed by a flag) is ignored, not a dir named --print", () => {
+    expect(agentHomeOverride(["--agent-home"])).toBeNull();
+    expect(agentHomeOverride(["--agent-home", "--print"])).toBeNull();
+    expect(agentHomeOverride(["--agent-home="])).toBeNull();
+  });
+  it("null when the flag is absent, stops at the -- terminator", () => {
+    expect(agentHomeOverride(["--print", "hi"])).toBeNull();
+    expect(agentHomeOverride(["--", "--agent-home", "/x"])).toBeNull();
+  });
+});
+
 describe("runBundledAgent passes config overrides to the child via env", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("serializes the override into AGENCY_CONFIG_OVERRIDES", () => {
@@ -102,5 +129,23 @@ describe("runBundledAgent passes config overrides to the child via env", () => {
     runBundledAgent({}, "agency-agent", ["--print", "hi"], { spawn: spawnMock as never });
     const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
     expect(opts.env[CONFIG_OVERRIDES_ENV]).toBeUndefined();
+  });
+
+  it("--agent-home sets AGENCY_AGENT_HOME in the child env, beating an inherited value", () => {
+    vi.stubEnv("AGENCY_AGENT_HOME", "/from/env");
+    const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
+    runBundledAgent({}, "agency-agent", ["--agent-home", "/from/flag", "hi"], {
+      spawn: spawnMock as never,
+    });
+    const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
+    expect(opts.env.AGENCY_AGENT_HOME).toBe("/from/flag");
+  });
+
+  it("without the flag, an inherited AGENCY_AGENT_HOME passes through untouched", () => {
+    vi.stubEnv("AGENCY_AGENT_HOME", "/from/env");
+    const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
+    runBundledAgent({}, "agency-agent", ["hi"], { spawn: spawnMock as never });
+    const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
+    expect(opts.env.AGENCY_AGENT_HOME).toBe("/from/env");
   });
 });

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -13,19 +13,20 @@ import { parseArgs } from "node:util";
 
 const currentDir = path.dirname(new URL(import.meta.url).pathname);
 
-// The debug flags every bundled agent understands. Same names the agent
-// declares (for --help) and that `agency run` accepts.
-const AGENT_DEBUG_FLAGS = ["--trace", "--log-file"] as const;
+// The flags every bundled agent understands that this launcher pre-scans
+// out of the forwarded argv (the agent also declares them, for --help).
+const AGENT_PRESCAN_FLAGS = ["--trace", "--log-file", "--agent-home"] as const;
 
 /**
- * Rewrite a bare debug flag to its empty attached form (`--trace` → `--trace=`)
- * when its next token is absent or starts with `-`. This replicates exactly
- * what `std::args` does before parsing (lib/stdlib/args.ts:499-505), so the
- * agent's own parser and this pre-scan agree: `--trace --print` and `--trace
- * -p` are BOTH bare here, not a trace file named "--print" / "-p". Stops at the
- * `--` terminator (everything after is positional).
+ * Rewrite a bare pre-scanned flag to its empty attached form (`--trace` →
+ * `--trace=`) when its next token is absent or starts with `-`. This
+ * replicates exactly what `std::args` does before parsing
+ * (lib/stdlib/args.ts:499-505), so the agent's own parser and this pre-scan
+ * agree: `--trace --print` and `--trace -p` are BOTH bare here, not a trace
+ * file named "--print" / "-p". Stops at the `--` terminator (everything after
+ * is positional).
  */
-function normalizeBareDebugFlags(args: string[]): string[] {
+function normalizeBareFlags(args: string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const token = args[i];
@@ -33,7 +34,7 @@ function normalizeBareDebugFlags(args: string[]): string[] {
       out.push(...args.slice(i));
       break;
     }
-    if ((AGENT_DEBUG_FLAGS as readonly string[]).includes(token)) {
+    if ((AGENT_PRESCAN_FLAGS as readonly string[]).includes(token)) {
       const next = args[i + 1];
       const bare = next === undefined || next === "--" || next.startsWith("-");
       out.push(bare ? `${token}=` : token);
@@ -58,7 +59,7 @@ function normalizeBareDebugFlags(args: string[]): string[] {
  */
 export function agentConfigOverride(args: string[]): Partial<AgencyConfig> {
   const { values } = parseArgs({
-    args: normalizeBareDebugFlags(args),
+    args: normalizeBareFlags(args),
     options: { trace: { type: "string" }, "log-file": { type: "string" } },
     strict: false,
     allowPositionals: true,
@@ -73,6 +74,29 @@ export function agentConfigOverride(args: string[]): Partial<AgencyConfig> {
     flags.logFile = values["log-file"];
   }
   return applyCliFlags({}, flags);
+}
+
+/**
+ * Extract `--agent-home <dir>` — the flag form of the AGENCY_AGENT_HOME env
+ * var — from a bundled agent's forwarded argv, using the same pre-scan
+ * tokenization rules as `agentConfigOverride`. Returns the directory resolved
+ * to an absolute path (the child would otherwise resolve a relative one
+ * against whatever its cwd happens to be), or null when the flag is absent or
+ * bare. A bare `--agent-home` is a usage error the agent's own parser
+ * reports, so it is only skipped here, never defaulted.
+ */
+export function agentHomeOverride(args: string[]): string | null {
+  const { values } = parseArgs({
+    args: normalizeBareFlags(args),
+    options: { "agent-home": { type: "string" } },
+    strict: false,
+    allowPositionals: true,
+  });
+  const home = values["agent-home"];
+  if (typeof home !== "string" || home === "") {
+    return null;
+  }
+  return path.resolve(home);
 }
 
 export function runBundledAgent(
@@ -101,13 +125,18 @@ export function runBundledAgent(
   }
 
   const overrides = agentConfigOverride(args);
-  const env =
-    Object.keys(overrides).length > 0
-      ? {
-          ...process.env,
-          [CONFIG_OVERRIDES_ENV]: serializeConfigOverrides(overrides),
-        }
-      : process.env;
+  const agentHome = agentHomeOverride(args);
+  const env = { ...process.env };
+  if (Object.keys(overrides).length > 0) {
+    env[CONFIG_OVERRIDES_ENV] = serializeConfigOverrides(overrides);
+  }
+  // The agent home must be in the env before the child starts: the agent's
+  // config module derives its settings/policy/history paths from it in
+  // static-const initializers, which run before the agent's main() could
+  // parse any flag. The flag beats an inherited AGENCY_AGENT_HOME.
+  if (agentHome !== null) {
+    env.AGENCY_AGENT_HOME = agentHome;
+  }
 
   const nodeProcess = spawn(
     process.execPath,

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -2,6 +2,7 @@ import { parseAgency } from "@/parser.js";
 import { GraphNodeDefinition } from "@/types.js";
 import { getNodesOfType } from "@/utils/node.js";
 import fs from "fs";
+import os from "os";
 import prompts from "prompts";
 import {
   execFileAsync,
@@ -1062,11 +1063,18 @@ async function runTsTestDir(
       !!process.env.AGENCY_USE_TEST_LLM_PROVIDER ||
       fs.existsSync(path.join(dir, "useTestLLMProvider"));
     let mocksEnv: Record<string, string> = {};
+    let agentHomeCleanup: (() => void) | undefined;
     if (useDeterministic) {
       const mocks = fs.existsSync(mocksFile)
         ? fs.readFileSync(mocksFile, "utf-8")
         : "[]";
       mocksEnv = { AGENCY_LLM_MOCKS: mocks };
+      // Same agent-home sandbox as executeNodeAsync (issue #469).
+      const agentHome = fs.mkdtempSync(path.join(os.tmpdir(), "agency-agent-home-"));
+      mocksEnv.AGENCY_AGENT_HOME = agentHome;
+      agentHomeCleanup = () => {
+        fs.rmSync(agentHome, { recursive: true, force: true });
+      };
     }
 
     // Fetch mocks activate independently of the LLM deterministic flag: the
@@ -1099,6 +1107,7 @@ async function runTsTestDir(
       return { success: false, dir };
     } finally {
       fetchMocksCleanup?.();
+      agentHomeCleanup?.();
     }
 
     if (!fs.existsSync(resultFile)) {

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -4,6 +4,7 @@ const onCancel = () => {
   process.exit(0);
 };
 import fs, { readFileSync } from "fs";
+import os from "os";
 import path from "path";
 import { execFile, execFileSync } from "child_process";
 import { promisify } from "util";
@@ -384,6 +385,19 @@ export async function executeNodeAsync({
     ? { AGENCY_LLM_MOCKS: JSON.stringify(llmMocks ?? []) }
     : {};
 
+  // Sandbox the agent home per test case: the agent config derives every
+  // ~/.agency-agent path from AGENCY_AGENT_HOME when set, so tests can
+  // never delete/corrupt the developer's real settings or race each other
+  // on the shared file (issue #469).
+  let agentHomeCleanup: (() => void) | undefined;
+  if (useDeterministic) {
+    const agentHome = fs.mkdtempSync(path.join(os.tmpdir(), "agency-agent-home-"));
+    env.AGENCY_AGENT_HOME = agentHome;
+    agentHomeCleanup = () => {
+      fs.rmSync(agentHome, { recursive: true, force: true });
+    };
+  }
+
   // Activate the fetch shim whenever fetchMocks is *defined* — an empty array
   // means "this test may make no fetch calls" and must still install the shim
   // (so any fetch throws), matching the llmMocks precedent. `undefined` means
@@ -399,6 +413,7 @@ export async function executeNodeAsync({
     return await runAgencyNode({ ...rest, env });
   } finally {
     fetchMocksCleanup?.();
+    agentHomeCleanup?.();
   }
 }
 

--- a/packages/agency-lang/tests/agency/agent-home-resolve.agency
+++ b/packages/agency-lang/tests/agency/agent-home-resolve.agency
@@ -1,0 +1,21 @@
+import test { resolveAgentHome } from "../../lib/agents/agency-agent/lib/config.agency"
+
+// resolveAgentHome turns the AGENCY_AGENT_HOME override (env var or
+// --agent-home flag) into the agent home directory. The load-bearing
+// case is the empty string: env("AGENCY_AGENT_HOME") returns "" when the
+// var is set-but-empty, and without the guard every derived path
+// (settings.json, policy.json, history) would silently become
+// cwd-relative — a destructive footgun.
+node main(): string {
+  if (resolveAgentHome("/custom/home") != "/custom/home") {
+    return "override ignored: ${resolveAgentHome("/custom/home")}"
+  }
+  const defaultHome = resolveAgentHome(null)
+  if (!defaultHome.endsWith(".agency-agent")) {
+    return "default is not ~/.agency-agent: ${defaultHome}"
+  }
+  if (resolveAgentHome("") != defaultHome) {
+    return "empty string not treated as unset: ${resolveAgentHome("")}"
+  }
+  return "ok"
+}

--- a/packages/agency-lang/tests/agency/agent-home-resolve.test.json
+++ b/packages/agency-lang/tests/agency/agent-home-resolve.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "resolveAgentHome honors a non-empty override, falls back to ~/.agency-agent when the override is null, and treats an empty string the same as unset (an empty AGENCY_AGENT_HOME must not turn the settings/policy paths into cwd-relative paths)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/agent-home-sandbox.agency
+++ b/packages/agency-lang/tests/agency/agent-home-sandbox.agency
@@ -1,0 +1,17 @@
+import { env } from "std::system"
+import { POLICY_DIR } from "../../lib/agents/agency-agent/lib/config.agency"
+
+// Under the test harness, AGENCY_AGENT_HOME must be set to a sandbox dir
+// and the agent's POLICY_DIR (from which settings/policy/history paths all
+// derive) must resolve to it — so tests can never touch the developer's
+// real ~/.agency-agent (issue #469).
+node main(): string {
+  const sandbox = env("AGENCY_AGENT_HOME")
+  if (sandbox == null) {
+    return "AGENCY_AGENT_HOME not set"
+  }
+  if (POLICY_DIR != sandbox) {
+    return "POLICY_DIR ignores the override: ${POLICY_DIR}"
+  }
+  return "sandboxed"
+}

--- a/packages/agency-lang/tests/agency/agent-home-sandbox.test.json
+++ b/packages/agency-lang/tests/agency/agent-home-sandbox.test.json
@@ -3,9 +3,10 @@
     {
       "nodeName": "main",
       "input": "",
+      "useTestLLMProvider": true,
       "expectedOutput": "\"sandboxed\"",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "The test harness sets AGENCY_AGENT_HOME to a per-test sandbox dir, and the agent config resolves POLICY_DIR (hence settings/policy/history paths) to it instead of the real ~/.agency-agent (issue #469)."
+      "description": "The test harness sets AGENCY_AGENT_HOME to a per-test sandbox dir (only in deterministic mode, hence useTestLLMProvider), and the agent config resolves POLICY_DIR (hence settings/policy/history paths) to it instead of the real ~/.agency-agent (issue #469)."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/agent-home-sandbox.test.json
+++ b/packages/agency-lang/tests/agency/agent-home-sandbox.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"sandboxed\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "The test harness sets AGENCY_AGENT_HOME to a per-test sandbox dir, and the agent config resolves POLICY_DIR (hence settings/policy/history paths) to it instead of the real ~/.agency-agent (issue #469)."
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #469: the agent settings tests read and wrote the REAL `~/.agency-agent/settings.json` — every local `test:agents` run destroyed the developer settings (leaving test fixture data behind), and the shared file raced under `-p 12` (observed: `roundTripsModelSlots` loading mid-corruption).

## Fix

One env var at the root of the path derivation, plus the harness setting it:

- `lib/agents/agency-agent/lib/config.agency`: `POLICY_DIR = env("AGENCY_AGENT_HOME") ?? path.join(os.homedir(), ".agency-agent")`. Settings, policy, session-policy, and history paths all derive from `POLICY_DIR`, so the whole agent home redirects at once.
- The test harness sets `AGENCY_AGENT_HOME` to a fresh temp dir per test case (`executeNodeAsync`, deterministic mode only) and per agency-js test dir (`runTsTestDir`), removed after the subprocess exits. Non-test paths are untouched — the var is only set where `AGENCY_LLM_MOCKS` already is.
- Per-case isolation also dissolves the `-p 12` race: no two test cases share a home anymore.

## Verification

- New execution test (`tests/agency/agent-home-sandbox.agency`): the harness sets the sandbox and `POLICY_DIR` resolves to it (was RED before the fix).
- **Acceptance**: full `test:agents` (16 files green, including the settings suite that raced) with the real `~/.agency-agent/settings.json` hash- and mtime-identical before/after.
- Full vitest suite, agency + agency-js slices, lint clean. (Three `scripts/agency.test.ts` CLI-spawn tests timed out at 5s under full-suite machine load; 11/11 in isolation — pre-existing load sensitivity, unrelated paths.)

## Review follow-ups (da802a9b)

- **New `agency agent --agent-home <dir>` flag** (review ask): use that directory instead of `~/.agency-agent` for settings, policy, and history — the user-facing form of the env var, mirroring Claude Code's `CLAUDE_CONFIG_DIR` + flag pair. Implemented via the existing `--trace`/`--log-file` mechanism: `runBundledAgent` pre-scans the forwarded argv (`agentHomeOverride`, same std::args-matching tokenization) and injects `AGENCY_AGENT_HOME` into the child env, since the agent derives its paths in static-const initializers that run before `main()` parses flags. Flag beats env var; dir resolved absolute; bare `--agent-home` is a usage error. Documented in `docs/site/cli/agent.md`.
- **Empty-string guard** (Copilot): a set-but-empty `AGENCY_AGENT_HOME` previously passed the `??` fallback and made every derived path cwd-relative. `resolveAgentHome` now treats `""` as unset (`tests/agency/agent-home-resolve.agency`).
- `agent-home-sandbox.test.json` pins `useTestLLMProvider` so the sandbox assertion also holds on a single-file `agency test` run.

Verification for the follow-ups: `lib/cli` vitest slice 360/360 (incl. new `agentHomeOverride` + spawn-env cases), full `test:agents` 152/152, both agency execution tests, lint clean, `--help`/bare-flag smoke.

Note for reviewers: your local `~/.agency-agent/settings.json` currently contains test residue from before this fix — worth reconfiguring model slots after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

