### PR TITLE
Strict structured-output validation + opt-in validation retries

### DIFF
--- a/packages/agency-lang/docs/site/guide/llm-part-2.md
+++ b/packages/agency-lang/docs/site/guide/llm-part-2.md
@@ -59,6 +59,23 @@ Connection drops (ECONNRESET, fetch failed, …), `5xx`, `429`. A `429` is for r
 
 The call returns a `Failure`, which is covered in the chapter on [error handling](/guide/error-handling). 
 
+### Validation retries
+
+Transport retries handle a provider that failed to answer. Validation
+retries handle a provider that answered with the wrong shape. When an
+`llm()` call declares a result type and the response fails validation,
+Agency sends the validation error back to the model and asks again:
+
+```ts
+const person: Person = llm("Describe a scientist", { validationRetries: 2 })
+```
+
+After the retries run out, the call returns a failure. Use the bang
+syntax (`Person!`) to handle it locally, or `catch` for a default value.
+Validation retries cost tokens, unlike transport retries, so they are
+off by default. `setLlmOptions({ validationRetries: 2 })` sets a
+branch-wide default.
+
 ## Other options to llm()
 
 You can pass an options object as the second parameter, or use named arguments. All options are optional, and are grouped below by purpose.
@@ -87,11 +104,12 @@ You can pass an options object as the second parameter, or use named arguments. 
 
 ### Resilience
 
-| Option | Type |
-|---|---|
-| `retries` | `number` |
-| `timeout` | `duration` |
-| `backoff` | `{ initial?: duration, factor?: number, max?: duration }` |
+| Option | Type | Description |
+|---|---|---|
+| `retries` | `number` | Transport retries: the provider failed to answer. |
+| `timeout` | `duration` | Per-attempt deadline. |
+| `backoff` | `{ initial?: duration, factor?: number, max?: duration }` | Wait between transport retries. |
+| `validationRetries` | `number` | Retries when a structured-output response fails schema validation. Each retry sends the validation error back to the model. Disabled by default (0). Independent of `retries`. |
 
 See [retries and timeouts](#retries-and-timeouts) for more info.
 

--- a/packages/agency-lang/docs/site/guide/llm-part-2.md
+++ b/packages/agency-lang/docs/site/guide/llm-part-2.md
@@ -59,23 +59,6 @@ Connection drops (ECONNRESET, fetch failed, …), `5xx`, `429`. A `429` is for r
 
 The call returns a `Failure`, which is covered in the chapter on [error handling](/guide/error-handling). 
 
-### Validation retries
-
-Transport retries handle a provider that failed to answer. Validation
-retries handle a provider that answered with the wrong shape. When an
-`llm()` call declares a result type and the response fails validation,
-Agency sends the validation error back to the model and asks again:
-
-```ts
-const person: Person = llm("Describe a scientist", { validationRetries: 2 })
-```
-
-After the retries run out, the call returns a failure. Use the bang
-syntax (`Person!`) to handle it locally, or `catch` for a default value.
-Validation retries cost tokens, unlike transport retries, so they are
-off by default. `setLlmOptions({ validationRetries: 2 })` sets a
-branch-wide default.
-
 ## Other options to llm()
 
 You can pass an options object as the second parameter, or use named arguments. All options are optional, and are grouped below by purpose.

--- a/packages/agency-lang/docs/site/stdlib/data/usaspending.md
+++ b/packages/agency-lang/docs/site/stdlib/data/usaspending.md
@@ -49,7 +49,7 @@ export type Award = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L46))
 
 ### Executive
 
@@ -63,7 +63,7 @@ export type Executive = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L59))
 
 ### AwardDetail
 
@@ -89,7 +89,7 @@ export type AwardDetail = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L65))
 
 ## Effects
 
@@ -102,7 +102,7 @@ effect std::usaspending {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L30))
 
 ## Functions
 
@@ -137,7 +137,7 @@ Search U.S. federal awards. Returns each award's id, recipient, amount, awarding
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L229))
 
 ### usaspendingAward
 
@@ -161,4 +161,4 @@ Fetch full detail for one federal award. Returns amount, recipient and UEI, awar
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L252))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L252))

--- a/packages/agency-lang/docs/site/stdlib/data/usaspending.md
+++ b/packages/agency-lang/docs/site/stdlib/data/usaspending.md
@@ -49,7 +49,7 @@ export type Award = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L46))
 
 ### Executive
 
@@ -63,7 +63,7 @@ export type Executive = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L59))
 
 ### AwardDetail
 
@@ -89,7 +89,7 @@ export type AwardDetail = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L65))
 
 ## Effects
 
@@ -102,7 +102,7 @@ effect std::usaspending {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L30))
 
 ## Functions
 
@@ -137,7 +137,7 @@ Search U.S. federal awards. Returns each award's id, recipient, amount, awarding
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L229))
 
 ### usaspendingAward
 
@@ -161,4 +161,4 @@ Fetch full detail for one federal award. Returns amount, recipient and UEI, awar
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/usaspending.agency#L252))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L252))

--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -43,7 +43,10 @@ export type LlmDefaults = {
   reasoningEffort?: "low" | "medium" | "high";
   maxTokens?: number;
   maxToolResultChars?: number;
-  maxToolCallRounds?: number
+  maxToolCallRounds?: number;
+  retries?: number;
+  timeout?: number;
+  validationRetries?: number
 }
 ```
 
@@ -63,7 +66,7 @@ export type HostedModelInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L138))
 
 ## Functions
 
@@ -84,7 +87,7 @@ Set default options for subsequent llm() calls. Only the fields you
 |---|---|---|
 | opts | [LlmDefaults](#llmdefaults) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L48))
 
 ### setModel
 
@@ -102,7 +105,7 @@ Set the default model for subsequent llm() calls.
 |---|---|---|
 | name | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L58))
 
 ### envVarFor
 
@@ -127,7 +130,7 @@ Return the environment variable that holds the API key for a recognized
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L67))
 
 ### pickProvider
 
@@ -150,7 +153,7 @@ Return the first provider in `order` whose API-key environment variable
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L93))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L96))
 
 ### registerProviderModule
 
@@ -169,7 +172,7 @@ Load a provider module by path at runtime and register its custom provider
 |---|---|---|
 | path | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L126))
 
 ### listHostedModels
 
@@ -182,7 +185,7 @@ Return all known hosted text models (the built-in catalog plus any
 
 **Returns:** `HostedModelInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L148))
 
 ### hostedModelInfo
 
@@ -203,7 +206,7 @@ Metadata for one hosted model by name, or null if the name is unknown or
 
 **Returns:** `HostedModelInfo | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L153))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L156))
 
 ### modelSupportsInput
 
@@ -228,7 +231,7 @@ Whether a model accepts a given input modality ("image" or "pdf").
 
 **Returns:** `boolean | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L166))
 
 ### loadModelData
 
@@ -251,4 +254,4 @@ Load model data from a JSON file (the shape `agency models refresh`
 
 **Returns:** `Result<number>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/llm.agency#L186))

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -284,7 +284,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Throws:** `std::memory::recall`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L203))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L211))
 
 ### forget
 
@@ -306,4 +306,4 @@ Soft-delete facts matching the query from the knowledge graph. Data is
 
 **Throws:** `std::memory::forget`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L221))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L229))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -381,7 +381,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L325))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L330))
 
 ### currentThreadId
 
@@ -396,7 +396,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L378))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L383))
 
 ### getThread
 
@@ -428,4 +428,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L388))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L393))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -235,6 +235,9 @@ export def retryReasonLabel(reason: string): string {
   if (reason == "serverError") {
     return "Server error"
   }
+  if (reason == "invalidStructuredOutput") {
+    return "Output failed validation"
+  }
   return reason
 }
 

--- a/packages/agency-lang/lib/agents/agency-agent/tests/turnFailure.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/turnFailure.agency
@@ -33,3 +33,7 @@ node unknownFailureEchoesRawError(): boolean {
   const msg = formatTurnFailure("some other problem")
   return msg.includes("some other problem")
 }
+
+node invalidOutputLabel(): boolean {
+  return retryReasonLabel("invalidStructuredOutput") == "Output failed validation"
+}

--- a/packages/agency-lang/lib/agents/agency-agent/tests/turnFailure.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/turnFailure.test.json
@@ -4,61 +4,37 @@
       "nodeName": "connectionLostLabel",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
+      "evaluationCriteria": [{ "type": "exact" }]
     },
     {
       "nodeName": "unknownReasonPassesThrough",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
+      "evaluationCriteria": [{ "type": "exact" }]
     },
     {
       "nodeName": "connectionLostFailureIsFriendly",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
+      "evaluationCriteria": [{ "type": "exact" }]
     },
     {
       "nodeName": "timeoutFailureIsFriendly",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
+      "evaluationCriteria": [{ "type": "exact" }]
     },
     {
       "nodeName": "unknownFailureEchoesRawError",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
+      "evaluationCriteria": [{ "type": "exact" }]
     },
     {
       "nodeName": "invalidOutputLabel",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [
-        {
-          "type": "exact"
-        }
-      ]
+      "evaluationCriteria": [{ "type": "exact" }]
     }
   ]
 }

--- a/packages/agency-lang/lib/agents/agency-agent/tests/turnFailure.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/turnFailure.test.json
@@ -4,31 +4,61 @@
       "nodeName": "connectionLostLabel",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "unknownReasonPassesThrough",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "connectionLostFailureIsFriendly",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "timeoutFailureIsFriendly",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     },
     {
       "nodeName": "unknownFailureEchoesRawError",
       "input": "",
       "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }]
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "invalidOutputLabel",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/lib/lowering/patternLowering.test.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.test.ts
@@ -752,3 +752,42 @@ match ((r is success) && y) {
     expect(findTaggedAssignment(lifted.nodes)).toBeDefined();
   });
 });
+
+describe("lowering inside thread blocks", () => {
+  it("lowers `if (r is success(v))` inside a thread block — no isExpression survives", () => {
+    // Regression: mapBodies had no messageThread case, so lowering never
+    // descended into `thread { ... }` bodies. The raw isExpression reached
+    // the TypeScriptBuilder, which crashed with
+    // "Unhandled Agency node type: isExpression".
+    const lowered = lower(`
+thread {
+  let r = foo()
+  if (r is success(v)) {
+    print(v)
+  } else {
+    print("failed")
+  }
+}
+`);
+    const survived = walkNodesArray(lowered).some(
+      ({ node }) => node.type === "isExpression",
+    );
+    expect(survived).toBe(false);
+  });
+});
+
+describe("lowering inside with-wrapped statements", () => {
+  it("lowers a boolean `is` inside `stmt with approve` — no isExpression survives", () => {
+    // Regression: mapBodies (now bodySlots) skipped withModifier, so the
+    // wrapped statement was never lowered and a raw isExpression could
+    // reach codegen.
+    const lowered = lower(`
+let r = foo()
+print(r is success) with approve
+`);
+    const survived = walkNodesArray(lowered).some(
+      ({ node }) => node.type === "isExpression",
+    );
+    expect(survived).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/runtime/llmRetry.test.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.test.ts
@@ -60,7 +60,7 @@ describe("classifyLlmError", () => {
   });
 });
 
-const policy = { retries: 2, timeout: 0, backoff: { initial: 100, factor: 2, max: 1000 } };
+const policy = { retries: 2, timeout: 0, backoff: { initial: 100, factor: 2, max: 1000 }, validationRetries: 0 };
 
 describe("decideRetry", () => {
   it("propagates user aborts", () => {
@@ -100,6 +100,7 @@ describe("resolveRetryPolicy", () => {
       retries: 2,
       timeout: 600000,
       backoff: { initial: 500, factor: 2, max: 10000 },
+      validationRetries: 0,
     });
   });
 
@@ -137,5 +138,32 @@ describe("enrichSchemaLimitationError (#487)", () => {
   it("returns null for unrelated errors", () => {
     expect(enrichSchemaLimitationError(new Error("rate limited"))).toBeNull();
     expect(enrichSchemaLimitationError("not an error")).toBeNull();
+  });
+});
+
+describe("resolveRetryPolicy — validationRetries", () => {
+  it("defaults validationRetries to 0 (opt-in)", () => {
+    const p = resolveRetryPolicy({}, {});
+    expect(p.validationRetries).toBe(0);
+  });
+
+  it("per-call value beats branch default", () => {
+    const p = resolveRetryPolicy({ validationRetries: 3 }, { validationRetries: 5 });
+    expect(p.validationRetries).toBe(3);
+  });
+
+  it("per-call 0 beats a truthy branch default (falsy override respected)", () => {
+    const p = resolveRetryPolicy({ validationRetries: 0 }, { validationRetries: 3 });
+    expect(p.validationRetries).toBe(0);
+  });
+
+  it("branch default beats the built-in", () => {
+    const p = resolveRetryPolicy({}, { validationRetries: 2 });
+    expect(p.validationRetries).toBe(2);
+  });
+
+  it("clamps negative values to 0", () => {
+    const p = resolveRetryPolicy({ validationRetries: -2 }, {});
+    expect(p.validationRetries).toBe(0);
   });
 });

--- a/packages/agency-lang/lib/runtime/llmRetry.test.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { classifyLlmError, decideRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
+import {
+  classifyLlmError,
+  decideRetry,
+  decideValidationRetry,
+  DEFAULT_RETRY_POLICY,
+  enrichSchemaLimitationError,
+  resolveRetryPolicy,
+  type RetryPolicy,
+} from "./llmRetry.js";
+import { success, failure } from "./result.js";
 import { AgencyAbort, makeAbortCause } from "./errors.js";
 import type { NormalizedLLMError } from "./llmClient.js";
 
@@ -165,5 +174,48 @@ describe("resolveRetryPolicy — validationRetries", () => {
   it("clamps negative values to 0", () => {
     const p = resolveRetryPolicy({ validationRetries: -2 }, {});
     expect(p.validationRetries).toBe(0);
+  });
+});
+
+const POLICY_2: RetryPolicy = { ...DEFAULT_RETRY_POLICY, validationRetries: 2 };
+
+describe("decideValidationRetry", () => {
+  it("accepts a successful extraction regardless of attempt", () => {
+    const d = decideValidationRetry(success({ name: "Ada" }), "raw", 99, POLICY_2);
+    expect(d).toEqual({ kind: "accept", value: { name: "Ada" } });
+  });
+
+  it("retries below the cap, with feedback naming the error", () => {
+    const d = decideValidationRetry(failure("expected object"), "prose", 0, POLICY_2);
+    expect(d.kind).toBe("retry");
+    if (d.kind === "retry") {
+      expect(d.reason).toBe("invalidStructuredOutput");
+      expect(d.feedback).toContain("expected object");
+      expect(d.feedback).toContain("did not match the required output format");
+    }
+  });
+
+  it("surfaces a failure at the cap (attempt == validationRetries)", () => {
+    const d = decideValidationRetry(failure("expected object"), "prose text here", 2, POLICY_2);
+    expect(d.kind).toBe("surfaceFailure");
+    if (d.kind === "surfaceFailure") {
+      expect(d.message).toContain("expected object");
+      expect(d.message).toContain("prose text here");
+    }
+  });
+
+  it("validationRetries 0 surfaces immediately", () => {
+    const p = { ...DEFAULT_RETRY_POLICY, validationRetries: 0 };
+    const d = decideValidationRetry(failure("bad"), "raw", 0, p);
+    expect(d.kind).toBe("surfaceFailure");
+  });
+
+  it("truncates a huge validation error in the feedback", () => {
+    const d = decideValidationRetry(failure("x".repeat(10000)), "raw", 0, POLICY_2);
+    if (d.kind === "retry") {
+      expect(d.feedback.length).toBeLessThan(3000);
+    } else {
+      throw new Error("expected retry");
+    }
   });
 });

--- a/packages/agency-lang/lib/runtime/llmRetry.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.ts
@@ -115,18 +115,27 @@ function classifyByMessage(message: string): Classification {
 }
 
 export type RetryPolicy = {
+  /** Transport retries: the provider failed to answer (timeout, 5xx,
+   *  dropped connection). Independent of validationRetries. */
   retries: number;
   timeout: number;
   backoff: { initial: number; factor: number; max: number };
+  /** Validation retries: the provider answered, but the structured output
+   *  failed schema validation. Each retry feeds the validation error back
+   *  to the model. Independent of `retries` — setting one never affects
+   *  the other. 0 disables (the default: validation retries cost tokens). */
+  validationRetries: number;
 };
 
 /** Built-in policy: 2 retries, a 10-minute per-call deadline, exponential
- *  backoff (500ms × 2, capped at 10s). Per-call llm() options and
- *  setLlmOptions / agency.json defaults override these (see resolveRetryPolicy). */
+ *  backoff (500ms × 2, capped at 10s), validation retries off. Per-call
+ *  llm() options and setLlmOptions / agency.json defaults override these
+ *  (see resolveRetryPolicy). */
 export const DEFAULT_RETRY_POLICY: RetryPolicy = {
   retries: 2,
   timeout: 600000,
   backoff: { initial: 500, factor: 2, max: 10000 },
+  validationRetries: 0,
 };
 
 export type RetryDecision =
@@ -177,6 +186,7 @@ export type RetryConfig = {
   retries?: number;
   timeout?: number;
   backoff?: { initial?: number; factor?: number; max?: number };
+  validationRetries?: number;
 };
 
 function firstDefined<T>(...values: Array<T | undefined>): T {
@@ -200,6 +210,14 @@ export function resolveRetryPolicy(opts: RetryConfig, branchDefaults: RetryConfi
   return {
     retries: firstDefined(opts.retries, branchDefaults.retries, DEFAULT_RETRY_POLICY.retries),
     timeout: firstDefined(opts.timeout, branchDefaults.timeout, DEFAULT_RETRY_POLICY.timeout),
+    validationRetries: Math.max(
+      0,
+      firstDefined(
+        opts.validationRetries,
+        branchDefaults.validationRetries,
+        DEFAULT_RETRY_POLICY.validationRetries,
+      ),
+    ),
     backoff: {
       initial: firstDefined(
         opts.backoff?.initial,

--- a/packages/agency-lang/lib/runtime/llmRetry.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.ts
@@ -7,7 +7,8 @@ export type LLMRetryReason =
   | "streamInterrupted"
   | "rateLimit"
   | "serverError"
-  | "overloaded";
+  | "overloaded"
+  | "invalidStructuredOutput";
 
 export type Classification =
   | { kind: "retryable"; reason: LLMRetryReason; detail: string; retryAfterMs?: number }

--- a/packages/agency-lang/lib/runtime/llmRetry.ts
+++ b/packages/agency-lang/lib/runtime/llmRetry.ts
@@ -1,5 +1,7 @@
 import { isAbortError, readCause } from "./errors.js";
 import type { NormalizedLLMError } from "./llmClient.js";
+import { isSuccess, type ResultValue } from "./result.js";
+import { truncate } from "./truncate.js";
 
 export type LLMRetryReason =
   | "timeout"
@@ -258,4 +260,59 @@ export function enrichSchemaLimitationError(err: unknown): Error | null {
     `schema(YourType).parseJSON(...) on it, or switch this call to a provider that ` +
     `supports recursive schemas (OpenAI, Gemini). Provider error: ${err.message}`;
   return err;
+}
+
+export type ValidationDecision =
+  | { kind: "accept"; value: unknown }
+  | { kind: "surfaceFailure"; message: string }
+  | { kind: "retry"; feedback: string; reason: LLMRetryReason; detail: string };
+
+/** The user message injected before a validation retry. The response format
+ *  is still enforced by the request's responseFormat, so the message only
+ *  says WHAT was wrong, not the whole schema.
+ *  COUPLING: the agency-js retry tests key their mock on the literal
+ *  "did not match the required output format". Rewording this string
+ *  breaks those mocks loudly (they stop returning valid JSON). */
+export function buildValidationRetryMessage(error: string): string {
+  return (
+    `Your previous response did not match the required output format. ` +
+    `Validation error: ${truncate(error, 2000)}\n` +
+    `Respond again. Return only the structured output, with no extra text.`
+  );
+}
+
+/**
+ * Pure decision for one drained response under a structured-output schema:
+ * accept it, retry with feedback, or surface a failure. The validation
+ * twin of `decideRetry` — no I/O, no hooks — so the policy is testable in
+ * isolation and runPrompt's loop stays a thin driver. Takes the extraction
+ * ResultValue rather than running the extraction itself, so this module
+ * does not import runtime/utils (import cycle) and the function stays
+ * pure over data.
+ *
+ * The 2000/500 truncation caps differ on purpose: the feedback goes back
+ * to the model (roomy); the hook detail goes to UI/telemetry (tight).
+ */
+export function decideValidationRetry(
+  extracted: ResultValue,
+  rawContent: unknown,
+  attempt: number,
+  policy: RetryPolicy,
+): ValidationDecision {
+  if (isSuccess(extracted)) {
+    return { kind: "accept", value: extracted.value };
+  }
+  const error = String(extracted.error);
+  if (attempt >= policy.validationRetries) {
+    const message =
+      `LLM structured output failed validation: ${error}. ` +
+      `Raw output (first 200 chars): ${JSON.stringify(truncate(rawContent))}`;
+    return { kind: "surfaceFailure", message };
+  }
+  return {
+    kind: "retry",
+    feedback: buildValidationRetryMessage(error),
+    reason: "invalidStructuredOutput",
+    detail: truncate(error, 500),
+  };
 }

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -133,7 +133,7 @@ describe("armCallTimeout", () => {
 });
 
 describe("runWithRetry", () => {
-  const policy = { retries: 2, timeout: 0, backoff: { initial: 1, factor: 2, max: 10 } };
+  const policy = { retries: 2, timeout: 0, backoff: { initial: 1, factor: 2, max: 10 }, validationRetries: 0 };
   const noHooks = { onRetry: async () => {}, onTimeout: async () => {} };
   // Test normalizer: read status off a SmolError, else just the message.
   const normalize = (err: unknown) => {
@@ -217,7 +217,7 @@ describe("runWithRetry", () => {
 
   it("#8 timeout with retries:0 fires onLLMTimeout once, no retry, surfaces", async () => {
     vi.useFakeTimers();
-    const timeoutPolicy = { retries: 0, timeout: 20, backoff: policy.backoff };
+    const timeoutPolicy = { retries: 0, timeout: 20, backoff: policy.backoff, validationRetries: 0 };
     let timeouts = 0;
     const dispatch = (signal: AbortSignal | undefined) => {
       return new Promise((_resolve, reject) => {
@@ -263,7 +263,7 @@ describe("runWithRetry", () => {
         order.push("timeout");
       },
     };
-    const timeoutPolicy = { retries: 1, timeout: 20, backoff: { initial: 1, factor: 2, max: 5 } };
+    const timeoutPolicy = { retries: 1, timeout: 20, backoff: { initial: 1, factor: 2, max: 5 }, validationRetries: 0 };
 
     const promise = _internal.runWithRetry(dispatch, timeoutPolicy, undefined, hooks, normalize);
     await vi.advanceTimersByTimeAsync(30);
@@ -274,7 +274,7 @@ describe("runWithRetry", () => {
   });
 
   it("the exhaustion message reads 'attempt(s)', not 'retries' (so retries:0 reads correctly)", async () => {
-    const zeroRetryPolicy = { retries: 0, timeout: 0, backoff: policy.backoff };
+    const zeroRetryPolicy = { retries: 0, timeout: 0, backoff: policy.backoff, validationRetries: 0 };
     const dispatch = async () => {
       throw new SmolError("503", { status: 503 });
     };

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -790,6 +790,7 @@ export async function runPrompt(args: {
     retries: ccRetries,
     timeout: ccTimeout,
     backoff: ccBackoff,
+    validationRetries: ccValidationRetries,
     ...restClientConfig
   } = (args.clientConfig || {}) as Partial<smoltalk.SmolConfig> &
     RetryConfig & {
@@ -805,8 +806,16 @@ export async function runPrompt(args: {
   //      verbatim as `clientConfig`, which may include retry/timeout/backoff)
   //   3. branch defaults (`stack.other.llmDefaults`, set by `setLlmOptions`)
   //   4. built-in defaults
+  // Known limitation: when a direct TS caller passes `args.retryConfig`,
+  // only the fields that caller sets apply (same as retries/timeout/backoff
+  // have always behaved on that path).
   const perCallRetry: RetryConfig =
-    args.retryConfig ?? { retries: ccRetries, timeout: ccTimeout, backoff: ccBackoff };
+    args.retryConfig ?? {
+      retries: ccRetries,
+      timeout: ccTimeout,
+      backoff: ccBackoff,
+      validationRetries: ccValidationRetries,
+    };
   const branchRetryDefaults = (stateStack?.other?.llmDefaults as RetryConfig | undefined) ?? {};
   const retryPolicy = resolveRetryPolicy(perCallRetry, branchRetryDefaults);
 

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -16,7 +16,7 @@ import {
 } from "./replyAttachments.js";
 import { AgencyCancelledError, isAbortError, makeAbortCause, readCause } from "./errors.js";
 import { abortableSleep } from "../stdlib/abortable.js";
-import { decideRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
+import { decideRetry, decideValidationRetry, enrichSchemaLimitationError, resolveRetryPolicy } from "./llmRetry.js";
 import type { RetryPolicy, RetryConfig, LLMRetryReason } from "./llmRetry.js";
 import type { NormalizedLLMError } from "./llmClient.js";
 import {
@@ -30,7 +30,7 @@ import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
 // See docs/dev/promptRunner.md for the control-flow abstraction used here.
 import { PromptBailout, PromptRunner } from "./promptRunner.js";
-import { failure, isFailure, isSuccess } from "./result.js";
+import { failure, isFailure } from "./result.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { LlmDefaults } from "../stdlib/llm.js";
@@ -738,6 +738,7 @@ export async function runPrompt(args: {
     self.removedTools = args.removedTools || [];
     self.toolErrorCounts = {};
     self.toolCallRound = 0;
+    self.validationAttempt = 0;
     self.messagesJSON = null;
     self.pendingToolCalls = null;
   }
@@ -1207,311 +1208,402 @@ export async function runPrompt(args: {
       );
     };
 
-    // Handle tool calls
-    while (toolCalls.length > 0) {
-      if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
-      // Capture round BEFORE incrementing so pr.step keys are stable
-      // across resume. The actual increment happens inside the
-      // `nextLlmCall` step body, after a successful LLM round — that
-      // way bailout from a per-tool callback leaves the counter
-      // unchanged and resume re-enters this iteration with the same
-      // `round` value, so completedSteps keys match.
-      const round = self.toolCallRound;
+    // Validation-retry outer loop: each iteration drains tool calls, then
+    // validates the final assistant message when a responseFormat is set.
+    // A "retry" decision pushes the validation error back to the model as
+    // a user message, dispatches one more round, and loops. Bounded by
+    // retryPolicy.validationRetries via decideValidationRetry.
+    while (true) {
+      // Handle tool calls
+      while (toolCalls.length > 0) {
+        if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
+        // Capture round BEFORE incrementing so pr.step keys are stable
+        // across resume. The actual increment happens inside the
+        // `nextLlmCall` step body, after a successful LLM round — that
+        // way bailout from a per-tool callback leaves the counter
+        // unchanged and resume re-enters this iteration with the same
+        // `round` value, so completedSteps keys match.
+        const round = self.toolCallRound;
 
-      // Tool calls in one round run concurrently via pr.parallel. Each
-      // tool gets its own BranchRunner. If any branch's `step` returns
-      // interrupts, sibling branches still run to completion; pr.parallel
-      // batches the collected interrupts, stamps ONE shared checkpoint,
-      // and throws PromptBailout — bailout is caught at the outer try.
-      //
-      // `removedTools` and `toolErrorCounts` use eventually-consistent
-      // semantics across branches (strategy B in the plan): same-round
-      // removal is best-effort and removals always take effect from the
-      // NEXT round (the .filter() after this parallel call).
-      const parallelResult = await pr.parallel(
-        `round.${round}.tools`,
-        toolCalls,
-        // keyFor: MUST match the branchKey the body uses below
-        // (`stack.getOrCreateBranch(branchKey)`) so runBatch and the body
-        // operate on the same branch. Keyed by the tool call's POSITION in
-        // the round, not its id: some providers (notably Google Gemini)
-        // return tool calls with no id — Gemini matches responses to calls
-        // by function name + position, so smoltalk defaults the missing id
-        // to "". Two id-less parallel calls would otherwise collide on the
-        // branch key ("tool_") and trip `runBatch: duplicate child key`.
-        // The id is folded in after the index only for readability; the
-        // index alone guarantees uniqueness within the round.
-        (toolCall, i) => `tool_${i}_${toolCall.id}`,
-        async (toolCall, b, index) => {
-          if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
+        // Tool calls in one round run concurrently via pr.parallel. Each
+        // tool gets its own BranchRunner. If any branch's `step` returns
+        // interrupts, sibling branches still run to completion; pr.parallel
+        // batches the collected interrupts, stamps ONE shared checkpoint,
+        // and throws PromptBailout — bailout is caught at the outer try.
+        //
+        // `removedTools` and `toolErrorCounts` use eventually-consistent
+        // semantics across branches (strategy B in the plan): same-round
+        // removal is best-effort and removals always take effect from the
+        // NEXT round (the .filter() after this parallel call).
+        const parallelResult = await pr.parallel(
+          `round.${round}.tools`,
+          toolCalls,
+          // keyFor: MUST match the branchKey the body uses below
+          // (`stack.getOrCreateBranch(branchKey)`) so runBatch and the body
+          // operate on the same branch. Keyed by the tool call's POSITION in
+          // the round, not its id: some providers (notably Google Gemini)
+          // return tool calls with no id — Gemini matches responses to calls
+          // by function name + position, so smoltalk defaults the missing id
+          // to "". Two id-less parallel calls would otherwise collide on the
+          // branch key ("tool_") and trip `runBatch: duplicate child key`.
+          // The id is folded in after the index only for readability; the
+          // index alone guarantees uniqueness within the round.
+          (toolCall, i) => `tool_${i}_${toolCall.id}`,
+          async (toolCall, b, index) => {
+            if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
 
-          // Per-call slug used for the branch key, every resume-idempotency
-          // step path, and the per-tool timing key below. Position-based so
-          // it stays unique even when `toolCall.id` is "" (see keyFor). Must
-          // NOT leak into message `tool_call_id` fields — those keep the
-          // real (possibly empty) id so provider pairing / threadRepair are
-          // byte-for-byte unchanged.
-          const callSlug = `${index}_${toolCall.id}`;
+            // Per-call slug used for the branch key, every resume-idempotency
+            // step path, and the per-tool timing key below. Position-based so
+            // it stays unique even when `toolCall.id` is "" (see keyFor). Must
+            // NOT leak into message `tool_call_id` fields — those keep the
+            // real (possibly empty) id so provider pairing / threadRepair are
+            // byte-for-byte unchanged.
+            const callSlug = `${index}_${toolCall.id}`;
 
-          const handler = toolFunctions.find(
-            (fn) => fn.name === toolCall.name,
-          );
-          if (!handler) {
-            await b.step(
-              `round.${round}.tool.${callSlug}.unhandled`,
-              async () => {
-                console.error(
-                  `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
-                );
-                messages.push(
-                  smoltalk.toolMessage(
-                    `Error: No handler found for tool call ${toolCall.name}`,
-                    { tool_call_id: toolCall.id, name: toolCall.name },
-                  ),
-                );
-              },
+            const handler = toolFunctions.find(
+              (fn) => fn.name === toolCall.name,
             );
-            return;
-          }
-
-          if (self.toolCallRound >= effectiveMaxToolCallRounds) {
-            await b.step(
-              `round.${round}.tool.${callSlug}.tooManyRounds`,
-              async () => {
-                messages.push(
-                  smoltalk.toolMessage(
-                    `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
-                    { tool_call_id: toolCall.id, name: toolCall.name },
-                  ),
-                );
-              },
-            );
-            return;
-          }
-
-
-          // Gated start (strategy B): if the tool is already in
-          // removedTools (either from a prior round or from an earlier
-          // sibling in this round that pushed first), skip with a
-          // notice toolMessage.
-          if (removedTools.includes(handler.name)) {
-            await b.step(
-              `round.${round}.tool.${callSlug}.removed`,
-              async () => {
-                messages.push(
-                  smoltalk.toolMessage(
-                    `Error: Handler for tool call ${handler.name} has been removed already due to previous errors, and will not be executed.`,
-                    { tool_call_id: toolCall.id, name: toolCall.name },
-                  ),
-                );
-              },
-            );
-            return;
-          }
-
-          const branchKey = `tool_${callSlug}`;
-          // Note: a "cached result" short-circuit used to live here for
-          // resume after a sibling interrupt; idempotency is now handled
-          // uniformly by completedSteps inside b.step (start/invoke/end
-          // each get marked done on success and skipped on resume).
-          const branchStack = stack.getOrCreateBranch(branchKey).stack;
-          const namedArgs = dropNullDefaultedArgs(
-            toolCall.arguments,
-            handler.params,
-          );
-
-          await b.step(
-            `round.${round}.tool.${callSlug}.start`,
-            async () => {
-              // Pass `branchStack` so scoped callbacks registered inside
-              // the branch's frame chain are discovered by
-              // `gatherCallbacks`. Callback bodies cannot interrupt
-              // (typechecker-enforced), so this is purely about scope
-              // discovery, not interrupt routing.
-              await invokeCallbacks({
-                ctx,
-                name: "onToolCallStart",
-                data: { toolName: handler.name, args: namedArgs },
-                stateStack: branchStack,
-              });
-            },
-          );
-          if (b.interrupts) return;
-
-          const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
-          let toolResult: any;
-          let invokeOutcome:
-            | "success"
-            | "failed"
-            | "rejected"
-            | "interrupted"
-            | "crashed" = "success";
-
-          // Persist the measured tool execution duration in
-          // self.runnerState so resume (where the invoke step is
-          // skipped) doesn't report ~0ms to onToolCallEnd /
-          // statelogClient.toolCall. Keyed per tool call id; rides
-          // along with completedSteps on the same frame.
-          self.runnerState.toolTimings ??= {};
-          // IMPORTANT: keep the toolExecution span open across the
-          // invoke + end-hook + log steps so the toolCall event inherits
-          // the toolExecution span_id (logsViewer aggregates tool
-          // duration off that). try/finally guarantees we close it even
-          // on bailout / unexpected throw.
-          try {
-            const toolCallStartTime = performance.now();
-            // Emit toolCallStart inside the same toolExecution span as
-            // the (later) toolCall end event so consumers can pair the
-            // two by span_id. Wrap in b.step so resume-replay doesn't
-            // duplicate the event. Designed to leave a trace of every
-            // tool that began even when the run is killed before it
-            // completes (the matching toolCall event won't fire).
-            await b.step(
-              `round.${round}.tool.${callSlug}.logStart`,
-              async () => {
-                ctx.statelogClient.toolCallStart({
-                  toolName: handler.name,
-                  args: namedArgs,
-                  model: JSON.stringify(clientConfig.model),
-                  threadId: __threads()?.activeId() ?? null,
-                });
-              },
-            );
-            // Invoke step: returns the interrupts when the tool halts
-            // with them so BranchRunner.step can collect. All other
-            // outcomes (success, failure, reject, crash) update outer
-            // state in place via runInvokeStep; the step completes
-            // (returns void unless interrupted) and is marked done so
-            // resume skips this whole block.
-            await b.step(
-              `round.${round}.tool.${callSlug}.invoke`,
-              async () => {
-                const outcome = await runInvokeStep({
-                  handler,
-                  toolCall,
-                  namedArgs,
-                  branchKey,
-                  branchStack,
-                });
-                toolResult = outcome.toolResult;
-                invokeOutcome = outcome.invokeOutcome;
-                if (outcome.invokeOutcome === "success") {
-                  self.runnerState.toolTimings[callSlug] =
-                    performance.now() - toolCallStartTime;
-                }
-                return outcome.interrupts;
-              },
-            );
-
-            if (b.interrupts || invokeOutcome !== "success") return;
-
-            // On resume after an end-hook bailout, the `invoke` step is
-            // skipped and `toolResult` is undefined. Restore it from the
-            // per-branch result that `setResultOnBranch` persisted before
-            // the bailout, so the end-hook sees the actual tool output.
-            if (toolResult === undefined) {
-              toolResult = stack.getBranch(branchKey)?.result?.result;
+            if (!handler) {
+              await b.step(
+                `round.${round}.tool.${callSlug}.unhandled`,
+                async () => {
+                  console.error(
+                    `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
+                  );
+                  messages.push(
+                    smoltalk.toolMessage(
+                      `Error: No handler found for tool call ${toolCall.name}`,
+                      { tool_call_id: toolCall.id, name: toolCall.name },
+                    ),
+                  );
+                },
+              );
+              return;
             }
 
-            // Reuse the persisted duration so onToolCallEnd /
-            // statelogClient.toolCall always report the real exec time,
-            // not the resume pass's overhead.
-            const timeTaken: number =
-              self.runnerState.toolTimings[callSlug] ?? 0;
+            if (self.toolCallRound >= effectiveMaxToolCallRounds) {
+              await b.step(
+                `round.${round}.tool.${callSlug}.tooManyRounds`,
+                async () => {
+                  messages.push(
+                    smoltalk.toolMessage(
+                      `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
+                      { tool_call_id: toolCall.id, name: toolCall.name },
+                    ),
+                  );
+                },
+              );
+              return;
+            }
+
+
+            // Gated start (strategy B): if the tool is already in
+            // removedTools (either from a prior round or from an earlier
+            // sibling in this round that pushed first), skip with a
+            // notice toolMessage.
+            if (removedTools.includes(handler.name)) {
+              await b.step(
+                `round.${round}.tool.${callSlug}.removed`,
+                async () => {
+                  messages.push(
+                    smoltalk.toolMessage(
+                      `Error: Handler for tool call ${handler.name} has been removed already due to previous errors, and will not be executed.`,
+                      { tool_call_id: toolCall.id, name: toolCall.name },
+                    ),
+                  );
+                },
+              );
+              return;
+            }
+
+            const branchKey = `tool_${callSlug}`;
+            // Note: a "cached result" short-circuit used to live here for
+            // resume after a sibling interrupt; idempotency is now handled
+            // uniformly by completedSteps inside b.step (start/invoke/end
+            // each get marked done on success and skipped on resume).
+            const branchStack = stack.getOrCreateBranch(branchKey).stack;
+            const namedArgs = dropNullDefaultedArgs(
+              toolCall.arguments,
+              handler.params,
+            );
+
             await b.step(
-              `round.${round}.tool.${callSlug}.end`,
+              `round.${round}.tool.${callSlug}.start`,
               async () => {
-                // Same scope-discovery rationale as the .start hook.
+                // Pass `branchStack` so scoped callbacks registered inside
+                // the branch's frame chain are discovered by
+                // `gatherCallbacks`. Callback bodies cannot interrupt
+                // (typechecker-enforced), so this is purely about scope
+                // discovery, not interrupt routing.
                 await invokeCallbacks({
                   ctx,
-                  name: "onToolCallEnd",
-                  data: {
-                    toolName: handler.name,
-                    result: toolResult,
-                    timeTaken,
-                  },
+                  name: "onToolCallStart",
+                  data: { toolName: handler.name, args: namedArgs },
                   stateStack: branchStack,
                 });
               },
             );
-            // Wrap the toolCall log in its own b.step so it's idempotent
-            // when pr.parallel re-runs a fully-completed branch on resume
-            // (e.g. after a later `nextLlmCall` step bails). Without this
-            // guard, every re-entry would emit a duplicate toolCall event.
-            await b.step(
-              `round.${round}.tool.${callSlug}.log`,
-              async () => {
-                ctx.statelogClient.toolCall({
-                  toolName: handler.name,
-                  args: namedArgs,
-                  output: toolResult,
-                  model: JSON.stringify(clientConfig.model),
-                  timeTaken,
-                  threadId: __threads()?.activeId() ?? null,
-                });
-              },
+            if (b.interrupts) return;
+
+            const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
+            let toolResult: any;
+            let invokeOutcome:
+              | "success"
+              | "failed"
+              | "rejected"
+              | "interrupted"
+              | "crashed" = "success";
+
+            // Persist the measured tool execution duration in
+            // self.runnerState so resume (where the invoke step is
+            // skipped) doesn't report ~0ms to onToolCallEnd /
+            // statelogClient.toolCall. Keyed per tool call id; rides
+            // along with completedSteps on the same frame.
+            self.runnerState.toolTimings ??= {};
+            // IMPORTANT: keep the toolExecution span open across the
+            // invoke + end-hook + log steps so the toolCall event inherits
+            // the toolExecution span_id (logsViewer aggregates tool
+            // duration off that). try/finally guarantees we close it even
+            // on bailout / unexpected throw.
+            try {
+              const toolCallStartTime = performance.now();
+              // Emit toolCallStart inside the same toolExecution span as
+              // the (later) toolCall end event so consumers can pair the
+              // two by span_id. Wrap in b.step so resume-replay doesn't
+              // duplicate the event. Designed to leave a trace of every
+              // tool that began even when the run is killed before it
+              // completes (the matching toolCall event won't fire).
+              await b.step(
+                `round.${round}.tool.${callSlug}.logStart`,
+                async () => {
+                  ctx.statelogClient.toolCallStart({
+                    toolName: handler.name,
+                    args: namedArgs,
+                    model: JSON.stringify(clientConfig.model),
+                    threadId: __threads()?.activeId() ?? null,
+                  });
+                },
+              );
+              // Invoke step: returns the interrupts when the tool halts
+              // with them so BranchRunner.step can collect. All other
+              // outcomes (success, failure, reject, crash) update outer
+              // state in place via runInvokeStep; the step completes
+              // (returns void unless interrupted) and is marked done so
+              // resume skips this whole block.
+              await b.step(
+                `round.${round}.tool.${callSlug}.invoke`,
+                async () => {
+                  const outcome = await runInvokeStep({
+                    handler,
+                    toolCall,
+                    namedArgs,
+                    branchKey,
+                    branchStack,
+                  });
+                  toolResult = outcome.toolResult;
+                  invokeOutcome = outcome.invokeOutcome;
+                  if (outcome.invokeOutcome === "success") {
+                    self.runnerState.toolTimings[callSlug] =
+                      performance.now() - toolCallStartTime;
+                  }
+                  return outcome.interrupts;
+                },
+              );
+
+              if (b.interrupts || invokeOutcome !== "success") return;
+
+              // On resume after an end-hook bailout, the `invoke` step is
+              // skipped and `toolResult` is undefined. Restore it from the
+              // per-branch result that `setResultOnBranch` persisted before
+              // the bailout, so the end-hook sees the actual tool output.
+              if (toolResult === undefined) {
+                toolResult = stack.getBranch(branchKey)?.result?.result;
+              }
+
+              // Reuse the persisted duration so onToolCallEnd /
+              // statelogClient.toolCall always report the real exec time,
+              // not the resume pass's overhead.
+              const timeTaken: number =
+                self.runnerState.toolTimings[callSlug] ?? 0;
+              await b.step(
+                `round.${round}.tool.${callSlug}.end`,
+                async () => {
+                  // Same scope-discovery rationale as the .start hook.
+                  await invokeCallbacks({
+                    ctx,
+                    name: "onToolCallEnd",
+                    data: {
+                      toolName: handler.name,
+                      result: toolResult,
+                      timeTaken,
+                    },
+                    stateStack: branchStack,
+                  });
+                },
+              );
+              // Wrap the toolCall log in its own b.step so it's idempotent
+              // when pr.parallel re-runs a fully-completed branch on resume
+              // (e.g. after a later `nextLlmCall` step bails). Without this
+              // guard, every re-entry would emit a duplicate toolCall event.
+              await b.step(
+                `round.${round}.tool.${callSlug}.log`,
+                async () => {
+                  ctx.statelogClient.toolCall({
+                    toolName: handler.name,
+                    args: namedArgs,
+                    output: toolResult,
+                    model: JSON.stringify(clientConfig.model),
+                    timeTaken,
+                    threadId: __threads()?.activeId() ?? null,
+                  });
+                },
+              );
+            } finally {
+              ctx.statelogClient.endSpan(toolSpanId);
+            }
+          },
+        );
+
+        // pr.parallel returns a RunBatchResult tagged union; if any tool
+        // branch surfaced interrupts, runBatch already stamped the shared
+        // checkpoint. Bail out of runPrompt with the merged batch — the
+        // outer caller checkpoints / propagates as usual. (Replaces the
+        // former PromptBailout throw with an explicit return so runBatch's
+        // no-throw-Interrupt contract is preserved.)
+        if (parallelResult.kind === "interrupts") {
+          shouldPop = false;
+          return parallelResult.interrupts;
+        }
+
+        // All tool calls complete — runBatch already popped branches on the
+        // no-interrupt success path, but call again defensively in case any
+        // branchFn-level cleanup added new branches mid-flight.
+        stack.popBranches();
+        tools = tools.filter((t) => !removedTools.includes(t.name));
+        toolFunctions = toolFunctions.filter(
+          (fn) => !removedTools.includes(fn.name),
+        );
+
+        // Reply attachments harvested from this round's tools (and any
+        // earlier round whose injection was pre-empted by an interrupt):
+        // inject ONE labeled user message after ALL tool results — the
+        // provider adjacency rules require the assistant's tool calls to
+        // be answered by every tool result before any other message.
+        // Resume-safety (verified): pr.step marks the key in
+        // completedSteps and skips it on resume; PromptRunner snapshots
+        // messagesJSON in beforeCheckpoint (promptRunner.ts) so a
+        // checkpoint stamped after this step completes carries the
+        // injected message, and resume restores messages from
+        // messagesJSON — the same mechanism that preserves sibling
+        // tool-message pushes. Clearing the buffer inside the step keeps
+        // the outer guard consistent on replay. The explicit messagesJSON
+        // write matches the pattern at the first-LLM-call and nextLlmCall
+        // sites.
+        const pendingReplies = (self.runnerState.replyAttachments ??
+          []) as HarvestedReplyAttachment[];
+        if (pendingReplies.length > 0) {
+          await pr.step(`round.${round}.attachReplies`, async () => {
+            messages.push(
+              smoltalk.userMessage(
+                buildReplyUserMessage(pendingReplies) as smoltalk.UserContentInput,
+              ),
             );
-          } finally {
-            ctx.statelogClient.endSpan(toolSpanId);
-          }
-        },
-      );
+            self.runnerState.replyAttachments = [];
+            self.messagesJSON = messages.toJSON().messages;
+          });
+        }
 
-      // pr.parallel returns a RunBatchResult tagged union; if any tool
-      // branch surfaced interrupts, runBatch already stamped the shared
-      // checkpoint. Bail out of runPrompt with the merged batch — the
-      // outer caller checkpoints / propagates as usual. (Replaces the
-      // former PromptBailout throw with an explicit return so runBatch's
-      // no-throw-Interrupt contract is preserved.)
-      if (parallelResult.kind === "interrupts") {
-        shouldPop = false;
-        return parallelResult.interrupts;
-      }
-
-      // All tool calls complete — runBatch already popped branches on the
-      // no-interrupt success path, but call again defensively in case any
-      // branchFn-level cleanup added new branches mid-flight.
-      stack.popBranches();
-      tools = tools.filter((t) => !removedTools.includes(t.name));
-      toolFunctions = toolFunctions.filter(
-        (fn) => !removedTools.includes(fn.name),
-      );
-
-      // Reply attachments harvested from this round's tools (and any
-      // earlier round whose injection was pre-empted by an interrupt):
-      // inject ONE labeled user message after ALL tool results — the
-      // provider adjacency rules require the assistant's tool calls to
-      // be answered by every tool result before any other message.
-      // Resume-safety (verified): pr.step marks the key in
-      // completedSteps and skips it on resume; PromptRunner snapshots
-      // messagesJSON in beforeCheckpoint (promptRunner.ts) so a
-      // checkpoint stamped after this step completes carries the
-      // injected message, and resume restores messages from
-      // messagesJSON — the same mechanism that preserves sibling
-      // tool-message pushes. Clearing the buffer inside the step keeps
-      // the outer guard consistent on replay. The explicit messagesJSON
-      // write matches the pattern at the first-LLM-call and nextLlmCall
-      // sites.
-      const pendingReplies = (self.runnerState.replyAttachments ??
-        []) as HarvestedReplyAttachment[];
-      if (pendingReplies.length > 0) {
-        await pr.step(`round.${round}.attachReplies`, async () => {
-          messages.push(
-            smoltalk.userMessage(
-              buildReplyUserMessage(pendingReplies) as smoltalk.UserContentInput,
-            ),
-          );
-          self.runnerState.replyAttachments = [];
+        // Next LLM call wrapped in pr.step for resume idempotency. Once
+        // marked done, resume re-entries skip the LLM call. The llmCall
+        // span stays open across rounds (one span per llm() call), so we
+        // do NOT close/reopen it here — this round's promptCompletion
+        // nests under the same span as the first round's.
+        await pr.step(`round.${round}.nextLlmCall`, async () => {
+          const nextResult = await _runPrompt({
+            ctx,
+            messages,
+            tools: tools || [],
+            prompt,
+            responseFormat,
+            clientConfig,
+            stateStack,
+            retryPolicy,
+          });
+          messages = nextResult.messages;
+          toolCalls = nextResult.toolCalls;
+          // Increment the round counter only after a successful LLM round,
+          // so resume after a tool-batch interrupt re-enters the SAME round.
+          self.toolCallRound = round + 1;
           self.messagesJSON = messages.toJSON().messages;
+          self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
         });
       }
+      // Tool calls are drained. No schema means nothing to validate; the
+      // plain-content return after the finally handles it.
+      if (!responseFormat) {
+        break;
+      }
 
-      // Next LLM call wrapped in pr.step for resume idempotency. Once
-      // marked done, resume re-entries skip the LLM call. The llmCall
-      // span stays open across rounds (one span per llm() call), so we
-      // do NOT close/reopen it here — this round's promptCompletion
-      // nests under the same span as the first round's.
-      await pr.step(`round.${round}.nextLlmCall`, async () => {
+      // Validate the last ASSISTANT message, not the last message: a
+      // resume that replays past a completed feedback step arrives here
+      // with our own feedback user message at the tail, and a string
+      // schema would happily "validate" it via envelope-skip recovery.
+      const lastAssistant = [...messages.getMessages()]
+        .reverse()
+        .find((m) => m.role === "assistant");
+      const validationExtract = extractStructuredResponse(
+        lastAssistant?.content,
+        responseFormat,
+      );
+      const validationAttempt = self.validationAttempt as number;
+      const decision = decideValidationRetry(
+        validationExtract,
+        lastAssistant?.content,
+        validationAttempt,
+        retryPolicy,
+      );
+
+      if (decision.kind === "accept") {
+        return decision.value;
+      }
+      if (decision.kind === "surfaceFailure") {
+        // Strict contract (issue #494): schema-constrained output either
+        // validates or comes back as a failure Result, never raw content.
+        // Loud in the statelog too, so a rotting integration is visible
+        // even when the caller swallows the failure. Fires with the
+        // llmCall span still open; pairing consumers ignore error events.
+        ctx.statelogClient.error({
+          errorType: "structuredOutput",
+          message: decision.message,
+        });
+        return failure(decision.message);
+      }
+
+      // decision.kind === "retry". Steps mirror attachReplies/nextLlmCall:
+      // keys derive from the PERSISTED counter, and the counter only
+      // advances inside the dispatch step, so a resume re-entry recomputes
+      // identical keys and skips completed steps instead of double-pushing
+      // feedback or double-counting the attempt.
+      await pr.step(`validation.${validationAttempt}.feedback`, async () => {
+        // Same hook transport retries fire (the agent renders it as a
+        // "retrying" line). Inside the step so a resume replay does not
+        // re-emit it. No backoff sleep: the provider is healthy, the
+        // content was just wrong.
+        await callHook({
+          ctx,
+          name: "onLLMRetry",
+          data: {
+            attempt: validationAttempt + 1,
+            maxRetries: retryPolicy.validationRetries,
+            delayMs: 0,
+            reason: decision.reason,
+            detail: decision.detail,
+          },
+        });
+        messages.push(smoltalk.userMessage(decision.feedback));
+        self.messagesJSON = messages.toJSON().messages;
+      });
+      await pr.step(`validation.${validationAttempt}.llmCall`, async () => {
         const nextResult = await _runPrompt({
           ctx,
           messages,
@@ -1524,12 +1616,15 @@ export async function runPrompt(args: {
         });
         messages = nextResult.messages;
         toolCalls = nextResult.toolCalls;
-        // Increment the round counter only after a successful LLM round,
-        // so resume after a tool-batch interrupt re-enters the SAME round.
-        self.toolCallRound = round + 1;
+        // Advance ONLY here, like nextLlmCall advances toolCallRound: a
+        // bailout before this step completes leaves the counter unchanged,
+        // so resume re-enters the SAME attempt with the same step keys.
+        self.validationAttempt = validationAttempt + 1;
         self.messagesJSON = messages.toJSON().messages;
         self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
       });
+      // Loop: the retry response may itself contain tool calls; the inner
+      // loop drains them before validation runs again.
     }
   } catch (error) {
     if (error instanceof PromptBailout) {
@@ -1565,33 +1660,7 @@ export async function runPrompt(args: {
     );
   }
 
-  if (responseFormat) {
-    // Strict contract (issue #494): a schema-constrained result either
-    // validates or comes back as a failure Result. It is NEVER the raw
-    // content masquerading as the declared type — that fail-open silently
-    // broke memory extraction for weeks. Bang-validated callers receive
-    // the failure untouched (validation never re-validates failures);
-    // plain typed callers hold a failure value they can inspect instead
-    // of a mistyped string.
-    const extracted = extractStructuredResponse(
-      responseMessage.content,
-      responseFormat,
-    );
-    if (isSuccess(extracted)) {
-      return extracted.value;
-    }
-    const rawPreview = String(responseMessage.content ?? "").slice(0, 200);
-    const message =
-      `LLM structured output failed validation: ${extracted.error}. ` +
-      `Raw output (first 200 chars): ${JSON.stringify(rawPreview)}`;
-    // Loud in the statelog too, so a rotting integration is visible in
-    // logs even when the caller swallows the failure.
-    ctx.statelogClient.error({
-      errorType: "structuredOutput",
-      message,
-    });
-    return failure(message);
-  }
-
+  // Only the no-schema path reaches here; schema-constrained calls return
+  // from inside the validation-retry loop above (issue #494).
   return responseMessage.content;
 }

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -30,7 +30,7 @@ import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
 // See docs/dev/promptRunner.md for the control-flow abstraction used here.
 import { PromptBailout, PromptRunner } from "./promptRunner.js";
-import { isFailure } from "./result.js";
+import { failure, isFailure, isSuccess } from "./result.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { LlmDefaults } from "../stdlib/llm.js";
@@ -39,7 +39,7 @@ import { StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { handleStreamingResponse } from "./streaming.js";
 import { GraphState } from "./types.js";
-import { extractResponse, updateTokenStats } from "./utils.js";
+import { extractStructuredResponse, updateTokenStats } from "./utils.js";
 
 type Tool = {
   name: string;
@@ -1557,21 +1557,31 @@ export async function runPrompt(args: {
   }
 
   if (responseFormat) {
-    try {
-      const rawResult = JSON.parse(responseMessage.content || "");
-      const extracted = extractResponse(rawResult, responseFormat);
-      return extracted;
-    } catch (e) {
-      try {
-        const extracted = extractResponse(
-          responseMessage.content,
-          responseFormat,
-        );
-        return extracted;
-      } catch (e) {
-        return responseMessage.content;
-      }
+    // Strict contract (issue #494): a schema-constrained result either
+    // validates or comes back as a failure Result. It is NEVER the raw
+    // content masquerading as the declared type — that fail-open silently
+    // broke memory extraction for weeks. Bang-validated callers receive
+    // the failure untouched (validation never re-validates failures);
+    // plain typed callers hold a failure value they can inspect instead
+    // of a mistyped string.
+    const extracted = extractStructuredResponse(
+      responseMessage.content,
+      responseFormat,
+    );
+    if (isSuccess(extracted)) {
+      return extracted.value;
     }
+    const rawPreview = String(responseMessage.content ?? "").slice(0, 200);
+    const message =
+      `LLM structured output failed validation: ${extracted.error}. ` +
+      `Raw output (first 200 chars): ${JSON.stringify(rawPreview)}`;
+    // Loud in the statelog too, so a rotting integration is visible in
+    // logs even when the caller swallows the failure.
+    ctx.statelogClient.error({
+      errorType: "structuredOutput",
+      message,
+    });
+    return failure(message);
   }
 
   return responseMessage.content;

--- a/packages/agency-lang/lib/runtime/utils.test.ts
+++ b/packages/agency-lang/lib/runtime/utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { deepFreeze, updateTokenStats } from "./utils.js";
+import { deepFreeze, extractStructuredResponse, updateTokenStats } from "./utils.js";
+import { isSuccess, isFailure } from "./result.js";
+import { z } from "zod";
 import { GlobalStore } from "./state/globalStore.js";
 
 const usage = (i: number, o: number) => ({
@@ -154,5 +156,32 @@ describe("updateTokenStats per-model breakdown", () => {
       outputTokens: 1,
       totalCost: 0.0002,
     });
+  });
+});
+
+describe("extractStructuredResponse — wrapper-key unwrapping (step 5)", () => {
+  const envelope = z.object({ response: z.number() });
+
+  it("unwraps a properties-wrapped envelope instead of returning success(undefined)", () => {
+    // Regression (PR #500 review): the old heuristic returned
+    // inner.data["properties"], which is undefined for this common shape.
+    const r = extractStructuredResponse({ properties: { response: 42 } }, envelope);
+    expect(isSuccess(r)).toBe(true);
+    if (isSuccess(r)) {
+      expect(r.value).toBe(42);
+    }
+  });
+
+  it("unwraps a double-wrapped response envelope", () => {
+    const r = extractStructuredResponse({ response: { response: 42 } }, envelope);
+    expect(isSuccess(r)).toBe(true);
+    if (isSuccess(r)) {
+      expect(r.value).toBe(42);
+    }
+  });
+
+  it("still fails when the wrapped value does not match the schema", () => {
+    const r = extractStructuredResponse({ properties: { response: "prose" } }, envelope);
+    expect(isFailure(r)).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -3,6 +3,7 @@ import { GlobalStore } from "./state/globalStore.js";
 import { ThreadStore } from "./index.js";
 import { RunNodeResult } from "./types.js";
 import { nativeTypeReplacer, nativeTypeReviver } from "./revivers/index.js";
+import { failure, isSuccess, success, ResultValue } from "./result.js";
 
 export function deepClone<T>(obj: T): T {
   return JSON.parse(JSON.stringify(obj, nativeTypeReplacer), nativeTypeReviver);
@@ -30,40 +31,62 @@ export function deepFreeze<T>(obj: T, seen: WeakSet<object> = new WeakSet()): T 
   return obj;
 }
 
-// not as necessary, smoltalk does this, though only when strict = true
-export function extractResponse(rawValue: any, schema: any): any {
+/** Strict structured-output extraction: unwrap the provider's response
+ *  shape and validate against the schema. Returns success(value) with the
+ *  validated value, or failure(schemaError) — never the raw content. The
+ *  unwrap heuristics mirror the shapes providers actually return: the
+ *  { response: ... } wrapper for primitive schemas, single-key wrappers,
+ *  stringified JSON, and single-element arrays. */
+export function extractStructuredResponse(
+  rawValue: any,
+  schema: any,
+): ResultValue {
   // 1. Direct match — try parsing as-is
   const direct = schema.safeParse(rawValue);
   if (direct.success) {
-    if ("response" in direct.data) {
-      return direct.data.response;
+    if (direct.data !== null && typeof direct.data === "object" && "response" in direct.data) {
+      return success(direct.data.response);
     }
-    return direct.data;
+    return success(direct.data);
+  }
+  const schemaError = direct.error?.message ?? "schema mismatch";
+
+  // 1.25 Envelope-skipping recovery. The codegen always requests the
+  // { response: T } envelope, and models routinely return bare T anyway.
+  // Validate the raw value against the INNER schema — this is schema-
+  // checked recovery, not a fail-open.
+  const responseShape = (schema as any).shape?.response;
+  if (responseShape && typeof responseShape.safeParse === "function") {
+    const inner = responseShape.safeParse(rawValue);
+    if (inner.success) {
+      return success(inner.data);
+    }
   }
 
   // 1.5 Look for { type: "object", properties: { response: { ... } } } pattern
-  if (rawValue.type === "object" && rawValue.properties) {
-    return extractResponse(rawValue.properties, schema);
+  if (rawValue != null && rawValue.type === "object" && rawValue.properties) {
+    return extractStructuredResponse(rawValue.properties, schema);
   }
 
-  // 2. String → try JSON.parse, then recurse
+  // 2. String → try JSON.parse, then recurse. A string that is not JSON
+  // cannot satisfy an object/wrapped schema that already failed step 1.
   if (typeof rawValue === "string") {
-    const stripped = rawValue;
     try {
-      return extractResponse(JSON.parse(stripped), schema);
-    } catch {}
-    return rawValue;
+      return extractStructuredResponse(JSON.parse(rawValue), schema);
+    } catch {
+      return failure(schemaError);
+    }
   }
 
   // 3. Null/undefined/primitive — nothing to unwrap
   if (rawValue == null || typeof rawValue !== "object") {
-    return rawValue;
+    return failure(schemaError);
   }
 
   // 4. Array with one element — unwrap
   if (Array.isArray(rawValue) && rawValue.length === 1) {
     const inner = schema.safeParse(rawValue[0]);
-    if (inner.success) return inner.data;
+    if (inner.success) return success(inner.data);
   }
 
   // 5. Object with "response" or "properties" key — unwrap
@@ -71,7 +94,7 @@ export function extractResponse(rawValue: any, schema: any): any {
   for (const key of wrapKeys) {
     if (key in rawValue) {
       const inner = schema.safeParse(rawValue[key]);
-      if (inner.success) return inner.data[key];
+      if (inner.success) return success(inner.data[key]);
     }
   }
 
@@ -79,16 +102,27 @@ export function extractResponse(rawValue: any, schema: any): any {
   const keys = Object.keys(rawValue);
   if (keys.length === 1) {
     const inner = schema.safeParse(rawValue[keys[0]]);
-    if (inner.success) return inner.data;
+    if (inner.success) return success(inner.data);
   }
 
   // 7. Shallow search — check every value of the object
   for (const key of keys) {
     const inner = schema.safeParse(rawValue[key]);
-    if (inner.success) return inner.data;
+    if (inner.success) return success(inner.data);
   }
 
-  // 8. Nothing worked — return the original value as-is
+  // 8. Nothing matched the schema.
+  return failure(schemaError);
+}
+
+// not as necessary, smoltalk does this, though only when strict = true.
+// Back-compat lenient wrapper: kept because it is publicly re-exported.
+// New code should use extractStructuredResponse, which can say NO.
+export function extractResponse(rawValue: any, schema: any): any {
+  const extracted = extractStructuredResponse(rawValue, schema);
+  if (isSuccess(extracted)) {
+    return extracted.value;
+  }
   return rawValue;
 }
 

--- a/packages/agency-lang/lib/runtime/utils.ts
+++ b/packages/agency-lang/lib/runtime/utils.ts
@@ -89,12 +89,17 @@ export function extractStructuredResponse(
     if (inner.success) return success(inner.data);
   }
 
-  // 5. Object with "response" or "properties" key — unwrap
+  // 5. Object with "response" or "properties" key — strip the wrapper and
+  // recurse, so step 1's direct-match (and its envelope unwrap) does the
+  // extraction. The old form indexed the validated value by the SAME key
+  // again (`inner.data[key]`), which returned undefined for shapes like
+  // { properties: { response: 42 } } (PR #500 review). Terminates: each
+  // recursion strips one layer of a finite, acyclic provider payload.
   const wrapKeys = ["response", "properties"];
   for (const key of wrapKeys) {
     if (key in rawValue) {
-      const inner = schema.safeParse(rawValue[key]);
-      if (inner.success) return success(inner.data[key]);
+      const inner = extractStructuredResponse(rawValue[key], schema);
+      if (isSuccess(inner)) return inner;
     }
   }
 

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1219,7 +1219,7 @@ export class StatelogClient {
     sourceLocation,
     tools,
   }: {
-    errorType: "toolError" | "llmError" | "runtimeError" | "validationError" | "limitExceeded";
+    errorType: "toolError" | "llmError" | "runtimeError" | "validationError" | "limitExceeded" | "structuredOutput";
     message: string;
     functionName?: string;
     retryable?: boolean;

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -27,6 +27,7 @@ import { z } from "zod";
 import * as smoltalk from "smoltalk";
 import { agency, type ThreadInfoTS } from "../runtime/agency.js";
 import { registerGlobalHook } from "../runtime/hooks.js";
+import { isFailure } from "../runtime/result.js";
 import { MessageThread } from "../runtime/state/messageThread.js";
 import { createLogger } from "../logger.js";
 
@@ -218,6 +219,20 @@ export async function _eagerSummarizeIfNeeded(evt: {
         maxTokens: 256,
       },
     );
+    // The structured-output contract returns a failure Result when the
+    // model's summary did not validate (issue #494). Treat it like the
+    // other best-effort failures: record it, keep the thread usable.
+    if (isFailure(result)) {
+      const ctxMaybe = agency.ctxMaybe();
+      createLogger(ctxMaybe?.logLevel ?? "info").debug(
+        `eager summarize failed validation for thread ${evt.threadId}: ${(result as any).error}`,
+      );
+      ctxMaybe?.statelogClient?.threadEndHookError?.({
+        threadId: evt.threadId,
+        error: String((result as any).error),
+      });
+      return;
+    }
     _setThreadSummary(evt.threadId, result.summary);
   } catch (e) {
     // Best-effort — lazy summarize will retry on next listThreads().

--- a/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
+++ b/packages/agency-lang/lib/typeChecker/builtinNamedArgs.test.ts
@@ -135,3 +135,21 @@ describe("builtin named-arg validation (llm options)", () => {
     expect(errors.some((e) => /constructor/.test(e.message))).toBe(true);
   });
 });
+
+describe("llm() validationRetries option", () => {
+  it("accepts validationRetries on llm()", () => {
+    const errors = errorsFrom(
+      `node main() {\n  const r: string = llm("hi", { validationRetries: 2 })\n  print(r)\n}`,
+    );
+    const unknown = errors.filter((e) => e.message.includes("Unknown property"));
+    expect(unknown).toHaveLength(0);
+  });
+
+  it("accepts validationRetries on setLlmOptions", () => {
+    const errors = errorsFrom(
+      `import { setLlmOptions } from "std::llm"\nnode main() {\n  setLlmOptions({ validationRetries: 2 })\n}`,
+    );
+    const unknown = errors.filter((e) => e.message.includes("Unknown property"));
+    expect(unknown).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -108,6 +108,9 @@ const llmOptionProperties: { key: string; value: VariableType }[] = [
         ],
       }),
     },
+    // Validation retries: re-ask the model when structured output fails
+    // schema validation. `0` disables. Independent of `retries`.
+    { key: "validationRetries", value: optional(number) },
     // `any` already accepts undefined, so no need to wrap in optional.
     { key: "metadata", value: ANY_T },
 ];

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -77,6 +77,21 @@ describe("buildFlowGraph — linear", () => {
     expect(end.kind).toBe("exit");
   });
 
+  it("`return interrupt effect(...)` falls through — later statements stay reachable", () => {
+    // The gated-work idiom (stdlib git/wikipedia/memory): `return interrupt`
+    // resumes past itself on approval, so the statements after it are live.
+    // Before this fix the flow builder treated it as `exit`, so refs after it
+    // got no flow node and narrowing silently degraded to bare scope.lookup.
+    const body = parseBody(`return interrupt confirm("sure?")\nlet x = 5\nprint(x)`);
+    const scope = new Scope("t");
+    scope.declare("x", NUM);
+    const env = freshEnv(scope);
+    const end = buildFlowGraph(body, { kind: "start", scope }, env);
+    expect(end.kind).not.toBe("exit");
+    const xRef = find(body, (n) => n.type === "variableName" && n.value === "x");
+    expect(env.flowOf.get(xRef)).toBeDefined();
+  });
+
   it("stops at unreachable code after a return (no throw, even with a later loop)", () => {
     const body = parseBody(`return x\nwhile (c) {\n  y = 1\n}`);
     const scope = new Scope("t");

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -213,6 +213,14 @@ const statementRules: StatementRuleTable = {
 
   returnStatement: (node, flow, env) => {
     attachExpressionsToFlow(node.value, flow, env);
+    // `return interrupt effect(...)` may RESUME: on approval, execution falls
+    // through to the next statement (the gated-work idiom — see stdlib
+    // git/wikipedia/memory). Treating it as `exit` would leave every statement
+    // after it flow-less, silently degrading narrowing to bare scope.lookup.
+    // Same passThrough-on-may-resume convention as `raise` (whileLoop note).
+    if ((node.value as AgencyNode | undefined)?.type === "interruptStatement") {
+      return flow;
+    }
     return { kind: "exit" };
   },
 

--- a/packages/agency-lang/lib/utils/bodySlots.ts
+++ b/packages/agency-lang/lib/utils/bodySlots.ts
@@ -1,0 +1,170 @@
+/**
+ * bodySlots — the single source of truth for "which fields of a node hold
+ * statements". The statement-body twin of `expressionChildren` (node.ts).
+ *
+ * Consumed by:
+ *   - `mapBodies` (mapBodies.ts) — immutable rewrite of every body
+ *   - `walkNodes` (node.ts) — read descent into every body
+ *
+ * Adding a new body-bearing node type means adding ONE case here; both
+ * consumers pick it up. Before this existed, each consumer hand-listed the
+ * node types and they drifted (mapBodies missed `messageThread`, then
+ * `withModifier`/`staticStatement` — each miss silently skipped lowering).
+ *
+ * Class methods are intentionally NOT included — classes are being removed
+ * from the language. Add them here if that decision is reversed.
+ */
+import type { AgencyNode } from "../types.js";
+import type { FunctionDefinition } from "../types/function.js";
+import type { GraphNodeDefinition } from "../types/graphNode.js";
+import type { IfElse } from "../types/ifElse.js";
+import type { WhileLoop } from "../types/whileLoop.js";
+import type { ForLoop } from "../types/forLoop.js";
+import type { MatchBlock, MatchBlockCase } from "../types/matchBlock.js";
+import type { HandleBlock } from "../types/handleBlock.js";
+import type { ParallelBlock, SeqBlock } from "../types/parallelBlock.js";
+import type { BlockArgument } from "../types/blockArgument.js";
+import type { FunctionCall } from "../types/function.js";
+import type { MessageThread } from "../types/messageThread.js";
+import type { WithModifier } from "../types/withModifier.js";
+import type { StaticStatement } from "../types/staticStatement.js";
+
+export type BodySlot = {
+  /** Statements at this slot. A read view — never mutate it in place. */
+  body: AgencyNode[];
+  /** Set on slots that wrap a single statement field (`with ...` /
+   *  `static ...`): a rewrite must map the one statement to exactly one. */
+  single?: boolean;
+  /** Extra ancestor between the owner and the body during walks — the
+   *  functionCall's inline `block:` argument. */
+  blockAncestor?: BlockArgument;
+  /** Fresh copy of `owner` with this slot's statements replaced. Takes the
+   *  CURRENT owner (not the node bodySlots was called on) so a fold over
+   *  several slots composes: each write builds on the previous one. */
+  write: (owner: AgencyNode, body: AgencyNode[]) => AgencyNode;
+};
+
+/** One slot for a plain top-level `body` field. */
+function bodyField(node: { body: AgencyNode[] }): BodySlot {
+  return {
+    body: node.body,
+    write: (owner, body) => ({ ...owner, body }) as AgencyNode,
+  };
+}
+
+/** One `single` slot for a `statement` field (`with ...` / `static ...`). */
+function statementField(node: { statement: AgencyNode }): BodySlot {
+  return {
+    body: [node.statement],
+    single: true,
+    write: (owner, body) => ({ ...owner, statement: body[0] }) as AgencyNode,
+  };
+}
+
+/** Immediate statement bodies of `node`, each with an immutable writer.
+ *  Returns `[]` for nodes that carry no statements. Shallow by design:
+ *  consumers drive their own recursion. */
+// eslint-disable-next-line max-lines-per-function -- exhaustive per-node-type enumeration; one case per body-bearing kind
+export function bodySlots(node: AgencyNode): BodySlot[] {
+  switch (node.type) {
+    case "function":
+      return [bodyField(node as FunctionDefinition)];
+    case "graphNode":
+      return [bodyField(node as GraphNodeDefinition)];
+    case "ifElse": {
+      const n = node as IfElse;
+      const slots: BodySlot[] = [
+        {
+          body: n.thenBody,
+          write: (owner, body) => ({ ...owner, thenBody: body }) as AgencyNode,
+        },
+      ];
+      if (n.elseBody) {
+        slots.push({
+          body: n.elseBody,
+          write: (owner, body) => ({ ...owner, elseBody: body }) as AgencyNode,
+        });
+      }
+      return slots;
+    }
+    case "whileLoop":
+      return [bodyField(node as WhileLoop)];
+    case "forLoop":
+      return [bodyField(node as ForLoop)];
+    case "matchBlock": {
+      const n = node as MatchBlock;
+      const slots: BodySlot[] = [];
+      n.cases.forEach((c, index) => {
+        if (c.type !== "matchBlockCase") {
+          return;
+        }
+        slots.push({
+          body: c.body,
+          write: (owner, body) => {
+            const o = owner as MatchBlock;
+            return {
+              ...o,
+              cases: o.cases.map((oc, j) =>
+                j === index ? ({ ...oc, body } as MatchBlockCase) : oc,
+              ),
+            };
+          },
+        });
+      });
+      return slots;
+    }
+    case "handleBlock": {
+      const n = node as HandleBlock;
+      const slots: BodySlot[] = [
+        {
+          body: n.body,
+          write: (owner, body) => ({ ...owner, body }) as AgencyNode,
+        },
+      ];
+      if (n.handler.kind === "inline") {
+        slots.push({
+          body: n.handler.body,
+          write: (owner, body) => {
+            const o = owner as HandleBlock;
+            return { ...o, handler: { ...o.handler, body } } as AgencyNode;
+          },
+        });
+      }
+      return slots;
+    }
+    case "parallelBlock":
+      return [bodyField(node as ParallelBlock)];
+    case "seqBlock":
+      return [bodyField(node as SeqBlock)];
+    case "messageThread":
+      return [bodyField(node as MessageThread)];
+    case "blockArgument":
+      return [bodyField(node as unknown as BlockArgument)];
+    case "functionCall": {
+      const n = node as FunctionCall;
+      if (!n.block) {
+        return [];
+      }
+      const block = n.block;
+      return [
+        {
+          body: block.body,
+          blockAncestor: block,
+          write: (owner, body) => {
+            const o = owner as FunctionCall;
+            if (!o.block) {
+              return o;
+            }
+            return { ...o, block: { ...o.block, body } };
+          },
+        },
+      ];
+    }
+    case "withModifier":
+      return [statementField(node as WithModifier)];
+    case "staticStatement":
+      return [statementField(node as StaticStatement)];
+    default:
+      return [];
+  }
+}

--- a/packages/agency-lang/lib/utils/mapBodies.ts
+++ b/packages/agency-lang/lib/utils/mapBodies.ts
@@ -1,80 +1,36 @@
 /**
- * mapBodies — apply a transform to every `body: AgencyNode[]` field reachable
- * from a node, returning a structurally-fresh copy with bodies replaced.
+ * mapBodies — apply a transform to every immediate statement body of a node,
+ * returning a structurally-fresh copy with bodies replaced.
  *
- * Useful for AST passes that need to recurse into every block-bearing node
+ * Useful for AST passes that need to rewrite every block-bearing node
  * uniformly (lowering passes, instrumenting, scope analysis, …) without
  * hand-listing every body-bearing node type at every call site.
  *
- * Coverage: function definitions, graph nodes, if/else (then + else),
- * while/for loops, match block arm bodies, handle blocks (incl. inline
- * handler body), parallel/seq blocks, block arguments (including the inline
- * `block:` field on function calls).
+ * The per-node-type body enumeration lives in `bodySlots` (bodySlots.ts) —
+ * the same table `walkNodes` descends by — so a new node type registers its
+ * bodies in one place and both read and rewrite pick it up.
  *
- * Class methods are intentionally NOT recursed into — classes are being
- * removed from the language. Add them here if that decision is reversed.
+ * Shallow by design: only IMMEDIATE bodies are transformed. Callers that
+ * want deep rewrites recurse inside their transform (see patternLowering's
+ * `lowerBody`).
  */
 import type { AgencyNode } from "../types.js";
-import type { FunctionDefinition } from "../types/function.js";
-import type { GraphNodeDefinition } from "../types/graphNode.js";
-import type { IfElse } from "../types/ifElse.js";
-import type { WhileLoop } from "../types/whileLoop.js";
-import type { ForLoop } from "../types/forLoop.js";
-import type { MatchBlock, MatchBlockCase } from "../types/matchBlock.js";
-import type { HandleBlock } from "../types/handleBlock.js";
-import type { ParallelBlock, SeqBlock } from "../types/parallelBlock.js";
-import type { BlockArgument } from "../types/blockArgument.js";
-import type { FunctionCall } from "../types/function.js";
+import { bodySlots } from "./bodySlots.js";
 
 export type BodyTransform = (body: AgencyNode[]) => AgencyNode[];
 
-/** Return a shallow copy of `node` with every body field transformed by `fn`. */
+/** Return a shallow copy of `node` with every body transformed by `fn`. */
 export function mapBodies(node: AgencyNode, fn: BodyTransform): AgencyNode {
-  switch (node.type) {
-    case "function":
-      return { ...(node as FunctionDefinition), body: fn((node as FunctionDefinition).body) };
-    case "graphNode":
-      return { ...(node as GraphNodeDefinition), body: fn((node as GraphNodeDefinition).body) };
-    case "ifElse": {
-      const n = node as IfElse;
-      return { ...n, thenBody: fn(n.thenBody), elseBody: n.elseBody ? fn(n.elseBody) : undefined };
+  let out = node;
+  for (const slot of bodySlots(node)) {
+    const mapped = fn(slot.body);
+    if (slot.single && mapped.length !== 1) {
+      throw new Error(
+        `mapBodies: a '${node.type}' wraps exactly one statement, but the ` +
+          `transform returned ${mapped.length} statements`,
+      );
     }
-    case "whileLoop":
-      return { ...(node as WhileLoop), body: fn((node as WhileLoop).body) };
-    case "forLoop":
-      return { ...(node as ForLoop), body: fn((node as ForLoop).body) };
-    case "matchBlock": {
-      const n = node as MatchBlock;
-      return {
-        ...n,
-        cases: n.cases.map((c) =>
-          c.type === "matchBlockCase"
-            ? ({ ...c, body: fn(c.body) } as MatchBlockCase)
-            : c,
-        ),
-      };
-    }
-    case "handleBlock": {
-      const n = node as HandleBlock;
-      const handler = n.handler.kind === "inline"
-        ? { ...n.handler, body: fn(n.handler.body) }
-        : n.handler;
-      return { ...n, body: fn(n.body), handler };
-    }
-    case "parallelBlock":
-      return { ...(node as ParallelBlock), body: fn((node as ParallelBlock).body) };
-    case "seqBlock":
-      return { ...(node as SeqBlock), body: fn((node as SeqBlock).body) };
-    case "blockArgument":
-      return { ...(node as BlockArgument), body: fn((node as BlockArgument).body) };
-    case "functionCall": {
-      const n = node as FunctionCall;
-      if (n.block) {
-        return { ...n, block: { ...n.block, body: fn(n.block.body) } };
-      }
-      return n;
-    }
-    default:
-      return node;
+    out = slot.write(out, mapped);
   }
+  return out;
 }

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -17,6 +17,7 @@ import {
 import type { BlockArgument } from "@/types/blockArgument.js";
 import { variableTypeToString } from "@/backends/typescriptGenerator/typeToString.js";
 import { color } from "@/utils/termcolors.js";
+import { bodySlots } from "@/utils/bodySlots.js";
 
 /** `BlockArgument` is a child of `FunctionCall`, not a standalone statement,
  * so it isn't in the `AgencyNode` union. But blocks DO appear on the ancestors
@@ -394,58 +395,30 @@ export function* walkNodes(
     if (walkNodeDebug)
       console.log(color.magenta("walkNodes:"), { node, ancestors });
     yield { node, ancestors, scopes };
-    if (node.type === "function") {
-      yield* walkNodes(
-        node.body,
-        [...ancestors, node],
-        [...scopes, functionScope(node.functionName)],
-      );
-    } else if (node.type === "graphNode") {
-      yield* walkNodes(
-        node.body,
-        [...ancestors, node],
-        [...scopes, nodeScope(node.nodeName)],
-      );
-    } else if (node.type === "newExpression") {
+    // Expression descent: per-type, hand-enumerated below. Statement-BODY
+    // descent is NOT enumerated here — it runs generically at the end of
+    // this iteration, driven by `bodySlots` (bodySlots.ts), the shared
+    // body-field table `mapBodies` rewrites by.
+    if (node.type === "newExpression") {
       yield* walkNodes(node.arguments as AgencyNode[], [...ancestors, node], scopes);
     } else if (node.type === "ifElse") {
       yield* walkNodes([node.condition], [...ancestors, node], scopes);
-      yield* walkNodes(node.thenBody, [...ancestors, node], scopes);
-      if (node.elseBody) {
-        yield* walkNodes(node.elseBody, [...ancestors, node], scopes);
-      }
     } else if (node.type === "forLoop") {
       yield* walkNodes([node.iterable as AgencyNode], [...ancestors, node], scopes);
-      yield* walkNodes(node.body, [...ancestors, node], scopes);
     } else if (node.type === "whileLoop") {
       yield* walkNodes([node.condition], [...ancestors, node], scopes);
-      yield* walkNodes(node.body, [...ancestors, node], scopes);
-    } else if (
-      node.type === "messageThread" ||
-      node.type === "parallelBlock" ||
-      node.type === "seqBlock"
-    ) {
+    } else if (node.type === "messageThread") {
       // messageThread carries optional named-arg expressions
       // (`label`, `summarize`, `continue`, `session`, `hidden`).
       // They must be walked so the symbol-table resolver populates
       // the `scope` field on any variable references inside them —
       // otherwise codegen emits bare identifiers instead of
       // `__stack.locals.foo`.
-      if (node.type === "messageThread") {
-        if (node.label) yield* walkNodes([node.label as AgencyNode], [...ancestors, node], scopes);
-        if (node.summarize) yield* walkNodes([node.summarize as AgencyNode], [...ancestors, node], scopes);
-        if (node.continueExpr) yield* walkNodes([node.continueExpr as AgencyNode], [...ancestors, node], scopes);
-        if (node.sessionExpr) yield* walkNodes([node.sessionExpr as AgencyNode], [...ancestors, node], scopes);
-        if (node.hidden) yield* walkNodes([node.hidden as AgencyNode], [...ancestors, node], scopes);
-      }
-      yield* walkNodes(node.body, [...ancestors, node], scopes);
-    } else if (node.type === "handleBlock") {
-      yield* walkNodes(node.body, [...ancestors, node], scopes);
-      if (node.handler.kind === "inline") {
-        yield* walkNodes(node.handler.body, [...ancestors, node], scopes);
-      }
-    } else if (node.type === "withModifier") {
-      yield* walkNodes([node.statement], [...ancestors, node], scopes);
+      if (node.label) yield* walkNodes([node.label as AgencyNode], [...ancestors, node], scopes);
+      if (node.summarize) yield* walkNodes([node.summarize as AgencyNode], [...ancestors, node], scopes);
+      if (node.continueExpr) yield* walkNodes([node.continueExpr as AgencyNode], [...ancestors, node], scopes);
+      if (node.sessionExpr) yield* walkNodes([node.sessionExpr as AgencyNode], [...ancestors, node], scopes);
+      if (node.hidden) yield* walkNodes([node.hidden as AgencyNode], [...ancestors, node], scopes);
     } else if (node.type === "returnStatement" || node.type === "matchYield") {
       if (node.value) yield* walkNodes([node.value], [...ancestors, node], scopes);
     } else if (node.type === "gotoStatement") {
@@ -479,20 +452,6 @@ export function* walkNodes(
       for (const arg of node.arguments) {
         yield* walkNodes([unwrapCallArg(arg) as AgencyNode], [...ancestors, node], scopes);
       }
-      if (node.block) {
-        yield* walkNodes(
-          node.block.body,
-          [...ancestors, node, node.block],
-          scopes,
-        );
-      }
-    } else if (node.type === "blockArgument") {
-      // A standalone block expression (a `\… -> …` lambda passed as a
-      // named-arg / positional value, or assigned to a variable). Descend
-      // into its body with the block pushed onto `ancestors` so block-scope
-      // resolution treats it as a frame and resolves references to enclosing
-      // block locals (otherwise they emit bare, unscoped identifiers).
-      yield* walkNodes(node.body, [...ancestors, node], scopes);
     } else if (node.type === "matchBlock") {
       yield* walkNodes([node.expression], [...ancestors, node], scopes);
       for (const caseItem of node.cases) {
@@ -501,7 +460,6 @@ export function* walkNodes(
         if (caseItem.caseValue !== "_") {
           yield* walkNodes([caseItem.caseValue as AgencyNode], [...ancestors, node], scopes);
         }
-        yield* walkNodes(caseItem.body, [...ancestors, node], scopes);
       }
     } else if (node.type === "valueAccess") {
       yield* walkNodes([node.base], [...ancestors, node], scopes);
@@ -560,6 +518,23 @@ export function* walkNodes(
       for (const arg of node.arguments) {
         yield* walkNodes([unwrapCallArg(arg) as AgencyNode], [...ancestors, node], scopes);
       }
+    }
+    // Generic statement-body descent, driven by the shared `bodySlots`
+    // table. Function/node definitions push their own scope; a
+    // functionCall's inline `block:` pushes the block onto `ancestors` so
+    // block-scope resolution treats it as a frame (references to enclosing
+    // block locals would otherwise emit bare, unscoped identifiers).
+    for (const slot of bodySlots(node)) {
+      let childScopes = scopes;
+      if (node.type === "function") {
+        childScopes = [...scopes, functionScope(node.functionName)];
+      } else if (node.type === "graphNode") {
+        childScopes = [...scopes, nodeScope(node.nodeName)];
+      }
+      const childAncestors: WalkAncestor[] = slot.blockAncestor
+        ? [...ancestors, node, slot.blockAncestor]
+        : [...ancestors, node];
+      yield* walkNodes(slot.body, childAncestors, childScopes);
     }
   }
 }

--- a/packages/agency-lang/stdlib/llm.agency
+++ b/packages/agency-lang/stdlib/llm.agency
@@ -39,7 +39,10 @@ export type LlmDefaults = {
   reasoningEffort?: "low" | "medium" | "high";
   maxTokens?: number;
   maxToolResultChars?: number;
-  maxToolCallRounds?: number
+  maxToolCallRounds?: number;
+  retries?: number;
+  timeout?: number;
+  validationRetries?: number
 }
 
 export def setLlmOptions(opts: LlmDefaults) {

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -194,8 +194,16 @@ export def remember(content: string) {
 
     thread {
       const prompt = _buildExtractionPrompt(content)
-      const result: ExtractionResult = llm(prompt)
-      _applyExtractionResult(result)
+      // Bang validation: a malformed extraction is a failure Result, not
+      // a mistyped value. Before this, a provider returning prose or an
+      // empty string crashed the tool and memory silently stopped
+      // persisting (issue #494).
+      const result: ExtractionResult! = llm(prompt)
+      if (result is success(extraction)) {
+        _applyExtractionResult(extraction)
+      } else {
+        return result
+      }
     }
   }
 }
@@ -233,8 +241,14 @@ export def forget(query: string) {
 
     thread {
       const prompt = _buildForgetPrompt(query)
-      const result: ForgetResult = llm(prompt)
-      _applyForgetResult(result)
+      // Bang validation, same contract as remember: malformed output is
+      // a failure Result the caller can see, never a crash.
+      const result: ForgetResult! = llm(prompt)
+      if (result is success(forgetPlan)) {
+        _applyForgetResult(forgetPlan)
+      } else {
+        return result
+      }
     }
   }
 }

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -295,8 +295,13 @@ def summarize(messages: ThreadMessage[]): string {
   }
   let summary = ""
   thread(hidden: true) {
-    const r: SummaryResult = llm("Summarize this conversation in 1-2 sentences:\n" + transcript, { maxTokens: 256 })
-    summary = r.summary
+    // Bang validation: a malformed summary is a failure Result. The
+    // summary stays "" then, which the cache treats as an intentional
+    // empty marker.
+    const result: SummaryResult! = llm("Summarize this conversation in 1-2 sentences:\n" + transcript, { maxTokens: 256 })
+    if (result is success(value)) {
+      summary = value.summary
+    }
   }
   return summary
 }

--- a/packages/agency-lang/tests/agency-js/structured-output-retry-resume/agency.json
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry-resume/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-retry-resume/agent.agency
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry-resume/agent.agency
@@ -1,0 +1,22 @@
+// The hard path: response 1 fails validation → feedback retry →
+// response 2 calls a tool that INTERRUPTS → resume → tool result →
+// response 3 is valid. Proves: the retry round re-enters the tool loop;
+// resume lands on the same attempt (no duplicate feedback, no
+// re-dispatch); the final value comes out clean.
+type Person = {
+  name: string;
+  age: number
+}
+
+def interruptTool(): string {
+  interrupt("approve")
+  return "tool result"
+}
+
+node main() {
+  const result: Person! = llm("give me a person", { tools: [interruptTool], validationRetries: 1 })
+  if (result is success(person)) {
+    return person.name
+  }
+  return "failure"
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-retry-resume/fixture.json
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry-resume/fixture.json
@@ -1,0 +1,6 @@
+{
+  "result": "Ada",
+  "llmCalls": 3,
+  "feedbackMessages": 1,
+  "validationErrorEvents": 0
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-retry-resume/test.js
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry-resume/test.js
@@ -1,0 +1,103 @@
+import {
+  main,
+  hasInterrupts,
+  approve,
+  respondToInterrupts,
+  __setLLMClient,
+} from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+let feedbackCountOnFinalCall = -1;
+const client = {
+  async text(config) {
+    const idx = callIndex++;
+    if (idx === 0) {
+      // Fails validation → triggers the feedback retry.
+      return {
+        success: true,
+        value: { output: "just prose", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+      };
+    }
+    if (idx === 1) {
+      // The retry round calls a tool that interrupts.
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [new ToolCall("c1", "interruptTool", {})],
+          model: "test",
+          usage: USAGE,
+          cost: COST,
+        },
+      };
+    }
+    // Post-resume: count feedback messages (must be exactly 1 — a resume
+    // that re-ran the feedback step would have pushed a second one), then
+    // answer with valid JSON.
+    // COUPLING: the literal must match buildValidationRetryMessage.
+    feedbackCountOnFinalCall = (config.messages ?? []).filter(
+      (m) =>
+        m.role === "user" &&
+        String(m.content ?? "").includes("did not match the required output format"),
+    ).length;
+    return {
+      success: true,
+      value: {
+        output: JSON.stringify({ name: "Ada", age: 36 }),
+        toolCalls: [],
+        model: "test",
+        usage: USAGE,
+        cost: COST,
+      },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const initial = await main();
+if (!hasInterrupts(initial.data)) {
+  throw new Error(`Expected interrupts, got: ${JSON.stringify(initial.data)}`);
+}
+const final = await respondToInterrupts(initial.data, [approve()]);
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+const validationErrors = events.filter(
+  (e) => e.data?.type === "error" && e.data?.errorType === "structuredOutput",
+).length;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      result: final.data,
+      llmCalls: callIndex,
+      feedbackMessages: feedbackCountOnFinalCall,
+      validationErrorEvents: validationErrors,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/structured-output-retry/agency.json
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-retry/agent.agency
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry/agent.agency
@@ -1,0 +1,58 @@
+// Validation-retry contract, end to end. The mock returns prose by
+// default; it returns valid JSON only when answering a feedback message
+// in the retrySucceeds flow. retryReasons captures the onLLMRetry hook
+// so the reason string is pinned end-to-end (the label test in
+// turnFailure.agency cannot catch a typo in the firing site).
+import { setLlmOptions } from "std::llm"
+
+type Person = {
+  name: string;
+  age: number
+}
+
+let retryReasons: string[] = []
+
+callback("onLLMRetry") as data {
+  retryReasons.push(data.reason)
+}
+
+node retrySucceeds() {
+  const result: Person = llm("give me a person", { validationRetries: 1 })
+  if (isFailure(result)) {
+    return "unexpected-failure"
+  }
+  return result.name
+}
+
+node retriesExhausted() {
+  const result: Person! = llm("always prose", { validationRetries: 2 })
+  if (result is success(person)) {
+    return "unexpected-success"
+  }
+  return "failure"
+}
+
+node retryDisabled() {
+  const result: Person! = llm("always prose", { validationRetries: 0 })
+  if (result is success(person)) {
+    return "unexpected-success"
+  }
+  return "failure"
+}
+
+node branchDefault() {
+  setLlmOptions({ validationRetries: 2 })
+  const result: Person! = llm("always prose")
+  if (result is success(person)) {
+    return "unexpected-success"
+  }
+  return "failure"
+}
+
+node hookReasons() {
+  const result: Person! = llm("always prose", { validationRetries: 1 })
+  if (result is success(person)) {
+    return "unexpected-success"
+  }
+  return retryReasons.join(",")
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-retry/fixture.json
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry/fixture.json
@@ -1,0 +1,12 @@
+{
+  "retrySucceeds": "Ada",
+  "retrySucceedsCalls": 2,
+  "retriesExhausted": "failure",
+  "retriesExhaustedCalls": 3,
+  "retryDisabled": "failure",
+  "retryDisabledCalls": 1,
+  "branchDefault": "failure",
+  "branchDefaultCalls": 3,
+  "hookReasons": "invalidStructuredOutput",
+  "validationErrorEvents": 4
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-retry/test.js
+++ b/packages/agency-lang/tests/agency-js/structured-output-retry/test.js
@@ -1,0 +1,102 @@
+import {
+  retrySucceeds,
+  retriesExhausted,
+  retryDisabled,
+  branchDefault,
+  hookReasons,
+  __setLLMClient,
+} from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callCount = 0;
+const client = {
+  async text(config) {
+    callCount += 1;
+    const msgs = config.messages ?? [];
+    const lastUser = [...msgs].reverse().find((m) => m.role === "user");
+    const firstUser = msgs.find((m) => m.role === "user");
+    const prompt = String(lastUser?.content ?? "");
+    const original = String(firstUser?.content ?? "");
+    // Default: prose that fails validation. Valid JSON only when
+    // answering the feedback message in the "give me a person" flow —
+    // the "always prose" flows must keep failing through their retries.
+    // COUPLING: the trigger literal must match buildValidationRetryMessage
+    // (lib/runtime/llmRetry.ts).
+    let output = "I am sorry, I cannot produce structured data.";
+    if (
+      prompt.includes("did not match the required output format") &&
+      original.includes("give me a person")
+    ) {
+      output = JSON.stringify({ name: "Ada", age: 36 });
+    }
+    return {
+      success: true,
+      value: { output, toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+callCount = 0;
+const succeeded = await retrySucceeds();
+const succeededCalls = callCount;
+
+callCount = 0;
+const exhausted = await retriesExhausted();
+const exhaustedCalls = callCount;
+
+callCount = 0;
+const disabled = await retryDisabled();
+const disabledCalls = callCount;
+
+callCount = 0;
+const branch = await branchDefault();
+const branchCalls = callCount;
+
+const hook = await hookReasons();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+const validationErrors = events.filter(
+  (e) => e.data?.type === "error" && e.data?.errorType === "structuredOutput",
+).length;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      retrySucceeds: succeeded.data,
+      retrySucceedsCalls: succeededCalls,
+      retriesExhausted: exhausted.data,
+      retriesExhaustedCalls: exhaustedCalls,
+      retryDisabled: disabled.data,
+      retryDisabledCalls: disabledCalls,
+      branchDefault: branch.data,
+      branchDefaultCalls: branchCalls,
+      hookReasons: hook.data,
+      validationErrorEvents: validationErrors,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/structured-output-strict/agency.json
+++ b/packages/agency-lang/tests/agency-js/structured-output-strict/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-strict/agent.agency
+++ b/packages/agency-lang/tests/agency-js/structured-output-strict/agent.agency
@@ -1,0 +1,37 @@
+// The structured-output contract: a schema-constrained llm() result that
+// cannot be parsed and validated is a FAILURE, never the raw content
+// masquerading as the declared type. Regression test for the fail-open
+// that silently broke memory extraction (issue #494).
+type Person = {
+  name: string;
+  age: number
+}
+
+node plainInvalid() {
+  const result: Person = llm("give me prose")
+  if (isFailure(result)) {
+    return "failure"
+  }
+  return "not-failure:${typeof result}"
+}
+
+node bangInvalid() {
+  const result: Person! = llm("give me prose")
+  if (result is success(person)) {
+    return "unexpected-success"
+  }
+  return "failure"
+}
+
+node bangValid() {
+  const result: Person! = llm("give me json")
+  if (result is success(person)) {
+    return person.name
+  }
+  return "unexpected-failure"
+}
+
+node primitiveStillWorks() {
+  const count: number = llm("give me a number")
+  return "${count}"
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-strict/fixture.json
+++ b/packages/agency-lang/tests/agency-js/structured-output-strict/fixture.json
@@ -1,0 +1,7 @@
+{
+  "plainInvalid": "failure",
+  "bangInvalid": "failure",
+  "bangValid": "Ada",
+  "primitive": "42",
+  "validationErrorEvents": 2
+}

--- a/packages/agency-lang/tests/agency-js/structured-output-strict/test.js
+++ b/packages/agency-lang/tests/agency-js/structured-output-strict/test.js
@@ -1,0 +1,70 @@
+import { plainInvalid, bangInvalid, bangValid, primitiveStillWorks, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+// The mock answers by prompt content: prose for the invalid cases, valid
+// JSON for the others. The "response" wrapper on the primitive matches
+// what providers return for wrapped primitive schemas.
+const client = {
+  async text(config) {
+    const lastUser = [...(config.messages ?? [])].reverse().find((m) => m.role === "user");
+    const prompt = String(lastUser?.content ?? "");
+    let output = "I am sorry, I cannot produce structured data.";
+    if (prompt.includes("give me json")) {
+      output = JSON.stringify({ name: "Ada", age: 36 });
+    }
+    if (prompt.includes("give me a number")) {
+      output = JSON.stringify({ response: 42 });
+    }
+    return {
+      success: true,
+      value: { output, toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const plain = await plainInvalid();
+const bangBad = await bangInvalid();
+const bangGood = await bangValid();
+const primitive = await primitiveStillWorks();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((line) => line.trim() !== "")
+  .map((line) => JSON.parse(line));
+const validationErrors = events.filter(
+  (e) => e.data?.type === "error" && e.data?.errorType === "structuredOutput",
+).length;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      plainInvalid: plain.data,
+      bangInvalid: bangBad.data,
+      bangValid: bangGood.data,
+      primitive: primitive.data,
+      validationErrorEvents: validationErrors,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
Fixes #494.

## What this does

Two layered changes, one commit each stage:

**1. Strict structured-output validation (the #494 fix).** A schema-constrained `llm()` result now either validates or comes back as a failure Result. It is never the raw content masquerading as the declared type. The old fail-open silently broke memory extraction: a provider returning prose crashed three calls downstream with no log at the cause. Validation failures now post a statelog error (new errorType `structuredOutput`) at the moment they happen, and stdlib call sites (memory remember/forget, thread summarize, the eager summarizer) adopt bang validation.

**2. Validation retries, opt-in.** A new `validationRetries` resilience option: when the response fails schema validation, Agency sends the validation error back to the model and asks again, up to the configured count, before surfacing the failure.

```agency
const person: Person = llm("Describe a scientist", { validationRetries: 2 })
```

Default is 0 (off): validation retries cost tokens, unlike transport retries. Configure per call, per branch via `setLlmOptions({ validationRetries: n })`, or leave off. Retries render in the agent REPL as a "retrying" line via the existing `onLLMRetry` hook (reason `invalidStructuredOutput`).

## Design notes

- The retry decision is a pure function, `decideValidationRetry`, mirroring the `decideRetry`/`runWithRetry` split transport retries already use. The loop in `runPrompt` is a thin driver.
- The driver wraps the tool loop: a retry response may itself contain tool calls, which drain before re-validation. Most of the `prompt.ts` diff is a 2-space re-indent of the existing tool loop; review with whitespace hidden.
- Resume discipline mirrors `nextLlmCall`: the `validation.N` step keys derive from the frame-backed attempt counter, which only advances inside the dispatch step. A dedicated e2e test interrupts mid-retry and asserts no duplicate feedback, no re-dispatch, no double-counted attempt.
- Validation reads the last assistant message: after a resume, the tail message can be our own feedback text, which a string schema would accept via envelope-skip recovery.
- Two hand-synced mirrors of `RetryConfig` gained the new key: the typeChecker llm-option allowlist and the agency-side `LlmDefaults`. The latter was also missing `retries`/`timeout` (pre-existing gap: the runtime honored them, the type rejected them) — fixed here. `backoff` stays off the agency type (needs a nested type alias, no consumer).

## Ride-along compiler fixes (surfaced by the stdlib bang adoption)

- `mapBodies` rebuilt as a fold over a new shared `bodySlots` table (the statement-body twin of `expressionChildren`); `walkNodes` descends bodies off the same table. Fixes pattern lowering never descending into `thread {}` blocks ("Unhandled Agency node type: isExpression") and adds missing `withModifier`/`staticStatement` coverage.
- The flow builder now treats `return interrupt effect(...)` as fall-through (it resumes on approval), fixing false ".value is only available on a success Result" errors after the gated-work idiom used across git/wikipedia/memory stdlib.

## Testing

- Unit: resolver precedence incl. falsy-0 override; `decideValidationRetry` accept/retry/surface/cap/truncation; both type surfaces compile without "Unknown property" warnings.
- E2E (`tests/agency-js/structured-output-retry`): five call-counted nodes — retry succeeds on feedback (2 calls), explicit cap exhausts (3), 0 disables (1), branch default applies (3), hook reason captured via callback.
- E2E (`tests/agency-js/structured-output-retry-resume`): fails validation → retry round calls a tool that interrupts → resume → valid. Each fixture key maps to a specific resume failure mode.
- Full vitest (7752 tests), make, lint:structure, memory + threads-registry agency suites, and the statelog pairing/span/resume suites all pass locally.

## Known limitations (named)

- Direct TS callers passing `args.retryConfig` get only the fields they set (same as retries/timeout/backoff on that path).
- Transport-retry x validation-retry multiplication is untested as a product; each mechanism is tested alone.
- No `agency.json` llm-defaults block (transport retries lack one too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
