### PR TITLE
Fix recursive and forward-referencing type aliases (closes #470, #473)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-recursive-types-review.md
+++ b/docs/superpowers/plans/2026-07-09-recursive-types-review.md
@@ -1,0 +1,447 @@
+# Review: Recursive Type Aliases Fix Plan (#470 + #473)
+
+Reviewed against the code at main (12213f22). Every claim below was checked by reading the
+named file, not from memory.
+
+## Verdict
+
+The architecture is right: coinductive pair stack for `isAssignable`, `z.lazy` for
+not-yet-emitted consts, one canonical `typeKey`. All three mirror idioms the codebase
+already owns (`resolveTypeWithGuard`'s `inProgress` set, per-module builder state). The
+plan's "verified facts" all check out — I re-verified each one (details at the bottom).
+
+But there are two must-fix correctness gaps, one plan-code bug that won't compile as
+written, and a test that doesn't pin the behavior it claims to pin. Fix these before
+executing.
+
+---
+
+## Must fix
+
+### 1. Task 3 does not cover the validation-descriptor path — validated recursive/forward aliases stay broken
+
+Task 3 threads `pendingAliases` only through `zodSchemaFor` → `mapTypeToValidationSchema`.
+But a validated alias (`@validate` anywhere in its body) emits a SECOND module-load-time
+structure: `(Alias as any).__agency_descriptor = <descriptor>` (`typescriptBuilder.ts:802-807`),
+and the descriptor builder has two eager reference sites of its own:
+
+- `validationDescriptor.ts:296-302` — a nested alias ref with validators emits
+  `(Alias as any).__agency_descriptor`, read eagerly at module load. For a forward ref
+  this is a TDZ crash the z.lazy fix does not touch. For a SELF-ref it does not crash
+  (the const is initialized one statement earlier) but reads `undefined` — the nested
+  validation silently disappears. Silent validator loss is worse than the crash.
+- `validationDescriptor.ts:173-179` (`schemaNode`) — descriptors embed schema strings via
+  a direct `mapTypeToValidationSchema` call that Task 3's threading never reaches, so
+  bare forward alias names still appear inside descriptors at module load.
+
+So after Task 3 ships, `type Tree = { @validate(positive) value: number, children: Tree[] }`
+either crashes at load (forward/mutual case) or silently drops nested validation
+(self-recursive case). The plan's Task 3 tests only use unvalidated aliases, so nothing
+catches this.
+
+Options, in order of preference:
+1. Make the descriptor references lazy too (a thunk or getter for the
+   `__agency_descriptor` read, and thread `pendingAliases` into `schemaNode`). Check what
+   the runtime walker in `validateChain.ts` needs before choosing the shape.
+2. If that grows too large, detect a validated alias whose body reaches a pending alias
+   and fail compilation with a clear "validated recursive aliases are not yet supported"
+   error, plus a pinning test and a named follow-up issue.
+
+Either way, add a validated-recursive-alias case to the Task 3 test matrix. Validation is
+a safety surface in this codebase; shipping it silently broken is not acceptable.
+
+### 2. `canonical()` ignores `valueArgs` — distinct instantiations of a value-param alias key equal
+
+`TypeAliasVariable.valueArgs` and `GenericType.valueArgs` (`lib/types/typeHints.ts:254,49`)
+never appear in the canonical string. And value-arg substitution only rewrites *tags*
+(`applyValueArgs` per `assignability.ts:78-80`), which `canonical()` strips. Net effect:
+
+- `typeKey(Age(18)) === typeKey(Age(21))`, nested or top-level.
+- At dedup sites, `NumberInRange(0, 10) | NumberInRange(0, 100)` collapses to one member,
+  dropping whichever validation range loses.
+- As a coinduction pair key, two genuinely different pairs share a key, so the guard can
+  return a premature `true` for a pair that was never actually in flight.
+
+Fix: include `valueArgs` in the canonical form (e.g. via `tagArgToTs`, which already
+stringifies the tag-argument expression subset; do not `JSON.stringify` the expression
+node — it carries `loc`). Also state explicitly in the typeKey doc comment that stripping
+`tags` is a deliberate identity decision and why it is safe at the flow/synth dedup sites
+(they feed diagnostics, not codegen schemas) — today the plan strips them without arguing
+it.
+
+### 3. Plan's `widenAtLoopBackEdge` replacement doesn't type-check — `before`/`after` are `ScopeType`, which includes `"any"`
+
+`typeAt` returns `ScopeType` (`VariableType | "any"`), and `widenAtLoopBackEdge`
+(`flow.ts:328`) compares `before`/`after` where either can be `"any"`. The plan's
+replacement `typeKey(before, env.typeAliases) === typeKey(after, env.typeAliases)` passes
+`"any"` into a `VariableType`-typed parameter — tsc rejects it, and if forced through,
+`canonical("any")` falls off the switch and returns `undefined` (accidentally "working"
+via `undefined === undefined`). Short-circuit first:
+
+```ts
+const unchanged =
+  before === "any" || after === "any"
+    ? before === after
+    : typeKey(before, env.typeAliases) === typeKey(after, env.typeAliases);
+```
+
+Also give `canonical()` a `never`-typed default branch (the file-level convention per
+`typeHints.ts:8-13` is exhaustive switches enforced by a never default) rather than
+relying on the plan's "if tsc reports a missed variant" note — without a default branch
+tsc reports nothing; it just returns `undefined`.
+
+### 4. Task 2 test 4 does not pin removal-on-exit
+
+The "sibling repeats" test passes two bad arguments to `two(a, b)`. But each argument
+check is a separate top-level `isAssignable` call, and each call creates a fresh
+`Set` (the default parameter). A buggy implementation that never removes pairs still
+passes this test — the stale entry dies with the set at call exit.
+
+To pin removal you need the stale `true` to flip an outcome *within one comparison tree*.
+Union member order does it:
+
+```
+type Tree = { value: number, children: Tree[] }
+type NamedTree = { name: string, children: NamedTree[] }
+type Target = {
+  a: NamedTree | Tree,   // checks Tree~>NamedTree (false, pair added+removed), then Tree~>Tree (true)
+  b: NamedTree,          // re-checks Tree~>NamedTree — a leaked entry makes this wrongly true
+}
+```
+
+Pass `{ a: t, b: t }` where `t: Tree`. Correct implementation rejects (prop `b` fails);
+a no-removal memo accepts. Assert the error is reported. Keep the existing test too if
+you like, but don't label it as the removal pin.
+
+---
+
+## Should fix
+
+### 5. `pendingAliasNames()` over-includes imported aliases — guaranteed fixture churn, contradicting Step 6's zero-churn gate
+
+`visibleTypeAliasesFull()` returns the compilation unit's visible registry
+(`scopeManager.ts:106-108`), which includes imported aliases — that is how cross-module
+alias refs resolve. Imported aliases are never pushed onto `emittedAliasNames` (their
+consts live in another module), so every imported alias ref classifies as pending and
+gets wrapped in `z.lazy`. Harmless at runtime (imports initialize first), but every
+cross-module-alias fixture churns, and Step 6's own instruction then says "stop and fix."
+
+Compute pending from aliases *declared in the current module* (walk the program's
+`typeAlias` nodes) minus emitted, not from the visible registry. The plan already
+gestures at this fallback in the Step 4 NOTE — make it the primary design, not the
+fallback.
+
+Related lifecycle points to make explicit in Task 3:
+- Builder is per-module (`typescriptGenerator.ts:77`), so the instance field is fine.
+- Only the module-level emission path should push onto `emittedAliasNames`.
+  `processTypeAlias` is also called from `hoistBodyTypeAliases` (`typescriptBuilder.ts:686-697`)
+  for function-body aliases, whose consts initialize at function-call time, not module
+  load. A body alias sharing a name with a later module-level alias would otherwise mark
+  the module alias "emitted" early → bare name → real TDZ. Obscure, but it is exactly the
+  under-inclusion direction the plan itself calls unsafe.
+- Generic and value-param aliases return early from `processTypeAlias` (stub / factory /
+  nothing) and never reach the const path. Refs to them are inlined or emitted as factory
+  *calls* (function declarations hoist, so no TDZ). Fine — but say so, since they will sit
+  in the pending set forever.
+
+### 6. Two `JSON.stringify` dedup sites are missing from Task 1
+
+The plan claims typeKey is "THE replacement for raw JSON.stringify at the dedup sites"
+and #473 presumably wants all of them. Two are not in the task list:
+
+- `lib/typeChecker/inference.ts:162` — `unionTypes()`. Harder: its signature has no alias
+  table, so migrating ripples to callers. If you scope it out, say so in the PR and note
+  it on #473 rather than letting "the dedup sites" overclaim.
+- `lib/typeChecker/synthesizer.ts:1215` — block return-type dedup. Same shape as the
+  three sites the plan does migrate; `ctx` is in scope there. Just add it.
+
+### 7. Module-load tool definitions can still TDZ on def-before-type — verify and scope
+
+Function/tool registrations emit at module load with eager schemas
+(`toolDefinition: { ..., schema: z.object(...) }` — see
+`tests/typescriptGenerator/asyncAssigned.mjs:322-325`), and the shared mapper emits bare
+alias names (`typeToZodSchema.ts:226`). So `def f(x: Tree)` written *before*
+`type Tree = ...` should crash at load today, and Task 3 does not touch this path.
+
+This may be acceptable scope (the PR fixes alias-to-alias references), but the PR title
+says "forward-referencing type aliases work," and a user will read that as covering
+def-before-type. Probe it (two-line .agency file). If it crashes: either thread pending
+through this path too, or state the limitation in the docs paragraph and file a follow-up.
+Don't leave it undiscovered until a bug report.
+
+---
+
+## Minor
+
+- **zod version confirmed**: `package.json` has `zod: ^4.3.5`, so Task 4's probe should go
+  straight to `z.toJSONSchema` (zod 4 handles cycles with `$ref` by default via the `cycles`
+  option; the throwing branch is unlikely but the plan's two-branch handling is fine).
+- **`z.infer` circularity (Task 3 Step 5)**: generated output keeps TS annotations but runs
+  as `.mjs` (see `asyncAssigned.mjs:330` — `__state: GraphState` in a .mjs file), i.e. it is
+  transpiled, not type-checked. `type Tree = z.infer<typeof Tree>` degrading is therefore
+  likely invisible at runtime. The plan's "observe and decide" hedge is fine; this note
+  just predicts the observation.
+- **`uniteTypes` param rename**: switching to `typeKey(t, _aliases)` makes `_aliases` used;
+  rename to `aliases` (the underscore convention marks it unused today).
+- **`canonical()` silently ignores `blockType.raises` and `ObjectProperty.description`**.
+  `raises` is fine (compatibility unchecked today, per the field's own doc comment) and
+  description-stripping means union dedup keeps the first member's description — both are
+  reasonable, but list them in the doc comment as deliberate, next to `tags`.
+- **Recursive value-param alias = compile-time infinite loop**: `mapTypeToSchemaInner`
+  inlines value-param instantiations by recursion (`typeToZodSchema.ts:208-225`) with no
+  `seen` guard. `type Weird(n: number) = { next: Weird(n) }` would hang codegen. Out of
+  scope, but a one-line mention in the PR (or a follow-up issue) beats rediscovering it.
+- **Task 2 Step 5 perf gate is sound** — worth one comment in the code when you add it:
+  internal recursive calls pass *resolved* nodes, but any cycle must pass through a named
+  reference (`typeAliasVariable`/`genericType`), so gating the pair-key on named nodes
+  cannot miss a cycle.
+
+---
+
+## Verified facts — re-checked, all hold
+
+- `isAssignable` at `assignability.ts:363`, signature `(source, target, typeAliases)`, the
+  `"any"` sentinel check first, fresh `safeResolveType` per call; internal recursive call
+  sites at lines 419–698, count ≈ 17. ✓
+- `safeResolveType` → `resolveTypeWithGuard` resolves only the top-level alias chain
+  (non-alias nodes return at `assignability.ts:150` without descending), so typeKey on an
+  alias is cheap and inner refs stay nominal. ✓
+- `deepResolveNode` (`assignability.ts:245-261`) leaves non-generic alias refs intact —
+  the codegen bug is purely const ordering. ✓
+- Alias consts emit at `typescriptBuilder.ts:782` in source order; bare-name emission at
+  `typeToZodSchema.ts:226`. ✓
+- `uniteTypes` has an unused `_aliases` param and the exact KNOWN-LIMITATION comment the
+  plan says to delete (`flow.ts:128-143`); `widenAtLoopBackEdge` stringify-compare at
+  `flow.ts:328`; synthesizer sites at 460/462, 639, 711; `ctx.getTypeAliases()` exists. ✓
+- `typecheckSource` exists in `lib/typeChecker/testUtils.ts:20`. ✓
+- The Task 3 agency test mirrors `tests/agency/utility-partial.agency` exactly (same
+  `isSuccess(r)` + `r.value` narrowing pattern, same test.json shape and output
+  serialization), so the syntax and harness expectations are right. ✓
+- Builder is instantiated per module, so per-instance emitted-alias state is safe. ✓
+- The canonical() switch covers all 13 `VariableType` variants. ✓
+
+## Suggested execution order change
+
+None structurally — the task order is right (typeKey → coinduction → codegen). Fold
+must-fix items 2–4 into Tasks 1–2 before starting, and decide item 1's option (lazy
+descriptors vs. clear error) before Task 3, since it changes Task 3's file list.
+
+---
+
+## Anti-pattern audit (docs/dev/anti-patterns.md)
+
+Checked every code block the plan proposes against the catalog. Overall: Tasks 1 and 2
+genuinely encapsulate imperative complexity behind declarative interfaces. Task 3 is the
+exception — its emitted-alias tracking is the catalog's "order-dependent mutable state"
+anti-pattern, and it has a cleaner stateless formulation.
+
+### Where the plan does it right
+
+- **`typeKey` (Task 1)** is the catalog's good pattern in its purest form: callers state
+  *what* they want ("the canonical identity of this type") and the recursive `canonical()`
+  walk is the hidden *how*. It also fixes an existing duplication (five hand-rolled
+  `JSON.stringify` idioms collapse into one function), which is the catalog's first entry.
+- **Coinduction (Task 2)** mirrors the file's own established encapsulation
+  (`resolveType` public / `resolveTypeWithGuard` private with an explicit `inProgress`
+  set). Consistency with the existing pattern is itself a catalog requirement.
+- **`z.lazy` choice (Task 3)** is declarative at the emission site: "this reference is
+  pending, so defer it" — no reordering pass, no SCC computation. The right altitude.
+
+### Findings
+
+**A. (Real hit) Task 3's `emittedAliasNames` is order-dependent mutable state.**
+The catalog's third entry, exactly: a private mutable field that is correct only if
+every emission site remembers to push after emitting, and `pendingAliasNames()` silently
+returns wrong answers if any call is reordered, skipped, or added on a new emission path
+(the hoisted-body-alias path in must-fix item 5 is precisely such a silent break, already
+latent in the plan). The catalog's only exemption is parsers.
+
+The state is unnecessary. Module-level alias consts emit in source order, so "pending at
+the time alias #i emits" is a pure function of the program: collect the module's
+`typeAlias` declarations once, in order; when emitting the alias at index `i`, the pending
+set is `names[i..end]` (self included). No field, no push-after-emit invariant, nothing to
+keep in sync — and it fixes the imported-alias over-inclusion (item 5) for free, since the
+list is built from declarations, not scope visibility. Recommend replacing the
+`emittedAliasNames` field + `pendingAliasNames()` helper with this derived computation.
+
+(An even simpler stateless design — always emit `z.lazy` for any same-module alias
+reference — was presumably rejected for fixture churn. That trade is defensible, but the
+plan should say so; the zero-churn constraint is what bought this machinery.)
+
+**B. (Mild leak) The coinduction set appears on the exported `isAssignable` signature.**
+`inProgress?: Set<string>` on the public function is an internal detail leaking into the
+interface — the "leaky abstraction" entry, in miniature. The file's own precedent avoids
+it: `resolveType(vt, aliases)` stays two-arg and the guarded recursion lives in a private
+helper. Same shape works here:
+
+```ts
+export function isAssignable(source, target, typeAliases): boolean {
+  return isAssignableGuarded(source, target, typeAliases, new Set());
+}
+function isAssignableGuarded(source, target, typeAliases, inProgress): boolean {
+  // "any" check, pair-key guard, try/finally, then the existing body;
+  // all ~17 internal recursive sites call isAssignableGuarded.
+}
+```
+
+Public API unchanged (three args, no optional tail), guard still applied at every
+recursion level, and it matches `resolveTypeWithGuard` exactly instead of half-matching.
+
+**C. (Catalog hit) Nested ternary in `canonical()`'s sort comparator.**
+`.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))` is the "nested ternaries"
+entry verbatim. Simplest fix is also more internally consistent: render each property to
+its string first, then `.sort()` the strings — which is exactly what the plan's own
+`unionType` case does one line below. Two cases, one pattern.
+
+**D. (Watch, not fix) Parameter threading in the zod mapper is nearing sprawl.**
+`mapTypeToSchemaInner` grows to six positional parameters, three of them optional
+(`resultHandler`, `typeAliasesFull`, `optionalKeyMode`, now `pendingAliases`). The plan
+correctly mirrors the existing `optionalKeyMode` threading (consistency beats a drive-by
+refactor), so this is not a blocker — but it is the trajectory toward the "leaky
+abstraction" entry, where every new emission concern touches four signatures. Worth one
+line in the PR noting that the next parameter should trigger consolidating these into an
+options/context object.
+
+**E. (Checked, clean) The rest of the catalog.**
+No silent catch blocks (Task 2 uses try/finally, no catch). No dynamic imports (the plan
+explicitly designs around the cycle instead). No magic numbers, no nested type-definition
+objects, no `...(x ? { x } : {})`. Guard-clause one-line ifs in the plan's snippets match
+the pervasive style of the exact file being edited (`assignability.ts:51,63,71,...`), so
+matching them is consistency, not a violation. Single-letter `t` for types likewise
+matches the file's own convention. The `Set` for `inProgress` is the plan's explicitly
+justified exception (mirrors `resolveTypeWithGuard`); if finding A is adopted, the
+`pendingAliases` set becomes a small derived value and can be an array lookup per the
+objects-not-maps/arrays-not-sets rule, or keep `Set` for the O(1) `has` — either is
+defensible, just pick consciously.
+
+---
+
+## Test-plan review
+
+Question asked of every test: if the code it guards breaks or gets reverted, does this
+test go red? Findings below; the reversion matrix at the end summarizes.
+
+### What the plan gets right
+
+- **Every task has an explicit red step with a named failure mode** (module-not-found,
+  `RangeError`, `ReferenceError`) — the tests are proven to detect the bug before the fix
+  exists. This is the strongest part of the test plan.
+- **Task 2 test 3 (incompatible recursive types still REJECT)** is the essential
+  anti-vacuity test: a coinduction guard that returns `true` too eagerly fails it. Present
+  and correctly constructed. (Note it differs at recursion level 1 — `name` vs `value` —
+  which is sufficient for the mechanism, since any structural difference is reachable at
+  finite depth.)
+- **Task 3's `rejects` node validates at nesting depth 2**, proving the lazy schema
+  actually validates recursively instead of degrading to `z.any()`. Without this test,
+  `z.lazy(() => z.any())`-style bugs would pass `accepts` and ship.
+- **Step 6's zero-churn gate** (`git status --short tests/`) turns the entire existing
+  fixture corpus into a regression net for over-wrapping. Cheap and effective.
+- Plan test code compiles as written: `Tag` needs only `type`/`name`/`arguments` (`loc`
+  is optional on `BaseNode`), `TypeAliasEntry` accepts `{ body }`, `typecheckSource`
+  errors carry `.message`.
+
+### Tests that do NOT test what they claim
+
+**T1. Task 2 test 4 ("sibling repeats") cannot fail on the bug it names.** Covered as
+must-fix item 4 above: each argument check is a separate top-level `isAssignable` call
+with a fresh `Set`, so a leaked (never-removed) entry dies with the set before the
+sibling runs. A memoizing implementation — the exact bug the try/finally exists to
+prevent — passes this test. Replace with the single-comparison union-order construction
+from item 4, where a leaked `false`-pair entry flips the overall verdict to a wrong
+accept.
+
+**T2. Task 1 test 4's `k1 === k2` assertion is vacuous.** `typeKey` is a pure function;
+calling it twice on the same input and comparing proves determinism, which nothing
+threatens. The test's real value is termination (an unguarded implementation
+stack-overflows, failing the test by crashing) — keep that, but replace the vacuous
+assertion with something semantic: two same-shaped recursive aliases with different
+names (`Tree` / `Tree2`) must key DIFFERENTLY (inner refs are nominal). That pins the
+design decision the whole recursion story rests on, and today no test does.
+
+**T3. Task 1 test 2 claims to test trivia but constructs none.** The test name says
+"ignores tags, trivia, and effect-set flags"; the bodies cover tags and `isEffectSet`
+only. Because `canonical()` is an allowlist (it rebuilds from known fields), trivia and
+`loc` are stripped by construction — but then the test should either include an
+`objectType` with a `trivia` entry or drop "trivia" from the name. As written, someone
+adding trivia leakage later gets a green suite and a lying test name.
+
+### Silent-revert holes (code breaks, suite stays green)
+
+**T4. Nothing pins the Task 1 call-site wiring.** If someone reverts the
+`flow.ts`/`synthesizer.ts` edits back to `JSON.stringify`, the typeKey unit tests still
+pass — they test the function, not its adoption. Step 5's "expect dedup diffs in existing
+tests" may leave churned assertions that pin it incidentally, but that's indeterminate
+until executed. Add at least one behavior-level test that only passes through typeKey:
+e.g. a `typecheckSource` case where an if/else join unites `{ a: 1, b: 2 }` with
+`{ b: 2, a: 1 }` (property order flipped) and the resulting diagnostic or synthesized
+type shows a single object type, not a two-member union.
+
+**T5. Nothing pins the union-member sort.** `canonical()` sorts union members so
+`A | B` keys equal `B | A` — highlighted in the plan's own doc comment, tested nowhere.
+One two-line unit test. Same for the nested-nominal rule: `typeKey({a: AgeRef})` must
+DIFFER from `typeKey({a: number})` (nested refs deliberately stay nominal; only the top
+resolves). Both are design decisions someone could "fix" while refactoring, greenly.
+
+**T6. Task 4's good branch commits no test.** If the zod probe shows `$ref`/`$defs`
+works, the plan commits documentation and nothing else — the probe is scratch. Zod is
+pinned with a caret (`^4.3.5`); a minor zod upgrade that changes cycle handling in
+`toJSONSchema` regresses recursive structured output with a fully green suite. Commit a
+unit-level test that runs the same conversion smoltalk uses on the generated `Tree`
+schema shape and asserts a `$ref` appears (no LLM call needed). The throwing branch
+already commits a pinning test; the working branch deserves one too.
+
+### Missing test cases
+
+Ordered by importance:
+
+1. **Validated recursive/forward alias** (ties to must-fix item 1). Whichever way item 1
+   is resolved — lazy descriptors or a clear compile error — there is currently no test
+   exercising `@validate` + recursion, and the self-recursive case fails *silently*
+   (descriptor reads `undefined`, validation vanishes). This is the most dangerous
+   untested path in the plan.
+2. **Recursive alias as a function parameter, executed** (ties to item 7). Task 2's
+   `def id(x: Tree)` tests typecheck only; no execution test compiles-and-loads a module
+   where a function's tool-registration schema (module-load-time `z.object`, see
+   `asyncAssigned.mjs:322-325`) references a recursive alias. Add `def f(x: Tree)` to
+   `recursive-type.agency` (declared after the type) and call it; separately probe
+   def-before-type to settle item 7's scope question.
+3. **Mutual recursion, executed.** Employee/Manager exists only as a textual fixture grep
+   (Step 6), which pins emission shape but never runs. Add a `schema(Employee).parseJSON`
+   round-trip to the execution test — it would catch a back-edge/forward-edge direction
+   bug that happens to load without crashing.
+4. **Utility-type × recursion at codegen.** Task 5 pins `Partial<Tree>` in the
+   typechecker only. Add `type TreePatch = Partial<Tree>` to the codegen fixture (alias
+   const whose *expanded* initializer contains a pending self-reference — exercises the
+   pending-set logic through the builtin-generic expansion path) and an execution
+   `schema(Partial<Tree>).parseJSON("{}")` test mirroring `utility-partial.agency`.
+5. **Self-reference in union position.** The fixture covers object-property and
+   array-element positions. `type Json = string | number | Json[]` puts the self-ref
+   under `z.union([...])` in the const initializer — a different structural path through
+   `mapTypeToSchemaInner`. One fixture line plus one grep.
+6. **Non-empty nested literal in Task 2 test 1.** `children: []` means the green run
+   never structurally compares a nested `Tree` literal against the alias. Use
+   `{ value: 3, children: [{ value: 4, children: [] }] }` — the red expectation is
+   unchanged (the crash comes from the `Tree`-vs-`Tree` call-site check), and green gains
+   depth.
+7. **Degenerate `type Loop = Loop`.** Today's behavior after this plan: typechecker keys
+   it nominally (fine), but codegen emits `const Loop = z.lazy(() => Loop)`, which
+   stack-overflows at first parse. Decide the behavior (a "circularly references itself"
+   compile error, like TS, is the obvious choice) and pin it — or explicitly scope it out
+   in the PR. Zero-cost to detect: the alias body resolves to a bare self-reference.
+
+### Reversion matrix (summary)
+
+| Break | Caught by |
+|---|---|
+| typeKey deleted/broken | Task 1 unit tests ✓ |
+| typeKey call sites reverted | **nothing** (T4) |
+| Union sort / nested-nominal removed | **nothing** (T5) |
+| Coinduction guard removed | Task 2 tests 1–2 (stack overflow) ✓ |
+| Guard never removes pairs (memo bug) | **nothing as written** (T1); fixed test 4 ✓ |
+| Guard accepts everything | Task 2 test 3 ✓ |
+| z.lazy emission removed | Task 3 tests (load crash) ✓ |
+| Backward refs over-wrapped | Step 6 zero-churn gate ✓ |
+| Wrong lazy target | Task 3 accepts/rejects ✓ |
+| Validated recursive alias breaks | **nothing** (missing case 1) |
+| zod upgrade breaks $ref conversion | **nothing** (T6) |
+| Recursive param in tool schema breaks | **nothing** (missing case 2) |

--- a/docs/superpowers/plans/2026-07-09-recursive-types.md
+++ b/docs/superpowers/plans/2026-07-09-recursive-types.md
@@ -1,0 +1,1171 @@
+# Recursive Type Aliases Fix Implementation Plan (#470 + #473) — rev 2 (review applied)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (owner preference: inline execution in the main session, NOT subagent-driven). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make recursive and forward-referencing type aliases work: fix the `isAssignable` stack overflow with coinduction, fix the module-load TDZ crashes with lazy references (zod schema consts AND validation descriptors), and land the canonical `typeKey()` (#473) the coinduction keys build on.
+
+**Architecture:** Four mechanisms. (1) `typeKey(t, aliases)` — one canonical structural-identity function replacing raw `JSON.stringify` at the dedup sites. (2) Coinductive assignability — an in-progress pair stack in a private `isAssignableGuarded` helper (public `isAssignable` keeps its three-arg signature, mirroring the `resolveType`/`resolveTypeWithGuard` split); re-encountering an in-flight pair returns true, entries removed on exit. (3) Lazy-if-not-yet-emitted zod refs — when an alias schema const initializer references a same-module plain alias whose const has not been emitted yet, emit `z.lazy(() => Name)`; pending-ness is DERIVED from the module's declaration order (no mutable emitted-set — review finding A). (4) Lazy validation-descriptor refs — a new `{ kind: "ref", get }` descriptor node defers the `__agency_descriptor` read to walk time, fixing both the forward-ref TDZ and the silent self-ref validator loss (review must-fix 1).
+
+**Verified facts** (plan author + independent reviewer both checked these against code):
+- `isAssignable` (`lib/typeChecker/assignability.ts:363`) has ~17 internal recursive call sites (lines 419–698); each resolves aliases with a fresh guard — the stack-overflow mechanism. Cycles can only arise through NAMED references (`typeAliasVariable`/`genericType`), so gating the pair guard on named nodes cannot miss a cycle.
+- Alias schema consts emit in source order (`typescriptBuilder.ts:782`); bare alias-name emission at the `return variableType.aliasName;` site in `typeToZodSchema.ts`. `deepResolveNode` never inlines non-generic aliases, so the codegen bug is purely initializer ordering. PROBE-CONFIRMED: plain forward refs (`type A = { b: B }` before `B`) TDZ-crash today too.
+- VALIDATED aliases emit a second module-load structure: `(Alias as any).__agency_descriptor = ...` (`typescriptBuilder.ts:802-807`). Two eager reference sites inside `validationDescriptor.ts`: the nested alias-ref read (`(Alias as any).__agency_descriptor`, ~line 296) — TDZ for forward refs, silently `undefined` for self-refs (validators vanish) — and `schemaNode`'s direct `mapTypeToValidationSchema` call (~line 173) which embeds bare alias names.
+- The runtime walker (`lib/runtime/validateChain.ts`) consumes a plain `TypeValidationDescriptor` union (leaf/object/array/union/nullable) and already enforces `maxDepth` (default 64) — recursion-safe by design; a `ref` thunk kind slots in cleanly.
+- zod is `^4.3.5` (zod 4): the structured-output probe should go straight to `z.toJSONSchema`, which handles cycles via `$ref`. Generated `.mjs` is transpiled, not type-checked, so `z.infer` circularity degradation is invisible at runtime.
+- Only PLAIN top-level aliases emit schema consts. Generic aliases and value-param aliases never reach the const path (inlined / factory calls / stubs), and function-body aliases (`hoistBodyTypeAliases`, `typescriptBuilder.ts:686-697`) initialize at call time, not module load. The pending-names list must therefore be: top-level `typeAlias` nodes with neither `typeParams` nor `valueParams`.
+- The builder is instantiated per module, and node-body `schema(...)` sites execute after module load — they never need lazy wrapping.
+- The runtime validation walker depth cap means no walker-termination work is needed.
+
+**Known scope-outs (say these in the PR):**
+- `lib/typeChecker/inference.ts:162` (`unionTypes`) keeps `JSON.stringify` — its signature has no alias table and migrating ripples to callers. Noted on #473 as a residual.
+- Recursive VALUE-PARAM aliases (`type Weird(n: number) = { next: Weird(n) }`) would hang codegen (`mapTypeToSchemaInner` inlines instantiations with no seen-guard) — pre-existing, out of scope, file a follow-up issue from the PR.
+- The zod mapper's parameter threading is nearing sprawl (six positionals after this PR); note in the PR that the next parameter should trigger an options-object consolidation (review finding D).
+
+## Global Constraints
+
+- Fresh worktree: `git worktree add .claude/worktrees/recursive-types -b recursive-types`, then `cd .claude/worktrees/recursive-types && pnpm install && cd packages/agency-lang && make`.
+- Never commit to `main`. No apostrophes in commit-message command lines. Save test output to files. Run `make` before CLI-based steps. Do NOT run the full agency suite locally.
+- The coinduction guard must live in a PRIVATE helper (`isAssignableGuarded`); the exported `isAssignable` keeps exactly three parameters (review finding B).
+- The guard must REMOVE pairs on exit (try/finally) — the Task 2 union-order test exists specifically to catch a memoizing implementation.
+- Codegen pending-ness must be DERIVED (pure function of declaration order), never a mutable emitted-set (review finding A).
+- Zero churn in EXISTING `tests/typescriptGenerator` fixtures is a hard gate for the zod-schema path (Task 3). Descriptor-emission churn (Task 4) is EXPECTED and deliberate — review each diff, don't block on it.
+
+---
+
+### Task 1: `typeKey()` — canonical structural type identity (#473)
+
+**Files:**
+- Create: `lib/typeChecker/typeKey.ts`
+- Test: `lib/typeChecker/typeKey.test.ts`
+- Modify: `lib/typeChecker/flow.ts` (`uniteTypes`, `widenAtLoopBackEdge`)
+- Modify: `lib/typeChecker/synthesizer.ts` (`synthLogical` ~460, `synthArray` ~639, `synthObject` ~711, block return-type dedup ~1215)
+
+**Interfaces:**
+- Produces: `typeKey(t: VariableType, aliases: Record<string, TypeAliasEntry>): string`. Canonical rules (each is a deliberate, documented identity decision): top node resolved ONE step via `safeResolveType` (recursive self-refs stay nominal); nested alias refs key nominally (`alias:Name`); object properties sorted; union members sorted by canonical form; `valueArgs` INCLUDED (review must-fix 2 — `Age(18)` must not key equal to `Age(21)`); `tags`, `trivia`, `description`, `loc`, `isEffectSet`, and `blockType.raises` STRIPPED.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/typeChecker/typeKey.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { typeKey } from "./typeKey.js";
+import type { VariableType, TypeAliasEntry } from "../types.js";
+
+const STR: VariableType = { type: "primitiveType", value: "string" };
+const NUM: VariableType = { type: "primitiveType", value: "number" };
+const NO_ALIASES: Record<string, TypeAliasEntry> = {};
+
+function treeAliases(name: string): Record<string, TypeAliasEntry> {
+  return {
+    [name]: {
+      body: {
+        type: "objectType",
+        properties: [
+          { key: "value", value: NUM },
+          {
+            key: "children",
+            value: {
+              type: "arrayType",
+              elementType: { type: "typeAliasVariable", aliasName: name },
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe("typeKey", () => {
+  it("is property-order insensitive", () => {
+    const ab: VariableType = {
+      type: "objectType",
+      properties: [
+        { key: "a", value: STR },
+        { key: "b", value: NUM },
+      ],
+    };
+    const ba: VariableType = {
+      type: "objectType",
+      properties: [
+        { key: "b", value: NUM },
+        { key: "a", value: STR },
+      ],
+    };
+    expect(typeKey(ab, NO_ALIASES)).toBe(typeKey(ba, NO_ALIASES));
+  });
+
+  it("is union-member-order insensitive", () => {
+    const ab: VariableType = { type: "unionType", types: [STR, NUM] };
+    const ba: VariableType = { type: "unionType", types: [NUM, STR] };
+    expect(typeKey(ab, NO_ALIASES)).toBe(typeKey(ba, NO_ALIASES));
+  });
+
+  it("ignores tags, trivia, descriptions, and effect-set flags", () => {
+    const plainObj: VariableType = {
+      type: "objectType",
+      properties: [{ key: "a", value: STR }],
+    };
+    const decoratedObj: VariableType = {
+      type: "objectType",
+      properties: [
+        {
+          key: "a",
+          value: {
+            type: "primitiveType",
+            value: "string",
+            tags: [{ type: "tag", name: "validate", arguments: [] }],
+          },
+          description: "described",
+        },
+      ],
+      trivia: [{ anchorIndex: 0, comments: [] }],
+    };
+    expect(typeKey(decoratedObj, NO_ALIASES)).toBe(typeKey(plainObj, NO_ALIASES));
+    const union: VariableType = { type: "unionType", types: [STR, NUM] };
+    const effectUnion: VariableType = {
+      type: "unionType",
+      types: [STR, NUM],
+      isEffectSet: true,
+    };
+    expect(typeKey(effectUnion, NO_ALIASES)).toBe(typeKey(union, NO_ALIASES));
+  });
+
+  it("resolves a top-level alias one step so alias and body key equal", () => {
+    const aliases: Record<string, TypeAliasEntry> = { Age: { body: NUM } };
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "Age" };
+    expect(typeKey(ref, aliases)).toBe(typeKey(NUM, aliases));
+  });
+
+  it("keeps NESTED alias refs nominal: {a: AgeRef} differs from {a: number}", () => {
+    const aliases: Record<string, TypeAliasEntry> = { Age: { body: NUM } };
+    const nominal: VariableType = {
+      type: "objectType",
+      properties: [{ key: "a", value: { type: "typeAliasVariable", aliasName: "Age" } }],
+    };
+    const structural: VariableType = {
+      type: "objectType",
+      properties: [{ key: "a", value: NUM }],
+    };
+    expect(typeKey(nominal, aliases)).not.toBe(typeKey(structural, aliases));
+  });
+
+  it("keys a recursive alias without looping, and DIFFERENT recursive aliases key differently", () => {
+    const aliases = { ...treeAliases("Tree"), ...treeAliases("Tree2") };
+    const tree: VariableType = { type: "typeAliasVariable", aliasName: "Tree" };
+    const tree2: VariableType = { type: "typeAliasVariable", aliasName: "Tree2" };
+    // Same shape, different names: inner refs are nominal, so keys differ.
+    expect(typeKey(tree, aliases)).not.toBe(typeKey(tree2, aliases));
+  });
+
+  it("distinguishes value-param instantiations (valueArgs are identity)", () => {
+    const age18: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "Age",
+      valueArgs: [{ type: "number", value: 18 }],
+    };
+    const age21: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "Age",
+      valueArgs: [{ type: "number", value: 21 }],
+    };
+    // Unknown alias — stays nominal; the valueArgs must still distinguish.
+    expect(typeKey(age18, NO_ALIASES)).not.toBe(typeKey(age21, NO_ALIASES));
+  });
+
+  it("distinguishes genuinely different types", () => {
+    expect(typeKey(STR, NO_ALIASES)).not.toBe(typeKey(NUM, NO_ALIASES));
+    const arr: VariableType = { type: "arrayType", elementType: STR };
+    expect(typeKey(arr, NO_ALIASES)).not.toBe(typeKey(STR, NO_ALIASES));
+  });
+});
+```
+
+NOTE: check the number-literal expression shape before running — `{ type: "number", value: 18 }` must match the parser's number node (`lib/types/literals.ts`); adjust the two `valueArgs` literals if the field name differs.
+
+- [ ] **Step 2: Run to verify red**
+
+```bash
+pnpm test:run lib/typeChecker/typeKey.test.ts > /tmp/rec-task1-red.log 2>&1; tail -3 /tmp/rec-task1-red.log
+```
+
+Expected: FAIL — cannot find module `./typeKey.js`.
+
+- [ ] **Step 3: Implement**
+
+Create `lib/typeChecker/typeKey.ts`:
+
+```ts
+import type { Expression, TypeAliasEntry, VariableType } from "../types.js";
+import { safeResolveType } from "./assignability.js";
+
+/**
+ * Canonical structural identity for a type — THE replacement for raw
+ * `JSON.stringify(t)` at identity sites (uniteTypes, loop widening, union
+ * dedup in synthesis, coinduction pair keys). Fixes the gaps raw stringify
+ * had (issue #473): property-order sensitivity, non-semantic metadata
+ * leaking into the key, and unresolved top-level aliases keying
+ * differently from their bodies.
+ *
+ * Deliberate identity decisions (all safe because the consumers feed
+ * dedup/diagnostics and cycle detection, never codegen schemas):
+ * - The TOP node resolves ONE step via safeResolveType (recursive
+ *   self-refs stay nominal via its guard); NESTED alias refs key
+ *   nominally as `alias:Name` — never expanded, so recursion terminates
+ *   and same-name refs always key equal.
+ * - `valueArgs` ARE identity: `Age(18)` and `Age(21)` are different types.
+ * - `tags`, `trivia`, property `description`s, `loc`, `isEffectSet`, and
+ *   `blockType.raises` are NOT identity: two types differing only in
+ *   annotations/formatting dedup together (first member's metadata wins
+ *   at union joins — acceptable for diagnostics).
+ * - Union members sort by canonical form (`A | B` keys equal `B | A`);
+ *   object properties sort by key.
+ */
+export function typeKey(
+  t: VariableType,
+  aliases: Record<string, TypeAliasEntry>,
+): string {
+  return canonical(safeResolveType(t, aliases));
+}
+
+/**
+ * Canonicalize a tag-argument-subset expression (literals, identifiers,
+ * object literals) for valueArgs identity. Falls back to a loc-stripped
+ * JSON walk for shapes outside the subset — stable, if verbose.
+ */
+function canonicalExpr(e: Expression): string {
+  return JSON.stringify(e, (key, value) =>
+    key === "loc" ? undefined : value,
+  );
+}
+
+function canonicalValueArgs(valueArgs: Expression[] | undefined): string {
+  if (!valueArgs || valueArgs.length === 0) return "";
+  return `,"vargs":[${valueArgs.map(canonicalExpr).join(",")}]`;
+}
+
+function canonical(t: VariableType): string {
+  switch (t.type) {
+    case "typeAliasVariable":
+      return `{"alias":${JSON.stringify(t.aliasName)}${canonicalValueArgs(t.valueArgs)}}`;
+    case "objectType": {
+      const props = t.properties
+        .map((p) => `${JSON.stringify(p.key)}:${canonical(p.value)}`)
+        .sort();
+      return `{"object":{${props.join(",")}}}`;
+    }
+    case "unionType":
+      return `{"union":[${t.types.map(canonical).sort().join(",")}]}`;
+    case "arrayType":
+      return `{"array":${canonical(t.elementType)}}`;
+    case "resultType":
+      return `{"result":[${canonical(t.successType)},${canonical(t.failureType)}]}`;
+    case "schemaType":
+      return `{"schema":${canonical(t.inner)}}`;
+    case "genericType":
+      return `{"generic":${JSON.stringify(t.name)},"args":[${t.typeArgs.map(canonical).join(",")}]${canonicalValueArgs(t.valueArgs)}}`;
+    case "blockType":
+      return `{"block":[${t.params.map((p) => canonical(p.typeAnnotation)).join(",")}],"ret":${canonical(t.returnType)}}`;
+    case "functionRefType":
+      return `{"fnref":${JSON.stringify(t.name)}}`;
+    case "primitiveType":
+      return `{"prim":${JSON.stringify(t.value)}}`;
+    case "stringLiteralType":
+      return `{"strlit":${JSON.stringify(t.value)}}`;
+    case "numberLiteralType":
+      return `{"numlit":${JSON.stringify(t.value)}}`;
+    case "booleanLiteralType":
+      return `{"boollit":${JSON.stringify(t.value)}}`;
+    default: {
+      // Exhaustiveness enforced per the typeHints.ts convention: a new
+      // VariableType variant fails compilation here instead of silently
+      // returning undefined.
+      const exhausted: never = t;
+      throw new Error(`typeKey: unhandled type variant ${JSON.stringify(exhausted)}`);
+    }
+  }
+}
+```
+
+Cycle note: `typeKey.ts` value-imports `safeResolveType` from `assignability.ts`; Task 2 makes `assignability.ts` value-import `typeKey` back. Both uses are inside function bodies (never at module init), so the ESM cycle is safe at runtime — but if vitest/tsc complains in Task 2, move `typeKey` INTO `assignability.ts` and re-export from `typeKey.ts`.
+
+The object-property sort renders each property string first and sorts the strings — same pattern as the union case (review finding C; no comparator ternaries). Note this canonicalizes `{a, b}` ordering correctly because each rendered string starts with the JSON-quoted key.
+
+- [ ] **Step 4: Replace the stringify identity sites (all four)**
+
+- `lib/typeChecker/flow.ts` `uniteTypes`: key by `typeKey(t, aliases)`; rename the `_aliases` param to `aliases` (it becomes used). Delete the KNOWN-LIMITATION comment (typeKey closes exactly those gaps) and point to `typeKey.ts` instead.
+- `lib/typeChecker/flow.ts` `widenAtLoopBackEdge`: the unchanged-check must short-circuit the `"any"` sentinel BEFORE typeKey (review must-fix 3 — `ScopeType` includes `"any"`, which must never reach `canonical`):
+
+```ts
+    const unchanged =
+      before === "any" || after === "any"
+        ? before === after
+        : typeKey(before, env.typeAliases) === typeKey(after, env.typeAliases);
+    if (unchanged) {
+      widened[referenceKey(r)] = before;
+    } else {
+      widened[referenceKey(r)] = uniteTypes(
+        [before, after].filter((x): x is VariableType => x !== "any"),
+        env.typeAliases,
+      );
+    }
+```
+
+CAREFUL: check `uniteTypes`'s current handling of `"any"` members before rewriting this call — if it already accepts `ScopeType[]` and returns `"any"` when any member is `"any"` (it does today), keep passing `[before, after]` unchanged and only replace the unchanged-check. Preserve existing behavior exactly; only the comparison changes.
+
+- `lib/typeChecker/synthesizer.ts`: `synthLogical` (`seen.set(JSON.stringify(m), m)`), `synthArray` (`const key = JSON.stringify(t)`), `synthObject` (`uniqBy(allValueTypes, (t) => JSON.stringify(t))`), AND the block return-type dedup at ~line 1215 (review item 6 — same shape, `ctx` in scope) — all switch to `typeKey(x, ctx.getTypeAliases())`.
+
+- [ ] **Step 5: Add the adoption pin test (review T4)**
+
+Append to `lib/typeChecker/typeKey.test.ts`:
+
+```ts
+import { typecheckSource } from "./testUtils.js";
+
+describe("typeKey adoption at the dedup sites", () => {
+  it("a flow join of property-order-flipped object types unites to ONE member", () => {
+    // Only passes when uniteTypes keys via typeKey: raw JSON.stringify
+    // sees two distinct members and the union leaks into the return type,
+    // making the declared annotation check fail.
+    const errors = typecheckSource(`
+def pick(flag: boolean): { a: number, b: number } {
+  if (flag) {
+    return { a: 1, b: 2 }
+  }
+  return { b: 2, a: 1 }
+}
+node main() {
+  return pick(true)
+}
+`);
+    expect(errors).toEqual([]);
+  });
+});
+```
+
+NOTE: verify during execution that this program actually FAILS before the flow.ts edit (run it in the red phase of Step 2 order — i.e., write it in Step 1 if convenient, or confirm red here by temporarily stashing the flow.ts change). If the checker accepts it even with raw stringify (e.g. return-position checking never goes through uniteTypes), find the join path that DOES (an `if/else`-assigned local read after the join) and pin that instead — the requirement is one behavior-level test that flips when the flow.ts wiring reverts.
+
+- [ ] **Step 6: Suites, triage, commit**
+
+```bash
+pnpm test:run lib/typeChecker > /tmp/rec-task1-suite.log 2>&1; tail -5 /tmp/rec-task1-suite.log
+pnpm test:run lib > /tmp/rec-task1-lib.log 2>&1; tail -3 /tmp/rec-task1-lib.log
+pnpm run lint:structure > /tmp/rec-task1-lint.log 2>&1; tail -2 /tmp/rec-task1-lint.log
+```
+
+Unions now dedup more aggressively (aliased duplicates collapse, order stops mattering). A test asserting a union that now collapses/reorders is expected churn — update it and say so in the commit. Any other failure: stop and investigate.
+
+```bash
+git add lib/typeChecker/typeKey.ts lib/typeChecker/typeKey.test.ts lib/typeChecker/flow.ts lib/typeChecker/synthesizer.ts
+git commit -m "Add canonical typeKey and adopt it at all structural-identity sites"
+```
+
+---
+
+### Task 2: Coinductive `isAssignable` — fix the stack overflow
+
+**Files:**
+- Modify: `lib/typeChecker/assignability.ts`
+- Test: `lib/typeChecker/recursiveAssignability.test.ts` (new)
+
+**Interfaces:**
+- PUBLIC `isAssignable(source, target, typeAliases)` — unchanged three-arg signature.
+- PRIVATE `isAssignableGuarded(source, target, typeAliases, inProgress: Set<string>)` — all ~17 internal recursive call sites switch to this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/typeChecker/recursiveAssignability.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { typecheckSource } from "./testUtils.js";
+
+// Regression tests for issue #470 bug 2: comparing a recursive alias to
+// itself used to recurse forever (each isAssignable call re-resolved the
+// alias with a fresh guard) and crash with RangeError.
+describe("assignability of recursive type aliases", () => {
+  it("self-recursive alias vs itself terminates and accepts", () => {
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+def id(x: Tree): Tree {
+  return x
+}
+node main() {
+  const a: Tree = { value: 3, children: [{ value: 4, children: [] }] }
+  const b: Tree = id(a)
+  return b.value
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("mutually recursive aliases terminate and accept", () => {
+    const errors = typecheckSource(`
+type Forest = {
+  trees: Tree[],
+}
+type Tree = {
+  value: number,
+  forest: Forest | null,
+}
+def id(f: Forest): Forest {
+  return f
+}
+node main() {
+  const f: Forest = { trees: [] }
+  return id(f)
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("still REJECTS a genuinely incompatible recursive type", () => {
+    // Anti-vacuity: a guard that returns true too eagerly fails here.
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+type NamedTree = {
+  name: string,
+  children: NamedTree[],
+}
+def wantsNamed(x: NamedTree): number {
+  return 1
+}
+node main() {
+  const t: Tree = { value: 3, children: [] }
+  return wantsNamed(t)
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("removal-on-exit: a refuted pair must not be assumed true later in the SAME comparison", () => {
+    // Review must-fix 4. Inside ONE top-level isAssignable call:
+    // property a checks Tree ~> (NamedTree | Tree): the union tries
+    // Tree~>NamedTree first (false — pair added then REMOVED), then
+    // Tree~>Tree (true). Property b then re-checks Tree~>NamedTree.
+    // A memoizing guard (never removes) sees the stale pair and wrongly
+    // accepts; correct removal-on-exit recomputes and rejects b.
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+type NamedTree = {
+  name: string,
+  children: NamedTree[],
+}
+type Target = {
+  a: NamedTree | Tree,
+  b: NamedTree,
+}
+def wants(x: Target): number {
+  return 1
+}
+node main() {
+  const t: Tree = { value: 3, children: [] }
+  return wants({ a: t, b: t })
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify red (stack overflow)**
+
+```bash
+pnpm test:run lib/typeChecker/recursiveAssignability.test.ts > /tmp/rec-task2-red.log 2>&1; tail -5 /tmp/rec-task2-red.log
+```
+
+Expected: FAIL — the accepting tests crash with `RangeError: Maximum call stack size exceeded` (that IS the bug). The rejecting tests may crash too; all four must be green after Step 3.
+
+- [ ] **Step 3: Implement — private guarded helper, public signature unchanged**
+
+In `lib/typeChecker/assignability.ts` (mirroring the file's own `resolveType`/`resolveTypeWithGuard` split — review finding B):
+
+```ts
+import { typeKey } from "./typeKey.js";
+
+export function isAssignable(
+  source: VariableType | "any",
+  target: VariableType | "any",
+  typeAliases: Record<string, TypeAliasEntry>,
+): boolean {
+  return isAssignableGuarded(source, target, typeAliases, new Set());
+}
+
+function isAssignableGuarded(
+  source: VariableType | "any",
+  target: VariableType | "any",
+  typeAliases: Record<string, TypeAliasEntry>,
+  inProgress: Set<string>,
+): boolean {
+  if (source === "any" || target === "any") return true;
+
+  // Coinductive cycle guard (issue #470). Cycles can only re-enter through
+  // a NAMED reference (typeAliasVariable / genericType) — internal
+  // recursive calls otherwise pass structurally smaller resolved nodes —
+  // so the pair key is only computed when a named node is involved (perf:
+  // typeKey stays off the hot path for plain structural comparisons).
+  // Re-encountering an in-flight pair means we are inside the very
+  // comparison that would prove or refute it — assume it holds, exactly
+  // like resolveTypeWithGuard's inProgress set and TS's relation stack.
+  // Entries are REMOVED on exit (try/finally): only genuine in-flight
+  // cycles short-circuit; sibling repeats recompute real results.
+  const named =
+    source.type === "typeAliasVariable" ||
+    source.type === "genericType" ||
+    target.type === "typeAliasVariable" ||
+    target.type === "genericType";
+  if (!named) {
+    return isAssignableInner(source, target, typeAliases, inProgress);
+  }
+  const pair = `${typeKey(source, typeAliases)}~>${typeKey(target, typeAliases)}`;
+  if (inProgress.has(pair)) return true;
+  inProgress.add(pair);
+  try {
+    return isAssignableInner(source, target, typeAliases, inProgress);
+  } finally {
+    inProgress.delete(pair);
+  }
+}
+```
+
+Rename the existing function body (from the current alias-resolution lines down) to `isAssignableInner(source, target, typeAliases, inProgress)`, and change every internal recursive call: within `assignability.ts`, each `isAssignable(<args>, typeAliases)` call inside the inner body becomes `isAssignableGuarded(<args>, typeAliases, inProgress)` (grep `isAssignable(` — ~17 sites at lines 419–698; the export and any same-file non-recursive uses of the public form stay).
+
+The `"any"` sentinel check lives in the guarded helper (recursion re-enters there), so `typeKey` never sees the sentinel.
+
+- [ ] **Step 4: Run to verify green, full suites, commit**
+
+```bash
+pnpm test:run lib/typeChecker/recursiveAssignability.test.ts > /tmp/rec-task2-green.log 2>&1; tail -3 /tmp/rec-task2-green.log
+pnpm test:run lib > /tmp/rec-task2-lib.log 2>&1; tail -3 /tmp/rec-task2-lib.log
+```
+
+Expected: 4/4 PASS; full lib green. Compare wall-clock against Task 1's lib run — the named-node gate should keep the delta negligible; if the suite slowed noticeably anyway, profile before proceeding (do not silently accept a checker slowdown).
+
+```bash
+git add lib/typeChecker/assignability.ts lib/typeChecker/recursiveAssignability.test.ts
+git commit -m "Coinductive isAssignable via private guarded helper: fixes recursive-alias stack overflow"
+```
+
+---
+
+### Task 3: Codegen — lazy-if-not-yet-emitted zod refs (derived pending, no mutable state)
+
+**Files:**
+- Modify: `lib/backends/typescriptGenerator/typeToZodSchema.ts` (alias-ref site + `pendingAliases` threading)
+- Modify: `lib/backends/typescriptBuilder.ts` (derived pending computation; `Loop = Loop` guard; tool-definition path if the probe demands it)
+- Create: `tests/agency/recursive-type.agency` + `tests/agency/recursive-type.test.json`
+- Create: `tests/typescriptGenerator/recursiveTypes.agency` (+ generated `.mjs`)
+
+**Interfaces:**
+- `mapTypeToValidationSchema(vt, typeAliases, typeAliasesFull?, pendingAliases?: Set<string>)` — when an alias reference names a pending alias, emit `z.lazy(() => Name)`.
+- Builder-side: `pendingAliasesAt(name: string): Set<string>` — PURE function of the module's declaration list (review finding A): collect once, in source order, the names of top-level `typeAlias` nodes that have neither `typeParams` nor `valueParams` (only those emit schema consts; generic/value-param aliases inline or emit hoisted factory functions, and function-body aliases initialize at call time). Pending at the emission of alias `name` = the names at and after `name`'s index. No mutable emitted-set, no push-after-emit invariant.
+
+- [ ] **Step 1: Create the failing execution test**
+
+`tests/agency/recursive-type.agency`:
+
+```
+// Issue #470 bug 1: recursive/forward alias schema consts used to emit
+// self/forward references in their initializers and crash at module load
+// with a TDZ ReferenceError. Covers self-recursion, plain forward
+// references, mutual recursion (executed, not just emitted), and a
+// recursive alias used as an executed function parameter (its tool
+// registration builds a module-load-time schema).
+type Ahead = {
+  b: Behind,
+}
+
+type Behind = {
+  x: number,
+}
+
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+
+type Employee = {
+  name: string,
+  manager: Manager | null,
+}
+
+type Manager = {
+  reports: Employee[],
+}
+
+def depth(t: Tree): number {
+  return 1
+}
+
+node forwardRef() {
+  const a: Ahead = { b: { x: 1 } }
+  return a
+}
+
+node accepts() {
+  const s = schema(Tree)
+  const r = s.parseJSON("{\"value\": 1, \"children\": [{\"value\": 2, \"children\": []}]}")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node rejects() {
+  const s = schema(Tree)
+  const r = s.parseJSON("{\"value\": 1, \"children\": [{\"value\": \"nope\", \"children\": []}]}")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}
+
+node mutual() {
+  const s = schema(Employee)
+  const r = s.parseJSON("{\"name\": \"a\", \"manager\": {\"reports\": [{\"name\": \"b\", \"manager\": null}]}}")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node paramUse() {
+  const t: Tree = { value: 1, children: [] }
+  return depth(t)
+}
+```
+
+`tests/agency/recursive-type.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "forwardRef",
+      "input": "",
+      "expectedOutput": "{\"b\":{\"x\":1}}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "forward alias reference loads and runs"
+    },
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "{\"value\":1,\"children\":[{\"value\":2,\"children\":[]}]}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "recursive schema parses nested payload"
+    },
+    {
+      "nodeName": "rejects",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "recursive schema validates at depth 2"
+    },
+    {
+      "nodeName": "mutual",
+      "input": "",
+      "expectedOutput": "{\"name\":\"a\",\"manager\":{\"reports\":[{\"name\":\"b\",\"manager\":null}]}}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "mutual recursion executes end to end"
+    },
+    {
+      "nodeName": "paramUse",
+      "input": "",
+      "expectedOutput": "1",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "recursive alias as executed function parameter (tool schema at module load)"
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Run to verify red (TDZ crash)**
+
+```bash
+make > /tmp/rec-task3-make.log 2>&1; tail -2 /tmp/rec-task3-make.log
+pnpm run agency test tests/agency/recursive-type.agency > /tmp/rec-task3-red.log 2>&1; echo "exit=$?"; grep -m1 'ReferenceError' /tmp/rec-task3-red.log
+```
+
+Expected: exit 1 with `ReferenceError: Cannot access ... before initialization`.
+
+- [ ] **Step 3: Probe def-before-type (review item 7 — settle the scope question with evidence)**
+
+```bash
+cat > probe-def-first.agency <<'AGEOF'
+def f(x: Later): number {
+  return 1
+}
+
+type Later = {
+  v: number,
+}
+
+node main() {
+  return f({ v: 1 })
+}
+AGEOF
+pnpm run agency probe-def-first.agency > /tmp/rec-task3-defprobe.log 2>&1; echo "exit=$?"; grep -m1 'ReferenceError' /tmp/rec-task3-defprobe.log; rm -f probe-def-first.agency probe-def-first.js
+```
+
+Branch on the outcome:
+- **Crashes:** find the tool-definition schema emission call site (`grep -n "toolDefinition" lib/backends/typescriptBuilder.ts` — the eager `schema: z.object(...)` per `asyncAssigned.mjs:322-325`) and thread the SAME pending mechanism there: pending at a def emitted before any alias = every pending alias name at that source position (the derived list handles this: use the source position of the def relative to the alias declarations — a def before alias index i has pending = names[i..end] where i is the first alias declared after it; simplest correct form: pending = names not yet declared ABOVE the def's position). The `paramUse` execution test plus the probe re-run then verify it.
+- **Does not crash** (tool schemas emit lazily already): record the observation in the plan margin, keep `paramUse` as the pin, move on.
+
+- [ ] **Step 4: Thread `pendingAliases` through the zod mapper**
+
+In `typeToZodSchema.ts`: add optional `pendingAliases?: Set<string>` to `mapTypeToValidationSchema` → `mapTypeToSchema` → `mapTypeToSchemaInner` (threaded exactly like `optionalKeyMode`), and change the plain alias-reference return:
+
+```ts
+    // A plain alias reference emits the alias schema const by name. When
+    // the target alias is declared in the CURRENT module but its const
+    // has not been emitted yet at this point (forward reference,
+    // self-recursion, or a cycle back-edge), a bare name is a TDZ crash
+    // at module load — defer with z.lazy, which resolves at first parse,
+    // after all consts exist. Backward references keep the bare name
+    // (zero churn, no indirection). Imported aliases are never pending:
+    // imports initialize before the module body runs, and the pending
+    // list is built from CURRENT-module declarations only.
+    if (pendingAliases?.has(variableType.aliasName)) {
+      return `z.lazy(() => ${variableType.aliasName})`;
+    }
+    return variableType.aliasName;
+```
+
+(`mapTypeToZodSchema` — the LLM-path wrapper — does NOT take the param; prompt schemas execute at run time.)
+
+- [ ] **Step 5: Derived pending computation in the builder + the `Loop = Loop` guard**
+
+In `typescriptBuilder.ts`:
+
+```ts
+  /**
+   * Names of top-level plain aliases (no typeParams, no valueArgs params —
+   * only those emit `const Name = <zod>;` statements) in declaration
+   * order. Computed once per builder (builders are per-module). Function-
+   * body aliases are excluded: their consts initialize at call time.
+   */
+  private moduleAliasEmissionOrder(): string[] {
+    return this.program.nodes
+      .filter(
+        (n): n is TypeAlias =>
+          n.type === "typeAlias" && !n.typeParams && !n.valueParams,
+      )
+      .map((n) => n.aliasName);
+  }
+
+  /**
+   * Aliases whose const is NOT yet initialized when `name`'s const
+   * initializer runs: `name` itself and everything declared after it.
+   * PURE function of declaration order — no mutable emitted-set to keep
+   * in sync (a stale set would silently mis-classify; see the plan
+   * review, finding A).
+   */
+  private pendingAliasesAt(name: string): Set<string> {
+    const order = this.moduleAliasEmissionOrder();
+    const idx = order.indexOf(name);
+    return new Set(idx === -1 ? order : order.slice(idx));
+  }
+```
+
+Adjust field/receiver names to the builder's actual shape (`this.program` — check the constructor; if the builder holds nodes differently, memoize `moduleAliasEmissionOrder()` in a lazily-initialized private field). In the typeAlias emission path (the method with `const ${node.aliasName} = ${zodSchema};`), compute `const pending = this.pendingAliasesAt(node.aliasName);` and pass through `zodSchemaFor(aliasedWithTags, pending)`; `zodSchemaFor` gains the optional param and forwards it to `mapTypeToValidationSchema`. Other `zodSchemaFor` callers pass nothing.
+
+Degenerate self-loop guard (review missing-case 7): in the same emission path, BEFORE building the schema, reject an alias whose body resolves to a bare reference to itself — `z.lazy(() => Loop)` would loop forever at first parse:
+
+```ts
+    // `type Loop = Loop` (directly or through a chain that lands back on
+    // itself as a BARE reference) has no base case: its lazy schema would
+    // recurse at first parse. TS rejects this shape too.
+    if (
+      node.aliasedType.type === "typeAliasVariable" &&
+      resolveTypeDeep(node.aliasedType, this.scopes.visibleTypeAliasesFull())
+        .type === "typeAliasVariable"
+    ) {
+      throw new Error(
+        `Type alias '${node.aliasName}' circularly references itself with no structure (type ${node.aliasName} = ${(node.aliasedType as { aliasName: string }).aliasName}). Give it an object, array, or union shape.`,
+      );
+    }
+```
+
+Verify the throw surfaces as a compile error with the file named (the builder's existing error path). Add a typecheckSource-style or compile-CLI test pinning the message — whichever harness the builder's existing error tests use (`grep -rn "circular" lib/backends --include="*.test.ts"` for precedent; if none, a compile-level test via the CLI on a scratch file inside the test, mirroring how other builder errors are tested).
+
+- [ ] **Step 6: Rebuild, verify green, fixture + zero-churn gate**
+
+```bash
+make > /tmp/rec-task3-make2.log 2>&1; tail -2 /tmp/rec-task3-make2.log
+pnpm run agency test tests/agency/recursive-type.agency > /tmp/rec-task3-green.log 2>&1; echo "exit=$?"; tail -3 /tmp/rec-task3-green.log
+```
+
+Expected: exit 0, 5/5. (`z.infer` circularity note: generated output is transpiled, not type-checked, so inferred-type degradation is invisible at runtime — review-confirmed; if `make` itself complains about the generated fixture, observe the actual error and decide there.)
+
+Create `tests/typescriptGenerator/recursiveTypes.agency`:
+
+```
+type Ahead = {
+  b: Behind,
+}
+
+type Behind = {
+  x: number,
+}
+
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+
+type Employee = {
+  name: string,
+  manager: Manager | null,
+}
+
+type Manager = {
+  reports: Employee[],
+}
+
+type Json = string | number | Json[]
+
+node main() {
+  const t: Tree = { value: 1, children: [] }
+  return t
+}
+```
+
+```bash
+make fixtures > /tmp/rec-task3-fixtures.log 2>&1; tail -2 /tmp/rec-task3-fixtures.log
+grep -n "z.lazy\|const Ahead\|const Tree\|const Employee\|const Manager\|const Json" tests/typescriptGenerator/recursiveTypes.mjs
+git status --short tests/
+```
+
+Expected: `const Ahead` wraps its `Behind` ref in `z.lazy` (forward edge); `const Tree` wraps `Tree` (self, array-element position); `Employee` wraps `Manager` (forward edge of the mutual cycle) while `Manager` references `Employee` bare (backward edge); `const Json` wraps its self-ref inside `z.union([...])` (union position — a distinct mapper path). `git status` shows ONLY the new recursiveTypes files — any other churn means over-wrapping (likely imported aliases leaking into pending); stop and fix.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/backends/typescriptGenerator/typeToZodSchema.ts lib/backends/typescriptBuilder.ts tests/agency/recursive-type.agency tests/agency/recursive-type.test.json tests/typescriptGenerator/recursiveTypes.agency tests/typescriptGenerator/recursiveTypes.mjs
+git commit -m "Emit z.lazy for not-yet-emitted alias references: fixes recursive and forward alias TDZ crashes"
+```
+
+(Include any tool-definition-path files from Step 3's crashing branch.)
+
+---
+
+### Task 4: Validated recursive/forward aliases — lazy descriptor refs (review must-fix 1)
+
+Validation is a safety surface: today a validated self-recursive alias SILENTLY DROPS nested validators (the `(Tree as any).__agency_descriptor` read inside Tree's own descriptor initializer sees `undefined`), and a validated forward ref TDZ-crashes. Chosen fix: a deferred descriptor node — small, runtime-walker-native, and the walker's existing `maxDepth` already bounds recursive walks. Fallback if execution reveals this ballooning: replace with a clear compile error ("validated recursive aliases are not yet supported") plus a pinning test and a follow-up issue — do NOT ship the silent loss.
+
+**Files:**
+- Modify: `lib/runtime/validateChain.ts` (new descriptor kind + walker case)
+- Modify: `lib/backends/typescriptGenerator/validationDescriptor.ts` (lazy alias-ref emission; thread `pendingAliases` into `schemaNode`)
+- Modify: `lib/backends/typescriptBuilder.ts` (pass pending into `buildValidationDescriptor`)
+- Test: `lib/runtime/validateChain.test.ts` (walker case), `tests/agency/recursive-type-validated.agency` + `.test.json`
+
+- [ ] **Step 1: Write the failing execution test**
+
+`tests/agency/recursive-type-validated.agency`:
+
+```
+// Validated recursive alias: nested validators must run at every level.
+// Before the lazy-descriptor fix, the self-referencing descriptor read
+// its own __agency_descriptor mid-assignment (undefined) and nested
+// validation silently vanished — accepts() would pass a payload that
+// rejects() proves should fail one level down.
+def positive(n: number): Result<number, string> {
+  if (n > 0) {
+    return success(n)
+  }
+  return failure("must be positive")
+}
+
+type Tree = {
+  @validate(positive)
+  value: number,
+  children: Tree[],
+}
+
+node accepts() {
+  const s = schema(Tree)
+  const r = s.parseJSON("{\"value\": 1, \"children\": [{\"value\": 2, \"children\": []}]}")
+  if (isSuccess(r)) {
+    return "ok"
+  }
+  return "parse failed"
+}
+
+node rejectsNested() {
+  const s = schema(Tree)
+  const r = s.parseJSON("{\"value\": 1, \"children\": [{\"value\": -5, \"children\": []}]}")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}
+```
+
+`tests/agency/recursive-type-validated.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "valid nested payload passes recursive validation"
+    },
+    {
+      "nodeName": "rejectsNested",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "validator fires at nesting depth 2 (silent-loss regression pin)"
+    }
+  ]
+}
+```
+
+NOTE: verify the `@validate` + `schema(...).parseJSON` combination runs validators (the validation path is `mapTypeToValidationSchema` + descriptor walk — see `docs/dev/validation-annotations.md`); if validators only fire through the `!` annotation form, rewrite the two nodes to use `const t: Tree! = ...`-style validated assignment with the same accept/reject structure. The load-bearing assertion is `rejectsNested`.
+
+- [ ] **Step 2: Run to verify red**
+
+```bash
+make > /tmp/rec-task4-make.log 2>&1; tail -2 /tmp/rec-task4-make.log
+pnpm run agency test tests/agency/recursive-type-validated.agency > /tmp/rec-task4-red.log 2>&1; echo "exit=$?"; tail -4 /tmp/rec-task4-red.log
+```
+
+Expected after Task 3: loads fine (z.lazy fixed the const), `accepts` passes, `rejectsNested` FAILS with `"accepted"` — the silent validator loss, observed. (If it crashes instead, that is the forward-ref TDZ variant; same fix.)
+
+- [ ] **Step 3: Add the `ref` descriptor kind and walker case**
+
+In `lib/runtime/validateChain.ts`, extend the union:
+
+```ts
+  | {
+      kind: "ref";
+      /**
+       * Deferred descriptor read. Emitted for alias references whose
+       * target descriptor is not initialized yet at module load (forward
+       * refs) or is the descriptor currently being built (self-recursion).
+       * Resolved at walk time, when every __agency_descriptor exists.
+       */
+      get: () => TypeValidationDescriptor;
+    }
+```
+
+and add the walker case (in the `walk` function's dispatch; depth passes through unchanged — the structural kinds below the ref already increment it, and `maxDepth` bounds runaway):
+
+```ts
+    case "ref":
+      return walk(value, descriptor.get(), depth, maxDepth);
+```
+
+Unit-test in `lib/runtime/validateChain.test.ts` following the file's existing test style: a self-referential object descriptor via `ref` validates a two-level value and rejects a bad nested leaf; a `maxDepth`-exceeded deep value hits the existing cap behavior (pin whatever the cap does today — error or accept — do not change it).
+
+- [ ] **Step 4: Emit lazy descriptor refs + thread pending into `schemaNode`**
+
+In `validationDescriptor.ts`:
+
+1. The nested alias-ref site (~line 296) becomes ALWAYS deferred (unconditional — laziness is always safe here, and conditioning on pending would leave the self-ref silent-loss case since the self name IS pending anyway):
+
+```ts
+    if (entry && hasAliasValidate(entry, typeAliasesFull)) {
+      // Deferred: reading `(Alias as any).__agency_descriptor` eagerly is
+      // a TDZ crash for forward refs and — worse — silently `undefined`
+      // for self-refs (the assignment is in progress), which drops nested
+      // validation. `{ kind: "ref", get }` defers the read to walk time.
+      const aliasRef = ts.raw(
+        `{ kind: "ref", get: () => (${variableType.aliasName} as any).__agency_descriptor }`,
+      );
+      return withUseSiteValidators(aliasRef, useSiteValidators);
+    }
+```
+
+CHECK `withUseSiteValidators` first: if it wraps by spreading fields onto the node, wrapping a `ref` needs the wrap to happen INSIDE `get()` or via a `nullable`-style wrapper node — read its implementation and put the use-site validators on whichever layer keeps them running (add a walker unit test for ref-with-use-site-validators either way).
+
+2. Thread `pendingAliases` into `schemaNode` (~line 173) and its `mapTypeToValidationSchema` call, plumbed from `buildValidationDescriptor`'s signature; in `typescriptBuilder.ts`, the descriptor build site (~line 793-799) passes the same `pending` set Task 3 computed.
+
+- [ ] **Step 5: Verify green, fixture churn review, commit**
+
+```bash
+make > /tmp/rec-task4-make2.log 2>&1; tail -2 /tmp/rec-task4-make2.log
+pnpm test:run lib/runtime/validateChain.test.ts > /tmp/rec-task4-walker.log 2>&1; tail -3 /tmp/rec-task4-walker.log
+pnpm run agency test tests/agency/recursive-type-validated.agency > /tmp/rec-task4-green.log 2>&1; echo "exit=$?"; tail -3 /tmp/rec-task4-green.log
+make fixtures > /tmp/rec-task4-fixtures.log 2>&1; git status --short tests/ | tee /tmp/rec-task4-churn.log
+```
+
+Descriptor-path fixture churn is EXPECTED here (alias-ref descriptors change shape everywhere they exist) — review each churned fixture diff: every change must be exactly `(X as any).__agency_descriptor` → `{ kind: "ref", get: () => (X as any).__agency_descriptor }` (or schemaNode lazy wraps). Anything else: stop.
+
+```bash
+git add lib/runtime/validateChain.ts lib/runtime/validateChain.test.ts lib/backends/typescriptGenerator/validationDescriptor.ts lib/backends/typescriptBuilder.ts tests/agency/recursive-type-validated.agency tests/agency/recursive-type-validated.test.json tests/typescriptGenerator
+git commit -m "Defer validation-descriptor alias reads: fixes TDZ and silent validator loss on recursive aliases"
+```
+
+---
+
+### Task 5: Structured-output path — pin the `$ref` conversion (review T6)
+
+**Files:**
+- Modify: `tests/typescriptGenerator/recursiveTypes.agency` (llm node)
+- Create: `lib/backends/typescriptGenerator/recursiveSchemaJson.test.ts`
+
+- [ ] **Step 1: LLM-path fixture node**
+
+Append to `tests/typescriptGenerator/recursiveTypes.agency` and regenerate:
+
+```
+node llmTree() {
+  const suggested: Tree = llm("Suggest a small tree")
+  return suggested
+}
+```
+
+```bash
+make fixtures > /tmp/rec-task5-fixtures.log 2>&1; grep -n "responseFormat" -A3 tests/typescriptGenerator/recursiveTypes.mjs | head -8
+```
+
+Expected: `responseFormat` references the `Tree` const by name (runtime reference — no lazy needed, executes post-load).
+
+- [ ] **Step 2: Find the runtime JSON-schema conversion and COMMIT a pin test**
+
+```bash
+grep -rn "toJSONSchema\|zodToJson" lib/ --include="*.ts" | grep -v test | head -5
+grep -rn "toJSONSchema" node_modules/smoltalk/dist/*.js 2>/dev/null | head -3
+```
+
+zod is `^4.3.5`, so the conversion is `z.toJSONSchema` (zod 4 handles cycles via `$ref`). Create `lib/backends/typescriptGenerator/recursiveSchemaJson.test.ts` pinning the conversion ON THE SHAPE THIS PLAN EMITS (a caret-range zod upgrade changing cycle handling must go red here, not in production):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+// Pins that the exact schema shape our codegen emits for recursive
+// aliases (z.lazy self-reference, per tests/typescriptGenerator/
+// recursiveTypes.mjs) survives the JSON-schema conversion the LLM
+// structured-output path uses, producing a $ref instead of throwing or
+// inlining forever. zod is caret-pinned; an upgrade that changes cycle
+// handling must fail THIS test, not a user request.
+describe("recursive zod schema to JSON schema", () => {
+  it("z.lazy self-reference converts with a $ref and does not throw", () => {
+    const Tree: z.ZodType = z.object({
+      value: z.number(),
+      children: z.array(z.lazy(() => Tree)),
+    });
+    const json = JSON.stringify(z.toJSONSchema(Tree));
+    expect(json).toContain("$ref");
+  });
+});
+```
+
+Adjust the conversion call to whatever the first grep shows the runtime ACTUALLY uses (same API, same options — if smoltalk calls it with options, mirror them; if the conversion lives in smoltalk internals, import and call the same smoltalk entry point the prompt path uses). If the conversion THROWS on cycles (unexpected for zod 4): switch to the plan rev-1 fallback — a guarded, actionable error at the prompt-construction site (`Recursive type cannot be used as a structured-output type with this provider — parse with schema(...).parseJSON instead`) plus an execution test pinning the message with no LLM call.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/typescriptGenerator lib/backends/typescriptGenerator/recursiveSchemaJson.test.ts
+git commit -m "Pin recursive-type structured-output JSON schema conversion"
+```
+
+---
+
+### Task 6: Utility-type composition + docs
+
+**Files:**
+- Test: extend `lib/typeChecker/builtinGenerics.test.ts`; extend `tests/typescriptGenerator/recursiveTypes.agency`; create `tests/agency/recursive-type-partial.agency` + `.test.json`
+- Modify: `docs/site/guide/types.md`, `docs/dev/typechecker/README.md`
+
+- [ ] **Step 1: Typecheck pin — `Partial<Tree>`**
+
+Append to the pipeline describe in `lib/typeChecker/builtinGenerics.test.ts`:
+
+```ts
+  it("Partial of a recursive alias works shallowly (#470 unblocked)", () => {
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+node main() {
+  const t: Partial<Tree> = { value: null, children: null }
+  return t
+}
+`);
+    expect(errors).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Codegen + execution — `Partial<Tree>` through the pending logic**
+
+Add to `tests/typescriptGenerator/recursiveTypes.agency` (before `node main`), regenerate, and grep:
+
+```
+type TreePatch = Partial<Tree>
+```
+
+Expected in the `.mjs`: `const TreePatch = z.object(...)` whose expanded initializer wraps its `Tree` reference in `z.lazy` — this exercises pending through the builtin-generic expansion path (the Partial transform inlines Tree's body whose `children` element is a nominal `Tree` ref, still pending at TreePatch's position ONLY if TreePatch precedes... it does NOT: TreePatch is declared after Tree, so the ref is BACKWARD and stays bare. Move the `TreePatch` declaration ABOVE `type Tree` in the fixture so the expanded ref is genuinely forward and must wrap.) Verify the grep shows `z.lazy(() => Tree)` inside `const TreePatch`.
+
+Create `tests/agency/recursive-type-partial.agency` + `.test.json` mirroring `utility-partial.agency`: `schema(Partial<Tree>).parseJSON("{}")` (bind schema to a variable first — chaining on `schema(...)` does not parse, #480) accepts with keys null-coalesced, and a reject case with a wrongly-typed present key. Expected outputs follow the utility-partial serialization exactly.
+
+- [ ] **Step 3: Docs**
+
+`docs/site/guide/types.md` — short section (the owner trims verbosity; keep it to this):
+
+```markdown
+## Recursive types
+
+Type aliases can reference themselves, each other, or aliases declared
+later in the file:
+
+```ts
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+```
+
+`schema(Tree)` validates nested payloads at every level, including
+`@validate` annotations on nested fields.
+```
+
+`docs/dev/typechecker/README.md` — in the `isAssignable` section: one paragraph on coinduction (in-progress pair stack keyed by `typeKey`, entries removed on exit, gated on named references; what makes recursive aliases comparable). In the narrowing/`never` cross-references, remove any "recursion unsupported" claims if present.
+
+- [ ] **Step 4: Run the new tests, commit**
+
+```bash
+pnpm test:run lib/typeChecker/builtinGenerics.test.ts > /tmp/rec-task6-bg.log 2>&1; tail -3 /tmp/rec-task6-bg.log
+pnpm run agency test tests/agency/recursive-type-partial.agency > /tmp/rec-task6-partial.log 2>&1; echo "exit=$?"
+git add lib/typeChecker/builtinGenerics.test.ts tests/typescriptGenerator tests/agency/recursive-type-partial.agency tests/agency/recursive-type-partial.test.json docs/site/guide/types.md docs/dev/typechecker/README.md
+git commit -m "Pin utility-type and recursion composition; document recursive types"
+```
+
+---
+
+### Task 7: Full verification, push, PR
+
+- [ ] **Step 1: Full sweep**
+
+```bash
+pnpm test:run lib > /tmp/rec-task7-lib.log 2>&1; tail -3 /tmp/rec-task7-lib.log
+pnpm run lint:structure > /tmp/rec-task7-lint.log 2>&1; echo "lint=$?"
+make > /tmp/rec-task7-make.log 2>&1; echo "make=$?"
+for t in recursive-type recursive-type-validated recursive-type-partial utility-partial; do pnpm run agency test tests/agency/$t.agency > /tmp/rec-task7-$t.log 2>&1; echo "$t: $?"; done
+```
+
+All green (utility-partial re-run guards the merged feature against typeKey/coinduction regressions).
+
+- [ ] **Step 2: PR**
+
+Body file must cover: closes #470, closes #473; the forward-reference and silent-validator-loss discoveries; the four mechanisms and why each (derived pending over mutable state, private guarded helper over signature leak, lazy descriptor refs over a compile error, named-node gate soundness); the def-before-type probe outcome; and the scope-outs (inference.ts `unionTypes` stringify residual noted on #473; recursive value-param alias codegen hang → file the follow-up issue and link it; zod-mapper parameter sprawl watch). Then:
+
+```bash
+git push -u origin recursive-types
+gh pr create --title "Fix recursive and forward-referencing type aliases (closes #470, closes #473)" --body-file /tmp/rec-pr-body.md
+```

--- a/packages/agency-lang/docs/dev/typechecker/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/README.md
@@ -195,6 +195,25 @@ structure.
 6. **Same-kind matching**: two primitive types match if their values are equal; two literal types match if their values are equal; two array types match if their element types are assignable; two object types use structural matching (source must have all target properties with compatible types)
 7. Otherwise, return `false`
 
+### Coinduction: recursive aliases are comparable
+
+Assignability is **coinductive** (issue #470): the private
+`isAssignableGuarded` helper keeps an in-progress stack of comparison
+pairs, keyed by `typeKey` (`lib/typeChecker/typeKey.ts` — the canonical
+structural identity, also used at union-dedup sites). Re-encountering a
+pair already on the stack means the walk is inside the very comparison
+that would prove or refute it — it is assumed to hold, exactly like
+`resolveTypeWithGuard`'s `inProgress` set and TypeScript's relation
+stack. Two load-bearing details: entries are REMOVED on exit
+(try/finally), so a pair refuted in one sibling position is recomputed —
+never assumed — in another; and the pair key is only computed when a
+NAMED reference (`typeAliasVariable`/`genericType`) is involved, which is
+sound because cycles can only re-enter through a named reference, and
+keeps `typeKey` off the hot path for plain structural comparisons. This
+is what makes `type Tree = { children: Tree[] }` comparable to itself
+instead of a stack overflow. The public `isAssignable` signature is
+unchanged (three args).
+
 ### The `never` type
 
 `never` is Agency's bottom type, represented as `{ type: "primitiveType", value: "never" }` — mirroring how `any` (the top type) and `unknown`/`void`/`null` are modeled as primitives, rather than as a distinct AST node. Its rules:

--- a/packages/agency-lang/docs/site/guide/types.md
+++ b/packages/agency-lang/docs/site/guide/types.md
@@ -203,6 +203,22 @@ def updateUser(id: string, changes: Partial<User>): string {
 }
 ```
 
+## Recursive types
+
+Type aliases can reference themselves, each other, or aliases declared
+later in the file:
+
+```ts
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+```
+
+`schema(Tree)` validates nested payloads at every level, and `@validate`
+annotations on nested fields fire at every depth through the `!`
+validated-assignment form.
+
 ## References
 
 - [Schemas](/guide/schemas)

--- a/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypeScriptBuilder } from "./typescriptBuilder.js";
+import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { printTs } from "../ir/prettyPrint.js";
+import type { AgencyConfig } from "@/config.js";
+
+function generate(source: string): string {
+  const parseResult = parseAgency(source, {}, false);
+  if (!parseResult.success)
+    throw new Error(`Failed to parse: ${parseResult.message}`);
+  const info = buildCompilationUnit(parseResult.result);
+  const preprocessor = new TypescriptPreprocessor(parseResult.result, {}, info);
+  const pre = preprocessor.preprocess();
+  const builder = new TypeScriptBuilder({} as AgencyConfig, info, "test.agency");
+  return printTs(builder.build(pre));
+}
+
+// Issue #470 bug 1: alias schema consts referencing not-yet-emitted aliases
+// (self-recursion, forward refs, cycle back-edges) must defer with z.lazy;
+// backward references stay bare (zero churn for existing code).
+describe("recursive/forward alias codegen", () => {
+  it("wraps a self-reference in z.lazy", () => {
+    const out = generate(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("z.array(z.lazy(() => Tree))");
+  });
+
+  it("wraps a forward reference in z.lazy but keeps backward refs bare", () => {
+    const out = generate(`
+type Ahead = {
+  b: Behind,
+}
+type Behind = {
+  x: number,
+}
+type After = {
+  b: Behind,
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("z.lazy(() => Behind)"); // forward (in Ahead)
+    // Backward ref (in After) stays a bare const reference.
+    expect(out).toMatch(/const After = z\.object\(\{ "b": Behind \}\)/);
+  });
+
+  it("splits a mutual cycle: forward edge lazy, backward edge bare", () => {
+    const out = generate(`
+type Employee = {
+  name: string,
+  manager: Manager | null,
+}
+type Manager = {
+  reports: Employee[],
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("z.lazy(() => Manager)");
+    expect(out).toMatch(/const Manager = z\.object\(\{ "reports": z\.array\(Employee\) \}\)/);
+  });
+
+  it("wraps a def-before-type tool-schema reference in z.lazy", () => {
+    // Tool definitions initialize at module load; a def declared before
+    // the alias it references used to TDZ-crash (probe-confirmed).
+    const out = generate(`
+def f(x: Later): number {
+  return 1
+}
+type Later = {
+  v: number,
+}
+node main() {
+  return f({ v: 1 })
+}
+`);
+    expect(out).toContain("z.lazy(() => Later)");
+  });
+
+  it("rejects type Loop = Loop with a clear error", () => {
+    expect(() =>
+      generate(`
+type Loop = Loop
+node main() {
+  return 1
+}
+`),
+    ).toThrow(/circularly references itself with no structure/);
+  });
+});

--- a/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
@@ -88,6 +88,51 @@ node main() {
     expect(out).toContain("z.lazy(() => Later)");
   });
 
+  it("accepts a legitimate alias-of-alias (regression: guard false positive)", () => {
+    // `type Point = Coords` compiled on main but the first guard version
+    // rejected it: resolveTypeDeep leaves plain alias refs intact by
+    // design, so every bare-alias body looked circular. safeResolveType
+    // resolves the CHAIN; only chains that land back on a known alias ref
+    // (genuine cycles) throw.
+    const out = generate(`
+type Coords = {
+  x: number,
+}
+type Point = Coords
+node main() {
+  return 1
+}
+`);
+    expect(out).toMatch(/const Point = Coords/);
+  });
+
+  it("emits z.lazy for a FORWARD alias-of-alias", () => {
+    const out = generate(`
+type Point = Coords
+type Coords = {
+  x: number,
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("const Point = z.lazy(() => Coords)");
+  });
+
+  it("rejects a bare two-alias cycle (type A = B, type B = A)", () => {
+    // Must STAY rejected: a validated bare cycle would emit ref -> ref
+    // descriptors with no structural node between them.
+    expect(() =>
+      generate(`
+type A = B
+type B = A
+node main() {
+  return 1
+}
+`),
+    ).toThrow(/circularly references itself with no structure/);
+  });
+
   it("rejects type Loop = Loop with a clear error", () => {
     expect(() =>
       generate(`

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -453,6 +453,17 @@ export class TypeScriptBuilder {
   // ------- Main entry point -------
 
   build(program: AgencyProgram): TsNode {
+    // Plain top-level aliases in source order — the basis for the derived
+    // pending-alias computation (see pendingAliasesFor). Captured once;
+    // partitionProgram keeps top-level declarations in source order, so
+    // source offsets are a faithful oracle for const-initialization order.
+    this.aliasEmissionOrder = program.nodes
+      .filter(
+        (n): n is TypeAlias =>
+          n.type === "typeAlias" && !n.typeParams && !n.valueParams,
+      )
+      .map((n) => ({ name: n.aliasName, start: n.loc?.start ?? 0 }));
+
     // Generate tool registry (empty — AgencyFunction.create() populates it)
     this.generatedStatements.push(this.generateToolRegistry());
 
@@ -777,7 +788,22 @@ export class TypeScriptBuilder {
           tags: [...(node.aliasedType.tags ?? []), ...node.tags],
         }
       : node.aliasedType;
-    const zodSchema = this.zodSchemaFor(aliasedWithTags);
+    // `type Loop = Loop` (directly or through a chain landing back on a
+    // bare self-reference) has no base case: its lazy schema would recurse
+    // at first parse. TS rejects the shape too.
+    if (
+      node.aliasedType.type === "typeAliasVariable" &&
+      resolveTypeDeep(node.aliasedType, this.scopes.visibleTypeAliasesFull())
+        .type === "typeAliasVariable"
+    ) {
+      throw new Error(
+        `Type alias '${node.aliasName}' circularly references itself with no structure. Give it an object, array, or union shape.`,
+      );
+    }
+    const zodSchema = this.zodSchemaFor(
+      aliasedWithTags,
+      this.pendingAliasesFor(node.loc?.start),
+    );
     const stmts: TsNode[] = [
       ts.raw(`${exportPrefix}const ${node.aliasName} = ${zodSchema};`),
       ts.raw(
@@ -815,13 +841,39 @@ export class TypeScriptBuilder {
    * like `Container<number>` become a concrete object/array/etc. before the
    * (alias-unaware) zod mapper runs.
    */
-  private zodSchemaFor(t: VariableType): string {
+  private zodSchemaFor(t: VariableType, pendingAliases?: Set<string>): string {
     const aliasesFull = this.scopes.visibleTypeAliasesFull();
     const resolved = resolveTypeDeep(t, aliasesFull);
     return mapTypeToValidationSchema(
       resolved,
       this.scopes.visibleTypeAliases(),
       aliasesFull,
+      pendingAliases,
+    );
+  }
+
+  /** See build() — plain top-level aliases in source order. */
+  private aliasEmissionOrder: { name: string; start: number }[] = [];
+
+  /**
+   * Aliases whose schema const is NOT yet initialized when module-load
+   * code originating at source offset `start` runs: every plain top-level
+   * alias declared at-or-after that offset. A PURE derivation from the
+   * program captured in build() — no mutable emitted-set to keep in sync.
+   * Generic/value-param aliases never emit consts (inlined / hoisted
+   * factory functions) and function-body aliases initialize at call time,
+   * so neither is listed. `start` undefined treats ALL listed aliases as
+   * pending — z.lazy is always safe; over-inclusion only costs
+   * indirection.
+   */
+  private pendingAliasesFor(start: number | undefined): Set<string> {
+    if (start === undefined) {
+      return new Set(this.aliasEmissionOrder.map((a) => a.name));
+    }
+    return new Set(
+      this.aliasEmissionOrder
+        .filter((a) => a.start >= start)
+        .map((a) => a.name),
     );
   }
 
@@ -1716,6 +1768,7 @@ export class TypeScriptBuilder {
    */
   private paramSchemaContribution(
     param: FunctionParameter,
+    pendingAliases: Set<string>,
   ):
     | { kind: "drop" }
     | { kind: "scalar"; zod: string }
@@ -1733,7 +1786,7 @@ export class TypeScriptBuilder {
               type: "primitiveType" as const,
               value: "string",
             });
-      const elementZod = this.zodSchemaFor(elementHint);
+      const elementZod = this.zodSchemaFor(elementHint, pendingAliases);
       return { kind: "array", zod: `z.array(${elementZod})` };
     }
 
@@ -1741,7 +1794,7 @@ export class TypeScriptBuilder {
       type: "primitiveType" as const,
       value: "string",
     };
-    let zod = this.zodSchemaFor(typeHint);
+    let zod = this.zodSchemaFor(typeHint, pendingAliases);
     if (param.defaultValue) {
       const defaultStr = expressionToString(param.defaultValue);
       // A widened optional param (`x?: T` → `T | null`) is already nullable;
@@ -1781,9 +1834,14 @@ export class TypeScriptBuilder {
       );
     }
 
+    // Tool definitions initialize at module load (the __AgencyFunction
+    // const), so alias refs in param schemas need the same pending
+    // treatment alias consts get — a def declared BEFORE a type it
+    // references used to TDZ-crash (probe-confirmed).
+    const pendingAliases = this.pendingAliasesFor(node.loc?.start);
     const contributions = parameters.map((p) => ({
       param: p,
-      contribution: this.paramSchemaContribution(p),
+      contribution: this.paramSchemaContribution(p, pendingAliases),
     }));
 
     // Declaration order is preserved by iterating `parameters` directly;

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -753,10 +753,16 @@ export class TypeScriptBuilder {
       // intact lets `buildValidationDescriptor` emit a nested factory CALL
       // for any value-param reference (validators resolve in their own
       // module); the schema strings still substitute identifiers locally.
+      // Value-param factories HOIST but their bodies execute when called —
+      // possibly from a load-time descriptor initializer ANYWHERE in the
+      // module, so no source position bounds which aliases are safe. Treat
+      // every module alias as pending: z.lazy is always safe and only
+      // costs indirection.
       const vpDescriptor = buildValidationDescriptor(
         vpAliasedWithTags,
         this.scopes.visibleTypeAliases(),
         vpAliasesFull,
+        this.pendingAliasesFor(undefined),
       );
       // Bake value-param DEFAULTS into the factory signature so an omitted
       // use-site arg (e.g. `Age()!` or bare `Age!`) resolves the same default
@@ -821,6 +827,7 @@ export class TypeScriptBuilder {
         resolved,
         this.scopes.visibleTypeAliases(),
         aliasesFull,
+        this.pendingAliasesFor(node.loc?.start),
       );
       // `(Foo as any).__agency_descriptor = ...` — keeps the runtime metadata
       // co-located with the schema and avoids exporting/importing a second

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -95,7 +95,7 @@ import {
   hasAliasValidate,
 } from "./typescriptGenerator/validationDescriptor.js";
 import { tagArgToTs } from "./typescriptGenerator/tagArgToTs.js";
-import { resolveTypeDeep } from "../typeChecker/assignability.js";
+import { resolveTypeDeep, safeResolveType } from "../typeChecker/assignability.js";
 import { isFunctionTyped } from "../typeChecker/utils.js";
 
 import { $, ts } from "../ir/builders.js";
@@ -794,17 +794,26 @@ export class TypeScriptBuilder {
           tags: [...(node.aliasedType.tags ?? []), ...node.tags],
         }
       : node.aliasedType;
-    // `type Loop = Loop` (directly or through a chain landing back on a
-    // bare self-reference) has no base case: its lazy schema would recurse
-    // at first parse. TS rejects the shape too.
-    if (
-      node.aliasedType.type === "typeAliasVariable" &&
-      resolveTypeDeep(node.aliasedType, this.scopes.visibleTypeAliasesFull())
-        .type === "typeAliasVariable"
-    ) {
-      throw new Error(
-        `Type alias '${node.aliasName}' circularly references itself with no structure. Give it an object, array, or union shape.`,
-      );
+    // `type Loop = Loop` (directly or via `type A = B` + `type B = A`) has
+    // no base case: its lazy schema would recurse at first parse, and its
+    // validation descriptors would chain ref -> ref forever. TS rejects the
+    // shape too. Resolve the alias CHAIN with safeResolveType — its
+    // in-progress guard leaves genuinely circular chains as a nominal ref,
+    // while a legitimate alias-of-alias (`type Point = Coords`) resolves
+    // through to the referenced body. An unknown alias also stays nominal
+    // but has no registry entry: fall through to the regular
+    // undefined-alias diagnostic instead of a misleading circularity error.
+    if (node.aliasedType.type === "typeAliasVariable") {
+      const aliasesFull = this.scopes.visibleTypeAliasesFull();
+      const chainEnd = safeResolveType(node.aliasedType, aliasesFull);
+      if (
+        chainEnd.type === "typeAliasVariable" &&
+        aliasesFull[chainEnd.aliasName]
+      ) {
+        throw new Error(
+          `Type alias '${node.aliasName}' circularly references itself with no structure. Give it an object, array, or union shape.`,
+        );
+      }
     }
     const zodSchema = this.zodSchemaFor(
       aliasedWithTags,

--- a/packages/agency-lang/lib/backends/typescriptGenerator/recursiveSchemaJson.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/recursiveSchemaJson.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+// Pins that the exact schema shape our codegen emits for recursive aliases
+// (z.lazy self-reference, per tests/typescriptGenerator/recursiveTypes.mjs)
+// survives the JSON-schema conversion the LLM structured-output path uses
+// (`z.toJSONSchema` — see lib/runtime/schema.ts and the responseFormat
+// conversion in lib/runtime/simpleOpenAIClient.ts), producing a $ref
+// instead of throwing or inlining forever. zod is caret-pinned (^4.x); an
+// upgrade that changes cycle handling must fail THIS test, not a user
+// request.
+describe("recursive zod schema to JSON schema", () => {
+  it("z.lazy self-reference converts with a $ref and does not throw", () => {
+    const Tree: z.ZodType = z.object({
+      value: z.number(),
+      children: z.array(z.lazy(() => Tree)),
+    });
+    const json = JSON.stringify(z.toJSONSchema(Tree));
+    expect(json).toContain("$ref");
+  });
+
+  it("mutual z.lazy cycle converts too (Employee/Manager shape)", () => {
+    const Employee: z.ZodType = z.object({
+      name: z.string(),
+      manager: z.union([z.lazy(() => Manager), z.null()]),
+    });
+    const Manager: z.ZodType = z.object({
+      reports: z.array(Employee),
+    });
+    // Manager references Employee bare (backward edge) exactly as emitted.
+    const json = JSON.stringify(z.toJSONSchema(Manager));
+    expect(json).toContain("$ref");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -69,9 +69,10 @@ function mapTypeToSchema(
   resultHandler: (vt: VariableType, ta: Record<string, VariableType>) => string,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
   optionalKeyMode: OptionalKeyMode = "required-nullable",
+  pendingAliases?: Set<string>,
 ): string {
   return appendMeta(
-    mapTypeToSchemaInner(variableType, typeAliases, resultHandler, typeAliasesFull, optionalKeyMode),
+    mapTypeToSchemaInner(variableType, typeAliases, resultHandler, typeAliasesFull, optionalKeyMode, pendingAliases),
     variableType.tags,
   );
 }
@@ -82,10 +83,11 @@ function mapTypeToSchemaInner(
   resultHandler: (vt: VariableType, ta: Record<string, VariableType>) => string,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
   optionalKeyMode: OptionalKeyMode = "required-nullable",
+  pendingAliases?: Set<string>,
 ): string {
   const recurse = (vt: VariableType) =>
     appendMeta(
-      mapTypeToSchemaInner(vt, typeAliases, resultHandler, typeAliasesFull, optionalKeyMode),
+      mapTypeToSchemaInner(vt, typeAliases, resultHandler, typeAliasesFull, optionalKeyMode, pendingAliases),
       vt.tags,
     );
 
@@ -169,6 +171,7 @@ function mapTypeToSchemaInner(
           resultHandler,
           typeAliasesFull,
           optionalKeyMode,
+          pendingAliases,
         );
         // .describe(...) must come BEFORE .meta(...) — Zod requires
         // .meta() to be the final call in the chain or the metadata is
@@ -223,6 +226,18 @@ function mapTypeToSchemaInner(
         optionalKeyMode,
       );
     }
+    // A plain alias reference emits the alias schema const by name. When
+    // the target alias is declared in the CURRENT module but its const
+    // has not been emitted yet at this point (forward reference,
+    // self-recursion, or a cycle back-edge), a bare name is a TDZ crash
+    // at module load — defer with z.lazy, which resolves at first parse,
+    // after all consts exist. Backward references keep the bare name
+    // (zero churn, no indirection). Imported aliases are never pending:
+    // imports initialize before the module body runs, and the pending
+    // set is built from CURRENT-module declarations only.
+    if (pendingAliases?.has(variableType.aliasName)) {
+      return `z.lazy(() => ${variableType.aliasName})`;
+    }
     return variableType.aliasName;
   } else if (variableType.type === "genericType") {
     if (variableType.name === "Record") {
@@ -268,6 +283,7 @@ export function mapTypeToValidationSchema(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
+  pendingAliases?: Set<string>,
 ): string {
   return mapTypeToSchema(
     variableType,
@@ -282,5 +298,6 @@ export function mapTypeToValidationSchema(
     },
     typeAliasesFull,
     "optional-coalesce",
+    pendingAliases,
   );
 }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -35,8 +35,15 @@ export function buildValidationDescriptor(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
+  pendingAliases?: Set<string>,
 ): TsNode {
-  return descriptor(variableType, typeAliases, typeAliasesFull ?? {});
+  return descriptor(
+    variableType,
+    typeAliases,
+    typeAliasesFull ?? {},
+    new Set(),
+    pendingAliases,
+  );
 }
 
 /**
@@ -174,8 +181,11 @@ function schemaNode(
   t: VariableType,
   typeAliases: Record<string, VariableType>,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
+  pendingAliases?: Set<string>,
 ): TsNode {
-  return ts.raw(mapTypeToValidationSchema(t, typeAliases, typeAliasesFull));
+  return ts.raw(
+    mapTypeToValidationSchema(t, typeAliases, typeAliasesFull, pendingAliases),
+  );
 }
 
 /**
@@ -235,14 +245,14 @@ function valueParamDescriptor(
   typeAliases: Record<string, VariableType>,
   typeAliasesFull: Record<string, TypeAliasEntry>,
   seen: Set<string>,
+  pendingAliases?: Set<string>,
 ): TsNode {
   if (isGenericAlias(entry)) {
     return descriptor(
       resolveTypeDeep(variableType, typeAliasesFull),
       typeAliases,
       typeAliasesFull,
-      seen,
-    );
+      seen, pendingAliases);
   }
   if (entry && hasAliasValidate(entry, typeAliasesFull)) {
     const argList = (variableType.valueArgs ?? [])
@@ -261,7 +271,7 @@ function valueParamDescriptor(
     ...substituted.body,
     tags: mergeTagSets(substituted.body.tags, merged),
   };
-  return descriptor(bodyWithTags, typeAliases, typeAliasesFull, seen);
+  return descriptor(bodyWithTags, typeAliases, typeAliasesFull, seen, pendingAliases);
 }
 
 function descriptor(
@@ -269,6 +279,7 @@ function descriptor(
   typeAliases: Record<string, VariableType>,
   typeAliasesFull: Record<string, TypeAliasEntry>,
   seen: Set<string> = new Set(),
+  pendingAliases?: Set<string>,
 ): TsNode {
   // For an alias reference whose alias body has any `@validate(...)` tag,
   // reference the alias's runtime descriptor (attached as
@@ -291,21 +302,32 @@ function descriptor(
         typeAliases,
         typeAliasesFull,
         seen,
+        pendingAliases,
       );
     }
     if (entry && hasAliasValidate(entry, typeAliasesFull)) {
-      // `(Alias as any).__agency_descriptor`
+      // Deferred: reading `(Alias as any).__agency_descriptor` eagerly is
+      // a TDZ crash for forward refs and — worse — silently `undefined`
+      // for self-refs (the assignment is in progress), which drops nested
+      // validation. `{ kind: "ref", get }` defers the read to walk time,
+      // when every descriptor exists. Use-site validators wrap INSIDE
+      // get(): the walker dispatches `ref` before running validators, so
+      // they must ride the resolved descriptor, not the ref node.
       const aliasRef = ts.prop(
         ts.raw(`(${variableType.aliasName} as any)`),
         "__agency_descriptor",
       );
-      return withUseSiteValidators(aliasRef, useSiteValidators);
+      const resolved = withUseSiteValidators(aliasRef, useSiteValidators);
+      return ts.obj([
+        ts.set('"kind"', ts.str("ref")),
+        ts.set('"get"', ts.arrowFn([], ts.statements([ts.return(resolved)]))),
+      ]);
     }
     // No alias-level validators — emit a leaf using only the alias schema and
     // any use-site validators.
     return objEntries([
       ["kind", ts.str("leaf")],
-      ["schema", schemaNode(variableType, typeAliases, typeAliasesFull)],
+      ["schema", schemaNode(variableType, typeAliases, typeAliasesFull, pendingAliases)],
       ["validators", ts.arr(useSiteValidators)],
     ]);
   }
@@ -324,11 +346,10 @@ function descriptor(
       resolveTypeDeep(variableType, typeAliasesFull),
       typeAliases,
       typeAliasesFull,
-      seen,
-    );
+      seen, pendingAliases);
   }
 
-  const schema = schemaNode(variableType, typeAliases, typeAliasesFull);
+  const schema = schemaNode(variableType, typeAliases, typeAliasesFull, pendingAliases);
   const validatorsArr = ts.arr(validatorNodes(variableType.tags));
 
   if (variableType.type === "arrayType") {
@@ -336,8 +357,7 @@ function descriptor(
       variableType.elementType,
       typeAliases,
       typeAliasesFull,
-      seen,
-    );
+      seen, pendingAliases);
     return objEntries([
       ["kind", ts.str("array")],
       ["schema", schema],
@@ -354,8 +374,7 @@ function descriptor(
         childType,
         typeAliases,
         typeAliasesFull,
-        seen,
-      );
+        seen, pendingAliases);
       return ts.set(JSON.stringify(p.key), childDesc);
     });
     return objEntries([
@@ -381,8 +400,7 @@ function descriptor(
         innerMembers[0],
         typeAliases,
         typeAliasesFull,
-        seen,
-      );
+        seen, pendingAliases);
       return objEntries([
         ["kind", ts.str("nullable")],
         ["schema", schema],
@@ -395,8 +413,8 @@ function descriptor(
 
   if (variableType.type === "unionType") {
     const branches = variableType.types.map((m) => {
-      const branchSchema = schemaNode(m, typeAliases, typeAliasesFull);
-      const branchDesc = descriptor(m, typeAliases, typeAliasesFull, seen);
+      const branchSchema = schemaNode(m, typeAliases, typeAliasesFull, pendingAliases);
+      const branchDesc = descriptor(m, typeAliases, typeAliasesFull, seen, pendingAliases);
       // `(v) => (<branchSchema>).safeParse(v).success`
       const test = ts.arrowFn(
         [{ name: "v" }],
@@ -424,8 +442,7 @@ function descriptor(
       variableType.successType,
       typeAliases,
       typeAliasesFull,
-      seen,
-    );
+      seen, pendingAliases);
     return objEntries([
       ["kind", ts.str("nullable")],
       ["schema", schema],

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -161,3 +161,82 @@ describe("__validateChainRecursive", () => {
     expect(typeof err.valuePreview === "string").toBe(true);
   });
 });
+
+describe("ref descriptors (deferred reads for recursive/forward aliases)", () => {
+  it("resolves a self-referential ref at walk time and validates every level", async () => {
+    // Mirrors the emitted shape for `type Tree = { @validate(pos) value,
+    // children: Tree[] }`: the array element is a ref whose get() reads the
+    // completed descriptor — the eager-read emission this replaced saw
+    // `undefined` mid-assignment and nested validation vanished.
+    const isPositive: AgencyValidator = async (v) =>
+      typeof v === "number" && v > 0
+        ? success(v)
+        : failure("must be positive");
+    const treeSchema: z.ZodType = z.object({
+      value: z.number(),
+      children: z.array(z.lazy(() => treeSchema)),
+    });
+    const tree: TypeValidationDescriptor = {
+      kind: "object",
+      schema: treeSchema,
+      validators: [],
+      properties: {
+        value: { kind: "leaf", schema: z.number(), validators: [isPositive] },
+        children: {
+          kind: "array",
+          schema: z.array(z.lazy(() => treeSchema)),
+          validators: [],
+          element: { kind: "ref", get: () => tree },
+        },
+      },
+    };
+    const ok = await __validateChainRecursive(
+      { value: 1, children: [{ value: 2, children: [] }] },
+      tree,
+    );
+    expect(isSuccess(ok)).toBe(true);
+    const bad = await __validateChainRecursive(
+      { value: 1, children: [{ value: -5, children: [] }] },
+      tree,
+    );
+    expect(isFailure(bad)).toBe(true);
+  });
+
+  it("use-site validators merged onto the resolved descriptor still run through a ref", async () => {
+    // The emitter wraps use-site validators INSIDE get() (the walker
+    // dispatches ref before running validators). Simulate that shape.
+    const rejectAll: AgencyValidator = async () => failure("nope");
+    const leaf: TypeValidationDescriptor = {
+      kind: "leaf",
+      schema: z.number(),
+      validators: [],
+    };
+    const ref: TypeValidationDescriptor = {
+      kind: "ref",
+      get: () => ({ ...leaf, validators: [rejectAll] }),
+    };
+    expect(isFailure(await __validateChainRecursive(1, ref))).toBe(true);
+  });
+
+  it("depth cap still bounds a cyclic ref walk", async () => {
+    // A degenerate always-recursing descriptor must hit maxDepth, not hang.
+    const selfRef: TypeValidationDescriptor = {
+      kind: "ref",
+      get: () => wrapper,
+    };
+    const wrapper: TypeValidationDescriptor = {
+      kind: "object",
+      schema: z.any(),
+      validators: [],
+      properties: { next: selfRef },
+    };
+    const deep: { next?: unknown } = {};
+    let cursor = deep;
+    for (let i = 0; i < 200; i++) {
+      cursor.next = {};
+      cursor = cursor.next as { next?: unknown };
+    }
+    const r = await __validateChainRecursive(deep, wrapper, { maxDepth: 16 });
+    expect(isFailure(r)).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -218,6 +218,15 @@ describe("ref descriptors (deferred reads for recursive/forward aliases)", () =>
     expect(isFailure(await __validateChainRecursive(1, ref))).toBe(true);
   });
 
+  it("a pure ref -> ref cycle fails on the consecutive-hop cap instead of hanging", async () => {
+    // Codegen rejects the alias shapes that emit this, but runtime
+    // termination must not depend on that guard staying airtight.
+    const a: TypeValidationDescriptor = { kind: "ref", get: () => b };
+    const b: TypeValidationDescriptor = { kind: "ref", get: () => a };
+    const r = await __validateChainRecursive(1, a);
+    expect(isFailure(r)).toBe(true);
+  });
+
   it("depth cap still bounds a cyclic ref walk", async () => {
     // A degenerate always-recursing descriptor must hit maxDepth, not hang.
     const selfRef: TypeValidationDescriptor = {

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -141,11 +141,22 @@ export async function __validateChainRecursive(
   return walk(value, descriptor, 0, maxDepth);
 }
 
+/**
+ * Consecutive ref-hop cap. Structural kinds reset it, so it only bounds
+ * degenerate ref -> ref chains. Codegen rejects the alias shapes that
+ * would emit such chains (`type Loop = Loop`, `type A = B` + `type B = A`
+ * — see the circularity guard in processTypeAlias), so this is
+ * belt-and-suspenders: runtime termination must not depend on a
+ * compile-time guard staying airtight.
+ */
+const MAX_CONSECUTIVE_REF_HOPS = 8;
+
 async function walk(
   value: unknown,
   descriptor: TypeValidationDescriptor,
   depth: number,
   maxDepth: number,
+  refHops: number = 0,
 ): Promise<ResultValue> {
   if (depth > maxDepth) {
     return failure({
@@ -158,9 +169,17 @@ async function walk(
   if (isFailure(value)) return value as ResultValue;
 
   if (descriptor.kind === "ref") {
-    // Depth passes through unchanged: the structural kinds below the ref
-    // increment it, and maxDepth bounds runaway recursion.
-    return walk(value, descriptor.get(), depth, maxDepth);
+    // Depth passes through unchanged — the structural kinds below the ref
+    // increment it — but consecutive ref hops are capped so a descriptor
+    // cycle built purely from refs fails instead of hanging.
+    if (refHops >= MAX_CONSECUTIVE_REF_HOPS) {
+      return failure({
+        reason: "validation descriptor ref chain exceeded",
+        limit: MAX_CONSECUTIVE_REF_HOPS,
+        valuePreview: previewValue(value),
+      });
+    }
+    return walk(value, descriptor.get(), depth, maxDepth, refHops + 1);
   }
 
   // Step 1: parse + own validators at this node.

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -107,6 +107,19 @@ export type TypeValidationDescriptor =
       schema: z.ZodType;
       validators: AgencyValidator[];
       inner: TypeValidationDescriptor;
+    }
+  | {
+      kind: "ref";
+      /**
+       * Deferred descriptor read. Emitted for alias references whose
+       * target descriptor is not initialized yet at module load (forward
+       * refs) or is the descriptor currently being built (self-recursion).
+       * Resolved at walk time, when every __agency_descriptor exists.
+       * Dispatched BEFORE the own-validator step: a ref carries no schema
+       * or validators of its own — use-site validators are merged onto
+       * the resolved descriptor inside get() at emission time.
+       */
+      get: () => TypeValidationDescriptor;
     };
 
 export type RecursiveValidationOpts = {
@@ -143,6 +156,12 @@ async function walk(
     });
   }
   if (isFailure(value)) return value as ResultValue;
+
+  if (descriptor.kind === "ref") {
+    // Depth passes through unchanged: the structural kinds below the ref
+    // increment it, and maxDepth bounds runaway recursion.
+    return walk(value, descriptor.get(), depth, maxDepth);
+  }
 
   // Step 1: parse + own validators at this node.
   const own = await __validateChain(

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -5,6 +5,7 @@ import { mapTypes } from "./typeWalker.js";
 import { mergeTagSets } from "./mergeTags.js";
 import { applyValueArgs } from "./valueParamSubstitution.js";
 import { resultToObjectUnion } from "./resultUnion.js";
+import { typeKey } from "./typeKey.js";
 import { evalBuiltinGeneric, isBuiltinGenericName } from "./builtinGenerics.js";
 
 /**
@@ -359,14 +360,59 @@ export function isOptionalType(
   return false;
 }
 
-// eslint-disable-next-line max-lines-per-function -- large switch over type kinds; refactor tracked separately
 export function isAssignable(
   source: VariableType | "any",
   target: VariableType | "any",
   typeAliases: Record<string, TypeAliasEntry>,
 ): boolean {
+  return isAssignableGuarded(source, target, typeAliases, new Set());
+}
+
+/**
+ * Coinductive entry point (issue #470). Cycles can only re-enter through a
+ * NAMED reference (typeAliasVariable / genericType) — internal recursive
+ * calls otherwise pass structurally smaller resolved nodes — so the pair
+ * key is only computed when a named node is involved (perf: typeKey stays
+ * off the hot path for plain structural comparisons). Re-encountering an
+ * in-flight pair means we are inside the very comparison that would prove
+ * or refute it — assume it holds, exactly like resolveTypeWithGuard's
+ * inProgress set and TypeScript's relation stack. Entries are REMOVED on
+ * exit (try/finally): only genuine in-flight cycles short-circuit; sibling
+ * repeats recompute real results.
+ */
+function isAssignableGuarded(
+  source: VariableType | "any",
+  target: VariableType | "any",
+  typeAliases: Record<string, TypeAliasEntry>,
+  inProgress: Set<string>,
+): boolean {
   if (source === "any" || target === "any") return true;
 
+  const named =
+    source.type === "typeAliasVariable" ||
+    source.type === "genericType" ||
+    target.type === "typeAliasVariable" ||
+    target.type === "genericType";
+  if (!named) {
+    return isAssignableInner(source, target, typeAliases, inProgress);
+  }
+  const pair = `${typeKey(source, typeAliases)}~>${typeKey(target, typeAliases)}`;
+  if (inProgress.has(pair)) return true;
+  inProgress.add(pair);
+  try {
+    return isAssignableInner(source, target, typeAliases, inProgress);
+  } finally {
+    inProgress.delete(pair);
+  }
+}
+
+// eslint-disable-next-line max-lines-per-function -- large switch over type kinds; refactor tracked separately
+function isAssignableInner(
+  source: VariableType,
+  target: VariableType,
+  typeAliases: Record<string, TypeAliasEntry>,
+  inProgress: Set<string>,
+): boolean {
   const resolvedSource = safeResolveType(source, typeAliases);
   const resolvedTarget = safeResolveType(target, typeAliases);
 
@@ -416,14 +462,14 @@ export function isAssignable(
   // Union type as source: every member must be assignable to target
   if (resolvedSource.type === "unionType") {
     return resolvedSource.types.every((t) =>
-      isAssignable(t, resolvedTarget, typeAliases),
+      isAssignableGuarded(t, resolvedTarget, typeAliases, inProgress),
     );
   }
 
   // Union type as target: source must be assignable to at least one member
   if (resolvedTarget.type === "unionType") {
     return resolvedTarget.types.some((t) =>
-      isAssignable(resolvedSource, t, typeAliases),
+      isAssignableGuarded(resolvedSource, t, typeAliases, inProgress),
     );
   }
 
@@ -509,11 +555,10 @@ export function isAssignable(
     resolvedSource.type === "arrayType" &&
     resolvedTarget.type === "arrayType"
   ) {
-    return isAssignable(
+    return isAssignableGuarded(
       resolvedSource.elementType,
       resolvedTarget.elementType,
-      typeAliases,
-    );
+      typeAliases, inProgress);
   }
 
   // Block types: contravariant in parameters, covariant in return — standard
@@ -526,19 +571,17 @@ export function isAssignable(
       return false;
     for (let i = 0; i < resolvedSource.params.length; i++) {
       if (
-        !isAssignable(
+        !isAssignableGuarded(
           resolvedTarget.params[i].typeAnnotation,
           resolvedSource.params[i].typeAnnotation,
-          typeAliases,
-        )
+          typeAliases, inProgress)
       )
         return false;
     }
-    return isAssignable(
+    return isAssignableGuarded(
       resolvedSource.returnType,
       resolvedTarget.returnType,
-      typeAliases,
-    );
+      typeAliases, inProgress);
   }
 
   // Result<T, E>: covariant in both type parameters.
@@ -547,8 +590,8 @@ export function isAssignable(
     resolvedTarget.type === "resultType"
   ) {
     return (
-      isAssignable(resolvedSource.successType, resolvedTarget.successType, typeAliases) &&
-      isAssignable(resolvedSource.failureType, resolvedTarget.failureType, typeAliases)
+      isAssignableGuarded(resolvedSource.successType, resolvedTarget.successType, typeAliases, inProgress) &&
+      isAssignableGuarded(resolvedSource.failureType, resolvedTarget.failureType, typeAliases, inProgress)
     );
   }
 
@@ -560,11 +603,10 @@ export function isAssignable(
   // target Result to its object union and check structurally. Only when the
   // source is NOT itself a Result (that case is handled covariantly above).
   if (resolvedTarget.type === "resultType" && resolvedSource.type !== "resultType") {
-    return isAssignable(
+    return isAssignableGuarded(
       resolvedSource,
       resultToObjectUnion(resolvedTarget, typeAliases),
-      typeAliases,
-    );
+      typeAliases, inProgress);
   }
 
   // Schema<T>: covariant in the validated type. There's no parser surface
@@ -574,7 +616,7 @@ export function isAssignable(
     resolvedSource.type === "schemaType" &&
     resolvedTarget.type === "schemaType"
   ) {
-    return isAssignable(resolvedSource.inner, resolvedTarget.inner, typeAliases);
+    return isAssignableGuarded(resolvedSource.inner, resolvedTarget.inner, typeAliases, inProgress);
   }
 
   // Record<K, V> -> Record<K, V>: covariant in both K and V.
@@ -583,16 +625,14 @@ export function isAssignable(
   // can pass Record<string, "approve"> where Record<string, string> is expected.
   if (isRecord(resolvedSource) && isRecord(resolvedTarget)) {
     return (
-      isAssignable(
+      isAssignableGuarded(
         resolvedSource.typeArgs[0],
         resolvedTarget.typeArgs[0],
-        typeAliases,
-      ) &&
-      isAssignable(
+        typeAliases, inProgress) &&
+      isAssignableGuarded(
         resolvedSource.typeArgs[1],
         resolvedTarget.typeArgs[1],
-        typeAliases,
-      )
+        typeAliases, inProgress)
     );
   }
 
@@ -608,7 +648,7 @@ export function isAssignable(
       for (const k of requiredKeys) if (!sourceKeys.has(k)) return false;
     }
     return resolvedSource.properties.every((p) =>
-      isAssignable(p.value, valueType, typeAliases),
+      isAssignableGuarded(p.value, valueType, typeAliases, inProgress),
     );
   }
 
@@ -633,7 +673,7 @@ export function isAssignable(
         if (isOptionalType(targetProp.value, typeAliases)) continue;
         return false;
       }
-      if (!isAssignable(sourceProp.value, targetProp.value, typeAliases))
+      if (!isAssignableGuarded(sourceProp.value, targetProp.value, typeAliases, inProgress))
         return false;
     }
     return true;
@@ -663,10 +703,10 @@ export function isAssignable(
       const sourceHint = sourceParams[i].typeHint;
       const targetHint = targetParams[i].typeHint;
       if (!sourceHint || !targetHint) continue;
-      if (!isAssignable(targetHint, sourceHint, typeAliases)) return false;
+      if (!isAssignableGuarded(targetHint, sourceHint, typeAliases, inProgress)) return false;
     }
     if (resolvedSource.returnType && resolvedTarget.returnType) {
-      return isAssignable(resolvedSource.returnType, resolvedTarget.returnType, typeAliases);
+      return isAssignableGuarded(resolvedSource.returnType, resolvedTarget.returnType, typeAliases, inProgress);
     }
     return true;
   }
@@ -692,14 +732,13 @@ export function isAssignable(
       const sourceHint = sourceParams[i].typeHint;
       const targetHint = resolvedTarget.params[i].typeAnnotation;
       if (!sourceHint || !targetHint) continue;
-      if (!isAssignable(targetHint, sourceHint, typeAliases)) return false;
+      if (!isAssignableGuarded(targetHint, sourceHint, typeAliases, inProgress)) return false;
     }
     if (resolvedSource.returnType && resolvedTarget.returnType) {
-      return isAssignable(
+      return isAssignableGuarded(
         resolvedSource.returnType,
         resolvedTarget.returnType,
-        typeAliases,
-      );
+        typeAliases, inProgress);
     }
     return true;
   }

--- a/packages/agency-lang/lib/typeChecker/builtinGenerics.test.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinGenerics.test.ts
@@ -611,3 +611,19 @@ describe("use-site tag precedence", () => {
     ).toEqual(["fromAlias", "fromUseSite"]);
   });
 });
+
+describe("utility types over recursive aliases (#470 unblocked)", () => {
+  it("Partial of a recursive alias works shallowly", () => {
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+node main() {
+  const t: Partial<Tree> = { value: null, children: null }
+  return t
+}
+`);
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -4,6 +4,7 @@ import { narrowByRefine } from "./narrowing.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { NEVER_T } from "./primitives.js";
 import { isNever, safeResolveType } from "./assignability.js";
+import { typeKey } from "./typeKey.js";
 // The pure path-segment core lives in its own module so `narrowing.ts` can
 // value-import it (chainToSegments) without a runtime cycle back through
 // `flow.ts` (which value-imports `narrowByRefine` from `narrowing.ts`). Re-export
@@ -125,22 +126,20 @@ export type FlowEnvironment = {
  * `never`. Literal members are preserved (not widened to primitives) so a
  * discriminant union survives a join with full precision.
  *
- * KNOWN LIMITATION (PR 1a): dedup is by `JSON.stringify` structural equality
- * and does NOT resolve type aliases. Two members that resolve to the same
- * underlying type via different aliases will both survive. PR 2 will hit this
- * the moment alias-typed locals flow through a join — fix then by resolving
- * with `_aliases` before keying.
+ * Dedup keys via `typeKey` (typeKey.ts), which resolves top-level aliases,
+ * ignores property order and non-semantic metadata, and keys recursive
+ * references nominally — the gaps raw `JSON.stringify` keying had.
  */
 export function uniteTypes(
   types: ScopeType[],
-  _aliases: Record<string, TypeAliasEntry>,
+  aliases: Record<string, TypeAliasEntry>,
 ): ScopeType {
   if (types.some((t) => t === "any")) return "any";
   const concrete = (types as VariableType[]).filter((t) => !isNever(t));
   if (concrete.length === 0) return NEVER_T;
   const seen: Record<string, VariableType> = {};
   for (const t of concrete) {
-    const key = JSON.stringify(t);
+    const key = typeKey(t, aliases);
     if (!(key in seen)) seen[key] = t;
   }
   const uniques = Object.values(seen);
@@ -306,10 +305,10 @@ export function mergeFlows(flows: FlowNode[]): FlowNode {
  * changed. Can over-widen when a narrowing actually holds across iterations —
  * acceptable, documented (no fixpoint).
  *
- * The unchanged-check uses `JSON.stringify` equality (same as `uniteTypes`) and
- * does NOT resolve type aliases — two structurally-different-but-equivalent
- * aliased types read as "changed" and pessimistically widen. Same caveat as
- * `uniteTypes`; revisit alongside it.
+ * The unchanged-check uses `typeKey` equality (same as `uniteTypes`), so
+ * alias-vs-body and property-order differences no longer pessimistically
+ * widen. The `"any"` sentinel short-circuits before typeKey, which only
+ * accepts real VariableTypes.
  */
 export function widenAtLoopBackEdge(
   loopEntry: FlowNode,
@@ -325,7 +324,11 @@ export function widenAtLoopBackEdge(
     const r: Reference = { variable: name, chain: [] };
     const before = typeAt(r, loopEntry, env);
     const after = bodyEnd.kind === "exit" ? before : typeAt(r, bodyEnd, env);
-    if (JSON.stringify(before) === JSON.stringify(after)) {
+    const unchanged =
+      before === "any" || after === "any"
+        ? before === after
+        : typeKey(before, env.typeAliases) === typeKey(after, env.typeAliases);
+    if (unchanged) {
       widened[referenceKey(r)] = before;
     } else {
       widened[referenceKey(r)] = uniteTypes([before, after], env.typeAliases);

--- a/packages/agency-lang/lib/typeChecker/recursiveAssignability.test.ts
+++ b/packages/agency-lang/lib/typeChecker/recursiveAssignability.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { typecheckSource } from "./testUtils.js";
+
+// Regression tests for issue #470 bug 2: comparing a recursive alias to
+// itself used to recurse forever (each isAssignable call re-resolved the
+// alias with a fresh guard) and crash with RangeError.
+describe("assignability of recursive type aliases", () => {
+  it("self-recursive alias vs itself terminates and accepts", () => {
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+def id(x: Tree): Tree {
+  return x
+}
+node main() {
+  const a: Tree = { value: 3, children: [{ value: 4, children: [] }] }
+  const b: Tree = id(a)
+  return b.value
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("mutually recursive aliases terminate and accept", () => {
+    const errors = typecheckSource(`
+type Forest = {
+  trees: Tree[],
+}
+type Tree = {
+  value: number,
+  forest: Forest | null,
+}
+def id(f: Forest): Forest {
+  return f
+}
+node main() {
+  const f: Forest = { trees: [] }
+  return id(f)
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("still REJECTS a genuinely incompatible recursive type", () => {
+    // Anti-vacuity: a guard that returns true too eagerly fails here.
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+type NamedTree = {
+  name: string,
+  children: NamedTree[],
+}
+def wantsNamed(x: NamedTree): number {
+  return 1
+}
+node main() {
+  const t: Tree = { value: 3, children: [] }
+  return wantsNamed(t)
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("removal-on-exit: a refuted pair must not be assumed true later in the SAME comparison", () => {
+    // Review must-fix 4. Inside ONE top-level isAssignable call:
+    // property a checks Tree ~> (NamedTree | Tree): the union tries
+    // Tree~>NamedTree first (false — pair added then REMOVED), then
+    // Tree~>Tree (true). Property b then re-checks Tree~>NamedTree.
+    // A memoizing guard (never removes) sees the stale pair and wrongly
+    // accepts; correct removal-on-exit recomputes and rejects b.
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+type NamedTree = {
+  name: string,
+  children: NamedTree[],
+}
+type Target = {
+  a: NamedTree | Tree,
+  b: NamedTree,
+}
+def wants(x: Target): number {
+  return 1
+}
+node main() {
+  const t: Tree = { value: 3, children: [] }
+  return wants({ a: t, b: t })
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -13,6 +13,7 @@ import { BUILTIN_FUNCTION_TYPES, AGENCY_FUNCTION_METHOD_TYPES } from "./builtins
 import { isAssignable, isNever, safeResolveType } from "./assignability.js";
 import { typeAt, flowHasNarrowFor, stablePrefix } from "./flow.js";
 import { literalToType } from "./literalType.js";
+import { typeKey } from "./typeKey.js";
 import { resultTypeForValidation } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
@@ -457,9 +458,9 @@ function synthLogical(
   const seen = new Map<string, VariableType>();
   const collect = (t: VariableType) => {
     if (t.type === "unionType") {
-      for (const m of t.types) seen.set(JSON.stringify(m), m);
+      for (const m of t.types) seen.set(typeKey(m, ctx.getTypeAliases()), m);
     } else {
-      seen.set(JSON.stringify(t), t);
+      seen.set(typeKey(t, ctx.getTypeAliases()), t);
     }
   };
   collect(left);
@@ -636,7 +637,7 @@ function synthArray(
   // Deduplicate structurally identical types
   const seen = new Map<string, VariableType>();
   for (const t of concreteTypes) {
-    const key = JSON.stringify(t);
+    const key = typeKey(t, ctx.getTypeAliases());
     if (!seen.has(key)) seen.set(key, t);
   }
   const unique = Array.from(seen.values());
@@ -708,7 +709,7 @@ function synthObject(
       ...computedValueTypes,
     ];
     if (allValueTypes.length === 0) return "any";
-    const unique = uniqBy(allValueTypes, (t) => JSON.stringify(t));
+    const unique = uniqBy(allValueTypes, (t) => typeKey(t, ctx.getTypeAliases()));
     const valueType: VariableType =
       unique.length === 1
         ? unique[0]
@@ -1212,7 +1213,7 @@ function synthBlockReturnType(
   // Dedupe structurally identical types.
   const seen = new Map<string, VariableType>();
   for (const t of concrete) {
-    const key = JSON.stringify(t);
+    const key = typeKey(t, ctx.getTypeAliases());
     if (!seen.has(key)) seen.set(key, t);
   }
   const unique = Array.from(seen.values());

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -456,11 +456,12 @@ function synthLogical(
   const right = synthType(expr.right, scope, ctx);
   if (left === "any" || right === "any") return "any";
   const seen = new Map<string, VariableType>();
+  const aliases = ctx.getTypeAliases();
   const collect = (t: VariableType) => {
     if (t.type === "unionType") {
-      for (const m of t.types) seen.set(typeKey(m, ctx.getTypeAliases()), m);
+      for (const m of t.types) seen.set(typeKey(m, aliases), m);
     } else {
-      seen.set(typeKey(t, ctx.getTypeAliases()), t);
+      seen.set(typeKey(t, aliases), t);
     }
   };
   collect(left);
@@ -636,8 +637,9 @@ function synthArray(
   }
   // Deduplicate structurally identical types
   const seen = new Map<string, VariableType>();
+  const aliases = ctx.getTypeAliases();
   for (const t of concreteTypes) {
-    const key = typeKey(t, ctx.getTypeAliases());
+    const key = typeKey(t, aliases);
     if (!seen.has(key)) seen.set(key, t);
   }
   const unique = Array.from(seen.values());
@@ -1212,8 +1214,9 @@ function synthBlockReturnType(
   if (concrete.length === 1) return concrete[0];
   // Dedupe structurally identical types.
   const seen = new Map<string, VariableType>();
+  const aliases = ctx.getTypeAliases();
   for (const t of concrete) {
-    const key = typeKey(t, ctx.getTypeAliases());
+    const key = typeKey(t, aliases);
     if (!seen.has(key)) seen.set(key, t);
   }
   const unique = Array.from(seen.values());

--- a/packages/agency-lang/lib/typeChecker/typeKey.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typeKey.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { typeKey } from "./typeKey.js";
+import { uniteTypes } from "./flow.js";
+import { typecheckSource } from "./testUtils.js";
+import type { VariableType, TypeAliasEntry } from "../types.js";
+
+const STR: VariableType = { type: "primitiveType", value: "string" };
+const NUM: VariableType = { type: "primitiveType", value: "number" };
+const NO_ALIASES: Record<string, TypeAliasEntry> = {};
+
+function treeAliases(name: string): Record<string, TypeAliasEntry> {
+  return {
+    [name]: {
+      body: {
+        type: "objectType",
+        properties: [
+          { key: "value", value: NUM },
+          {
+            key: "children",
+            value: {
+              type: "arrayType",
+              elementType: { type: "typeAliasVariable", aliasName: name },
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe("typeKey", () => {
+  it("is property-order insensitive", () => {
+    const ab: VariableType = {
+      type: "objectType",
+      properties: [
+        { key: "a", value: STR },
+        { key: "b", value: NUM },
+      ],
+    };
+    const ba: VariableType = {
+      type: "objectType",
+      properties: [
+        { key: "b", value: NUM },
+        { key: "a", value: STR },
+      ],
+    };
+    expect(typeKey(ab, NO_ALIASES)).toBe(typeKey(ba, NO_ALIASES));
+  });
+
+  it("is union-member-order insensitive", () => {
+    const ab: VariableType = { type: "unionType", types: [STR, NUM] };
+    const ba: VariableType = { type: "unionType", types: [NUM, STR] };
+    expect(typeKey(ab, NO_ALIASES)).toBe(typeKey(ba, NO_ALIASES));
+  });
+
+  it("ignores tags, trivia, descriptions, and effect-set flags", () => {
+    const plainObj: VariableType = {
+      type: "objectType",
+      properties: [{ key: "a", value: STR }],
+    };
+    const decoratedObj: VariableType = {
+      type: "objectType",
+      properties: [
+        {
+          key: "a",
+          value: {
+            type: "primitiveType",
+            value: "string",
+            tags: [{ type: "tag", name: "validate", arguments: [] }],
+          },
+          description: "described",
+        },
+      ],
+      trivia: [{ anchorIndex: 0, comments: [] }],
+    };
+    expect(typeKey(decoratedObj, NO_ALIASES)).toBe(typeKey(plainObj, NO_ALIASES));
+    const union: VariableType = { type: "unionType", types: [STR, NUM] };
+    const effectUnion: VariableType = {
+      type: "unionType",
+      types: [STR, NUM],
+      isEffectSet: true,
+    };
+    expect(typeKey(effectUnion, NO_ALIASES)).toBe(typeKey(union, NO_ALIASES));
+  });
+
+  it("resolves a top-level alias one step so alias and body key equal", () => {
+    const aliases: Record<string, TypeAliasEntry> = { Age: { body: NUM } };
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "Age" };
+    expect(typeKey(ref, aliases)).toBe(typeKey(NUM, aliases));
+  });
+
+  it("keeps NESTED alias refs nominal: {a: AgeRef} differs from {a: number}", () => {
+    const aliases: Record<string, TypeAliasEntry> = { Age: { body: NUM } };
+    const nominal: VariableType = {
+      type: "objectType",
+      properties: [{ key: "a", value: { type: "typeAliasVariable", aliasName: "Age" } }],
+    };
+    const structural: VariableType = {
+      type: "objectType",
+      properties: [{ key: "a", value: NUM }],
+    };
+    expect(typeKey(nominal, aliases)).not.toBe(typeKey(structural, aliases));
+  });
+
+  it("keys a recursive alias without looping, and DIFFERENT recursive aliases key differently", () => {
+    const aliases = { ...treeAliases("Tree"), ...treeAliases("Tree2") };
+    const tree: VariableType = { type: "typeAliasVariable", aliasName: "Tree" };
+    const tree2: VariableType = { type: "typeAliasVariable", aliasName: "Tree2" };
+    // Same shape, different names: inner refs are nominal, so keys differ.
+    expect(typeKey(tree, aliases)).not.toBe(typeKey(tree2, aliases));
+  });
+
+  it("distinguishes value-param instantiations (valueArgs are identity)", () => {
+    const age18: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "Age",
+      valueArgs: [{ type: "number", value: "18" }],
+    };
+    const age21: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "Age",
+      valueArgs: [{ type: "number", value: "21" }],
+    };
+    // Unknown alias — stays nominal; the valueArgs must still distinguish.
+    expect(typeKey(age18, NO_ALIASES)).not.toBe(typeKey(age21, NO_ALIASES));
+  });
+
+  it("distinguishes genuinely different types", () => {
+    expect(typeKey(STR, NO_ALIASES)).not.toBe(typeKey(NUM, NO_ALIASES));
+    const arr: VariableType = { type: "arrayType", elementType: STR };
+    expect(typeKey(arr, NO_ALIASES)).not.toBe(typeKey(STR, NO_ALIASES));
+  });
+});
+
+describe("typeKey adoption at the dedup sites", () => {
+  it("uniteTypes dedups property-order-flipped members to ONE (pins the flow.ts wiring)", () => {
+    // Direct pin: reverting uniteTypes to raw JSON.stringify keying makes
+    // this return a 2-member union. (A pipeline-level observable proved
+    // unreachable: assignability is already order-insensitive and the
+    // assignment diagnostic renders the declared scope type, not the
+    // join — verified during execution.)
+    const objAB: VariableType = {
+      type: "objectType",
+      properties: [
+        { key: "a", value: NUM },
+        { key: "b", value: NUM },
+      ],
+    };
+    const objBA: VariableType = {
+      type: "objectType",
+      properties: [
+        { key: "b", value: NUM },
+        { key: "a", value: NUM },
+      ],
+    };
+    const joined = uniteTypes([objAB, objBA], NO_ALIASES);
+    expect(joined).toEqual(objAB);
+  });
+
+  it("a joined branch-reassignment program typechecks clean (general regression)", () => {
+    const errors = typecheckSource(`
+def f(flag: boolean): number {
+  let x = { a: 1, b: 2 }
+  if (flag) {
+    x = { b: 2, a: 1 }
+  }
+  const n: number = x
+  return n
+}
+node main() {
+  return f(true)
+}
+`);
+    const msg = errors.map((e) => e.message).join("\n");
+    expect(msg).toMatch(/not assignable/);
+    expect(msg).not.toMatch(/\|/);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/typeKey.ts
+++ b/packages/agency-lang/lib/typeChecker/typeKey.ts
@@ -1,0 +1,94 @@
+import type { Expression, TypeAliasEntry, VariableType } from "../types.js";
+import { safeResolveType } from "./assignability.js";
+
+/**
+ * Canonical structural identity for a type — THE replacement for raw
+ * `JSON.stringify(t)` at identity sites (uniteTypes, loop widening, union
+ * dedup in synthesis, coinduction pair keys). Fixes the gaps raw stringify
+ * had (issue #473): property-order sensitivity, non-semantic metadata
+ * leaking into the key, and unresolved top-level aliases keying
+ * differently from their bodies.
+ *
+ * Deliberate identity decisions (all safe because the consumers feed
+ * dedup/diagnostics and cycle detection, never codegen schemas):
+ * - The TOP node resolves ONE step via safeResolveType (recursive
+ *   self-refs stay nominal via its guard); NESTED alias refs key
+ *   nominally as `alias:Name` — never expanded, so recursion terminates
+ *   and same-name refs always key equal.
+ * - `valueArgs` ARE identity: `Age(18)` and `Age(21)` are different types.
+ * - `tags`, `trivia`, property `description`s, `loc`, `isEffectSet`, and
+ *   `blockType.raises` are NOT identity: two types differing only in
+ *   annotations/formatting dedup together (first member's metadata wins
+ *   at union joins — acceptable for diagnostics).
+ * - Union members sort by canonical form (`A | B` keys equal `B | A`);
+ *   object properties sort by key.
+ */
+export function typeKey(
+  t: VariableType,
+  aliases: Record<string, TypeAliasEntry>,
+): string {
+  return canonical(safeResolveType(t, aliases));
+}
+
+/**
+ * Canonicalize a tag-argument-subset expression (literals, identifiers,
+ * object literals) for valueArgs identity. A loc-stripped JSON walk —
+ * stable, if verbose; the subset is small and rarely deep.
+ */
+function canonicalExpr(e: Expression): string {
+  return JSON.stringify(e, (key, value) =>
+    key === "loc" ? undefined : value,
+  );
+}
+
+function canonicalValueArgs(valueArgs: Expression[] | undefined): string {
+  if (!valueArgs || valueArgs.length === 0) return "";
+  return `,"vargs":[${valueArgs.map(canonicalExpr).join(",")}]`;
+}
+
+function canonical(t: VariableType): string {
+  switch (t.type) {
+    case "typeAliasVariable":
+      return `{"alias":${JSON.stringify(t.aliasName)}${canonicalValueArgs(t.valueArgs)}}`;
+    case "objectType": {
+      // Render each property first, then sort the strings — same pattern
+      // as the union case. Each rendered string starts with the quoted
+      // key, so the sort is effectively by key.
+      const props = t.properties
+        .map((p) => `${JSON.stringify(p.key)}:${canonical(p.value)}`)
+        .sort();
+      return `{"object":{${props.join(",")}}}`;
+    }
+    case "unionType":
+      return `{"union":[${t.types.map(canonical).sort().join(",")}]}`;
+    case "arrayType":
+      return `{"array":${canonical(t.elementType)}}`;
+    case "resultType":
+      return `{"result":[${canonical(t.successType)},${canonical(t.failureType)}]}`;
+    case "schemaType":
+      return `{"schema":${canonical(t.inner)}}`;
+    case "genericType":
+      return `{"generic":${JSON.stringify(t.name)},"args":[${t.typeArgs.map(canonical).join(",")}]${canonicalValueArgs(t.valueArgs)}}`;
+    case "blockType":
+      return `{"block":[${t.params.map((p) => canonical(p.typeAnnotation)).join(",")}],"ret":${canonical(t.returnType)}}`;
+    case "functionRefType":
+      return `{"fnref":${JSON.stringify(t.name)}}`;
+    case "primitiveType":
+      return `{"prim":${JSON.stringify(t.value)}}`;
+    case "stringLiteralType":
+      return `{"strlit":${JSON.stringify(t.value)}}`;
+    case "numberLiteralType":
+      return `{"numlit":${JSON.stringify(t.value)}}`;
+    case "booleanLiteralType":
+      return `{"boollit":${JSON.stringify(t.value)}}`;
+    default: {
+      // Exhaustiveness enforced per the typeHints.ts convention: a new
+      // VariableType variant fails compilation here instead of silently
+      // returning undefined.
+      const exhausted: never = t;
+      throw new Error(
+        `typeKey: unhandled type variant ${JSON.stringify(exhausted)}`,
+      );
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/recursive-type-partial.agency
+++ b/packages/agency-lang/tests/agency/recursive-type-partial.agency
@@ -1,0 +1,26 @@
+// Utility-type x recursion composition: Partial<Tree> parses with missing
+// keys null-coalesced, and still validates a wrongly-typed present key.
+// (Schema bound to a variable first — chaining on schema(...) does not
+// parse, see #480.)
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+
+node accepts() {
+  const s = schema(Partial<Tree>)
+  const r = s.parseJSON("{}")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node rejects() {
+  const s = schema(Partial<Tree>)
+  const r = s.parseJSON("{\"value\": \"nope\"}")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}

--- a/packages/agency-lang/tests/agency/recursive-type-partial.test.json
+++ b/packages/agency-lang/tests/agency/recursive-type-partial.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "{\"value\":null,\"children\":null}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Partial of recursive alias null-coalesces missing keys"
+    },
+    {
+      "nodeName": "rejects",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "wrong value type still rejected under Partial of recursive alias"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/recursive-type-validated.agency
+++ b/packages/agency-lang/tests/agency/recursive-type-validated.agency
@@ -1,0 +1,34 @@
+// Validated recursive alias: nested validators must run at every level.
+// Validators fire through the `!` validated-assignment path (schema(...)
+// parse is zod-only). Before the lazy-descriptor fix, the alias's own
+// __agency_descriptor initializer read itself mid-assignment (undefined),
+// so walking into `children` hit a dead descriptor and nested validation
+// broke — rejectsNested() proves the validator now fires one level down.
+def positive(n: number): Result<number, string> {
+  if (n > 0) {
+    return success(n)
+  }
+  return failure("must be positive")
+}
+
+type Tree = {
+  @validate(positive)
+  value: number,
+  children: Tree[],
+}
+
+node accepts() {
+  const t: Tree! = { value: 1, children: [{ value: 2, children: [] }] }
+  if (isSuccess(t)) {
+    return "ok"
+  }
+  return "invalid"
+}
+
+node rejectsNested() {
+  const t: Tree! = { value: 1, children: [{ value: -5, children: [] }] }
+  if (isFailure(t)) {
+    return "rejected"
+  }
+  return "accepted"
+}

--- a/packages/agency-lang/tests/agency/recursive-type-validated.test.json
+++ b/packages/agency-lang/tests/agency/recursive-type-validated.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "valid nested payload passes recursive validation"
+    },
+    {
+      "nodeName": "rejectsNested",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "validator fires at nesting depth 2 (silent-loss regression pin)"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/recursive-type.agency
+++ b/packages/agency-lang/tests/agency/recursive-type.agency
@@ -1,0 +1,68 @@
+// Issue #470 bug 1: recursive/forward alias schema consts used to emit
+// self/forward references in their initializers and crash at module load
+// with a TDZ ReferenceError. Covers self-recursion, plain forward
+// references, mutual recursion (executed, not just emitted), and a
+// recursive alias used as an executed function parameter (its tool
+// registration builds a module-load-time schema).
+type Ahead = {
+  b: Behind,
+}
+
+type Behind = {
+  x: number,
+}
+
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+
+type Employee = {
+  name: string,
+  manager: Manager | null,
+}
+
+type Manager = {
+  reports: Employee[],
+}
+
+def depth(t: Tree): number {
+  return 1
+}
+
+node forwardRef() {
+  const a: Ahead = { b: { x: 1 } }
+  return a
+}
+
+node accepts() {
+  const s = schema(Tree)
+  const r = s.parseJSON("{\"value\": 1, \"children\": [{\"value\": 2, \"children\": []}]}")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node rejects() {
+  const s = schema(Tree)
+  const r = s.parseJSON("{\"value\": 1, \"children\": [{\"value\": \"nope\", \"children\": []}]}")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}
+
+node mutual() {
+  const s = schema(Employee)
+  const r = s.parseJSON("{\"name\": \"a\", \"manager\": {\"reports\": [{\"name\": \"b\", \"manager\": null}]}}")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node paramUse() {
+  const t: Tree = { value: 1, children: [] }
+  return depth(t)
+}

--- a/packages/agency-lang/tests/agency/recursive-type.test.json
+++ b/packages/agency-lang/tests/agency/recursive-type.test.json
@@ -1,0 +1,39 @@
+{
+  "tests": [
+    {
+      "nodeName": "forwardRef",
+      "input": "",
+      "expectedOutput": "{\"b\":{\"x\":1}}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "forward alias reference loads and runs"
+    },
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "{\"value\":1,\"children\":[{\"value\":2,\"children\":[]}]}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "recursive schema parses nested payload"
+    },
+    {
+      "nodeName": "rejects",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "recursive schema validates at depth 2"
+    },
+    {
+      "nodeName": "mutual",
+      "input": "",
+      "expectedOutput": "{\"name\":\"a\",\"manager\":{\"reports\":[{\"name\":\"b\",\"manager\":null}]}}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "mutual recursion executes end to end"
+    },
+    {
+      "nodeName": "paramUse",
+      "input": "",
+      "expectedOutput": "1",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "recursive alias as executed function parameter (tool schema at module load)"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.agency
@@ -6,6 +6,8 @@ type Behind = {
   x: number,
 }
 
+type TreePatch = Partial<Tree>
+
 type Tree = {
   value: number,
   children: Tree[],

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.agency
@@ -1,0 +1,28 @@
+type Ahead = {
+  b: Behind,
+}
+
+type Behind = {
+  x: number,
+}
+
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+
+type Employee = {
+  name: string,
+  manager: Manager | null,
+}
+
+type Manager = {
+  reports: Employee[],
+}
+
+type Json = string | number | Json[]
+
+node main() {
+  const t: Tree = { value: 1, children: [] }
+  return t
+}

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.agency
@@ -26,3 +26,8 @@ node main() {
   const t: Tree = { value: 1, children: [] }
   return t
 }
+
+node llmTree() {
+  const suggested: Tree = llm("Suggest a small tree")
+  return suggested
+}

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -268,6 +268,102 @@ await callHook({
     };
   }
 })
+graph.node("llmTree", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "recursiveTypes.agency", scopeName: "llmTree", threads: __setupData.threads });
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __ctx.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onNodeStart",
+          data: {
+            nodeName: "llmTree"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.suggested = await runPrompt({
+          prompt: `Suggest a small tree`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: Tree
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
+// halt if this is an interrupt
+if (hasInterrupts(__stack.locals.suggested)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.suggested
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+runner.halt({
+          messages: __threads(),
+          data: __stack.locals.suggested
+        })
+return;
+      });
+    })
+    if (runner.halted) return runner.haltResult;
+    await runner.hook(3, async () => {
+await callHook({
+        name: "onNodeEnd",
+        data: {
+          nodeName: "llmTree",
+          data: undefined
+        }
+      })
+    });
+    return {
+      messages: __threads(),
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof AgencyAbort) {
+      throw __error
+    }
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node llmTree crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "llmTree",
+              });
+            }
+    return {
+      messages: __threads(),
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "llmTree" })
+    };
+  }
+})
 export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
   return runNode({
     ctx: __globalCtx,
@@ -281,6 +377,19 @@ export async function main({ messages, callbacks }: { messages?: any; callbacks?
   });
 }
 export const __mainNodeParams = [];
+export async function llmTree({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "llmTree",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals,
+    registerTopLevelCallbacks: __registerTopLevelCallbacks,
+    moduleDir: __dirname
+  });
+}
+export const __llmTreeNodeParams = [];
 if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   try {
     const initialState = {
@@ -296,4 +405,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"recursiveTypes.agency:main":{"1":{"line":25,"col":2},"2":{"line":26,"col":2}}};
+export const __sourceMap = {"recursiveTypes.agency:main":{"1":{"line":25,"col":2},"2":{"line":26,"col":2}},"recursiveTypes.agency:llmTree":{"1":{"line":30,"col":2},"2":{"line":31,"col":2}}};

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -181,6 +181,8 @@ const Ahead = z.object({ "b": z.lazy(() => Behind) });
 type Ahead = z.infer<typeof Ahead>;
 const Behind = z.object({ "x": z.number() });
 type Behind = z.infer<typeof Behind>;
+const TreePatch = z.object({ "value": z.union([z.number(), z.null()]).optional().default(null), "children": z.union([z.array(z.lazy(() => Tree)), z.null()]).optional().default(null) });
+type TreePatch = z.infer<typeof TreePatch>;
 const Tree = z.object({ "value": z.number(), "children": z.array(z.lazy(() => Tree)) });
 type Tree = z.infer<typeof Tree>;
 const Employee = z.object({ "name": z.string(), "manager": z.union([z.lazy(() => Manager), z.null()]).optional().default(null) });
@@ -405,4 +407,4 @@ Agent crashed: ${__error.message}`)
   }
 }
 export default graph
-export const __sourceMap = {"recursiveTypes.agency:main":{"1":{"line":25,"col":2},"2":{"line":26,"col":2}},"recursiveTypes.agency:llmTree":{"1":{"line":30,"col":2},"2":{"line":31,"col":2}}};
+export const __sourceMap = {"recursiveTypes.agency:main":{"1":{"line":27,"col":2},"2":{"line":28,"col":2}},"recursiveTypes.agency:llmTree":{"1":{"line":32,"col":2},"2":{"line":33,"col":2}}};

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -1,0 +1,299 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "agency-lang/zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import os from "os";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
+  RestoreSignal,
+  AgencyAbort,
+  deepClone as __deepClone,
+  deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  functionRefReviver as __functionRefReviver,
+  DeterministicClient as __DeterministicClient,
+  installFetchMock as __installFetchMock,
+  createLogger as __createLogger,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false,
+    observability: false
+  },
+  smoltalkDefaults: {
+    apiKey: {
+      openAi: __process.env["OPENAI_API_KEY"] || "",
+      google: __process.env["GEMINI_API_KEY"] || "",
+      anthropic: __process.env["ANTHROPIC_API_KEY"] || "",
+      openRouter: __process.env["OPENROUTER_API_KEY"] || "",
+      deepInfra: __process.env["DEEPINFRA_API_KEY"] || "",
+      liteLlm: __process.env["LITELLM_API_KEY"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_API_KEY"] || ""
+    },
+    baseUrl: {
+      liteLlm: __process.env["LITELLM_BASE_URL"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
+    },
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  logLevel: "info",
+  traceConfig: {
+    program: "recursiveTypes.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Handler result builtins and interrupt response constructors (unified types)
+export function approve(value?: any) { return { type: "approve" as const, value }; }
+export function reject(value?: any) { return { type: "reject" as const, value }; }
+function propagate() { return { type: "propagate" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, hasInterrupts, isDebugger };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
+export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+// Auto-activate the deterministic LLM client when AGENCY_LLM_MOCKS is set.
+// The test runner (lib/cli/util.ts) populates this env var as a JSON string
+// when AGENCY_USE_TEST_LLM_PROVIDER=1. Both the agency evaluate template
+// and the agency-js test.js paths import this module, so this single block
+// covers both code paths.
+if (__process.env.AGENCY_LLM_MOCKS) {
+  __globalCtx.setLLMClient(
+    new __DeterministicClient(JSON.parse(__process.env.AGENCY_LLM_MOCKS))
+  );
+}
+
+// Auto-activate fetch mocking when AGENCY_FETCH_MOCKS_FILE points at a mocks
+// file. The runner writes resolved mocks (returnFile bodies already inlined) to
+// a temp file and passes its path — a file, not an inline env value, so a large
+// response body can't blow the exec arg/env size limit (ARG_MAX). Independent of
+// AGENCY_LLM_MOCKS — a test may mock the network while using a real LLM, or vice
+// versa. Installed before any node runs, ahead of any http.ts / stdlib / interop
+// fetch.
+if (__process.env.AGENCY_FETCH_MOCKS_FILE) {
+  __installFetchMock(JSON.parse(readFileSync(__process.env.AGENCY_FETCH_MOCKS_FILE, "utf-8")));
+}
+
+// Share a single registry object across every compiled module. With
+// composite "module:name" keys, all modules' helpers — plus
+// runtime-created blocks registered by `AgencyFunction.create` while
+// a function is executing — stay reachable from `FunctionRefReviver`
+// no matter which module touched the registry last.
+export const __toolRegistry: Record<string, any> = (__functionRefReviver.registry ??= {} as any);
+
+function __registerTool(value: unknown, _aliasName?: string) {
+  // Composite "module:name" key keyed off the function's *own*
+  // identity, not the importing module's local alias — so different
+  // modules that import the same function don't shadow each other in
+  // the shared global registry that `FunctionRefReviver` reads from.
+  // `_aliasName` is kept in the signature for backwards compatibility
+  // with already-compiled callers that pass it.
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[`${value.module}:${value.name}`] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const _run = __AgencyFunction.create({ name: "_run", module: "__runtime", fn: __runtime_run_impl, params: [{ name: "compiled", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "node", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "args", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "wallClock", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "memory", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "ipcPayload", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "stdout", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "configOverrides", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "cwd", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "maxDepth", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+
+function registerTools(tools: any[]) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[`${tool.module}:${tool.name}`] = tool;
+    }
+  }
+}
+
+async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("recursiveTypes.agency")) {
+    return;
+  }
+  __ctx.globals.markInitialized("recursiveTypes.agency")
+}
+__registerGlobalsInit("recursiveTypes.agency", __initializeGlobals);
+async function __registerTopLevelCallbacks(__ctx) {
+  __ctx.topLevelCallbacks = [];
+}
+__functionRefReviver.registry = __toolRegistry;
+const Ahead = z.object({ "b": z.lazy(() => Behind) });
+type Ahead = z.infer<typeof Ahead>;
+const Behind = z.object({ "x": z.number() });
+type Behind = z.infer<typeof Behind>;
+const Tree = z.object({ "value": z.number(), "children": z.array(z.lazy(() => Tree)) });
+type Tree = z.infer<typeof Tree>;
+const Employee = z.object({ "name": z.string(), "manager": z.union([z.lazy(() => Manager), z.null()]).optional().default(null) });
+type Employee = z.infer<typeof Employee>;
+const Manager = z.object({ "reports": z.array(Employee) });
+type Manager = z.infer<typeof Manager>;
+const Json = z.union([z.string(), z.number(), z.array(z.lazy(() => Json))]);
+type Json = z.infer<typeof Json>;
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "recursiveTypes.agency", scopeName: "main", threads: __setupData.threads });
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __ctx.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.t = {
+          "value": 1,
+          "children": []
+        };
+      });
+      await runner.step(2, async (runner) => {
+runner.halt({
+          messages: __threads(),
+          data: __stack.locals.t
+        })
+return;
+      });
+    })
+    if (runner.halted) return runner.haltResult;
+    await runner.hook(3, async () => {
+await callHook({
+        name: "onNodeEnd",
+        data: {
+          nodeName: "main",
+          data: undefined
+        }
+      })
+    });
+    return {
+      messages: __threads(),
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof AgencyAbort) {
+      throw __error
+    }
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
+    return {
+      messages: __threads(),
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals,
+    registerTopLevelCallbacks: __registerTopLevelCallbacks,
+    moduleDir: __dirname
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    const __result = await main(initialState);
+    reportUnhandledInterrupts(__result)
+  } catch (__error: any) {
+    console.error(`
+Agent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"recursiveTypes.agency:main":{"1":{"line":25,"col":2},"2":{"line":26,"col":2}}};


### PR DESCRIPTION
Closes #470. Closes #473.

Recursive type aliases used to crash twice: the typechecker stack-overflowed comparing a recursive alias to itself, and the generated module TDZ-crashed at load (`const Tree = z.object({... z.array(Tree)})`). Execution surfaced two more variants of the same family, both fixed here: **plain forward references** (`type A = { b: B }` before `B`) TDZ-crashed too, and **def-before-type** crashed through the module-load tool-definition schema. A fourth, nastier variant: a **validated self-recursive alias silently dropped nested validation** (its descriptor read its own `__agency_descriptor` mid-assignment and got `undefined`) — probe-confirmed, a nested `-5` passed a `@validate(positive)` field before this PR.

## The four mechanisms

1. **`typeKey()`** (#473, `lib/typeChecker/typeKey.ts`) — one canonical structural identity replacing raw `JSON.stringify` at the dedup sites (`uniteTypes`, loop widening, three synthesis sites, block-return dedup). Property-order-insensitive, union-order-insensitive, metadata-stripped (tags/trivia/descriptions — deliberate, argued in the doc comment), `valueArgs` ARE identity, nested alias refs key nominally so recursion terminates.
2. **Coinductive `isAssignable`** — a private `isAssignableGuarded` keeps an in-progress pair stack (public three-arg signature unchanged, mirroring the `resolveType`/`resolveTypeWithGuard` split). Entries are REMOVED on exit, so a refuted pair is never assumed true in a sibling position (a dedicated union-order test pins this against memoizing implementations). The pair key is gated on named references — the only way cycles re-enter — keeping `typeKey` off the structural hot path; the full suite shows no slowdown.
3. **Lazy-if-not-yet-emitted zod refs** — an alias reference inside a module-load-time schema (alias consts AND tool definitions) wraps in `z.lazy(() => Name)` when the target alias is declared at-or-after that source position. Pending-ness is a PURE derivation from declaration order (no mutable emitted-set); `partitionProgram` keeps top-level declarations in source order, so offsets are a faithful oracle. Backward references stay bare: **zero churn across the existing fixture corpus** (verified). `type Loop = Loop` is rejected with a clear error instead of an infinite lazy loop.
4. **Lazy validation descriptors** — a new `{ kind: "ref", get }` descriptor node defers `__agency_descriptor` reads to walk time (the walker's existing `maxDepth` bounds cyclic walks). Use-site validators merge INSIDE `get()` because the walker dispatches `ref` before running validators. `pendingAliases` also threads into descriptor-embedded schema strings.

## Verification

- 7627 lib tests green, structural linter clean, `make` clean.
- New: 9 typeKey unit tests + a wiring pin (proven red when the flow.ts adoption is stashed), 4 coinduction pipeline tests (red-run confirmed as `RangeError` crashes), 5 codegen unit tests (self/forward/mutual/def-before-type/Loop-guard), 3 walker ref tests, 2 committed `$ref` JSON-schema conversion pins (zod is caret-pinned; a zod upgrade that changes cycle handling fails these, not a user request — zod 4 emits `$defs`/`$ref` for both self and mutual cycles).
- 4 agency execution suites (no LLM calls): recursive-type (5 nodes: forward ref, nested parse accept/reject at depth 2, mutual recursion executed, recursive param through a tool schema), recursive-type-validated (the silent-loss pin: nested validator fires through `!` assignment), recursive-type-partial (`Partial<Tree>` composes; the fixture declares `TreePatch` BEFORE `Tree` so the expanded reference is genuinely forward and must wrap), plus a re-run of utility-partial as a regression guard for the merged utility-types feature.
- Codegen fixture pins all reference shapes: forward, self (array position), mutual (forward edge lazy / backward edge bare), union-position self-ref (`type Json = string | number | Json[]`), and `Partial`-expanded pending refs.

## Execution notes (differences from the plan, all recorded in it)

- The plan's pipeline-level typeKey adoption test proved unreachable (assignability is already order-insensitive and the assignment diagnostic renders the declared scope type, not the join) — replaced with a direct `uniteTypes` pin, verified red without the wiring.
- Validators do NOT run through `schema(...).parseJSON` (zod-only; see `lib/runtime/schema.ts`) — the validated-recursive tests use the `!` validated-assignment form, per the plan's fallback note.
- Value-param factories can be called from load-time descriptors anywhere in the module, so their schema strings treat ALL module aliases as pending (always-safe over-inclusion).

## Scope-outs

- `lib/typeChecker/inference.ts` `unionTypes()` keeps `JSON.stringify` (no alias table in its signature) — noted on #473.
- Recursive value-parameterized aliases still hang codegen (pre-existing, unguarded inline expansion) — filed as #484.
- The zod mapper is at six positional params after this PR; the next addition should consolidate into an options object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
