### PR TITLE
Quick wins: value-param recursion guard, pipeline ordering assertions, Anthropic schema-limitation guidance (closes #475, #484, #487)

### DIFF
--- a/packages/agency-lang/docs/site/guide/types.md
+++ b/packages/agency-lang/docs/site/guide/types.md
@@ -219,11 +219,9 @@ type Tree = {
 annotations on nested fields fire at every depth through the `!`
 validated-assignment form.
 
-One provider limitation: recursive types work as LLM structured-output
-contracts (`const t: Tree = llm(...)`) on OpenAI and Gemini, but
-Anthropic's structured-output API rejects self-referencing schemas. On
-Anthropic, ask for a string and parse it yourself with
-`schema(Tree).parseJSON(...)` — parsing and validation are unaffected.
+Anthropic does not support recursive types as LLM output contracts
+(OpenAI and Gemini do). On Anthropic, parse the response yourself with
+`schema(Tree).parseJSON(...)`.
 
 ## References
 

--- a/packages/agency-lang/docs/site/guide/types.md
+++ b/packages/agency-lang/docs/site/guide/types.md
@@ -219,6 +219,12 @@ type Tree = {
 annotations on nested fields fire at every depth through the `!`
 validated-assignment form.
 
+One provider limitation: recursive types work as LLM structured-output
+contracts (`const t: Tree = llm(...)`) on OpenAI and Gemini, but
+Anthropic's structured-output API rejects self-referencing schemas. On
+Anthropic, ask for a string and parse it yourself with
+`schema(Tree).parseJSON(...)` — parsing and validation are unaffected.
+
 ## References
 
 - [Schemas](/guide/schemas)

--- a/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
@@ -183,6 +183,62 @@ node main() {
     ).toThrow(/recursive value-parameterized/i);
   });
 
+  it("rejects a recursive value-param alias declared inside a function body", () => {
+    // Body aliases hoist through the same processTypeAlias path — the
+    // guard must fire there too (owner review question, probe-verified).
+    expect(() =>
+      generate(`
+def f(): number {
+  type W(n: number) = {
+    next: W(n),
+  }
+  type H = {
+    w: W(1),
+  }
+  return 1
+}
+node main() {
+  return f()
+}
+`),
+    ).toThrow(/recursive value-parameterized/i);
+  });
+
+  it("rejects a recursive combined generic+value-param alias", () => {
+    expect(() =>
+      generate(`
+type Foo<T>(n: number) = {
+  v: T,
+  next: Foo<T>(n),
+}
+type H = {
+  f: Foo<number>(1),
+}
+node main() {
+  return 1
+}
+`),
+    ).toThrow(/recursive value-parameterized/i);
+  });
+
+  it("accepts a vp alias cycling through a PLAIN alias (named const breaks the inline cycle)", () => {
+    // Weird(n) references Mid by NAME (a const, z.lazy if forward), so
+    // inlining stops — the guard deliberately follows only value-param
+    // entries. Pins the boundary so nobody "fixes" the guard to over-reject.
+    const out = generate(`
+type Weird(n: number) = {
+  next: Mid,
+}
+type Mid = {
+  w: Weird(2),
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("const Mid");
+  });
+
   it("still accepts a NON-recursive value-param alias chain at a use site", () => {
     const out = generate(`
 type Age(low: number) = number

--- a/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/recursiveAliases.codegen.test.ts
@@ -144,3 +144,58 @@ node main() {
     ).toThrow(/circularly references itself with no structure/);
   });
 });
+
+describe("recursive value-parameterized aliases (#484)", () => {
+  // The unguarded inline expansion fires when the instantiation is USED
+  // (a declaration alone emits nothing) — each test includes a use site.
+  it("rejects a directly self-referencing value-param alias with a clear error", () => {
+    expect(() =>
+      generate(`
+type Weird(n: number) = {
+  next: Weird(n),
+}
+type Holder = {
+  w: Weird(1),
+}
+node main() {
+  return 1
+}
+`),
+    ).toThrow(/recursive value-parameterized/i);
+  });
+
+  it("rejects a mutually recursive value-param alias pair", () => {
+    expect(() =>
+      generate(`
+type A(n: number) = {
+  next: B(n),
+}
+type B(n: number) = {
+  next: A(n),
+}
+type Holder = {
+  w: A(1),
+}
+node main() {
+  return 1
+}
+`),
+    ).toThrow(/recursive value-parameterized/i);
+  });
+
+  it("still accepts a NON-recursive value-param alias chain at a use site", () => {
+    const out = generate(`
+type Age(low: number) = number
+type Person(low: number) = {
+  age: Age(low),
+}
+type Holder = {
+  p: Person(1),
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("const Holder");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -96,6 +96,7 @@ import {
 } from "./typescriptGenerator/validationDescriptor.js";
 import { tagArgToTs } from "./typescriptGenerator/tagArgToTs.js";
 import { resolveTypeDeep, safeResolveType } from "../typeChecker/assignability.js";
+import { visitTypes } from "../typeChecker/typeWalker.js";
 import { isFunctionTyped } from "../typeChecker/utils.js";
 
 import { $, ts } from "../ir/builders.js";
@@ -707,7 +708,44 @@ export class TypeScriptBuilder {
     return out;
   }
 
+  /**
+   * Reject value-parameterized aliases whose bodies cycle back to a
+   * value-parameterized alias already on the walk (directly or mutually).
+   * Their instantiations are INLINED by the zod mapper and the descriptor
+   * builder — unlike plain aliases, which emit named consts and defer
+   * cycles with z.lazy — so a cycle has no representation: expansion
+   * recurses until the stack blows (#484). Detected at declaration so the
+   * error names the alias instead of surfacing as a RangeError at some
+   * use site.
+   */
+  private rejectValueParamCycle(node: TypeAlias): void {
+    const aliasesFull = this.scopes.visibleTypeAliasesFull();
+    const walk = (body: VariableType, seen: string[]): void => {
+      visitTypes(body, (t) => {
+        const refName =
+          t.type === "typeAliasVariable"
+            ? t.aliasName
+            : t.type === "genericType"
+              ? t.name
+              : undefined;
+        if (refName === undefined) return;
+        const entry = aliasesFull[refName];
+        if (!entry?.valueParams) return;
+        if (seen.includes(refName)) {
+          throw new Error(
+            `Type alias '${node.aliasName}' is a recursive value-parameterized alias (cycle: ${[...seen, refName].join(" -> ")}). Value-param instantiations are inlined into their use sites and cannot recurse; use a plain recursive alias instead.`,
+          );
+        }
+        walk(entry.body, [...seen, refName]);
+      });
+    };
+    walk(node.aliasedType, [node.aliasName]);
+  }
+
   private processTypeAlias(node: TypeAlias): TsNode {
+    if (node.valueParams) {
+      this.rejectValueParamCycle(node);
+    }
     // Generic aliases (type Container<T> = ...) can't be turned into a single
     // zod schema because the body references type parameters that have no
     // runtime value. Usages like `Container<number>` are normalized away by

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -96,7 +96,7 @@ import {
 } from "./typescriptGenerator/validationDescriptor.js";
 import { tagArgToTs } from "./typescriptGenerator/tagArgToTs.js";
 import { resolveTypeDeep, safeResolveType } from "../typeChecker/assignability.js";
-import { visitTypes } from "../typeChecker/typeWalker.js";
+import { rejectValueParamCycle } from "./valueParamCycle.js";
 import { isFunctionTyped } from "../typeChecker/utils.js";
 
 import { $, ts } from "../ir/builders.js";
@@ -708,43 +708,9 @@ export class TypeScriptBuilder {
     return out;
   }
 
-  /**
-   * Reject value-parameterized aliases whose bodies cycle back to a
-   * value-parameterized alias already on the walk (directly or mutually).
-   * Their instantiations are INLINED by the zod mapper and the descriptor
-   * builder — unlike plain aliases, which emit named consts and defer
-   * cycles with z.lazy — so a cycle has no representation: expansion
-   * recurses until the stack blows (#484). Detected at declaration so the
-   * error names the alias instead of surfacing as a RangeError at some
-   * use site.
-   */
-  private rejectValueParamCycle(node: TypeAlias): void {
-    const aliasesFull = this.scopes.visibleTypeAliasesFull();
-    const walk = (body: VariableType, seen: string[]): void => {
-      visitTypes(body, (t) => {
-        const refName =
-          t.type === "typeAliasVariable"
-            ? t.aliasName
-            : t.type === "genericType"
-              ? t.name
-              : undefined;
-        if (refName === undefined) return;
-        const entry = aliasesFull[refName];
-        if (!entry?.valueParams) return;
-        if (seen.includes(refName)) {
-          throw new Error(
-            `Type alias '${node.aliasName}' is a recursive value-parameterized alias (cycle: ${[...seen, refName].join(" -> ")}). Value-param instantiations are inlined into their use sites and cannot recurse; use a plain recursive alias instead.`,
-          );
-        }
-        walk(entry.body, [...seen, refName]);
-      });
-    };
-    walk(node.aliasedType, [node.aliasName]);
-  }
-
   private processTypeAlias(node: TypeAlias): TsNode {
     if (node.valueParams) {
-      this.rejectValueParamCycle(node);
+      rejectValueParamCycle(node, this.scopes.visibleTypeAliasesFull());
     }
     // Generic aliases (type Container<T> = ...) can't be turned into a single
     // zod schema because the body references type parameters that have no

--- a/packages/agency-lang/lib/backends/valueParamCycle.ts
+++ b/packages/agency-lang/lib/backends/valueParamCycle.ts
@@ -1,0 +1,48 @@
+import type { TypeAliasEntry, VariableType } from "../types.js";
+import type { TypeAlias } from "../types/typeHints.js";
+import { visitTypes } from "../typeChecker/typeWalker.js";
+
+/**
+ * Reject value-parameterized aliases whose bodies cycle back to a
+ * value-parameterized alias already on the walk (directly or mutually).
+ * Their instantiations are INLINED by the zod mapper and the descriptor
+ * builder — unlike plain aliases, which emit named consts and defer
+ * cycles with z.lazy — so a cycle has no representation: expansion
+ * recurses until the stack blows (#484). Detected at declaration so the
+ * error names the alias instead of surfacing as a RangeError at some
+ * use site.
+ *
+ * The walk deliberately follows ONLY value-parameterized entries: a plain
+ * alias in the chain emits a named const and is referenced by name, which
+ * breaks the inline cycle naturally (probe-verified — such programs
+ * compile and run).
+ *
+ * Called from `processTypeAlias` for every value-parameterized alias,
+ * which covers top-level declarations AND function/node-body aliases
+ * (those are hoisted through the same method).
+ */
+export function rejectValueParamCycle(
+  node: TypeAlias,
+  aliasesFull: Record<string, TypeAliasEntry>,
+): void {
+  const walk = (body: VariableType, seen: string[]): void => {
+    visitTypes(body, (t) => {
+      const refName =
+        t.type === "typeAliasVariable"
+          ? t.aliasName
+          : t.type === "genericType"
+            ? t.name
+            : undefined;
+      if (refName === undefined) return;
+      const entry = aliasesFull[refName];
+      if (!entry?.valueParams) return;
+      if (seen.includes(refName)) {
+        throw new Error(
+          `Type alias '${node.aliasName}' is a recursive value-parameterized alias (cycle: ${[...seen, refName].join(" -> ")}). Value-param instantiations are inlined into their use sites and cannot recurse; use a plain recursive alias instead.`,
+        );
+      }
+      walk(entry.body, [...seen, refName]);
+    });
+  };
+  walk(node.aliasedType, [node.aliasName]);
+}

--- a/packages/agency-lang/lib/runtime/llmRetry.test.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { classifyLlmError, decideRetry, resolveRetryPolicy } from "./llmRetry.js";
+import { classifyLlmError, decideRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
 import { AgencyAbort, makeAbortCause } from "./errors.js";
 import type { NormalizedLLMError } from "./llmClient.js";
 
@@ -112,5 +112,25 @@ describe("resolveRetryPolicy", () => {
     const resolved = resolveRetryPolicy({ retries: 0, timeout: 0 }, {});
     expect(resolved.retries).toBe(0);
     expect(resolved.timeout).toBe(0);
+  });
+});
+
+describe("enrichSchemaLimitationError (#487)", () => {
+  it("enriches the Anthropic circular-reference 400 with actionable guidance", () => {
+    // Exact message shape from a live probe (2026-07-09):
+    const err = new Error(
+      'invalid_request_error: output_format.schema: Circular reference detected in schema definitions: __schema0 -> __schema0. Self-referencing or mutually-referencing definitions are not supported.',
+    );
+    const enriched = enrichSchemaLimitationError(err);
+    expect(enriched).not.toBeNull();
+    expect(enriched!.message).toMatch(/recursive type/i);
+    expect(enriched!.message).toMatch(/parseJSON/);
+    // Original provider text preserved for debugging.
+    expect(enriched!.message).toContain("Circular reference detected");
+  });
+
+  it("returns null for unrelated errors", () => {
+    expect(enrichSchemaLimitationError(new Error("rate limited"))).toBeNull();
+    expect(enrichSchemaLimitationError("not an error")).toBeNull();
   });
 });

--- a/packages/agency-lang/lib/runtime/llmRetry.test.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.test.ts
@@ -121,12 +121,17 @@ describe("enrichSchemaLimitationError (#487)", () => {
     const err = new Error(
       'invalid_request_error: output_format.schema: Circular reference detected in schema definitions: __schema0 -> __schema0. Self-referencing or mutually-referencing definitions are not supported.',
     );
+    (err as Error & { status?: number }).status = 400;
     const enriched = enrichSchemaLimitationError(err);
     expect(enriched).not.toBeNull();
     expect(enriched!.message).toMatch(/recursive type/i);
     expect(enriched!.message).toMatch(/parseJSON/);
     // Original provider text preserved for debugging.
     expect(enriched!.message).toContain("Circular reference detected");
+    // The ORIGINAL instance is preserved (metadata + stack survive), not a
+    // fresh wrapper Error.
+    expect(enriched).toBe(err);
+    expect((enriched as Error & { status?: number }).status).toBe(400);
   });
 
   it("returns null for unrelated errors", () => {

--- a/packages/agency-lang/lib/runtime/llmRetry.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.ts
@@ -215,3 +215,25 @@ export function resolveRetryPolicy(opts: RetryConfig, branchDefaults: RetryConfi
     },
   };
 }
+
+/**
+ * Known provider schema-limitation 400s, rethrown with guidance the user
+ * can act on. Today: Anthropic structured outputs reject recursive
+ * ($ref-cyclic) schemas — the raw message names zod-internal identifiers
+ * ("__schema0 -> __schema0") instead of the user's type (#487; behavior
+ * live-probed 2026-07-09). OpenAI and Gemini accept recursive schemas, so
+ * the guidance names the provider-specific workaround. Returns null for
+ * anything unrecognized (caller rethrows the original).
+ */
+export function enrichSchemaLimitationError(err: unknown): Error | null {
+  if (!(err instanceof Error)) return null;
+  if (!/Circular reference detected in schema definitions/.test(err.message)) {
+    return null;
+  }
+  return new Error(
+    `This provider does not support recursive types as structured-output contracts. ` +
+      `Parse the response yourself instead: declare the result as a string and run ` +
+      `schema(YourType).parseJSON(...) on it, or switch this call to a provider that ` +
+      `supports recursive schemas (OpenAI, Gemini). Provider error: ${err.message}`,
+  );
+}

--- a/packages/agency-lang/lib/runtime/llmRetry.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.ts
@@ -230,10 +230,13 @@ export function enrichSchemaLimitationError(err: unknown): Error | null {
   if (!/Circular reference detected in schema definitions/.test(err.message)) {
     return null;
   }
-  return new Error(
+  // Rewrite the message on the ORIGINAL instance rather than wrapping in a
+  // new Error: provider metadata (e.g. SmolError.status) and the original
+  // stack must survive for callers that read them.
+  err.message =
     `This provider does not support recursive types as structured-output contracts. ` +
-      `Parse the response yourself instead: declare the result as a string and run ` +
-      `schema(YourType).parseJSON(...) on it, or switch this call to a provider that ` +
-      `supports recursive schemas (OpenAI, Gemini). Provider error: ${err.message}`,
-  );
+    `Parse the response yourself instead: declare the result as a string and run ` +
+    `schema(YourType).parseJSON(...) on it, or switch this call to a provider that ` +
+    `supports recursive schemas (OpenAI, Gemini). Provider error: ${err.message}`;
+  return err;
 }

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -171,6 +171,21 @@ describe("runWithRetry", () => {
     expect(fired[1].delayMs).toBeGreaterThanOrEqual(fired[0].delayMs);
   });
 
+  it("rethrows a terminal circular-schema 400 ENRICHED (wiring for enrichSchemaLimitationError)", async () => {
+    // Pins the prompt.ts terminal-branch wiring, not just the pure helper:
+    // reverting `throw enrichSchemaLimitationError(err) ?? err` back to
+    // `throw err` fails this test.
+    const dispatch = async () => {
+      throw new SmolError(
+        "Circular reference detected in schema definitions: __schema0 -> __schema0.",
+        { status: 400 },
+      );
+    };
+    const promise = _internal.runWithRetry(dispatch, policy, undefined, noHooks, normalize);
+    await expect(promise).rejects.toThrow(/recursive types as structured-output contracts/);
+    await expect(promise).rejects.toThrow(/parseJSON/);
+  });
+
   it("surfaces a plain Error (→ Failure) classified by reason after exhausting retries", async () => {
     const dispatch = async () => {
       throw new SmolError("503", { status: 503 });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -16,7 +16,7 @@ import {
 } from "./replyAttachments.js";
 import { AgencyCancelledError, isAbortError, makeAbortCause, readCause } from "./errors.js";
 import { abortableSleep } from "../stdlib/abortable.js";
-import { decideRetry, resolveRetryPolicy } from "./llmRetry.js";
+import { decideRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
 import type { RetryPolicy, RetryConfig, LLMRetryReason } from "./llmRetry.js";
 import type { NormalizedLLMError } from "./llmClient.js";
 import {
@@ -321,11 +321,16 @@ async function runWithRetry<T>(
       const normalized = normalizeError(err);
       const decision = decideRetry(err, normalized, attempt, policy);
 
-      if (decision.kind === "propagate" || decision.kind === "terminal") {
-        // propagate: a user/abort cause re-throws untouched (cancel).
-        // terminal: a terminal provider error (e.g. content policy / 4xx) is a
-        // plain Error → the function/node catch ladder converts it to a Failure.
+      if (decision.kind === "propagate") {
+        // A user/abort cause re-throws untouched (cancel).
         throw err;
+      }
+      if (decision.kind === "terminal") {
+        // A terminal provider error (e.g. content policy / 4xx) is a plain
+        // Error → the function/node catch ladder converts it to a Failure.
+        // Known schema-limitation 400s are rethrown with actionable
+        // guidance (#487) — the raw provider text names zod internals.
+        throw enrichSchemaLimitationError(err) ?? err;
       }
       if (decision.kind === "surfaceFailure") {
         // Retries exhausted. Surface a plain Error (NOT an AgencyAbort) so the

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { refineInlineHandlerParams } from "./handlerParamTyping.js";
 import { writeFileSync, unlinkSync } from "fs";
 import path from "path";
 import os from "os";
@@ -403,5 +404,16 @@ node main() {
   }
 }`);
     expect(errs.some((x) => /not available on every member/i.test(x.message))).toBe(true);
+  });
+});
+
+describe("ordering assertion", () => {
+  it("throws if called after buildFlowGraphs (flowEnv already set)", () => {
+    const ctx = { flowEnv: {} } as unknown as Parameters<
+      typeof refineInlineHandlerParams
+    >[2];
+    expect(() => refineInlineHandlerParams([], {}, ctx, {})).toThrow(
+      /must run before buildFlowGraphs/,
+    );
   });
 });

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
@@ -89,6 +89,15 @@ export function refineInlineHandlerParams(
   ctx: TypeCheckerContext,
   registry: Record<string, ObjectType>,
 ): void {
+  // ORDERING ASSERTION (load-bearing — see TypeChecker.check()): this pass
+  // MUTATES scope types, so it must run BEFORE buildFlowGraphs seeds the
+  // typeAt memo. Running after would require the memo-reset contract this
+  // ordering exists to avoid; a reorder would silently produce stale types.
+  if (ctx.flowEnv) {
+    throw new Error(
+      "refineInlineHandlerParams must run before buildFlowGraphs (ctx.flowEnv is already set)",
+    );
+  }
   for (const info of scopes) {
     ctx.withScope(info.scopeKey, () => {
       // Count EVERY inline handler param name (eligible or not) — a shared name

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -146,7 +146,7 @@ export class TypeChecker {
     this.errors = [];
     const ctx = this.makeContext();
 
-    // 1. Validate type alias references
+    // Validate type alias references
     for (const [sk, scopeAliases] of this.scopedTypeAliases.scopes()) {
       this.withScope(sk, () => {
         for (const [name, entry] of Object.entries(scopeAliases)) {
@@ -184,7 +184,7 @@ export class TypeChecker {
       });
     }
 
-    // 1b. Warn on local definitions that shadow imported functions/nodes.
+    // Warn on local definitions that shadow imported functions/nodes.
     // functionDefs and nodeDefs are mutually exclusive by construction
     // (a name is parsed as one or the other, never both).
     const shadowWarning = (name: string, loc: SourceLocation | undefined) =>
@@ -200,7 +200,7 @@ export class TypeChecker {
       if (this.importedFunctions[name]) shadowWarning(name, def.loc);
     }
 
-    // 1c. Reserve names baked into the language. The synth pipeline relies
+    // Reserve names baked into the language. The synth pipeline relies
     // on `success(x)` and `failure(msg)` parameterizing ResultType, and on
     // `Result` being the built-in type. Allowing user definitions of these
     // names would silently change semantics.
@@ -225,7 +225,7 @@ export class TypeChecker {
       }
     }
 
-    // 1d. Reserved names cannot be `let`/`const` / `static const` declared
+    // Reserved names cannot be `let`/`const` / `static const` declared
     // either. The variable would be unusable as a function (e.g. `schema(X)`
     // always parses as a SchemaExpression regardless of scope), and shadowing
     // primitives like `success`/`failure` silently changes semantics.
@@ -268,7 +268,7 @@ export class TypeChecker {
       checkValidatedParamReturn(name, def);
     }
 
-    // 1f. Doc strings must not interpolate function/node parameters.
+    // Doc strings must not interpolate function/node parameters.
     // The description is built when the tool object is constructed at module
     // load time — long before the function is ever called — so parameter
     // values are simply not bound yet. Catch the obvious case here:
@@ -298,33 +298,33 @@ export class TypeChecker {
       checkDocStringParams(def);
     }
 
-    // 2. Infer return types
+    // Infer return types
     inferReturnTypes(ctx);
 
-    // 3. Build scopes (collects variable types and checks assignments)
+    // Build scopes (collects variable types and checks assignments)
     const scopes = buildScopes(ctx);
 
-    // 3a. Analyze interrupts (pure — returns transitive effect sets and pushes
+    // Analyze interrupts (pure — returns transitive effect sets and pushes
     // no diagnostics; the ctx.errors sites in interruptAnalysis.ts belong to the
     // consumer passes below). Moved ahead of flow/checkScopes so the handler-param
     // refinement can run before field-access checking.
     const interruptEffectsByFunction = analyzeInterruptsFromScopes(scopes, ctx);
 
-    // 3b. Build the ambient effect→payload registry ONCE and share it with both
-    // the handler-param refinement (below) and checkEffectPayloads (6d). Building
+    // Build the ambient effect→payload registry ONCE and share it with both
+    // the handler-param refinement (below) and checkEffectPayloads below. Building
     // it once avoids double-reporting payload conflicts.
     const effectRegistry = buildEffectRegistry(ctx);
 
-    // 3c. H3: re-type each eligible inline handler param `e` as a per-effect
+    // H3: re-type each eligible inline handler param `e` as a per-effect
     // discriminated union carrying that effect's declared payload as `data`.
     // MUST run before checkScopes so `e.data` usage sites narrow correctly.
     refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, effectRegistry);
 
-    // 3d. Build the flow graph AFTER the param retype, so its `typeAt` oracle is
+    // Build the flow graph AFTER the param retype, so its `typeAt` oracle is
     // seeded with the refined `e` (no stale-memo reset needed).
     buildFlowGraphs(scopes, ctx);
 
-    // 3e. Compute the value type of every expression-position `match` (union of
+    // Compute the value type of every expression-position `match` (union of
     // its matchYield types). Runs AFTER buildFlowGraphs so yield synthesis sees
     // flow-narrowed bindings (e.g. `"a" => e.val` under a discriminant match),
     // and before checkScopes so the `__matchval_<id>` synth hook and the
@@ -334,55 +334,55 @@ export class TypeChecker {
     // FlowEnvironment soundness contract) so no stale entry survives.
     computeMatchExprTypes(scopes, ctx);
 
-    // 4. Check function calls, return types, and expressions. `e.data` is now
+    // Check function calls, return types, and expressions. `e.data` is now
     // payload-typed → narrowing on `e.effect` makes `e.data` concrete here.
     checkScopes(scopes, ctx);
 
-    // 5a. Build the per-function interrupt call graph used by
+    // Build the per-function interrupt call graph used by
     // `agency interrupts` for static handler-set analysis. The
     // existing analyzeInterruptsFromScopes pass continues to compute
     // transitive kinds; this is purely additive structural info.
     const interruptCallGraph = buildInterruptCallGraph(scopes, ctx);
 
-    // 6. Check for unhandled interrupt warnings (uses transitive results)
+    // Check for unhandled interrupt warnings (uses transitive results)
     checkUnhandledInterruptWarnings(scopes, interruptEffectsByFunction, ctx);
 
-    // 6a. Reject `interrupt` inside any callback body. Callbacks fire as
+    // Reject `interrupt` inside any callback body. Callbacks fire as
     // side effects; their body cannot pause execution.
     checkCallbackBodyInterrupts(scopes, interruptEffectsByFunction, ctx);
 
-    // 6b. Reject handlers whose body may itself raise an interrupt — that
+    // Reject handlers whose body may itself raise an interrupt — that
     // re-enters the handler chain and recurses (see HandlerRecursionError).
     checkHandlerBodyInterrupts(scopes, interruptEffectsByFunction, ctx);
 
-    // 6c. Verify each function/node's declared `raises` clause is not
+    // Verify each function/node's declared `raises` clause is not
     // exceeded by its transitively-inferred effect set.
     checkRaisesDeclarations(interruptEffectsByFunction, ctx);
 
-    // 6d. Check interrupt payloads against `effect` declarations (shared registry).
+    // Check interrupt payloads against `effect` declarations (shared registry).
     checkEffectPayloads(scopes, ctx, effectRegistry);
 
-    // 6e. Match exhaustiveness over closed value types.
+    // Match exhaustiveness over closed value types.
     checkMatchExhaustiveness(scopes, ctx);
 
-    // 6f. Definite-return: a function with a non-void return type must `return`
+    // Definite-return: a function with a non-void return type must `return`
     // on every path. Reads the per-scope terminal flow node from buildFlowGraphs.
     checkDefiniteReturns(scopes, ctx);
 
-    // 7. Check for undefined function calls (config-controlled severity).
+    // Check for undefined function calls (config-controlled severity).
     checkUndefinedFunctions(scopes, ctx);
 
-    // 8. Check for undefined variable references (config-controlled severity).
+    // Check for undefined variable references (config-controlled severity).
     checkUndefinedVariables(scopes, ctx);
 
-    // 9a. Tool-position binding validator: at every llm(...) call site
+    // Tool-position binding validator: at every llm(...) call site
     // with a statically-known tools array, require every function-typed
     // parameter to be bound (error) or warn when an optional one is left
     // dropped. See lib/typeChecker/toolBlockBinding.ts for the helpers
     // and docs/superpowers/specs/2026-06-03-tool-params-blocks-and-variadics-design.md §4.2(e).
     checkToolBlockBindings(this.program, ctx);
 
-    // 9. Validate static initializers + `static <bare>` statements.
+    // Validate static initializers + `static <bare>` statements.
     // Direct-only checks against the Phase A surface — per-run-only
     // primitive calls (e.g. `llm()`, `interrupt()`) and obvious
     // post-declaration mutations of statics. Cross-module global

--- a/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
@@ -34,6 +34,16 @@ export function computeMatchExprTypes(
   scopes: ScopeInfo[],
   ctx: TypeCheckerContext,
 ): void {
+  // ORDERING ASSERTION (load-bearing — see TypeChecker.check()): yield
+  // synthesis must see flow-narrowed bindings, and this pass patches the
+  // eagerly-snapshotted matchConsumerAssignFlows nodes — both require the
+  // flow graph to exist. A reorder would silently type every
+  // expression-match as its un-narrowed synthesis.
+  if (!ctx.flowEnv) {
+    throw new Error(
+      "computeMatchExprTypes must run after buildFlowGraphs (ctx.flowEnv is not set)",
+    );
+  }
   for (const info of scopes) {
     ctx.withScope(info.scopeKey, () => {
       const yieldsByMatch: Record<number, MatchYield[]> = {};

--- a/packages/agency-lang/lib/typeChecker/matchExpression.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExpression.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { computeMatchExprTypes } from "./matchExprTypes.js";
 import { parseAgency } from "../parser.js";
 import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck } from "./index.js";
@@ -256,5 +257,14 @@ const label: string = match(env) {
 }
 node main(): string { return label }`);
     expect(errs).toEqual([]);
+  });
+});
+
+describe("computeMatchExprTypes ordering assertion", () => {
+  it("throws if called before buildFlowGraphs (flowEnv not set)", () => {
+    const ctx = {} as unknown as Parameters<typeof computeMatchExprTypes>[1];
+    expect(() => computeMatchExprTypes([], ctx)).toThrow(
+      /must run after buildFlowGraphs/,
+    );
   });
 });


### PR DESCRIPTION
Closes #475. Closes #484. Closes #487.

Three small independent fixes, one commit each.

## #484 — recursive value-parameterized aliases no longer blow the stack

`type Weird(n: number) = { next: Weird(n) }` used to crash with a bare `RangeError: Maximum call stack size exceeded` when the instantiation was USED (value-param instantiations are inlined by the zod mapper and descriptor builder — unlike plain aliases, they have no named const to defer to with `z.lazy`, so a cycle has no representation). Now rejected at DECLARATION with an error naming the cycle (`Weird -> Weird`, or `A -> B -> A` for mutual cycles). Non-recursive value-param chains (`Person(low)` referencing `Age(low)`) still work — pinned by test. One nuance found in execution: the crash needs a use site; a bare declaration emits nothing, which is why the test programs include one.

## #475 — pipeline ordering assertions + comment numbering

The two load-bearing "MUST run before/after buildFlowGraphs" ordering constraints in `TypeChecker.check()` are now runtime assertions: `refineInlineHandlerParams` throws if `ctx.flowEnv` is already set, `computeMatchExprTypes` throws if it is not — each with a comment explaining what silently breaks on reorder (stale memo types / un-narrowed match yields). Both assertion paths are unit-tested. The drifted phase numbering (1, 1b-1f with no 1e, 9a before 9) is dropped entirely in favor of the descriptive text — numbers only drift; the ordering contract now lives in prose plus the assertions. No cross-references to the numbers existed outside the file (grep-verified).

## #487 — Anthropic recursive-schema limitation: guidance instead of zod internals

Live-probed (all three providers): recursive `$ref` structured-output schemas work on OpenAI and Gemini, but Anthropic 400s with `Circular reference detected in schema definitions: __schema0 -> __schema0` — naming zod-internal identifiers, not the user's type. The terminal-error path in the prompt retry ladder now rethrows that class of error with actionable guidance (declare the result a string and `schema(T).parseJSON` it, or use a provider that supports recursion), preserving the original provider text for debugging. Pure helper (`enrichSchemaLimitationError` in `llmRetry.ts`) with unit tests; the guide's recursive-types section documents the limitation in three sentences.

## Verification

7658 lib tests green, structural linter clean, `make` clean. (One unrelated flake observed and cleared: `topsortCycleErrors.test.ts` timed out once in the full-suite run, passes in isolation — subprocess-isolation timing, untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
