### PR TITLE
Statelog visibility: promptStart/promptCancelled pairing + threadEndHooks attribution

### DIFF
--- a/packages/agency-lang/docs/dev/statelog.md
+++ b/packages/agency-lang/docs/dev/statelog.md
@@ -40,7 +40,12 @@ At the start of execution, the full graph topology is logged: all node IDs, all 
 - **`afterHook(nodeId, startData, endData, timeTaken)`** — after-node hook execution
 
 ### LLM calls
+- **`promptStart(model, threadId, messageCount, toolCount, hasResponseFormat, maxTokens)`** — fired immediately before an LLM request is dispatched. Small payload: the request shape, not its content. Pairs with a terminator by span + order (the nth start in an llmCall span pairs with the nth terminator: a `promptCompletion`, an `error` with errorType `llmError`, or a `promptCancelled`). An unpaired start means the call never finished — the signature of a hung or killed-mid-call run, and the live in-flight indicator in follow mode.
 - **`promptCompletion(messages, completion, model, timeTaken, tools, responseFormat)`** — logs the full message history, model response, model name, tools provided, and response format
+- **`promptCancelled(threadId)`** — terminator for a promptStart whose call was cancelled: a race loser's abort, Esc-cancel, or a timeout. Deliberately not an error event — a cancel is a normal outcome, and without this terminator every healthy `race()` would leave its losers' starts unpaired.
+
+### Thread-end hooks
+- **`threadEndHooksStart(threadId, eagerSummarize, messageCount)`** / **`threadEndHooksEnd(threadId, timeTaken)`** — bracket `Runner.thread`'s onThreadEnd hook invocation, inside a `threadEndHooks` span. Hook-initiated LLM calls (the eager thread summarizer) nest under that span, so the log answers WHY a call ran. The end event posts from a finally, so a throwing hook is still bracketed.
 
 ### Tool execution
 - **`toolCall(toolName, args, output, model, timeTaken)`** — logs each tool invocation with its arguments, output, and timing

--- a/packages/agency-lang/lib/logsViewer/summary.test.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.test.ts
@@ -361,3 +361,66 @@ describe("summarizeSpanStyled", () => {
     expect(s).not.toMatch(/\{[a-z-]+-fg\}1500 tok/);
   });
 });
+
+describe("summarize (prompt visibility events)", () => {
+  it("summarizes an unpaired promptStart with the runaway fingerprint", () => {
+    const line = summarize({
+      format_version: 1,
+      trace_id: "",
+      project_id: "",
+      span_id: "s",
+      parent_span_id: null,
+      data: {
+        type: "promptStart",
+        timestamp: "",
+        model: '"qwen"',
+        messageCount: 39,
+        toolCount: 0,
+        hasResponseFormat: true,
+        maxTokens: 2000,
+      },
+    });
+    expect(line).toContain("promptStart qwen");
+    expect(line).toContain("never completed");
+    expect(line).toContain("schema");
+    expect(line).toContain("maxTokens 2000");
+    expect(line).toContain("39 msgs");
+  });
+
+  it("summarizes promptCancelled and the threadEndHooks pair", () => {
+    const cancelledLine = summarize({
+      format_version: 1,
+      trace_id: "",
+      project_id: "",
+      span_id: "s",
+      parent_span_id: null,
+      data: { type: "promptCancelled", timestamp: "", threadId: "1" },
+    });
+    const startLine = summarize({
+      format_version: 1,
+      trace_id: "",
+      project_id: "",
+      span_id: "s",
+      parent_span_id: null,
+      data: {
+        type: "threadEndHooksStart",
+        timestamp: "",
+        threadId: "t1",
+        eagerSummarize: true,
+        messageCount: 3,
+      },
+    });
+    const endLine = summarize({
+      format_version: 1,
+      trace_id: "",
+      project_id: "",
+      span_id: "s",
+      parent_span_id: null,
+      data: { type: "threadEndHooksEnd", timestamp: "", threadId: "t1", timeTaken: 9 },
+    });
+    expect(cancelledLine).toContain("promptCancelled");
+    expect(startLine).toContain("thread-end hooks");
+    expect(startLine).toContain("summarize: on");
+    expect(endLine).toContain("done");
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/summary.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.ts
@@ -12,6 +12,25 @@ export function summarize(evt: EventEnvelope): string {
   switch (d.type) {
     case "promptCompletion":
       return `promptCompletion ${stripQuotes(d.model)} (${fmtDuration(d.timeTaken)})`;
+    case "promptStart": {
+      // Only unpaired starts reach the tree, so this line IS the
+      // "call in flight / never completed" indicator. The parenthetical
+      // is the runaway fingerprint: schema + cap + prompt size.
+      const shape = [
+        d.hasResponseFormat ? "schema" : null,
+        d.maxTokens != null ? `maxTokens ${d.maxTokens}` : null,
+        `${d.messageCount} msgs`,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      return `⏳ promptStart ${stripQuotes(d.model)} — never completed (${shape})`;
+    }
+    case "promptCancelled":
+      return `promptCancelled`;
+    case "threadEndHooksStart":
+      return `thread-end hooks (summarize: ${d.eagerSummarize ? "on" : "off"})`;
+    case "threadEndHooksEnd":
+      return `thread-end hooks done (${fmtDuration(d.timeTaken)})`;
     case "toolCallStart":
       return `toolCallStart "${d.toolName}"`;
     case "toolCall":

--- a/packages/agency-lang/lib/logsViewer/tree.test.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.test.ts
@@ -427,6 +427,21 @@ describe("promptStart pairing", () => {
     expect(leavesBySpan).toContainEqual(["promptCompletion"]);
   });
 
+  it("tolerates prototype-chain span ids in a crafted log (no crash, still pairs)", () => {
+    // Untrusted-input guard: with a plain-object accumulator, span_id
+    // "constructor"/"__proto__" resolved through the prototype chain and
+    // .push threw, crashing the viewer on a crafted or corrupt log.
+    const forest = buildForest([
+      start("constructor"),
+      completion("constructor"),
+      start("__proto__"),
+    ]);
+    const spans = forest[0].children;
+    const leavesBySpan = spans.map((s) => s.children.map((c) => c.label));
+    expect(leavesBySpan).toContainEqual(["promptCompletion"]);
+    expect(leavesBySpan).toContainEqual(["promptStart"]);
+  });
+
   it("labels the threadEndHooks span from its start event", () => {
     const forest = buildForest([
       evt({

--- a/packages/agency-lang/lib/logsViewer/tree.test.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.test.ts
@@ -341,3 +341,109 @@ describe("buildForest", () => {
     expect(forest[0].children[0].parentId).toBe(forest[0].id);
   });
 });
+
+describe("promptStart pairing", () => {
+  const start = (span: string) =>
+    evt({
+      span_id: span,
+      data: {
+        type: "promptStart",
+        timestamp: "",
+        model: '"m"',
+        threadId: "1",
+        messageCount: 2,
+        toolCount: 0,
+        hasResponseFormat: true,
+        maxTokens: 2000,
+      },
+    });
+  const completion = (span: string) =>
+    evt({
+      span_id: span,
+      data: { type: "promptCompletion", timestamp: "", model: '"m"', timeTaken: 5 },
+    });
+  const llmError = (span: string) =>
+    evt({
+      span_id: span,
+      data: { type: "error", timestamp: "", errorType: "llmError", message: "boom" },
+    });
+  const cancelled = (span: string) =>
+    evt({
+      span_id: span,
+      data: { type: "promptCancelled", timestamp: "", threadId: "1" },
+    });
+
+  it("hides a paired promptStart leaf, keeps the completion", () => {
+    const forest = buildForest([start("s1"), completion("s1")]);
+    const span = forest[0].children[0];
+    expect(span.children.map((c) => c.label)).toEqual(["promptCompletion"]);
+  });
+
+  it("renders an unpaired promptStart, labeling its span llmCall", () => {
+    const forest = buildForest([start("s1")]);
+    const span = forest[0].children[0];
+    expect(span.children.map((c) => c.label)).toEqual(["promptStart"]);
+    expect(span.label).toBe("llmCall");
+  });
+
+  it("pairs nth start with nth terminator per span (multi-round)", () => {
+    const forest = buildForest([start("s1"), completion("s1"), start("s1")]);
+    const span = forest[0].children[0];
+    expect(span.children.map((c) => c.label)).toEqual([
+      "promptCompletion",
+      "promptStart",
+    ]);
+  });
+
+  it("an llmError terminates (pairs) a start", () => {
+    const forest = buildForest([start("s1"), llmError("s1")]);
+    const span = forest[0].children[0];
+    expect(span.children.map((c) => c.label)).toEqual(["error"]);
+  });
+
+  it("a promptCancelled terminates (pairs) a start — healthy race losers stay quiet", () => {
+    const forest = buildForest([start("s1"), cancelled("s1")]);
+    const span = forest[0].children[0];
+    expect(span.children.map((c) => c.label)).toEqual(["promptCancelled"]);
+  });
+
+  it("pairing is per-span: a completion in another span pairs nothing", () => {
+    const forest = buildForest([start("s1"), completion("s2")]);
+    const spans = forest[0].children;
+    const allLeafLabels = spans.flatMap((s) => s.children.map((c) => c.label));
+    expect(allLeafLabels).toContain("promptStart");
+  });
+
+  it("the post-resume shape: abandoned start alone in span A, paired start in span B", () => {
+    // On resume the llmCall span is re-opened with a NEW span id
+    // (deliberately outside pr.step), so a killed-mid-call run leaves:
+    // span A = one abandoned unpaired start; span B = start +
+    // completion. The abandoned one must render; the resumed one must
+    // hide.
+    const forest = buildForest([start("sA"), start("sB"), completion("sB")]);
+    const spans = forest[0].children;
+    const leavesBySpan = spans.map((s) => s.children.map((c) => c.label));
+    expect(leavesBySpan).toContainEqual(["promptStart"]);
+    expect(leavesBySpan).toContainEqual(["promptCompletion"]);
+  });
+
+  it("labels the threadEndHooks span from its start event", () => {
+    const forest = buildForest([
+      evt({
+        span_id: "h1",
+        data: {
+          type: "threadEndHooksStart",
+          timestamp: "",
+          threadId: "t1",
+          eagerSummarize: true,
+          messageCount: 3,
+        },
+      }),
+      evt({
+        span_id: "h1",
+        data: { type: "threadEndHooksEnd", timestamp: "", threadId: "t1", timeTaken: 9 },
+      }),
+    ]);
+    expect(forest[0].children[0].label).toBe("threadEndHooks");
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/tree.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.ts
@@ -19,7 +19,10 @@ const STRONG_LABEL_EVENTS = new Set<string>([
   "agentEnd",
   "enterNode",
   "promptCompletion",
+  "promptStart",
   "embedCompletion",
+  "threadEndHooksStart",
+  "threadEndHooksEnd",
   "toolCallStart",
   "toolCall",
   "forkStart",
@@ -28,6 +31,40 @@ const STRONG_LABEL_EVENTS = new Set<string>([
   "subprocessEnd",
   "handlerDecision",
 ]);
+
+/** Pair promptStart events with their terminators — a promptCompletion,
+ *  an error event with errorType "llmError", or a promptCancelled — by
+ *  span and order: the nth start in a span pairs with the nth
+ *  terminator. Returns the set of PAIRED starts; anything not in the
+ *  set never completed (a hung, killed, or in-flight call — in follow
+ *  mode this is the live in-flight indicator). Paired starts are hidden
+ *  from the tree: the terminator row already carries the interesting
+ *  data, and doubling every call's rows would make the common case
+ *  worse to read. */
+export function pairedPromptStarts(events: EventEnvelope[]): Set<EventEnvelope> {
+  const pendingBySpan: Record<string, EventEnvelope[]> = {};
+  const paired = new Set<EventEnvelope>();
+  for (const event of events) {
+    const spanKey = event.span_id ?? "";
+    const eventType = event.data.type;
+    if (eventType === "promptStart") {
+      if (!pendingBySpan[spanKey]) {
+        pendingBySpan[spanKey] = [];
+      }
+      pendingBySpan[spanKey].push(event);
+    } else if (
+      eventType === "promptCompletion" ||
+      eventType === "promptCancelled" ||
+      (eventType === "error" && event.data.errorType === "llmError")
+    ) {
+      const pending = pendingBySpan[spanKey];
+      if (pending && pending.length > 0) {
+        paired.add(pending.shift()!);
+      }
+    }
+  }
+  return paired;
+}
 
 export function buildForest(events: EventEnvelope[]): TreeNode[] {
   // traceId → trace root
@@ -85,9 +122,11 @@ export function buildForest(events: EventEnvelope[]): TreeNode[] {
   // trace root if it has no span_id), preserving arrival order. Some
   // event types are noise (e.g. the `graph` schema dump) and are
   // hidden from the viewer entirely.
+  const pairedStarts = pairedPromptStarts(events);
   let leafCounter = 0;
   for (const evt of events) {
     if (HIDDEN_EVENT_TYPES.has(evt.data.type)) continue;
+    if (evt.data.type === "promptStart" && pairedStarts.has(evt)) continue;
     const traceRoot = traces[evt.trace_id];
     const parent = evt.span_id ? spans[evt.span_id] : traceRoot;
     const leaf: TreeNode = {
@@ -203,8 +242,15 @@ function inferSpanLabel(evt: EventEnvelope): string {
       return "agentRun";
     case "enterNode":
       return "nodeExecution";
+    case "promptStart":
+      // Arrives first in its llmCall span, so it is usually the
+      // span-introducing event.
+      return "llmCall";
     case "promptCompletion":
       return "llmCall";
+    case "threadEndHooksStart":
+    case "threadEndHooksEnd":
+      return "threadEndHooks";
     case "embedCompletion":
       // Embedding spans share the chat-completion shape but get their
       // own label so the viewer can color/filter them separately and

--- a/packages/agency-lang/lib/logsViewer/tree.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.ts
@@ -42,7 +42,12 @@ const STRONG_LABEL_EVENTS = new Set<string>([
  *  data, and doubling every call's rows would make the common case
  *  worse to read. */
 export function pairedPromptStarts(events: EventEnvelope[]): Set<EventEnvelope> {
-  const pendingBySpan: Record<string, EventEnvelope[]> = {};
+  // Null-prototype: span_id comes from the log file, which the viewer
+  // must treat as untrusted input. With a plain object, a span_id of
+  // "constructor" or "__proto__" resolves through the prototype chain
+  // to a non-array and the .push below throws, crashing the viewer on
+  // a crafted or corrupt log. Same pattern as lib/optimize/registry.ts.
+  const pendingBySpan: Record<string, EventEnvelope[]> = Object.create(null);
   const paired = new Set<EventEnvelope>();
   for (const event of events) {
     const spanKey = event.span_id ?? "";
@@ -67,14 +72,18 @@ export function pairedPromptStarts(events: EventEnvelope[]): Set<EventEnvelope> 
 }
 
 export function buildForest(events: EventEnvelope[]): TreeNode[] {
-  // traceId → trace root
-  const traces: Record<string, TreeNode> = {};
+  // traceId → trace root. Null-prototype (like pendingBySpan in
+  // pairedPromptStarts): ids come from the log file — untrusted input —
+  // and a plain object resolves ids like "constructor" through the
+  // prototype chain, so the `in` existence checks lie and pass 2
+  // crashes. Pre-existing bug surfaced by the pairing tests.
+  const traces: Record<string, TreeNode> = Object.create(null);
   // span_id → span node (lookup across all traces; span_ids are globally unique per nanoid)
-  const spans: Record<string, TreeNode> = {};
+  const spans: Record<string, TreeNode> = Object.create(null);
   // span_id → its desired parent_span_id (as observed on first sight).
   // Tracked separately so pass 1b can re-resolve parents once every
   // span exists, without polluting the public TreeNode shape.
-  const desiredParent: Record<string, string | null> = {};
+  const desiredParent: Record<string, string | null> = Object.create(null);
 
   // Pass 1a: create traces and spans, linking each span to its parent
   // (or trace root) in arrival order. This puts child spans into their

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -493,6 +493,23 @@ async function _runPrompt({
     metadata: clientConfig,
   } as any;
 
+  // In-flight visibility: record the request SHAPE before dispatch, so a
+  // call that never completes (hang, kill, runaway generation) still
+  // leaves a trace. Pairs with promptCompletion/llmError/promptCancelled
+  // by span + order. Un-awaited like promptCompletion (post() detaches
+  // the remote send; the file sink is a sync append). Sits inside the
+  // same idempotent pr.step as the completion, so resumed runs do not
+  // double-emit for replayed steps. Retries inside dispatchWithRetry
+  // share this one start.
+  ctx.statelogClient.promptStart({
+    model: JSON.stringify(clientConfig.model),
+    threadId: __threads()?.activeId() ?? null,
+    messageCount: messages.getMessages().length,
+    toolCount: tools.length,
+    hasResponseFormat: responseFormat != null,
+    maxTokens: clientConfig.maxTokens ?? null,
+  });
+
   let completion: PromptResult;
   let toolCalls: ToolCallJSON[];
   try {
@@ -524,6 +541,13 @@ async function _runPrompt({
     // the `delivered` de-dup flag stays shared across the two trip paths.
     const cause = readCause(err) ?? readCause(ctx.getAbortSignal(stateStack));
     if (cause || ctx.isCancelled(stateStack) || isAbortError(err)) {
+      // Terminate the promptStart pair: a cancelled call (race loser,
+      // Esc, timeout abort) is a NORMAL outcome, not a request failure —
+      // no llmError — but leaving the start unpaired would make every
+      // healthy race() render "never completed" warnings.
+      ctx.statelogClient.promptCancelled({
+        threadId: __threads()?.activeId() ?? null,
+      });
       throw new AgencyCancelledError(undefined, cause);
     }
     // The success-path `promptCompletion` event below is the only place the

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -425,6 +425,37 @@ export const _internal = {
   dropNullDefaultedArgs,
 };
 
+/** In-flight visibility: record the request SHAPE before dispatch, so a
+ *  call that never completes (hang, kill, runaway generation) still
+ *  leaves a trace. Pairs with promptCompletion/llmError/promptCancelled
+ *  by span + order. Un-awaited like promptCompletion (post() detaches
+ *  the remote send; the file sink is a sync append). Called inside the
+ *  same idempotent pr.step as the completion, so resumed runs do not
+ *  double-emit for replayed steps. Retries inside dispatchWithRetry
+ *  share the one start. */
+function emitPromptStart({
+  ctx,
+  messages,
+  tools,
+  responseFormat,
+  clientConfig,
+}: {
+  ctx: RuntimeContext<GraphState>;
+  messages: MessageThread;
+  tools: Tool[];
+  responseFormat?: any;
+  clientConfig: Partial<smoltalk.SmolConfig>;
+}): void {
+  ctx.statelogClient.promptStart({
+    model: JSON.stringify(clientConfig.model),
+    threadId: __threads()?.activeId() ?? null,
+    messageCount: messages.getMessages().length,
+    toolCount: tools.length,
+    hasResponseFormat: responseFormat != null,
+    maxTokens: clientConfig.maxTokens ?? null,
+  });
+}
+
 async function _runPrompt({
   ctx,
   messages,
@@ -493,22 +524,7 @@ async function _runPrompt({
     metadata: clientConfig,
   } as any;
 
-  // In-flight visibility: record the request SHAPE before dispatch, so a
-  // call that never completes (hang, kill, runaway generation) still
-  // leaves a trace. Pairs with promptCompletion/llmError/promptCancelled
-  // by span + order. Un-awaited like promptCompletion (post() detaches
-  // the remote send; the file sink is a sync append). Sits inside the
-  // same idempotent pr.step as the completion, so resumed runs do not
-  // double-emit for replayed steps. Retries inside dispatchWithRetry
-  // share this one start.
-  ctx.statelogClient.promptStart({
-    model: JSON.stringify(clientConfig.model),
-    threadId: __threads()?.activeId() ?? null,
-    messageCount: messages.getMessages().length,
-    toolCount: tools.length,
-    hasResponseFormat: responseFormat != null,
-    maxTokens: clientConfig.maxTokens ?? null,
-  });
+  emitPromptStart({ ctx, messages, tools, responseFormat, clientConfig });
 
   let completion: PromptResult;
   let toolCalls: ToolCallJSON[];

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,3 +1,4 @@
+import { withThreadEndHooksEvents } from "./threadEndHooksEvents.js";
 import { nanoid } from "nanoid";
 import { __globals, agencyStore } from "./asyncContext.js";
 import { debugStep } from "./debugger.js";
@@ -714,35 +715,45 @@ export class Runner {
       // Fire onThreadEnd so the registry stdlib hook sees the
       // close. We fire from `finally` so exceptions thrown inside
       // the body still record a close event.
-      try {
-        await invokeCallbacks({
-          ctx: this.ctx,
-          name: "onThreadEnd",
-          data: {
-            threadId: slug,
-            // Prefer persisted label so resumed threads emit the
-            // original label even when the resumption call site
-            // omits it (mirrors onThreadStart above).
-            label: closingThread?.label ?? opts.label ?? undefined,
-            eagerSummarize: opts.summarize === true,
-            messages: messagesSnapshot,
-          },
-        });
-      } catch (e) {
-        // Swallow hook errors in finally to avoid masking the
-        // primary exception. `fireWithGuard` inside invokeCallbacks
-        // already logs JS errors; this catch is belt-and-braces for
-        // unexpected throws from the dispatcher itself.
-        if (e instanceof RestoreSignal) throw e;
-        // Surface the failure as a structured statelog event so it
-        // shows up in traces (replaces the prior bare console.error).
-        // Optional chaining: older test contexts may construct a
-        // statelogClient without the threadEndHookError method.
-        this.ctx.statelogClient?.threadEndHookError?.({
+      await withThreadEndHooksEvents(
+        this.ctx.statelogClient,
+        {
           threadId: slug,
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
+          eagerSummarize: opts.summarize === true,
+          messageCount: messagesSnapshot.length,
+        },
+        async () => {
+          try {
+            await invokeCallbacks({
+              ctx: this.ctx,
+              name: "onThreadEnd",
+              data: {
+                threadId: slug,
+                // Prefer persisted label so resumed threads emit the
+                // original label even when the resumption call site
+                // omits it (mirrors onThreadStart above).
+                label: closingThread?.label ?? opts.label ?? undefined,
+                eagerSummarize: opts.summarize === true,
+                messages: messagesSnapshot,
+              },
+            });
+          } catch (e) {
+            // Swallow hook errors in finally to avoid masking the
+            // primary exception. `fireWithGuard` inside invokeCallbacks
+            // already logs JS errors; this catch is belt-and-braces for
+            // unexpected throws from the dispatcher itself.
+            if (e instanceof RestoreSignal) throw e;
+            // Surface the failure as a structured statelog event so it
+            // shows up in traces (replaces the prior bare console.error).
+            // Optional chaining: older test contexts may construct a
+            // statelogClient without the threadEndHookError method.
+            this.ctx.statelogClient?.threadEndHookError?.({
+              threadId: slug,
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }
+        },
+      );
     }
 
     if (this.halted) return;

--- a/packages/agency-lang/lib/runtime/threadEndHooksEvents.test.ts
+++ b/packages/agency-lang/lib/runtime/threadEndHooksEvents.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { withThreadEndHooksEvents } from "./threadEndHooksEvents.js";
+
+function recordingClient() {
+  const calls: string[] = [];
+  return {
+    calls,
+    startSpan: (type: string) => {
+      calls.push(`startSpan:${type}`);
+      return "span-1";
+    },
+    endSpan: (spanId?: string) => {
+      calls.push(`endSpan:${spanId}`);
+      return undefined;
+    },
+    threadEndHooksStart: async (payload: any) => {
+      calls.push(`start:${payload.threadId}:${payload.eagerSummarize}`);
+    },
+    threadEndHooksEnd: async (payload: any) => {
+      calls.push(`end:${payload.threadId}:${typeof payload.timeTaken}`);
+    },
+  };
+}
+
+const PAYLOAD = { threadId: "t1", eagerSummarize: true, messageCount: 2 };
+
+describe("withThreadEndHooksEvents", () => {
+  it("brackets fn with span + start/end events and returns its value", async () => {
+    const client = recordingClient();
+    const value = await withThreadEndHooksEvents(client as any, PAYLOAD, async () => "hook-result");
+    expect(value).toBe("hook-result");
+    expect(client.calls).toEqual([
+      "startSpan:threadEndHooks",
+      "start:t1:true",
+      "end:t1:number",
+      "endSpan:span-1",
+    ]);
+  });
+
+  it("posts the end event and closes the span even when fn throws, propagating the error", async () => {
+    const client = recordingClient();
+    await expect(
+      withThreadEndHooksEvents(client as any, { ...PAYLOAD, threadId: "t2", eagerSummarize: false }, async () => {
+        throw new Error("hook boom");
+      }),
+    ).rejects.toThrow("hook boom");
+    expect(client.calls).toEqual([
+      "startSpan:threadEndHooks",
+      "start:t2:false",
+      "end:t2:number",
+      "endSpan:span-1",
+    ]);
+  });
+
+  it("degrades to a bare fn() when the client is null", async () => {
+    const value = await withThreadEndHooksEvents(null as any, PAYLOAD, async () => 42);
+    expect(value).toBe(42);
+  });
+
+  it("degrades to a bare fn() when the client lacks the new methods", async () => {
+    // Older test contexts construct partial statelog clients (see the
+    // ?.threadEndHookError?. guard in runner.ts). Instrumentation must
+    // never be the thing that throws from thread's finally.
+    const partial = { startSpan: () => "s" };
+    const value = await withThreadEndHooksEvents(partial as any, PAYLOAD, async () => "ok");
+    expect(value).toBe("ok");
+  });
+});

--- a/packages/agency-lang/lib/runtime/threadEndHooksEvents.test.ts
+++ b/packages/agency-lang/lib/runtime/threadEndHooksEvents.test.ts
@@ -57,6 +57,18 @@ describe("withThreadEndHooksEvents", () => {
     expect(value).toBe(42);
   });
 
+  it("degrades when the client has the start method but not the end method", async () => {
+    // The finally posts the end event; a client missing only that method
+    // would throw from the finally and mask the primary exception.
+    const lopsided = {
+      startSpan: () => "s",
+      endSpan: () => undefined,
+      threadEndHooksStart: async () => undefined,
+    };
+    const value = await withThreadEndHooksEvents(lopsided as any, PAYLOAD, async () => "ok");
+    expect(value).toBe("ok");
+  });
+
   it("degrades to a bare fn() when the client lacks the new methods", async () => {
     // Older test contexts construct partial statelog clients (see the
     // ?.threadEndHookError?. guard in runner.ts). Instrumentation must

--- a/packages/agency-lang/lib/runtime/threadEndHooksEvents.ts
+++ b/packages/agency-lang/lib/runtime/threadEndHooksEvents.ts
@@ -27,7 +27,18 @@ export async function withThreadEndHooksEvents<T>(
   payload: { threadId: string; eagerSummarize: boolean; messageCount: number },
   fn: () => Promise<T>,
 ): Promise<T> {
-  if (!client || typeof (client as any).threadEndHooksStart !== "function") {
+  // Degrade unless EVERY method the bracket uses is present: a client
+  // with the start method but not the end method would otherwise throw
+  // from the finally — exactly the mask-the-primary-exception hazard
+  // this guard exists to prevent.
+  const partial = client as any;
+  if (
+    !client ||
+    typeof partial.threadEndHooksStart !== "function" ||
+    typeof partial.threadEndHooksEnd !== "function" ||
+    typeof partial.startSpan !== "function" ||
+    typeof partial.endSpan !== "function"
+  ) {
     return fn();
   }
   const spanId = client.startSpan("threadEndHooks");

--- a/packages/agency-lang/lib/runtime/threadEndHooksEvents.ts
+++ b/packages/agency-lang/lib/runtime/threadEndHooksEvents.ts
@@ -1,0 +1,45 @@
+import type { StatelogClient } from "../statelogClient.js";
+
+/**
+ * Wrap the onThreadEnd hook invocation with observability: a
+ * `threadEndHooks` span (so hook-initiated LLM calls — the eager thread
+ * summarizer — nest under an explanation of WHY they ran) and a
+ * threadEndHooksStart/End event pair (so a hook that hangs before
+ * reaching its own LLM call is still visible as an unpaired start).
+ *
+ * The end event and span close post from a finally: a throwing hook
+ * still gets bracketed, and the error propagates to the caller
+ * (Runner.thread's existing catch owns swallow-vs-rethrow policy).
+ * The event posts are deliberately un-awaited, matching the
+ * promptCompletion idiom — the file sink appends synchronously, so
+ * on-disk ordering holds.
+ *
+ * Degrades to a bare fn() when the client is missing or lacks the new
+ * methods: older test contexts construct partial statelog clients, and
+ * this runs inside thread's finally, where a throw would mask the
+ * primary exception.
+ *
+ * Extracted from Runner.thread so the bracket-on-throw and degraded-
+ * client guarantees are unit-testable without constructing a Runner.
+ */
+export async function withThreadEndHooksEvents<T>(
+  client: StatelogClient,
+  payload: { threadId: string; eagerSummarize: boolean; messageCount: number },
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!client || typeof (client as any).threadEndHooksStart !== "function") {
+    return fn();
+  }
+  const spanId = client.startSpan("threadEndHooks");
+  const startTime = performance.now();
+  client.threadEndHooksStart(payload);
+  try {
+    return await fn();
+  } finally {
+    client.threadEndHooksEnd({
+      threadId: payload.threadId,
+      timeTaken: performance.now() - startTime,
+    });
+    client.endSpan(spanId);
+  }
+}

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -811,6 +811,76 @@ describe("StatelogClient", () => {
       expect(fs.existsSync(file)).toBe(false);
     });
   });
+
+  it("promptStart posts the small request-shape payload and nothing heavy", async () => {
+    const file = tmpLogFile("prompt-start");
+    tmpDirs.push(path.dirname(file));
+    const client = fileClient(file);
+    await client.promptStart({
+      model: '"test-model"',
+      threadId: "7",
+      messageCount: 3,
+      toolCount: 2,
+      hasResponseFormat: true,
+      maxTokens: 2000,
+    });
+    const events = readEvents(file);
+    expect(events).toHaveLength(1);
+    expect(events[0].data).toMatchObject({
+      type: "promptStart",
+      model: '"test-model"',
+      threadId: "7",
+      messageCount: 3,
+      toolCount: 2,
+      hasResponseFormat: true,
+      maxTokens: 2000,
+    });
+    // Payload-bloat guard: the request CONTENT stays on promptCompletion.
+    expect(events[0].data).not.toHaveProperty("messages");
+    expect(events[0].data).not.toHaveProperty("tools");
+  });
+
+  it("promptStart normalizes absent threadId/maxTokens to null", async () => {
+    const file = tmpLogFile("prompt-start-nulls");
+    tmpDirs.push(path.dirname(file));
+    const client = fileClient(file);
+    await client.promptStart({
+      messageCount: 1,
+      toolCount: 0,
+      hasResponseFormat: false,
+    });
+    const events = readEvents(file);
+    expect(events[0].data.threadId).toBeNull();
+    expect(events[0].data.maxTokens).toBeNull();
+  });
+
+  it("promptCancelled posts a tiny terminator", async () => {
+    const file = tmpLogFile("prompt-cancelled");
+    tmpDirs.push(path.dirname(file));
+    const client = fileClient(file);
+    await client.promptCancelled({ threadId: "3" });
+    const events = readEvents(file);
+    expect(events[0].data).toMatchObject({ type: "promptCancelled", threadId: "3" });
+  });
+
+  it("threadEndHooks start/end events post their payloads", async () => {
+    const file = tmpLogFile("hooks-pair");
+    tmpDirs.push(path.dirname(file));
+    const client = fileClient(file);
+    await client.threadEndHooksStart({
+      threadId: "t3",
+      eagerSummarize: true,
+      messageCount: 5,
+    });
+    await client.threadEndHooksEnd({ threadId: "t3", timeTaken: 12.5 });
+    const events = readEvents(file);
+    expect(events.map((e) => e.data.type)).toEqual([
+      "threadEndHooksStart",
+      "threadEndHooksEnd",
+    ]);
+    expect(events[0].data).toMatchObject({ eagerSummarize: true, messageCount: 5 });
+    expect(events[1].data).toMatchObject({ threadId: "t3", timeTaken: 12.5 });
+  });
 });
 
 describe("getStatelogClient", () => {

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -23,6 +23,10 @@ export type SpanType =
   | "nodeExecution"
   | "llmCall"
   | "toolExecution"
+  // Wraps Runner.thread's onThreadEnd hook invocation, so hook-initiated
+  // work (the eager thread summarizer's llmCall span) nests under an
+  // explanation of why it ran. See the threadEndHooksStart/End events.
+  | "threadEndHooks"
   | "forkAll"
   | "race"
   | "handlerChain"
@@ -430,6 +434,97 @@ export class StatelogClient {
       toNodeId,
       isConditionalEdge,
       data,
+    });
+  }
+
+  /** Fired immediately before an LLM request is dispatched. Paired with a
+   *  terminator — `promptCompletion` (success), an `error` event with
+   *  errorType "llmError" (failure), or `promptCancelled` (race loser /
+   *  Esc / timeout abort) — by span + order: the nth promptStart in an
+   *  llmCall span pairs with the nth terminator. An unpaired start means
+   *  the call vanished — a hung or killed-mid-call run. Mirrors the
+   *  toolCallStart/toolCall pair (same OTEL start+end merge story).
+   *  Small payload by design: the request SHAPE, not its content — the
+   *  redacted message array stays on promptCompletion. hasResponseFormat
+   *  + maxTokens are the runaway-generation fingerprint (grammar-
+   *  constrained plus uncapped). `model` arrives JSON.stringify-quoted,
+   *  like every model field on the wire. */
+  async promptStart({
+    model,
+    threadId,
+    messageCount,
+    toolCount,
+    hasResponseFormat,
+    maxTokens,
+  }: {
+    model?: string;
+    threadId?: string | null;
+    messageCount: number;
+    toolCount: number;
+    hasResponseFormat: boolean;
+    maxTokens?: number | null;
+  }): Promise<void> {
+    await this.post({
+      type: "promptStart",
+      model,
+      threadId: threadId ?? null,
+      messageCount,
+      toolCount,
+      hasResponseFormat,
+      maxTokens: maxTokens ?? null,
+    });
+  }
+
+  /** Terminator for a promptStart whose call was cancelled — a race
+   *  loser's abort, Esc-cancel, or a timeout. Deliberately NOT an error
+   *  event: a user cancel is not a request failure (the cancellation
+   *  path skips llmError for the same reason). Without this, every
+   *  healthy race() would leave its losers' starts unpaired and the
+   *  viewer would cry wolf. */
+  async promptCancelled({
+    threadId,
+  }: {
+    threadId?: string | null;
+  }): Promise<void> {
+    await this.post({
+      type: "promptCancelled",
+      threadId: threadId ?? null,
+    });
+  }
+
+  /** Fired when Runner.thread starts invoking onThreadEnd hooks. Paired
+   *  with threadEndHooksEnd; both live inside the threadEndHooks span so
+   *  hook-initiated LLM calls nest underneath. */
+  async threadEndHooksStart({
+    threadId,
+    eagerSummarize,
+    messageCount,
+  }: {
+    threadId: string;
+    eagerSummarize: boolean;
+    messageCount: number;
+  }): Promise<void> {
+    await this.post({
+      type: "threadEndHooksStart",
+      threadId,
+      eagerSummarize,
+      messageCount,
+    });
+  }
+
+  /** Fired when Runner.thread finishes invoking onThreadEnd hooks —
+   *  including when a hook threw (the wrapper posts from a finally). */
+  async threadEndHooksEnd({
+    threadId,
+    timeTaken,
+  }: {
+    threadId: string;
+    timeTaken: number;
+  }): Promise<void> {
+    await this.post({
+      type: "threadEndHooksEnd",
+      threadId,
+      timeTaken,
     });
   }
 

--- a/packages/agency-lang/tests/agency-js/prompt-start-cancelled/agency.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-cancelled/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-cancelled/agent.agency
+++ b/packages/agency-lang/tests/agency-js/prompt-start-cancelled/agent.agency
@@ -1,0 +1,11 @@
+// Two racing branches each make an llm() call. The mock resolves branch
+// A instantly and parks branch B until its abort signal fires (the race
+// loser abort). The loser's start must be terminated by promptCancelled
+// — NOT llmError (a cancel is not a failure), NOT left unpaired (a
+// healthy race must not render "never completed" warnings). See test.js.
+node main() {
+  const winner = race([1, 2]) as item {
+    return llm("branch ${item}")
+  }
+  return winner
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-cancelled/fixture.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-cancelled/fixture.json
@@ -1,0 +1,7 @@
+{
+  "finalData": "fast",
+  "startCount": 2,
+  "completionCount": 1,
+  "cancelledCount": 1,
+  "llmErrorCount": 0
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-cancelled/test.js
+++ b/packages/agency-lang/tests/agency-js/prompt-start-cancelled/test.js
@@ -1,0 +1,73 @@
+import { main, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+const client = {
+  async text(config) {
+    const idx = callIndex++;
+    if (idx === 0) {
+      return {
+        success: true,
+        value: { output: "fast", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+      };
+    }
+    // The loser: park until the race abort fires, then reject the way a
+    // real provider SDK does when its request is aborted.
+    return new Promise((resolve, reject) => {
+      const signal = config?.abortSignal;
+      if (!signal) {
+        reject(new Error("expected an abortSignal on the loser branch"));
+        return;
+      }
+      if (signal.aborted) {
+        reject(Object.assign(new Error("Request was aborted."), { name: "AbortError" }));
+        return;
+      }
+      signal.addEventListener("abort", () => {
+        reject(Object.assign(new Error("Request was aborted."), { name: "AbortError" }));
+      });
+    });
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const result = await main();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+
+const startCount = events.filter((e) => e.data?.type === "promptStart").length;
+const completionCount = events.filter((e) => e.data?.type === "promptCompletion").length;
+const cancelledCount = events.filter((e) => e.data?.type === "promptCancelled").length;
+const llmErrorCount = events.filter(
+  (e) => e.data?.type === "error" && e.data?.errorType === "llmError",
+).length;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    { finalData: result.data, startCount, completionCount, cancelledCount, llmErrorCount },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/prompt-start-failure/agency.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-failure/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-failure/agent.agency
+++ b/packages/agency-lang/tests/agency-js/prompt-start-failure/agent.agency
@@ -1,0 +1,34 @@
+// failing(): the client throws and retries are disabled — the start must
+// already be on disk (it can only have been emitted BEFORE dispatch) and
+// the llmError event must share its span so the pair terminates.
+// retried(): the client fails once then succeeds with retries: 1 — the
+// retry lives INSIDE dispatchWithRetry, below the emission, so exactly
+// one start and one completion appear.
+//
+// The llm() calls are wrapped in defs because `try llm(...)` DIRECTLY
+// loses the success value (try + builtin-llm codegen bug, isolated
+// 2026-07-10: `try llm()` yields success(undefined) while `try def()`
+// wrapping the same call round-trips fine). Unrelated to this feature.
+def failingCall(): string {
+  return llm("this will fail", { retries: 0 })
+}
+
+def retriedCall(): string {
+  return llm("fails once", { retries: 1 })
+}
+
+node failing() {
+  const result = try failingCall()
+  if (result is success(reply)) {
+    return "unexpected-success"
+  }
+  return "failed"
+}
+
+node retried() {
+  const result = try retriedCall()
+  if (result is success(reply)) {
+    return reply
+  }
+  return "unexpected-failure"
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-failure/fixture.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-failure/fixture.json
@@ -1,0 +1,14 @@
+{
+  "failData": "failed",
+  "retryData": "recovered",
+  "failPhase": {
+    "startCount": 1,
+    "completionCount": 0,
+    "llmErrorCount": 1,
+    "errorSharesStartSpan": true
+  },
+  "retryPhase": {
+    "startsAdded": 1,
+    "llmErrorsAdded": 0
+  }
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-failure/test.js
+++ b/packages/agency-lang/tests/agency-js/prompt-start-failure/test.js
@@ -1,0 +1,95 @@
+import { failing, retried, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+// Phase 1 (failing): every call throws. Phase 2 (retried): first call
+// throws, second succeeds. test.js flips the phase between nodes.
+let phase = "always-fail";
+let phaseCallIndex = 0;
+const client = {
+  async text() {
+    const idx = phaseCallIndex++;
+    if (phase === "always-fail") {
+      return { success: false, error: "synthetic provider failure" };
+    }
+    if (idx === 0) {
+      // "fetch failed" message-matches the retry classifier's transport-
+      // drop list (connectionLost, retryable); an arbitrary message would
+      // classify terminal and never retry.
+      return { success: false, error: "fetch failed" };
+    }
+    return {
+      success: true,
+      value: { output: "recovered", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const failResult = await failing();
+
+const midEvents = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+const failStarts = midEvents.filter((e) => e.data?.type === "promptStart");
+const failCompletions = midEvents.filter((e) => e.data?.type === "promptCompletion");
+// The REAL llmError shape the viewer pairs on: data.type === "error"
+// with data.errorType === "llmError", sharing the start's span.
+const failErrors = midEvents.filter(
+  (e) => e.data?.type === "error" && e.data?.errorType === "llmError",
+);
+
+phase = "fail-once";
+phaseCallIndex = 0;
+const retryResult = await retried();
+
+const allEvents = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+const totalStarts = allEvents.filter((e) => e.data?.type === "promptStart").length;
+const totalErrors = allEvents.filter(
+  (e) => e.data?.type === "error" && e.data?.errorType === "llmError",
+).length;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      failData: failResult.data,
+      retryData: retryResult.data,
+      failPhase: {
+        startCount: failStarts.length,
+        completionCount: failCompletions.length,
+        llmErrorCount: failErrors.length,
+        errorSharesStartSpan:
+          failStarts[0]?.span_id != null &&
+          failStarts[0]?.span_id === failErrors[0]?.span_id,
+      },
+      retryPhase: {
+        startsAdded: totalStarts - failStarts.length,
+        llmErrorsAdded: totalErrors - failErrors.length,
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/prompt-start-pairing/agency.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-pairing/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-pairing/agent.agency
+++ b/packages/agency-lang/tests/agency-js/prompt-start-pairing/agent.agency
@@ -1,0 +1,22 @@
+// main(): two-round tool loop — round 1 the model calls getArea, round 2
+// it answers. Each round must emit a promptStart BEFORE its
+// promptCompletion, all four events sharing the one llmCall span.
+// shaped(): the runaway fingerprint — a schema-constrained, capped call
+// must stamp hasResponseFormat=true and maxTokens on its start.
+// See test.js.
+def getArea(country: string): number {
+  return 100
+}
+
+type Shaped = {
+  answer: string
+}
+
+node main() {
+  return llm("Get the area of France using your getArea tool.", { tools: [getArea] })
+}
+
+node shaped() {
+  const result: Shaped = llm("give me json", { maxTokens: 123 })
+  return result.answer
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-pairing/fixture.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-pairing/fixture.json
@@ -1,0 +1,18 @@
+{
+  "mainData": "ok",
+  "shapedData": "json-ok",
+  "startCount": 3,
+  "completionCount": 3,
+  "perSpanAlternation": true,
+  "spanCount": 2,
+  "firstStartShape": {
+    "toolCount": 1,
+    "hasResponseFormat": false,
+    "hasMessages": false,
+    "threadIdMatchesCompletion": true
+  },
+  "fingerprint": {
+    "found": true,
+    "maxTokens": 123
+  }
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-pairing/test.js
+++ b/packages/agency-lang/tests/agency-js/prompt-start-pairing/test.js
@@ -1,0 +1,119 @@
+import { main, shaped, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+// promptStart pairing contract: every promptCompletion is preceded by a
+// promptStart in the same span, in strict start→completion alternation
+// PER SPAN. The payload carries the request shape (message/tool counts,
+// schema + maxTokens fingerprint, threadId), not the messages.
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+const client = {
+  async text() {
+    const idx = callIndex++;
+    if (idx === 0) {
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [new ToolCall("call-1", "getArea", { country: "France" })],
+          model: "test",
+          usage: USAGE,
+          cost: COST,
+        },
+      };
+    }
+    if (idx === 1) {
+      return {
+        success: true,
+        value: { output: "ok", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+      };
+    }
+    return {
+      success: true,
+      value: {
+        output: JSON.stringify({ answer: "json-ok" }),
+        toolCalls: [],
+        model: "test",
+        usage: USAGE,
+        cost: COST,
+      },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const mainResult = await main();
+const shapedResult = await shaped();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+
+const starts = events.filter((e) => e.data?.type === "promptStart");
+const completions = events.filter((e) => e.data?.type === "promptCompletion");
+
+// Per-span alternation: within each span, starts and completions must
+// strictly alternate S,C,S,C,...
+const bySpan = {};
+for (const event of events) {
+  if (event.data?.type === "promptStart" || event.data?.type === "promptCompletion") {
+    const key = event.span_id ?? "none";
+    if (!bySpan[key]) {
+      bySpan[key] = "";
+    }
+    bySpan[key] += event.data.type === "promptStart" ? "S" : "C";
+  }
+}
+const perSpanAlternation = Object.values(bySpan).every((sequence) =>
+  /^(SC)+$/.test(sequence),
+);
+
+const fingerprintStart = starts.find((e) => e.data.hasResponseFormat === true);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      mainData: mainResult.data,
+      shapedData: shapedResult.data,
+      startCount: starts.length,
+      completionCount: completions.length,
+      perSpanAlternation,
+      spanCount: Object.keys(bySpan).length,
+      firstStartShape: {
+        toolCount: starts[0]?.data.toolCount,
+        hasResponseFormat: starts[0]?.data.hasResponseFormat,
+        hasMessages: "messages" in (starts[0]?.data ?? {}),
+        threadIdMatchesCompletion:
+          starts[0]?.data.threadId === completions[0]?.data.threadId &&
+          starts[0]?.data.threadId != null,
+      },
+      fingerprint: {
+        found: fingerprintStart != null,
+        maxTokens: fingerprintStart?.data.maxTokens,
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/prompt-start-resume/agency.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-resume/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-resume/agent.agency
+++ b/packages/agency-lang/tests/agency-js/prompt-start-resume/agent.agency
@@ -1,0 +1,14 @@
+// Round 1: the model calls interruptTool, which raises an interrupt —
+// the run pauses mid-llm()-tool-loop and resumes via
+// respondToInterrupts. Round 2 answers. The resume must NOT re-emit
+// round 1's promptStart (the emission sits inside the same idempotent
+// pr.step as the completion), so the final log has exactly 2 starts and
+// 2 completions. See test.js.
+def interruptTool(): string {
+  interrupt("approve")
+  return "tool result"
+}
+
+node main() {
+  return llm("call the tool", { tools: [interruptTool] })
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-resume/fixture.json
+++ b/packages/agency-lang/tests/agency-js/prompt-start-resume/fixture.json
@@ -1,0 +1,6 @@
+{
+  "finalData": "done",
+  "llmCalls": 2,
+  "startCount": 2,
+  "completionCount": 2
+}

--- a/packages/agency-lang/tests/agency-js/prompt-start-resume/test.js
+++ b/packages/agency-lang/tests/agency-js/prompt-start-resume/test.js
@@ -1,0 +1,76 @@
+import {
+  main,
+  hasInterrupts,
+  approve,
+  respondToInterrupts,
+  __setLLMClient,
+} from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+const client = {
+  async text() {
+    const idx = callIndex++;
+    if (idx === 0) {
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [new ToolCall("c1", "interruptTool", {})],
+          model: "test",
+          usage: USAGE,
+          cost: COST,
+        },
+      };
+    }
+    return {
+      success: true,
+      value: { output: "done", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const initial = await main();
+if (!hasInterrupts(initial.data)) {
+  throw new Error(`Expected interrupts, got: ${JSON.stringify(initial.data)}`);
+}
+const final = await respondToInterrupts(initial.data, [approve()]);
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+
+const startCount = events.filter((e) => e.data?.type === "promptStart").length;
+const completionCount = events.filter(
+  (e) => e.data?.type === "promptCompletion",
+).length;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    { finalData: final.data, llmCalls: callIndex, startCount, completionCount },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/agency.json
+++ b/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/agent.agency
+++ b/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/agent.agency
@@ -1,0 +1,18 @@
+import { userMessage } from "std::thread"
+
+// The std::thread import is load-bearing: the eager summarizer is a
+// global onThreadEnd hook that lib/stdlib/threads.ts registers at module
+// load, so a program that never imports std::thread has no summarizer.
+//
+// A summarize-on thread block: at close, the eager summarizer (a global
+// onThreadEnd hook) makes its own llm() call. That call's llmCall span
+// must be a CHILD of the threadEndHooks span — the attribution that was
+// missing during the 2026-07-09 incident. See test.js.
+node main() {
+  let reply = ""
+  thread(label: "attributed", summarize: true) {
+    userMessage("please greet me")
+    reply = llm("say hello")
+  }
+  return reply
+}

--- a/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/fixture.json
+++ b/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/fixture.json
@@ -1,0 +1,8 @@
+{
+  "finalData": "hello there",
+  "llmCalls": 2,
+  "hookStartCount": 1,
+  "hookEndCount": 1,
+  "eagerSummarizeFlags": [true],
+  "attributedSummarizerStarts": 1
+}

--- a/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/test.js
+++ b/packages/agency-lang/tests/agency-js/thread-end-hooks-attribution/test.js
@@ -1,0 +1,67 @@
+import { main, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+// Call 1 = the user's llm(); call 2 = the summarizer's structured-output
+// call (returns {summary} JSON).
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+const client = {
+  async text() {
+    const idx = callIndex++;
+    const output = idx === 0 ? "hello there" : JSON.stringify({ summary: "a greeting" });
+    return {
+      success: true,
+      value: { output, toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const result = await main();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+
+const hookStarts = events.filter((e) => e.data?.type === "threadEndHooksStart");
+const hookEnds = events.filter((e) => e.data?.type === "threadEndHooksEnd");
+// The summarizer's promptStart: its own span_id is its llmCall span; its
+// envelope parent_span_id is the enclosing threadEndHooks span.
+const hookSpanIds = new Set(hookStarts.map((e) => e.span_id));
+const attributedStarts = events.filter(
+  (e) => e.data?.type === "promptStart" && hookSpanIds.has(e.parent_span_id),
+);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      finalData: result.data,
+      llmCalls: callIndex,
+      hookStartCount: hookStarts.length,
+      hookEndCount: hookEnds.length,
+      eagerSummarizeFlags: hookStarts.map((e) => e.data.eagerSummarize),
+      attributedSummarizerStarts: attributedStarts.length,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## What

Statelog visibility for in-flight and hook-driven LLM calls:

- **`promptStart`** — emitted at the `runPrompt` chokepoint before every dispatch round. Small payload (model, threadId, message/tool counts, `hasResponseFormat`, `maxTokens` — the runaway-generation fingerprint), always on. Pairs with a terminator by span + order: `promptCompletion`, an `llmError`, or the new **`promptCancelled`** (race losers, Esc, timeout aborts — a cancel is a normal outcome, not an error, and without a terminator every healthy `race()` would render noise).
- **`threadEndHooks` span + `threadEndHooksStart`/`End` events** — bracket `Runner.thread`'s onThreadEnd hook invocation via a small extracted wrapper (`withThreadEndHooksEvents`) that degrades to a bare call for partial statelog clients and posts its end event from a finally. Hook-initiated LLM calls (the eager thread summarizer) now nest under an explanation of why they ran.
- **Viewer** — a pure pairing pass (`pairedPromptStarts`): paired starts are hidden (the terminator row carries the data), unpaired starts render loudly: `⏳ promptStart <model> — never completed (schema, maxTokens 2000, 39 msgs)`. In follow mode that line doubles as the live in-flight indicator. `threadEndHooks` renders as a grouping node with duration/token rollup.

## Why

During the 2026-07-09 local-model hang, the statelog ended at a successful `promptCompletion` while a second, hook-initiated LLM call generated tokens invisibly for minutes; diagnosis required sampling native thread stacks and patching trace lines into the installed provider. Re-creating that incident against this branch (truncating a real log at the summarizer's start) renders exactly:

```
⏳ promptStart claude-sonnet-4-6 — never completed (schema, maxTokens 256, 1 msgs)
```

Spec: `docs/superpowers/specs/2026-07-10-statelog-prompt-visibility-design.md`. Design decisions: always-on small payload (a debug-gated event would have been off during the actual incident); `toolCallStart`/`toolCall` as the pairing precedent; `promptCancelled` per plan-review finding 2 (owner-approved).

## Event-volume delta

One `promptStart` per LLM round, one `promptCancelled` per cancelled call, two events per thread close. File sink is a sync append; remote posts are detached by default.

## Test plan

- Unit: 4 new statelogClient cases (payload shapes, null normalization, payload-bloat negatives), 4 wrapper cases (bracket, bracket-on-throw with error propagation, null client, partial client), 9 viewer pairing cases (paired hidden, unpaired rendered + llmCall label, multi-round, llmError-terminated, promptCancelled-terminated, per-span isolation, the two-span post-resume shape, threadEndHooks labeling) + 2 summary cases. All 237 pass.
- Integration (agency-js, deterministic clients): **pairing** (per-span SCSC alternation, one shared llmCall span, threadId match, schema+maxTokens fingerprint on the wire); **attribution** (the summarizer's promptStart has the threadEndHooks span as parent — the incident regression pin); **resume** (interrupt + respondToInterrupts → exactly 2 starts, no replay double-emit); **failure** (throwing client with retries: 0 → 1 start, 0 completions, llmError sharing the start's span — proving before-dispatch emission); **retry** (fail-once with retries: 1 → one start, retries share it); **cancellation** (race with a parked, signal-respecting loser → loser terminates via promptCancelled, no llmError). Plus the pre-existing `llm-call-single-span` guard.
- Real-log smoke: hosted one-shot run → 2 starts = 2 completions, one threadEndHooks bracket; tree render shows the summarizer's llmCall nested under `thread-end hooks (summarize: on)` and zero in-flight rows; the truncated-log recreation above shows the loud row.
- `make` clean, `lint:structure` clean (the linter's 150-line cap caught `_runPrompt` and forced the `emitPromptStart` extraction — a good trade).

## Deviations + a bug found along the way

- The spec's attribution test was planned as an extension of `tests/agency/threads-registry/eager-summarize`; that harness asserts node output only and cannot read span envelopes, so it ships as a new agency-js test making the same assertion, stronger.
- The attribution test's `import { userMessage } from "std::thread"` is load-bearing: the eager summarizer is a global hook registered at that module's load — a program that never imports `std::thread` has no summarizer. Comment in the test explains it.
- **Pre-existing codegen bug, isolated but not fixed here:** `try llm(...)` DIRECTLY yields `success(undefined)` — the value is lost — while `try` around a def wrapping the same call round-trips fine. The failure test works around it with def wrappers and documents the repro in a comment. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
