### PR TITLE
Cross-provider memory: assignable embedding slot wired into enableMemory with key validation

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -33,7 +33,7 @@ export type MemoryConfig = {
   model?: string;
   autoExtract?: { interval: number | null };
   compaction?: { trigger: "token" | "messages" | null; threshold: number | null };
-  embeddings?: { model: string | null }
+  embeddings?: { model: string | null; provider: string | null }
 }
 ```
 

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -702,12 +702,23 @@ def editCapabilities() {
       patch = {
         memory: picked == "on"
       }
-      if (picked == "on" && providerLacksEmbeddings(getCapabilityProvider())) {
-        pushMessage(
-          color.dim(
-          "Note: ${getCapabilityProvider()} has no embeddings endpoint — memory runs with Tier-2 semantic recall disabled (structured recall still works).",
-        ),
-        )
+      if (picked == "on") {
+        const status = embeddingKeyStatus(getResolvedSlots())
+        if (status.state == "key-missing") {
+          pushMessage(
+            color.red(
+            "Cannot enable memory: the embedding slot needs ${status.varName}, which is not set. Export it, or point the embedding slot elsewhere via /model.",
+          ),
+          )
+          return
+        }
+        if (status.state == "no-override" && providerLacksEmbeddings(getCapabilityProvider())) {
+          pushMessage(
+            color.dim(
+            "Note: ${getCapabilityProvider()} has no embeddings endpoint, so Tier-2 semantic recall stays off. Point the embedding slot at a provider that has one, e.g. /model embedding=openai/text-embedding-3-small.",
+          ),
+          )
+        }
       }
     }
   }

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -9,7 +9,7 @@ import { map } from "std::array"
 import { today } from "std::date"
 import { generateImage } from "std::image"
 import { applyAgentCwd, setAgentCwd } from "std::index"
-import { listHostedModels, hostedModelInfo, setLlmOptions, envVarFor } from "std::llm"
+import { listHostedModels, hostedModelInfo, setLlmOptions } from "std::llm"
 import { setMemoryId, disableMemory } from "std::memory"
 import { keys } from "std::object"
 import { basename, dirname } from "std::path"
@@ -57,7 +57,8 @@ import {
   BUILTIN_POLICIES,
  } from "./lib/defaultPolicy.agency"
 import { filterHostedModels, ModelFilters } from "./lib/modelFilters.agency"
-import { parseModelFlag, parseModelSpec, knownProviders, Resolved } from "./lib/models.agency"
+import { parseModelFlag, parseModelSpec, knownProviders, embeddingSpecHasProvider, missingProviderEnvVar, Resolved } from "./lib/models.agency"
+import { SLOTS } from "./lib/slots.agency"
 import {
   buildLayers,
   resolveAll,
@@ -103,7 +104,7 @@ import {
   memoryEnablePlan,
   overrideFromResolved,
   embeddingsOverride,
-  providerKeyMissing,
+  providerEnvMissing,
   demoteProvider,
  } from "./shared.agency"
 import { codeAgent, setCodeOneShot } from "./subagents/code.agency"
@@ -403,9 +404,9 @@ export def switchModel(
     slots: nextSlots
   }
   const parsed = parseModelFlag(spec)
-  if (parsed.slot != "" && parsed.slot != "main" && parsed.slot != "reasoning" && parsed.slot != "embedding") {
+  if (parsed.slot != "" && !SLOTS.includes(parsed.slot)) {
     pushMessage(
-      color.red("Unknown model slot '${parsed.slot}'. Valid slots: main, reasoning, embedding."),
+      color.red("Unknown model slot '${parsed.slot}'. Valid slots: ${SLOTS.join(", ")}."),
     )
     return {
       session: prior,
@@ -413,21 +414,18 @@ export def switchModel(
       changes: []
     }
   }
-  if (parsed.slot == "embedding") {
+  if (parsed.slot == "embedding" && !embeddingSpecHasProvider(parsed.model)) {
     // The embedding slot exists to point AWAY from the chat provider, so
     // the provider can never be inferred. Require the explicit form.
-    const spec2 = parseModelSpec(parsed.model, false, knownProviders())
-    if (spec2.provider == "") {
-      pushMessage(
-        color.red(
-        "Embedding models need the provider/model form, e.g. embedding=openai/text-embedding-3-small.",
-      ),
-      )
-      return {
-        session: prior,
-        resolved: before,
-        changes: []
-      }
+    pushMessage(
+      color.red(
+      "Embedding models need the provider/model form, e.g. embedding=openai/text-embedding-3-small.",
+    ),
+    )
+    return {
+      session: prior,
+      resolved: before,
+      changes: []
     }
   }
   if (parsed.slot == "") {
@@ -473,10 +471,11 @@ export def switchModel(
   returns when a selective toggle lands.) Returns true if it emitted the notice. */
 export def reactToSlotChange(change: SlotChange): boolean {
   if (change.slot == "main" && change.before.provider != change.after.provider) {
-    // When the embedding slot pins the embed model, a main-provider
-    // change no longer changes the embedding space behind recall, so
-    // the pause would be a false positive.
-    if (embeddingsOverride(getResolvedSlots()) != null) {
+    // Skip the pause only when startup actually enabled memory WITH the
+    // override. A set-but-keyless slot took the fallback path, so memory
+    // runs on derived embeddings and the provider change still shifts
+    // the embedding space behind recall.
+    if (_memoryEmbeddingsPinned) {
       return false
     }
     pushMessage(
@@ -491,10 +490,21 @@ export def reactToSlotChange(change: SlotChange): boolean {
   }
   if (change.slot == "embedding") {
     const override = overrideFromResolved(change.after)
-    if (override != null && providerKeyMissing(override.provider)) {
+    if (override != null) {
+      const missing = missingProviderEnvVar(override.provider)
+      if (missing != "") {
+        pushMessage(
+          color.yellow(
+          "Warning: the embedding slot needs ${missing}, which is not set. The assignment takes effect at next agent start, and memory falls back to the default embedding behavior until it is exported.",
+        ),
+        )
+        return true
+      }
+      // The healthy path must not be silent: enableMemory already ran,
+      // so the user would otherwise believe embeddings switched now.
       pushMessage(
-        color.yellow(
-        "Warning: the embedding slot needs ${envVarFor(override.provider)}, which is not set. The assignment takes effect at next agent start, and memory falls back to the default embedding behavior until the key is exported.",
+        color.dim(
+        "Embedding slot set: memory embeddings use ${override.provider}/${override.model} at next agent start.",
       ),
       )
       return true
@@ -1297,9 +1307,22 @@ static const mainAgentTools = [
   pointed the embedding slot at a provider, embeddings run there. A
   missing API key degrades to the default embedding behavior with one
   notice. It never blocks startup. */
+// Whether startup actually enabled memory WITH the embedding override.
+// The pause guard in reactToSlotChange consults this instead of
+// re-deriving from the slots: a keyless override took the fallback path,
+// so memory runs on DERIVED embeddings and a main-provider change still
+// shifts the embedding space. Exported mutator so tests can drive the
+// guard directly.
+let _memoryEmbeddingsPinned = false
+
+export def markMemoryEmbeddingsPinned(pinned: boolean) {
+  _memoryEmbeddingsPinned = pinned
+}
+
 def maybeEnableMemory() {
   const status = embeddingKeyStatus(getResolvedSlots())
   const plan = memoryEnablePlan(getCapabilities().memory, status)
+  markMemoryEmbeddingsPinned(plan == "enable-override")
   if (plan == "skip") {
     return
   }
@@ -1803,8 +1826,7 @@ node main() {
       } else if (parsed.slot == "reasoning") {
         slowFlag = parsed.model
       } else if (parsed.slot == "embedding") {
-        const spec2 = parseModelSpec(parsed.model, false, knownProviders())
-        if (spec2.provider == "") {
+        if (!embeddingSpecHasProvider(parsed.model)) {
           print(
             color.red(
             "Embedding models need the provider/model form, e.g. --model embedding=openai/text-embedding-3-small.",
@@ -1816,7 +1838,7 @@ node main() {
       } else {
         print(
           color.red(
-          "Unknown model slot '${parsed.slot}' in --model. Valid slots: main, reasoning, embedding.",
+          "Unknown model slot '${parsed.slot}' in --model. Valid slots: ${SLOTS.join(", ")}.",
         ),
         )
         process.exit(1)

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -9,7 +9,7 @@ import { map } from "std::array"
 import { today } from "std::date"
 import { generateImage } from "std::image"
 import { applyAgentCwd, setAgentCwd } from "std::index"
-import { listHostedModels, hostedModelInfo, setLlmOptions } from "std::llm"
+import { listHostedModels, hostedModelInfo, setLlmOptions, envVarFor } from "std::llm"
 import { setMemoryId, disableMemory } from "std::memory"
 import { keys } from "std::object"
 import { basename, dirname } from "std::path"
@@ -103,6 +103,7 @@ import {
   memoryEnablePlan,
   overrideFromResolved,
   embeddingsOverride,
+  providerKeyMissing,
  } from "./shared.agency"
 import { codeAgent, setCodeOneShot } from "./subagents/code.agency"
 import { explorerAgent } from "./subagents/explorer.agency"
@@ -462,6 +463,12 @@ export def switchModel(
   returns when a selective toggle lands.) Returns true if it emitted the notice. */
 export def reactToSlotChange(change: SlotChange): boolean {
   if (change.slot == "main" && change.before.provider != change.after.provider) {
+    // When the embedding slot pins the embed model, a main-provider
+    // change no longer changes the embedding space behind recall, so
+    // the pause would be a false positive.
+    if (embeddingsOverride(getResolvedSlots()) != null) {
+      return false
+    }
     pushMessage(
       color.dim(
       "Warning: provider changed - memory is paused until restart (recall would be unreliable).",
@@ -471,6 +478,17 @@ export def reactToSlotChange(change: SlotChange): boolean {
     // provider switch, not asking the user — so don't surface an approval prompt.
     disableMemory() with approve
     return true
+  }
+  if (change.slot == "embedding") {
+    const override = overrideFromResolved(change.after)
+    if (override != null && providerKeyMissing(override.provider)) {
+      pushMessage(
+        color.yellow(
+        "Warning: the embedding slot needs ${envVarFor(override.provider)}, which is not set. The assignment takes effect at next agent start, and memory falls back to the default embedding behavior until the key is exported.",
+      ),
+      )
+      return true
+    }
   }
   return false
 }

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -104,6 +104,7 @@ import {
   overrideFromResolved,
   embeddingsOverride,
   providerKeyMissing,
+  demoteProvider,
  } from "./shared.agency"
 import { codeAgent, setCodeOneShot } from "./subagents/code.agency"
 import { explorerAgent } from "./subagents/explorer.agency"
@@ -384,6 +385,15 @@ export def switchModel(
   ctx: Ctx,
   before: Record<string, Resolved>,
 ): { session: Session; resolved: Record<string, Resolved>; changes: SlotChange[] } {
+  // The caller builds ctx from currentProvider(), which returns the
+  // PROMOTED name on openai sessions. priceDefault and the built-in
+  // tables key by public provider names, so demote before resolving —
+  // otherwise a switch that lets any slot fall through to the built-in
+  // defaults fails with "openai-responses has no built-in defaults".
+  const ctx2: Ctx = {
+    provider: demoteProvider(ctx.provider),
+    price: ctx.price
+  }
   let nextSlots: Record<string, string> = {}
   for (key in Object.keys(prior.slots)) {
     nextSlots[key] = prior.slots[key]
@@ -439,7 +449,7 @@ export def switchModel(
     knownProviders(),
     providerEstablished,
   )
-  const all = resolveAll(layers, ctx)
+  const all = resolveAll(layers, ctx2)
   if (isFailure(all)) {
     pushMessage(color.red("Could not switch model: ${all.error}"))
     return {

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -99,6 +99,10 @@ import {
   getCapabilityModelKey,
   getCapabilityProvider,
   refreshCapabilities,
+  embeddingKeyStatus,
+  memoryEnablePlan,
+  overrideFromResolved,
+  embeddingsOverride,
  } from "./shared.agency"
 import { codeAgent, setCodeOneShot } from "./subagents/code.agency"
 import { explorerAgent } from "./subagents/explorer.agency"
@@ -1250,16 +1254,28 @@ static const mainAgentTools = [
   generateImageFile,
 ]
 
-/** Enable memory only when the capability profile allows it.
-
-  Providers without an embeddings endpoint default the field to off. A
-  user override still works: memory then runs with Tier-2 semantic recall
-  disabled, and std::memory prints its one-time notice. The embedding
-  slot is a no-op today, so nothing here validates against it. */
+/** Enable memory when the capability profile allows it. When the user
+  pointed the embedding slot at a provider, embeddings run there. A
+  missing API key degrades to the default embedding behavior with one
+  notice. It never blocks startup. */
 def maybeEnableMemory() {
-  if (getCapabilities().memory) {
-    enableAgentMemory()
+  const status = embeddingKeyStatus(getResolvedSlots())
+  const plan = memoryEnablePlan(getCapabilities().memory, status)
+  if (plan == "skip") {
+    return
   }
+  if (plan == "enable-override") {
+    enableAgentMemory(status.override)
+    return
+  }
+  if (plan == "enable-fallback") {
+    print(
+      color.dim(
+      "Memory: the embedding slot needs ${status.varName}, which is not set. Falling back to the default embedding behavior.",
+    ),
+    )
+  }
+  enableAgentMemory()
 }
 
 def mainAgent(prompt: string | (string | Attachment)[]): string {

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -57,7 +57,7 @@ import {
   BUILTIN_POLICIES,
  } from "./lib/defaultPolicy.agency"
 import { filterHostedModels, ModelFilters } from "./lib/modelFilters.agency"
-import { parseModelFlag, knownProviders, Resolved } from "./lib/models.agency"
+import { parseModelFlag, parseModelSpec, knownProviders, Resolved } from "./lib/models.agency"
 import {
   buildLayers,
   resolveAll,
@@ -388,14 +388,31 @@ export def switchModel(
     slots: nextSlots
   }
   const parsed = parseModelFlag(spec)
-  if (parsed.slot != "" && parsed.slot != "main" && parsed.slot != "reasoning") {
+  if (parsed.slot != "" && parsed.slot != "main" && parsed.slot != "reasoning" && parsed.slot != "embedding") {
     pushMessage(
-      color.red("Unknown model slot '${parsed.slot}'. Valid slots: main, reasoning."),
+      color.red("Unknown model slot '${parsed.slot}'. Valid slots: main, reasoning, embedding."),
     )
     return {
       session: prior,
       resolved: before,
       changes: []
+    }
+  }
+  if (parsed.slot == "embedding") {
+    // The embedding slot exists to point AWAY from the chat provider, so
+    // the provider can never be inferred. Require the explicit form.
+    const spec2 = parseModelSpec(parsed.model, false, knownProviders())
+    if (spec2.provider == "") {
+      pushMessage(
+        color.red(
+        "Embedding models need the provider/model form, e.g. embedding=openai/text-embedding-3-small.",
+      ),
+      )
+      return {
+        session: prior,
+        resolved: before,
+        changes: []
+      }
     }
   }
   if (parsed.slot == "") {
@@ -1722,6 +1739,7 @@ node main() {
     let modelGlobal = ""
     let fastFlag = ""
     let slowFlag = ""
+    let embeddingFlag = ""
     if (modelArg != "") {
       if (parsed.slot == "") {
         modelGlobal = parsed.model
@@ -1729,10 +1747,21 @@ node main() {
         fastFlag = parsed.model
       } else if (parsed.slot == "reasoning") {
         slowFlag = parsed.model
+      } else if (parsed.slot == "embedding") {
+        const spec2 = parseModelSpec(parsed.model, false, knownProviders())
+        if (spec2.provider == "") {
+          print(
+            color.red(
+            "Embedding models need the provider/model form, e.g. --model embedding=openai/text-embedding-3-small.",
+          ),
+          )
+          process.exit(1)
+        }
+        embeddingFlag = parsed.model
       } else {
         print(
           color.red(
-          "Unknown model slot '${parsed.slot}' in --model. Valid slots: main, reasoning.",
+          "Unknown model slot '${parsed.slot}' in --model. Valid slots: main, reasoning, embedding.",
         ),
         )
         process.exit(1)
@@ -1746,7 +1775,7 @@ node main() {
     if (sm != "") {
       slowFlag = sm
     }
-    configureModels(modelGlobal, fastFlag, slowFlag, args.flags.provider ?? "")
+    configureModels(modelGlobal, fastFlag, slowFlag, embeddingFlag, args.flags.provider ?? "")
     configureSearch(false)
   }
 

--- a/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/config.agency
@@ -18,7 +18,9 @@ export static const HISTORY_FILE = "history"
 // set-but-empty var, and without the guard every derived path would
 // silently become cwd-relative (a stray `settings.json` written into —
 // or read from — whatever directory the agent runs in).
-def resolveAgentHome(override: string | null): string {
+// Exported: shared.agency expresses the memory dir through this same
+// resolver, so the two agent-home decisions cannot drift.
+export def resolveAgentHome(override: string | null): string {
   if (override == null || override == "") {
     return path.join(os.homedir(), ".agency-agent")
   }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/models.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/models.agency
@@ -66,24 +66,44 @@ static const BASE_URL_PROVIDERS: Record<string, string> = {
   litellm: "LITELLM_BASE_URL"
 }
 
-/** Verify a provider's required env config is present. Checks the API-key
- *  var (via `envVarFor`) and, for proxy providers, the base-URL var. A
- *  truly-custom/local provider (no recognized key var, no base-URL
- *  requirement) passes through untouched, so `--provider llama-cpp --model
- *  x.gguf` still needs no hosted key. Returns the provider on success or a
- *  ready-to-print failure. */
-def checkProviderEnv(provider: string): Result<string> {
+/** The first env var the provider requires that the environment leaves
+ *  unset or empty, or "" when the provider is fully configured. Checks the
+ *  API-key var, then the base-URL var for proxy providers. A truly-custom
+ *  or local provider requires nothing and always returns "". The single
+ *  home of "is this provider usable" — checkProviderEnv and the memory
+ *  embedding validation both consume it. */
+export def missingProviderEnvVar(provider: string): string {
   const varName = envVarFor(provider)
   if (varName != "" && (env(varName) == null || env(varName) == "")) {
-    return failure("No API key for provider '${provider}'. Set ${varName}.")
+    return varName
   }
   const baseVar = BASE_URL_PROVIDERS[provider]
   if (baseVar != undefined && (env(baseVar) == null || env(baseVar) == "")) {
-    return failure(
-      "Provider '${provider}' needs a base URL. Set ${baseVar} (your proxy URL).",
-    )
+    return baseVar
   }
-  return success(provider)
+  return ""
+}
+
+/** Verify a provider's required env config is present. Returns the
+ *  provider on success or a ready-to-print failure naming the var. */
+def checkProviderEnv(provider: string): Result<string> {
+  const missing = missingProviderEnvVar(provider)
+  if (missing == "") {
+    return success(provider)
+  }
+  if (missing == envVarFor(provider)) {
+    return failure("No API key for provider '${provider}'. Set ${missing}.")
+  }
+  return failure(
+    "Provider '${provider}' needs a base URL. Set ${missing} (your proxy URL).",
+  )
+}
+
+/** True when an embedding slot value carries its required provider
+ *  prefix. The rule lives once; /model, --model, and settings sanitize
+ *  all consume it. */
+export def embeddingSpecHasProvider(value: string): boolean {
+  return parseModelSpec(value, false, knownProviders()).provider != ""
 }
 
 // The agent always uses the OpenAI Responses API (not Chat Completions) for

--- a/packages/agency-lang/lib/agents/agency-agent/lib/models.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/models.agency
@@ -273,6 +273,20 @@ export def priceDefault(
   slot: string,
   price: string,
 ): Result<Resolved> {
+  // The derived default is provider-independent, so it must not gate on
+  // the MODELS lookup. Before this ordering, a bare /model pin on an
+  // openai session failed: pins skip derived slots, the embedding slot
+  // fell through to here, and the promoted "openai-responses" ctx
+  // provider has no MODELS entry.
+  if (slotKind(slot) == "derived") {
+    return success(
+      {
+      model: "",
+      provider: "",
+      via: "built-in:embedding(derived)"
+    },
+    )
+  }
   if (MODELS[provider] == null) {
     return failure(
       "Provider '${provider}' has no built-in defaults; pass an explicit model.",

--- a/packages/agency-lang/lib/agents/agency-agent/lib/resolution.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/resolution.agency
@@ -4,7 +4,7 @@
 import { keys } from "std::object"
 import { Resolved, priceDefault, parseModelSpec } from "./models.agency"
 import { ModelSettings } from "./settings.agency"
-import { canonicalSlot, SLOTS } from "./slots.agency"
+import { canonicalSlot, slotKind, SLOTS } from "./slots.agency"
 
 export type SlotValue = {
   model: string;
@@ -28,8 +28,15 @@ export type SlotChange = {
   after: Resolved
 }
 
-def finalProvider(value: SlotValue, ctx: Ctx): string {
+def finalProvider(slot: string, value: SlotValue, ctx: Ctx): string {
   if (value.provider == "") {
+    // Derived slots never inherit the main provider. The embedding slot
+    // exists to point somewhere ELSE, so inheriting is exactly wrong;
+    // an empty provider means "not usable" and downstream treats the
+    // slot as unset.
+    if (slotKind(slot) == "derived") {
+      return ""
+    }
     return ctx.provider
   }
   return value.provider
@@ -46,16 +53,19 @@ export def resolveSlot(
       return success(
         {
         model: perSlotValue.model,
-        provider: finalProvider(perSlotValue, ctx),
+        provider: finalProvider(slot, perSlotValue, ctx),
         via: "${layer.name}:per-slot"
       },
       )
     }
-    if (layer.pin != null) {
+    // A global pin names a chat model, so it must not splash into a
+    // derived slot. Without this guard, --model claude-opus-4-8 would
+    // become the memory embedding model.
+    if (layer.pin != null && slotKind(slot) != "derived") {
       return success(
         {
         model: layer.pin.model,
-        provider: finalProvider(layer.pin, ctx),
+        provider: finalProvider(slot, layer.pin, ctx),
         via: "${layer.name}:global-pin"
       },
       )
@@ -66,7 +76,7 @@ export def resolveSlot(
     return builtin
   }
   const resolved = builtin.value
-  if (resolved.provider == "") {
+  if (resolved.provider == "" && slotKind(slot) != "derived") {
     // Return a new object rather than mutating priceDefault's result, so this
     // stays pure and cannot alias a reused default.
     return success(
@@ -114,7 +124,12 @@ def slotMapToValues(
 ): Record<string, SlotValue> {
   let output: Record<string, SlotValue> = {}
   for (key in Object.keys(slots)) {
-    output[canonicalSlot(key)] = parseSlotValue(slots[key], providers, providerEstablished)
+    const canonical = canonicalSlot(key)
+    // A derived slot's value always parses its provider prefix. An
+    // established provider describes the CHAT session, and the whole
+    // point of a derived slot is to point somewhere else.
+    const established = providerEstablished && slotKind(canonical) != "derived"
+    output[canonical] = parseSlotValue(slots[key], providers, established)
   }
   return output
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/settings.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/settings.agency
@@ -24,6 +24,7 @@ import { exists } from "std::shell"
 
 import { SETTINGS_PATH, POLICY_DIR, SETTINGS_FILE } from "./config.agency"
 import { CapabilitySettings, sanitizeCapabilitySettings } from "./capabilities.agency"
+import { parseModelSpec, knownProviders } from "./models.agency"
 import { isKnownSlot, canonicalSlot } from "./slots.agency"
 
 
@@ -58,13 +59,25 @@ export def sanitizeModelSettings(settings: ModelSettings): ModelSettings {
   }
   let kept: Record<string, string> = {}
   for (key in Object.keys(slots)) {
-    if (isKnownSlot(key)) {
-      kept[canonicalSlot(key)] = slots[key]
-    } else {
+    if (!isKnownSlot(key)) {
       print(
         "Warning: settings.json model.slots has unknown slot '${key}'; ignoring it.",
       )
+      continue
     }
+    const canonical = canonicalSlot(key)
+    if (canonical == "embedding") {
+      // The embedding slot points away from the chat provider, so its
+      // provider can never be inferred. Require the explicit form.
+      const spec = parseModelSpec(slots[key], false, knownProviders())
+      if (spec.provider == "") {
+        print(
+          "Warning: settings.json model.slots.embedding needs the provider/model form, e.g. openai/text-embedding-3-small; ignoring it.",
+        )
+        continue
+      }
+    }
+    kept[canonical] = slots[key]
   }
   return {
     ...settings,

--- a/packages/agency-lang/lib/agents/agency-agent/lib/settings.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/settings.agency
@@ -24,7 +24,7 @@ import { exists } from "std::shell"
 
 import { SETTINGS_PATH, POLICY_DIR, SETTINGS_FILE } from "./config.agency"
 import { CapabilitySettings, sanitizeCapabilitySettings } from "./capabilities.agency"
-import { parseModelSpec, knownProviders } from "./models.agency"
+import { embeddingSpecHasProvider } from "./models.agency"
 import { isKnownSlot, canonicalSlot } from "./slots.agency"
 
 
@@ -66,16 +66,13 @@ export def sanitizeModelSettings(settings: ModelSettings): ModelSettings {
       continue
     }
     const canonical = canonicalSlot(key)
-    if (canonical == "embedding") {
+    if (canonical == "embedding" && !embeddingSpecHasProvider(slots[key])) {
       // The embedding slot points away from the chat provider, so its
       // provider can never be inferred. Require the explicit form.
-      const spec = parseModelSpec(slots[key], false, knownProviders())
-      if (spec.provider == "") {
-        print(
-          "Warning: settings.json model.slots.embedding needs the provider/model form, e.g. openai/text-embedding-3-small; ignoring it.",
-        )
-        continue
-      }
+      print(
+        "Warning: settings.json model.slots.embedding needs the provider/model form, e.g. openai/text-embedding-3-small; ignoring it.",
+      )
+      continue
     }
     kept[canonical] = slots[key]
   }

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -58,7 +58,14 @@ export def resolveMaxToolCallRounds(
 // agency-lang#230. Falls back to `.` if `HOME` is unset (rare; mostly
 // a Windows concern — the `.` puts the dir under cwd as a last
 // resort instead of crashing module init).
-def computeAgentDir(): string {
+export def computeAgentDir(): string {
+  // The sandbox variable wins, matching POLICY_DIR in lib/config.agency.
+  // Before this check, sandboxed agent tests wrote to the real
+  // ~/.agency-agent/memory while settings and policy stayed sandboxed.
+  const sandbox = env("AGENCY_AGENT_HOME")
+  if (sandbox != null && sandbox != "") {
+    return sandbox
+  }
   const home = env("HOME")
   if (home == null) {
     return "./.agency-agent"

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -198,6 +198,13 @@ export def promoteAll(
     if (resolved == null) {
       continue
     }
+    // The promotion exists for chat calls, which need the Responses API
+    // for hosted web search. A derived slot names an embed endpoint, so
+    // it keeps its public provider name.
+    if (slotKind(slot) == "derived") {
+      promoted[slot] = resolved
+      continue
+    }
     promoted[slot] = {
       model: resolved.model,
       provider: promoteProvider(resolved.provider),
@@ -262,6 +269,7 @@ export def configureModels(
   model: string,
   fast: string,
   slow: string,
+  embedding: string,
   provider: string,
 ) {
   const settings = getModelSettings(loadSettings())
@@ -289,6 +297,9 @@ export def configureModels(
     price: "standard"
   }
   let cliSlots: Record<string, string> = {}
+  if (embedding != "") {
+    cliSlots["embedding"] = embedding
+  }
   if (fast != "") {
     cliSlots["main"] = fast
   }

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -86,14 +86,13 @@ export static const AGENCY_AGENT_DIR = computeAgentDir()
 // local run works fine without it. Calling `enableMemory(...)` from `main()`
 // is the documented pattern (see `stdlib/memory.agency`); `with approve`
 // auto-approves the dir creation and has the enclosing step path it needs
-// inside this def. We deliberately do NOT pin `embeddings.model`: for hosted
-// providers the memory layer derives it from the active LLM provider
-// (openai → text-embedding-3-small, google → text-embedding-004,
-// ollama → nomic-embed-text). Set `embeddings.model` explicitly to override.
-export def enableAgentMemory() {
-  enableMemory({
-    dir: "${AGENCY_AGENT_DIR}/memory"
-  }) with approve
+// inside this def. By default the memory layer derives the embedding
+// model from the active LLM provider (openai → text-embedding-3-small,
+// google → text-embedding-004, ollama → nomic-embed-text). When the user
+// assigned the embedding slot, the caller passes the override and memory
+// embeddings run on that model and provider instead.
+export def enableAgentMemory(embeddings: (EmbeddingsOverride | null) = null) {
+  enableMemory(memoryConfigFor(embeddings)) with approve
 }
 
 // The slow ("deep reasoning") model + its provider, set once by

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -20,8 +20,9 @@ import {
   Capabilities,
   ResolvedCapabilities,
  } from "./lib/capabilities.agency"
-import { resolveDetected, knownProviders, Resolved } from "./lib/models.agency"
+import { resolveDetected, knownProviders, missingProviderEnvVar, Resolved } from "./lib/models.agency"
 import { resolveAll, buildLayers, Ctx } from "./lib/resolution.agency"
+import { resolveAgentHome } from "./lib/config.agency"
 import { getCapabilitySettings, getModelSettings, loadSettings } from "./lib/settings.agency"
 import { slotKind } from "./lib/slots.agency"
 
@@ -59,18 +60,10 @@ export def resolveMaxToolCallRounds(
 // a Windows concern — the `.` puts the dir under cwd as a last
 // resort instead of crashing module init).
 export def computeAgentDir(): string {
-  // The sandbox variable wins, matching POLICY_DIR in lib/config.agency.
-  // Before this check, sandboxed agent tests wrote to the real
-  // ~/.agency-agent/memory while settings and policy stayed sandboxed.
-  const sandbox = env("AGENCY_AGENT_HOME")
-  if (sandbox != null && sandbox != "") {
-    return sandbox
-  }
-  const home = env("HOME")
-  if (home == null) {
-    return "./.agency-agent"
-  }
-  return "${home}/.agency-agent"
+  // One resolver for the agent home: settings, policy, history, and the
+  // memory dir all go through resolveAgentHome, so the sandbox variable
+  // and the home fallback cannot drift between them.
+  return resolveAgentHome(env("AGENCY_AGENT_HOME"))
 }
 
 export static const AGENCY_AGENT_DIR = computeAgentDir()
@@ -173,16 +166,11 @@ export def embeddingsOverride(
   return overrideFromResolved(slots["embedding"])
 }
 
-/** True when the provider has a known API-key variable and the
-  environment leaves it unset or empty. Providers without a known
-  variable never report missing. */
-export def providerKeyMissing(provider: string): boolean {
-  const varName = envVarFor(provider)
-  if (varName == "") {
-    return false
-  }
-  const value = env(varName)
-  return value == null || value == ""
+/** True when the provider requires env configuration that is unset —
+  the API-key var, or the base-URL var for proxy providers. Providers
+  that require nothing never report missing. */
+export def providerEnvMissing(provider: string): boolean {
+  return missingProviderEnvVar(provider) != ""
 }
 
 /** The embedding-key question, answered once. Every checkpoint that
@@ -205,17 +193,18 @@ export def embeddingKeyStatus(
       varName: ""
     }
   }
-  if (providerKeyMissing(override.provider)) {
+  const missing = missingProviderEnvVar(override.provider)
+  if (missing != "") {
     return {
       state: "key-missing",
       override: override,
-      varName: envVarFor(override.provider)
+      varName: missing
     }
   }
   return {
     state: "ready",
     override: override,
-    varName: envVarFor(override.provider)
+    varName: ""
   }
 }
 
@@ -243,13 +232,14 @@ export def memoryEnablePlan(
 export def memoryConfigFor(
   embeddings: (EmbeddingsOverride | null),
 ): MemoryConfig {
+  const dir = "${AGENCY_AGENT_DIR}/memory"
   if (embeddings == null) {
     return {
-      dir: "${AGENCY_AGENT_DIR}/memory"
+      dir: dir
     }
   }
   return {
-    dir: "${AGENCY_AGENT_DIR}/memory",
+    dir: dir,
     embeddings: {
       model: embeddings.model,
       provider: embeddings.provider

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -11,8 +11,8 @@
  */
 import { registerLocalModel } from "std::agency/local"
 import { keys } from "std::object"
-import { setLlmOptions } from "std::llm"
-import { enableMemory } from "std::memory"
+import { setLlmOptions, envVarFor } from "std::llm"
+import { enableMemory, MemoryConfig } from "std::memory"
 import { env } from "std::system"
 
 import {
@@ -140,6 +140,122 @@ export def demoteProvider(provider: string): string {
     return "openai"
   }
   return provider
+}
+
+
+/** The embedding slot's model and provider, demoted. */
+export type EmbeddingsOverride = {
+  model: string;
+  provider: string
+}
+
+/** Map one resolved slot value to an embeddings override. Null when the
+  value is absent, its model is empty, or its provider is empty. The
+  provider comes out demoted as belt-and-braces; promoteAll already
+  exempts derived slots, so demotion is normally a no-op here. This is
+  the single home of that rule. embeddingsOverride and reactToSlotChange
+  both use it. */
+export def overrideFromResolved(
+  resolved: (Resolved | null),
+): (EmbeddingsOverride | null) {
+  if (resolved == null || resolved.model == "" || resolved.provider == "") {
+    return null
+  }
+  return {
+    model: resolved.model,
+    provider: demoteProvider(resolved.provider)
+  }
+}
+
+/** The embeddings override from the resolved slots, or null. */
+export def embeddingsOverride(
+  slots: Record<string, Resolved>,
+): (EmbeddingsOverride | null) {
+  return overrideFromResolved(slots["embedding"])
+}
+
+/** True when the provider has a known API-key variable and the
+  environment leaves it unset or empty. Providers without a known
+  variable never report missing. */
+export def providerKeyMissing(provider: string): boolean {
+  const varName = envVarFor(provider)
+  if (varName == "") {
+    return false
+  }
+  const value = env(varName)
+  return value == null || value == ""
+}
+
+/** The embedding-key question, answered once. Every checkpoint that
+  needs "is the embedding slot usable right now" consumes this instead
+  of re-deriving override plus demotion plus key check. */
+export type EmbeddingKeyStatus = {
+  state: ("no-override" | "key-missing" | "ready");
+  override: (EmbeddingsOverride | null);
+  varName: string
+}
+
+export def embeddingKeyStatus(
+  slots: Record<string, Resolved>,
+): EmbeddingKeyStatus {
+  const override = embeddingsOverride(slots)
+  if (override == null) {
+    return {
+      state: "no-override",
+      override: null,
+      varName: ""
+    }
+  }
+  if (providerKeyMissing(override.provider)) {
+    return {
+      state: "key-missing",
+      override: override,
+      varName: envVarFor(override.provider)
+    }
+  }
+  return {
+    state: "ready",
+    override: override,
+    varName: envVarFor(override.provider)
+  }
+}
+
+/** Decide how maybeEnableMemory should enable memory. Pure, so the
+  branching is testable without the environment or the memory runtime. */
+export def memoryEnablePlan(
+  memoryOn: boolean,
+  status: EmbeddingKeyStatus,
+): ("skip" | "enable-default" | "enable-fallback" | "enable-override") {
+  if (!memoryOn) {
+    return "skip"
+  }
+  if (status.state == "no-override") {
+    return "enable-default"
+  }
+  if (status.state == "key-missing") {
+    return "enable-fallback"
+  }
+  return "enable-override"
+}
+
+/** Build the enableMemory config. Extracted so a test can assert the
+  wiring seam: the override reaches the config, and null keeps the
+  default shape. */
+export def memoryConfigFor(
+  embeddings: (EmbeddingsOverride | null),
+): MemoryConfig {
+  if (embeddings == null) {
+    return {
+      dir: "${AGENCY_AGENT_DIR}/memory"
+    }
+  }
+  return {
+    dir: "${AGENCY_AGENT_DIR}/memory",
+    embeddings: {
+      model: embeddings.model,
+      provider: embeddings.provider
+    }
+  }
 }
 
 // Capability profile for the current main model. refreshCapabilities()

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentDir.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentDir.agency
@@ -1,0 +1,17 @@
+import { setEnv } from "std::system"
+
+import { computeAgentDir } from "../shared.agency"
+
+// The memory dir must follow the sandbox variable, like settings and
+// policy do. Before this fix, sandboxed agent tests wrote to the real
+// ~/.agency-agent/memory. AGENCY_AGENT_DIR is a module-init static, so
+// this calls the def directly; a sandboxed process sets the variable
+// before launch.
+node agentDirHonorsSandbox(): string {
+  setEnv("AGENCY_AGENT_HOME", "/tmp/agency-sandbox-test") with approve
+  const sandboxed = computeAgentDir()
+  setEnv("AGENCY_AGENT_HOME", "") with approve
+  const normal = computeAgentDir()
+  const backToHome = normal != "/tmp/agency-sandbox-test"
+  return "${sandboxed}/${backToHome}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentDir.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentDir.agency
@@ -12,6 +12,9 @@ node agentDirHonorsSandbox(): string {
   const sandboxed = computeAgentDir()
   setEnv("AGENCY_AGENT_HOME", "") with approve
   const normal = computeAgentDir()
-  const backToHome = normal != "/tmp/agency-sandbox-test"
+  // endsWith pins the empty-counts-as-unset rule: both real fallbacks end
+  // with the dir name, and the empty string a dropped guard would return
+  // does not.
+  const backToHome = normal.endsWith(".agency-agent")
   return "${sandboxed}/${backToHome}"
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentDir.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentDir.test.json
@@ -1,0 +1,15 @@
+{
+  "sourceFile": "agentDir.agency",
+  "tests": [
+    {
+      "nodeName": "agentDirHonorsSandbox",
+      "input": "",
+      "expectedOutput": "\"/tmp/agency-sandbox-test/true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
@@ -21,6 +21,7 @@ import {
   SlotChange,
  } from "../lib/resolution.agency"
 import { saveSettings } from "../lib/settings.agency"
+import { setEnv } from "std::system"
 import { applyResolved, getResolvedSlots, promoteAll } from "../shared.agency"
 
 node respondsToAMessage(): boolean {
@@ -271,4 +272,78 @@ node pinDoesNotReachEmbedding(): string {
     return "empty"
   }
   return "leaked: ${resolved.model}"
+}
+
+// A keyless embedding assignment warns. The openai-responses case pins
+// the demotion: without it, envVarFor gets the internal alias, returns
+// "", and the warning never fires.
+node reactWarnsOnKeylessEmbeddingSlot(): string {
+  setEnv("OPENAI_API_KEY", "") with approve
+  const change: SlotChange = {
+    slot: "embedding",
+    before: {
+      model: "",
+      provider: "",
+      via: "x"
+    },
+    after: {
+      model: "text-embedding-3-small",
+      provider: "openai-responses",
+      via: "y"
+    }
+  }
+  const warned = reactToSlotChange(change)
+  setEnv("OPENAI_API_KEY", "test-key") with approve
+  const quiet = reactToSlotChange(change)
+  return "${warned}/${quiet}"
+}
+
+// Clearing the slot never warns, even when a key is missing.
+node reactStaysQuietOnClearedEmbeddingSlot(): boolean {
+  setEnv("OPENAI_API_KEY", "") with approve
+  const change: SlotChange = {
+    slot: "embedding",
+    before: {
+      model: "text-embedding-3-small",
+      provider: "openai",
+      via: "x"
+    },
+    after: {
+      model: "",
+      provider: "",
+      via: "y"
+    }
+  }
+  return reactToSlotChange(change)
+}
+
+// A main-provider change does not pause memory when the embedding slot
+// pins the embed model.
+node mainProviderChangeSkipsPauseWithPinnedEmbedding(): boolean {
+  applyResolved({
+    "main": {
+      model: "claude-sonnet-4-6",
+      provider: "anthropic",
+      via: "test"
+    },
+    "embedding": {
+      model: "text-embedding-3-small",
+      provider: "openai",
+      via: "test"
+    }
+  })
+  const change: SlotChange = {
+    slot: "main",
+    before: {
+      model: "claude-sonnet-4-6",
+      provider: "anthropic",
+      via: "x"
+    },
+    after: {
+      model: "gpt-5.5",
+      provider: "openai-responses",
+      via: "y"
+    }
+  }
+  return reactToSlotChange(change)
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
@@ -84,8 +84,10 @@ static const SWITCH_BEFORE: Record<string, Resolved> = {
     via: "x"
   },
   embedding: {
+    // Derived slots never inherit the ctx provider under the resolution
+    // rules, so the resolved shape carries an empty provider.
     model: "",
-    provider: "anthropic",
+    provider: "",
     via: "x"
   }
 }
@@ -233,4 +235,40 @@ node parseModelsProviderArg(): boolean {
 node parseModelsTrailingSpaceIsEmpty(): boolean {
   const filters = parseModelsFilters("/models   ")
   return filters.provider == null
+}
+
+// The embedding slot accepts the provider/model form and resolves both
+// parts. Promotion must not touch the embed provider: promoteAll exempts
+// derived slots, so "openai" stays "openai".
+node switchAcceptsPrefixedEmbedding(): string {
+  saveSettings({}) with approve
+  const out = switchModel(freshSession(), "embedding=openai/text-embedding-3-small", SWITCH_CTX, SWITCH_BEFORE)
+  const resolved = out.resolved["embedding"]
+  if (resolved == null) {
+    return "unresolved"
+  }
+  return "${resolved.model}/${resolved.provider}"
+}
+
+// A bare embedding model is refused and nothing changes.
+node switchRejectsBareEmbedding(): string {
+  saveSettings({}) with approve
+  const out = switchModel(freshSession(), "embedding=text-embedding-3-small", SWITCH_CTX, SWITCH_BEFORE)
+  const resolved = out.resolved["embedding"]
+  let model = ""
+  if (resolved != null) {
+    model = resolved.model
+  }
+  return "${model}|${out.changes.length}"
+}
+
+// A global pin must not splash into the embedding slot.
+node pinDoesNotReachEmbedding(): string {
+  saveSettings({}) with approve
+  const out = switchModel(freshSession(), "claude-opus-4-8", SWITCH_CTX, SWITCH_BEFORE)
+  const resolved = out.resolved["embedding"]
+  if (resolved == null || resolved.model == "") {
+    return "empty"
+  }
+  return "leaked: ${resolved.model}"
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
@@ -11,6 +11,7 @@ import {
   agentReply,
   switchModel,
   reactToSlotChange,
+  markMemoryEmbeddingsPinned,
   Session,
  } from "../agent.agency"
 import { knownProviders, Resolved } from "../lib/models.agency"
@@ -274,9 +275,10 @@ node pinDoesNotReachEmbedding(): string {
   return "leaked: ${resolved.model}"
 }
 
-// A keyless embedding assignment warns. The openai-responses case pins
-// the demotion: without it, envVarFor gets the internal alias, returns
-// "", and the warning never fires.
+// A keyless embedding assignment warns; a healthy one prints the
+// next-start notice instead of staying silent. Both return true. The
+// openai-responses case pins the demotion: without it, the env-var
+// lookup gets the internal alias and neither message fires.
 node reactWarnsOnKeylessEmbeddingSlot(): string {
   setEnv("OPENAI_API_KEY", "") with approve
   const change: SlotChange = {
@@ -294,8 +296,8 @@ node reactWarnsOnKeylessEmbeddingSlot(): string {
   }
   const warned = reactToSlotChange(change)
   setEnv("OPENAI_API_KEY", "test-key") with approve
-  const quiet = reactToSlotChange(change)
-  return "${warned}/${quiet}"
+  const noticed = reactToSlotChange(change)
+  return "${warned}/${noticed}"
 }
 
 // Clearing the slot never warns, even when a key is missing.
@@ -317,9 +319,32 @@ node reactStaysQuietOnClearedEmbeddingSlot(): boolean {
   return reactToSlotChange(change)
 }
 
-// A main-provider change does not pause memory when the embedding slot
-// pins the embed model.
+static const MAIN_PROVIDER_CHANGE: SlotChange = {
+  slot: "main",
+  before: {
+    model: "claude-sonnet-4-6",
+    provider: "anthropic",
+    via: "x"
+  },
+  after: {
+    model: "gpt-5.5",
+    provider: "openai-responses",
+    via: "y"
+  }
+}
+
+// The pause is skipped only when startup actually enabled memory WITH
+// the override, recorded by the pinned flag.
 node mainProviderChangeSkipsPauseWithPinnedEmbedding(): boolean {
+  markMemoryEmbeddingsPinned(true)
+  return reactToSlotChange(MAIN_PROVIDER_CHANGE)
+}
+
+// The failure case the flag exists for: a set-but-keyless slot took the
+// fallback path at startup, so memory runs on DERIVED embeddings and the
+// provider change still shifts the embedding space. The pause must fire.
+node mainProviderChangeStillPausesWhenOverrideFellBack(): boolean {
+  markMemoryEmbeddingsPinned(false)
   applyResolved({
     "main": {
       model: "claude-sonnet-4-6",
@@ -332,20 +357,7 @@ node mainProviderChangeSkipsPauseWithPinnedEmbedding(): boolean {
       via: "test"
     }
   })
-  const change: SlotChange = {
-    slot: "main",
-    before: {
-      model: "claude-sonnet-4-6",
-      provider: "anthropic",
-      via: "x"
-    },
-    after: {
-      model: "gpt-5.5",
-      provider: "openai-responses",
-      via: "y"
-    }
-  }
-  return reactToSlotChange(change)
+  return reactToSlotChange(MAIN_PROVIDER_CHANGE)
 }
 
 // Regression: a bare pin on an openai session. currentProvider() hands

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.agency
@@ -347,3 +347,40 @@ node mainProviderChangeSkipsPauseWithPinnedEmbedding(): boolean {
   }
   return reactToSlotChange(change)
 }
+
+// Regression: a bare pin on an openai session. currentProvider() hands
+// switchModel the PROMOTED name, pins skip the embedding slot, and the
+// slot falls through to priceDefault, which used to fail with
+// "openai-responses has no built-in defaults" and revert the switch.
+node switchPinFromPromotedOpenaiSession(): string {
+  saveSettings({}) with approve
+  const promotedCtx: Ctx = {
+    provider: "openai-responses",
+    price: "standard"
+  }
+  const out = switchModel(freshSession(), "claude-sonnet-4-6", promotedCtx, SWITCH_BEFORE)
+  const main = out.resolved["main"]
+  const embedding = out.resolved["embedding"]
+  if (main == null || embedding == null) {
+    return "unresolved"
+  }
+  return "${main.model}/${embedding.model}|${embedding.via}"
+}
+
+// Regression: a per-slot switch on an openai session lets the OTHER chat
+// slot fall through to priceDefault. The demoted ctx must resolve it to
+// the openai built-ins instead of failing.
+node switchPerSlotFromPromotedOpenaiSession(): string {
+  saveSettings({}) with approve
+  const promotedCtx: Ctx = {
+    provider: "openai-responses",
+    price: "standard"
+  }
+  const out = switchModel(freshSession(), "reasoning=claude-opus-4-8", promotedCtx, SWITCH_BEFORE)
+  const main = out.resolved["main"]
+  const reasoning = out.resolved["reasoning"]
+  if (main == null || reasoning == null) {
+    return "unresolved"
+  }
+  return "${main.model}/${reasoning.model}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
@@ -4,25 +4,207 @@
       "nodeName": "respondsToAMessage",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "Hi from the agent!" }]
+      "llmMocks": [
+        {
+          "return": "Hi from the agent!"
+        }
+      ]
     },
-    { "nodeName": "applyResolvedSetsSlots", "input": "", "expectedOutput": "\"claude-sonnet-4-6|claude-opus-4-8|anthropic\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "promotesOpenaiProvider", "input": "", "expectedOutput": "\"openai-responses\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "switchPinsAllSlots", "input": "", "expectedOutput": "\"gpt-5.5|gpt-5.5\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "switchPerSlotOnly", "input": "", "expectedOutput": "\"claude-opus-4-8|claude-sonnet-4-6\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "switchReportsChanges", "input": "", "expectedOutput": "1", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "switchDoesNotMutatePrior", "input": "", "expectedOutput": "\"\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "switchRejectsUnknownSlot", "input": "", "expectedOutput": "\"claude-sonnet-4-6|0\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "reactNotifiesOnMainProviderChange", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "reactSilentOnSameProvider", "input": "", "expectedOutput": "false", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "modelItemsNonEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "modelItemsFilterOnlyAnthropic", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "modelItemsFilterNarrows", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "modelItemKeyIsModelName", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "parseModelsBareIsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "parseModelsProviderArg", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "parseModelsTrailingSpaceIsEmpty", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "applyResolvedSetsSlots",
+      "input": "",
+      "expectedOutput": "\"claude-sonnet-4-6|claude-opus-4-8|anthropic\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "promotesOpenaiProvider",
+      "input": "",
+      "expectedOutput": "\"openai-responses\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchPinsAllSlots",
+      "input": "",
+      "expectedOutput": "\"gpt-5.5|gpt-5.5\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchPerSlotOnly",
+      "input": "",
+      "expectedOutput": "\"claude-opus-4-8|claude-sonnet-4-6\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchReportsChanges",
+      "input": "",
+      "expectedOutput": "1",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchDoesNotMutatePrior",
+      "input": "",
+      "expectedOutput": "\"\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchRejectsUnknownSlot",
+      "input": "",
+      "expectedOutput": "\"claude-sonnet-4-6|0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "reactNotifiesOnMainProviderChange",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "reactSilentOnSameProvider",
+      "input": "",
+      "expectedOutput": "false",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modelItemsNonEmpty",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modelItemsFilterOnlyAnthropic",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modelItemsFilterNarrows",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "modelItemKeyIsModelName",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "parseModelsBareIsEmpty",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "parseModelsProviderArg",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "parseModelsTrailingSpaceIsEmpty",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchAcceptsPrefixedEmbedding",
+      "input": "",
+      "expectedOutput": "\"text-embedding-3-small/openai\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchRejectsBareEmbedding",
+      "input": "",
+      "expectedOutput": "\"|0\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "pinDoesNotReachEmbedding",
+      "input": "",
+      "expectedOutput": "\"empty\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
@@ -235,6 +235,26 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "switchPinFromPromotedOpenaiSession",
+      "input": "",
+      "expectedOutput": "\"claude-sonnet-4-6/|built-in:embedding(derived)\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "switchPerSlotFromPromotedOpenaiSession",
+      "input": "",
+      "expectedOutput": "\"gpt-4o-mini/claude-opus-4-8\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
@@ -209,7 +209,7 @@
     {
       "nodeName": "reactWarnsOnKeylessEmbeddingSlot",
       "input": "",
-      "expectedOutput": "\"true/false\"",
+      "expectedOutput": "\"true/true\"",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -250,6 +250,16 @@
       "nodeName": "switchPerSlotFromPromotedOpenaiSession",
       "input": "",
       "expectedOutput": "\"gpt-4o-mini/claude-opus-4-8\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "mainProviderChangeStillPausesWhenOverrideFellBack",
+      "input": "",
+      "expectedOutput": "true",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/agentTurn.test.json
@@ -205,6 +205,36 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "reactWarnsOnKeylessEmbeddingSlot",
+      "input": "",
+      "expectedOutput": "\"true/false\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "reactStaysQuietOnClearedEmbeddingSlot",
+      "input": "",
+      "expectedOutput": "false",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "mainProviderChangeSkipsPauseWithPinnedEmbedding",
+      "input": "",
+      "expectedOutput": "false",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.agency
@@ -1,0 +1,129 @@
+import { setEnv } from "std::system"
+
+import {
+  overrideFromResolved,
+  embeddingsOverride,
+  providerKeyMissing,
+  embeddingKeyStatus,
+  memoryEnablePlan,
+  memoryConfigFor,
+  EmbeddingKeyStatus,
+ } from "../shared.agency"
+
+// The override maps the slot value and demotes the provider.
+node overrideFromSlot(): string {
+  const override = embeddingsOverride({
+    "embedding": {
+      model: "text-embedding-3-small",
+      provider: "openai-responses",
+      via: "test"
+    }
+  })
+  if (override == null) {
+    return "null"
+  }
+  return "${override.model}/${override.provider}"
+}
+
+// Empty model, empty provider, and an absent slot all mean unset. The
+// checks are explicit so a wrong non-null result cannot pin itself
+// into the fixture.
+node overrideNullCases(): string {
+  const emptyModel = overrideFromResolved({
+    model: "",
+    provider: "llama-cpp",
+    via: "local"
+  })
+  const emptyProvider = overrideFromResolved({
+    model: "text-embedding-3-small",
+    provider: "",
+    via: "settings"
+  })
+  const absent = embeddingsOverride({})
+  if (emptyModel == null && emptyProvider == null && absent == null) {
+    return "all-null"
+  }
+  return "not-null"
+}
+
+// setEnv makes the key check deterministic. A set key is present, an
+// empty key is missing, and unknown providers never report missing.
+// The value == null branch stays untested here: std::system has no
+// unsetEnv, and the inherited environment is machine-dependent. The
+// degraded run in the e2e task covers it.
+node keyMissingStates(): string {
+  setEnv("OPENROUTER_API_KEY", "test-key") with approve
+  const present = providerKeyMissing("openrouter")
+  setEnv("OPENROUTER_API_KEY", "") with approve
+  const missing = providerKeyMissing("openrouter")
+  const unknown = providerKeyMissing("llama-cpp")
+  return "${present}/${missing}/${unknown}"
+}
+
+// The status composes override + key check, and carries the payload the
+// checkpoints need.
+node statusStates(): string {
+  setEnv("OPENROUTER_API_KEY", "") with approve
+  const slots = {
+    "embedding": {
+      model: "some-embed",
+      provider: "openrouter",
+      via: "test"
+    }
+  }
+  const missing = embeddingKeyStatus(slots)
+  setEnv("OPENROUTER_API_KEY", "key") with approve
+  const ready = embeddingKeyStatus(slots)
+  const none = embeddingKeyStatus({})
+  return "${missing.state}:${missing.varName}/${ready.state}/${none.state}"
+}
+
+// The plan covers all four outcomes, including the precedence case
+// where memory is on, no override exists, and a stale key flag could
+// mislead a wrong implementation.
+node planOutcomes(): string {
+  const ready: EmbeddingKeyStatus = {
+    state: "ready",
+    override: {
+      model: "m",
+      provider: "openai"
+    },
+    varName: "OPENAI_API_KEY"
+  }
+  const missing: EmbeddingKeyStatus = {
+    state: "key-missing",
+    override: {
+      model: "m",
+      provider: "openai"
+    },
+    varName: "OPENAI_API_KEY"
+  }
+  const none: EmbeddingKeyStatus = {
+    state: "no-override",
+    override: null,
+    varName: ""
+  }
+  const off = memoryEnablePlan(false, ready)
+  const noSlot = memoryEnablePlan(true, none)
+  const keyless = memoryEnablePlan(true, missing)
+  const good = memoryEnablePlan(true, ready)
+  return "${off}/${noSlot}/${keyless}/${good}"
+}
+
+// The wiring seam: the override reaches the config, and null keeps the
+// default shape. This is what makes an ignored parameter in
+// enableAgentMemory fail a test instead of shipping.
+node configCarriesOverride(): string {
+  const withOverride = memoryConfigFor({
+    model: "text-embedding-3-small",
+    provider: "openai"
+  })
+  const bare = memoryConfigFor(null)
+  const embeddings = withOverride.embeddings
+  if (embeddings == null) {
+    return "override-lost"
+  }
+  const bareHasNone = bare.embeddings == null
+  const dirsMatch = withOverride.dir == bare.dir
+  return "${embeddings.model}/${embeddings.provider}/${bareHasNone}/${dirsMatch}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.agency
@@ -3,7 +3,7 @@ import { setEnv } from "std::system"
 import {
   overrideFromResolved,
   embeddingsOverride,
-  providerKeyMissing,
+  providerEnvMissing,
   embeddingKeyStatus,
   memoryEnablePlan,
   memoryConfigFor,
@@ -53,11 +53,30 @@ node overrideNullCases(): string {
 // degraded run in the e2e task covers it.
 node keyMissingStates(): string {
   setEnv("OPENROUTER_API_KEY", "test-key") with approve
-  const present = providerKeyMissing("openrouter")
+  const present = providerEnvMissing("openrouter")
   setEnv("OPENROUTER_API_KEY", "") with approve
-  const missing = providerKeyMissing("openrouter")
-  const unknown = providerKeyMissing("llama-cpp")
+  const missing = providerEnvMissing("openrouter")
+  const unknown = providerEnvMissing("llama-cpp")
   return "${present}/${missing}/${unknown}"
+}
+
+// Proxy providers also need their base URL. A litellm override with the
+// key set but no base URL is unusable, and the status names the base-URL
+// var so the notices point at the right fix.
+node baseUrlCountsAsMissing(): string {
+  setEnv("LITELLM_API_KEY", "test-key") with approve
+  setEnv("LITELLM_BASE_URL", "") with approve
+  const slots = {
+    "embedding": {
+      model: "some-embed",
+      provider: "litellm",
+      via: "test"
+    }
+  }
+  const missing = embeddingKeyStatus(slots)
+  setEnv("LITELLM_BASE_URL", "http://localhost:4000") with approve
+  const ready = embeddingKeyStatus(slots)
+  return "${missing.state}:${missing.varName}/${ready.state}"
 }
 
 // The status composes override + key check, and carries the payload the

--- a/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.test.json
@@ -1,0 +1,11 @@
+{
+  "sourceFile": "memoryWiring.agency",
+  "tests": [
+    { "nodeName": "overrideFromSlot", "input": "", "expectedOutput": "\"text-embedding-3-small/openai\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "overrideNullCases", "input": "", "expectedOutput": "\"all-null\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "keyMissingStates", "input": "", "expectedOutput": "\"false/true/false\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "statusStates", "input": "", "expectedOutput": "\"key-missing:OPENROUTER_API_KEY/ready/no-override\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "planOutcomes", "input": "", "expectedOutput": "\"skip/enable-default/enable-fallback/enable-override\"", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "configCarriesOverride", "input": "", "expectedOutput": "\"text-embedding-3-small/openai/true/true\"", "evaluationCriteria": [{ "type": "exact" }] }
+  ]
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/memoryWiring.test.json
@@ -1,11 +1,75 @@
 {
   "sourceFile": "memoryWiring.agency",
   "tests": [
-    { "nodeName": "overrideFromSlot", "input": "", "expectedOutput": "\"text-embedding-3-small/openai\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "overrideNullCases", "input": "", "expectedOutput": "\"all-null\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "keyMissingStates", "input": "", "expectedOutput": "\"false/true/false\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "statusStates", "input": "", "expectedOutput": "\"key-missing:OPENROUTER_API_KEY/ready/no-override\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "planOutcomes", "input": "", "expectedOutput": "\"skip/enable-default/enable-fallback/enable-override\"", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "configCarriesOverride", "input": "", "expectedOutput": "\"text-embedding-3-small/openai/true/true\"", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "overrideFromSlot",
+      "input": "",
+      "expectedOutput": "\"text-embedding-3-small/openai\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "overrideNullCases",
+      "input": "",
+      "expectedOutput": "\"all-null\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "keyMissingStates",
+      "input": "",
+      "expectedOutput": "\"false/true/false\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "statusStates",
+      "input": "",
+      "expectedOutput": "\"key-missing:OPENROUTER_API_KEY/ready/no-override\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "planOutcomes",
+      "input": "",
+      "expectedOutput": "\"skip/enable-default/enable-fallback/enable-override\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "configCarriesOverride",
+      "input": "",
+      "expectedOutput": "\"text-embedding-3-small/openai/true/true\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "baseUrlCountsAsMissing",
+      "input": "",
+      "expectedOutput": "\"key-missing:LITELLM_BASE_URL/ready\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/resolution.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/resolution.agency
@@ -182,3 +182,55 @@ node buildLayersImmediacyOuter(): Resolved {
   return reasoning
 }
 
+
+// Rule 1: a derived slot always parses its provider prefix, even when the
+// session provider is established. buildLayers with providerEstablished
+// true must still split the embedding value.
+node derivedSlotAlwaysParsesPrefix(): Resolved {
+  const layers = buildLayers(
+    "",
+    {},
+    "",
+    {},
+    {
+    slots: {
+      embedding: "openai/text-embedding-3-small"
+    }
+  },
+    ["anthropic", "openai", "google"],
+    true,
+  )
+  return unwrapResolved(resolveSlot("embedding", layers, CTX))
+}
+
+// Rule 2: a derived slot with no provider prefix resolves with an EMPTY
+// provider instead of inheriting the ctx provider.
+node derivedSlotNeverInheritsProvider(): Resolved {
+  const layers = buildLayers(
+    "",
+    {},
+    "",
+    {},
+    {
+    slots: {
+      embedding: "text-embedding-3-small"
+    }
+  },
+    ["anthropic", "openai", "google"],
+    false,
+  )
+  return unwrapResolved(resolveSlot("embedding", layers, CTX))
+}
+
+// Rule 3: a global pin resolves the chat slots but never the embedding
+// slot, which falls through to the built-in empty derived value.
+node pinSkipsDerivedSlot(): string {
+  let cliLayer = emptyLayer("cli")
+  cliLayer.pin = {
+    model: "claude-opus-4-8",
+    provider: ""
+  }
+  const main = unwrapResolved(resolveSlot("main", [cliLayer], CTX))
+  const embedding = unwrapResolved(resolveSlot("embedding", [cliLayer], CTX))
+  return "${main.model}/${embedding.model}|${embedding.via}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/resolution.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/resolution.test.json
@@ -1,13 +1,115 @@
 {
   "sourceFile": "resolution.agency",
   "tests": [
-    { "nodeName": "cliPinBeatsSettingsSlot", "input": "", "expectedOutput": "{\"model\":\"gpt-5.5\",\"provider\":\"anthropic\",\"via\":\"cli:global-pin\"}", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "inSessionPerSlotBeatsCli", "input": "", "expectedOutput": "{\"model\":\"a-model\",\"provider\":\"anthropic\",\"via\":\"in-session:per-slot\"}", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "inSessionPinBeatsCliPin", "input": "", "expectedOutput": "{\"model\":\"a-model\",\"provider\":\"anthropic\",\"via\":\"in-session:global-pin\"}", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "settingsPerSlotBeatsSettingsPin", "input": "", "expectedOutput": "{\"model\":\"slot-model\",\"provider\":\"anthropic\",\"via\":\"settings:per-slot\"}", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "fallsToBuiltinDefault", "input": "", "expectedOutput": "{\"model\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\",\"via\":\"built-in:price=standard\"}", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "resolveAllPropagatesFailure", "input": "", "expectedOutput": "true", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "parityMainAnthropic", "input": "", "expectedOutput": "{\"model\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\",\"via\":\"built-in:price=standard\"}", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "buildLayersImmediacyOuter", "input": "", "expectedOutput": "{\"model\":\"gpt-5.5\",\"provider\":\"anthropic\",\"via\":\"cli:global-pin\"}", "evaluationCriteria": [{ "type": "exact" }] }
+    {
+      "nodeName": "cliPinBeatsSettingsSlot",
+      "input": "",
+      "expectedOutput": "{\"model\":\"gpt-5.5\",\"provider\":\"anthropic\",\"via\":\"cli:global-pin\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "inSessionPerSlotBeatsCli",
+      "input": "",
+      "expectedOutput": "{\"model\":\"a-model\",\"provider\":\"anthropic\",\"via\":\"in-session:per-slot\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "inSessionPinBeatsCliPin",
+      "input": "",
+      "expectedOutput": "{\"model\":\"a-model\",\"provider\":\"anthropic\",\"via\":\"in-session:global-pin\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "settingsPerSlotBeatsSettingsPin",
+      "input": "",
+      "expectedOutput": "{\"model\":\"slot-model\",\"provider\":\"anthropic\",\"via\":\"settings:per-slot\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "fallsToBuiltinDefault",
+      "input": "",
+      "expectedOutput": "{\"model\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\",\"via\":\"built-in:price=standard\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "resolveAllPropagatesFailure",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "parityMainAnthropic",
+      "input": "",
+      "expectedOutput": "{\"model\":\"claude-sonnet-4-6\",\"provider\":\"anthropic\",\"via\":\"built-in:price=standard\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "buildLayersImmediacyOuter",
+      "input": "",
+      "expectedOutput": "{\"model\":\"gpt-5.5\",\"provider\":\"anthropic\",\"via\":\"cli:global-pin\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "derivedSlotAlwaysParsesPrefix",
+      "input": "",
+      "expectedOutput": "{\"model\":\"text-embedding-3-small\",\"provider\":\"openai\",\"via\":\"settings:per-slot\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "derivedSlotNeverInheritsProvider",
+      "input": "",
+      "expectedOutput": "{\"model\":\"text-embedding-3-small\",\"provider\":\"\",\"via\":\"settings:per-slot\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "pinSkipsDerivedSlot",
+      "input": "",
+      "expectedOutput": "\"claude-opus-4-8/|built-in:embedding(derived)\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/settings.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/settings.agency
@@ -163,3 +163,34 @@ node nullEntryAndReservedKeySurviveLoad(): string {
   }
   return "${models["broken"]}/${okEntry.summarize}"
 }
+
+node dropsBareEmbeddingSlotValue(): string {
+  const cleaned = sanitizeModelSettings(
+    {
+    slots: {
+      embedding: "text-embedding-3-small",
+      reasoning: "opus"
+    }
+  },
+  )
+  const slots = cleaned.slots
+  if (slots == null) {
+    return "no-slots"
+  }
+  return "${slots["embedding"]}/${slots["reasoning"]}"
+}
+
+node keepsPrefixedEmbeddingSlotValue(): string {
+  const cleaned = sanitizeModelSettings(
+    {
+    slots: {
+      embedding: "openai/text-embedding-3-small"
+    }
+  },
+  )
+  const slots = cleaned.slots
+  if (slots == null) {
+    return "no-slots"
+  }
+  return "${slots["embedding"]}"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/settings.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/settings.test.json
@@ -100,6 +100,26 @@
           "type": "exact"
         }
       ]
+    },
+    {
+      "nodeName": "dropsBareEmbeddingSlotValue",
+      "input": "",
+      "expectedOutput": "\"undefined/opus\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "keepsPrefixedEmbeddingSlotValue",
+      "input": "",
+      "expectedOutput": "\"openai/text-embedding-3-small\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -64,7 +64,7 @@ export type MemoryConfig = {
   model?: string;
   autoExtract?: { interval: number | undefined };
   compaction?: { trigger: "token" | "messages" | undefined; threshold: number | undefined };
-  embeddings?: { model: string | undefined }
+  embeddings?: { model: string | undefined; provider: string | undefined }
 }
 
 effect std::memory::enableMemory { dir: string }


### PR DESCRIPTION
## What

Cross-provider memory: point the embedding slot at one provider while chatting on another, e.g. OpenAI embeddings under a Google or Anthropic session.

- **The embedding slot is now assignable**: `/model embedding=openai/text-embedding-3-small` and the `--model` flag accept it. The value requires the `provider/model` form; bare names are refused with a message showing the form. Three new derived-slot resolution rules make the slot safe: it always parses its provider prefix even when a session provider is established, it never inherits the main provider, and a global pin never splashes into it (so `--model claude-opus-4-8` cannot become the memory embedding model). `promoteAll` exempts derived slots — the openai-responses promotion is a chat concern, and the embed endpoint uses the public provider name (the judgment call the plan flagged; recorded in the Task 1 commit).
- **The override reaches `enableMemory`** through a pure, tested seam: `embeddingKeyStatus` answers "is the slot usable" once with the payload the checkpoints need, `memoryEnablePlan` returns the enable path as a literal union, and `memoryConfigFor` builds the config so the wiring is testable. The Agency `MemoryConfig` type gains the `provider` field the TS type already had.
- **Key validation at three checkpoints**: startup degrades to default embedding behavior with one notice when the slot's key is missing; `/settings` memory-on refuses with a concrete message; `/model embedding=` warns immediately, with next-start timing stated.
- **Behavior change**: a main-provider change no longer pauses memory when the embedding slot pins the embed model — the embedding space behind recall did not change. Pinned by a test.
- **Sandbox fix**: the memory dir now honors `AGENCY_AGENT_HOME` like settings and policy. Before this, sandboxed agent tests wrote to the real `~/.agency-agent/memory`. This is what let the e2e below run fully sandboxed.

Spec: `docs/superpowers/specs/2026-07-10-cross-provider-memory-design.md` (revised after plan review — the review caught that no surface could set the slot at all, which became Task 1).

## Test plan

- 69 agent-harness tests across six suites, all green: the three resolution rules (including the pin-splash case), switchModel accept/refuse, settings sanitize of bare values, the pure helpers (override mapping + demotion, deterministic key checks via setEnv, the plan's four outcomes including the stale-flag precedence case, the config seam), the keyless-assignment warning (with an openai-responses case that pins demotion and a cleared-slot case that pins the empty-model guard), the conditional pause, and the sandbox fix. Lint and make clean.
- **Sandboxed e2e, healthy path** (Google chat + OpenAI embeddings, `AGENCY_AGENT_HOME` scratch dir): every `embedCompletion` names `text-embedding-3-small` and none name `gemini-embedding-001` — the override beat Google's own derivation, and smoltalk authenticated the embed from the environment (the spec's remaining verify-item).
- **Sandboxed e2e, degraded path** (`env -u OPENAI_API_KEY`): the fallback notice prints exactly once, the only embed event is `gemini-embedding-001` (derivation resumed), and the `memoryRecall` span shows memory stayed enabled — observed, not assumed.

## Pre-existing issues surfaced by the e2e (none caused here; diff touches none of these paths)

1. **Memory-internal LLM calls do not follow a forced provider.** Under `settings.model.provider: "google"`, the recall step and the eager thread summarizer still issued `claude-sonnet-4-6` calls (which failed: the Anthropic account is out of credits). Worth its own issue: the memory manager's internal model chain and the summarizer pick up defaults that ignore the resolved slots.
2. **Gemini extraction shape**: `remember`'s typed extraction result came back missing `expirations`, crashing the tool (`result.expirations is not iterable`). Related to the structured-output reliability track (#486).
3. Because of 1 + 2, the full remember→recall round-trip could not complete in this environment; the e2e instead proves the override contract directly through the embed events, which is what this PR owns.

## Manual items for the owner

- The `/settings` interactive smoke: memory → on with the slot set and key unset (expect the red refusal), and with no slot on an Anthropic session (expect the note naming the slot).
- `npm i -g smoltalk-llama-cpp@latest` is still pending on this machine (global copy is the Jun 27 0.1.0 build).
- The Anthropic API account is out of credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
