### PR TITLE
Failure propagation — Stage 2: flip the default to on

### DIFF
--- a/packages/agency-lang/docs/site/guide/agency-config-file.md
+++ b/packages/agency-lang/docs/site/guide/agency-config-file.md
@@ -133,7 +133,6 @@ Safety guards that stop a program from running away.
 ```json
 {
   "maxCallDepth": 2048,
-  "failurePropagation": "on",
   "maxToolCallRounds": 10,
   "checkpoints": { "maxRestores": 100 }
 }
@@ -142,7 +141,6 @@ Safety guards that stop a program from running away.
 | Option | Description |
 | --- | --- |
 | `maxCallDepth` | The runaway-recursion guard. Default `2048`; raise it for legitimately deep recursion. |
-| `failurePropagation` | What happens when a failure value reaches a parameter not typed to accept Results. `"on"` (default) skips the call and propagates the failure. `"warn"` logs without changing behavior. `"off"` disables the checks. |
 | `maxToolCallRounds` | How many times the LLM can loop between calling tools and reacting to their output before Agency halts it. Default `10`. |
 | `checkpoints.maxRestores` | Cap on how often one checkpoint can be restored before it errors out. Default `100`. |
 

--- a/packages/agency-lang/docs/site/guide/agency-config-file.md
+++ b/packages/agency-lang/docs/site/guide/agency-config-file.md
@@ -133,6 +133,7 @@ Safety guards that stop a program from running away.
 ```json
 {
   "maxCallDepth": 2048,
+  "failurePropagation": "on",
   "maxToolCallRounds": 10,
   "checkpoints": { "maxRestores": 100 }
 }
@@ -141,6 +142,7 @@ Safety guards that stop a program from running away.
 | Option | Description |
 | --- | --- |
 | `maxCallDepth` | The runaway-recursion guard. Default `2048`; raise it for legitimately deep recursion. |
+| `failurePropagation` | What happens when a failure value reaches a parameter not typed to accept Results. `"on"` (default) skips the call and propagates the failure. `"warn"` logs without changing behavior. `"off"` disables the checks. |
 | `maxToolCallRounds` | How many times the LLM can loop between calling tools and reacting to their output before Agency halts it. Default `10`. |
 | `checkpoints.maxRestores` | Cap on how often one checkpoint can be restored before it errors out. Default `100`. |
 

--- a/packages/agency-lang/docs/site/guide/error-handling.md
+++ b/packages/agency-lang/docs/site/guide/error-handling.md
@@ -147,9 +147,7 @@ Agency also adds an automatic try-catch around every function definition, and if
 
 ## Failure propagation
 
-A failure is self-propagating. If you pass one to a function that is not
-typed to accept Results, the function does not run. The call returns the
-original failure instead, exactly like a pipe chain short-circuiting:
+A failure is self-propagating. If you pass one to a function whose parameter is not typed to accept Results (`Result`, explicit `any`, or a union containing either), the function is skipped and the call returns the original failure, exactly like a pipe chain short-circuiting. Each skipped hop is recorded on the failure's `skippedFunctions` list, so the error you eventually inspect still points at the function that produced it. Passing a failure to an imported TypeScript function, or calling a method on a Result you forgot to unwrap, throws an error naming the producer instead.
 
 ```ts
 def getReport(id: string): Result {
@@ -163,31 +161,10 @@ def wordCount(text: string): number {
 node main() {
   const report = getReport("abc")   // oops: never checked
   const count = wordCount(report)   // wordCount is skipped
-  // count IS the original failure. count.error is the 404 message, and
+  // count IS the original failure: count.error is the 404 message, and
   // count.skippedFunctions is [{ name: "wordCount", param: "text" }].
 }
 ```
-
-A parameter accepts failures only if its type says so. `Result`,
-`Result<...>`, explicit `any`, or a union containing either accepts.
-Untyped parameters reject.
-
-Passing a failure to an imported TypeScript function throws an error
-instead, because TypeScript code does not know about Results. Calling a
-method on a Result (like `.split()` on a failure you forgot to unwrap)
-also throws. Both errors name the function that produced the failure.
-If your own TypeScript helper legitimately takes failures, tag it:
-
-```ts
-import { acceptsFailures } from "agency-lang";
-
-export const myLogger = acceptsFailures((value) => {
-  console.log(value);
-});
-```
-
-Set `failurePropagation` in `agency.json` to `"warn"` (log a statelog
-warning and a stderr line, keep legacy behavior) or `"off"` to disable.
 
 ## `Result` type parameters
 

--- a/packages/agency-lang/docs/site/guide/error-handling.md
+++ b/packages/agency-lang/docs/site/guide/error-handling.md
@@ -145,6 +145,50 @@ const result = try foo()
 
 Agency also adds an automatic try-catch around every function definition, and if an error is thrown, it returns a `Failure` type.
 
+## Failure propagation
+
+A failure is self-propagating. If you pass one to a function that is not
+typed to accept Results, the function does not run. The call returns the
+original failure instead, exactly like a pipe chain short-circuiting:
+
+```ts
+def getReport(id: string): Result {
+  return failure("HTTP 404: report not found")
+}
+
+def wordCount(text: string): number {
+  return text.split(" ").length
+}
+
+node main() {
+  const report = getReport("abc")   // oops: never checked
+  const count = wordCount(report)   // wordCount is skipped
+  // count IS the original failure. count.error is the 404 message, and
+  // count.skippedFunctions is [{ name: "wordCount", param: "text" }].
+}
+```
+
+A parameter accepts failures only if its type says so. `Result`,
+`Result<...>`, explicit `any`, or a union containing either accepts.
+Untyped parameters reject.
+
+Passing a failure to an imported TypeScript function throws an error
+instead, because TypeScript code does not know about Results. Calling a
+method on a Result (like `.split()` on a failure you forgot to unwrap)
+also throws. Both errors name the function that produced the failure.
+If your own TypeScript helper legitimately takes failures, tag it:
+
+```ts
+import { acceptsFailures } from "agency-lang";
+
+export const myLogger = acceptsFailures((value) => {
+  console.log(value);
+});
+```
+
+Set `failurePropagation` in `agency.json` to `"warn"` (log a statelog
+warning and a stderr line, keep legacy behavior) or `"off"` to disable.
+
 ## `Result` type parameters
 
 The `Result` type has two type parameters, the success type and the failure type. If you don't specify them, they default to `any`:

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -224,11 +224,11 @@ export interface AgencyConfig {
    * programs that legitimately recurse very deeply. Default: 2048. */
   maxCallDepth?: number;
 
-  /** Failure-propagation mode. "warn" (current default, flips to "on" in a
-   * follow-up release): warnings only, legacy behavior otherwise. "on": a
-   * failure value passed to a parameter not typed to accept Results skips
-   * the call and propagates the original failure; failures into plain TS
-   * functions and method calls on Results throw. "off": no checks. */
+  /** Failure-propagation mode. "on" (default): a failure value passed to a
+   * parameter not typed to accept Results skips the call and propagates the
+   * original failure; failures into plain TS functions and method calls on
+   * Results throw. "warn": warnings only, legacy behavior otherwise.
+   * "off": no checks. */
   failurePropagation?: "off" | "warn" | "on";
 
   /** Enable execution tracing — writes checkpoints to a .trace file */

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -229,11 +229,11 @@ export class RuntimeContext<T> {
     this.statelogConfig = statelogConfig;
     this.maxRestores = args.maxRestores ?? 100;
     this.maxCallDepth = args.maxCallDepth ?? DEFAULT_MAX_CALL_DEPTH;
-    // Stage 1 rollout default: every real compiled program warns without
-    // changing behavior. Stage 2 flips this one literal to "on" after the
-    // corpus measurement (do NOT touch the frameless "on" fallback in
-    // failurePropagation.ts, which serves unit tests).
-    this.failurePropagation = args.failurePropagation ?? "warn";
+    // Strict by default since the Stage 2 flip (the Stage 1 "warn" default
+    // shipped one release as the rollout measurement). The frameless "on"
+    // fallback in failurePropagation.ts is a SEPARATE default serving unit
+    // tests — this literal is the one that governs compiled programs.
+    this.failurePropagation = args.failurePropagation ?? "on";
     this.statelogClient = new StatelogClient(statelogConfig);
     this.stateStack = new StateStack();
     this.globals = GlobalStore.withTokenStats();

--- a/packages/agency-lang/tests/agency/result/failure-array-collect.agency
+++ b/packages/agency-lang/tests/agency/result/failure-array-collect.agency
@@ -1,0 +1,20 @@
+def mightFail(n: number): Result {
+  if (n % 2 == 0) {
+    return failure("even ${n}")
+  }
+  return success(n)
+}
+
+node main() {
+  const collected = []
+  for (n in [1, 2, 3, 4]) {
+    collected.push(mightFail(n))
+  }
+  let failures = 0
+  for (r in collected) {
+    if (isFailure(r)) {
+      failures = failures + 1
+    }
+  }
+  return "collected ${collected.length}, failures ${failures}"
+}

--- a/packages/agency-lang/tests/agency/result/failure-array-collect.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-array-collect.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"collected 4, failures 2\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "arr.push(someFailure) must work: method arguments are never scanned (the TS-function check lives in __call only)"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-async-propagation.agency
+++ b/packages/agency-lang/tests/agency/result/failure-async-propagation.agency
@@ -1,0 +1,16 @@
+def bad(): Result {
+  return failure("boom")
+}
+
+def use(s: string) {
+  return "used"
+}
+
+node main() {
+  const f = bad()
+  const x = async use(f)
+  if (isFailure(x)) {
+    return "async propagated ${x.error}"
+  }
+  return "async not propagated"
+}

--- a/packages/agency-lang/tests/agency/result/failure-async-propagation.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-async-propagation.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"async propagated boom\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "an async call with a failure argument surfaces the propagated failure as its awaited result"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-block-failopen.agency
+++ b/packages/agency-lang/tests/agency/result/failure-block-failopen.agency
@@ -1,0 +1,18 @@
+def eachOf(items: any, block: (any) -> string): string {
+  let out = ""
+  for (item in items) {
+    out = block(item)
+  }
+  return out
+}
+
+node main() {
+  const mixed = [success(1), failure("bad")]
+  const last = eachOf(mixed) as item {
+    if (isFailure(item)) {
+      return "block saw failure"
+    }
+    return "block saw value"
+  }
+  return last
+}

--- a/packages/agency-lang/tests/agency/result/failure-block-failopen.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-block-failopen.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"block saw failure\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "block params always accept failures in v1 (emission sites carry no acceptsResult flags) \u2014 the block body runs and can guard with isFailure"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-helpers.js
+++ b/packages/agency-lang/tests/agency/result/failure-helpers.js
@@ -1,0 +1,3 @@
+export function tsFormat(x) {
+  return "formatted:" + String(x);
+}

--- a/packages/agency-lang/tests/agency/result/failure-method-call.agency
+++ b/packages/agency-lang/tests/agency/result/failure-method-call.agency
@@ -1,0 +1,51 @@
+def getF(): Result {
+  return failure("nope")
+}
+
+def callSplitOn(v: any) {
+  const parts = v.split(" ")
+  return "no throw"
+}
+
+def callToFixedOn(v: any) {
+  const s = v.toFixed(1)
+  return "no throw"
+}
+
+def addOne(n: number) {
+  return n + 1
+}
+
+node main() {
+  const f = getF()
+
+  let failureMsg = "?"
+  const r1 = try callSplitOn(f)
+  if (isFailure(r1)) {
+    let hasSplit = "no"
+    if (r1.error.includes("split")) {
+      hasSplit = "yes"
+    }
+    let hasOrigin = "no"
+    if (r1.error.includes("getF")) {
+      hasOrigin = "yes"
+    }
+    failureMsg = "split=${hasSplit} origin=${hasOrigin}"
+  }
+
+  let successMsg = "?"
+  const s = success(5)
+  const r2 = try callToFixedOn(s)
+  if (isFailure(r2)) {
+    let hasHint = "no"
+    if (r2.error.includes(".value.")) {
+      hasHint = "yes"
+    }
+    successMsg = "hint=${hasHint}"
+  }
+
+  const wrapped = success(addOne)
+  const called = wrapped.value(41)
+
+  return "${failureMsg} | ${successMsg} | value()=${called}"
+}

--- a/packages/agency-lang/tests/agency/result/failure-method-call.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-method-call.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"split=yes origin=yes | hint=yes | value()=42\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "method calls on failures/successes throw rich catchable errors; r.value() on a function-wrapping success still works"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-basic.agency
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-basic.agency
@@ -1,0 +1,22 @@
+def getReport(id: string): Result {
+  return failure("HTTP 404: report not found")
+}
+
+def wordCount(text: string) {
+  return 999
+}
+
+def formatSummary(report: string) {
+  return "summary"
+}
+
+node main() {
+  const report = getReport("abc")
+  const count = wordCount(report)
+  const summary = formatSummary(count)
+  if (isFailure(summary)) {
+    const trail = JSON.stringify(summary.skippedFunctions)
+    return "propagated ${summary.error} via ${trail}"
+  }
+  return "no propagation"
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-basic.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-basic.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"propagated HTTP 404: report not found via [{\\\"name\\\":\\\"wordCount\\\",\\\"param\\\":\\\"text\\\"},{\\\"name\\\":\\\"formatSummary\\\",\\\"param\\\":\\\"report\\\"}]\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "a failure skips two typed/untyped params in a row and carries the two-hop trail"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-compose.agency
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-compose.agency
@@ -1,0 +1,18 @@
+def bad(): Result {
+  return failure("boom")
+}
+
+def use(s: string) {
+  return "used ${s}"
+}
+
+node main() {
+  const f = bad()
+  const withCatch = use(f) catch "fallback"
+  const withTry = try use(f)
+  let tryMsg = "try not failure"
+  if (isFailure(withTry)) {
+    tryMsg = "try failure ${withTry.error}"
+  }
+  return "${withCatch} | ${tryMsg}"
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-compose.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-compose.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"fallback | try failure boom\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "catch unwraps a propagated failure into the fallback; try passes it through unchanged"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-modes.agency
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-modes.agency
@@ -1,0 +1,50 @@
+def handle(r: Result) {
+  if (isFailure(r)) {
+    return "handled ${r.error}"
+  }
+  return "not failure"
+}
+
+def anything(x: any) {
+  if (isFailure(x)) {
+    return "any got failure"
+  }
+  return "any got value"
+}
+
+def pick(a: string, b: string) {
+  return "ran pick"
+}
+
+def gather(...items) {
+  return "ran gather"
+}
+
+node main() {
+  const f1 = failure("first")
+  const f2 = failure("second")
+
+  const viaResult = handle(f1)
+  const viaAny = anything(f1)
+
+  let leftmost = "?"
+  const picked = pick(f1, f2)
+  if (isFailure(picked)) {
+    leftmost = "${picked.error}:${JSON.stringify(picked.skippedFunctions)}"
+  }
+
+  let variadic = "?"
+  const gathered = gather("ok", f1)
+  if (isFailure(gathered)) {
+    variadic = JSON.stringify(gathered.skippedFunctions)
+  }
+
+  let bound = "?"
+  const pickA = pick.partial(a: f1)
+  const boundOut = pickA("fine")
+  if (isFailure(boundOut)) {
+    bound = JSON.stringify(boundOut.skippedFunctions)
+  }
+
+  return "${viaResult} | ${viaAny} | ${leftmost} | ${variadic} | ${bound}"
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-modes.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-modes.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"handled first | any got failure | first:[{\\\"name\\\":\\\"pick\\\",\\\"param\\\":\\\"a\\\"}] | [{\\\"name\\\":\\\"gather\\\",\\\"param\\\":\\\"items\\\"}] | [{\\\"name\\\":\\\"pick\\\",\\\"param\\\":\\\"a\\\"}]\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Result/any params accept; leftmost failure wins; variadic elements and .partial()-bound values are checked"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-print.agency
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-print.agency
@@ -1,0 +1,12 @@
+def bad(): Result {
+  return failure("boom")
+}
+
+node main() {
+  const f = bad()
+  const r = print(f)
+  if (isFailure(r)) {
+    return "print was skipped"
+  }
+  return "printed"
+}

--- a/packages/agency-lang/tests/agency/result/failure-propagation-print.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-propagation-print.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"printed\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "print accepts a failure value under the strict rule (any[] variadic annotation); a skip would flip the output"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/result/failure-ts-function.agency
+++ b/packages/agency-lang/tests/agency/result/failure-ts-function.agency
@@ -1,0 +1,33 @@
+import { tsFormat } from "./failure-helpers.js"
+
+def getF(): Result {
+  return failure("boom")
+}
+
+def callTs(v: any) {
+  return tsFormat(v)
+}
+
+node main() {
+  const f = getF()
+
+  let untagged = "?"
+  const r1 = try callTs(f)
+  if (isFailure(r1)) {
+    let hasHint = "no"
+    if (r1.error.includes("acceptsFailures")) {
+      hasHint = "yes"
+    }
+    untagged = "threw hint=${hasHint}"
+  }
+
+  const okValue = tsFormat("plain")
+
+  const check = isFailure
+  let aliased = "alias broken"
+  if (check(f)) {
+    aliased = "alias ok"
+  }
+
+  return "${untagged} | ${okValue} | ${aliased}"
+}

--- a/packages/agency-lang/tests/agency/result/failure-ts-function.test.json
+++ b/packages/agency-lang/tests/agency/result/failure-ts-function.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"threw hint=yes | formatted:plain | alias ok\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "failure into an untagged TS function throws with the acceptsFailures hint; normal values pass; aliased isFailure works because it ships pre-tagged"
+    }
+  ]
+}


### PR DESCRIPTION
## Failure propagation — Stage 2: flip the default to `"on"`

Follow-up to #489, which shipped the full mechanism with the `ExecutionContext` default at `"warn"`. This PR is the flip: one literal in `context.ts` from `?? "warn"` to `?? "on"`, plus the strict-default tests and user docs.

**This PR's CI run over the execution corpus is the rollout measurement** the spec calls for (`docs/superpowers/specs/2026-07-08-failure-propagation-design.md`, Rollout section). The fixture drift from the field addition was already cleaned up in #489, so any trip here is a genuinely new legitimate site.

### What changes for programs

A failure Result passed to a parameter not typed to accept Results (`Result`, explicit `any`, or a union containing either) now skips the call and propagates the original failure, carrying a `skippedFunctions` trail. Failures into untagged plain TypeScript functions, and method calls on Results, throw catchable errors naming the producer. `failurePropagation: "warn"` or `"off"` in `agency.json` restores the old behavior.

The frameless fallback in `failurePropagation.ts` is untouched — it was already `"on"` and serves unit tests only.

### Included

- **Task 10**: the one-literal flip + the `config.ts` docstring (now documents `"on"` as default).
- **Task 11**: nine strict-default execution tests in `tests/agency/result/` — two-hop propagation trail, accepting vs rejecting params, leftmost-rejecting-param, variadic elements, `.partial()`-bound failures, `catch`/`try` composition, method calls (including the `r.value()` own-callable exemption), untagged TS function + aliased `isFailure`, the `arr.push(failure)` regression pin, the block fail-open pin, async propagation, and the print smoke test (observable via `print`'s return value).
- **Task 12**: "Failure propagation" section in the error-handling guide (including the `acceptsFailures` escape hatch) and the config-file reference entry.

### Verification

- Full unit suite: 7736 passed.
- All nine new execution tests pass locally.
- The three agency-js mode tests (`off`/`warn`/`on`) pass — they set their mode explicitly, so the default flip does not change their outcomes.
- `tsc` and `lint:structure` clean.

### Triage protocol for CI failures here

1. A test legitimately passes a failure into an untyped param → annotate that param `any`/`Result` at the site.
2. Anything else → treat as a real bug in the mechanism; fix before merging.
3. If legitimate sites are widespread (double digits), hold this PR — main works in warn mode indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
