### PR TITLE
std::http: POST-with-body support (method + body, gate-able via policy/PFA)

### DIFF
--- a/packages/agency-lang/docs/dev/adding-connectors.md
+++ b/packages/agency-lang/docs/dev/adding-connectors.md
@@ -269,14 +269,15 @@ Only add the **semantic** effect (`std::littlesis`) — `std::http::fetchJSON` i
 If a connector has natural allow/deny defaults, consider exporting a ready-made `std::policy`
 (`stdlib/policy.agency`) so users don't have to hand-write a handler. A policy is
 declarative data keyed by effect with glob `match` on the payload, and — because the payload has an
-`op` discriminant and the fetch carries `{ baseUrl, path }` — it can gate per-operation or
-per-domain today. An exported policy **must be `static`** (globals can't be exported):
+`op` discriminant and the fetch carries `{ baseUrl, path, method }` — it can gate per-operation,
+per-domain, or per-method (e.g. allow GETs, deny POSTs). An exported policy **must be `static`**
+(globals can't be exported):
 
 ```
 export static const POLICY: Policy = {
   "std::littlesis": [{ action: "approve" }],
   "std::http::fetchJSON": [
-    { match: { baseUrl: "https://littlesis.org/api" }, action: "approve" },
+    { match: { baseUrl: "https://littlesis.org/api", method: "GET" }, action: "approve" },
     { action: "reject" }
   ]
 }
@@ -317,8 +318,8 @@ test. Copy `tests/agency-js/data-people-littlesis/`.
   a real captured body over a hand-authored one — a wrong field path otherwise ships green.)*
 - **Interrupt gating** — assert (a) rejecting the semantic effect short-circuits before any fetch;
   (b) a plain caller sees only the semantic effect; (c) an outer handler that `propagate()`s the
-  fetch surfaces `std::http::fetchJSON` with the exact `{ baseUrl, path }` — this proves the wiring
-  *and* the built URL **offline, with no network**; (d) invalid input fails before the interrupt.
+  fetch surfaces `std::http::fetchJSON` with the exact `{ baseUrl, path, method }` — this proves the
+  wiring *and* the built URL **offline, with no network**; (d) invalid input fails before the interrupt.
 - **Capability** — a `node netCheck() raises <Network>` that calls the connector (compile-only).
 
 **Live** (`*-live/`, gated on `AGENCY_LIVE_TESTS`): a real end-to-end call, `{ skipped: true }` by

--- a/packages/agency-lang/docs/site/stdlib/http.md
+++ b/packages/agency-lang/docs/site/stdlib/http.md
@@ -21,11 +21,17 @@ Fetch URLs from Agency code. Returns the response as text, JSON, or Markdown.
 
 ### HttpMethod
 
-An HTTP request method. Non-GET methods may carry a body.
+An HTTP request method. POST/PUT/PATCH/DELETE may carry a body; GET/HEAD do not.
 
 ```ts
-/** An HTTP request method. Non-GET methods may carry a body. */
-export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+/** An HTTP request method. POST/PUT/PATCH/DELETE may carry a body; GET/HEAD do not. */
+export type HttpMethod =
+  | "GET"
+  | "HEAD"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L29))
@@ -73,7 +79,7 @@ effect std::http::fetchMarkdown {
 ### fetch
 
 ```ts
-fetch(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: any): Result
+fetch(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: Record<string, any> | string | null): Result
 ```
 
 Fetch a URL and return the response as text.
@@ -98,7 +104,7 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 | headers | `Record<string, any>` | {} |
 | allowedDomains | `string[]` | [] |
 | method | [HttpMethod](#httpmethod) | "GET" |
-| body | `any` | null |
+| body | `Record<string, any> \| string \| null` | null |
 
 **Returns:** `Result`
 
@@ -109,7 +115,7 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 ### fetchJSON
 
 ```ts
-fetchJSON(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: any): Result
+fetchJSON(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: Record<string, any> | string | null): Result
 ```
 
 Fetch a URL and return the response parsed as JSON.
@@ -134,7 +140,7 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 | headers | `Record<string, any>` | {} |
 | allowedDomains | `string[]` | [] |
 | method | [HttpMethod](#httpmethod) | "GET" |
-| body | `any` | null |
+| body | `Record<string, any> \| string \| null` | null |
 
 **Returns:** `Result`
 
@@ -145,7 +151,7 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 ### fetchMarkdown
 
 ```ts
-fetchMarkdown(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: any): Result
+fetchMarkdown(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: Record<string, any> | string | null): Result
 ```
 
 Fetch a URL and return the body as readable markdown when the response is HTML, or as plain text otherwise. Good for extracting page content for an LLM. Fails on network errors, domain violations, or if the response body exceeds 10 MB.
@@ -170,7 +176,7 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 | headers | `Record<string, any>` | {} |
 | allowedDomains | `string[]` | [] |
 | method | [HttpMethod](#httpmethod) | "GET" |
-| body | `any` | null |
+| body | `Record<string, any> \| string \| null` | null |
 
 **Returns:** `Result`
 

--- a/packages/agency-lang/docs/site/stdlib/http.md
+++ b/packages/agency-lang/docs/site/stdlib/http.md
@@ -17,6 +17,19 @@ Fetch URLs from Agency code. Returns the response as text, JSON, or Markdown.
   }
   ```
 
+## Types
+
+### HttpMethod
+
+An HTTP request method. Non-GET methods may carry a body.
+
+```ts
+/** An HTTP request method. Non-GET methods may carry a body. */
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L29))
+
 ## Effects
 
 ### std::http::fetch
@@ -24,7 +37,8 @@ Fetch URLs from Agency code. Returns the response as text, JSON, or Markdown.
 ```ts
 effect std::http::fetch {
   baseUrl: string;
-  path: string
+  path: string;
+  method: string
 }
 ```
 
@@ -35,7 +49,8 @@ effect std::http::fetch {
 ```ts
 effect std::http::fetchJSON {
   baseUrl: string;
-  path: string
+  path: string;
+  method: string
 }
 ```
 
@@ -46,7 +61,8 @@ effect std::http::fetchJSON {
 ```ts
 effect std::http::fetchMarkdown {
   baseUrl: string;
-  path: string
+  path: string;
+  method: string
 }
 ```
 
@@ -57,7 +73,7 @@ effect std::http::fetchMarkdown {
 ### fetch
 
 ```ts
-fetch(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[]): Result
+fetch(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: any): Result
 ```
 
 Fetch a URL and return the response as text.
@@ -66,6 +82,8 @@ Fetch a URL and return the response as text.
   @param path - Optional path appended to baseUrl
   @param headers - Custom request headers
   @param allowedDomains - Restrict fetches to these domains (empty allows all)
+  @param method - The HTTP method
+  @param body - Request body: a string is sent as-is, a non-string is sent as JSON
 
 On abort, Agency tears down the in-flight HTTP request and body read. The
   abort surfaces as an AgencyCancelledError that propagates out of the
@@ -79,17 +97,19 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 | path | `string` | "" |
 | headers | `Record<string, any>` | {} |
 | allowedDomains | `string[]` | [] |
+| method | [HttpMethod](#httpmethod) | "GET" |
+| body | `any` | null |
 
 **Returns:** `Result`
 
 **Throws:** `std::http::fetch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L33))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L36))
 
 ### fetchJSON
 
 ```ts
-fetchJSON(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[]): Result
+fetchJSON(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: any): Result
 ```
 
 Fetch a URL and return the response parsed as JSON.
@@ -98,6 +118,8 @@ Fetch a URL and return the response parsed as JSON.
   @param path - Optional path appended to baseUrl
   @param headers - Custom request headers
   @param allowedDomains - Restrict fetches to these domains (empty allows all)
+  @param method - The HTTP method
+  @param body - Request body: a string is sent as-is, a non-string is sent as JSON
 
 On abort, Agency tears down the in-flight HTTP request and body read. The
   abort surfaces as an AgencyCancelledError that propagates out of the
@@ -111,17 +133,19 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 | path | `string` | "" |
 | headers | `Record<string, any>` | {} |
 | allowedDomains | `string[]` | [] |
+| method | [HttpMethod](#httpmethod) | "GET" |
+| body | `any` | null |
 
 **Returns:** `Result`
 
 **Throws:** `std::http::fetchJSON`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L67))
 
 ### fetchMarkdown
 
 ```ts
-fetchMarkdown(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[]): Result
+fetchMarkdown(baseUrl: string, path: string, headers: Record<string, any>, allowedDomains: string[], method: HttpMethod, body: any): Result
 ```
 
 Fetch a URL and return the body as readable markdown when the response is HTML, or as plain text otherwise. Good for extracting page content for an LLM. Fails on network errors, domain violations, or if the response body exceeds 10 MB.
@@ -130,6 +154,8 @@ Fetch a URL and return the body as readable markdown when the response is HTML, 
   @param path - Optional path appended to baseUrl
   @param headers - Custom request headers
   @param allowedDomains - Restrict fetches to these domains (empty allows all)
+  @param method - The HTTP method
+  @param body - Request body: a string is sent as-is, a non-string is sent as JSON
 
 On abort, Agency tears down the in-flight HTTP request and body read. The
   abort surfaces as an AgencyCancelledError that propagates out of the
@@ -143,9 +169,11 @@ On abort, Agency tears down the in-flight HTTP request and body read. The
 | path | `string` | "" |
 | headers | `Record<string, any>` | {} |
 | allowedDomains | `string[]` | [] |
+| method | [HttpMethod](#httpmethod) | "GET" |
+| body | `any` | null |
 
 **Returns:** `Result`
 
 **Throws:** `std::http::fetchMarkdown`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/http.agency#L98))

--- a/packages/agency-lang/lib/stdlib/http.ts
+++ b/packages/agency-lang/lib/stdlib/http.ts
@@ -67,6 +67,38 @@ function validateUrl(
   return url;
 }
 
+function hasContentType(headers: Record<string, string>): boolean {
+  return Object.keys(headers).some((k) => k.toLowerCase() === "content-type");
+}
+
+/**
+ * Build the `fetch` request init. A body is attached only for methods that
+ * carry one (not GET/HEAD): a string is sent as-is, a non-string is
+ * JSON-serialized with a default `Content-Type: application/json` (unless the
+ * caller already set a content-type header). Headers are copied so the default
+ * doesn't mutate the caller's object.
+ */
+function buildInit(
+  method: string,
+  headers: Record<string, string>,
+  body: any,
+  signal: AbortSignal,
+): RequestInit {
+  const h: Record<string, string> = { ...headers };
+  const init: RequestInit = { method, headers: h, signal };
+  if (body != null && method !== "GET" && method !== "HEAD") {
+    if (typeof body === "string") {
+      init.body = body;
+    } else {
+      init.body = JSON.stringify(body);
+      if (!hasContentType(h)) {
+        h["Content-Type"] = "application/json";
+      }
+    }
+  }
+  return init;
+}
+
 /**
  * A structured `failure` for a non-2xx response, or `null` when the status is
  * ok (`Response.ok`, i.e. in [200, 300)). Returning a `failure` — rather than
@@ -153,21 +185,23 @@ async function fetchImpl(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<string | ResultFailure> {
   const url = validateUrl(baseUrl, urlPath, allowedDomains);
   const signal = ctx.getAbortSignal(stack);
   return await runHttp(async () => {
-    const result = await fetch(url, { headers, signal });
-    let body: string;
+    const result = await fetch(url, buildInit(method, headers, body, signal));
+    let responseBody: string;
     try {
-      body = await readBodyCapped(result, url, signal);
+      responseBody = await readBodyCapped(result, url, signal);
     } catch (e) {
       if (isAbortError(e)) throw e;
       throw new Error(`Failed to get text from ${url}: ${e}`);
     }
-    const statusFailure = httpStatusFailure(result, url, body);
+    const statusFailure = httpStatusFailure(result, url, responseBody);
     if (statusFailure) return statusFailure;
-    return body;
+    return responseBody;
   }, url);
 }
 
@@ -181,8 +215,10 @@ export async function __internal_fetch(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<string | ResultFailure> {
-  return fetchImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains);
+  return fetchImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
 
 /** ALS-reading replacement for `__internal_fetch`. */
@@ -191,9 +227,11 @@ export async function _fetch(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<string | ResultFailure> {
   const { ctx, stack } = getRuntimeContext();
-  return fetchImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains);
+  return fetchImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
 
 async function fetchJSONImpl(
@@ -203,11 +241,13 @@ async function fetchJSONImpl(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<any> {
   const url = validateUrl(baseUrl, urlPath, allowedDomains);
   const signal = ctx.getAbortSignal(stack);
   return await runHttp(async () => {
-    const result = await fetch(url, { headers, signal });
+    const result = await fetch(url, buildInit(method, headers, body, signal));
     const text = await readBodyCapped(result, url, signal);
     const statusFailure = httpStatusFailure(result, url, text);
     if (statusFailure) return statusFailure;
@@ -228,8 +268,10 @@ export async function __internal_fetchJSON(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<any> {
-  return fetchJSONImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains);
+  return fetchJSONImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
 
 /** ALS-reading replacement for `__internal_fetchJSON`. */
@@ -238,9 +280,11 @@ export async function _fetchJSON(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<any> {
   const { ctx, stack } = getRuntimeContext();
-  return fetchJSONImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains);
+  return fetchJSONImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
 
 async function fetchMarkdownImpl(
@@ -250,19 +294,21 @@ async function fetchMarkdownImpl(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<string | ResultFailure> {
   const url = validateUrl(baseUrl, urlPath, allowedDomains);
   const signal = ctx.getAbortSignal(stack);
   return await runHttp(async () => {
-    const result = await fetch(url, { headers, signal });
+    const result = await fetch(url, buildInit(method, headers, body, signal));
     const contentType = result.headers.get("content-type") ?? "";
-    const body = await readBodyCapped(result, url, signal);
-    const statusFailure = httpStatusFailure(result, url, body);
+    const responseBody = await readBodyCapped(result, url, signal);
+    const statusFailure = httpStatusFailure(result, url, responseBody);
     if (statusFailure) return statusFailure;
     if (contentType.includes("text/html")) {
-      return htmlToMarkdown(body);
+      return htmlToMarkdown(responseBody);
     }
-    return body;
+    return responseBody;
   }, url);
 }
 
@@ -275,8 +321,10 @@ export async function __internal_fetchMarkdown(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<string | ResultFailure> {
-  return fetchMarkdownImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains);
+  return fetchMarkdownImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
 
 /** ALS-reading replacement for `__internal_fetchMarkdown`. */
@@ -285,9 +333,11 @@ export async function _fetchMarkdown(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
+  method: string,
+  body: any,
 ): Promise<string | ResultFailure> {
   const { ctx, stack } = getRuntimeContext();
-  return fetchMarkdownImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains);
+  return fetchMarkdownImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
 
 function htmlToMarkdown(html: string): string {

--- a/packages/agency-lang/lib/stdlib/http.ts
+++ b/packages/agency-lang/lib/stdlib/http.ts
@@ -215,8 +215,8 @@ export async function __internal_fetch(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
-  method: string,
-  body: any,
+  method: string = "GET",
+  body: any = null,
 ): Promise<string | ResultFailure> {
   return fetchImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
@@ -268,8 +268,8 @@ export async function __internal_fetchJSON(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
-  method: string,
-  body: any,
+  method: string = "GET",
+  body: any = null,
 ): Promise<any> {
   return fetchJSONImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }
@@ -321,8 +321,8 @@ export async function __internal_fetchMarkdown(
   urlPath: string,
   headers: Record<string, string>,
   allowedDomains: string[],
-  method: string,
-  body: any,
+  method: string = "GET",
+  body: any = null,
 ): Promise<string | ResultFailure> {
   return fetchMarkdownImpl(ctx, stack, baseUrl, urlPath, headers, allowedDomains, method, body);
 }

--- a/packages/agency-lang/stdlib/http.agency
+++ b/packages/agency-lang/stdlib/http.agency
@@ -21,20 +21,25 @@ import {
   _fetchMarkdown,
 } from "agency-lang/stdlib-lib/http.js"
 
-effect std::http::fetch { baseUrl: string, path: string }
-effect std::http::fetchJSON { baseUrl: string, path: string }
-effect std::http::fetchMarkdown { baseUrl: string, path: string }
+effect std::http::fetch { baseUrl: string, path: string, method: string }
+effect std::http::fetchJSON { baseUrl: string, path: string, method: string }
+effect std::http::fetchMarkdown { baseUrl: string, path: string, method: string }
+
+/** An HTTP request method. Non-GET methods may carry a body. */
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
 
 /**
   On abort, Agency tears down the in-flight HTTP request and body read. The
   abort surfaces as an AgencyCancelledError that propagates out of the
   surrounding `try`.
 */
-export safe def fetch(
+export def fetch(
   baseUrl: string,
   path: string = "",
   headers: Record<string, any> = {},
   allowedDomains: string[] = [],
+  method: HttpMethod = "GET",
+  body: any = null,
 ): Result {
   """
   Fetch a URL and return the response as text.
@@ -43,12 +48,15 @@ export safe def fetch(
   @param path - Optional path appended to baseUrl
   @param headers - Custom request headers
   @param allowedDomains - Restrict fetches to these domains (empty allows all)
+  @param method - The HTTP method
+  @param body - Request body: a string is sent as-is, a non-string is sent as JSON
   """
-  return interrupt std::http::fetch("Are you sure you want to fetch this URL?", {
+  return interrupt std::http::fetch("Allow a ${method} request to this URL?", {
     baseUrl: baseUrl,
-    path: path
+    path: path,
+    method: method
   })
-  return try _fetch(baseUrl, path, headers, allowedDomains)
+  return try _fetch(baseUrl, path, headers, allowedDomains, method, body)
 }
 
 /**
@@ -56,11 +64,13 @@ export safe def fetch(
   abort surfaces as an AgencyCancelledError that propagates out of the
   surrounding `try`.
 */
-export safe def fetchJSON(
+export def fetchJSON(
   baseUrl: string,
   path: string = "",
   headers: Record<string, any> = {},
   allowedDomains: string[] = [],
+  method: HttpMethod = "GET",
+  body: any = null,
 ): Result {
   """
   Fetch a URL and return the response parsed as JSON.
@@ -69,12 +79,15 @@ export safe def fetchJSON(
   @param path - Optional path appended to baseUrl
   @param headers - Custom request headers
   @param allowedDomains - Restrict fetches to these domains (empty allows all)
+  @param method - The HTTP method
+  @param body - Request body: a string is sent as-is, a non-string is sent as JSON
   """
-  return interrupt std::http::fetchJSON("Are you sure you want to fetch this URL and parse it as JSON?", {
+  return interrupt std::http::fetchJSON("Allow a ${method} request to this URL and parse the response as JSON?", {
     baseUrl: baseUrl,
-    path: path
+    path: path,
+    method: method
   })
-  return try _fetchJSON(baseUrl, path, headers, allowedDomains)
+  return try _fetchJSON(baseUrl, path, headers, allowedDomains, method, body)
 }
 
 /**
@@ -82,7 +95,7 @@ export safe def fetchJSON(
   abort surfaces as an AgencyCancelledError that propagates out of the
   surrounding `try`.
 */
-export safe def fetchMarkdown(baseUrl: string, path: string = "", headers: Record<string, any> = {}, allowedDomains: string[] = []): Result {
+export def fetchMarkdown(baseUrl: string, path: string = "", headers: Record<string, any> = {}, allowedDomains: string[] = [], method: HttpMethod = "GET", body: any = null): Result {
   """
   Fetch a URL and return the body as readable markdown when the response is HTML, or as plain text otherwise. Good for extracting page content for an LLM. Fails on network errors, domain violations, or if the response body exceeds 10 MB.
 
@@ -90,10 +103,13 @@ export safe def fetchMarkdown(baseUrl: string, path: string = "", headers: Recor
   @param path - Optional path appended to baseUrl
   @param headers - Custom request headers
   @param allowedDomains - Restrict fetches to these domains (empty allows all)
+  @param method - The HTTP method
+  @param body - Request body: a string is sent as-is, a non-string is sent as JSON
   """
-  return interrupt std::http::fetchMarkdown("Are you sure you want to fetch this URL?", {
+  return interrupt std::http::fetchMarkdown("Allow a ${method} request to this URL?", {
     baseUrl: baseUrl,
-    path: path
+    path: path,
+    method: method
   })
-  return try _fetchMarkdown(baseUrl, path, headers, allowedDomains)
+  return try _fetchMarkdown(baseUrl, path, headers, allowedDomains, method, body)
 }

--- a/packages/agency-lang/stdlib/http.agency
+++ b/packages/agency-lang/stdlib/http.agency
@@ -25,8 +25,8 @@ effect std::http::fetch { baseUrl: string, path: string, method: string }
 effect std::http::fetchJSON { baseUrl: string, path: string, method: string }
 effect std::http::fetchMarkdown { baseUrl: string, path: string, method: string }
 
-/** An HTTP request method. Non-GET methods may carry a body. */
-export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+/** An HTTP request method. POST/PUT/PATCH/DELETE may carry a body; GET/HEAD do not. */
+export type HttpMethod = "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE"
 
 /**
   On abort, Agency tears down the in-flight HTTP request and body read. The
@@ -39,7 +39,7 @@ export def fetch(
   headers: Record<string, any> = {},
   allowedDomains: string[] = [],
   method: HttpMethod = "GET",
-  body: any = null,
+  body: Record<string, any> | string | null = null,
 ): Result {
   """
   Fetch a URL and return the response as text.
@@ -70,7 +70,7 @@ export def fetchJSON(
   headers: Record<string, any> = {},
   allowedDomains: string[] = [],
   method: HttpMethod = "GET",
-  body: any = null,
+  body: Record<string, any> | string | null = null,
 ): Result {
   """
   Fetch a URL and return the response parsed as JSON.
@@ -95,7 +95,7 @@ export def fetchJSON(
   abort surfaces as an AgencyCancelledError that propagates out of the
   surrounding `try`.
 */
-export def fetchMarkdown(baseUrl: string, path: string = "", headers: Record<string, any> = {}, allowedDomains: string[] = [], method: HttpMethod = "GET", body: any = null): Result {
+export def fetchMarkdown(baseUrl: string, path: string = "", headers: Record<string, any> = {}, allowedDomains: string[] = [], method: HttpMethod = "GET", body: Record<string, any> | string | null = null): Result {
   """
   Fetch a URL and return the body as readable markdown when the response is HTML, or as plain text otherwise. Good for extracting page content for an LLM. Fails on network errors, domain violations, or if the response body exceeds 10 MB.
 

--- a/packages/agency-lang/tests/agency-js/http-post/agent.agency
+++ b/packages/agency-lang/tests/agency-js/http-post/agent.agency
@@ -1,0 +1,30 @@
+import { fetch, fetchJSON } from "std::http"
+
+// POST with a JSON body → returns the mocked response. `with approve` lets the mocked fetch run.
+node postCreate(): any {
+  const r = fetchJSON(baseUrl: "https://api.example.com", path: "/create", method: "POST", body: { name: "widget" }) with approve
+  return r catch "FAIL"
+}
+
+// GET default → returns the mocked response (regression: existing GET path unchanged).
+node getData(): any {
+  const r = fetchJSON(baseUrl: "https://api.example.com", path: "/data") with approve
+  return r catch "FAIL"
+}
+
+// POST with a string body → sent as-is.
+node postRaw(): any {
+  const r = fetch(baseUrl: "https://api.example.com", path: "/raw", method: "POST", body: "hello-raw") with approve
+  return r catch "FAIL"
+}
+
+// Plain caller (no handler): raises std::http::fetchJSON so test.js can inspect the payload's method.
+node callPost(): any {
+  return fetchJSON(baseUrl: "https://api.example.com", path: "/x", method: "POST")
+}
+
+// PFA: a GET-locked fetcher. test.js asserts its raised interrupt carries method GET.
+node callPfaGet(): any {
+  const getOnly = fetchJSON.partial(method: "GET")
+  return getOnly(baseUrl: "https://api.example.com", path: "/x")
+}

--- a/packages/agency-lang/tests/agency-js/http-post/fetchMocks.json
+++ b/packages/agency-lang/tests/agency-js/http-post/fetchMocks.json
@@ -1,0 +1,5 @@
+[
+  { "url": "https://api.example.com/create", "method": "POST", "body": { "name": "widget" }, "return": { "id": 7 } },
+  { "url": "https://api.example.com/data", "return": { "answer": 42 } },
+  { "url": "https://api.example.com/raw", "method": "POST", "body": "hello-raw", "return": "ok-raw" }
+]

--- a/packages/agency-lang/tests/agency-js/http-post/fixture.json
+++ b/packages/agency-lang/tests/agency-js/http-post/fixture.json
@@ -1,0 +1,5 @@
+{
+  "postCreate": { "id": 7 },
+  "getData": { "answer": 42 },
+  "postRaw": "ok-raw"
+}

--- a/packages/agency-lang/tests/agency-js/http-post/test.js
+++ b/packages/agency-lang/tests/agency-js/http-post/test.js
@@ -1,0 +1,33 @@
+import { postCreate, getData, postRaw, callPost, callPfaGet, hasInterrupts } from "./agent.js";
+import { writeFileSync } from "node:fs";
+
+const unwrap = (r) => r?.data ?? r;
+
+// --- interrupt payload assertions (throw on mismatch) ---
+
+// (A) The std::http::fetchJSON interrupt payload carries `method` — the field a std::policy rule
+// matches on to allow GET and deny POST.
+const i1 = await callPost();
+if (!hasInterrupts(i1.data)) throw new Error("callPost did not raise an interrupt");
+const iv = i1.data[0];
+if (iv.effect !== "std::http::fetchJSON") throw new Error("wrong effect: " + iv.effect);
+if (iv.data.method !== "POST") throw new Error("payload missing method=POST, got: " + iv.data.method);
+
+// (B) PFA attenuation: fetchJSON.partial(method: "GET") locks the method — its raised interrupt
+// reports GET even though the caller passed no method.
+const p1 = await callPfaGet();
+if (!hasInterrupts(p1.data)) throw new Error("callPfaGet did not raise an interrupt");
+if (p1.data[0].data.method !== "GET") throw new Error("PFA did not lock method=GET, got: " + p1.data[0].data.method);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      postCreate: unwrap(await postCreate()),
+      getData: unwrap(await getData()),
+      postRaw: unwrap(await postRaw()),
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## What

`std::http`'s `fetch` / `fetchJSON` / `fetchMarkdown` were GET-only. This adds POST-with-body (and PUT/PATCH/DELETE), designed so the HTTP method is a **governance signal** — policies gate it and PFA attenuates it.

## API

Two new params on all three functions:
- `method: HttpMethod = "GET"` — a new enum `HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"`.
- `body: any = null` — a string is sent as-is; a non-string is JSON-serialized with a default `Content-Type: application/json` (unless a content-type header is already set). Bodies are omitted for GET/HEAD.

## Governance (the point of the design)

**Policy** — the interrupt payload grows from `{ baseUrl, path }` to `{ baseUrl, path, method }`, and the prompt is method-aware. That field lets a `std::policy` rule allow GETs and deny writes:

```
{ "std::http::fetchJSON": [
    { match: { method: "GET" }, action: "approve" },
    { action: "reject" }
]}
```

The **body is deliberately excluded** from the payload — it routinely carries secrets/PII, and the payload feeds prompts + the statelog. `method` fully expresses the GET-vs-POST distinction.

**PFA** — because `method`/`baseUrl`/`allowedDomains`/`body` are named params, `.partial()` attenuates the capability before you hand it off:

```
const readOnly  = fetchJSON.partial(method: "GET")                       // can only GET
const postToApi = fetchJSON.partial(baseUrl: "https://api.x", method: "POST",
                                    allowedDomains: ["api.x"]).preapprove()
```

## `safe`

The three functions are **no longer `safe`** — a function that can write shouldn't advertise itself as safe-to-auto-retry. `safe` isn't transitive, so connectors' own `safe` GET helpers still call the now-non-`safe` `fetchJSON`.

## Backward compatibility

Every existing connector calls these with no `method`/`body` → defaults to GET, identical behavior. The payload gain is additive (existing gating tests assert `baseUrl`/`path`, unaffected).

## Tests

`tests/agency-js/http-post/`: POST with a JSON body reaches the server (mock matches method + body subset, proving serialization), string body sent as-is, GET regression, `method` present in the interrupt payload, and `.partial(method: "GET")` locks the method. Regression: fetch-mock / httpStatus / littlesis / yc / hackernews / wikidata all pass.

## Follow-up

Unblocks the **USASpending** connector (its award/recipient search endpoints are POST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
