### PR TITLE
Add keyof and indexed access type operators

### DIFF
--- a/docs/superpowers/plans/2026-07-10-keyof-indexed-access-review.md
+++ b/docs/superpowers/plans/2026-07-10-keyof-indexed-access-review.md
@@ -1,0 +1,100 @@
+# Review: keyof + indexed access implementation plan
+
+**Date:** 2026-07-10
+**Plan:** `docs/superpowers/plans/2026-07-10-keyof-indexed-access.md`
+**Verdict:** Strong plan. It absorbed the spec review's parser findings (unionItemParser integration, full-type-expression brackets, ordering, the reserved-name set) and its verified-facts section is almost entirely accurate — I re-checked the helper names, AST shapes, Agency test syntax, and zod emission format against the code, and they all hold. Two problems block execution as written: Task 1 Step 4's parser design is internally contradictory (finding 1), and Task 2 still re-implements helpers that `builtinGenerics.ts` owns, which the spec review already flagged (finding 2). Both have small fixes.
+
+## Blocking findings
+
+### 1. Task 1 Step 4 cannot work as written: the suffix loop and the keyof operand contradict each other
+
+The step says: rework `arrayTypeParser`'s suffix from `count(str("[]"))` to a loop that stops "when neither matches", and give `keyofTypeParser` the operand `capture(lazy(() => arrayTypeParser), "operand")`. Whether the loop requires at least one suffix is left unstated, and neither choice works:
+
+- **Loop requires ≥1 suffix** (what `count` does today — it fails on zero matches, `tarsec/dist/combinators.js:79`): then `keyof User` fails to parse. The operand parser is `arrayTypeParser`, `User` has no bracket suffix, so the operand fails.
+- **Loop allows 0 suffixes:** then `arrayTypeParser` succeeds on any bare base type. Its base chain contains `typeAliasVariableParser`, and it sits BEFORE the slot the plan assigns to `keyofTypeParser` in both or-chains (position 3 in `variableTypeParser`, position 4 in `unionItemParser`). On input `keyof User`, `arrayTypeParser` matches the bare identifier `keyof` with zero suffixes and returns `typeAliasVariable("keyof")`, leaving ` User` unconsumed. `or()` commits to the first success, so `keyofTypeParser` never runs and every `keyof` annotation is a parse error one token later. The plan's ordering instruction ("before genericTypeParser, typeAliasVariableParser") misses this because those parsers are also embedded inside `arrayTypeParser`'s base chain.
+
+**Fix:** split the two roles. Extract the shared pieces: the base or-chain and a `typeSuffix` parser (`[]` → array wrap, `[<type>]` → index wrap). Then:
+
+- `arrayTypeParser` (the or-chain member, exported name unchanged) = base + **many1**(suffix). This preserves today's or-chain behavior exactly: bare types still fall through to the later alternatives, and `User["name"]` matches because the index bracket counts as the one required suffix.
+- keyof's operand = a private `postfixOperandParser` = base + **many0**(suffix). Only `keyofTypeParser` uses it, so its bare-match greediness leaks nowhere.
+
+`(keyof User)[]` still works without extra code: `parenthesizedTypeParser` is in the base chain and routes through `variableTypeParser`, which will contain `keyofTypeParser`.
+
+### 2. Task 2 re-implements what `builtinGenerics.ts` already owns (spec-review finding not absorbed)
+
+The plan's `resolveObjectOperand` is a line-for-line duplicate of `resolveObjectArg` (`lib/typeChecker/builtinGenerics.ts:105`), down to the error string. The missing-key error diverges from Pick's ("no property 'x' on the indexed type" vs Pick's "Pick key 'x' does not exist on the target type", :227) — the spec said same wording family, and shared code is how the family stays a family. `resolveKeysArg` (:120) already implements "resolve an index to literal strings."
+
+**Fix:** export `resolveObjectArg` (and `resolveKeysArg` if it fits the index-resolution shape) from `builtinGenerics.ts` and consume them in `typeOperators.ts`, parameterized by operator name. If the executor finds a concrete reason the helpers do not fit, the plan permits divergence — but say so in a comment at the divergence site, not silently. This also keeps the two "expects an object type" messages from drifting apart later.
+
+## Should-fix findings
+
+### 3. The resolver branches drop `vt.tags`
+
+Task 2 Step 3's branches call `evalKeyof(vt.operand, ...)` and discard the occurrence node's `tags`. Compare the `genericType` branch it sits next to: `evalBuiltinGeneric(vt.name, vt.typeArgs, resolve, vt.tags)` threads them through. Today no parser path sets tags on the new variants, so nothing breaks — but then the plan is declaring a `tags?: Tag[]` field that nothing writes and the resolver ignores. Pick one: thread `vt.tags` into the result with `mergeTagSets` (one line, mirrors `withUseSiteTags`), or drop the field from both variants and note why. Shipping a dead field plus an asymmetric resolver is the worst of the three options.
+
+### 4. Printer parenthesization is missing, and the round-trip tests will not catch it
+
+`formatTypeHint` prints `arrayType` as `${recurse(elementType)}[]` (`lib/utils/formatType.ts:35-36`). With a `keyofType` case that prints `keyof <operand>`, the type `(keyof User)[]` — an arrayType whose element is a keyofType — prints as `keyof User[]`, which re-parses as `keyof (User[])`. Same trap for an indexed access whose object is a parenthesized keyof. The plan's round-trip cases (`keyof User`, `User["name"]`) are both flat and will pass over the bug.
+
+**Fix:** in both printers, parenthesize a `keyofType` that appears as an array element or as an indexed-access object. Add round-trip tests for `(keyof User)[]` and `keyof User[]` (asserting they stay distinct) alongside the flat cases.
+
+### 5. Small gaps versus the spec
+
+- **The reserved-name grep is missing.** The spec requires a grep confirming no stdlib or test code uses `keyof` as an alias/identifier before reserving the keyword. Add it to Task 1 (or Global Constraints) with the command and the expectation of zero hits in `.agency` sources.
+- **Union index parse is untested.** `User["a" | "b"]` is exercised at eval level only. The suffix parser accepts it because brackets take a full `variableTypeParser`, but nothing pins that. One parse test.
+- **Optional-property indexed access is unpinned.** `foo?: T` desugars to `T | null` at parse time (`parsers.ts:1110-1137`), so `User["optionalField"]` should include null with zero new code. One pipeline case documents the interaction.
+- **`keyof UnknownAlias` behavior is unpinned.** Unknown aliases resolve to themselves (`resolveTypeWithGuard` returns `vt` when the entry is missing), so this lands in the swallowed-TypeError family: zero typecheck diagnostics, fatal at codegen. Task 2 Step 3 says "add a test rather than code if it already falls out" for reference validation — make this the named test case.
+
+## Minor notes
+
+- **"Verified facts" #11 overstates tsc's reach.** "the never-defaults catch the variant everywhere else" — they catch `typeKey` and `valueParamSubstitution` only. `formatTypeHint`'s default throws at runtime (not compile time), the zod mapper falls back silently, and the walkers pass through silently. The plan handles each site explicitly in its steps, so only the sentence needs fixing — but fix it, or the executor may trust `make` as the complete checklist.
+- **`keyof(User)` without a space will not parse** because `keyofTypeParser` requires `spaces` after the keyword. That same requirement is what makes `keyofish` fall through to an identifier, so it is a fine trade — worth one line in the parser comment so nobody "fixes" the spaces into optional and breaks the keyword boundary.
+- **The last Task 2 pipeline test's hedge is good.** `type keyof = ...` still parses (alias names come from `many1WithJoin(varNameChar)`, not the type-expression grammar), so the reserved-name check at `lib/typeChecker/index.ts:220` is what fires; the toThrow fallback note is the right kind of hedging.
+
+## Anti-pattern audit (docs/dev/anti-patterns.md)
+
+The plan's interface design passes the catalog's central test: `evalKeyof`/`evalIndexedAccess` are pure, resolver-injected functions mirroring `evalBuiltinGeneric`, the operator nodes are invisible downstream of resolution (no leaky abstraction), and the parser rework hides behind `arrayTypeParser`'s existing name. The imperative suffix loop is fine — the catalog exempts parsers, and the existing `arrayTypeParser` already uses the same mutate-and-wrap style.
+
+Two entries are tripped, and both restate findings 2 and 3 with catalog backing:
+
+- **Duplicating existing code.** `resolveObjectOperand` duplicates `resolveObjectArg` (builtinGenerics.ts:105), and the imperative core of `evalIndexedAccess` — the map callback that resolves members and validates literal-ness — duplicates `resolveKeysArg` (:120). `collectLiteralKeys` (assignability.ts:277) is already a third implementation of literal-key extraction; the plan would add a fourth.
+- **Inconsistent patterns.** The missing-key error wording diverges from Pick's for the same operation, and the new resolver branches drop `vt.tags` while the adjacent `genericType` branch threads them through.
+
+These converge on one fix: consume an exported `resolveKeysArg`, and `evalIndexedAccess` collapses to `keys = resolveKeysArg(...); results = keys.map(lookupProperty)` — declarative shape, no duplication, no wording drift, in one change.
+
+Non-findings, checked deliberately: the `length === 0` / `length === 1` returns in `evalKeyof` are not useless special cases (the parser enforces unions have ≥2 members, so unwrapping is required); no order-dependent mutable state outside parsers; no swallowed catches, nested ternaries, magic numbers, dynamic requires, or nested type definitions. The brace-less guard returns technically violate the one-line-if entry, but that guard style is pervasive in the exact files being modified (assignability.ts:52,64,72,163) and matching surrounding code wins; `lint:structure`, which the plan runs, is the arbiter.
+
+## Test-plan audit: will the tests fail when the code breaks?
+
+### Tests that cannot fail for the failure mode they exist to catch
+
+- **Task 3, "indexed-access alias emits the property schema" is a false-green.** It asserts `const N = z.string()` for `type N = User["name"]`. But the zod mapper's fallback for unresolved nodes is `DEFAULT_SCHEMA` = `z.string()` (`typeToZodSchema.ts:125-126`; the `never` case's own comment confirms the fallthrough target). If `deepResolveNode` never routes `indexedAccessType`, the unresolved node falls through to `z.string()` and the test passes anyway. The plan's own red-first step betrays this: Step 2 predicts only the `K` assertion goes red — the `N` test is born green. **Fix: index a non-string property.** `type N = User["age"]` → assert `const N = z.number()`, which the fallback cannot fake.
+- **The union-index and keyof-composition unit tests assert only `{ type: "unionType" }`.** `evalIndexedAccess(user(), idx, id)` returning the union of KEYS instead of the union of VALUES — a plausible bug, since the index is itself a union — still passes both. Assert the members: `types: [STR, { ...NUM with the validate tag }]` for the union-index case, and the concrete value types for the `T[keyof T]` composition case.
+
+### Verified strong points (checked against the code, not just the plan)
+
+- The match-missing-case test is the real safety net for silent degradation: if evaluation throws and `safeResolveType` degrades `keyof User` to `any`, exhaustiveness checking disappears and the expected `/age/` diagnostic never fires — the test fails. Positive-accept tests alone would all keep passing under `any`.
+- The indexed-annotation reject test (`= 5` expects `/not assignable/`) doubles as a crash detector: if a diagnostic formats the unresolved `indexedAccessType` and `formatTypeHint` lacks the case, its default throws (`formatType.ts:83`) and the test fails loudly.
+- The execution test's `rejects` node catches the z.string() fallback end-to-end: a fallback schema would accept `"email"`.
+- `evalKeyof`/tag tests use `toEqual` (exact), so key order, tag ride-along, and no-tags-on-keyof are all pinned, and the no-mutation test guards the resolver-input contract.
+- The `keyof number` zero-diagnostics pin is a deliberate tripwire that will fail when located diagnostics land — correct use of a pin.
+
+### Missing test cases
+
+1. **Direct negative for keyof assignability.** Every keyof pipeline test is positive-accept except the match case. Add `const k: keyof User = 12345` (or `"bogus"`) → `/not assignable/`. Cheaper and more direct than relying on the match net.
+2. **Formatter round-trip in alias position.** The spec requires round-trips "in parameter and alias positions"; the plan tests parameters only. Add `type F = keyof User` and `type N = User["name"]` through the generator.
+3. **`keyof` on a union of objects.** TypeScript distributes keyof over unions (intersection of keys); Agency v1 errors instead. That divergence is owner-decided and nothing pins it. Add the unit error case (and `keyof string[]`, which is in the spec's semantics table but absent from the unit tests — only `number` and `Record` are covered).
+4. **End-to-end tag enforcement after indexing.** The unit test checks the tag OBJECT rides along; nothing proves the `@validate` annotation still enforces at runtime once the property type is extracted (`type N = User["age"]` with a range validate; schema parse rejects an out-of-range value). The descriptor/walker codegen path (`validationDescriptor.ts`) branches on `VariableType.type` and is otherwise untested for the new variants.
+5. **Keyword-boundary regression pin.** `keyofish` parsing as a plain identifier is load-bearing (it is what the required `spaces` buys) and untested — the first person to make the whitespace optional breaks it silently.
+6. From earlier findings, still open: union-index parse (`User["a" | "b"]`), `(keyof User)[]` parse + parenthesization round-trips, `keyof UnknownAlias` swallow pin, `User["nope"]`-in-source swallow pin (only `keyof number` is pinned), optional-property indexing includes null.
+
+## Claims I verified as accurate
+
+- `typecheckSource` exists at `lib/typeChecker/testUtils.ts:20` and runs the full parse → SymbolTable → CompilationUnit → typeCheck pipeline.
+- The execution-test syntax is exactly right: `isSuccess(r)` / `r.value` / `isFailure(r)` and the JSON-wrapped `expectedOutput` match `tests/agency/utility-partial.agency` and its test.json line for line.
+- The codegen expectations match real emission: fixtures emit `const Category = z.union([z.literal("bug"), z.literal("feature"), ...])` with exactly that spacing, and `typeToZodSchema.ts:131,138` produce those forms.
+- `parseAgency(source, {}, false)` matches the signature (`lib/parser.ts:256`); `n.type === "function"` is the right discriminant; the Tag literal in the unit tests matches `lib/types/tag.ts` (`{ type, name, arguments }`).
+- Match-arm syntax `"a" => { ... }` matches existing tests (`tests/agency/goto-match-arm.agency`). Definite-returns skips functions containing match, so the exhaustive-match test's `expect(errors).toEqual([])` will not trip on a stray warning.
+- `tests/agency/utility-partial.agency` and `tests/agency/recursive-type.agency` exist, so Task 5's regression loop runs real tests.
+- The forward-reference codegen test is sound: keyof evaluates through the order-independent alias table, so `type K = keyof Later` inlines literal keys with no z.lazy needed.
+- Task 3's red-first sequencing genuinely observes the `deepResolveNode` trap before fixing it, and the fixture zero-churn gate plus the Task 5 re-runs of the utility-type and recursive-alias tests are the right guards for a change that sits on every type annotation's parse path.

--- a/docs/superpowers/plans/2026-07-10-keyof-indexed-access.md
+++ b/docs/superpowers/plans/2026-07-10-keyof-indexed-access.md
@@ -1,0 +1,981 @@
+# keyof + Indexed Access Implementation Plan — rev 2 (review applied)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (owner preference: inline execution in the main session, NOT subagent-driven). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `keyof T` and `T["key"]` type operators per the approved spec `docs/superpowers/specs/2026-07-10-keyof-indexed-access-design.md`.
+
+**Architecture:** Two new `VariableType` variants (`keyofType`, `indexedAccessType`) that exist only between parse and resolution. The parser splits into a shared base chain plus a `typeSuffix` parser; `arrayTypeParser` keeps its exported name and or-chain behavior (base + at-least-one suffix), while keyof's operand uses a private zero-or-more-suffix variant (review finding 1). Evaluation is eager in `resolveTypeWithGuard`, implemented in `lib/typeChecker/typeOperators.ts`, CONSUMING the helpers `builtinGenerics.ts` already owns (review finding 2). `deepResolveNode` routes the two variants so alias bodies resolve before codegen.
+
+**Verified facts (plan author + independent reviewer):**
+- `arrayTypeParser` (`lib/parsers/parsers.ts:995`): its own base or-chain plus `count(str("[]"))`, and `count` FAILS on zero matches — so today's or-chain member never matches a bare type. The rework must preserve that (finding 1): a zero-suffix postfix parser placed in the or-chain would swallow `keyof` as `typeAliasVariable("keyof")` and break every keyof annotation, because `or()` commits to the first success.
+- `builtinGenerics.ts` owns `resolveObjectArg` (:105) and `resolveKeysArg` (:120) — currently private. `typeOperators.ts` consumes them (exported, parameterized by operator name) instead of re-implementing. `withUseSiteTags` is also there for tag threading.
+- `typeKey`'s `canonical()` and `valueParamSubstitution`'s switches have `never`-defaults: tsc fails until their cases exist. That is the FULL reach of compile-time enforcement — `formatTypeHint`'s default throws at runtime, the zod mapper falls back to `z.string()` silently, and `mapTypes`/`visitTypes` pass unknown nodes through silently. Each of those gets an explicit step; do not treat `make` as the complete checklist.
+- The zod mapper's fallback for unresolved nodes is `z.string()` — which is why codegen pins must use NON-string properties (review test-audit).
+- `deepResolveNode` (`lib/typeChecker/assignability.ts`) routes only `genericType` and `typeAliasVariable` — the spec's trap.
+- Codegen harness: `generate()` from `lib/backends/recursiveAliases.codegen.test.ts`. Execution tests bind `schema(...)` to a variable first (#480). `parseAgency(source, {}, false)` is the right signature; Tag literals are `{ type, name, arguments }`.
+- Unknown aliases resolve to themselves, so `keyof UnknownAlias` lands in the swallowed-TypeError family (pin it, review finding 5).
+- `type keyof = ...` still parses as a declaration (alias names use `many1WithJoin(varNameChar)`), so the reserved-name check in `lib/typeChecker/index.ts` is what rejects it.
+
+## Global Constraints
+
+- Fresh worktree: `git worktree add .claude/worktrees/keyof-indexed -b keyof-indexed origin/main`, then `cd .claude/worktrees/keyof-indexed && pnpm install && cd packages/agency-lang && make`.
+- Never commit to `main`. No apostrophes in commit-message command lines. Save test output to files. Run `make` before CLI steps. Do NOT run the full agency suite locally.
+- `typeOperators.ts` must NOT import `assignability.ts` (resolver injected).
+- Zero churn in existing `tests/typescriptGenerator` fixtures is a hard gate.
+- Both operators are object-only in v1.
+- Reserved-name pre-check (spec requirement): before Task 1, run
+  `grep -rn "keyof" stdlib/ tests/agency/ tests/typescriptGenerator/ lib/agents/ --include="*.agency" | grep -v "keyof "` and expect zero hits — no existing `.agency` code uses `keyof` as an identifier. Record the result in the Task 1 commit message.
+
+---
+
+### Task 1: AST variants + parser + printers
+
+**Files:**
+- Modify: `lib/types/typeHints.ts` (two variants + header checklist update)
+- Modify: `lib/parsers/parsers.ts` (base/suffix split; `keyofTypeParser`)
+- Modify: `lib/utils/formatType.ts` (+ the generator's type printer if separate)
+- Test: `lib/parsers/typeOperatorParsing.test.ts` (new), `lib/backends/agencyGenerator.test.ts`
+
+**Interfaces produced:**
+
+```ts
+export type KeyofType = {
+  type: "keyofType";
+  operand: VariableType;
+  tags?: Tag[];
+};
+
+export type IndexedAccessType = {
+  type: "indexedAccessType";
+  objectType: VariableType;
+  index: VariableType;
+  tags?: Tag[];
+};
+```
+
+The `tags` fields are NOT dead (review finding 3): Task 2's resolver branches thread them through `withUseSiteTags`, mirroring the adjacent `genericType` branch.
+
+- [ ] **Step 1: Write the failing parse tests**
+
+Create `lib/parsers/typeOperatorParsing.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+
+function firstParamHint(source: string): unknown {
+  const parsed = parseAgency(source, {}, false);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) throw new Error("unreachable");
+  const def = parsed.result.nodes.find((n) => n.type === "function") as {
+    parameters: { typeHint?: unknown }[];
+  };
+  return def.parameters[0].typeHint;
+}
+
+describe("keyof parsing", () => {
+  it("parses keyof over an alias reference", () => {
+    expect(firstParamHint("def f(k: keyof User) { k }")).toMatchObject({
+      type: "keyofType",
+      operand: { type: "typeAliasVariable", aliasName: "User" },
+    });
+  });
+
+  it("binds tighter than union: keyof A | keyof B is a union of keyofs", () => {
+    expect(firstParamHint("def f(k: keyof A | keyof B) { k }")).toMatchObject({
+      type: "unionType",
+      types: [
+        { type: "keyofType", operand: { aliasName: "A" } },
+        { type: "keyofType", operand: { aliasName: "B" } },
+      ],
+    });
+  });
+
+  it("postfix binds tighter than keyof: keyof User[] is keyof (User[])", () => {
+    expect(firstParamHint("def f(k: keyof User[]) { k }")).toMatchObject({
+      type: "keyofType",
+      operand: { type: "arrayType" },
+    });
+  });
+
+  it("parenthesized keyof takes a suffix: (keyof User)[] is an ARRAY of keyofs", () => {
+    expect(firstParamHint("def f(k: (keyof User)[]) { k }")).toMatchObject({
+      type: "arrayType",
+      elementType: { type: "keyofType" },
+    });
+  });
+
+  it("keyword boundary: keyofish stays a plain identifier", () => {
+    // The required whitespace after `keyof` is load-bearing: it is what
+    // stops the keyword from eating identifier prefixes. Pin it so nobody
+    // makes the spaces optional (review test-audit #5).
+    expect(firstParamHint("def f(k: keyofish) { k }")).toMatchObject({
+      type: "typeAliasVariable",
+      aliasName: "keyofish",
+    });
+  });
+});
+
+describe("indexed access parsing", () => {
+  it("parses a string-literal index", () => {
+    expect(firstParamHint('def f(x: User["name"]) { x }')).toMatchObject({
+      type: "indexedAccessType",
+      objectType: { type: "typeAliasVariable", aliasName: "User" },
+      index: { type: "stringLiteralType", value: "name" },
+    });
+  });
+
+  it("parses a union index", () => {
+    expect(firstParamHint('def f(x: User["a" | "b"]) { x }')).toMatchObject({
+      type: "indexedAccessType",
+      index: { type: "unionType" },
+    });
+  });
+
+  it("chains left to right", () => {
+    expect(
+      firstParamHint('def f(x: User["address"]["city"]) { x }'),
+    ).toMatchObject({
+      type: "indexedAccessType",
+      objectType: {
+        type: "indexedAccessType",
+        index: { value: "address" },
+      },
+      index: { value: "city" },
+    });
+  });
+
+  it("accepts a full type expression as the index (keyof composes)", () => {
+    expect(firstParamHint("def f(x: User[keyof User]) { x }")).toMatchObject({
+      type: "indexedAccessType",
+      index: { type: "keyofType" },
+    });
+  });
+
+  it('mixes with arrays: User["tags"][] is an array of the indexed type', () => {
+    expect(firstParamHint('def f(x: User["tags"][]) { x }')).toMatchObject({
+      type: "arrayType",
+      elementType: { type: "indexedAccessType" },
+    });
+  });
+
+  it("empty brackets still mean array", () => {
+    expect(firstParamHint("def f(x: number[]) { x }")).toMatchObject({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify red**
+
+```bash
+pnpm test:run lib/parsers/typeOperatorParsing.test.ts > /tmp/ki-task1-red.log 2>&1; tail -5 /tmp/ki-task1-red.log
+```
+
+Expected: keyof/indexed tests FAIL; the plain-array and keyofish tests PASS (pinning existing behavior first).
+
+- [ ] **Step 3: Add the variants + checklist update to `typeHints.ts`**
+
+Add both types to the file and the `VariableType` union. In the SAME edit, update the header checklist comment: add `typeKey` (`lib/typeChecker/typeKey.ts` — never-enforced, tsc catches it) and `deepResolveNode` (`lib/typeChecker/assignability.ts` — NOT enforced; passing nodes through unchanged is its correct behavior for most variants, so a miss silently sends unresolved nodes to the zod mapper's `z.string()` fallback; pin new variants with a codegen test. See docs/dev/adding-features.md).
+
+- [ ] **Step 4: The base/suffix parser split (review finding 1 — follow exactly)**
+
+In `lib/parsers/parsers.ts`, three pieces:
+
+1. **Extract the base chain** currently inside `arrayTypeParser` into a shared `typePostfixBase` parser (parenthesized, object, result, angle-array, generic, primitive, typeAliasVariable — unchanged membership and order).
+2. **A `typeSuffix` step**: given a current type, try `[]` → wrap in arrayType; else `[` + `variableTypeParser` + `]` → wrap in indexedAccessType. Implemented as a loop in the two consuming parsers (the file's existing mutate-and-wrap style is fine here; parsers are exempt from the accumulator rule).
+3. **Two consumers with different suffix arities:**
+   - `arrayTypeParser` (exported name and or-chain positions UNCHANGED) = base + AT LEAST ONE suffix. This preserves today's or-chain behavior exactly: bare types still fail through to later alternatives, and `User["name"]` matches because the index bracket is the one required suffix.
+   - A private `postfixOperandParser` = base + ZERO OR MORE suffixes. ONLY `keyofTypeParser` uses it, so its bare-match greediness leaks nowhere.
+
+```ts
+// keyof binds to the full postfix expression that follows: `keyof
+// User["address"]` means keyof (User["address"]) and `keyof User[]`
+// means keyof (User[]). Union binds looser. The whitespace after the
+// keyword is REQUIRED and load-bearing: it is the keyword boundary that
+// lets `keyofish` parse as a plain identifier. Do not make it optional.
+export const keyofTypeParser: Parser<KeyofType> = memo(
+  "keyofTypeParser",
+  seqC(
+    set("type", "keyofType"),
+    str("keyof"),
+    spaces,
+    capture(lazy(() => postfixOperandParser), "operand"),
+  ),
+);
+```
+
+Slot `keyofTypeParser` into `unionItemParser` and `variableTypeParser` BEFORE `arrayTypeParser` and `typeAliasVariableParser`. `(keyof User)[]` needs no extra code: `parenthesizedTypeParser` sits in the base chain and routes through `variableTypeParser`, which now contains `keyofTypeParser`.
+
+- [ ] **Step 5: Printers, with parenthesization (review finding 4)**
+
+`lib/utils/formatType.ts`:
+- `keyofType` → `keyof <operand>`.
+- `indexedAccessType` → `<object>[<index>]` with the index recursing normally (a string-literal index prints quoted).
+- `arrayType` printing: when the element is a `keyofType`, parenthesize — `(keyof User)[]`, never `keyof User[]` (which re-parses as `keyof (User[])`).
+- `indexedAccessType` printing: when the OBJECT is a `keyofType`, parenthesize it for the same reason.
+
+Locate the `AgencyGenerator` type-printing path (follow `arrayType`) and mirror all four rules if it does not delegate.
+
+- [ ] **Step 6: Fix the compile fan-out**
+
+```bash
+make > /tmp/ki-task1-make.log 2>&1; grep -E "error TS" /tmp/ki-task1-make.log | head -20
+```
+
+tsc reports `typeKey` and `valueParamSubstitution` (never-defaults). Fix those, PLUS the two silent sites tsc cannot report: `mapTypes` AND `visitTypes` in `typeWalker.ts` (add both, per the file's own pairing rule). `typeKey` cases: `keyofType` → `` `{"keyof":${canonical(t.operand)}}` ``; `indexedAccessType` → `` `{"index":[${canonical(t.objectType)},${canonical(t.index)}]}` ``.
+
+- [ ] **Step 7: Green + round-trips (flat, nested, and alias positions)**
+
+```bash
+pnpm test:run lib/parsers/typeOperatorParsing.test.ts > /tmp/ki-task1-green.log 2>&1; tail -3 /tmp/ki-task1-green.log
+```
+
+Append to `lib/backends/agencyGenerator.test.ts` — table cases:
+
+```ts
+      {
+        description: "keyof type hint round-trips",
+        input: "def f(k: keyof User) { k }",
+        expectedOutput: "def f(k: keyof User) {\nk\n}",
+      },
+      {
+        description: "indexed access type hint round-trips",
+        input: 'def f(x: User["name"]) { x }',
+        expectedOutput: 'def f(x: User["name"]) {\nx\n}',
+      },
+      {
+        description: "array-of-keyof keeps its parens (distinct from keyof-of-array)",
+        input: "def f(k: (keyof User)[]) { k }",
+        expectedOutput: "def f(k: (keyof User)[]) {\nk\n}",
+      },
+      {
+        description: "keyof-of-array stays unparenthesized",
+        input: "def f(k: keyof User[]) { k }",
+        expectedOutput: "def f(k: keyof User[]) {\nk\n}",
+      },
+```
+
+Plus alias-position round-trips (spec requirement; standalone tests in the same file, following the Type-preservation describe pattern): `type F = keyof User` and `type N = User["name"]` through the generator, asserting the output contains the written forms.
+
+```bash
+pnpm test:run lib/backends/agencyGenerator.test.ts > /tmp/ki-task1-fmt.log 2>&1; tail -3 /tmp/ki-task1-fmt.log
+pnpm test:run lib > /tmp/ki-task1-lib.log 2>&1; tail -3 /tmp/ki-task1-lib.log
+pnpm run lint:structure > /tmp/ki-task1-lint.log 2>&1; tail -2 /tmp/ki-task1-lint.log
+```
+
+The full-lib run is the guard for the parser split: `arrayTypeParser` feeds every existing annotation.
+
+- [ ] **Step 8: Commit** (note the reserved-name grep result in the message)
+
+```bash
+git add lib/types/typeHints.ts lib/parsers/parsers.ts lib/parsers/typeOperatorParsing.test.ts lib/utils/formatType.ts lib/backends/agencyGenerator.test.ts lib/typeChecker/typeKey.ts lib/typeChecker/valueParamSubstitution.ts lib/typeChecker/typeWalker.ts
+git commit -m "Add keyofType and indexedAccessType variants with split postfix parser and printers"
+```
+
+---
+
+### Task 2: Evaluation — typeOperators.ts consuming builtinGenerics helpers
+
+**Files:**
+- Modify: `lib/typeChecker/builtinGenerics.ts` (export `resolveObjectArg`, `resolveKeysArg`, `withUseSiteTags`)
+- Create: `lib/typeChecker/typeOperators.ts`
+- Test: `lib/typeChecker/typeOperators.test.ts`
+- Modify: `lib/typeChecker/assignability.ts` (two resolver branches, tag-threading)
+- Modify: `lib/typeChecker/index.ts` (`RESERVED_TYPE_NAMES` gains `"keyof"`)
+
+**Interfaces:**
+- `evalKeyof(operand, resolve): VariableType` — union of key literals; empty → `NEVER_T`; single unwraps; non-object → `TypeError` via the SHARED `resolveObjectArg` (so the message is the same family as Partial's).
+- `evalIndexedAccess(objectType, index, resolve): VariableType` — `resolveKeysArg` resolves the index to literal strings (shared error wording for non-literals); missing key → `TypeError` in Pick's wording family: `indexed access key 'nope' does not exist on the target type. Available keys: ...`; union of results (single unwraps); property tags ride along.
+
+- [ ] **Step 1: Export the shared helpers**
+
+In `builtinGenerics.ts`, add `export` to `resolveObjectArg`, `resolveKeysArg`, and `withUseSiteTags`. No behavior change; the existing callers keep working.
+
+- [ ] **Step 2: Write the failing unit tests**
+
+Create `lib/typeChecker/typeOperators.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { evalKeyof, evalIndexedAccess } from "./typeOperators.js";
+import type { VariableType } from "../types.js";
+
+const STR: VariableType = { type: "primitiveType", value: "string" };
+const NUM: VariableType = { type: "primitiveType", value: "number" };
+const AGE_TAG = { type: "tag" as const, name: "validate", arguments: [] };
+const id = (t: VariableType) => t;
+
+function user(): VariableType {
+  return {
+    type: "objectType",
+    properties: [
+      { key: "name", value: STR },
+      { key: "age", value: { ...NUM, tags: [AGE_TAG] } },
+    ],
+  };
+}
+
+function lit(value: string): VariableType {
+  return { type: "stringLiteralType", value };
+}
+
+describe("evalKeyof", () => {
+  it("returns the union of key literals", () => {
+    expect(evalKeyof(user(), id)).toEqual({
+      type: "unionType",
+      types: [lit("name"), lit("age")],
+    });
+  });
+
+  it("returns a single literal for a one-key object (no union wrapper)", () => {
+    const one: VariableType = {
+      type: "objectType",
+      properties: [{ key: "only", value: STR }],
+    };
+    expect(evalKeyof(one, id)).toEqual(lit("only"));
+  });
+
+  it("returns never for an empty object", () => {
+    expect(evalKeyof({ type: "objectType", properties: [] }, id)).toEqual({
+      type: "primitiveType",
+      value: "never",
+    });
+  });
+
+  it("resolves alias operands through the injected resolver", () => {
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "User" };
+    const resolve = (t: VariableType) =>
+      t.type === "typeAliasVariable" && t.aliasName === "User" ? user() : t;
+    expect(evalKeyof(ref, resolve)).toMatchObject({ type: "unionType" });
+  });
+
+  it("rejects every non-object operand form in the spec table", () => {
+    expect(() => evalKeyof(NUM, id)).toThrow(/keyof expects an object type/);
+    expect(() =>
+      evalKeyof({ type: "arrayType", elementType: STR }, id),
+    ).toThrow(/keyof expects an object type/);
+    const rec: VariableType = {
+      type: "genericType",
+      name: "Record",
+      typeArgs: [STR, NUM],
+    };
+    expect(() => evalKeyof(rec, id)).toThrow(/keyof expects an object type/);
+    const union: VariableType = { type: "unionType", types: [user(), user()] };
+    expect(() => evalKeyof(union, id)).toThrow(/keyof expects an object type/);
+  });
+
+  it("does not mutate its input", () => {
+    const input = user();
+    const snapshot = JSON.parse(JSON.stringify(input));
+    evalKeyof(input, id);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("evalIndexedAccess", () => {
+  it("returns the property type WITH its tags", () => {
+    expect(evalIndexedAccess(user(), lit("age"), id)).toEqual({
+      type: "primitiveType",
+      value: "number",
+      tags: [AGE_TAG],
+    });
+  });
+
+  it("a union index yields the union of property VALUE types (exact members)", () => {
+    const idx: VariableType = {
+      type: "unionType",
+      types: [lit("name"), lit("age")],
+    };
+    expect(evalIndexedAccess(user(), idx, id)).toEqual({
+      type: "unionType",
+      types: [STR, { ...NUM, tags: [AGE_TAG] }],
+    });
+  });
+
+  it("composes: indexing by keyof gives all VALUE types (exact members)", () => {
+    expect(evalIndexedAccess(user(), evalKeyof(user(), id), id)).toEqual({
+      type: "unionType",
+      types: [STR, { ...NUM, tags: [AGE_TAG] }],
+    });
+  });
+
+  it("rejects a missing key in the Pick wording family", () => {
+    expect(() => evalIndexedAccess(user(), lit("nope"), id)).toThrow(
+      /indexed access key 'nope' does not exist on the target type.*name, age/,
+    );
+  });
+
+  it("rejects a non-literal index (shared resolveKeysArg wording)", () => {
+    expect(() => evalIndexedAccess(user(), STR, id)).toThrow(
+      /expects string literal keys/,
+    );
+  });
+
+  it("rejects a non-object base", () => {
+    expect(() => evalIndexedAccess(NUM, lit("a"), id)).toThrow(
+      /expects an object type/,
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Red, then implement**
+
+```bash
+pnpm test:run lib/typeChecker/typeOperators.test.ts > /tmp/ki-task2-red.log 2>&1; tail -3 /tmp/ki-task2-red.log
+```
+
+Create `lib/typeChecker/typeOperators.ts`:
+
+```ts
+import type { VariableType } from "../types.js";
+import { resolveKeysArg, resolveObjectArg } from "./builtinGenerics.js";
+import { NEVER_T } from "./primitives.js";
+
+/**
+ * Eager evaluation for the type operators `keyof T` and `T["key"]`.
+ * Both run during type resolution and produce ordinary types, so nothing
+ * downstream knows the operator nodes exist.
+ *
+ * Argument validation is SHARED with the builtin generics
+ * (resolveObjectArg / resolveKeysArg) so the error wording stays one
+ * family across Partial, Pick, keyof, and indexed access.
+ *
+ * CYCLE RULE: this module must not import assignability.ts. The resolver
+ * arrives as the `resolve` callback, carrying the caller's in-progress
+ * guard, so recursive alias operands degrade the same way they do
+ * everywhere else.
+ */
+type Resolve = (t: VariableType) => VariableType;
+
+export function evalKeyof(
+  operand: VariableType,
+  resolve: Resolve,
+): VariableType {
+  const obj = resolveObjectArg("keyof", operand, resolve);
+  const keys: VariableType[] = obj.properties.map((p) => ({
+    type: "stringLiteralType",
+    value: p.key,
+  }));
+  if (keys.length === 0) return NEVER_T;
+  if (keys.length === 1) return keys[0];
+  return { type: "unionType", types: keys };
+}
+
+export function evalIndexedAccess(
+  objectType: VariableType,
+  index: VariableType,
+  resolve: Resolve,
+): VariableType {
+  const obj = resolveObjectArg("indexed access", objectType, resolve);
+  const keys = resolveKeysArg("indexed access", index, resolve);
+  const results = keys.map((key) => {
+    const prop = obj.properties.find((p) => p.key === key);
+    if (!prop) {
+      const available = obj.properties.map((p) => p.key).join(", ");
+      throw new TypeError(
+        `indexed access key '${key}' does not exist on the target type. Available keys: ${available}`,
+      );
+    }
+    return prop.value;
+  });
+  if (results.length === 1) return results[0];
+  return { type: "unionType", types: results };
+}
+```
+
+CHECK during execution: `resolveKeysArg`'s current error text is
+`` `${name} expects string literal keys, got '...'` `` — the unit regex
+matches it. If its signature or wording differs from this plan's memory
+of it, adapt the TEST to the shared helper, not the helper to the test.
+
+- [ ] **Step 4: Wire the resolver with tag threading (review finding 3)**
+
+In `resolveTypeWithGuard`, before the `genericType` block:
+
+```ts
+  if (vt.type === "keyofType") {
+    // Thread occurrence tags like the genericType branch does.
+    return withUseSiteTags(
+      evalKeyof(vt.operand, (t) =>
+        resolveTypeWithGuard(t, typeAliases, inProgress),
+      ),
+      vt.tags,
+    );
+  }
+  if (vt.type === "indexedAccessType") {
+    return withUseSiteTags(
+      evalIndexedAccess(vt.objectType, vt.index, (t) =>
+        resolveTypeWithGuard(t, typeAliases, inProgress),
+      ),
+      vt.tags,
+    );
+  }
+```
+
+`index.ts`: add `"keyof"` to `RESERVED_TYPE_NAMES` with a one-line comment (keyword in type position; an alias named keyof would silently change parse).
+
+- [ ] **Step 5: Pipeline tests**
+
+Append to `lib/typeChecker/typeOperators.test.ts`:
+
+```ts
+import { typecheckSource } from "./testUtils.js";
+
+describe("type operators through the full pipeline", () => {
+  it("keyof produces a closed union: match gets exhaustiveness checking", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+def label(field: keyof User): string {
+  match (field) {
+    "name" => { return "the name" }
+    "age" => { return "the age" }
+  }
+}
+node main() {
+  return label("name")
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a match missing a key case is reported", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+def label(field: keyof User): string {
+  match (field) {
+    "name" => { return "the name" }
+  }
+}
+node main() {
+  return label("name")
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/age/);
+  });
+
+  it("rejects a non-key value against a keyof annotation (direct negative)", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+node main() {
+  const k: keyof User = "bogus"
+  return k
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("indexed access types an annotation, and rejects a mismatch", () => {
+    const ok = typecheckSource(`
+type User = { name: string, age: number }
+node main() {
+  const n: User["name"] = "x"
+  return n
+}
+`);
+    expect(ok).toEqual([]);
+    const bad = typecheckSource(`
+type User = { name: string, age: number }
+node main() {
+  const n: User["name"] = 5
+  return n
+}
+`);
+    expect(bad.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("indexing an optional property includes null (desugared p?: interaction)", () => {
+    const errors = typecheckSource(`
+type User = { name: string, nickname?: string }
+node main() {
+  const n: User["nickname"] = null
+  return n
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("keyof works on a recursive alias (keys are top-level)", () => {
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+node main() {
+  const k: keyof Tree = "children"
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("chained indexed access resolves left to right", () => {
+    const errors = typecheckSource(`
+type User = {
+  name: string,
+  address: {
+    city: string,
+  },
+}
+node main() {
+  const c: User["address"]["city"] = "sf"
+  return c
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("composes with the utility types: Pick by keyof, Partial of an indexed type", () => {
+    const errors = typecheckSource(`
+type User = {
+  name: string,
+  address: {
+    city: string,
+  },
+}
+node main() {
+  const u: Pick<User, keyof User> = { name: "a", address: { city: "sf" } }
+  const a: Partial<User["address"]> = { city: null }
+  return u
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a generic alias can delegate: type Keys<T> = keyof T", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+type Keys<T> = keyof T
+node main() {
+  const k: Keys<User> = "name"
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("semantic errors stay swallowed at typecheck time: keyof number", () => {
+    const errors = typecheckSource(`
+node main() {
+  const k: keyof number = "x"
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("semantic errors stay swallowed: missing key in source, and keyof of an UNKNOWN alias", () => {
+    // Both land in the swallowed-TypeError family (safeResolveType
+    // degrades to any; codegen surfaces fatally). Pinned as tripwires for
+    // the located-diagnostics follow-up.
+    const missingKey = typecheckSource(`
+type User = { name: string }
+node main() {
+  const x: User["nope"] = 1
+  return x
+}
+`);
+    expect(missingKey).toEqual([]);
+    const unknownAlias = typecheckSource(`
+node main() {
+  const k: keyof NotDefined = "x"
+  return k
+}
+`);
+    // The undefined-alias diagnostic may legitimately fire here (operand
+    // reference validation); assert only that nothing CRASHES and record
+    // the observed diagnostics in the test.
+    expect(Array.isArray(unknownAlias)).toBe(true);
+  });
+
+  it("user redefinition of keyof as an alias name is rejected", () => {
+    const errors = typecheckSource(`
+type keyof = { x: number }
+node main() {
+  return 1
+}
+`);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 6: Verify, sweep, commit**
+
+```bash
+pnpm test:run lib/typeChecker/typeOperators.test.ts > /tmp/ki-task2-green.log 2>&1; tail -3 /tmp/ki-task2-green.log
+pnpm test:run lib/typeChecker > /tmp/ki-task2-suite.log 2>&1; tail -3 /tmp/ki-task2-suite.log
+git add lib/typeChecker/typeOperators.ts lib/typeChecker/typeOperators.test.ts lib/typeChecker/builtinGenerics.ts lib/typeChecker/assignability.ts lib/typeChecker/index.ts
+git commit -m "Evaluate keyof and indexed access eagerly, sharing builtinGenerics helpers"
+```
+
+---
+
+### Task 3: Codegen — deepResolveNode routing + non-fakeable pins
+
+**Files:**
+- Modify: `lib/typeChecker/assignability.ts` (`deepResolveNode`)
+- Test: `lib/backends/typeOperators.codegen.test.ts` (new)
+- Create: `tests/typescriptGenerator/typeOperators.agency` (+ `.mjs`)
+- Create: `tests/agency/keyof-type.agency` + `.test.json`
+
+- [ ] **Step 1: Write the failing codegen tests (fallback-proof assertions)**
+
+Create `lib/backends/typeOperators.codegen.test.ts` (copy the `generate()` helper from `recursiveAliases.codegen.test.ts`). The zod mapper's unresolved-node fallback is `z.string()`, so every assertion here uses a shape the fallback cannot fake (review test-audit):
+
+```ts
+describe("type operators in alias bodies (deepResolveNode routing)", () => {
+  it("type K = keyof User emits the literal-key union, NOT z.string()", () => {
+    const out = generate(`
+type User = {
+  name: string,
+  age: number,
+}
+type K = keyof User
+node main() {
+  return 1
+}
+`);
+    expect(out).toMatch(
+      /const K = z\.union\(\[z\.literal\("name"\), z\.literal\("age"\)\]\)/,
+    );
+  });
+
+  it("an indexed-access alias emits the property schema (non-string property)", () => {
+    const out = generate(`
+type User = {
+  name: string,
+  age: number,
+}
+type A = User["age"]
+node main() {
+  return 1
+}
+`);
+    expect(out).toMatch(/const A = z\.number\(\)/);
+  });
+
+  it("keyof of a FORWARD alias still emits literal keys (alias table is order-independent)", () => {
+    const out = generate(`
+type K = keyof Later
+type Later = {
+  a: string,
+  b: number,
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain('z.literal("a")');
+  });
+
+  it("an indexed property carrying @validate keeps enforcement (descriptor path)", () => {
+    // Tag ride-along must survive codegen, not just unit evaluation:
+    // the extracted property type carries the validate tag, so the alias
+    // gets a descriptor assignment, not just a bare schema const.
+    const out = generate(`
+def positive(n: number): Result<number, string> {
+  if (n > 0) {
+    return success(n)
+  }
+  return failure("must be positive")
+}
+type User = {
+  name: string,
+  @validate(positive)
+  age: number,
+}
+type A = User["age"]
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("A.__agency_descriptor");
+  });
+});
+```
+
+- [ ] **Step 2: Red, then route the variants**
+
+```bash
+pnpm test:run lib/backends/typeOperators.codegen.test.ts > /tmp/ki-task3-red.log 2>&1; tail -6 /tmp/ki-task3-red.log
+```
+
+Expected red: the `K` and `A` assertions fail with `z.string()` emissions — the trap, observed. Fix in `deepResolveNode`:
+
+```ts
+  if (n.type === "keyofType" || n.type === "indexedAccessType") {
+    // Same routing as genericType: these evaluate to concrete types and
+    // must never reach the zod mapper unresolved — the mapper's fallback
+    // silently emits z.string(). See docs/dev/adding-features.md.
+    return resolveType(n, typeAliases);
+  }
+```
+
+Re-run: green. If the `@validate` descriptor test stays red, the tag
+ride-along is dropping somewhere between `evalIndexedAccess` and
+`hasAnyValidateTag` — debug there before touching the test.
+
+- [ ] **Step 3: Fixture + execution test**
+
+`tests/typescriptGenerator/typeOperators.agency`:
+
+```
+type User = {
+  name: string,
+  age: number,
+}
+
+type Field = keyof User
+
+type Age = User["age"]
+
+node main() {
+  const f: Field = "name"
+  const a: Age = 1
+  return f
+}
+```
+
+```bash
+make > /tmp/ki-task3-make.log 2>&1; make fixtures > /tmp/ki-task3-fixtures.log 2>&1
+grep -n "const Field\|const Age" tests/typescriptGenerator/typeOperators.mjs
+git status --short tests/
+```
+
+Zero churn outside the new files (hard gate). `tests/agency/keyof-type.agency`:
+
+```
+// keyof produces a closed key union; the schema accepts real keys and
+// rejects anything else. (Schema bound to a variable first — #480.)
+type User = {
+  name: string,
+  age: number,
+}
+
+node accepts() {
+  const s = schema(keyof User)
+  const r = s.parseJSON("\"name\"")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node rejects() {
+  const s = schema(keyof User)
+  const r = s.parseJSON("\"email\"")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}
+```
+
+`tests/agency/keyof-type.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "\"name\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "a real key parses"
+    },
+    {
+      "nodeName": "rejects",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "a non-key is rejected (would pass under a z.string fallback)"
+    }
+  ]
+}
+```
+
+```bash
+pnpm run agency test tests/agency/keyof-type.agency > /tmp/ki-task3-exec.log 2>&1; echo "exit=$?"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/typeChecker/assignability.ts lib/backends/typeOperators.codegen.test.ts tests/typescriptGenerator/typeOperators.agency tests/typescriptGenerator/typeOperators.mjs tests/agency/keyof-type.agency tests/agency/keyof-type.test.json
+git commit -m "Route type operators through deepResolveNode; pin codegen with fallback-proof assertions"
+```
+
+---
+
+### Task 4: Documentation (including the owner-requested checklist fix)
+
+**Files:**
+- Modify: `docs/site/guide/types.md`
+- Modify: `docs/dev/typechecker/README.md`
+- Modify: `docs/dev/adding-features.md`
+
+- [ ] **Step 1: Guide section** (append before References; short sentences, active voice):
+
+```markdown
+## keyof and indexed access
+
+`keyof T` is the union of an object type's key names. `T["key"]` is the
+type of one field. Both update automatically when the source type
+changes:
+
+```ts
+type User = {
+  name: string,
+  email: string,
+}
+
+type Field = keyof User        // "name" | "email"
+type Name = User["name"]       // string
+```
+
+`keyof` produces a closed union, so `match` over a `keyof` value gets
+exhaustiveness checking. Add a field to `User` and every match over its
+keys reports a missing case.
+
+Both operators need a concrete object type. Records, arrays, and
+primitives are errors. Index keys must be string literals. A union of
+keys returns a union of field types, so `User[keyof User]` is the type
+of every value in `User`.
+```
+
+- [ ] **Step 2: Dev docs.** `docs/dev/typechecker/README.md`: one short paragraph next to the built-in generics section — the operators evaluate eagerly in `resolveTypeWithGuard` via `lib/typeChecker/typeOperators.ts`, sharing `builtinGenerics.ts` argument helpers; downstream never sees them; `keyof` is in `RESERVED_TYPE_NAMES`.
+
+- [ ] **Step 3: `docs/dev/adding-features.md` — "Adding a `VariableType` variant" section** (owner-requested). Point at the `typeHints.ts` header checklist as the source of truth. State exactly what is and is not compiler-enforced: `typeKey` and `valueParamSubstitution` fail the build via `never` defaults; `formatTypeHint`'s default throws at RUNTIME only; `mapTypes`/`visitTypes` pass unknown nodes through silently (hand-maintained pair); `deepResolveNode` passes nodes through silently AND that is its correct behavior for most variants, so a missing case sends unresolved nodes to the zod mapper's `z.string()` fallback with no error anywhere. Close with the rule: every new variant gets a codegen test asserting its emitted schema against a NON-string shape, because that test is the only net that catches a `deepResolveNode` miss.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/site/guide/types.md docs/dev/typechecker/README.md docs/dev/adding-features.md
+git commit -m "Document keyof, indexed access, and the VariableType variant checklist"
+```
+
+---
+
+### Task 5: Full verification, push, PR
+
+- [ ] **Step 1: Sweep**
+
+```bash
+pnpm test:run lib > /tmp/ki-task5-lib.log 2>&1; tail -3 /tmp/ki-task5-lib.log
+pnpm run lint:structure > /tmp/ki-task5-lint.log 2>&1; echo "lint=$?"
+make > /tmp/ki-task5-make.log 2>&1; echo "make=$?"
+for t in keyof-type utility-partial recursive-type recursive-type-validated; do pnpm run agency test tests/agency/$t.agency > /tmp/ki-task5-$t.log 2>&1; echo "$t: $?"; done
+```
+
+The three re-runs guard the merged features against the parser split (`arrayTypeParser` sits under every type annotation; `recursive-type-validated` also exercises the descriptor path the tag ride-along touches).
+
+- [ ] **Step 2: PR** (body file; no apostrophes on the command line). Cover: the two operators with the drift example and the match-exhaustiveness payoff; the parser split (call the reviewer's attention to the many1/many0 asymmetry and WHY — the bare-match greediness finding); the reserved-`keyof` note with the grep result; the `deepResolveNode` trap observed red before fixed; helper sharing with builtinGenerics; the checklist documentation fix; scope-outs (`Record` support, `typeof` with the architecture reasoning, `T[number]`).
+
+```bash
+git push -u origin keyof-indexed
+gh pr create --title "Add keyof and indexed access type operators" --body-file /tmp/ki-pr-body.md
+```

--- a/docs/superpowers/specs/2026-07-10-keyof-indexed-access-design.md
+++ b/docs/superpowers/specs/2026-07-10-keyof-indexed-access-design.md
@@ -1,0 +1,265 @@
+# keyof and indexed access types
+
+**Date:** 2026-07-10
+**Status:** Approved design, ready for planning
+**Prior art in this repo:** utility types (PR #478), recursive aliases (PR #485). This spec reuses their machinery and conventions throughout.
+
+## What we are building
+
+Two type operators, modeled on TypeScript.
+
+**`keyof T`** gives you the key names of an object type, as a type:
+
+```ts
+type User = {
+  name: string,
+  email: string,
+  age: number,
+}
+
+type UserField = keyof User
+// UserField is "name" | "email" | "age"
+```
+
+**`T["key"]`** gives you the type of one field:
+
+```ts
+type Address = User["address"]           // the nested object type
+type City = User["address"]["city"]      // string
+```
+
+Both replace hand-copied types that silently drift when the source type
+changes. `keyof` has a second payoff: it produces a closed literal union,
+so Agency's existing enforcement applies. A `match` over a `keyof User`
+value gets exhaustiveness checking. Add a field to `User`, and every
+match that handles "all fields of User" reports a missing case.
+
+## Decisions made during brainstorming
+
+- **Object-only in v1** (owner-approved): both operators error on
+  `Record<K, V>`, arrays, primitives, and unions-of-objects. This matches
+  the utility-types v1 stance. Relaxing later is easy.
+- **Two new `VariableType` variants** (`keyofType`, `indexedAccessType`).
+  These operators cannot ride the `genericType` node the way `Partial`
+  did: `keyof` is a prefix operator and `T["key"]` is postfix. Neither
+  parses as `Name<args>`.
+- **`typeof` is excluded** (owner-approved). See non-goals for the
+  reasoning; it is an architecture change, not a sibling feature.
+- **The `deepResolveNode` checklist gap gets fixed as part of this PR**
+  (owner-requested). See the documentation section.
+
+## Semantics
+
+Evaluation is eager, like the utility types: the resolver computes the
+result during type resolution, and nothing downstream ever sees the
+operator nodes. This passes the litmus test (every Agency type must
+eagerly evaluate to a concrete, JSON-schema-able shape), and it means
+there is no provider question. Providers only ever receive ordinary
+unions and object types.
+
+### keyof
+
+| Input | Result |
+|---|---|
+| `keyof { a: string, b: number }` | `"a" \| "b"` |
+| `keyof {}` | `never` |
+| `keyof SomeAlias` | resolve the alias first, then apply |
+| `keyof Tree` (recursive alias) | works; keys are top-level, one resolution step suffices |
+| `keyof number`, `keyof string[]`, `keyof Record<K,V>` | error: `keyof expects an object type, got '...'` |
+
+### Indexed access
+
+| Input | Result |
+|---|---|
+| `User["name"]` | the property's type |
+| `User["address"]["city"]` | chains left to right |
+| `User["name" \| "age"]` | union of the property types |
+| `User[keyof User]` | union of ALL property types (composition, free) |
+| `User["nope"]` | error listing available keys, same wording family as Pick |
+| `User[number]`, `User[SomeNonLiteral]` | error: index must be a string literal or union of string literals |
+| Non-object base | error, same as keyof |
+
+The index may be any type expression that RESOLVES to string literals.
+`User[keyof User]` works because `keyof User` evaluates first.
+
+### Composition
+
+These all work through the existing recursive resolver, with no special
+code:
+
+```ts
+Pick<User, keyof User>          // same as User
+Partial<User["address"]>        // nulls the nested object's fields
+type Keys<T> = keyof T          // generic alias; evaluates at use sites
+Tree["children"]                // Tree[] — recursion machinery unchanged
+```
+
+Generic alias declarations validate without evaluating. `type Keys<T> =
+keyof T` must not error at declaration, where `T` is a stubbed nominal
+reference. This falls out of the existing design: `validateTypeReferences`
+walks bodies without resolving, exactly as it does for `PartialOf<T>`.
+The spec calls it out so the executor adds the declaration-and-use-site
+test rather than discovering the subtlety.
+
+### Precedence
+
+Postfix binds tighter than prefix. `keyof User["address"]` means
+`keyof (User["address"])`. Parentheses group: `(keyof A) | (keyof B)`.
+A union of keyofs needs no parens (`keyof A | keyof B` parses as a union
+because `keyof` binds to the immediately following non-union type).
+
+### The keyword is reserved
+
+`keyof` becomes a keyword in type position. A user alias literally named
+`keyof` would stop parsing as before. Handle it the way the utility
+types handled their five names: add `keyof` to `RESERVED_TYPE_NAMES` so
+declaring `type keyof = ...` is a clear error rather than a silent
+parse change. Breaking in principle; no stdlib or test code uses the
+name (verify with a grep during execution).
+
+### Tags
+
+An indexed access returns the property's type WITH its property-level
+tags, so `@validate` annotations on the field ride along to the new use
+site. `keyof` results carry no tags (key names have no annotations).
+
+### Error surfacing
+
+Same as `Record` keys and the utility types: the resolver throws
+`TypeError`, which `safeResolveType` swallows at typecheck time and
+`resolveTypeDeep` surfaces fatally at codegen. This is the known,
+documented gap (located diagnostics are the standing follow-up). Pin it
+with a test, as the utility-types PR did.
+
+## Implementation
+
+### Parser
+
+- `keyof` — a prefix parser slotted into the `variableTypeParser`
+  or-chain: the keyword, whitespace, then a non-union type expression.
+- `T["key"]` — extends the existing postfix bracket handling where `T[]`
+  arrays parse. Disambiguate by bracket contents: empty brackets mean
+  array, a string literal means index. Loop for chains. The executor must
+  find the exact array-suffix parser and integrate there; array-of-result
+  (`User["tags"][]`) and index-of-array-element are decided by the same
+  loop.
+- Formatter: `AgencyGenerator` prints both forms as written.
+
+### Type tree
+
+Two variants in `lib/types/typeHints.ts`:
+
+```ts
+export type KeyofType = {
+  type: "keyofType";
+  operand: VariableType;
+  tags?: Tag[];
+};
+
+export type IndexedAccessType = {
+  type: "indexedAccessType";
+  objectType: VariableType;
+  index: VariableType;
+  tags?: Tag[];
+};
+```
+
+Both exist only between parse and resolution.
+
+### Evaluation
+
+Two branches in `resolveTypeWithGuard` (`lib/typeChecker/assignability.ts`),
+next to the alias and generic branches. Each resolves its operand(s) with
+the in-progress guard threaded through, so recursive aliases degrade the
+same way they do everywhere else. Implementation lives in a small pure
+module (`lib/typeChecker/typeOperators.ts`) following the
+`builtinGenerics.ts` pattern: resolver injected, no import cycle.
+
+### The fan-out checklist
+
+Adding variants touches a known list. Most sites are compiler-enforced
+(`never`-typed defaults); the two that are not get explicit attention:
+
+| Site | Enforced? |
+|---|---|
+| `typeKey` canonical cases | yes (never-default) |
+| `valueParamSubstitution` switches | yes (never-default) |
+| `mapTypes` / `visitTypes` walkers | check; add cases |
+| `formatTypeHint` | no; add cases |
+| `AgencyGenerator` printing | no; add cases + round-trip tests |
+| `validateTypeReferences` | no; validate operands without evaluating |
+| **`deepResolveNode`** | **no — the trap.** See below. |
+| zod mapper | nothing to add once deepResolveNode routes correctly |
+
+**The `deepResolveNode` trap.** `deepResolveNode`
+(`lib/typeChecker/assignability.ts`) prepares alias bodies for codegen,
+and today routes only `genericType` and `typeAliasVariable` through
+`resolveType`. Without new cases, `type K = keyof User` reaches the zod
+mapper unresolved and silently becomes the `z.string()` fallback. No
+error, wrong schema. The fix is two more routed cases plus a codegen
+fixture pinning the emitted literal-union schema, so any future
+regression fails a test instead of shipping.
+
+## Testing
+
+The recipe from the last three PRs:
+
+- **Unit** (`lib/typeChecker/typeOperators.test.ts`): every semantics-table
+  row above, every error, union indices, chained access, `T[keyof T]`,
+  composition with `Pick`/`Partial`, recursive-alias operands, tag
+  ride-along on indexed access, no-mutation of resolver inputs.
+- **Pipeline** (`typecheckSource`): a `match` over a `keyof`-typed value
+  gets exhaustiveness checking (add-a-field scenario); generic alias
+  `type Keys<T> = keyof T` declares clean and evaluates at use; the
+  swallowed-semantic-error pin (`keyof number` produces zero typecheck
+  diagnostics today).
+- **Codegen unit tests** (the `generate()` harness): `type K = keyof User`
+  emits a union of literal schemas, NOT `z.string()`; an indexed-access
+  alias emits the property's schema; both compose with the pending/z.lazy
+  machinery when the operand is a forward reference.
+- **Formatter round-trips**: `keyof User` and `User["name"]` survive
+  `fmt` as written, in parameter and alias positions.
+- **Execution test** (no LLM): `schema(keyof User)` parse-accepts a key
+  string and parse-rejects a non-key. Bind the schema to a variable
+  first (#480).
+- **Fixture**: both operators in alias bodies, checked into
+  `tests/typescriptGenerator/` with the zero-churn gate for existing
+  fixtures.
+
+## Documentation
+
+- `docs/site/guide/types.md`: a short section with the drift-prevention
+  example and the match-exhaustiveness payoff. Keep it tight.
+- `docs/dev/typechecker/README.md`: one paragraph on the operators and
+  eager evaluation.
+- **The checklist fix (owner-requested):** update the header comment in
+  `lib/types/typeHints.ts` — the designated "adding a variant" checklist —
+  to include `deepResolveNode` and `typeKey`, both missing today because
+  they postdate the comment. Add a short "adding a `VariableType`
+  variant" section to `docs/dev/adding-features.md` pointing at that
+  checklist. Rationale to state there: most switches are never-enforced,
+  but `deepResolveNode` cannot be (passing nodes through unchanged is its
+  correct behavior for most variants), so the checklist is the only
+  guard.
+
+## Non-goals
+
+- **`Record<K, V>` support** for either operator (v1 decision; relax
+  later if demand appears).
+- **`typeof`** (owner-approved exclusion). It looks like a sibling but
+  crosses a boundary these operators do not: `keyof` asks a question
+  about a type and needs only the alias table, while `typeof config`
+  asks about a VALUE and needs the checker's variable scopes. Those
+  scopes do not exist when aliases resolve. Adding it means threading a
+  scope and synthesizer through `resolveType` and every caller, solving
+  a pipeline-ordering problem (aliases resolve before scopes are built),
+  and teaching the builder to infer value types (compilation runs with
+  the typechecker disabled). Separate spec if ever wanted. Note the
+  keyword also collides with the planned runtime `typeof` narrowing
+  guard in the narrowing docs; the two can coexist as in TypeScript, but
+  that is a discussion for the typeof spec.
+- **`T[number]`** (array element extraction) and numeric indices: no
+  tuples exist (killed by the provider gate), so numeric indexing has no
+  v1 use case.
+- **Located diagnostics** for the resolver errors: standing follow-up
+  shared with `Record` and the utility types.

--- a/packages/agency-lang/docs/dev/adding-features.md
+++ b/packages/agency-lang/docs/dev/adding-features.md
@@ -13,6 +13,43 @@ Step-by-step guides for common tasks in the Agency codebase.
 
 ---
 
+## Adding a `VariableType` variant
+
+The source of truth is the header checklist in `lib/types/typeHints.ts`.
+Read it before you start; this section explains which parts the compiler
+enforces and which parts it cannot.
+
+Compiler-enforced (a missing case fails the build):
+
+- `substituteValueArgsInType` and `checkType` in
+  `lib/typeChecker/valueParamSubstitution.ts` — `never`-typed defaults.
+- `canonical` in `lib/typeChecker/typeKey.ts` — same mechanism.
+
+NOT enforced (a missing case fails silently or late):
+
+- `mapTypes` and `visitTypes` in `lib/typeChecker/typeWalker.ts` pass
+  unknown nodes through without visiting their children. Update the pair
+  together, per their own doc comment.
+- `formatTypeHint` (`lib/utils/formatType.ts`) throws at RUNTIME on an
+  unknown variant; `variableTypeToString`
+  (`lib/backends/typescriptGenerator/typeToString.ts`) prints the string
+  `"unknown"`.
+- `deepResolveNode` in `lib/typeChecker/assignability.ts` is the trap.
+  Passing nodes through unchanged is its CORRECT behavior for most
+  variants, so it cannot have an exhaustive switch. But a variant that
+  must resolve before codegen — any eagerly-evaluated form like the
+  utility types, `keyof`, or indexed access — silently reaches the zod
+  mapper unresolved without a case here, and the mapper falls back to
+  `z.string()`. No error anywhere; just a wrong schema.
+- `hasAnyValidateTag` and the descriptor builder in
+  `lib/backends/typescriptGenerator/validationDescriptor.ts` gate the
+  `@validate` emission path; a missing case silently skips validation.
+
+The rule that catches what the compiler cannot: every new variant gets a
+codegen test asserting its emitted schema against a NON-string shape
+(the fallback is `z.string()`, so a string assertion can be born green).
+See `lib/backends/typeOperators.codegen.test.ts` for the pattern.
+
 ## Adding a new pattern form
 
 Patterns (destructuring, `is`, match arms, for-loop binders) are

--- a/packages/agency-lang/docs/dev/typechecker/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/README.md
@@ -294,6 +294,16 @@ fatal at codegen via `resolveTypeDeep`. Located diagnostics are a named
 follow-up in the design spec
 (`docs/superpowers/specs/2026-07-09-utility-types-design.md`).
 
+### Type operators: keyof and indexed access
+
+`keyof T` and `T["key"]` are prefix/postfix type operators. Like the
+built-in generics, they evaluate EAGERLY in `resolveTypeWithGuard` (see
+`lib/typeChecker/typeOperators.ts`, which shares the argument helpers in
+`builtinGenerics.ts`), so no downstream pass sees the operator nodes.
+`keyof` yields a closed literal union, which plugs straight into match
+exhaustiveness and discriminant narrowing. The `keyof` keyword is in
+`RESERVED_TYPE_NAMES`.
+
 ## Type narrowing
 
 Flow-sensitive narrowing and exhaustiveness checking have their own subtree:

--- a/packages/agency-lang/docs/site/guide/types.md
+++ b/packages/agency-lang/docs/site/guide/types.md
@@ -223,31 +223,6 @@ Anthropic does not support recursive types as LLM output contracts
 (OpenAI and Gemini do). On Anthropic, parse the response yourself with
 `schema(Tree).parseJSON(...)`.
 
-## keyof and indexed access
-
-`keyof T` is the union of an object type's key names. `T["key"]` is the
-type of one field. Both update automatically when the source type
-changes:
-
-```ts
-type User = {
-  name: string,
-  email: string,
-}
-
-type Field = keyof User        // "name" | "email"
-type Name = User["name"]       // string
-```
-
-`keyof` produces a closed union, so `match` over a `keyof` value gets
-exhaustiveness checking. Add a field to `User` and every match over its
-keys reports a missing case.
-
-Both operators need a concrete object type. Records, arrays, and
-primitives are errors. Index keys must be string literals. A union of
-keys returns a union of field types, so `User[keyof User]` is the type
-of every value in `User`.
-
 ## References
 
 - [Schemas](/guide/schemas)

--- a/packages/agency-lang/docs/site/guide/types.md
+++ b/packages/agency-lang/docs/site/guide/types.md
@@ -223,6 +223,31 @@ Anthropic does not support recursive types as LLM output contracts
 (OpenAI and Gemini do). On Anthropic, parse the response yourself with
 `schema(Tree).parseJSON(...)`.
 
+## keyof and indexed access
+
+`keyof T` is the union of an object type's key names. `T["key"]` is the
+type of one field. Both update automatically when the source type
+changes:
+
+```ts
+type User = {
+  name: string,
+  email: string,
+}
+
+type Field = keyof User        // "name" | "email"
+type Name = User["name"]       // string
+```
+
+`keyof` produces a closed union, so `match` over a `keyof` value gets
+exhaustiveness checking. Add a field to `User` and every match over its
+keys reports a missing case.
+
+Both operators need a concrete object type. Records, arrays, and
+primitives are errors. Index keys must be string literals. A union of
+keys returns a union of field types, so `User[keyof User]` is the type
+of every value in `User`.
+
 ## References
 
 - [Schemas](/guide/schemas)

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -68,6 +68,27 @@ describe("AgencyGenerator - Function Parameter Type Hints", () => {
         input: 'def contact(c: Pick<User, "name" | "email">) { c }',
         expectedOutput: 'def contact(c: Pick<User, "name" | "email">) {\nc\n}',
       },
+
+      {
+        description: "keyof type hint round-trips",
+        input: "def f(k: keyof User) { k }",
+        expectedOutput: "def f(k: keyof User) {\nk\n}",
+      },
+      {
+        description: "indexed access type hint round-trips",
+        input: 'def f(x: User["name"]) { x }',
+        expectedOutput: 'def f(x: User["name"]) {\nx\n}',
+      },
+      {
+        description: "array-of-keyof keeps its parens (distinct from keyof-of-array)",
+        input: "def f(k: (keyof User)[]) { k }",
+        expectedOutput: "def f(k: (keyof User)[]) {\nk\n}",
+      },
+      {
+        description: "keyof-of-array stays unparenthesized",
+        input: "def f(k: keyof User[]) { k }",
+        expectedOutput: "def f(k: keyof User[]) {\nk\n}",
+      },
     ];
 
     testCases.forEach(({ description, input, expectedOutput }) => {
@@ -90,6 +111,23 @@ describe("AgencyGenerator - Function Parameter Type Hints", () => {
   });
 
   describe("Type preservation", () => {
+    it("preserves keyof and indexed access in alias declarations", () => {
+      const parseResult = parseAgency(
+        'type F = keyof User\ntype N = User["name"]',
+        {},
+        false,
+      );
+      expect(parseResult.success).toBe(true);
+
+      if (!parseResult.success) return;
+
+      const generator = new AgencyGenerator();
+      const result = generator.generate(parseResult.result);
+
+      expect(result.output).toContain("keyof User");
+      expect(result.output).toContain('User["name"]');
+    });
+
     it("preserves a utility type in a type alias declaration", () => {
       const parseResult = parseAgency("type UserPatch = Partial<User>", {}, false);
       expect(parseResult.success).toBe(true);

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -89,6 +89,16 @@ describe("AgencyGenerator - Function Parameter Type Hints", () => {
         input: "def f(k: keyof User[]) { k }",
         expectedOutput: "def f(k: keyof User[]) {\nk\n}",
       },
+      {
+        description: "keyof of a union keeps its parens",
+        input: "def f(k: keyof (A | B)) { k }",
+        expectedOutput: "def f(k: keyof (A | B)) {\nk\n}",
+      },
+      {
+        description: "indexed access on a union keeps its parens",
+        input: 'def f(x: (A | B)["k"]) { x }',
+        expectedOutput: 'def f(x: (A | B)["k"]) {\nx\n}',
+      },
     ];
 
     testCases.forEach(({ description, input, expectedOutput }) => {

--- a/packages/agency-lang/lib/backends/typeOperators.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/typeOperators.codegen.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypeScriptBuilder } from "./typescriptBuilder.js";
+import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { printTs } from "../ir/prettyPrint.js";
+import type { AgencyConfig } from "@/config.js";
+
+function generate(source: string): string {
+  const parseResult = parseAgency(source, {}, false);
+  if (!parseResult.success)
+    throw new Error(`Failed to parse: ${parseResult.message}`);
+  const info = buildCompilationUnit(parseResult.result);
+  const preprocessor = new TypescriptPreprocessor(parseResult.result, {}, info);
+  const pre = preprocessor.preprocess();
+  const builder = new TypeScriptBuilder({} as AgencyConfig, info, "test.agency");
+  return printTs(builder.build(pre));
+}
+
+// The zod mapper's fallback for unresolved nodes is z.string(), so every
+// assertion here uses a shape the fallback cannot fake.
+describe("type operators in alias bodies (deepResolveNode routing)", () => {
+  it("type K = keyof User emits the literal-key union, NOT z.string()", () => {
+    const out = generate(`
+type User = {
+  name: string,
+  age: number,
+}
+type K = keyof User
+node main() {
+  return 1
+}
+`);
+    expect(out).toMatch(
+      /const K = z\.union\(\[z\.literal\("name"\), z\.literal\("age"\)\]\)/,
+    );
+  });
+
+  it("an indexed-access alias emits the property schema (non-string property)", () => {
+    const out = generate(`
+type User = {
+  name: string,
+  age: number,
+}
+type A = User["age"]
+node main() {
+  return 1
+}
+`);
+    expect(out).toMatch(/const A = z\.number\(\)/);
+  });
+
+  it("keyof of a FORWARD alias still emits literal keys (alias table is order-independent)", () => {
+    const out = generate(`
+type K = keyof Later
+type Later = {
+  a: string,
+  b: number,
+}
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain('z.literal("a")');
+  });
+
+  it("an indexed property carrying @validate keeps enforcement (descriptor path)", () => {
+    // Tag ride-along must survive codegen, not just unit evaluation:
+    // the extracted property type carries the validate tag, so the alias
+    // gets a descriptor assignment, not just a bare schema const.
+    const out = generate(`
+def positive(n: number): Result<number, string> {
+  if (n > 0) {
+    return success(n)
+  }
+  return failure("must be positive")
+}
+type User = {
+  name: string,
+  @validate(positive)
+  age: number,
+}
+type A = User["age"]
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("(A as any).__agency_descriptor");
+    expect(out).toContain("const A = z.number()");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
@@ -208,7 +208,16 @@ export function variableTypeToString(
       .join(", ");
     return `${variableType.name}<${args}>${formatValueArgs(variableType.valueArgs)}`;
   } else if (variableType.type === "keyofType") {
-    return `keyof ${variableTypeToString(variableType.operand, typeAliases, forFormatting)}`;
+    const op = variableTypeToString(
+      variableType.operand,
+      typeAliases,
+      forFormatting,
+    );
+    // Parenthesize a union operand: `keyof (A | B)` must not print as
+    // `keyof A | B`, which re-parses as (keyof A) | B.
+    return variableType.operand.type === "unionType"
+      ? `keyof (${op})`
+      : `keyof ${op}`;
   } else if (variableType.type === "indexedAccessType") {
     const obj = variableTypeToString(
       variableType.objectType,
@@ -216,7 +225,10 @@ export function variableTypeToString(
       forFormatting,
     );
     const wrapped =
-      variableType.objectType.type === "keyofType" ? `(${obj})` : obj;
+      variableType.objectType.type === "keyofType" ||
+      variableType.objectType.type === "unionType"
+        ? `(${obj})`
+        : obj;
     const index = variableTypeToString(
       variableType.index,
       typeAliases,

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
@@ -136,7 +136,12 @@ export function variableTypeToString(
       typeAliases,
       forFormatting,
     );
-    if (variableType.elementType.type === "unionType") {
+    if (
+      variableType.elementType.type === "unionType" ||
+      variableType.elementType.type === "keyofType"
+    ) {
+      // keyof parenthesizes for the same re-parse reason as unions:
+      // `keyof User[]` reads as keyof (User[]).
       return `(${inner})[]`;
     }
     return `${inner}[]`;
@@ -202,6 +207,22 @@ export function variableTypeToString(
       .map((a) => variableTypeToString(a, typeAliases, forFormatting))
       .join(", ");
     return `${variableType.name}<${args}>${formatValueArgs(variableType.valueArgs)}`;
+  } else if (variableType.type === "keyofType") {
+    return `keyof ${variableTypeToString(variableType.operand, typeAliases, forFormatting)}`;
+  } else if (variableType.type === "indexedAccessType") {
+    const obj = variableTypeToString(
+      variableType.objectType,
+      typeAliases,
+      forFormatting,
+    );
+    const wrapped =
+      variableType.objectType.type === "keyofType" ? `(${obj})` : obj;
+    const index = variableTypeToString(
+      variableType.index,
+      typeAliases,
+      forFormatting,
+    );
+    return `${wrapped}[${index}]`;
   }
   return "unknown";
 }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -76,6 +76,17 @@ export function hasAnyValidateTag(
       return t.types.some((m) => hasAnyValidateTag(m, aliasesFull, seen));
     case "resultType":
       return hasAnyValidateTag(t.successType, aliasesFull, seen);
+    case "keyofType":
+      // keyof results are key-name literals and carry no validators, but
+      // the OPERAND may (over-approximation is safe: the descriptor is
+      // built from the RESOLVED type, so a false-positive gate only emits
+      // a validator-less descriptor).
+      return hasAnyValidateTag(t.operand, aliasesFull, seen);
+    case "indexedAccessType":
+      return (
+        hasAnyValidateTag(t.objectType, aliasesFull, seen) ||
+        hasAnyValidateTag(t.index, aliasesFull, seen)
+      );
     case "genericType": {
       // Type arguments may themselves carry @validate (e.g. `Array<Email>`).
       if (

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -86,6 +86,7 @@ import {
   AgencyComment,
   AgencyMultiLineComment,
   ArrayType,
+  KeyofType,
   BlockType,
   BooleanLiteralType,
   NumberLiteralType,
@@ -992,44 +993,112 @@ export const parenthesizedTypeParser: Parser<VariableType> = memo(
   ),
 );
 
-export const arrayTypeParser: Parser<ArrayType> = (input: string) => {
-  const parser = trace(
-    "arrayTypeParser",
-    seqC(
-      set("type", "arrayType"),
-      capture(
-        or(
-          parenthesizedTypeParser,
-          objectTypeParser,
-          lazy(() => resultTypeParser),
-          lazy(() => angleBracketsArrayTypeParser),
-          lazy(() => genericTypeParser),
-          primitiveTypeParser,
-          typeAliasVariableParser,
-        ),
-        "elementType",
-      ),
-      capture(count(str("[]")), "arrayDepth"),
-    ),
-  );
-  const result = parser(input);
-  if (result.success) {
-    // Wrap the elementType in ArrayType according to arrayDepth
-    let wrappedType: VariableType = result.result.elementType;
-    for (let i = 0; i < result.result.arrayDepth; i++) {
-      wrappedType = {
-        type: "arrayType",
-        elementType: wrappedType,
-      };
+// The shared base for postfix type expressions (`T[]` arrays and
+// `T["key"]` indexed access). Extracted from arrayTypeParser so keyof can
+// reuse it with a different suffix arity — see postfixOperandParser.
+// Constructed per call (not at module scope): several members are
+// declared later in this file, exactly like the original arrayTypeParser
+// which built its or() inside the function body.
+const typePostfixBase: Parser<VariableType> = (input: string) =>
+  or(
+    parenthesizedTypeParser,
+    objectTypeParser,
+    lazy(() => resultTypeParser),
+    lazy(() => angleBracketsArrayTypeParser),
+    lazy(() => genericTypeParser),
+    primitiveTypeParser,
+    typeAliasVariableParser,
+  )(input);
+
+/**
+ * Parse postfix suffixes onto a base type: `[]` wraps an array,
+ * `[<type>]` wraps an indexed access. `minSuffixes` controls the arity:
+ *
+ * - arrayTypeParser uses 1: as an or-chain member it must FAIL on a bare
+ *   base (exactly like the old `count(str("[]"))`, which failed on zero
+ *   matches), so bare types fall through to later alternatives. A
+ *   zero-suffix variant in the or-chain would greedily match `keyof` as
+ *   a plain identifier and break every keyof annotation, because or()
+ *   commits to the first success.
+ * - postfixOperandParser uses 0: keyof binds to the full postfix
+ *   expression that follows it (`keyof User`, `keyof User[]`,
+ *   `keyof User["a"]` all work). Only keyofTypeParser consumes it, so
+ *   the bare-match greediness leaks nowhere.
+ */
+function parseTypePostfix(
+  input: string,
+  minSuffixes: number,
+): ParserResult<VariableType> {
+  const base = typePostfixBase(input);
+  if (!base.success) return base;
+  let current: VariableType = base.result;
+  let rest = base.rest;
+  let suffixes = 0;
+  for (;;) {
+    const emptyBrackets = str("[]")(rest);
+    if (emptyBrackets.success) {
+      current = { type: "arrayType", elementType: current };
+      rest = emptyBrackets.rest;
+      suffixes += 1;
+      continue;
     }
+    const openBracket = char("[")(rest);
+    if (openBracket.success) {
+      const index = variableTypeParser(openBracket.rest);
+      if (index.success) {
+        const closeBracket = char("]")(index.rest);
+        if (closeBracket.success) {
+          current = {
+            type: "indexedAccessType",
+            objectType: current,
+            index: index.result,
+          };
+          rest = closeBracket.rest;
+          suffixes += 1;
+          continue;
+        }
+      }
+    }
+    break;
+  }
+  if (suffixes < minSuffixes) {
     return {
-      success: true,
-      rest: result.rest,
-      result: wrappedType as ArrayType,
+      success: false,
+      rest: input,
+      message: "expected at least one type suffix",
     };
   }
-  return result;
-};
+  return { success: true, rest, result: current };
+}
+
+export const arrayTypeParser: Parser<ArrayType> = (input: string) =>
+  trace("arrayTypeParser", (i: string) =>
+    parseTypePostfix(i, 1),
+  )(input) as ParserResult<ArrayType>;
+
+const postfixOperandParser: Parser<VariableType> = (input: string) =>
+  parseTypePostfix(input, 0);
+
+/**
+ * `keyof T` — prefix operator producing a KeyofType node. Binds to the
+ * full postfix expression that follows: `keyof User["address"]` means
+ * keyof (User["address"]) and `keyof User[]` means keyof (User[]).
+ * Union binds looser (the union parser splits on `|` before items
+ * parse), so `keyof A | keyof B` is a union of two keyofs.
+ *
+ * The whitespace after the keyword is REQUIRED and load-bearing: it is
+ * the keyword boundary that lets `keyofish` parse as a plain
+ * identifier. Do not make it optional.
+ */
+export const keyofTypeParser: Parser<KeyofType> = memo(
+  "keyofTypeParser",
+  seqC(
+    set("type", "keyofType"),
+    str("keyof"),
+    spaces,
+    capture(lazy(() => postfixOperandParser), "operand"),
+  ),
+);
 export const angleBracketsArrayTypeParser: Parser<ArrayType> = memo(
   "angleBracketsArrayTypeParser",
   seqC(
@@ -1303,6 +1372,7 @@ export const unionItemParser: Parser<VariableType> = memo(
   "unionItemParser",
   or(
     lazy(() => blockTypeParser),
+    lazy(() => keyofTypeParser),
     objectTypeParser,
     angleBracketsArrayTypeParser,
     arrayTypeParser,
@@ -1594,6 +1664,7 @@ export const variableTypeParser: Parser<VariableType> = memo(
   or(
     blockTypeParser,
     unionTypeParser,
+    keyofTypeParser,
     arrayTypeParser,
     objectTypeParser,
     angleBracketsArrayTypeParser,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1011,73 +1011,78 @@ const typePostfixBase: Parser<VariableType> = (input: string) =>
   )(input);
 
 /**
- * Parse postfix suffixes onto a base type: `[]` wraps an array,
- * `[<type>]` wraps an indexed access. `minSuffixes` controls the arity:
- *
- * - arrayTypeParser uses 1: as an or-chain member it must FAIL on a bare
- *   base (exactly like the old `count(str("[]"))`, which failed on zero
- *   matches), so bare types fall through to later alternatives. A
- *   zero-suffix variant in the or-chain would greedily match `keyof` as
- *   a plain identifier and break every keyof annotation, because or()
- *   commits to the first success.
- * - postfixOperandParser uses 0: keyof binds to the full postfix
- *   expression that follows it (`keyof User`, `keyof User[]`,
- *   `keyof User["a"]` all work). Only keyofTypeParser consumes it, so
- *   the bare-match greediness leaks nowhere.
+ * A postfix type suffix: `[]` wraps an array, `[<type>]` wraps an
+ * indexed access. Index brackets tolerate inner whitespace
+ * (`User[ "name" ]`), matching TypeScript; the bare `[]` array suffix
+ * stays space-intolerant, matching its old behavior.
  */
-function parseTypePostfix(
-  input: string,
-  minSuffixes: number,
-): ParserResult<VariableType> {
-  const base = typePostfixBase(input);
-  if (!base.success) return base;
-  let current: VariableType = base.result;
-  let rest = base.rest;
-  let suffixes = 0;
-  for (;;) {
-    const emptyBrackets = str("[]")(rest);
-    if (emptyBrackets.success) {
-      current = { type: "arrayType", elementType: current };
-      rest = emptyBrackets.rest;
-      suffixes += 1;
-      continue;
-    }
-    const openBracket = char("[")(rest);
-    if (openBracket.success) {
-      const index = variableTypeParser(openBracket.rest);
-      if (index.success) {
-        const closeBracket = char("]")(index.rest);
-        if (closeBracket.success) {
-          current = {
-            type: "indexedAccessType",
-            objectType: current,
-            index: index.result,
-          };
-          rest = closeBracket.rest;
-          suffixes += 1;
-          continue;
-        }
-      }
-    }
-    break;
-  }
-  if (suffixes < minSuffixes) {
-    return {
-      success: false,
-      rest: input,
-      message: "expected at least one type suffix",
-    };
-  }
-  return { success: true, rest, result: current };
+type TypeSuffix =
+  | { suffix: "array" }
+  | { suffix: "index"; index: VariableType };
+
+const typeSuffixParser: Parser<TypeSuffix> = or(
+  map(str("[]"), (): TypeSuffix => ({ suffix: "array" })),
+  map(
+    seqC(
+      char("["),
+      optionalSpaces,
+      capture(lazy(() => variableTypeParser), "index"),
+      optionalSpaces,
+      char("]"),
+    ),
+    ({ index }): TypeSuffix => ({ suffix: "index", index }),
+  ),
+);
+
+/** Fold suffixes onto a base type, left to right. */
+function applyTypeSuffixes(
+  base: VariableType,
+  suffixes: TypeSuffix[],
+): VariableType {
+  return suffixes.reduce<VariableType>(
+    (current, s) =>
+      s.suffix === "array"
+        ? { type: "arrayType", elementType: current }
+        : { type: "indexedAccessType", objectType: current, index: s.index },
+    base,
+  );
 }
 
-export const arrayTypeParser: Parser<ArrayType> = (input: string) =>
-  trace("arrayTypeParser", (i: string) =>
-    parseTypePostfix(i, 1),
-  )(input) as ParserResult<ArrayType>;
+/**
+ * Base + AT LEAST ONE suffix. As an or-chain member this parser must
+ * FAIL on a bare base (exactly like the old `count(str("[]"))`, which
+ * failed on zero matches), so bare types fall through to later
+ * alternatives. A zero-suffix variant in the or-chain would greedily
+ * match `keyof` as a plain identifier and break every keyof annotation,
+ * because or() commits to the first success.
+ *
+ * The name is historical: with index suffixes in the grammar, the
+ * top-level result may be an IndexedAccessType (`User["name"]`), so the
+ * declared type is Parser<VariableType>.
+ */
+export const arrayTypeParser: Parser<VariableType> = trace(
+  "arrayTypeParser",
+  map(
+    seqC(
+      capture(typePostfixBase, "base"),
+      capture(many1(typeSuffixParser), "suffixes"),
+    ),
+    ({ base, suffixes }) => applyTypeSuffixes(base, suffixes),
+  ),
+);
 
-const postfixOperandParser: Parser<VariableType> = (input: string) =>
-  parseTypePostfix(input, 0);
+/**
+ * Base + ZERO OR MORE suffixes. Only keyofTypeParser consumes this, so
+ * its bare-match greediness leaks nowhere: `keyof User`, `keyof User[]`,
+ * and `keyof User["a"]` all bind the full postfix expression.
+ */
+const postfixOperandParser: Parser<VariableType> = map(
+  seqC(
+    capture(typePostfixBase, "base"),
+    capture(many(typeSuffixParser), "suffixes"),
+  ),
+  ({ base, suffixes }) => applyTypeSuffixes(base, suffixes),
+);
 
 /**
  * `keyof T` — prefix operator producing a KeyofType node. Binds to the

--- a/packages/agency-lang/lib/parsers/typeOperatorParsing.test.ts
+++ b/packages/agency-lang/lib/parsers/typeOperatorParsing.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+
+function firstParamHint(source: string): unknown {
+  const parsed = parseAgency(source, {}, false);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) throw new Error("unreachable");
+  const def = parsed.result.nodes.find((n) => n.type === "function") as {
+    parameters: { typeHint?: unknown }[];
+  };
+  return def.parameters[0].typeHint;
+}
+
+describe("keyof parsing", () => {
+  it("parses keyof over an alias reference", () => {
+    expect(firstParamHint("def f(k: keyof User) { k }")).toMatchObject({
+      type: "keyofType",
+      operand: { type: "typeAliasVariable", aliasName: "User" },
+    });
+  });
+
+  it("binds tighter than union: keyof A | keyof B is a union of keyofs", () => {
+    expect(firstParamHint("def f(k: keyof A | keyof B) { k }")).toMatchObject({
+      type: "unionType",
+      types: [
+        { type: "keyofType", operand: { aliasName: "A" } },
+        { type: "keyofType", operand: { aliasName: "B" } },
+      ],
+    });
+  });
+
+  it("postfix binds tighter than keyof: keyof User[] is keyof (User[])", () => {
+    expect(firstParamHint("def f(k: keyof User[]) { k }")).toMatchObject({
+      type: "keyofType",
+      operand: { type: "arrayType" },
+    });
+  });
+
+  it("parenthesized keyof takes a suffix: (keyof User)[] is an ARRAY of keyofs", () => {
+    expect(firstParamHint("def f(k: (keyof User)[]) { k }")).toMatchObject({
+      type: "arrayType",
+      elementType: { type: "keyofType" },
+    });
+  });
+
+  it("keyword boundary: keyofish stays a plain identifier", () => {
+    // The required whitespace after `keyof` is load-bearing: it is what
+    // stops the keyword from eating identifier prefixes. Pin it so nobody
+    // makes the spaces optional.
+    expect(firstParamHint("def f(k: keyofish) { k }")).toMatchObject({
+      type: "typeAliasVariable",
+      aliasName: "keyofish",
+    });
+  });
+});
+
+describe("indexed access parsing", () => {
+  it("parses a string-literal index", () => {
+    expect(firstParamHint('def f(x: User["name"]) { x }')).toMatchObject({
+      type: "indexedAccessType",
+      objectType: { type: "typeAliasVariable", aliasName: "User" },
+      index: { type: "stringLiteralType", value: "name" },
+    });
+  });
+
+  it("parses a union index", () => {
+    expect(firstParamHint('def f(x: User["a" | "b"]) { x }')).toMatchObject({
+      type: "indexedAccessType",
+      index: { type: "unionType" },
+    });
+  });
+
+  it("chains left to right", () => {
+    expect(
+      firstParamHint('def f(x: User["address"]["city"]) { x }'),
+    ).toMatchObject({
+      type: "indexedAccessType",
+      objectType: {
+        type: "indexedAccessType",
+        index: { value: "address" },
+      },
+      index: { value: "city" },
+    });
+  });
+
+  it("accepts a full type expression as the index (keyof composes)", () => {
+    expect(firstParamHint("def f(x: User[keyof User]) { x }")).toMatchObject({
+      type: "indexedAccessType",
+      index: { type: "keyofType" },
+    });
+  });
+
+  it('mixes with arrays: User["tags"][] is an array of the indexed type', () => {
+    expect(firstParamHint('def f(x: User["tags"][]) { x }')).toMatchObject({
+      type: "arrayType",
+      elementType: { type: "indexedAccessType" },
+    });
+  });
+
+  it("empty brackets still mean array", () => {
+    expect(firstParamHint("def f(x: number[]) { x }")).toMatchObject({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+});

--- a/packages/agency-lang/lib/parsers/typeOperatorParsing.test.ts
+++ b/packages/agency-lang/lib/parsers/typeOperatorParsing.test.ts
@@ -97,6 +97,24 @@ describe("indexed access parsing", () => {
     });
   });
 
+  it("tolerates whitespace inside index brackets (TS parity)", () => {
+    expect(firstParamHint('def f(x: User[ "name" ]) { x }')).toMatchObject({
+      type: "indexedAccessType",
+      index: { type: "stringLiteralType", value: "name" },
+    });
+  });
+
+  it("parses union operands and objects when parenthesized", () => {
+    expect(firstParamHint("def f(k: keyof (A | B)) { k }")).toMatchObject({
+      type: "keyofType",
+      operand: { type: "unionType" },
+    });
+    expect(firstParamHint('def f(x: (A | B)["k"]) { x }')).toMatchObject({
+      type: "indexedAccessType",
+      objectType: { type: "unionType" },
+    });
+  });
+
   it("empty brackets still mean array", () => {
     expect(firstParamHint("def f(x: number[]) { x }")).toMatchObject({
       type: "arrayType",

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -6,7 +6,12 @@ import { mergeTagSets } from "./mergeTags.js";
 import { applyValueArgs } from "./valueParamSubstitution.js";
 import { resultToObjectUnion } from "./resultUnion.js";
 import { typeKey } from "./typeKey.js";
-import { evalBuiltinGeneric, isBuiltinGenericName } from "./builtinGenerics.js";
+import {
+  evalBuiltinGeneric,
+  isBuiltinGenericName,
+  withUseSiteTags,
+} from "./builtinGenerics.js";
+import { evalIndexedAccess, evalKeyof } from "./typeOperators.js";
 
 /**
  * Public resolveType: normalizes a VariableType by resolving type-alias
@@ -92,6 +97,26 @@ function resolveTypeWithGuard(
     }
     const resolved = resolveTypeWithGuard(substitutedEntry.body, typeAliases, next);
     return attachAliasTags(resolved, substitutedEntry.tags);
+  }
+
+  if (vt.type === "keyofType") {
+    // Eager evaluation (lib/typeChecker/typeOperators.ts): the node never
+    // survives resolution. Occurrence tags thread through like the
+    // genericType branch below.
+    return withUseSiteTags(
+      evalKeyof(vt.operand, (t) =>
+        resolveTypeWithGuard(t, typeAliases, inProgress),
+      ),
+      vt.tags,
+    );
+  }
+  if (vt.type === "indexedAccessType") {
+    return withUseSiteTags(
+      evalIndexedAccess(vt.objectType, vt.index, (t) =>
+        resolveTypeWithGuard(t, typeAliases, inProgress),
+      ),
+      vt.tags,
+    );
   }
 
   if (vt.type === "genericType") {
@@ -248,6 +273,12 @@ function deepResolveNode(
   typeAliases: Record<string, TypeAliasEntry>,
 ): VariableType {
   if (n.type === "genericType") return resolveType(n, typeAliases);
+  if (n.type === "keyofType" || n.type === "indexedAccessType") {
+    // Same routing as genericType: these evaluate to concrete types and
+    // must never reach the zod mapper unresolved — the mapper's fallback
+    // silently emits z.string(). See docs/dev/adding-features.md.
+    return resolveType(n, typeAliases);
+  }
   if (n.type === "typeAliasVariable") {
     const entry = typeAliases[n.aliasName];
     // Inline only generic aliases that can resolve themselves via defaults.

--- a/packages/agency-lang/lib/typeChecker/builtinGenerics.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinGenerics.ts
@@ -84,7 +84,7 @@ function stripNull(t: VariableType): VariableType {
  * ARGUMENT (alias-side per the `mergeTagSets` contract); the occurrence's
  * tags are the use-site layer and override on `@jsonSchema` key conflicts.
  */
-function withUseSiteTags(
+export function withUseSiteTags(
   t: VariableType,
   useSiteTags: Tag[] | undefined,
 ): VariableType {
@@ -102,7 +102,7 @@ function isValidRecordKey(t: VariableType): boolean {
   return false;
 }
 
-function resolveObjectArg(
+export function resolveObjectArg(
   name: string,
   arg: VariableType,
   resolve: Resolve,
@@ -117,7 +117,7 @@ function resolveObjectArg(
 }
 
 /** K must resolve to a string literal or a union of string literals. */
-function resolveKeysArg(
+export function resolveKeysArg(
   name: string,
   arg: VariableType,
   resolve: Resolve,

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -62,6 +62,9 @@ const RESERVED_TYPE_NAMES = new Set<string>([
   "Result",
   "Success",
   "Failure",
+  // `keyof` is a keyword in type position; an alias with this name would
+  // silently change how annotations parse.
+  "keyof",
   ...RESERVED_GENERIC_NAMES,
 ]);
 

--- a/packages/agency-lang/lib/typeChecker/typeKey.ts
+++ b/packages/agency-lang/lib/typeChecker/typeKey.ts
@@ -81,6 +81,10 @@ function canonical(t: VariableType): string {
       return `{"numlit":${JSON.stringify(t.value)}}`;
     case "booleanLiteralType":
       return `{"boollit":${JSON.stringify(t.value)}}`;
+    case "keyofType":
+      return `{"keyof":${canonical(t.operand)}}`;
+    case "indexedAccessType":
+      return `{"index":[${canonical(t.objectType)},${canonical(t.index)}]}`;
     default: {
       // Exhaustiveness enforced per the typeHints.ts convention: a new
       // VariableType variant fails compilation here instead of silently

--- a/packages/agency-lang/lib/typeChecker/typeOperators.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typeOperators.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from "vitest";
+import { evalKeyof, evalIndexedAccess } from "./typeOperators.js";
+import { typecheckSource } from "./testUtils.js";
+import type { VariableType } from "../types.js";
+
+const STR: VariableType = { type: "primitiveType", value: "string" };
+const NUM: VariableType = { type: "primitiveType", value: "number" };
+const AGE_TAG = { type: "tag" as const, name: "validate", arguments: [] };
+const id = (t: VariableType) => t;
+
+function user(): VariableType {
+  return {
+    type: "objectType",
+    properties: [
+      { key: "name", value: STR },
+      { key: "age", value: { ...NUM, tags: [AGE_TAG] } },
+    ],
+  };
+}
+
+function lit(value: string): VariableType {
+  return { type: "stringLiteralType", value };
+}
+
+describe("evalKeyof", () => {
+  it("returns the union of key literals", () => {
+    expect(evalKeyof(user(), id)).toEqual({
+      type: "unionType",
+      types: [lit("name"), lit("age")],
+    });
+  });
+
+  it("returns a single literal for a one-key object (no union wrapper)", () => {
+    const one: VariableType = {
+      type: "objectType",
+      properties: [{ key: "only", value: STR }],
+    };
+    expect(evalKeyof(one, id)).toEqual(lit("only"));
+  });
+
+  it("returns never for an empty object", () => {
+    expect(evalKeyof({ type: "objectType", properties: [] }, id)).toEqual({
+      type: "primitiveType",
+      value: "never",
+    });
+  });
+
+  it("resolves alias operands through the injected resolver", () => {
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "User" };
+    const resolve = (t: VariableType) =>
+      t.type === "typeAliasVariable" && t.aliasName === "User" ? user() : t;
+    expect(evalKeyof(ref, resolve)).toMatchObject({ type: "unionType" });
+  });
+
+  it("rejects every non-object operand form in the spec table", () => {
+    expect(() => evalKeyof(NUM, id)).toThrow(/keyof expects an object type/);
+    expect(() =>
+      evalKeyof({ type: "arrayType", elementType: STR }, id),
+    ).toThrow(/keyof expects an object type/);
+    const rec: VariableType = {
+      type: "genericType",
+      name: "Record",
+      typeArgs: [STR, NUM],
+    };
+    expect(() => evalKeyof(rec, id)).toThrow(/keyof expects an object type/);
+    const union: VariableType = { type: "unionType", types: [user(), user()] };
+    expect(() => evalKeyof(union, id)).toThrow(/keyof expects an object type/);
+  });
+
+  it("does not mutate its input", () => {
+    const input = user();
+    const snapshot = JSON.parse(JSON.stringify(input));
+    evalKeyof(input, id);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("evalIndexedAccess", () => {
+  it("returns the property type WITH its tags", () => {
+    expect(evalIndexedAccess(user(), lit("age"), id)).toEqual({
+      type: "primitiveType",
+      value: "number",
+      tags: [AGE_TAG],
+    });
+  });
+
+  it("a union index yields the union of property VALUE types (exact members)", () => {
+    const idx: VariableType = {
+      type: "unionType",
+      types: [lit("name"), lit("age")],
+    };
+    expect(evalIndexedAccess(user(), idx, id)).toEqual({
+      type: "unionType",
+      types: [STR, { ...NUM, tags: [AGE_TAG] }],
+    });
+  });
+
+  it("composes: indexing by keyof gives all VALUE types (exact members)", () => {
+    expect(evalIndexedAccess(user(), evalKeyof(user(), id), id)).toEqual({
+      type: "unionType",
+      types: [STR, { ...NUM, tags: [AGE_TAG] }],
+    });
+  });
+
+  it("rejects a missing key in the Pick wording family", () => {
+    expect(() => evalIndexedAccess(user(), lit("nope"), id)).toThrow(
+      /indexed access key 'nope' does not exist on the target type.*name, age/,
+    );
+  });
+
+  it("rejects a non-literal index (shared resolveKeysArg wording)", () => {
+    expect(() => evalIndexedAccess(user(), STR, id)).toThrow(
+      /expects string literal keys/,
+    );
+  });
+
+  it("rejects a non-object base", () => {
+    expect(() => evalIndexedAccess(NUM, lit("a"), id)).toThrow(
+      /expects an object type/,
+    );
+  });
+});
+
+describe("type operators through the full pipeline", () => {
+  it("keyof produces a closed union: match gets exhaustiveness checking", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+def label(field: keyof User): string {
+  return match (field) {
+    "name" => "the name"
+    "age" => "the age"
+  }
+}
+node main() {
+  return label("name")
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a match missing a key case is reported", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+def label(field: keyof User): string {
+  return match (field) {
+    "name" => "the name"
+  }
+}
+node main() {
+  return label("name")
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/age/);
+  });
+
+  it("rejects a non-key value against a keyof annotation (direct negative)", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+node main() {
+  const k: keyof User = "bogus"
+  return k
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("indexed access types an annotation, and rejects a mismatch", () => {
+    const ok = typecheckSource(`
+type User = { name: string, age: number }
+node main() {
+  const n: User["name"] = "x"
+  return n
+}
+`);
+    expect(ok).toEqual([]);
+    const bad = typecheckSource(`
+type User = { name: string, age: number }
+node main() {
+  const n: User["name"] = 5
+  return n
+}
+`);
+    expect(bad.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("indexing an optional property includes null (desugared p?: interaction)", () => {
+    const errors = typecheckSource(`
+type User = { name: string, nickname?: string }
+node main() {
+  const n: User["nickname"] = null
+  return n
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("keyof works on a recursive alias (keys are top-level)", () => {
+    const errors = typecheckSource(`
+type Tree = {
+  value: number,
+  children: Tree[],
+}
+node main() {
+  const k: keyof Tree = "children"
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("chained indexed access resolves left to right", () => {
+    const errors = typecheckSource(`
+type User = {
+  name: string,
+  address: {
+    city: string,
+  },
+}
+node main() {
+  const c: User["address"]["city"] = "sf"
+  return c
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("composes with the utility types: Pick by keyof, Partial of an indexed type", () => {
+    const errors = typecheckSource(`
+type User = {
+  name: string,
+  address: {
+    city: string,
+  },
+}
+node main() {
+  const u: Pick<User, keyof User> = { name: "a", address: { city: "sf" } }
+  const a: Partial<User["address"]> = { city: null }
+  return u
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a generic alias can delegate: type Keys<T> = keyof T", () => {
+    const errors = typecheckSource(`
+type User = { name: string, age: number }
+type Keys<T> = keyof T
+node main() {
+  const k: Keys<User> = "name"
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("semantic errors stay swallowed at typecheck time: keyof number", () => {
+    const errors = typecheckSource(`
+node main() {
+  const k: keyof number = "x"
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("semantic errors stay swallowed: missing key in source, and keyof of an UNKNOWN alias", () => {
+    // Both land in the swallowed-TypeError family (safeResolveType
+    // degrades to any; codegen surfaces fatally). Pinned as tripwires for
+    // the located-diagnostics follow-up.
+    const missingKey = typecheckSource(`
+type User = { name: string }
+node main() {
+  const x: User["nope"] = 1
+  return x
+}
+`);
+    expect(missingKey).toEqual([]);
+    const unknownAlias = typecheckSource(`
+node main() {
+  const k: keyof NotDefined = "x"
+  return k
+}
+`);
+    // The undefined-alias diagnostic may legitimately fire here (operand
+    // reference validation); assert only that nothing CRASHES.
+    expect(Array.isArray(unknownAlias)).toBe(true);
+  });
+
+  it("user redefinition of keyof as an alias name is rejected", () => {
+    const errors = typecheckSource(`
+type keyof = { x: number }
+node main() {
+  return 1
+}
+`);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/typeOperators.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typeOperators.test.ts
@@ -281,9 +281,12 @@ node main() {
   return k
 }
 `);
-    // The undefined-alias diagnostic may legitimately fire here (operand
-    // reference validation); assert only that nothing CRASHES.
-    expect(Array.isArray(unknownAlias)).toBe(true);
+    // The undefined-alias diagnostic fires through the keyof operand
+    // (validateTypeReferences descends via visitTypes) — pinned exactly,
+    // so this also trips if that behavior changes.
+    expect(unknownAlias.map((e) => e.message)).toEqual([
+      "Type alias 'NotDefined' is not defined (referenced in 'k').",
+    ]);
   });
 
   it("user redefinition of keyof as an alias name is rejected", () => {

--- a/packages/agency-lang/lib/typeChecker/typeOperators.ts
+++ b/packages/agency-lang/lib/typeChecker/typeOperators.ts
@@ -1,0 +1,54 @@
+import type { VariableType } from "../types.js";
+import { resolveKeysArg, resolveObjectArg } from "./builtinGenerics.js";
+import { NEVER_T } from "./primitives.js";
+
+/**
+ * Eager evaluation for the type operators `keyof T` and `T["key"]`.
+ * Both run during type resolution and produce ordinary types, so nothing
+ * downstream knows the operator nodes exist.
+ *
+ * Argument validation is SHARED with the builtin generics
+ * (resolveObjectArg / resolveKeysArg) so the error wording stays one
+ * family across Partial, Pick, keyof, and indexed access.
+ *
+ * CYCLE RULE: this module must not import assignability.ts. The resolver
+ * arrives as the `resolve` callback, carrying the caller's in-progress
+ * guard, so recursive alias operands degrade the same way they do
+ * everywhere else.
+ */
+type Resolve = (t: VariableType) => VariableType;
+
+export function evalKeyof(
+  operand: VariableType,
+  resolve: Resolve,
+): VariableType {
+  const obj = resolveObjectArg("keyof", operand, resolve);
+  const keys: VariableType[] = obj.properties.map((p) => ({
+    type: "stringLiteralType",
+    value: p.key,
+  }));
+  if (keys.length === 0) return NEVER_T;
+  if (keys.length === 1) return keys[0];
+  return { type: "unionType", types: keys };
+}
+
+export function evalIndexedAccess(
+  objectType: VariableType,
+  index: VariableType,
+  resolve: Resolve,
+): VariableType {
+  const obj = resolveObjectArg("indexed access", objectType, resolve);
+  const keys = resolveKeysArg("indexed access", index, resolve);
+  const results = keys.map((key) => {
+    const prop = obj.properties.find((p) => p.key === key);
+    if (!prop) {
+      const available = obj.properties.map((p) => p.key).join(", ");
+      throw new TypeError(
+        `indexed access key '${key}' does not exist on the target type. Available keys: ${available}`,
+      );
+    }
+    return prop.value;
+  });
+  if (results.length === 1) return results[0];
+  return { type: "unionType", types: results };
+}

--- a/packages/agency-lang/lib/typeChecker/typeWalker.ts
+++ b/packages/agency-lang/lib/typeChecker/typeWalker.ts
@@ -38,6 +38,14 @@ export function mapTypes(
       });
     case "schemaType":
       return fn({ ...t, inner: mapTypes(t.inner, fn) });
+    case "keyofType":
+      return fn({ ...t, operand: mapTypes(t.operand, fn) });
+    case "indexedAccessType":
+      return fn({
+        ...t,
+        objectType: mapTypes(t.objectType, fn),
+        index: mapTypes(t.index, fn),
+      });
     case "blockType":
       return fn({
         ...t,
@@ -89,6 +97,11 @@ export function visitTypes(
       );
     case "schemaType":
       return visitTypes(t.inner, visit);
+    case "keyofType":
+      return visitTypes(t.operand, visit);
+    case "indexedAccessType":
+      if (visitTypes(t.objectType, visit)) return true;
+      return visitTypes(t.index, visit);
     case "blockType":
       for (const p of t.params)
         if (visitTypes(p.typeAnnotation, visit)) return true;

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -682,6 +682,13 @@ function checkType(
       for (const p of vt.params) checkType(p.typeAnnotation, paramNames, aliasName);
       checkType(vt.returnType, paramNames, aliasName);
       break;
+    case "keyofType":
+      checkType(vt.operand, paramNames, aliasName);
+      break;
+    case "indexedAccessType":
+      checkType(vt.objectType, paramNames, aliasName);
+      checkType(vt.index, paramNames, aliasName);
+      break;
     // Leaf types: no inner valueArgs to inspect. Explicit cases plus a
     // `never`-typed default keep this exhaustive — TypeScript will fail
     // to compile if a new VariableType variant is added without a case.
@@ -773,6 +780,17 @@ export function substituteValueArgsInType(
           typeAnnotation: substituteValueArgsInType(p.typeAnnotation, bindings),
         })),
         returnType: substituteValueArgsInType(vt.returnType, bindings),
+      };
+    case "keyofType":
+      return {
+        ...vt,
+        operand: substituteValueArgsInType(vt.operand, bindings),
+      };
+    case "indexedAccessType":
+      return {
+        ...vt,
+        objectType: substituteValueArgsInType(vt.objectType, bindings),
+        index: substituteValueArgsInType(vt.index, bindings),
       };
     // primitiveType, stringLiteralType, numberLiteralType,
     // booleanLiteralType, functionRefType — no inner VariableType /

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -11,10 +11,22 @@ import type { Expression } from "../types.js";
  *   `lib/typeChecker/valueParamSubstitution.ts` — both functions have
  *   exhaustive switches over this union (enforced by a `never`-typed
  *   default branch, so TypeScript will fail to compile if you forget).
+ * - `canonical` in `lib/typeChecker/typeKey.ts` — also never-enforced;
+ *   tsc catches a missing case.
+ * - `mapTypes` AND `visitTypes` in `lib/typeChecker/typeWalker.ts` —
+ *   NOT enforced. Both pass unknown nodes through silently; update the
+ *   pair together, per their own doc comment.
+ * - `deepResolveNode` in `lib/typeChecker/assignability.ts` — NOT
+ *   enforced, and it cannot be: passing nodes through unchanged is its
+ *   correct behavior for most variants. A variant that must resolve
+ *   before codegen (any eagerly-evaluated form) silently reaches the
+ *   zod mapper unresolved without a case here, and the mapper falls
+ *   back to z.string(). Pin every new variant with a codegen test
+ *   asserting a NON-string schema shape.
  *
  * Codegen sites (`mapTypeToSchema`, `descriptor`, `hasAnyValidateTag`)
  * also branch on `VariableType.type`; review them when adding a
- * variant.
+ * variant. Full walkthrough: docs/dev/adding-features.md.
  */
 export type VariableType =
   | PrimitiveType
@@ -29,7 +41,9 @@ export type VariableType =
   | ResultType
   | SchemaType
   | FunctionRefType
-  | GenericType;
+  | GenericType
+  | KeyofType
+  | IndexedAccessType;
 
 /**
  * A concrete generic-type usage: Record<string, number>, Container<string>, etc.
@@ -55,6 +69,31 @@ export type GenericType = {
  * Example: in `type Container<T> = { value: T }`, the `T` is a TypeParam.
  * Defaults allow bare use of the alias: `type StringMap<V = any> = Record<string, V>`.
  */
+/**
+ * `keyof T` — the union of an object type's key names. Exists only
+ * between parse and resolution: `resolveTypeWithGuard` evaluates it
+ * eagerly (lib/typeChecker/typeOperators.ts) and downstream code never
+ * sees the node.
+ */
+export type KeyofType = {
+  type: "keyofType";
+  operand: VariableType;
+  tags?: Tag[];
+};
+
+/**
+ * `T["key"]` — the type of one field. Same lifecycle as KeyofType:
+ * eagerly evaluated at resolution, invisible downstream. The index is a
+ * full type expression; it must RESOLVE to a string literal or a union
+ * of string literals.
+ */
+export type IndexedAccessType = {
+  type: "indexedAccessType";
+  objectType: VariableType;
+  index: VariableType;
+  tags?: Tag[];
+};
+
 export type TypeParam = {
   name: string;
   default?: VariableType;

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -69,6 +69,11 @@ export type GenericType = {
  * Example: in `type Container<T> = { value: T }`, the `T` is a TypeParam.
  * Defaults allow bare use of the alias: `type StringMap<V = any> = Record<string, V>`.
  */
+export type TypeParam = {
+  name: string;
+  default?: VariableType;
+};
+
 /**
  * `keyof T` — the union of an object type's key names. Exists only
  * between parse and resolution: `resolveTypeWithGuard` evaluates it
@@ -94,10 +99,6 @@ export type IndexedAccessType = {
   tags?: Tag[];
 };
 
-export type TypeParam = {
-  name: string;
-  default?: VariableType;
-};
 
 /**
  * A value-parameter declaration on a value-parameterized type alias.

--- a/packages/agency-lang/lib/utils/formatType.ts
+++ b/packages/agency-lang/lib/utils/formatType.ts
@@ -83,13 +83,24 @@ export function formatTypeHint(
     }
     case "genericType":
       return `${vt.name}<${vt.typeArgs.map(recurse).join(", ")}>`;
-    case "keyofType":
-      return `keyof ${recurse(vt.operand)}`;
+    case "keyofType": {
+      // Parenthesize a union operand: `keyof (A | B)` must not print as
+      // `keyof A | B`, which re-parses as (keyof A) | B.
+      const op = recurse(vt.operand);
+      return vt.operand.type === "unionType"
+        ? `keyof (${op})`
+        : `keyof ${op}`;
+    }
     case "indexedAccessType": {
-      // Parenthesize a keyof object for the same re-parse reason as the
-      // arrayType case.
+      // Parenthesize keyof and union objects for the same re-parse
+      // reasons as the arrayType case: `(A | B)["k"]` must not print as
+      // `A | B["k"]`.
       const obj = recurse(vt.objectType);
-      const wrapped = vt.objectType.type === "keyofType" ? `(${obj})` : obj;
+      const wrapped =
+        vt.objectType.type === "keyofType" ||
+        vt.objectType.type === "unionType"
+          ? `(${obj})`
+          : obj;
       return `${wrapped}[${recurse(vt.index)}]`;
     }
     default:

--- a/packages/agency-lang/lib/utils/formatType.ts
+++ b/packages/agency-lang/lib/utils/formatType.ts
@@ -32,8 +32,12 @@ export function formatTypeHint(
   switch (vt.type) {
     case "primitiveType":
       return primitiveAliases?.[vt.value] ?? vt.value;
-    case "arrayType":
-      return `${recurse(vt.elementType)}[]`;
+    case "arrayType": {
+      // Parenthesize a keyof element: `(keyof User)[]` re-parses as
+      // written, while `keyof User[]` would re-parse as keyof (User[]).
+      const el = recurse(vt.elementType);
+      return vt.elementType.type === "keyofType" ? `(${el})[]` : `${el}[]`;
+    }
     case "stringLiteralType":
       return `"${vt.value}"`;
     case "numberLiteralType":
@@ -79,6 +83,15 @@ export function formatTypeHint(
     }
     case "genericType":
       return `${vt.name}<${vt.typeArgs.map(recurse).join(", ")}>`;
+    case "keyofType":
+      return `keyof ${recurse(vt.operand)}`;
+    case "indexedAccessType": {
+      // Parenthesize a keyof object for the same re-parse reason as the
+      // arrayType case.
+      const obj = recurse(vt.objectType);
+      const wrapped = vt.objectType.type === "keyofType" ? `(${obj})` : obj;
+      return `${wrapped}[${recurse(vt.index)}]`;
+    }
     default:
       throw new Error(`Unknown variable type: ${(vt as any).type}`);
   }

--- a/packages/agency-lang/tests/agency/keyof-type.agency
+++ b/packages/agency-lang/tests/agency/keyof-type.agency
@@ -1,0 +1,24 @@
+// keyof produces a closed key union; the schema accepts real keys and
+// rejects anything else. (Schema bound to a variable first — #480.)
+type User = {
+  name: string,
+  age: number,
+}
+
+node accepts() {
+  const s = schema(keyof User)
+  const r = s.parseJSON("\"name\"")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node rejects() {
+  const s = schema(keyof User)
+  const r = s.parseJSON("\"email\"")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}

--- a/packages/agency-lang/tests/agency/keyof-type.test.json
+++ b/packages/agency-lang/tests/agency/keyof-type.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "\"name\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "a real key parses"
+    },
+    {
+      "nodeName": "rejects",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "a non-key is rejected (would pass under a z.string fallback)"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.agency
@@ -1,0 +1,14 @@
+type User = {
+  name: string,
+  age: number,
+}
+
+type Field = keyof User
+
+type Age = User["age"]
+
+node main() {
+  const f: Field = "name"
+  const a: Age = 1
+  return f
+}

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -1,0 +1,293 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "agency-lang/zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import os from "os";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
+  RestoreSignal,
+  AgencyAbort,
+  deepClone as __deepClone,
+  deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  functionRefReviver as __functionRefReviver,
+  DeterministicClient as __DeterministicClient,
+  installFetchMock as __installFetchMock,
+  createLogger as __createLogger,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false,
+    observability: false
+  },
+  smoltalkDefaults: {
+    apiKey: {
+      openAi: __process.env["OPENAI_API_KEY"] || "",
+      google: __process.env["GEMINI_API_KEY"] || "",
+      anthropic: __process.env["ANTHROPIC_API_KEY"] || "",
+      openRouter: __process.env["OPENROUTER_API_KEY"] || "",
+      deepInfra: __process.env["DEEPINFRA_API_KEY"] || "",
+      liteLlm: __process.env["LITELLM_API_KEY"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_API_KEY"] || ""
+    },
+    baseUrl: {
+      liteLlm: __process.env["LITELLM_BASE_URL"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
+    },
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  logLevel: "info",
+  traceConfig: {
+    program: "typeOperators.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Handler result builtins and interrupt response constructors (unified types)
+export function approve(value?: any) { return { type: "approve" as const, value }; }
+export function reject(value?: any) { return { type: "reject" as const, value }; }
+function propagate() { return { type: "propagate" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, hasInterrupts, isDebugger };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
+export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+// Auto-activate the deterministic LLM client when AGENCY_LLM_MOCKS is set.
+// The test runner (lib/cli/util.ts) populates this env var as a JSON string
+// when AGENCY_USE_TEST_LLM_PROVIDER=1. Both the agency evaluate template
+// and the agency-js test.js paths import this module, so this single block
+// covers both code paths.
+if (__process.env.AGENCY_LLM_MOCKS) {
+  __globalCtx.setLLMClient(
+    new __DeterministicClient(JSON.parse(__process.env.AGENCY_LLM_MOCKS))
+  );
+}
+
+// Auto-activate fetch mocking when AGENCY_FETCH_MOCKS_FILE points at a mocks
+// file. The runner writes resolved mocks (returnFile bodies already inlined) to
+// a temp file and passes its path — a file, not an inline env value, so a large
+// response body can't blow the exec arg/env size limit (ARG_MAX). Independent of
+// AGENCY_LLM_MOCKS — a test may mock the network while using a real LLM, or vice
+// versa. Installed before any node runs, ahead of any http.ts / stdlib / interop
+// fetch.
+if (__process.env.AGENCY_FETCH_MOCKS_FILE) {
+  __installFetchMock(JSON.parse(readFileSync(__process.env.AGENCY_FETCH_MOCKS_FILE, "utf-8")));
+}
+
+// Share a single registry object across every compiled module. With
+// composite "module:name" keys, all modules' helpers — plus
+// runtime-created blocks registered by `AgencyFunction.create` while
+// a function is executing — stay reachable from `FunctionRefReviver`
+// no matter which module touched the registry last.
+export const __toolRegistry: Record<string, any> = (__functionRefReviver.registry ??= {} as any);
+
+function __registerTool(value: unknown, _aliasName?: string) {
+  // Composite "module:name" key keyed off the function's *own*
+  // identity, not the importing module's local alias — so different
+  // modules that import the same function don't shadow each other in
+  // the shared global registry that `FunctionRefReviver` reads from.
+  // `_aliasName` is kept in the signature for backwards compatibility
+  // with already-compiled callers that pass it.
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[`${value.module}:${value.name}`] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const _run = __AgencyFunction.create({ name: "_run", module: "__runtime", fn: __runtime_run_impl, params: [{ name: "compiled", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "node", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "args", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "wallClock", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "memory", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "ipcPayload", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "stdout", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "configOverrides", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "cwd", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "maxDepth", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+
+function registerTools(tools: any[]) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[`${tool.module}:${tool.name}`] = tool;
+    }
+  }
+}
+
+async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("typeOperators.agency")) {
+    return;
+  }
+  __ctx.globals.markInitialized("typeOperators.agency")
+}
+__registerGlobalsInit("typeOperators.agency", __initializeGlobals);
+async function __registerTopLevelCallbacks(__ctx) {
+  __ctx.topLevelCallbacks = [];
+}
+__functionRefReviver.registry = __toolRegistry;
+const User = z.object({ "name": z.string(), "age": z.number() });
+type User = z.infer<typeof User>;
+const Field = z.union([z.literal("name"), z.literal("age")]);
+type Field = z.infer<typeof Field>;
+const Age = z.number();
+type Age = z.infer<typeof Age>;
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeOperators.agency", scopeName: "main", threads: __setupData.threads });
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __ctx.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.f = `name`;
+      });
+      await runner.step(2, async (runner) => {
+__stack.locals.a = 1;
+      });
+      await runner.step(3, async (runner) => {
+runner.halt({
+          messages: __threads(),
+          data: __stack.locals.f
+        })
+return;
+      });
+    })
+    if (runner.halted) return runner.haltResult;
+    await runner.hook(4, async () => {
+await callHook({
+        name: "onNodeEnd",
+        data: {
+          nodeName: "main",
+          data: undefined
+        }
+      })
+    });
+    return {
+      messages: __threads(),
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof AgencyAbort) {
+      throw __error
+    }
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
+    return {
+      messages: __threads(),
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals,
+    registerTopLevelCallbacks: __registerTopLevelCallbacks,
+    moduleDir: __dirname
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    const __result = await main(initialState);
+    reportUnhandledInterrupts(__result)
+  } catch (__error: any) {
+    console.error(`
+Agent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"typeOperators.agency:main":{"1":{"line":10,"col":2},"2":{"line":11,"col":2},"3":{"line":12,"col":2}}};


### PR DESCRIPTION
Adds two type operators, per the spec and reviewed plan on this branch (`docs/superpowers/specs/2026-07-10-keyof-indexed-access-design.md`).

`keyof T` is the union of an object type's key names. `T["key"]` is the type of one field. Both replace hand-copied types that silently drift when the source type changes — and `keyof` produces a closed literal union, so `match` over a `keyof User` value gets exhaustiveness checking: add a field to `User` and every match over its keys reports a missing case (both directions tested).

## What

- **Two new `VariableType` variants** (`keyofType`, `indexedAccessType`) that exist only between parse and resolution. Evaluation is eager in `resolveTypeWithGuard` via `lib/typeChecker/typeOperators.ts`, which consumes the argument helpers `builtinGenerics.ts` already owns (`resolveObjectArg`, `resolveKeysArg`, `withUseSiteTags` — now exported), so error wording stays one family across Partial, Pick, keyof, and indexed access. Downstream passes never see the operator nodes; there is no provider surface.
- **Parser: reviewer, look here.** `arrayTypeParser`'s counted `[]` suffix became a shared base chain plus a suffix loop (`[]` wraps an array, `[<type>]` indexes — so `User[keyof User]` parses for free). The load-bearing asymmetry: the or-chain member requires AT LEAST ONE suffix (bare types must keep falling through to later alternatives), while keyof's operand uses a private zero-or-more variant. A zero-suffix parser in the or-chain would greedily match `keyof` as a plain identifier, because `or()` commits to the first success. This sits under every type annotation's parse path; the full lib suite (7768 tests) plus re-runs of the utility-types and recursive-types execution suites guard it.
- **Semantics:** object-only in v1 (`Record`, arrays, primitives, unions error — matching the utility-types stance); index keys must be string literals or unions of literals; union index yields the union of value types; missing keys error listing available keys; chains compose left to right; property tags ride along through indexing (`@validate` on a field survives extraction, verified down to the descriptor emission).
- **`keyof` is now a reserved type name** (like `Result`): `type keyof = ...` is rejected instead of silently changing how annotations parse. Grep confirmed zero existing `.agency` code uses the name. `keyofish` still parses as a plain identifier (keyword boundary pinned by test).

## The deepResolveNode trap, observed then fixed

`deepResolveNode` prepares alias bodies for codegen and only routed `genericType`/`typeAliasVariable`. Without new cases, `type K = keyof User` reached the zod mapper unresolved and silently emitted the `z.string()` fallback — no error, wrong schema. The codegen pins were written red-first (all four failed with the fallback), and every assertion uses a shape the fallback cannot fake (literal unions, `z.number()`). Execution also flushed out that `hasAnyValidateTag` needed cases for the new variants — without them, a validated indexed alias silently skipped the descriptor path.

## Docs

Beyond the guide section: `lib/types/typeHints.ts`'s variant checklist now names `typeKey` and `deepResolveNode` (both postdated the comment), and `docs/dev/adding-features.md` gains an "Adding a `VariableType` variant" walkthrough spelling out exactly which sites the compiler enforces and which fail silently — with the rule that every new variant gets a non-string codegen pin, because that is the only net that catches a `deepResolveNode` miss.

## Tests

11 parse tests (precedence, keyword boundary, union index, chains, paren distinctions), 24 unit+pipeline typechecker tests (semantics table, every error, exact-member union assertions, recursion/composition/`Keys<T>` delegation, swallowed-error tripwires), 4 fallback-proof codegen pins, fixture with zero churn elsewhere, 2-node execution test, 6 formatter round-trips including `(keyof User)[]` vs `keyof User[]` staying distinct.

## Scope-outs

- `Record<K,V>` operands (v1 decision, relaxable).
- `typeof` — looks like a sibling, is not: it needs the checker's VALUE scopes, which do not exist at alias-resolution time; adding it means threading a synthesizer through `resolveType` and every caller, a pipeline-ordering change, and a story for compiling with the typechecker disabled. Own spec if ever wanted.
- `T[number]` — no tuples (provider gate), so numeric indexing has no v1 use case.
- Located diagnostics for resolver errors — standing follow-up shared with Record and the utility types (tripwire tests pin today's swallowed behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
