### PR TITLE
Fix #498: never stage stale compiled agent .js over compiler output

### DIFF
--- a/packages/agency-lang/scripts/stage-agents.mjs
+++ b/packages/agency-lang/scripts/stage-agents.mjs
@@ -2,7 +2,15 @@
 // `rm -rf dist/lib/agents && cp -r` recipe, which deleted every compiled
 // agent output on every make and made incremental agent skips impossible.
 // Rules:
-//   1. copy every file from src over dest (overwrite);
+//   1. copy every file from src over dest (overwrite) — EXCEPT a compiled
+//      `.js` whose `.agency` sibling exists in src. Such a `.js` is stale
+//      build litter left in the SOURCE tree (agents were once compiled
+//      in-place); the compiler is the sole author of the corresponding
+//      dest `.js`. Copying it would clobber the compiler's fresh dest
+//      output, and the manifest's fresh-skip (keyed on the unchanged
+//      `.agency` sourceHash) would then never re-emit it, shipping a stale
+//      module that imports symbols its source no longer defines (#498).
+//      Handwritten `.js` helpers (no `.agency` sibling) are still copied.
 //   2. delete dest files whose source counterpart is gone — a deleted
 //      foo.agency takes its compiled foo.js with it;
 //   3. never touch dest/docs/ (owned by the stage-agent-docs recipe) and
@@ -34,6 +42,12 @@ export function syncAgents(srcDir, destDir) {
   let copied = 0;
   for (const srcFile of walk(srcDir)) {
     const rel = path.relative(srcDir, srcFile);
+    // Never stage a compiled `.js` whose `.agency` sibling lives in src:
+    // it is stale build litter, and copying it would clobber the
+    // compiler-owned dest output the incremental skip trusts (see rule 1).
+    if (rel.endsWith(".js") && fs.existsSync(srcFile.replace(/\.js$/, ".agency"))) {
+      continue;
+    }
     const destFile = path.join(destDir, rel);
     fs.mkdirSync(path.dirname(destFile), { recursive: true });
     fs.copyFileSync(srcFile, destFile);

--- a/packages/agency-lang/scripts/stage-agents.test.ts
+++ b/packages/agency-lang/scripts/stage-agents.test.ts
@@ -26,6 +26,38 @@ describe("syncAgents", () => {
     expect(fs.existsSync(path.join(dest, "review/agent.js"))).toBe(true);
   });
 
+  test("never overwrites a dest compiled .js with a stale src .js (issue #498)", () => {
+    // A .js with a .agency sibling in src is a stale compiled artifact
+    // left in the SOURCE tree; the compiler is the sole author of the dest
+    // .js. Copying it would clobber the compiler's fresh dest output, and
+    // the manifest's fresh-skip would then never re-emit it.
+    const src = tree({
+      "agency-agent/lib/defaultPolicy.agency": "src-v2",
+      "agency-agent/lib/defaultPolicy.js": "STALE-compiled-output",
+    });
+    const dest = tree({
+      "agency-agent/lib/defaultPolicy.agency": "src-v1",
+      "agency-agent/lib/defaultPolicy.js": "FRESH-compiled-output",
+    });
+    syncAgents(src, dest);
+    // Source is synced; the compiler-owned output is left untouched.
+    expect(fs.readFileSync(path.join(dest, "agency-agent/lib/defaultPolicy.agency"), "utf-8")).toBe(
+      "src-v2",
+    );
+    expect(fs.readFileSync(path.join(dest, "agency-agent/lib/defaultPolicy.js"), "utf-8")).toBe(
+      "FRESH-compiled-output",
+    );
+  });
+
+  test("still copies handwritten .js helpers that have no .agency sibling", () => {
+    const src = tree({ "agency-agent/toolWiring.js": "handwritten" });
+    const dest = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "agency-stage-")), "dest");
+    syncAgents(src, dest);
+    expect(fs.readFileSync(path.join(dest, "agency-agent/toolWiring.js"), "utf-8")).toBe(
+      "handwritten",
+    );
+  });
+
   test("deletes orphaned sources AND their compiled siblings", () => {
     const src = tree({ "review/keep.agency": "k" });
     const dest = tree({


### PR DESCRIPTION
Fixes #498.

## Symptom

`make agents` (incremental build) could leave `dist` internally inconsistent: a module's compiled `.js` lagged behind its source while consumer modules were rebuilt against the newer source. The reported case: a consumer imports `BUILTIN_POLICIES` from `defaultPolicy.js`, but the stale compiled output still exported the old `BUILTIN_POLICY_NAMES`. `make clean && make` always produced correct output.

## Root cause (reproduced, not guessed)

The bug is **not** in the manifest freshness logic — that logic is sound *given its core assumption that `dist/**/*.js` is the compiler's own output*. The culprit is the **staging step**, `scripts/stage-agents.mjs`.

Staging copied *every* file from `lib/agents` into `dist/lib/agents`, including stale compiled `.js` artifacts that linger in the source tree (gitignored litter from when agents were once compiled in-place — e.g. `lib/agents/.../defaultPolicy.js`, older than the source rename). The failure sequence:

1. Compiler writes correct `dist/.../defaultPolicy.js` and records the manifest (`sourceHash` = current source).
2. Next `make agents` → staging copies the **stale `lib/.../defaultPolicy.js` over the correct dist output**.
3. Compile step → manifest says the `.agency` is fresh (its `sourceHash` is unchanged) → **skip** → the compiler never re-emits → stale output ships.

Each step was verified directly: force-compile → dist correct; run staging alone → dist clobbered back to stale (`BUILTIN_POLICIES` 5→0, `BUILTIN_POLICY_NAMES` 0→4); manifest skip → stays stale.

## Fix

Staging never copies a `.js` whose `.agency` sibling exists in src — that `.js` is stale build litter and the compiler is the sole author of the corresponding dest `.js`. Handwritten `.js` helpers (no `.agency` sibling, e.g. `toolWiring.js`) are still copied. This mirrors the delete-side carve-out already in the file.

After the fix, repeated `make agents` keeps dist correct. All `.agency` sources under the compiled agent dirs are regenerated by the compiler, so no output is lost by skipping their stale `.js` copies.

## Tests

- Failing-first test reproducing the clobber (a stale src `.js` must not overwrite a fresh dest `.js`).
- Guard test that handwritten `.js` helpers with no `.agency` sibling still stage.
- All 66 tests across `stage-agents`, `buildManifest`, `manifestTracker`, and `buildSession` pass.

> Note: a checkout already stuck in the inconsistent state (correct output already clobbered + manifest already "fresh") still needs one `make clean`/`--force` build to recover — the documented workaround. After that, staging never re-corrupts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
