### PR TITLE
Validate spawn cwd exists before running, with a clear error

### DIFF
--- a/packages/agency-lang/lib/stdlib/shell.test.ts
+++ b/packages/agency-lang/lib/stdlib/shell.test.ts
@@ -139,3 +139,54 @@ describe("_exec / _bash cwd ~ expansion", () => {
     expect(result.stdout.trim()).not.toBe(fs.realpathSync(fakeHome));
   });
 });
+
+/**
+ * A missing spawn `cwd` used to surface as Node's cryptic
+ * `spawn <cmd> ENOENT`. `resolveSpawnCwd` now validates existence first
+ * and throws a clear, actionable message so an LLM agent can recover
+ * (create the directory, then retry). Regression target: the agent
+ * doing `setAgentCwd("/tmp/build")` before the `mkdir`.
+ */
+describe("_exec / _bash reject a nonexistent cwd with a clear error", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "shell-cwd-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("_bash throws 'does not exist', not 'spawn sh ENOENT'", async () => {
+    const ctx = makeMockCtx();
+    const missing = path.join(tmp, "not-created-yet");
+    await expect(
+      __internal_bash(ctx, new StateStack(), new ThreadStore(), "pwd", missing, 0, ""),
+    ).rejects.toThrow(/Working directory does not exist/);
+  });
+
+  it("_exec throws 'does not exist' for a missing cwd", async () => {
+    const ctx = makeMockCtx();
+    const missing = path.join(tmp, "nope");
+    await expect(
+      __internal_exec(ctx, new StateStack(), new ThreadStore(), "pwd", [], missing, 0, ""),
+    ).rejects.toThrow(/Working directory does not exist/);
+  });
+
+  it("rejects a cwd that exists but is a file (not a directory)", async () => {
+    const ctx = makeMockCtx();
+    const file = path.join(tmp, "afile");
+    fs.writeFileSync(file, "x");
+    await expect(
+      __internal_bash(ctx, new StateStack(), new ThreadStore(), "pwd", file, 0, ""),
+    ).rejects.toThrow(/is not a directory/);
+  });
+
+  it("still runs normally when the cwd exists", async () => {
+    const ctx = makeMockCtx();
+    const result = await __internal_bash(
+      ctx, new StateStack(), new ThreadStore(), "pwd", tmp, 0, "",
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(fs.realpathSync(tmp));
+  });
+});

--- a/packages/agency-lang/lib/stdlib/shell.test.ts
+++ b/packages/agency-lang/lib/stdlib/shell.test.ts
@@ -6,6 +6,8 @@ import { __internal_exec, __internal_bash } from "./shell.js";
 import { RuntimeContext } from "../runtime/state/context.js";
 import { StateStack } from "../runtime/state/stateStack.js";
 import { ThreadStore } from "../runtime/state/threadStore.js";
+import { safeDeleteDirectory } from "../utils.js";
+import { findPackageRoot } from "../importPaths.js";
 
 /**
  * Focused tests for the `~`-expansion + allow-list behavior on the
@@ -148,12 +150,16 @@ describe("_exec / _bash cwd ~ expansion", () => {
  * doing `setAgentCwd("/tmp/build")` before the `mkdir`.
  */
 describe("_exec / _bash reject a nonexistent cwd with a clear error", () => {
+  // Create the scratch dir INSIDE the project root so `safeDeleteDirectory`'s
+  // containment guard accepts it (it refuses anything outside the project, so
+  // a test can never delete the wrong thing).
+  const projectRoot = fs.realpathSync(findPackageRoot(__dirname));
   let tmp: string;
   beforeEach(() => {
-    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "shell-cwd-"));
+    tmp = fs.mkdtempSync(path.join(projectRoot, ".test-shell-cwd-"));
   });
   afterEach(() => {
-    fs.rmSync(tmp, { recursive: true, force: true });
+    safeDeleteDirectory(tmp, false);
   });
 
   it("_bash throws 'does not exist', not 'spawn sh ENOENT'", async () => {

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -67,7 +67,8 @@ async function resolveSpawnCwd(
     if (e?.code === "ENOENT") {
       throw new Error(
         `Working directory does not exist: ${resolved}. ` +
-          "Create it first (e.g. `mkdir -p` from an existing directory) " +
+          "Create it first (e.g. `mkdir -p` from an existing directory, or " +
+          "another tool to create directories that you have access to) " +
           "before running a command there.",
       );
     }

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -42,6 +42,43 @@ function buildSpawnOptions(
   return options;
 }
 
+/**
+ * Resolve a spawn `cwd` (empty string = inherit the parent's cwd) and verify
+ * the directory EXISTS before handing it to `child_process.spawn`.
+ *
+ * Node reports a missing spawn cwd as `spawn <command> ENOENT` — which reads
+ * as "the executable wasn't found" and gives an LLM agent nothing to act on.
+ * It fires whenever the agent points `cwd` at a directory it hasn't created
+ * yet — e.g. `setAgentCwd("/tmp/build")` (or `bash(cwd: "/tmp/build")`) before
+ * the `mkdir`, a chicken-and-egg the shell can't resolve because it can't even
+ * start in a directory that doesn't exist. Fail early with a clear, actionable
+ * message instead so the model creates the directory first.
+ */
+async function resolveSpawnCwd(
+  cwd: string,
+  allowedPaths: string[],
+): Promise<string> {
+  if (!cwd) return "";
+  const resolved = await resolveDir(cwd, allowedPaths, "cwd");
+  let stat;
+  try {
+    stat = await fs.stat(resolved);
+  } catch (e: any) {
+    if (e?.code === "ENOENT") {
+      throw new Error(
+        `Working directory does not exist: ${resolved}. ` +
+          "Create it first (e.g. `mkdir -p` from an existing directory) " +
+          "before running a command there.",
+      );
+    }
+    throw e;
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`Working directory is not a directory: ${resolved}.`);
+  }
+  return resolved;
+}
+
 export type ExecOptions = {
   /**
    * Allow-list of executable names. When set, only commands whose
@@ -85,15 +122,12 @@ async function execImpl(
     options?.blockedCommands ?? [],
   );
   if (cmdError) throw new Error(cmdError);
-  // Route through `resolveDir` (cwd-anchored) so `~` expansion +
-  // allow-list enforcement land in one place. Relative `cwd: "./sub"`
-  // stays anchored to `process.cwd()` (the existing semantics) because
-  // we pass `base: "cwd"`. Empty `cwd` is the "no override" sentinel —
-  // pass undefined to the spawn options so the child inherits the
-  // parent's cwd, matching the pre-migration behavior.
-  const cwdResolved = cwd
-    ? await resolveDir(cwd, options?.allowedPaths ?? [], "cwd")
-    : "";
+  // Route through `resolveSpawnCwd` (cwd-anchored) so `~` expansion,
+  // allow-list enforcement, and the exists-before-spawn check land in one
+  // place. Relative `cwd: "./sub"` stays anchored to `process.cwd()` (the
+  // existing semantics) because we pass `base: "cwd"`. Empty `cwd` is the
+  // "no override" sentinel — the child inherits the parent's cwd.
+  const cwdResolved = await resolveSpawnCwd(cwd, options?.allowedPaths ?? []);
   const signal = ctx.getAbortSignal(stack);
   return abortableSpawn(command, args, buildSpawnOptions(cwdResolved, timeout, stdin, signal));
 }
@@ -165,9 +199,7 @@ async function bashImpl(
     }
   }
   // See `execImpl` for the cwd-resolution rationale.
-  const cwdResolved = cwd
-    ? await resolveDir(cwd, options?.allowedPaths ?? [], "cwd")
-    : "";
+  const cwdResolved = await resolveSpawnCwd(cwd, options?.allowedPaths ?? []);
   const signal = ctx.getAbortSignal(stack);
   return abortableSpawn("sh", ["-c", command], buildSpawnOptions(cwdResolved, timeout, stdin, signal));
 }


### PR DESCRIPTION
## What

`bash` / `exec` passed the resolved `cwd` straight to `child_process.spawn`. When that directory didn't exist, Node threw `spawn <cmd> ENOENT` — which reads as "the executable wasn't found" and gives an LLM agent nothing to act on.

It fires whenever the agent points `cwd` at a directory it hasn't created yet, e.g.:

```
setAgentCwd("/tmp/build")            # or bash(cwd: "/tmp/build")
bash("mkdir -p /tmp/build && ...")   # spawn sh with cwd=/tmp/build → ENOENT
```

A chicken-and-egg: the shell can't even start in a directory that doesn't exist, so it can't run the `mkdir` that would create it.

## Fix

Add `resolveSpawnCwd`, shared by `execImpl` and `bashImpl`. It resolves the cwd (as before, via `resolveDir` — `~` expansion + allow-list) then `fs.stat`s it before spawning:

- missing → `Working directory does not exist: <path>. Create it first (e.g. \`mkdir -p\` from an existing directory) before running a command there.`
- a file → `Working directory is not a directory: <path>.`
- exists → unchanged behavior.

The clear message lets the agent recover (create the directory, retry) instead of getting a cryptic Failure.

## Why

Surfaced while benchmarking the agency agent on Terminal-Bench: it intermittently failed **compile-compcert**, **cancel-async-tasks**, **portfolio-optimization**, and **winning-avg-corewars** with `spawn sh ENOENT`.

## Tests

`shell.test.ts` — nonexistent cwd (both `bash` and `exec`) → "does not exist"; a file-as-cwd → "is not a directory"; and an existing cwd still runs normally (no regression). All 9 shell tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
