### PR TITLE
Add std::data/usaspending connector (first POST connector)

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -287,6 +287,10 @@ export default defineConfig({
                   text: "data/wikidata",
                   link: "/stdlib/data/wikidata",
                 },
+                {
+                  text: "data/usaspending",
+                  link: "/stdlib/data/usaspending",
+                },
               ],
             },
             { text: "date", link: "/stdlib/date" },

--- a/packages/agency-lang/docs/site/stdlib/capabilities.md
+++ b/packages/agency-lang/docs/site/stdlib/capabilities.md
@@ -85,7 +85,7 @@ Anything that talks to the outside world over the network.
 
 ```ts
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews, std::wikidata>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews, std::wikidata, std::usaspending>
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L45))

--- a/packages/agency-lang/docs/site/stdlib/data/usaspending.md
+++ b/packages/agency-lang/docs/site/stdlib/data/usaspending.md
@@ -1,0 +1,164 @@
+---
+name: "usaspending"
+---
+
+# usaspending
+
+## USASpending — U.S. federal awards
+
+  Query [USASpending](https://api.usaspending.gov), the U.S. Treasury's award-level spending API:
+  which companies and organizations received federal contracts and grants, from which agency, for
+  how much. Use it to follow federal money — pairs with `std::data/people/littlesis` (who is
+  connected) and `std::data/finance/edgar` (company filings).
+
+  No API key required. `usaspendingAwards` searches; its results carry a `generatedId` you can drill
+  into with `usaspendingAward`, which also surfaces recipient executive compensation and sub-award
+  totals.
+
+  ### Usage
+
+  ```ts
+  import { usaspendingAwards } from "std::data/usaspending"
+
+  node main() {
+    const awards = usaspendingAwards(recipient: "Lockheed Martin", limit: 5) catch []
+    for (a in awards) {
+      print("${a.amount}  ${a.recipient}  (${a.awardingAgency})")
+    }
+  }
+  ```
+
+## Types
+
+### Award
+
+One federal award from a search. `generatedId` drills into usaspendingAward; `amount` is USD.
+
+```ts
+/** One federal award from a search. `generatedId` drills into usaspendingAward; `amount` is USD. */
+export type Award = {
+  internalId: number;
+  generatedId: string;
+  id: string;
+  recipient: string;
+  amount: number;
+  awardingAgency: string;
+  startDate: string;
+  endDate: string;
+  description: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L46))
+
+### Executive
+
+A recipient officer and their compensation.
+
+```ts
+/** A recipient officer and their compensation. */
+export type Executive = {
+  name: string;
+  amount: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L59))
+
+### AwardDetail
+
+Curated detail for one federal award.
+
+```ts
+/** Curated detail for one federal award. */
+export type AwardDetail = {
+  id: string;
+  category: string;
+  awardType: string;
+  description: string;
+  amount: number;
+  recipient: string;
+  recipientUei: string;
+  awardingAgency: string;
+  startDate: string;
+  endDate: string;
+  placeOfPerformance: string;
+  subawardCount: number;
+  subawardAmount: number;
+  executives: Executive[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L65))
+
+## Effects
+
+### std::usaspending
+
+```ts
+effect std::usaspending {
+  op: string;
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L30))
+
+## Functions
+
+### usaspendingAwards
+
+```ts
+usaspendingAwards(recipient: string, agency: string, awardType: string, startDate: string, endDate: string, limit: number): Result<Award[]>
+```
+
+Search U.S. federal awards. Returns each award's id, recipient, amount, awarding agency, dates, and
+  description, most-funded first. An empty result set returns an empty list.
+
+  @param recipient - Recipient or company name to filter by (blank = any)
+  @param agency - Awarding agency name to filter by (blank = any)
+  @param awardType - Award category: contracts, grants, loans, direct_payments, or other
+  @param startDate - ISO start date bounding the award period (blank with endDate = all time)
+  @param endDate - ISO end date bounding the award period
+  @param limit - Maximum number of awards to return (max 100)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| recipient | `string` | "" |
+| agency | `string` | "" |
+| awardType | `string` | "contracts" |
+| startDate | `string` | "" |
+| endDate | `string` | "" |
+| limit | `number` | 20 |
+
+**Returns:** `Result<Award[]>`
+
+**Throws:** `std::usaspending`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L225))
+
+### usaspendingAward
+
+```ts
+usaspendingAward(awardId: string): Result<AwardDetail>
+```
+
+Fetch full detail for one federal award. Returns amount, recipient and UEI, awarding agency, dates,
+  place of performance, sub-award totals, and recipient executive compensation. Unknown id returns a
+  failure.
+
+  @param awardId - The award id: the generatedId from a search, or the numeric internalId as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| awardId | `string` |  |
+
+**Returns:** `Result<AwardDetail>`
+
+**Throws:** `std::usaspending`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L248))

--- a/packages/agency-lang/docs/site/stdlib/data/usaspending.md
+++ b/packages/agency-lang/docs/site/stdlib/data/usaspending.md
@@ -49,7 +49,7 @@ export type Award = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L46))
 
 ### Executive
 
@@ -63,7 +63,7 @@ export type Executive = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L59))
 
 ### AwardDetail
 
@@ -89,7 +89,7 @@ export type AwardDetail = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L65))
 
 ## Effects
 
@@ -102,7 +102,7 @@ effect std::usaspending {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L30))
 
 ## Functions
 
@@ -118,9 +118,9 @@ Search U.S. federal awards. Returns each award's id, recipient, amount, awarding
   @param recipient - Recipient or company name to filter by (blank = any)
   @param agency - Awarding agency name to filter by (blank = any)
   @param awardType - Award category: contracts, grants, loans, direct_payments, or other
-  @param startDate - ISO start date bounding the award period (blank with endDate = all time)
-  @param endDate - ISO end date bounding the award period
-  @param limit - Maximum number of awards to return (max 100)
+  @param startDate - ISO start date bounding the award period; only applied when endDate is also set
+  @param endDate - ISO end date bounding the award period; only applied when startDate is also set
+  @param limit - Maximum number of awards to return
 
 **Parameters:**
 
@@ -137,7 +137,7 @@ Search U.S. federal awards. Returns each award's id, recipient, amount, awarding
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L225))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L229))
 
 ### usaspendingAward
 
@@ -161,4 +161,4 @@ Fetch full detail for one federal award. Returns amount, recipient and UEI, awar
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L248))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L252))

--- a/packages/agency-lang/stdlib/capabilities.agency
+++ b/packages/agency-lang/stdlib/capabilities.agency
@@ -42,7 +42,7 @@ export effectSet FileSystem = <FileRead, FileWrite>
 export effectSet Shell = <std::bash, std::exec, std::run>
 
 /** Anything that talks to the outside world over the network. */
-export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews, std::wikidata>
+export effectSet Network = <std::http::fetch, std::http::fetchJSON, std::http::fetchMarkdown, std::search, std::tavilySearch, std::weather, std::browserUse, std::wikipedia::article, std::wikipedia::search, std::wikipedia::summary, std::gdelt, std::fred, std::dbnomics, std::edgar, std::littlesis, std::yc, std::hackernews, std::wikidata, std::usaspending>
 
 /** The std::data/finance connectors (news + macro + filings). Each also raises
     std::http::fetchJSON, which is covered by the broader Network set. */

--- a/packages/agency-lang/stdlib/data/usaspending.agency
+++ b/packages/agency-lang/stdlib/data/usaspending.agency
@@ -82,11 +82,11 @@ export type AwardDetail = {
 /** Map a friendly award-type category to its award_type_codes (one category per query — USASpending
     won't mix contract and assistance codes). Unknown → failure listing the valid types. Pure. */
 safe def parseAwardType(t: string): Result<string[]> {
-  const codes = AWARD_TYPE_CODES[t] ?? null
-  if (codes == null) {
-    return failure("unknown awardType '${t}'; valid: ${keys(AWARD_TYPE_CODES).join(", ")}")
+  const valid = keys(AWARD_TYPE_CODES)
+  if (valid.indexOf(t) < 0) {
+    return failure("unknown awardType '${t}'; valid: ${valid.join(", ")}")
   }
-  return success(codes)
+  return success(AWARD_TYPE_CODES[t])
 }
 
 /** Build the spending_by_award POST body. Optional filters are added only when provided (bracket
@@ -138,10 +138,14 @@ safe def parseAwards(raw: any): Award[] {
   }
 }
 
-/** Join city and state into "City, ST", or "" when both are missing. Pure. */
+/** Join city and state into "City, ST". When only one is present, return it alone; when both are
+    missing, return "". Pure. */
 safe def placeString(city: string, state: string): string {
-  if (city == "" && state == "") {
-    return ""
+  if (city == "") {
+    return state
+  }
+  if (state == "") {
+    return city
   }
   return "${city}, ${state}"
 }
@@ -230,9 +234,9 @@ export safe def usaspendingAwards(recipient: string = "", agency: string = "", a
   @param recipient - Recipient or company name to filter by (blank = any)
   @param agency - Awarding agency name to filter by (blank = any)
   @param awardType - Award category: contracts, grants, loans, direct_payments, or other
-  @param startDate - ISO start date bounding the award period (blank with endDate = all time)
-  @param endDate - ISO end date bounding the award period
-  @param limit - Maximum number of awards to return (max 100)
+  @param startDate - ISO start date bounding the award period; only applied when endDate is also set
+  @param endDate - ISO end date bounding the award period; only applied when startDate is also set
+  @param limit - Maximum number of awards to return
   """
   const codesResult = parseAwardType(awardType)
   if (codesResult is failure(msg)) {

--- a/packages/agency-lang/stdlib/data/usaspending.agency
+++ b/packages/agency-lang/stdlib/data/usaspending.agency
@@ -1,0 +1,259 @@
+import { fetchJSON, HttpMethod } from "std::http"
+import { keys } from "std::object"
+
+/** @module
+  ## USASpending — U.S. federal awards
+
+  Query [USASpending](https://api.usaspending.gov), the U.S. Treasury's award-level spending API:
+  which companies and organizations received federal contracts and grants, from which agency, for
+  how much. Use it to follow federal money — pairs with `std::data/people/littlesis` (who is
+  connected) and `std::data/finance/edgar` (company filings).
+
+  No API key required. `usaspendingAwards` searches; its results carry a `generatedId` you can drill
+  into with `usaspendingAward`, which also surfaces recipient executive compensation and sub-award
+  totals.
+
+  ### Usage
+
+  ```ts
+  import { usaspendingAwards } from "std::data/usaspending"
+
+  node main() {
+    const awards = usaspendingAwards(recipient: "Lockheed Martin", limit: 5) catch []
+    for (a in awards) {
+      print("${a.amount}  ${a.recipient}  (${a.awardingAgency})")
+    }
+  }
+  ```
+*/
+
+effect std::usaspending { op: string, query: string }
+
+static const USA_BASE = "https://api.usaspending.gov"
+static const USA_DOMAINS = ["api.usaspending.gov"]
+
+// Friendly award-type category → award_type_codes. Single source of truth: parseAwardType derives
+// both the lookup and the valid-list error message from this (like littlesis's CATEGORY_NAMES).
+static const AWARD_TYPE_CODES: Record<string, string[]> = {
+  contracts: ["A", "B", "C", "D"],
+  grants: ["02", "03", "04", "05"],
+  loans: ["07", "08"],
+  direct_payments: ["06", "10"],
+  other: ["09", "11", "-1"]
+}
+
+/** One federal award from a search. `generatedId` drills into usaspendingAward; `amount` is USD. */
+export type Award = {
+  internalId: number;
+  generatedId: string;
+  id: string;
+  recipient: string;
+  amount: number;
+  awardingAgency: string;
+  startDate: string;
+  endDate: string;
+  description: string
+}
+
+/** A recipient officer and their compensation. */
+export type Executive = {
+  name: string;
+  amount: number
+}
+
+/** Curated detail for one federal award. */
+export type AwardDetail = {
+  id: string;
+  category: string;
+  awardType: string;
+  description: string;
+  amount: number;
+  recipient: string;
+  recipientUei: string;
+  awardingAgency: string;
+  startDate: string;
+  endDate: string;
+  placeOfPerformance: string;
+  subawardCount: number;
+  subawardAmount: number;
+  executives: Executive[]
+}
+
+/** Map a friendly award-type category to its award_type_codes (one category per query — USASpending
+    won't mix contract and assistance codes). Unknown → failure listing the valid types. Pure. */
+safe def parseAwardType(t: string): Result<string[]> {
+  const codes = AWARD_TYPE_CODES[t] ?? null
+  if (codes == null) {
+    return failure("unknown awardType '${t}'; valid: ${keys(AWARD_TYPE_CODES).join(", ")}")
+  }
+  return success(codes)
+}
+
+/** Build the spending_by_award POST body. Optional filters are added only when provided (bracket
+    assignment on a mutable Record, as in policy[effect] / _firstEntry[category]). Pure. */
+safe def buildAwardsBody(codes: string[], recipient: string, agency: string, startDate: string, endDate: string, limit: number): Record<string, any> {
+  let filters: Record<string, any> = { award_type_codes: codes }
+  if (recipient != "") {
+    filters["recipient_search_text"] = [recipient]
+  }
+  if (agency != "") {
+    filters["agencies"] = [{ type: "awarding", tier: "toptier", name: agency }]
+  }
+  if (startDate != "" && endDate != "") {
+    filters["time_period"] = [{ start_date: startDate, end_date: endDate }]
+  }
+  return {
+    filters: filters,
+    fields: ["Award ID", "Recipient Name", "Award Amount", "Awarding Agency", "Start Date", "End Date", "Description"],
+    limit: limit,
+    page: 1,
+    sort: "Award Amount",
+    order: "desc"
+  }
+}
+
+/** Build the award-detail path (accepts the numeric internal id or the generated hash). Pure. */
+safe def buildAwardPath(awardId: string): string {
+  return "/api/v2/awards/${encodeURIComponent(awardId)}/"
+}
+
+/** Reshape a spending_by_award body into Award[]. Results are keyed by human field names with
+    spaces, read via bracket access. Pure/total. */
+safe def parseAwards(raw: any): Award[] {
+  const r: any = raw ?? {}
+  const results = r.results ?? []
+  return map(results) as a {
+    const aw: any = a ?? {}
+    return {
+      internalId: aw.internal_id ?? 0,
+      generatedId: aw.generated_internal_id ?? "",
+      id: aw["Award ID"] ?? "",
+      recipient: aw["Recipient Name"] ?? "",
+      amount: aw["Award Amount"] ?? 0,
+      awardingAgency: aw["Awarding Agency"] ?? "",
+      startDate: aw["Start Date"] ?? "",
+      endDate: aw["End Date"] ?? "",
+      description: aw["Description"] ?? ""
+    }
+  }
+}
+
+/** Join city and state into "City, ST", or "" when both are missing. Pure. */
+safe def placeString(city: string, state: string): string {
+  if (city == "" && state == "") {
+    return ""
+  }
+  return "${city}, ${state}"
+}
+
+/** Curate the deep award-detail response into AwardDetail. Pure/total. */
+safe def parseAwardDetail(raw: any): AwardDetail {
+  const r: any = raw ?? {}
+  const recipient: any = r.recipient ?? {}
+  const awarding: any = r.awarding_agency ?? {}
+  const toptier: any = awarding.toptier_agency ?? {}
+  const pop: any = r.period_of_performance ?? {}
+  const place: any = r.place_of_performance ?? {}
+  const execDetails: any = r.executive_details ?? {}
+  const officers: any[] = execDetails.officers ?? []
+  const city = place.city_name ?? ""
+  const state = place.state_code ?? ""
+  return {
+    id: r.generated_unique_award_id ?? "",
+    category: r.category ?? "",
+    awardType: r.type_description ?? "",
+    description: r.description ?? "",
+    amount: r.total_obligation ?? 0,
+    recipient: recipient.recipient_name ?? "",
+    recipientUei: recipient.recipient_uei ?? "",
+    awardingAgency: toptier.name ?? "",
+    startDate: pop.start_date ?? "",
+    endDate: pop.end_date ?? "",
+    placeOfPerformance: placeString(city, state),
+    subawardCount: r.subaward_count ?? 0,
+    subawardAmount: r.total_subaward_amount ?? 0,
+    executives: map(officers) as o {
+      const off: any = o ?? {}
+      return {
+        name: off.name ?? "",
+        amount: off.amount ?? 0
+      }
+    }
+  }
+}
+
+/** Shared failure message for a failed USASpending fetch. Pure. */
+safe def usaspendingError(err: any): string {
+  return "USASpending request failed: ${err.message ?? err}"
+}
+
+/** Turn a fetch Result into an Award[] Result. Pure. */
+safe def awardsFinalize(fetchResult: any): Result<Award[]> {
+  return match (fetchResult) {
+    success(body) => success(parseAwards(body))
+    failure(err) => failure(usaspendingError(err))
+  }
+}
+
+/** Turn a fetch Result into an AwardDetail Result; a null body → failure. Pure. */
+safe def awardDetailFinalize(fetchResult: any): Result<AwardDetail> {
+  return match (fetchResult) {
+    success(body) => {
+      if (body == null) {
+        return failure("USASpending returned no award")
+      }
+      return success(parseAwardDetail(body))
+    }
+    failure(err) => failure(usaspendingError(err))
+  }
+}
+
+/** Fetch a USASpending path (GET or POST) and return the parsed-JSON Result. Raises
+    std::http::fetchJSON but approves it internally, so a plain caller sees only the connector's own
+    std::usaspending prompt while an OUTER fetch handler still receives (and can reject/propagate) the
+    fetch — the POST search surfaces with method "POST" for policy gating. Private. */
+safe def usaspendingFetch(path: string, method: HttpMethod, body: Record<string, any> | string | null): Result raises <std::http::fetchJSON> {
+  handle {
+    return fetchJSON(baseUrl: USA_BASE, path: path, allowedDomains: USA_DOMAINS, method: method, body: body)
+  } with (data) {
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+  }
+}
+
+export safe def usaspendingAwards(recipient: string = "", agency: string = "", awardType: string = "contracts", startDate: string = "", endDate: string = "", limit: number = 20): Result<Award[]> raises <std::usaspending, std::http::fetchJSON> {
+  """
+  Search U.S. federal awards. Returns each award's id, recipient, amount, awarding agency, dates, and
+  description, most-funded first. An empty result set returns an empty list.
+
+  @param recipient - Recipient or company name to filter by (blank = any)
+  @param agency - Awarding agency name to filter by (blank = any)
+  @param awardType - Award category: contracts, grants, loans, direct_payments, or other
+  @param startDate - ISO start date bounding the award period (blank with endDate = all time)
+  @param endDate - ISO end date bounding the award period
+  @param limit - Maximum number of awards to return (max 100)
+  """
+  const codesResult = parseAwardType(awardType)
+  if (codesResult is failure(msg)) {
+    return failure(msg)
+  }
+  const codes = codesResult.value
+  return interrupt std::usaspending("Search USASpending federal awards?", { op: "awards", query: recipient })
+  const body = buildAwardsBody(codes, recipient, agency, startDate, endDate, limit)
+  const result = usaspendingFetch("/api/v2/search/spending_by_award/", "POST", body)
+  return awardsFinalize(result)
+}
+
+export safe def usaspendingAward(awardId: string): Result<AwardDetail> raises <std::usaspending, std::http::fetchJSON> {
+  """
+  Fetch full detail for one federal award. Returns amount, recipient and UEI, awarding agency, dates,
+  place of performance, sub-award totals, and recipient executive compensation. Unknown id returns a
+  failure.
+
+  @param awardId - The award id: the generatedId from a search, or the numeric internalId as a string
+  """
+  return interrupt std::usaspending("Fetch this USASpending award?", { op: "award", query: awardId })
+  const result = usaspendingFetch(buildAwardPath(awardId), "GET", null)
+  return awardDetailFinalize(result)
+}

--- a/packages/agency-lang/tests/agency-js/data-usaspending-live/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-usaspending-live/agent.agency
@@ -1,0 +1,28 @@
+import { usaspendingAwards, usaspendingAward } from "std::data/usaspending"
+
+// Real drift check: search, then drill into the first result's detail — returns awards.length only if
+// BOTH the search returned awards AND the detail parsed a recipient, so drift in either shape shows.
+node liveCheck(): number {
+  handle {
+    const awards = usaspendingAwards(recipient: "Lockheed Martin", limit: 3) catch []
+    if (awards.length == 0) {
+      return 0
+    }
+    const detailR = usaspendingAward(awards[0].generatedId)
+    if (detailR is failure(e)) {
+      return 0
+    }
+    if (detailR.value.recipient == "") {
+      return 0
+    }
+    return awards.length
+  } with (data) {
+    if (data.effect == "std::usaspending") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return approve()
+    }
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-usaspending-live/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-usaspending-live/fixture.json
@@ -1,0 +1,1 @@
+{ "skipped": true }

--- a/packages/agency-lang/tests/agency-js/data-usaspending-live/test.js
+++ b/packages/agency-lang/tests/agency-js/data-usaspending-live/test.js
@@ -1,0 +1,9 @@
+import { liveCheck } from "./agent.js";
+import { writeFileSync } from "node:fs";
+
+if (!process.env.AGENCY_LIVE_TESTS) {
+  writeFileSync("__result.json", JSON.stringify({ skipped: true }, null, 2));
+} else {
+  const n = (await liveCheck())?.data ?? -1;
+  writeFileSync("__result.json", JSON.stringify({ ok: n >= 1 }, null, 2));
+}

--- a/packages/agency-lang/tests/agency-js/data-usaspending/agent.agency
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/agent.agency
@@ -1,0 +1,130 @@
+import test { parseAwardType, buildAwardsBody, buildAwardPath, parseAwards, parseAwardDetail, usaspendingError, awardsFinalize, awardDetailFinalize, usaspendingAwards, usaspendingAward } from "std::data/usaspending"
+import { Network } from "std::capabilities"
+
+// --- pure-function wrappers ---
+
+node tParseAwardType(t: string): any {
+  const r = parseAwardType(t)
+  if (r is failure(e)) {
+    return "FAIL: ${e}"
+  }
+  return r.value
+}
+
+node tBuildAwardsBody(codes: string[], recipient: string, agency: string, startDate: string, endDate: string, limit: number): any {
+  return buildAwardsBody(codes, recipient, agency, startDate, endDate, limit)
+}
+
+node tAwardPath(awardId: string): string {
+  return buildAwardPath(awardId)
+}
+
+node tParseAwards(raw: any): any {
+  return parseAwards(raw)
+}
+
+node tParseAwardsNull(): any {
+  return parseAwards(null)
+}
+
+node tParseAwardDetail(raw: any): any {
+  return parseAwardDetail(raw)
+}
+
+node tAwardsFinalizeErr(): string {
+  const r = awardsFinalize(failure("boom"))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tAwardDetailFinalizeNull(): string {
+  const r = awardDetailFinalize(success(null))
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS"
+}
+
+node tError(err: any): string {
+  return usaspendingError(err)
+}
+
+// --- gating / capability ---
+
+// Compile-time capability assertion: usaspendingAwards raises std::usaspending + std::http::fetchJSON.
+node netCheck() raises <Network> {
+  const r = usaspendingAwards(recipient: "x") catch []
+  return r.length
+}
+
+// Plain caller as a REPORTING node: returns "REJECTED: …" if the call failed (e.g. the interrupt was
+// rejected) or "SUCCESS" if it ran to a success. Lets the reject test prove the call HALTED, and the
+// Option-C test prove approving std::usaspending resumes to success.
+node callAwards(): string {
+  const r = usaspendingAwards(recipient: "Lockheed")
+  if (r is failure(e)) {
+    return "REJECTED: ${e}"
+  }
+  return "SUCCESS"
+}
+
+// Plain caller for the detail endpoint, so a test can inspect its { op: "award", query } payload.
+node callAward(): string {
+  const r = usaspendingAward("22834500")
+  if (r is failure(e)) {
+    return "REJECTED: ${e}"
+  }
+  return "SUCCESS"
+}
+
+// Governed caller: approve std::usaspending, PROPAGATE the fetch so std::http::fetchJSON surfaces
+// with { baseUrl, path, method } — asserted offline (method must be POST for the search), then reject.
+node callAwardsGoverned(): any {
+  handle {
+    return usaspendingAwards(recipient: "Lockheed")
+  } with (data) {
+    if (data.effect == "std::usaspending") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return propagate()
+    }
+  }
+}
+
+// Governed caller for the GET detail — method must be GET, path must carry the id.
+node callAwardGoverned(): any {
+  handle {
+    return usaspendingAward("22834500")
+  } with (data) {
+    if (data.effect == "std::usaspending") {
+      return approve()
+    }
+    if (data.effect == "std::http::fetchJSON") {
+      return propagate()
+    }
+  }
+}
+
+// Bad awardType fails BEFORE the interrupt → failure Result offline (no fetch, no interrupt).
+node callAwardsBad(): string {
+  const r = usaspendingAwards(awardType: "bogus")
+  if (r is failure(e)) {
+    return e
+  }
+  return "UNEXPECTED_SUCCESS_OR_INTERRUPT"
+}
+
+// --- fetch-mocked end-to-end (see fetchMocks.json); `with approve` lets the mocked fetch run ---
+
+node mockAwards(): any {
+  const r = usaspendingAwards(recipient: "Lockheed") with approve
+  return r catch "FAIL"
+}
+
+node mockAward(): any {
+  const r = usaspendingAward("22834500") with approve
+  return r catch "FAIL"
+}

--- a/packages/agency-lang/tests/agency-js/data-usaspending/fetchMocks.json
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/fetchMocks.json
@@ -1,0 +1,4 @@
+[
+  { "url": "https://api.usaspending.gov/api/v2/search/spending_by_award/", "method": "POST", "body": { "filters": { "award_type_codes": ["A", "B", "C", "D"], "recipient_search_text": ["Lockheed"] } }, "returnFile": "sample-awards.json" },
+  { "urlPattern": "api\\.usaspending\\.gov/api/v2/awards/22834500/", "returnFile": "sample-award-detail.json" }
+]

--- a/packages/agency-lang/tests/agency-js/data-usaspending/fixture.json
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/fixture.json
@@ -1,0 +1,134 @@
+{
+  "typeContracts": ["A", "B", "C", "D"],
+  "typeGrants": ["02", "03", "04", "05"],
+  "typeBad": "FAIL: unknown awardType 'bogus'; valid: contracts, grants, loans, direct_payments, other",
+  "bodyMinimal": {
+    "filters": { "award_type_codes": ["02", "03", "04", "05"] },
+    "fields": ["Award ID", "Recipient Name", "Award Amount", "Awarding Agency", "Start Date", "End Date", "Description"],
+    "limit": 10,
+    "page": 1,
+    "sort": "Award Amount",
+    "order": "desc"
+  },
+  "bodyFull": {
+    "filters": {
+      "award_type_codes": ["A", "B", "C", "D"],
+      "recipient_search_text": ["Lockheed"],
+      "agencies": [{ "type": "awarding", "tier": "toptier", "name": "Department of Defense" }],
+      "time_period": [{ "start_date": "2023-01-01", "end_date": "2023-12-31" }]
+    },
+    "fields": ["Award ID", "Recipient Name", "Award Amount", "Awarding Agency", "Start Date", "End Date", "Description"],
+    "limit": 5,
+    "page": 1,
+    "sort": "Award Amount",
+    "order": "desc"
+  },
+  "bodyStartOnly": {
+    "filters": { "award_type_codes": ["A", "B", "C", "D"] },
+    "fields": ["Award ID", "Recipient Name", "Award Amount", "Awarding Agency", "Start Date", "End Date", "Description"],
+    "limit": 10,
+    "page": 1,
+    "sort": "Award Amount",
+    "order": "desc"
+  },
+  "awardPath": "/api/v2/awards/22834500/",
+  "awardPathEnc": "/api/v2/awards/a%20b%2Fc/",
+  "awards": [
+    {
+      "internalId": 22834500,
+      "generatedId": "CONT_AWD_SPE2DX16D1500_9700",
+      "id": "SPE2DX16D1500",
+      "recipient": "LOCKHEED MARTIN CORPORATION",
+      "amount": 12500000.5,
+      "awardingAgency": "Department of Defense",
+      "startDate": "2016-03-01",
+      "endDate": "2021-02-28",
+      "description": "AIRCRAFT PARTS"
+    }
+  ],
+  "awardsNull": [],
+  "awardsSparse": [
+    {
+      "internalId": 0,
+      "generatedId": "",
+      "id": "",
+      "recipient": "",
+      "amount": 0,
+      "awardingAgency": "",
+      "startDate": "",
+      "endDate": "",
+      "description": ""
+    }
+  ],
+  "detail": {
+    "id": "CONT_AWD_SPE2DX16D1500_9700",
+    "category": "contract",
+    "awardType": "DELIVERY ORDER",
+    "description": "AIRCRAFT PARTS",
+    "amount": 12500000.5,
+    "recipient": "LOCKHEED MARTIN CORPORATION",
+    "recipientUei": "ABC123DEF456",
+    "awardingAgency": "Department of Defense",
+    "startDate": "2016-03-01",
+    "endDate": "2021-02-28",
+    "placeOfPerformance": "FORT WORTH, TX",
+    "subawardCount": 3,
+    "subawardAmount": 4200000,
+    "executives": [
+      { "name": "Jane Doe", "amount": 20000000 },
+      { "name": "John Smith", "amount": 15000000 }
+    ]
+  },
+  "detailEmpty": {
+    "id": "",
+    "category": "",
+    "awardType": "",
+    "description": "",
+    "amount": 0,
+    "recipient": "",
+    "recipientUei": "",
+    "awardingAgency": "",
+    "startDate": "",
+    "endDate": "",
+    "placeOfPerformance": "",
+    "subawardCount": 0,
+    "subawardAmount": 0,
+    "executives": []
+  },
+  "awardsFinalizeErr": "USASpending request failed: boom",
+  "awardDetailFinalizeNull": "USASpending returned no award",
+  "errorMsg": "USASpending request failed: boom",
+  "errorMsgObj": "USASpending request failed: boom-msg",
+  "mockAwards": [
+    {
+      "internalId": 22834500,
+      "generatedId": "CONT_AWD_SPE2DX16D1500_9700",
+      "id": "SPE2DX16D1500",
+      "recipient": "LOCKHEED MARTIN CORPORATION",
+      "amount": 12500000.5,
+      "awardingAgency": "Department of Defense",
+      "startDate": "2016-03-01",
+      "endDate": "2021-02-28",
+      "description": "AIRCRAFT PARTS"
+    }
+  ],
+  "mockAward": {
+    "id": "CONT_AWD_SPE2DX16D1500_9700",
+    "category": "contract",
+    "awardType": "DELIVERY ORDER",
+    "description": "AIRCRAFT PARTS",
+    "amount": 12500000.5,
+    "recipient": "LOCKHEED MARTIN CORPORATION",
+    "recipientUei": "ABC123DEF456",
+    "awardingAgency": "Department of Defense",
+    "startDate": "2016-03-01",
+    "endDate": "2021-02-28",
+    "placeOfPerformance": "FORT WORTH, TX",
+    "subawardCount": 3,
+    "subawardAmount": 4200000,
+    "executives": [
+      { "name": "Jane Doe", "amount": 20000000 },
+      { "name": "John Smith", "amount": 15000000 }
+    ]
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-usaspending/sample-award-detail.json
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/sample-award-detail.json
@@ -1,0 +1,31 @@
+{
+  "id": 22834500,
+  "generated_unique_award_id": "CONT_AWD_SPE2DX16D1500_9700",
+  "category": "contract",
+  "type_description": "DELIVERY ORDER",
+  "description": "AIRCRAFT PARTS",
+  "total_obligation": 12500000.5,
+  "subaward_count": 3,
+  "total_subaward_amount": 4200000,
+  "recipient": {
+    "recipient_name": "LOCKHEED MARTIN CORPORATION",
+    "recipient_uei": "ABC123DEF456"
+  },
+  "awarding_agency": {
+    "toptier_agency": { "name": "Department of Defense" }
+  },
+  "period_of_performance": {
+    "start_date": "2016-03-01",
+    "end_date": "2021-02-28"
+  },
+  "place_of_performance": {
+    "city_name": "FORT WORTH",
+    "state_code": "TX"
+  },
+  "executive_details": {
+    "officers": [
+      { "name": "Jane Doe", "amount": 20000000 },
+      { "name": "John Smith", "amount": 15000000 }
+    ]
+  }
+}

--- a/packages/agency-lang/tests/agency-js/data-usaspending/sample-awards.json
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/sample-awards.json
@@ -1,0 +1,17 @@
+{
+  "limit": 20,
+  "page_metadata": { "page": 1, "hasNext": false },
+  "results": [
+    {
+      "internal_id": 22834500,
+      "generated_internal_id": "CONT_AWD_SPE2DX16D1500_9700",
+      "Award ID": "SPE2DX16D1500",
+      "Recipient Name": "LOCKHEED MARTIN CORPORATION",
+      "Award Amount": 12500000.5,
+      "Awarding Agency": "Department of Defense",
+      "Start Date": "2016-03-01",
+      "End Date": "2021-02-28",
+      "Description": "AIRCRAFT PARTS"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/data-usaspending/test.js
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/test.js
@@ -65,6 +65,18 @@ const bad = await callAwardsBad();
 if (hasInterrupts(bad.data)) throw new Error("bad awardType must fail before raising std::usaspending");
 if (!String(bad.data).includes("unknown awardType")) throw new Error("bad awardType must fail with the validation message, got: " + bad.data);
 
+// (G) parseAwardType validates via own-key membership, so prototype-chain keys (__proto__, constructor)
+// are rejected, not accidentally accepted by bracket indexing.
+const proto = String(unwrap(await tParseAwardType("__proto__")));
+if (!proto.startsWith("FAIL")) throw new Error("parseAwardType must reject prototype keys like __proto__, got: " + proto);
+
+// (H) placeString single-component cases: city-only or state-only returns the lone component, never
+// a dangling ", ST" or "City, ".
+const cityOnly = unwrap(await tParseAwardDetail({ place_of_performance: { city_name: "FORT WORTH" } }));
+if (cityOnly.placeOfPerformance !== "FORT WORTH") throw new Error("city-only place must be 'FORT WORTH', got: " + cityOnly.placeOfPerformance);
+const stateOnly = unwrap(await tParseAwardDetail({ place_of_performance: { state_code: "TX" } }));
+if (stateOnly.placeOfPerformance !== "TX") throw new Error("state-only place must be 'TX', got: " + stateOnly.placeOfPerformance);
+
 writeFileSync(
   "__result.json",
   JSON.stringify(

--- a/packages/agency-lang/tests/agency-js/data-usaspending/test.js
+++ b/packages/agency-lang/tests/agency-js/data-usaspending/test.js
@@ -1,0 +1,95 @@
+import { tParseAwardType, tBuildAwardsBody, tAwardPath, tParseAwards, tParseAwardsNull, tParseAwardDetail, tAwardsFinalizeErr, tAwardDetailFinalizeNull, tError, hasInterrupts, approve, reject, respondToInterrupts, callAwards, callAward, callAwardsGoverned, callAwardGoverned, callAwardsBad, mockAwards, mockAward } from "./agent.js";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const unwrap = (r) => r?.data ?? r;
+const load = (f) => JSON.parse(readFileSync(new URL(f, import.meta.url), "utf8"));
+const sampleAwards = load("./sample-awards.json");
+const sampleDetail = load("./sample-award-detail.json");
+
+// --- interrupt / effect assertions (throw on mismatch) ---
+
+// (A) Domain interrupt gates the call: it fires with the right payload, and rejecting it HALTS the
+// call with a failure (callAwards is a reporting node → "REJECTED: …"), not just "no more interrupts".
+const i1 = await callAwards();
+if (!hasInterrupts(i1.data)) throw new Error("usaspendingAwards did not raise an interrupt");
+const iv = i1.data[0];
+if (iv.effect !== "std::usaspending") throw new Error("wrong effect: " + iv.effect);
+if (iv.data.op !== "awards") throw new Error("wrong op: " + iv.data.op);
+if (iv.data.query !== "Lockheed") throw new Error("wrong query: " + iv.data.query);
+const rejected = await respondToInterrupts(i1.data, [reject()]);
+if (hasInterrupts(rejected.data)) throw new Error("rejecting std::usaspending must short-circuit before any fetch");
+if (!String(rejected.data).startsWith("REJECTED")) throw new Error("reject must halt the call with a failure, got: " + rejected.data);
+
+// (B) Plain caller sees ONLY std::usaspending (no fetch prompt at the first hop).
+if (i1.data.filter((x) => x.effect && x.effect !== "std::usaspending").length > 0) {
+  throw new Error("plain caller must see only std::usaspending at the first hop");
+}
+
+// (E) Option-C single prompt: APPROVING std::usaspending resumes into the internally-approved fetch —
+// no second (std::http::fetchJSON) prompt — and runs to success against the mock.
+const e1 = await callAwards();
+const resumed = await respondToInterrupts(e1.data, [approve()]);
+if (hasInterrupts(resumed.data)) throw new Error("Option C: approving std::usaspending must NOT surface a second (fetch) prompt");
+if (resumed.data !== "SUCCESS") throw new Error("approving std::usaspending should resume the internally-approved fetch to success, got: " + resumed.data);
+
+// (C) Governance + POST wiring: the search's propagated fetch surfaces std::http::fetchJSON with
+// method POST and the search path — asserted offline, then rejected (no network).
+const g1 = await callAwardsGoverned();
+if (!hasInterrupts(g1.data)) throw new Error("governed search should surface std::http::fetchJSON via propagate()");
+const gv = g1.data[0];
+if (gv.effect !== "std::http::fetchJSON") throw new Error("expected std::http::fetchJSON, got: " + gv.effect);
+if (gv.data.baseUrl !== "https://api.usaspending.gov") throw new Error("wrong baseUrl: " + gv.data.baseUrl);
+if (gv.data.path !== "/api/v2/search/spending_by_award/") throw new Error("wrong path: " + gv.data.path);
+if (gv.data.method !== "POST") throw new Error("search must fetch with method POST, got: " + gv.data.method);
+await respondToInterrupts(g1.data, [reject()]);
+
+// (C2) The detail fetch surfaces with method GET AND the id-bearing path.
+const g2 = await callAwardGoverned();
+if (!hasInterrupts(g2.data)) throw new Error("governed detail should surface std::http::fetchJSON");
+const g2v = g2.data[0];
+if (g2v.data.method !== "GET") throw new Error("detail must fetch with method GET, got: " + g2v.data.method);
+if (g2v.data.path !== "/api/v2/awards/22834500/") throw new Error("wrong detail path: " + g2v.data.path);
+await respondToInterrupts(g2.data, [reject()]);
+
+// (F) The detail interrupt payload carries op "award" and the award id.
+const d1 = await callAward();
+if (!hasInterrupts(d1.data)) throw new Error("usaspendingAward did not raise an interrupt");
+const dv = d1.data[0];
+if (dv.effect !== "std::usaspending") throw new Error("wrong detail effect: " + dv.effect);
+if (dv.data.op !== "award") throw new Error("wrong detail op: " + dv.data.op);
+if (dv.data.query !== "22834500") throw new Error("wrong detail query: " + dv.data.query);
+await respondToInterrupts(d1.data, [reject()]);
+
+// (D) Bad awardType fails BEFORE the interrupt (no fetch, no interrupt) and for the right reason.
+const bad = await callAwardsBad();
+if (hasInterrupts(bad.data)) throw new Error("bad awardType must fail before raising std::usaspending");
+if (!String(bad.data).includes("unknown awardType")) throw new Error("bad awardType must fail with the validation message, got: " + bad.data);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      typeContracts: unwrap(await tParseAwardType("contracts")),
+      typeGrants: unwrap(await tParseAwardType("grants")),
+      typeBad: unwrap(await tParseAwardType("bogus")),
+      bodyMinimal: unwrap(await tBuildAwardsBody(["02", "03", "04", "05"], "", "", "", "", 10)),
+      bodyFull: unwrap(await tBuildAwardsBody(["A", "B", "C", "D"], "Lockheed", "Department of Defense", "2023-01-01", "2023-12-31", 5)),
+      bodyStartOnly: unwrap(await tBuildAwardsBody(["A", "B", "C", "D"], "", "", "2023-01-01", "", 10)),
+      awardPath: unwrap(await tAwardPath("22834500")),
+      awardPathEnc: unwrap(await tAwardPath("a b/c")),
+      awards: unwrap(await tParseAwards(sampleAwards)),
+      awardsNull: unwrap(await tParseAwardsNull()),
+      awardsSparse: unwrap(await tParseAwards({ results: [{}] })),
+      detail: unwrap(await tParseAwardDetail(sampleDetail)),
+      detailEmpty: unwrap(await tParseAwardDetail({})),
+      awardsFinalizeErr: unwrap(await tAwardsFinalizeErr()),
+      awardDetailFinalizeNull: unwrap(await tAwardDetailFinalizeNull()),
+      errorMsg: unwrap(await tError("boom")),
+      errorMsgObj: unwrap(await tError({ message: "boom-msg" })),
+      mockAwards: unwrap(await mockAwards()),
+      mockAward: unwrap(await mockAward()),
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## What

`std::data/usaspending` — a free, keyless connector over the USASpending federal-awards API, and the **first connector to fetch with `method: "POST"`** (the payoff of the recent `std::http` POST support).

| Function | Method | Returns | Purpose |
|---|---|---|---|
| `usaspendingAwards(recipient="", agency="", awardType="contracts", startDate="", endDate="", limit=20)` | POST | `Award[]` | Search federal awards. Friendly params build the `filters`/`fields` body internally. |
| `usaspendingAward(awardId)` | GET | `AwardDetail` | Drill into one award (its `generatedId` from a search) — curated to amount, recipient+UEI, agency, dates, place of performance, sub-award totals, and recipient **executive compensation**. |

Maps companies → federal money; pairs with LittleSis (entities) and EDGAR (filings).

## Design

- **First POST connector:** one Option-C `usaspendingFetch(path, method, body)` issues POST for search and GET for detail. The search's `std::http::fetchJSON` interrupt carries `method: "POST"` in the payload — so a `std::policy` can allow the GET detail and gate the POST search. `std::usaspending` added to `Network`.
- Friendly `awardType` → `award_type_codes` (one category per query, since USASpending won't mix contract/assistance codes) from a single `AWARD_TYPE_CODES` source of truth; `buildAwardsBody` adds optional filters conditionally.
- Space-keyed search results (`result["Award ID"]`) parsed into a flat `Award`; the ~150-field detail curated to a flat `AwardDetail`. Only the two public functions + types are exported; helpers use `import test`.

## Testing

`tests/agency-js/data-usaspending/`:
- **Pure functions** — `parseAwardType`, `buildAwardsBody` (with/without each optional filter), `parseAwards` (+ sparse), `parseAwardDetail` (+ empty), finalizers, edge/encoding cases.
- **Interrupt gating** — reject *halts* the call (reporting node); a plain caller sees only `std::usaspending`; and — the key one — **approving `std::usaspending` resumes with no second fetch prompt** (the Option-C single-prompt claim, previously untested in any connector). The propagated fetch is asserted with `method: "POST"` + the search path (and `GET` + the id-bearing path for detail); the detail interrupt payload's `op`/`query` are pinned.
- **Fetch-mocked end-to-end** — the POST mock matches on `method` + a body subset (`award_type_codes` + `recipient_search_text`), proving the body is built and serialized; the detail mock matches the id-bearing GET path.
- **Live drift check** (`-live/`, opt-in) — runs search **and** detail; ran once against the real API → `{ ok: true }`, and every award-detail leaf path was pre-verified via `curl`.

Regression: littlesis / http-post pass (the `Network` change + POST plumbing).

## Note

`usaspendingFetch` is the third Option-C gated-fetch helper (after wikidata/littlesis) — rule-of-three is met, so a shared `std::http` helper is worth a later extraction. Followed the copy pattern here per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
