### PR TITLE
Add intersection types: the last type-system roadmap feature

### DIFF
--- a/docs/superpowers/plans/2026-07-10-intersection-types-review.md
+++ b/docs/superpowers/plans/2026-07-10-intersection-types-review.md
@@ -1,0 +1,92 @@
+# Review: Intersection Types (`&`) implementation plan — round 2
+
+**Plan reviewed:** `docs/superpowers/plans/2026-07-10-intersection-types.md` (revised)
+**Spec:** `docs/superpowers/specs/2026-07-10-intersection-types-design.md`
+**Reviewed against:** `origin/main` (commit `d771b88b7`), the plan's worktree base.
+
+**Verdict: Ship it.** All four substantive findings from round 1 are fixed, one of them better than I suggested. The rewritten merge pipeline is correct. I re-grounded every changed claim against `origin/main`; nothing new blocks.
+
+---
+
+## Round-1 findings — all resolved
+
+1. **Printer parenthesization (was blocking) — FIXED.** Task 1 Step 5 now extends the three existing paren conditions (`arrayType`, `keyofType`, `indexedAccessType`) for `intersectionType` operands in BOTH `formatType.ts` and `typeToString.ts`, and calls out that `formatType.ts`'s throwing default won't catch it. Round-trip tests for `keyof (A & B)`, `(A & B)[]`, `(A & B)["id"]` are added (Task 1 Step 6). I confirmed all three forms parse to the nesting the tests assume (`arrayType`/`keyofType`/`indexedAccessType` wrapping an `intersectionType` via `parenthesizedTypeParser`), so they genuinely exercise the printer fix.
+
+2. **Dropped `blockTypeParser` (was blocking) — FIXED.** Task 1 Step 4 now says keep ALL current members verbatim including `lazy(() => blockTypeParser)` as the first alternative, with the rationale inline.
+
+3. **`typeKey` cycle (was should-fix) — FIXED, and improved.** `evalIntersection` now takes an injected `TypeEquals` comparator, so `typeOperators.ts` never imports `typeKey`/assignability and its CYCLE RULE stays literally true. The resolver builds `(a, b) => typeKey(a, typeAliases) === typeKey(b, typeAliases)` on the **real** alias table — strictly better than the empty-table form, and cheaper than my "update the comment" fallback. Verified `typeKey(t: VariableType, aliases: Record<string, TypeAliasEntry>)` — the two-arg call is valid.
+
+4. **Missing unknown-alias-in-intersection test (was should-fix) — FIXED.** Added in Task 2 Step 4 (`type X = A & Undefined` expects "Type alias 'Undefined' is not defined"), proving the `visitTypes` → `validateTypeReferences` wiring.
+
+5. **Minor (imports, brittle codegen regex) — FIXED.** Task 2 Step 1 now extends the existing imports correctly; Task 3 Step 1 carries the "match the observed string" note.
+
+---
+
+## New content reviewed
+
+### The rewritten `evalIntersection` (group → combine → build) is correct
+
+I traced it against all nine unit tests:
+
+- **Disjoint keys, first-seen order** — `groupPropertiesByKey` records `keyOrder` on first sight; single-element groups pass through `combineGroup`'s initial-value-less `reduce` untouched. Left-operand keys first, then right's new keys. ✓
+- **Identical shared key (incl. non-object)** — `intersectPropertyValues` resolves both sides and returns `left` when `typesEqual`. This is exactly the case plain recursive-merge couldn't handle (`string & string`), so the comparator earns its place. ✓
+- **Recursive object merge** — both-`objectType` branch recurses through `mergeObjects([left, right], …)`; the nested-level `toEqual` assertion holds. Note the survivor property carries `tags: mergeTagSets(undefined, undefined) === undefined`; `toEqual` (not `toStrictEqual`) ignores undefined-valued keys, so the assertion passes. ✓
+- **Conflict** — neither-equal-nor-both-object throws, naming the key and both `formatTypeHint`s. ✓
+- **Tag merge / description** — `{...left}` preserves the LEFT description (spec rule 4); `mergeTagSets(left.tags, right.tags)` keeps both validate chains, left-first. ✓
+- **n-ary + associativity by construction** — grouping ALL operands in one pass (no pairwise top-level fold) means `(A&B)&C` and `A&(B&C)` produce identical key order `[id, name, age, extra]`; `typeKey` compares equal. Traced both nestings by hand. ✓
+- **No input mutation** — grouping only reads and pushes references; multi-element groups spread into fresh objects; single-element groups share references but are never mutated. This matches the existing `Partial` operator, which also passes properties through by reference. ✓
+- **`Object.create(null)` for `byKey`** — correctly guards against `__proto__`/`toString` key collisions, matching the scope.ts discipline. Good catch to include it.
+
+One observation, not a defect: the three-arg `evalIntersection(members, resolve, typesEqual)` is now the public signature and every caller/test passes all three — consistent throughout the plan.
+
+### Step 6b parse-performance gate — paths valid
+
+`stdlib/ui.agency` (57 KB, the largest stdlib module) and `stdlib/policy.agency` (29 KB) both exist and resolve from `packages/agency-lang`, so `pnpm run ast stdlib/ui.agency` is a real measurement, not a silent no-op. The ~5% budget and "record numbers, not expectations" framing are reasonable for a change that adds a parser level under every union item.
+
+---
+
+## Nothing blocking remains
+
+Everything I flagged is addressed and the additions are sound. Remaining items are all judgment calls the plan already makes reasonably (perf budget threshold, codegen regex tolerance). Approved to execute.
+
+---
+
+# Addendum: check against `docs/dev/anti-patterns.md`
+
+**Direct answer to the main question — "is the plan writing declarative interfaces that neatly encapsulate complexity and imperative code?"**
+
+**Yes, and it is the plan's strongest quality.** Task 2's rewrite is close to a textbook instance of what anti-pattern #2 ("Imperative code everywhere") prescribes: split the *what* from the *how*, encapsulate the imperative part in one place, and expose a declarative interface.
+
+- The `what` reads as four named steps — RESOLVE → GROUP → COMBINE → BUILD — each its own small function (`evalIntersection` / `groupPropertiesByKey` / `combineGroup` + `intersectPropertyValues` / `mergeObjects`).
+- The only imperative construct — the group-by loop — is isolated in `groupPropertiesByKey`. Everything above it is `map`/`reduce`.
+- The three shared-key rules sit in one readable ladder in `intersectPropertyValues` (identical → keep; both objects → recurse; else → error). A future rule change touches only that function.
+- n-ary and associativity hold *by construction* (all operands group in one pass), so there is no hand-managed accumulator to reason about.
+
+The rest of the plan (parser precedence level, printer `case`s, `typeKey`/`valueParamSubstitution`/`mapTypes`/`visitTypes` fan-out) is `map`/`case`-based and mirrors the existing operator family, so no imperative sprawl there either.
+
+## Anti-patterns explicitly AVOIDED (worth calling out as done-right)
+
+- **Useless special cases (avoided):** `combineGroup` uses `reduce` with no initial value, so a one-element (disjoint) group returns its property with no `length === 1` branch. This is exactly the catalog's "good" example.
+- **Leaky abstractions (avoided):** the injected `TypeEquals` comparator *hides* the `typeKey`/assignability dependency behind a callback instead of leaking it into `typeOperators.ts` — the fix to round-1 finding 3, and squarely on the right side of this anti-pattern.
+- **Order-dependent mutable state (avoided):** the pipeline is `const`-based; the only mutable locals (`keyOrder`, `byKey`) are self-contained accumulators inside one function, not cross-variable sequencing. Parser ordering is the catalog's explicitly-exempted case.
+- **Duplicating existing code (mostly avoided):** the plan reuses `resolveObjectArg`, `mergeTagSets`, `formatTypeHint`, `withUseSiteTags`, `visitTypes`/`mapTypes`, `deepResolveNode` rather than reimplementing them.
+
+## One finding worth a plan edit — the hand-rolled group-by vs. the existing `groupBy`
+
+There IS an existing `groupBy<T, K>(items, key): Record<K, T[]>` helper (private to `lib/typeChecker/effectPayloadCheck.ts`). On its face, hand-rolling `groupPropertiesByKey` looks like anti-pattern #1 (duplicating existing code). But the plan's version is actually the *correct* choice, for a non-obvious reason:
+
+- The existing `groupBy` returns a `Record` and its consumers iterate via `Object.entries`, which **reorders integer-like string keys** ("0", "1" sort ahead of "name").
+- Object-type property keys are parsed as `many1WithJoin(varNameChar)` (parsers.ts:1162), so an all-digit key like `"0"` is representable — and property order is semantically load-bearing for the merged schema.
+- The plan's explicit `keyOrder` array preserves true first-seen order regardless of key shape. Reusing `groupBy` + `Object.entries` would silently corrupt ordering for numeric keys.
+
+So this is not duplication to "fix" — it's a justified divergence. The risk is the opposite: a future reader sees the loop, notices `groupBy` exists, and "simplifies" it into `groupBy(allProps, p => p.key)` + `Object.entries`, quietly reintroducing the numeric-key reordering bug.
+
+**Recommended edit:** add a one-line comment on `keyOrder` stating *why* it exists — "preserve first-seen key order; `Object.entries` (and the shared `groupBy`) would reorder integer-like keys like `\"0\"`." That converts an invisible design decision into a guardrail. (Optionally, the inner `byKey` accumulation could reuse the shared `groupBy` while keeping the separate `keyOrder`, but that's cosmetic — the comment is the valuable part.)
+
+## Non-issues (checked, no action)
+
+- **One-line `if` (#):** `if (typesEqual(left, right)) return left;` is a one-line guard return, but the file it joins already uses exactly this style (`if (keys.length === 0) return NEVER_T;` in `typeOperators.ts`), and `lint:structure` — which the plan runs — passes on it. Consistency with the local file wins; leave it.
+- **Single-char names (#):** the comparator params `(a, b)` and lambda vars `m`/`t`/`p` match the existing file's conventions (`(p) => …`, `id = (t) => t`). Minor cosmetic nit: `(a, b)` in the comparators could be `(left, right)` to echo the pipeline's own naming, but it's conventional for a pure equality function.
+- **Nested ternaries / too-much-per-line / nested type objects / dynamic requires / magic numbers / swallowed try-catch / "ugly code":** none present. The one ternary (`members.length === 1 ? members[0] : {…}`) is single, and `IntersectionType`/`TypeEquals` are flat type defs.
+
+**Bottom line:** the plan is clean against the catalog and, on the specific concern you raised, is a positive exemplar. The single actionable item is the `keyOrder` justifying comment.

--- a/docs/superpowers/plans/2026-07-10-intersection-types.md
+++ b/docs/superpowers/plans/2026-07-10-intersection-types.md
@@ -1,0 +1,1001 @@
+# Intersection Types (`&`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (owner preference: inline execution in the main session, NOT subagent-driven). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `&` intersection operator per the approved spec `docs/superpowers/specs/2026-07-10-intersection-types-design.md`. This closes the type-system feature roadmap.
+
+**Architecture:** One new n-ary `intersectionType` variant that exists only between parse and resolution. The parser gains one precedence level between the union parser and its items (`&` binds tighter than `|`, looser than postfix/keyof). `evalIntersection` joins the operators in `lib/typeChecker/typeOperators.ts`, merging object types left to right with recursive shared-key intersection. The fan-out follows `docs/dev/adding-features.md` exactly.
+
+**Verified facts:**
+- `unionTypeParser` = `sepBy(pipe, unionItemParser)` with a ≥2-member check; `pipe` = `seqR(optionalSpacesOrNewline, str("|"), optionalSpacesOrNewline)`. The intersection level slots in by making `unionItemParser` an intersection EXPRESSION whose items are the old alternatives.
+- `variableTypeParser`'s or-chain: `blockTypeParser, unionTypeParser, keyofTypeParser, arrayTypeParser, ...`. A bare `A & B` (no `|`) fails `unionTypeParser` (one member), so `intersectionTypeParser` must ALSO appear in `variableTypeParser`, right after `unionTypeParser`. Its single-member passthrough then subsumes the later alternatives; they stay in the chain as harmless dead code (zero-risk minimal change; note it in a comment).
+- `typeOperators.ts` already consumes `resolveObjectArg` from `builtinGenerics.ts`; `mergeTagSets` (`lib/typeChecker/mergeTags.ts`) imports only types — no cycle. `typeKey` is NOT imported into `typeOperators.ts` (review finding: it transitively pulls in assignability, violating the file's CYCLE RULE comment). Instead, shared-key equality arrives as an INJECTED comparator, exactly like `resolve` — and the caller in assignability.ts builds it on the REAL alias table, which is strictly better than the empty-table workaround the injection replaces.
+- Shared-key equality semantics: the comparator compares RESOLVED values by `typeKey(x, typeAliases)`. Top-level aliases are already resolved by the `resolve` callback, so `Age & number` compares structurally; NESTED alias refs compare nominally (same ref = equal), the family's documented stance.
+- `ObjectProperty.description` is a separate field from tags: the shared-key survivor keeps the LEFT side's description; `mergeTagSets` handles tag-level description concatenation on its own.
+- `schemaExpressionParser` takes the full `variableTypeParser`, so `schema(Named & Aged)` parses once the level exists.
+- The compiler-enforced fan-out is `typeKey` + `valueParamSubstitution` (never-defaults). Hand-maintained: `mapTypes`/`visitTypes`, both printers, `hasAnyValidateTag`, `deepResolveNode` (the trap; red-first non-string pin required).
+
+## Global Constraints
+
+- Fresh worktree: `git worktree add .claude/worktrees/intersection -b intersection origin/main`, then `cd .claude/worktrees/intersection && pnpm install && cd packages/agency-lang && make`.
+- Never commit to `main`. No apostrophes in commit-message command lines. Save test output to files. Run `make` before CLI steps. Do NOT run the full agency suite locally.
+- Zero churn in existing `tests/typescriptGenerator` fixtures is a hard gate.
+- Object-only operands in v1; `never` operands ERROR (deliberate TS divergence, documented).
+- No user-facing guide edits (owner decision from the keyof PR).
+- If `make` regenerates unrelated stdlib docs (`usaspending.md` drift), revert them before committing.
+
+---
+
+### Task 1: Variant + parser level + printers + fan-out
+
+**Files:**
+- Modify: `lib/types/typeHints.ts` (variant)
+- Modify: `lib/parsers/parsers.ts` (intersection level)
+- Modify: `lib/utils/formatType.ts`, `lib/backends/typescriptGenerator/typeToString.ts` (printing + union-member parens)
+- Modify: `lib/typeChecker/typeKey.ts`, `lib/typeChecker/valueParamSubstitution.ts`, `lib/typeChecker/typeWalker.ts` (fan-out)
+- Test: `lib/parsers/intersectionParsing.test.ts` (new), `lib/backends/agencyGenerator.test.ts` (round-trips)
+
+**Interfaces produced:**
+
+```ts
+export type IntersectionType = {
+  type: "intersectionType";
+  types: VariableType[];
+  tags?: Tag[];
+};
+```
+
+- [ ] **Step 1: Write the failing parse tests**
+
+Create `lib/parsers/intersectionParsing.test.ts` (reuse the `firstParamHint` helper shape from `typeOperatorParsing.test.ts`):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+
+function firstParamHint(source: string): unknown {
+  const parsed = parseAgency(source, {}, false);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) throw new Error("unreachable");
+  const def = parsed.result.nodes.find((n) => n.type === "function") as {
+    parameters: { typeHint?: unknown }[];
+  };
+  return def.parameters[0].typeHint;
+}
+
+describe("intersection parsing", () => {
+  it("parses a two-member intersection", () => {
+    expect(firstParamHint("def f(x: A & B) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ aliasName: "A" }, { aliasName: "B" }],
+    });
+  });
+
+  it("is n-ary: A & B & C is one flat node", () => {
+    expect(firstParamHint("def f(x: A & B & C) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ aliasName: "A" }, { aliasName: "B" }, { aliasName: "C" }],
+    });
+  });
+
+  it("binds tighter than union: A & B | C is (A & B) | C", () => {
+    expect(firstParamHint("def f(x: A & B | C) { x }")).toMatchObject({
+      type: "unionType",
+      types: [
+        { type: "intersectionType" },
+        { type: "typeAliasVariable", aliasName: "C" },
+      ],
+    });
+  });
+
+  it("binds tighter than union on the right too: A | B & C", () => {
+    expect(firstParamHint("def f(x: A | B & C) { x }")).toMatchObject({
+      type: "unionType",
+      types: [
+        { type: "typeAliasVariable", aliasName: "A" },
+        { type: "intersectionType" },
+      ],
+    });
+  });
+
+  it("keyof binds tighter: keyof A & B is (keyof A) & B", () => {
+    expect(firstParamHint("def f(x: keyof A & B) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ type: "keyofType" }, { aliasName: "B" }],
+    });
+  });
+
+  it("postfix binds tighter: A[] & B intersects the array", () => {
+    expect(firstParamHint("def f(x: A[] & B) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ type: "arrayType" }, { aliasName: "B" }],
+    });
+  });
+
+  it("parenthesized union as an operand: (A | B) & C", () => {
+    expect(firstParamHint("def f(x: (A | B) & C) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ type: "unionType" }, { aliasName: "C" }],
+    });
+  });
+
+  it("a single member passes through with no intersection node", () => {
+    expect(firstParamHint("def f(x: A) { x }")).toMatchObject({
+      type: "typeAliasVariable",
+      aliasName: "A",
+    });
+  });
+
+  it("tolerates newlines around the ampersand, like union pipes", () => {
+    expect(
+      firstParamHint("def f(x: A &\n  B) { x }"),
+    ).toMatchObject({ type: "intersectionType" });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify red**
+
+```bash
+pnpm test:run lib/parsers/intersectionParsing.test.ts > /tmp/ix-task1-red.log 2>&1; tail -5 /tmp/ix-task1-red.log
+```
+
+Expected: intersection tests FAIL; the single-member passthrough test PASSES (pins existing behavior).
+
+- [ ] **Step 3: Add the variant**
+
+In `lib/types/typeHints.ts`: add `IntersectionType` (code above, with a doc comment noting parse-to-resolution lifecycle like its neighbors) BELOW `TypeParam` (keeping docstrings attached to their declarations — the keyof review lesson), and add it to the `VariableType` union.
+
+- [ ] **Step 4: The parser level**
+
+In `lib/parsers/parsers.ts`:
+
+1. Rename the current `unionItemParser` or-chain to `intersectionItemParser`, keeping ALL current members verbatim and in order — including `lazy(() => blockTypeParser)` as the FIRST alternative (review catch: an enumerated list that omits it silently drops function types from unions and intersections).
+2. Add the level:
+
+```ts
+const ampersand = seqR(
+  optionalSpacesOrNewline,
+  str("&"),
+  optionalSpacesOrNewline,
+);
+
+/**
+ * One precedence level below union items: `&` binds tighter than `|`
+ * and looser than postfix and keyof (all TS parity). A single member
+ * passes through unchanged — no node — so this parser is safe as a
+ * general alternative in variableTypeParser.
+ */
+export const intersectionTypeParser: Parser<VariableType> = map(
+  sepBy1(ampersand, intersectionItemParser),
+  (members): VariableType =>
+    members.length === 1
+      ? members[0]
+      : { type: "intersectionType", types: members },
+);
+
+// Union items are intersection EXPRESSIONS: this is what makes
+// `A & B | C` parse as (A & B) | C.
+export const unionItemParser: Parser<VariableType> = memo(
+  "unionItemParser",
+  intersectionTypeParser,
+);
+```
+
+3. In `variableTypeParser`, insert `intersectionTypeParser` immediately AFTER `unionTypeParser` (a bare `A & B` has one union member, so the union parser fails and this alternative catches it). Add a comment noting the alternatives after it are now subsumed by the single-member passthrough and kept only to avoid churn.
+
+Adapt to the file's actual shapes (`sepBy1` argument order, `map` availability — both confirmed present). If `unionItemParser`'s `memo` name is referenced elsewhere, keep the exported name stable as shown.
+
+- [ ] **Step 5: Printers + fan-out**
+
+- `formatTypeHint` (`lib/utils/formatType.ts`):
+
+```ts
+    case "intersectionType":
+      // A union member needs parens (`(A | B) & C`) because & binds
+      // tighter; an intersection inside a union needs none for the same
+      // reason.
+      return vt.types
+        .map((m) => (m.type === "unionType" ? `(${recurse(m)})` : recurse(m)))
+        .join(" & ");
+```
+
+  AND (review blocking finding): extend the three EXISTING paren
+  conditions, because `&` binds looser than postfix/keyof, so an
+  intersection can only appear under them via explicit parens that the
+  printers must restore:
+  - `arrayType` case: parenthesize `intersectionType` elements (alongside
+    the existing `keyofType`/`unionType` checks) — `(A & B)[]` must not
+    print as `A & B[]`.
+  - `keyofType` case: parenthesize `intersectionType` operands —
+    `keyof (A & B)` must not print as `keyof A & B`.
+  - `indexedAccessType` case: parenthesize `intersectionType` objects —
+    `(A & B)["id"]` must not print as `A & B["id"]`.
+
+  NOTE: `formatType.ts` ends in a THROWING default, not a never-typed
+  one — tsc will not flag these; only the round-trip tests below do.
+
+- `variableTypeToString` (`typeToString.ts`): same rules (the new case
+  and all three existing-case extensions), same comments, in its
+  else-if style.
+- `typeKey` `canonical()`: `` case "intersectionType": return `{"intersect":[${t.types.map(canonical).sort().join(",")}]}`; `` (members sorted — intersection is commutative).
+- `valueParamSubstitution` (both switches): recurse/rebuild over `t.types`, mirroring the `unionType` cases.
+- `mapTypes` AND `visitTypes` (`typeWalker.ts`): mirror the `unionType` cases; update both, per the pairing rule.
+
+- [ ] **Step 6: Build, then green + round-trips**
+
+```bash
+make > /tmp/ix-task1-make.log 2>&1; grep -E "error TS" /tmp/ix-task1-make.log | head -10
+```
+
+Fix anything tsc reports beyond the sites above. Then:
+
+```bash
+pnpm test:run lib/parsers/intersectionParsing.test.ts > /tmp/ix-task1-green.log 2>&1; tail -3 /tmp/ix-task1-green.log
+```
+
+Append round-trip cases to `lib/backends/agencyGenerator.test.ts` (after the keyof cases):
+
+```ts
+      {
+        description: "intersection round-trips",
+        input: "def f(x: A & B) { x }",
+        expectedOutput: "def f(x: A & B) {\nx\n}",
+      },
+      {
+        description: "intersection inside a union round-trips without parens",
+        input: "def f(x: A & B | C) { x }",
+        expectedOutput: "def f(x: A & B | C) {\nx\n}",
+      },
+      {
+        description: "union operand keeps its parens under intersection",
+        input: "def f(x: (A | B) & C) { x }",
+        expectedOutput: "def f(x: (A | B) & C) {\nx\n}",
+      },
+      {
+        description: "intersection operand keeps parens under keyof",
+        input: "def f(x: keyof (A & B)) { x }",
+        expectedOutput: "def f(x: keyof (A & B)) {\nx\n}",
+      },
+      {
+        description: "intersection element keeps parens under array suffix",
+        input: "def f(x: (A & B)[]) { x }",
+        expectedOutput: "def f(x: (A & B)[]) {\nx\n}",
+      },
+      {
+        description: "intersection object keeps parens under indexed access",
+        input: 'def f(x: (A & B)["id"]) { x }',
+        expectedOutput: 'def f(x: (A & B)["id"]) {\nx\n}',
+      },
+```
+
+Plus an alias-position round-trip (standalone test in the Type-preservation describe, like keyof's): `type Person = Named & Aged` generates output containing `Named & Aged`.
+
+```bash
+pnpm test:run lib/backends/agencyGenerator.test.ts > /tmp/ix-task1-fmt.log 2>&1; tail -3 /tmp/ix-task1-fmt.log
+pnpm test:run lib > /tmp/ix-task1-lib.log 2>&1; tail -3 /tmp/ix-task1-lib.log
+pnpm run lint:structure > /tmp/ix-task1-lint.log 2>&1; tail -2 /tmp/ix-task1-lint.log
+```
+
+The full-lib run guards the union-item restructure (it sits under every union annotation).
+
+- [ ] **Step 6b: Parse-performance gate (owner concern)**
+
+The new level runs on every union item, so measure it. The expected
+cost is one failed `&` probe per item (sepBy ends its loop on a failed
+separator probe — no backtracking into items), but record numbers, not
+expectations:
+
+```bash
+for f in stdlib/ui.agency stdlib/policy.agency; do
+  for i in 1 2 3; do
+    /usr/bin/time -p pnpm run ast $f > /dev/null 2>> /tmp/ix-parse-bench.log
+  done
+done
+grep real /tmp/ix-parse-bench.log
+```
+
+Run the same loop on a clean `origin/main` checkout (the main repo
+checkout works) and compare medians. Budget: stop and investigate past
+a ~5% regression on either file — the likely culprit would be memo
+boundary changes, not the sepBy probe. Record both medians in the
+Task 1 commit message.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/types/typeHints.ts lib/parsers/parsers.ts lib/parsers/intersectionParsing.test.ts lib/utils/formatType.ts lib/backends/typescriptGenerator/typeToString.ts lib/backends/agencyGenerator.test.ts lib/typeChecker/typeKey.ts lib/typeChecker/valueParamSubstitution.ts lib/typeChecker/typeWalker.ts
+git commit -m "Add intersectionType variant with a parser precedence level and printers"
+```
+
+---
+
+### Task 2: evalIntersection — a declarative merge pipeline
+
+**Files:**
+- Modify: `lib/typeChecker/typeOperators.ts` (add `evalIntersection` + helpers)
+- Test: `lib/typeChecker/typeOperators.test.ts` (extend)
+- Modify: `lib/typeChecker/assignability.ts` (resolver branch, builds the comparator)
+
+**Interfaces:**
+- `evalIntersection(members: VariableType[], resolve: Resolve, typesEqual: TypeEquals): VariableType` — every member must resolve to an object type; throws `TypeError` on non-object operands and shared-key conflicts.
+- `type TypeEquals = (a: VariableType, b: VariableType) => boolean` — injected structural-identity comparator, keeping `typeOperators.ts` free of the assignability import per its CYCLE RULE (review finding 3). The resolver branch passes `(a, b) => typeKey(a, typeAliases) === typeKey(b, typeAliases)`.
+
+**The design (owner readability requirement):** the merge reads as four
+named steps, each its own small function, with the imperative content
+confined to one group-by:
+
+```
+RESOLVE  every operand to an object type        (evalIntersection)
+GROUP    all properties across operands by key  (groupPropertiesByKey)
+COMBINE  each key group into one property       (combineGroup + the
+                                                 three-rule ladder in
+                                                 intersectPropertyValues)
+BUILD    an ordinary object type                (mergeObjects)
+```
+
+Group-by makes the shared-key rule local and visible (no index
+arithmetic), n-ary merging and associativity hold BY CONSTRUCTION (all
+operands group in one pass — there is no pairwise fold at the top), and
+the three shared-key rules sit in one ladder, one rule per line.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+At the top of `lib/typeChecker/typeOperators.test.ts`, extend the
+EXISTING imports (review note: `typecheckSource` is already imported;
+`evalIntersection` joins the existing typeOperators import; only
+`typeKey` is a new import line, used to build the test comparator):
+
+```ts
+import { evalKeyof, evalIndexedAccess, evalIntersection } from "./typeOperators.js";
+import { typeKey } from "./typeKey.js";
+```
+
+Test comparator helper, next to `id`:
+
+```ts
+const eq = (a: VariableType, b: VariableType) =>
+  typeKey(a, {}) === typeKey(b, {});
+```
+
+Then append:
+
+```ts
+describe("evalIntersection", () => {
+  const NAME_TAG = { type: "tag" as const, name: "validate", arguments: [] };
+
+  function named(): VariableType {
+    return {
+      type: "objectType",
+      properties: [
+        { key: "id", value: STR },
+        { key: "name", value: STR, tags: [NAME_TAG] },
+      ],
+    };
+  }
+
+  function aged(): VariableType {
+    return {
+      type: "objectType",
+      properties: [
+        { key: "id", value: STR },
+        { key: "age", value: NUM },
+      ],
+    };
+  }
+
+  it("merges disjoint keys in first-seen order", () => {
+    const out = evalIntersection([named(), aged()], id, eq);
+    expect(out).toMatchObject({
+      type: "objectType",
+      properties: [{ key: "id" }, { key: "name" }, { key: "age" }],
+    });
+  });
+
+  it("an identical shared key keeps one copy (non-object types included)", () => {
+    const out = evalIntersection([named(), aged()], id, eq) as {
+      properties: { key: string }[];
+    };
+    expect(out.properties.filter((p) => p.key === "id")).toHaveLength(1);
+  });
+
+  it("shared object-typed keys merge RECURSIVELY (nested level asserted)", () => {
+    const a: VariableType = {
+      type: "objectType",
+      properties: [
+        {
+          key: "config",
+          value: {
+            type: "objectType",
+            properties: [{ key: "host", value: STR }],
+          },
+        },
+      ],
+    };
+    const b: VariableType = {
+      type: "objectType",
+      properties: [
+        {
+          key: "config",
+          value: {
+            type: "objectType",
+            properties: [{ key: "port", value: NUM }],
+          },
+        },
+      ],
+    };
+    expect(evalIntersection([a, b], id, eq)).toEqual({
+      type: "objectType",
+      properties: [
+        {
+          key: "config",
+          value: {
+            type: "objectType",
+            properties: [
+              { key: "host", value: STR },
+              { key: "port", value: NUM },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("a conflicting shared key errors, naming the key and both types", () => {
+    const a: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: STR }],
+    };
+    const b: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: NUM }],
+    };
+    expect(() => evalIntersection([a, b], id, eq)).toThrow(
+      /cannot intersect key 'id'.*string.*number/,
+    );
+  });
+
+  it("shared-key tags merge: BOTH validate chains survive", () => {
+    const a: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: STR, tags: [NAME_TAG] }],
+    };
+    const otherTag = { type: "tag" as const, name: "validate", arguments: [] };
+    const b: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: STR, tags: [otherTag] }],
+    };
+    const out = evalIntersection([a, b], id, eq) as {
+      properties: { tags?: { name: string }[] }[];
+    };
+    // mergeTagSets collapses stacked @validate tags into ONE combined
+    // tag; assert a validate tag survives rather than counting tags.
+    expect(out.properties[0].tags?.some((t) => t.name === "validate")).toBe(
+      true,
+    );
+  });
+
+  it("three-way merge groups ALL operands at once", () => {
+    const c: VariableType = {
+      type: "objectType",
+      properties: [{ key: "extra", value: STR }],
+    };
+    const out = evalIntersection([named(), aged(), c], id, eq);
+    expect(out).toMatchObject({
+      properties: [
+        { key: "id" },
+        { key: "name" },
+        { key: "age" },
+        { key: "extra" },
+      ],
+    });
+  });
+
+  it("rejects every non-object operand, including never", () => {
+    expect(() => evalIntersection([named(), NUM], id, eq)).toThrow(
+      /intersection expects an object type/,
+    );
+    expect(() =>
+      evalIntersection(
+        [named(), { type: "primitiveType", value: "never" }],
+        id,
+        eq,
+      ),
+    ).toThrow(/intersection expects an object type/);
+    const rec: VariableType = {
+      type: "genericType",
+      name: "Record",
+      typeArgs: [STR, NUM],
+    };
+    expect(() => evalIntersection([named(), rec], id, eq)).toThrow(
+      /intersection expects an object type/,
+    );
+  });
+
+  it("does not mutate its inputs", () => {
+    const a = named();
+    const snapshot = JSON.parse(JSON.stringify(a));
+    evalIntersection([a, aged()], id, eq);
+    expect(a).toEqual(snapshot);
+  });
+
+  it("is associative on RESOLVED results (compared by typeKey)", () => {
+    const extra: VariableType = {
+      type: "objectType",
+      properties: [{ key: "extra", value: STR }],
+    };
+    const resolve = (t: VariableType): VariableType =>
+      t.type === "intersectionType"
+        ? evalIntersection(t.types, resolve, eq)
+        : t;
+    const leftNested = evalIntersection(
+      [{ type: "intersectionType", types: [named(), aged()] }, extra],
+      resolve,
+      eq,
+    );
+    const rightNested = evalIntersection(
+      [named(), { type: "intersectionType", types: [aged(), extra] }],
+      resolve,
+      eq,
+    );
+    expect(typeKey(leftNested, {})).toBe(typeKey(rightNested, {}));
+  });
+});
+```
+
+- [ ] **Step 2: Red, then implement the pipeline**
+
+```bash
+pnpm test:run lib/typeChecker/typeOperators.test.ts > /tmp/ix-task2-red.log 2>&1; tail -3 /tmp/ix-task2-red.log
+```
+
+Extend `lib/typeChecker/typeOperators.ts`. New imports merged into the
+existing lines: `ObjectProperty`, `ObjectType` (types), `mergeTagSets`,
+`formatTypeHint`. NO `typeKey` import — the comparator is injected,
+which is what keeps the file's CYCLE RULE true.
+
+```ts
+/** Injected structural-identity comparator — see the CYCLE RULE above:
+ *  typeKey lives behind assignability, so the caller provides equality
+ *  the same way it provides `resolve`. */
+export type TypeEquals = (a: VariableType, b: VariableType) => boolean;
+
+/**
+ * `A & B & ...` — merge object types. Four steps:
+ *
+ *   RESOLVE  every operand to an object type
+ *   GROUP    all properties across all operands by key,
+ *            in first-seen key order
+ *   COMBINE  each key group into one property (the shared-key
+ *            rules live in intersectPropertyValues)
+ *   BUILD    an ordinary object type
+ *
+ * Grouping ALL operands at once (rather than folding pairwise) is what
+ * makes the merge n-ary and associative by construction.
+ */
+export function evalIntersection(
+  members: VariableType[],
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): VariableType {
+  const objects = members.map((m) =>
+    resolveObjectArg("intersection", m, resolve),
+  );
+  return mergeObjects(objects, resolve, typesEqual);
+}
+
+function mergeObjects(
+  objects: ObjectType[],
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): ObjectType {
+  const groups = groupPropertiesByKey(objects);
+  const properties = groups.map((group) =>
+    combineGroup(group, resolve, typesEqual),
+  );
+  return { type: "objectType", properties };
+}
+
+/**
+ * Every declaration of every key, grouped, in first-seen key order.
+ * A disjoint key produces a one-element group; a shared key produces
+ * one group holding each side's declaration.
+ */
+function groupPropertiesByKey(objects: ObjectType[]): ObjectProperty[][] {
+  const keyOrder: string[] = [];
+  // Null-prototype dict: keys are user-controlled property names, so
+  // "__proto__"/"toString" must not collide with Object.prototype
+  // (the scope.ts discipline).
+  const byKey: Record<string, ObjectProperty[]> = Object.create(null);
+  for (const obj of objects) {
+    for (const prop of obj.properties) {
+      if (byKey[prop.key] === undefined) {
+        byKey[prop.key] = [];
+        keyOrder.push(prop.key);
+      }
+      byKey[prop.key].push(prop);
+    }
+  }
+  return keyOrder.map((key) => byKey[key]);
+}
+
+/**
+ * Fold a key group into one property. A one-element group returns its
+ * property untouched (reduce with no initial value). A shared key
+ * intersects the value types and merges the tags — a value of `A & B`
+ * must satisfy BOTH sides, so both validate chains apply. The LEFT
+ * declaration keeps its description (the spread).
+ */
+function combineGroup(
+  group: ObjectProperty[],
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): ObjectProperty {
+  return group.reduce((left, right) => ({
+    ...left,
+    value: intersectPropertyValues(
+      left.key,
+      left.value,
+      right.value,
+      resolve,
+      typesEqual,
+    ),
+    tags: mergeTagSets(left.tags, right.tags),
+  }));
+}
+
+/**
+ * The three shared-key rules, in order:
+ *
+ *   identical types   -> keep one copy
+ *   two object types  -> merge recursively (same pipeline)
+ *   anything else     -> no overlap; error naming the key
+ */
+function intersectPropertyValues(
+  key: string,
+  leftValue: VariableType,
+  rightValue: VariableType,
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): VariableType {
+  const left = resolve(leftValue);
+  const right = resolve(rightValue);
+  if (typesEqual(left, right)) return left;
+  if (left.type === "objectType" && right.type === "objectType") {
+    return mergeObjects([left, right], resolve, typesEqual);
+  }
+  throw new TypeError(
+    `cannot intersect key '${key}': '${formatTypeHint(left)}' and '${formatTypeHint(right)}' have no overlap`,
+  );
+}
+```
+
+- [ ] **Step 3: Wire the resolver (comparator built on the real alias table)**
+
+In `resolveTypeWithGuard` (`assignability.ts`), beside the keyof/indexed
+branches — assignability already imports `typeKey`, so the comparator
+costs one lambda:
+
+```ts
+  if (vt.type === "intersectionType") {
+    return withUseSiteTags(
+      evalIntersection(
+        vt.types,
+        (t) => resolveTypeWithGuard(t, typeAliases, inProgress),
+        (a, b) => typeKey(a, typeAliases) === typeKey(b, typeAliases),
+      ),
+      vt.tags,
+    );
+  }
+```
+
+- [ ] **Step 4: Pipeline tests**
+
+Append to the pipeline describe in `typeOperators.test.ts`:
+
+```ts
+  it("accepts a complete value against a merged type, rejects a partial one", () => {
+    const ok = typecheckSource(`
+type Named = { id: string, name: string }
+type Aged = { id: string, age: number }
+node main() {
+  const p: Named & Aged = { id: "1", name: "a", age: 3 }
+  return p
+}
+`);
+    expect(ok).toEqual([]);
+    const bad = typecheckSource(`
+type Named = { id: string, name: string }
+type Aged = { id: string, age: number }
+node main() {
+  const p: Named & Aged = { id: "1", name: "a" }
+  return p
+}
+`);
+    expect(bad.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("composes: Partial of a merge, keyof of a merge, index into a merge", () => {
+    const errors = typecheckSource(`
+type Named = { id: string, name: string }
+type Aged = { id: string, age: number }
+node main() {
+  const a: Partial<Named & Aged> = { id: null, name: null, age: null }
+  const k: keyof (Named & Aged) = "age"
+  const n: (Named & Aged)["age"] = 3
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a generic alias can delegate: type Mix<T> = T & Stamp", () => {
+    const errors = typecheckSource(`
+type Stamp = { createdAt: string }
+type Named = { name: string }
+type Mix<T> = T & Stamp
+node main() {
+  const m: Mix<Named> = { name: "a", createdAt: "now" }
+  return m
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a recursive alias can be an operand (nominal self-refs survive)", () => {
+    const errors = typecheckSource(`
+type Tree = { value: number, children: Tree[] }
+node main() {
+  const t: Tree & { label: string } = {
+    value: 1,
+    children: [],
+    label: "root",
+  }
+  return t
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("an unknown alias inside an intersection is reported (visitTypes wiring)", () => {
+    // Review finding: validateTypeReferences walks via visitTypes, whose
+    // intersection case Task 1 added — prove the wiring instead of
+    // assuming it.
+    const errors = typecheckSource(`
+type A = { x: number }
+type X = A & Undefined
+node main() {
+  return 1
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(
+      /Type alias 'Undefined' is not defined/,
+    );
+  });
+
+  it("semantic errors stay swallowed at typecheck time: string & number member", () => {
+    const errors = typecheckSource(`
+node main() {
+  const x: { id: string } & { id: number } = { id: "1" }
+  return x
+}
+`);
+    expect(errors).toEqual([]);
+  });
+```
+
+- [ ] **Step 5: Verify, sweep, commit**
+
+```bash
+pnpm test:run lib/typeChecker/typeOperators.test.ts > /tmp/ix-task2-green.log 2>&1; tail -3 /tmp/ix-task2-green.log
+pnpm test:run lib/typeChecker > /tmp/ix-task2-suite.log 2>&1; tail -3 /tmp/ix-task2-suite.log
+git add lib/typeChecker/typeOperators.ts lib/typeChecker/typeOperators.test.ts lib/typeChecker/assignability.ts
+git commit -m "Evaluate intersections with a declarative group-combine-build merge pipeline"
+```
+
+---
+
+### Task 3: deepResolveNode + hasAnyValidateTag + codegen/execution pins
+
+**Files:**
+- Modify: `lib/typeChecker/assignability.ts` (`deepResolveNode`)
+- Modify: `lib/backends/typescriptGenerator/validationDescriptor.ts` (`hasAnyValidateTag`)
+- Test: `lib/backends/typeOperators.codegen.test.ts` (extend)
+- Create: `tests/typescriptGenerator/intersectionTypes.agency` (+ `.mjs`)
+- Create: `tests/agency/intersection-type.agency` + `.test.json`
+
+- [ ] **Step 1: Failing codegen pins (fallback-proof, per the playbook)**
+
+Append to `lib/backends/typeOperators.codegen.test.ts`:
+
+```ts
+describe("intersections in alias bodies (deepResolveNode routing)", () => {
+  it("a merged alias emits the full z.object with a non-string property", () => {
+    const out = generate(`
+type Named = {
+  name: string,
+}
+type Aged = {
+  age: number,
+}
+type Person = Named & Aged
+node main() {
+  return 1
+}
+`);
+    // The red-first run prints the real emission — match the OBSERVED
+    // string if zod spacing differs from this regex (review note).
+    expect(out).toMatch(
+      /const Person = z\.object\(\{ "name": z\.string\(\), "age": z\.number\(\) \}\)/,
+    );
+  });
+
+  it("a validate tag on a shared key reaches the descriptor", () => {
+    const out = generate(`
+def positive(n: number): Result<number, string> {
+  if (n > 0) {
+    return success(n)
+  }
+  return failure("must be positive")
+}
+type A = {
+  @validate(positive)
+  id: number,
+}
+type B = {
+  id: number,
+}
+type Merged = A & B
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("(Merged as any).__agency_descriptor");
+    expect(out).toContain("const Merged = z.object");
+  });
+});
+```
+
+- [ ] **Step 2: Red, then route + gate**
+
+```bash
+pnpm test:run lib/backends/typeOperators.codegen.test.ts > /tmp/ix-task3-red.log 2>&1; tail -5 /tmp/ix-task3-red.log
+```
+
+Expected red: `const Person = z.string()` — the fallback, observed. Fixes:
+
+- `deepResolveNode`: add `"intersectionType"` to the routed condition alongside `keyofType`/`indexedAccessType` (same comment applies).
+- `hasAnyValidateTag`: `case "intersectionType": return t.types.some((m) => hasAnyValidateTag(m, aliasesFull, seen));`
+
+Re-run: green.
+
+- [ ] **Step 3: Fixture + execution test**
+
+`tests/typescriptGenerator/intersectionTypes.agency`:
+
+```
+type Named = {
+  name: string,
+}
+
+type Aged = {
+  age: number,
+}
+
+type Person = Named & Aged
+
+node main() {
+  const p: Person = { name: "a", age: 3 }
+  return p
+}
+```
+
+```bash
+make > /tmp/ix-task3-make.log 2>&1; make fixtures > /tmp/ix-task3-fixtures.log 2>&1
+grep -n "const Person" tests/typescriptGenerator/intersectionTypes.mjs
+git status --short tests/
+```
+
+Zero churn outside the new files. `tests/agency/intersection-type.agency`:
+
+```
+// A merged type's schema requires keys from BOTH sides. (Schema bound
+// to a variable first — #480.)
+type Named = {
+  name: string,
+}
+
+type Aged = {
+  age: number,
+}
+
+node accepts() {
+  const s = schema(Named & Aged)
+  const r = s.parseJSON("{\"name\": \"a\", \"age\": 3}")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node rejects() {
+  const s = schema(Named & Aged)
+  const r = s.parseJSON("{\"name\": \"a\"}")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}
+```
+
+`tests/agency/intersection-type.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "{\"name\":\"a\",\"age\":3}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "complete merged object parses"
+    },
+    {
+      "nodeName": "rejects",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "missing right-side key rejected"
+    }
+  ]
+}
+```
+
+```bash
+pnpm run agency test tests/agency/intersection-type.agency > /tmp/ix-task3-exec.log 2>&1; echo "exit=$?"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/typeChecker/assignability.ts lib/backends/typescriptGenerator/validationDescriptor.ts lib/backends/typeOperators.codegen.test.ts tests/typescriptGenerator/intersectionTypes.agency tests/typescriptGenerator/intersectionTypes.mjs tests/agency/intersection-type.agency tests/agency/intersection-type.test.json
+git commit -m "Route intersections through deepResolveNode; pin codegen and runtime behavior"
+```
+
+---
+
+### Task 4: Dev docs
+
+**Files:**
+- Modify: `docs/dev/typechecker/README.md`
+
+- [ ] **Step 1:** Extend the type-operators paragraph (added by the keyof PR): `&` joins the operator family; eager left-to-right merge with recursive shared-key intersection in `evalIntersection` (`typeOperators.ts`); object-only operands; NOTE the deliberate TS divergence — `A & never` errors here rather than absorbing to `never`, because a silently-`never` schema is a debugging trap in a schema-producing language. No user-facing guide edits (owner decision).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/dev/typechecker/README.md
+git commit -m "Document intersection types in the typechecker dev notes"
+```
+
+---
+
+### Task 5: Full verification, push, PR
+
+- [ ] **Step 1: Sweep**
+
+```bash
+pnpm test:run lib > /tmp/ix-task5-lib.log 2>&1; tail -3 /tmp/ix-task5-lib.log
+pnpm run lint:structure > /tmp/ix-task5-lint.log 2>&1; echo "lint=$?"
+make > /tmp/ix-task5-make.log 2>&1; echo "make=$?"
+for t in intersection-type keyof-type utility-partial recursive-type; do pnpm run agency test tests/agency/$t.agency > /tmp/ix-task5-$t.log 2>&1; echo "$t: $?"; done
+```
+
+The re-runs guard the union-item restructure (it sits under every union annotation, which every merged feature uses).
+
+- [ ] **Step 2: PR** (body file; no apostrophes on the command line). Cover: the mixin example; this closes the type-system feature roadmap (list what shipped and what was deliberately killed, with one line each); the precedence level design; the recursive shared-key merge with the tag-merge rationale; the `never` divergence; the red-first `deepResolveNode` observation; scope-outs (non-object operands, located diagnostics, user guide docs pending an owner call).
+
+```bash
+git push -u origin intersection
+gh pr create --title "Add intersection types: the last type-system roadmap feature" --body-file /tmp/ix-pr-body.md
+```

--- a/docs/superpowers/specs/2026-07-10-intersection-types-design.md
+++ b/docs/superpowers/specs/2026-07-10-intersection-types-design.md
@@ -1,0 +1,200 @@
+# Intersection types (`&`)
+
+**Date:** 2026-07-10
+**Status:** Approved design, ready for planning
+**Prior art in this repo:** utility types (PR #478), recursive aliases (PR #485), keyof + indexed access (PR #496). This spec reuses their machinery, conventions, and the variant-addition playbook in `docs/dev/adding-features.md`. It is the LAST feature on the type-system roadmap.
+
+## What we are building
+
+`A & B` combines two object types into one:
+
+```ts
+type Named = {
+  id: string,
+  name: string,
+}
+
+type Aged = {
+  id: string,
+  age: number,
+}
+
+type Person = Named & Aged
+// Person is { id: string, name: string, age: number }
+```
+
+The use case is mixins: shared shape fragments combined at the type
+level instead of copied. Like every operator in this family, `&`
+evaluates eagerly to a plain object type, so the LLM providers only
+ever see ordinary object schemas. There is no provider question.
+
+## Decisions made during brainstorming
+
+- **Shared keys intersect recursively** (owner-approved). Identical
+  types merge to one copy. Two object types merge recursively. Anything
+  else errors, naming the key.
+- **Object-only in v1**, matching the whole operator family: `Record`,
+  arrays, primitives, unions, and `never` operands all error.
+- **No user-facing guide section**, following the owner's revert on the
+  keyof PR. Dev docs only. Open offer stands: if user docs are wanted
+  on a dedicated page, say where.
+
+## Semantics
+
+### Precedence
+
+`&` binds tighter than `|` and looser than postfix and `keyof`, matching
+TypeScript:
+
+| Written | Means |
+|---|---|
+| `A & B \| C` | `(A & B) \| C` |
+| `A \| B & C` | `A \| (B & C)` |
+| `keyof A & B` | `(keyof A) & B` |
+| `A[] & B` | `(A[]) & B` |
+| `(A \| B) & C` | parenthesized union as an operand |
+
+`&` is punctuation, not a keyword — no reserved-name concerns.
+
+### The merge
+
+Every operand must resolve to an object type. Then:
+
+1. **Disjoint keys concatenate.** Left operand's keys first, in their
+   declared order, then the right operand's new keys in theirs.
+2. **Shared keys intersect recursively:**
+   - Identical types (by `typeKey`) keep one copy.
+   - Two object types merge by the same rules, recursively.
+   - Any other combination — `string & number`, an object against a
+     primitive — errors: `cannot intersect key 'id': 'string' and
+     'number' have no overlap`.
+3. **Property tags on a shared key merge via `mergeTagSets`.** This is
+   the semantically correct reading of intersection: a value of `A & B`
+   must satisfy BOTH sides, so both sides' `@validate` chains apply.
+   Descriptions concatenate per the existing `mergeTagSets` rules.
+4. **Property descriptions**: the shared-key survivor keeps the merged
+   tags' description behavior; nothing new.
+
+`A & B & C` is n-ary in the AST (one node, three members) and merges
+left to right — which, with rule 2, is associative.
+
+### Errors
+
+| Case | Behavior |
+|---|---|
+| Non-object operand (`Record`, array, primitive, union, `never`) | `TypeError` per operand: `intersection expects an object type, got '...'` — via the shared `resolveObjectArg` with `"intersection"` as the operator name, so the wording stays one family. |
+| Conflicting shared key | `TypeError` naming the key and both types. |
+| Surfacing | Same as the whole family: swallowed by `safeResolveType` at typecheck time, fatal at codegen via `resolveTypeDeep`. Pin with a tripwire test; located diagnostics remain the standing follow-up. |
+
+Note the `never` divergence from TypeScript: TS says `A & never` is
+`never`. Agency v1 errors instead, because the object-only rule wins and
+a silent `never` result would be a debugging trap in a schema-producing
+language. Document in the dev notes.
+
+### Composition
+
+All of these fall out of eager evaluation through the existing
+recursive resolver, with tests but no special code:
+
+```ts
+Partial<A & B>           // merge first, then null every property
+keyof (A & B)            // all keys of the merge
+(A & B)["id"]            // the merged property type
+type Mix<T> = T & Stamp  // generic alias delegation, evaluated at use
+Tree & { extra: string } // recursive alias operand; nominal self-refs
+                         // survive into the merged object
+```
+
+Generic alias bodies validate without evaluating (`type Mix<T> = T &
+Stamp` must not error at declaration where `T` is a stubbed nominal
+reference) — same story as `PartialOf<T>` and `Keys<T>`, verified by
+test.
+
+## Implementation
+
+### AST
+
+One new variant, n-ary like `unionType`:
+
+```ts
+export type IntersectionType = {
+  type: "intersectionType";
+  types: VariableType[];
+  tags?: Tag[];
+};
+```
+
+Exists only between parse and resolution. Occurrence tags thread
+through `withUseSiteTags` in the resolver branch, like the operator
+branches next to it.
+
+### Parser
+
+One new precedence level between the union parser and its items:
+
+- `unionTypeParser`'s items become intersection EXPRESSIONS.
+- An intersection expression is `sepBy1("&", <current union-item
+  alternatives>)`; a single member passes through unchanged (no node),
+  two or more build an `intersectionType`.
+- Whitespace around `&` tolerated, like the union's `|`.
+
+The existing union-item alternatives (keyof, postfix/array/indexed,
+object literals, literals, parens) become the intersection's items, so
+all the precedence rows above fall out of the level structure rather
+than special cases.
+
+### Evaluation
+
+`evalIntersection(members, resolve)` joins the other operators in
+`lib/typeChecker/typeOperators.ts`, consuming `resolveObjectArg` and
+`mergeTagSets`. One branch in `resolveTypeWithGuard` delegates, with
+the injected resolver carrying the in-progress guard (recursive alias
+operands degrade nominally, as everywhere).
+
+### The fan-out (per docs/dev/adding-features.md)
+
+Compiler-enforced: `typeKey` (`canonical` — members SORTED, intersection
+is commutative), `valueParamSubstitution` (both switches).
+
+Hand-maintained: `mapTypes` + `visitTypes` (the pair), `formatTypeHint`
++ `variableTypeToString` (print `A & B`; parenthesize a UNION member —
+`(A | B) & C` — since `&` binds tighter; an intersection inside a union
+needs no parens for the same reason), `validateTypeReferences` (walks
+members via the walker cases), `hasAnyValidateTag` (descend members),
+**`deepResolveNode`** (route the variant; red-first non-string codegen
+pin per the playbook rule).
+
+## Testing
+
+The established recipe:
+
+- **Parse**: every precedence row above, n-ary flattening, whitespace
+  tolerance, parenthesized-union operands.
+- **Unit** (`typeOperators.test.ts`): disjoint merge with order pinned;
+  identical shared key; recursive object merge (nested level actually
+  asserted); conflicting-key error naming the key; tag merge on shared
+  keys (both validate chains present); every non-object operand error
+  including `never`; no input mutation; n-ary associativity — the
+  RESOLVED merge of `(A & B) & C` equals that of `A & (B & C)`,
+  compared by `typeKey` (the parenthesized form nests an intersection
+  node as an operand, which the injected resolver evaluates first).
+- **Pipeline**: assignment accept/reject against a merged type; the
+  composition table above including `Mix<T>` delegation and the
+  recursive-alias operand; the swallowed-error tripwire.
+- **Codegen**: fallback-proof pins (a merged alias emits the full
+  `z.object` with a non-string property; `@validate` on a shared key
+  reaches the descriptor); fixture with the zero-churn gate.
+- **Execution** (no LLM): `schema(Named & Aged)` parse-accepts a
+  complete object and parse-rejects one missing a right-side key.
+- **Formatter round-trips**: `A & B`, `A & B | C`, `(A | B) & C`, and
+  alias-position.
+
+## Non-goals
+
+- Non-object operands (primitives, unions-of-objects distribution,
+  `never` absorption). All error in v1; TS-style distribution is
+  permanently unlikely given the litmus test.
+- Located diagnostics for resolver errors — the standing family-wide
+  follow-up.
+- User-facing guide docs — per the keyof-PR decision, pending an owner
+  call on where such docs should live.

--- a/packages/agency-lang/docs/dev/typechecker/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/README.md
@@ -304,6 +304,17 @@ built-in generics, they evaluate EAGERLY in `resolveTypeWithGuard` (see
 exhaustiveness and discriminant narrowing. The `keyof` keyword is in
 `RESERVED_TYPE_NAMES`.
 
+`A & B` joins the family: `evalIntersection` merges object types in a
+group-combine-build pipeline (all operands grouped by key at once, so
+n-ary merging is associative by construction), with shared keys
+intersecting recursively and both sides' `@validate` chains applying.
+Operands are object-only. One deliberate TypeScript divergence:
+`A & never` ERRORS here rather than absorbing to `never` — a silently
+never-typed schema would be a debugging trap in a schema-producing
+language. Structural equality for shared keys is INJECTED into the
+evaluator (a `typeKey`-based comparator built on the real alias table)
+so `typeOperators.ts` keeps its no-assignability-import cycle rule.
+
 ## Type narrowing
 
 Flow-sensitive narrowing and exhaustiveness checking have their own subtree:

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -99,6 +99,37 @@ describe("AgencyGenerator - Function Parameter Type Hints", () => {
         input: 'def f(x: (A | B)["k"]) { x }',
         expectedOutput: 'def f(x: (A | B)["k"]) {\nx\n}',
       },
+
+      {
+        description: "intersection round-trips",
+        input: "def f(x: A & B) { x }",
+        expectedOutput: "def f(x: A & B) {\nx\n}",
+      },
+      {
+        description: "intersection inside a union round-trips without parens",
+        input: "def f(x: A & B | C) { x }",
+        expectedOutput: "def f(x: A & B | C) {\nx\n}",
+      },
+      {
+        description: "union operand keeps its parens under intersection",
+        input: "def f(x: (A | B) & C) { x }",
+        expectedOutput: "def f(x: (A | B) & C) {\nx\n}",
+      },
+      {
+        description: "intersection operand keeps parens under keyof",
+        input: "def f(x: keyof (A & B)) { x }",
+        expectedOutput: "def f(x: keyof (A & B)) {\nx\n}",
+      },
+      {
+        description: "intersection element keeps parens under array suffix",
+        input: "def f(x: (A & B)[]) { x }",
+        expectedOutput: "def f(x: (A & B)[]) {\nx\n}",
+      },
+      {
+        description: "intersection object keeps parens under indexed access",
+        input: 'def f(x: (A & B)["id"]) { x }',
+        expectedOutput: 'def f(x: (A & B)["id"]) {\nx\n}',
+      },
     ];
 
     testCases.forEach(({ description, input, expectedOutput }) => {
@@ -121,6 +152,18 @@ describe("AgencyGenerator - Function Parameter Type Hints", () => {
   });
 
   describe("Type preservation", () => {
+    it("preserves an intersection in a type alias declaration", () => {
+      const parseResult = parseAgency("type Person = Named & Aged", {}, false);
+      expect(parseResult.success).toBe(true);
+
+      if (!parseResult.success) return;
+
+      const generator = new AgencyGenerator();
+      const result = generator.generate(parseResult.result);
+
+      expect(result.output).toContain("Named & Aged");
+    });
+
     it("preserves keyof and indexed access in alias declarations", () => {
       const parseResult = parseAgency(
         'type F = keyof User\ntype N = User["name"]',

--- a/packages/agency-lang/lib/backends/typeOperators.codegen.test.ts
+++ b/packages/agency-lang/lib/backends/typeOperators.codegen.test.ts
@@ -89,3 +89,50 @@ node main() {
     expect(out).toContain("const A = z.number()");
   });
 });
+
+// The zod mapper fallback is z.string(); assertions use shapes it cannot fake.
+describe("intersections in alias bodies (deepResolveNode routing)", () => {
+  it("a merged alias emits the full z.object with a non-string property", () => {
+    const out = generate(`
+type Named = {
+  name: string,
+}
+type Aged = {
+  age: number,
+}
+type Person = Named & Aged
+node main() {
+  return 1
+}
+`);
+    // The red-first run prints the real emission — match the OBSERVED
+    // string if zod spacing differs.
+    expect(out).toMatch(
+      /const Person = z\.object\(\{ "name": z\.string\(\), "age": z\.number\(\) \}\)/,
+    );
+  });
+
+  it("a validate tag on a shared key reaches the descriptor", () => {
+    const out = generate(`
+def positive(n: number): Result<number, string> {
+  if (n > 0) {
+    return success(n)
+  }
+  return failure("must be positive")
+}
+type A = {
+  @validate(positive)
+  id: number,
+}
+type B = {
+  id: number,
+}
+type Merged = A & B
+node main() {
+  return 1
+}
+`);
+    expect(out).toContain("(Merged as any).__agency_descriptor");
+    expect(out).toContain("const Merged = z.object");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
@@ -138,7 +138,8 @@ export function variableTypeToString(
     );
     if (
       variableType.elementType.type === "unionType" ||
-      variableType.elementType.type === "keyofType"
+      variableType.elementType.type === "keyofType" ||
+      variableType.elementType.type === "intersectionType"
     ) {
       // keyof parenthesizes for the same re-parse reason as unions:
       // `keyof User[]` reads as keyof (User[]).
@@ -207,15 +208,23 @@ export function variableTypeToString(
       .map((a) => variableTypeToString(a, typeAliases, forFormatting))
       .join(", ");
     return `${variableType.name}<${args}>${formatValueArgs(variableType.valueArgs)}`;
+  } else if (variableType.type === "intersectionType") {
+    return variableType.types
+      .map((m) => {
+        const s = variableTypeToString(m, typeAliases, forFormatting);
+        return m.type === "unionType" ? `(${s})` : s;
+      })
+      .join(" & ");
   } else if (variableType.type === "keyofType") {
     const op = variableTypeToString(
       variableType.operand,
       typeAliases,
       forFormatting,
     );
-    // Parenthesize a union operand: `keyof (A | B)` must not print as
-    // `keyof A | B`, which re-parses as (keyof A) | B.
-    return variableType.operand.type === "unionType"
+    // Parenthesize union AND intersection operands: `keyof (A | B)` /
+    // `keyof (A & B)` must not print bare (wrong re-parse precedence).
+    return variableType.operand.type === "unionType" ||
+      variableType.operand.type === "intersectionType"
       ? `keyof (${op})`
       : `keyof ${op}`;
   } else if (variableType.type === "indexedAccessType") {
@@ -226,7 +235,8 @@ export function variableTypeToString(
     );
     const wrapped =
       variableType.objectType.type === "keyofType" ||
-      variableType.objectType.type === "unionType"
+      variableType.objectType.type === "unionType" ||
+      variableType.objectType.type === "intersectionType"
         ? `(${obj})`
         : obj;
     const index = variableTypeToString(

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -87,6 +87,8 @@ export function hasAnyValidateTag(
         hasAnyValidateTag(t.objectType, aliasesFull, seen) ||
         hasAnyValidateTag(t.index, aliasesFull, seen)
       );
+    case "intersectionType":
+      return t.types.some((m) => hasAnyValidateTag(m, aliasesFull, seen));
     case "genericType": {
       // Type arguments may themselves carry @validate (e.g. `Array<Email>`).
       if (

--- a/packages/agency-lang/lib/parsers/intersectionParsing.test.ts
+++ b/packages/agency-lang/lib/parsers/intersectionParsing.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+
+function firstParamHint(source: string): unknown {
+  const parsed = parseAgency(source, {}, false);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) throw new Error("unreachable");
+  const def = parsed.result.nodes.find((n) => n.type === "function") as {
+    parameters: { typeHint?: unknown }[];
+  };
+  return def.parameters[0].typeHint;
+}
+
+describe("intersection parsing", () => {
+  it("parses a two-member intersection", () => {
+    expect(firstParamHint("def f(x: A & B) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ aliasName: "A" }, { aliasName: "B" }],
+    });
+  });
+
+  it("is n-ary: A & B & C is one flat node", () => {
+    expect(firstParamHint("def f(x: A & B & C) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ aliasName: "A" }, { aliasName: "B" }, { aliasName: "C" }],
+    });
+  });
+
+  it("binds tighter than union: A & B | C is (A & B) | C", () => {
+    expect(firstParamHint("def f(x: A & B | C) { x }")).toMatchObject({
+      type: "unionType",
+      types: [
+        { type: "intersectionType" },
+        { type: "typeAliasVariable", aliasName: "C" },
+      ],
+    });
+  });
+
+  it("binds tighter than union on the right too: A | B & C", () => {
+    expect(firstParamHint("def f(x: A | B & C) { x }")).toMatchObject({
+      type: "unionType",
+      types: [
+        { type: "typeAliasVariable", aliasName: "A" },
+        { type: "intersectionType" },
+      ],
+    });
+  });
+
+  it("keyof binds tighter: keyof A & B is (keyof A) & B", () => {
+    expect(firstParamHint("def f(x: keyof A & B) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ type: "keyofType" }, { aliasName: "B" }],
+    });
+  });
+
+  it("postfix binds tighter: A[] & B intersects the array", () => {
+    expect(firstParamHint("def f(x: A[] & B) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ type: "arrayType" }, { aliasName: "B" }],
+    });
+  });
+
+  it("parenthesized union as an operand: (A | B) & C", () => {
+    expect(firstParamHint("def f(x: (A | B) & C) { x }")).toMatchObject({
+      type: "intersectionType",
+      types: [{ type: "unionType" }, { aliasName: "C" }],
+    });
+  });
+
+  it("a single member passes through with no intersection node", () => {
+    expect(firstParamHint("def f(x: A) { x }")).toMatchObject({
+      type: "typeAliasVariable",
+      aliasName: "A",
+    });
+  });
+
+  it("tolerates newlines around the ampersand, like union pipes", () => {
+    expect(firstParamHint("def f(x: A &\n  B) { x }")).toMatchObject({
+      type: "intersectionType",
+    });
+  });
+});
+
+describe("regression: postfixed inline object types as members", () => {
+  it("an inline object type with an array suffix parses as a property value", () => {
+    // Found via stdlib/memory.agency: the intersection passthrough made
+    // an object-first item order commit to the bare object and strand
+    // the [] suffix.
+    const parsed = parseAgency(
+      "type X = { a: { n: string; t: string }[] }",
+    );
+    expect(parsed.success).toBe(true);
+  });
+
+  it("the same shape works as a UNION member (latent pre-existing gap, now fixed)", () => {
+    const parsed = parseAgency("type X = { a: number | { n: string }[] }");
+    expect(parsed.success).toBe(true);
+  });
+
+  it("and as an intersection member", () => {
+    expect(
+      firstParamHint("def f(x: { n: string }[] & B) { x }"),
+    ).toMatchObject({
+      type: "intersectionType",
+      types: [{ type: "arrayType" }, { aliasName: "B" }],
+    });
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1373,14 +1373,23 @@ export const objectTypeParser: Parser<ObjectType> = memo(
   ),
 );
 
-export const unionItemParser: Parser<VariableType> = memo(
-  "unionItemParser",
+// The alternatives an intersection operand can be — the old
+// unionItemParser members, with ONE deliberate reorder: arrayTypeParser
+// (base + postfix suffixes) must run BEFORE objectTypeParser. The old
+// object-first order was only safe because the union parser's >=2-member
+// gate threw away single-member matches and fell through to
+// variableTypeParser (which orders arrayType first); the intersection
+// passthrough SUCCEEDS on single members, so an object-first chain would
+// commit to a bare `{ n: string }` and strand the `[]` suffix of
+// `{ n: string }[]` (found via stdlib/memory.agency failing to compile).
+export const intersectionItemParser: Parser<VariableType> = memo(
+  "intersectionItemParser",
   or(
     lazy(() => blockTypeParser),
     lazy(() => keyofTypeParser),
+    arrayTypeParser,
     objectTypeParser,
     angleBracketsArrayTypeParser,
-    arrayTypeParser,
     lazy(() => resultTypeParser),
     lazy(() => genericTypeParser),
     stringLiteralTypeParser,
@@ -1390,6 +1399,33 @@ export const unionItemParser: Parser<VariableType> = memo(
     typeAliasVariableParser,
     parenthesizedTypeParser,
   ),
+);
+
+const ampersand = seqR(
+  optionalSpacesOrNewline,
+  str("&"),
+  optionalSpacesOrNewline,
+);
+
+/**
+ * One precedence level below union items: `&` binds tighter than `|`
+ * and looser than postfix and keyof (all TS parity). A single member
+ * passes through unchanged — no node — so this parser is safe as a
+ * general alternative in variableTypeParser.
+ */
+export const intersectionTypeParser: Parser<VariableType> = map(
+  sepBy1(ampersand, intersectionItemParser),
+  (members): VariableType =>
+    members.length === 1
+      ? members[0]
+      : { type: "intersectionType", types: members },
+);
+
+// Union items are intersection EXPRESSIONS: this is what makes
+// `A & B | C` parse as (A & B) | C.
+export const unionItemParser: Parser<VariableType> = memo(
+  "unionItemParser",
+  intersectionTypeParser,
 );
 
 const pipe = seqR(optionalSpacesOrNewline, str("|"), optionalSpacesOrNewline);
@@ -1669,6 +1705,10 @@ export const variableTypeParser: Parser<VariableType> = memo(
   or(
     blockTypeParser,
     unionTypeParser,
+    // Bare `A & B` (one union member) fails unionTypeParser; this catches
+    // it. Its single-member passthrough also subsumes the alternatives
+    // below, which are kept only to avoid churn.
+    intersectionTypeParser,
     keyofTypeParser,
     arrayTypeParser,
     objectTypeParser,

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -287,7 +287,11 @@ function deepResolveNode(
   typeAliases: Record<string, TypeAliasEntry>,
 ): VariableType {
   if (n.type === "genericType") return resolveType(n, typeAliases);
-  if (n.type === "keyofType" || n.type === "indexedAccessType") {
+  if (
+    n.type === "keyofType" ||
+    n.type === "indexedAccessType" ||
+    n.type === "intersectionType"
+  ) {
     // Same routing as genericType: these evaluate to concrete types and
     // must never reach the zod mapper unresolved — the mapper's fallback
     // silently emits z.string(). See docs/dev/adding-features.md.

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -11,7 +11,7 @@ import {
   isBuiltinGenericName,
   withUseSiteTags,
 } from "./builtinGenerics.js";
-import { evalIndexedAccess, evalKeyof } from "./typeOperators.js";
+import { evalIndexedAccess, evalIntersection, evalKeyof } from "./typeOperators.js";
 
 /**
  * Public resolveType: normalizes a VariableType by resolving type-alias
@@ -97,6 +97,20 @@ function resolveTypeWithGuard(
     }
     const resolved = resolveTypeWithGuard(substitutedEntry.body, typeAliases, next);
     return attachAliasTags(resolved, substitutedEntry.tags);
+  }
+
+  if (vt.type === "intersectionType") {
+    // Comparator built on the REAL alias table — assignability owns
+    // typeKey, so equality is injected the same way `resolve` is (the
+    // typeOperators CYCLE RULE).
+    return withUseSiteTags(
+      evalIntersection(
+        vt.types,
+        (t) => resolveTypeWithGuard(t, typeAliases, inProgress),
+        (a, b) => typeKey(a, typeAliases) === typeKey(b, typeAliases),
+      ),
+      vt.tags,
+    );
   }
 
   if (vt.type === "keyofType") {

--- a/packages/agency-lang/lib/typeChecker/typeKey.ts
+++ b/packages/agency-lang/lib/typeChecker/typeKey.ts
@@ -85,6 +85,9 @@ function canonical(t: VariableType): string {
       return `{"keyof":${canonical(t.operand)}}`;
     case "indexedAccessType":
       return `{"index":[${canonical(t.objectType)},${canonical(t.index)}]}`;
+    case "intersectionType":
+      // Sorted — intersection is commutative.
+      return `{"intersect":[${t.types.map(canonical).sort().join(",")}]}`;
     default: {
       // Exhaustiveness enforced per the typeHints.ts convention: a new
       // VariableType variant fails compilation here instead of silently

--- a/packages/agency-lang/lib/typeChecker/typeOperators.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typeOperators.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { evalKeyof, evalIndexedAccess } from "./typeOperators.js";
+import { evalKeyof, evalIndexedAccess, evalIntersection } from "./typeOperators.js";
+import { typeKey } from "./typeKey.js";
 import { typecheckSource } from "./testUtils.js";
 import type { VariableType } from "../types.js";
 
@@ -7,6 +8,8 @@ const STR: VariableType = { type: "primitiveType", value: "string" };
 const NUM: VariableType = { type: "primitiveType", value: "number" };
 const AGE_TAG = { type: "tag" as const, name: "validate", arguments: [] };
 const id = (t: VariableType) => t;
+const eq = (a: VariableType, b: VariableType) =>
+  typeKey(a, {}) === typeKey(b, {});
 
 function user(): VariableType {
   return {
@@ -297,5 +300,277 @@ node main() {
 }
 `);
     expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("evalIntersection", () => {
+  const NAME_TAG = { type: "tag" as const, name: "validate", arguments: [] };
+
+  function named(): VariableType {
+    return {
+      type: "objectType",
+      properties: [
+        { key: "id", value: STR },
+        { key: "name", value: STR, tags: [NAME_TAG] },
+      ],
+    };
+  }
+
+  function aged(): VariableType {
+    return {
+      type: "objectType",
+      properties: [
+        { key: "id", value: STR },
+        { key: "age", value: NUM },
+      ],
+    };
+  }
+
+  it("merges disjoint keys in first-seen order", () => {
+    const out = evalIntersection([named(), aged()], id, eq);
+    expect(out).toMatchObject({
+      type: "objectType",
+      properties: [{ key: "id" }, { key: "name" }, { key: "age" }],
+    });
+  });
+
+  it("an identical shared key keeps one copy (non-object types included)", () => {
+    const out = evalIntersection([named(), aged()], id, eq) as {
+      properties: { key: string }[];
+    };
+    expect(out.properties.filter((p) => p.key === "id")).toHaveLength(1);
+  });
+
+  it("shared object-typed keys merge RECURSIVELY (nested level asserted)", () => {
+    const a: VariableType = {
+      type: "objectType",
+      properties: [
+        {
+          key: "config",
+          value: {
+            type: "objectType",
+            properties: [{ key: "host", value: STR }],
+          },
+        },
+      ],
+    };
+    const b: VariableType = {
+      type: "objectType",
+      properties: [
+        {
+          key: "config",
+          value: {
+            type: "objectType",
+            properties: [{ key: "port", value: NUM }],
+          },
+        },
+      ],
+    };
+    expect(evalIntersection([a, b], id, eq)).toEqual({
+      type: "objectType",
+      properties: [
+        {
+          key: "config",
+          value: {
+            type: "objectType",
+            properties: [
+              { key: "host", value: STR },
+              { key: "port", value: NUM },
+            ],
+          },
+        },
+      ],
+    });
+  });
+
+  it("a conflicting shared key errors, naming the key and both types", () => {
+    const a: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: STR }],
+    };
+    const b: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: NUM }],
+    };
+    expect(() => evalIntersection([a, b], id, eq)).toThrow(
+      /cannot intersect key 'id'.*string.*number/,
+    );
+  });
+
+  it("shared-key tags merge: BOTH validate chains survive", () => {
+    const a: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: STR, tags: [NAME_TAG] }],
+    };
+    const otherTag = { type: "tag" as const, name: "validate", arguments: [] };
+    const b: VariableType = {
+      type: "objectType",
+      properties: [{ key: "id", value: STR, tags: [otherTag] }],
+    };
+    const out = evalIntersection([a, b], id, eq) as {
+      properties: { tags?: { name: string }[] }[];
+    };
+    // mergeTagSets collapses stacked @validate tags into ONE combined
+    // tag; assert a validate tag survives rather than counting tags.
+    expect(out.properties[0].tags?.some((t) => t.name === "validate")).toBe(
+      true,
+    );
+  });
+
+  it("three-way merge groups ALL operands at once", () => {
+    const c: VariableType = {
+      type: "objectType",
+      properties: [{ key: "extra", value: STR }],
+    };
+    const out = evalIntersection([named(), aged(), c], id, eq);
+    expect(out).toMatchObject({
+      properties: [
+        { key: "id" },
+        { key: "name" },
+        { key: "age" },
+        { key: "extra" },
+      ],
+    });
+  });
+
+  it("rejects every non-object operand, including never", () => {
+    expect(() => evalIntersection([named(), NUM], id, eq)).toThrow(
+      /intersection expects an object type/,
+    );
+    expect(() =>
+      evalIntersection(
+        [named(), { type: "primitiveType", value: "never" }],
+        id,
+        eq,
+      ),
+    ).toThrow(/intersection expects an object type/);
+    const rec: VariableType = {
+      type: "genericType",
+      name: "Record",
+      typeArgs: [STR, NUM],
+    };
+    expect(() => evalIntersection([named(), rec], id, eq)).toThrow(
+      /intersection expects an object type/,
+    );
+  });
+
+  it("does not mutate its inputs", () => {
+    const a = named();
+    const snapshot = JSON.parse(JSON.stringify(a));
+    evalIntersection([a, aged()], id, eq);
+    expect(a).toEqual(snapshot);
+  });
+
+  it("is associative on RESOLVED results (compared by typeKey)", () => {
+    const extra: VariableType = {
+      type: "objectType",
+      properties: [{ key: "extra", value: STR }],
+    };
+    const resolve = (t: VariableType): VariableType =>
+      t.type === "intersectionType"
+        ? evalIntersection(t.types, resolve, eq)
+        : t;
+    const leftNested = evalIntersection(
+      [{ type: "intersectionType", types: [named(), aged()] }, extra],
+      resolve,
+      eq,
+    );
+    const rightNested = evalIntersection(
+      [named(), { type: "intersectionType", types: [aged(), extra] }],
+      resolve,
+      eq,
+    );
+    expect(typeKey(leftNested, {})).toBe(typeKey(rightNested, {}));
+  });
+});
+
+describe("intersections through the full pipeline", () => {
+  it("accepts a complete value against a merged type, rejects a partial one", () => {
+    const ok = typecheckSource(`
+type Named = { id: string, name: string }
+type Aged = { id: string, age: number }
+node main() {
+  const p: Named & Aged = { id: "1", name: "a", age: 3 }
+  return p
+}
+`);
+    expect(ok).toEqual([]);
+    const bad = typecheckSource(`
+type Named = { id: string, name: string }
+type Aged = { id: string, age: number }
+node main() {
+  const p: Named & Aged = { id: "1", name: "a" }
+  return p
+}
+`);
+    expect(bad.map((e) => e.message).join("\n")).toMatch(/not assignable/);
+  });
+
+  it("composes: Partial of a merge, keyof of a merge, index into a merge", () => {
+    const errors = typecheckSource(`
+type Named = { id: string, name: string }
+type Aged = { id: string, age: number }
+node main() {
+  const a: Partial<Named & Aged> = { id: null, name: null, age: null }
+  const k: keyof (Named & Aged) = "age"
+  const n: (Named & Aged)["age"] = 3
+  return k
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a generic alias can delegate: type Mix<T> = T & Stamp", () => {
+    const errors = typecheckSource(`
+type Stamp = { createdAt: string }
+type Named = { name: string }
+type Mix<T> = T & Stamp
+node main() {
+  const m: Mix<Named> = { name: "a", createdAt: "now" }
+  return m
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("a recursive alias can be an operand (nominal self-refs survive)", () => {
+    const errors = typecheckSource(`
+type Tree = { value: number, children: Tree[] }
+node main() {
+  const t: Tree & { label: string } = {
+    value: 1,
+    children: [],
+    label: "root",
+  }
+  return t
+}
+`);
+    expect(errors).toEqual([]);
+  });
+
+  it("an unknown alias inside an intersection is reported (visitTypes wiring)", () => {
+    // Review finding: validateTypeReferences walks via visitTypes, whose
+    // intersection case Task 1 added — prove the wiring instead of
+    // assuming it.
+    const errors = typecheckSource(`
+type A = { x: number }
+type X = A & Undefined
+node main() {
+  return 1
+}
+`);
+    expect(errors.map((e) => e.message).join("\n")).toMatch(
+      /Type alias 'Undefined' is not defined/,
+    );
+  });
+
+  it("semantic errors stay swallowed at typecheck time: string & number member", () => {
+    const errors = typecheckSource(`
+node main() {
+  const x: { id: string } & { id: number } = { id: "1" }
+  return x
+}
+`);
+    expect(errors).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/typeOperators.ts
+++ b/packages/agency-lang/lib/typeChecker/typeOperators.ts
@@ -103,6 +103,10 @@ function mergeObjects(
  * one group holding each side's declaration.
  */
 function groupPropertiesByKey(objects: ObjectType[]): ObjectProperty[][] {
+  // keyOrder preserves first-seen order; a plain Record iterated via
+  // Object.entries (or the groupBy in effectPayloadCheck.ts) reorders
+  // integer-like keys ("0", "1") ahead of string keys, and all-digit
+  // property keys are parseable.
   const keyOrder: string[] = [];
   // Null-prototype dict: keys are user-controlled property names, so
   // "__proto__"/"toString" must not collide with Object.prototype

--- a/packages/agency-lang/lib/typeChecker/typeOperators.ts
+++ b/packages/agency-lang/lib/typeChecker/typeOperators.ts
@@ -1,4 +1,7 @@
 import type { VariableType } from "../types.js";
+import type { ObjectProperty, ObjectType } from "../types/typeHints.js";
+import { formatTypeHint } from "../utils/formatType.js";
+import { mergeTagSets } from "./mergeTags.js";
 import { resolveKeysArg, resolveObjectArg } from "./builtinGenerics.js";
 import { NEVER_T } from "./primitives.js";
 
@@ -51,4 +54,118 @@ export function evalIndexedAccess(
   });
   if (results.length === 1) return results[0];
   return { type: "unionType", types: results };
+}
+
+/** Injected structural-identity comparator — see the CYCLE RULE above:
+ *  typeKey lives behind assignability, so the caller provides equality
+ *  the same way it provides `resolve`. */
+export type TypeEquals = (a: VariableType, b: VariableType) => boolean;
+
+/**
+ * `A & B & ...` — merge object types. Four steps:
+ *
+ *   RESOLVE  every operand to an object type
+ *   GROUP    all properties across all operands by key,
+ *            in first-seen key order
+ *   COMBINE  each key group into one property (the shared-key
+ *            rules live in intersectPropertyValues)
+ *   BUILD    an ordinary object type
+ *
+ * Grouping ALL operands at once (rather than folding pairwise) is what
+ * makes the merge n-ary and associative by construction.
+ */
+export function evalIntersection(
+  members: VariableType[],
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): VariableType {
+  const objects = members.map((m) =>
+    resolveObjectArg("intersection", m, resolve),
+  );
+  return mergeObjects(objects, resolve, typesEqual);
+}
+
+function mergeObjects(
+  objects: ObjectType[],
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): ObjectType {
+  const groups = groupPropertiesByKey(objects);
+  const properties = groups.map((group) =>
+    combineGroup(group, resolve, typesEqual),
+  );
+  return { type: "objectType", properties };
+}
+
+/**
+ * Every declaration of every key, grouped, in first-seen key order.
+ * A disjoint key produces a one-element group; a shared key produces
+ * one group holding each side's declaration.
+ */
+function groupPropertiesByKey(objects: ObjectType[]): ObjectProperty[][] {
+  const keyOrder: string[] = [];
+  // Null-prototype dict: keys are user-controlled property names, so
+  // "__proto__"/"toString" must not collide with Object.prototype
+  // (the scope.ts discipline).
+  const byKey: Record<string, ObjectProperty[]> = Object.create(null);
+  for (const obj of objects) {
+    for (const prop of obj.properties) {
+      if (byKey[prop.key] === undefined) {
+        byKey[prop.key] = [];
+        keyOrder.push(prop.key);
+      }
+      byKey[prop.key].push(prop);
+    }
+  }
+  return keyOrder.map((key) => byKey[key]);
+}
+
+/**
+ * Fold a key group into one property. A one-element group returns its
+ * property untouched (reduce with no initial value). A shared key
+ * intersects the value types and merges the tags — a value of `A & B`
+ * must satisfy BOTH sides, so both validate chains apply. The LEFT
+ * declaration keeps its description (the spread).
+ */
+function combineGroup(
+  group: ObjectProperty[],
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): ObjectProperty {
+  return group.reduce((left, right) => ({
+    ...left,
+    value: intersectPropertyValues(
+      left.key,
+      left.value,
+      right.value,
+      resolve,
+      typesEqual,
+    ),
+    tags: mergeTagSets(left.tags, right.tags),
+  }));
+}
+
+/**
+ * The three shared-key rules, in order:
+ *
+ *   identical types   -> keep one copy
+ *   two object types  -> merge recursively (same pipeline)
+ *   anything else     -> no overlap; error naming the key
+ */
+function intersectPropertyValues(
+  key: string,
+  leftValue: VariableType,
+  rightValue: VariableType,
+  resolve: Resolve,
+  typesEqual: TypeEquals,
+): VariableType {
+  const left = resolve(leftValue);
+  const right = resolve(rightValue);
+  if (typesEqual(left, right)) return left;
+  if (left.type === "objectType" && right.type === "objectType") {
+    return mergeObjects([left, right], resolve, typesEqual);
+  }
+  throw new TypeError(
+    `cannot intersect key '${key}': '${formatTypeHint(left)}' and '${formatTypeHint(right)}' have no overlap`,
+  );
 }

--- a/packages/agency-lang/lib/typeChecker/typeWalker.ts
+++ b/packages/agency-lang/lib/typeChecker/typeWalker.ts
@@ -102,7 +102,8 @@ export function visitTypes(
     case "keyofType":
       return visitTypes(t.operand, visit);
     case "intersectionType":
-      return t.types.some((m) => visitTypes(m, visit));
+      for (const m of t.types) if (visitTypes(m, visit)) return true;
+      return false;
     case "indexedAccessType":
       if (visitTypes(t.objectType, visit)) return true;
       return visitTypes(t.index, visit);

--- a/packages/agency-lang/lib/typeChecker/typeWalker.ts
+++ b/packages/agency-lang/lib/typeChecker/typeWalker.ts
@@ -40,6 +40,8 @@ export function mapTypes(
       return fn({ ...t, inner: mapTypes(t.inner, fn) });
     case "keyofType":
       return fn({ ...t, operand: mapTypes(t.operand, fn) });
+    case "intersectionType":
+      return fn({ ...t, types: t.types.map((m) => mapTypes(m, fn)) });
     case "indexedAccessType":
       return fn({
         ...t,
@@ -99,6 +101,8 @@ export function visitTypes(
       return visitTypes(t.inner, visit);
     case "keyofType":
       return visitTypes(t.operand, visit);
+    case "intersectionType":
+      return t.types.some((m) => visitTypes(m, visit));
     case "indexedAccessType":
       if (visitTypes(t.objectType, visit)) return true;
       return visitTypes(t.index, visit);

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -685,6 +685,9 @@ function checkType(
     case "keyofType":
       checkType(vt.operand, paramNames, aliasName);
       break;
+    case "intersectionType":
+      for (const m of vt.types) checkType(m, paramNames, aliasName);
+      break;
     case "indexedAccessType":
       checkType(vt.objectType, paramNames, aliasName);
       checkType(vt.index, paramNames, aliasName);
@@ -785,6 +788,11 @@ export function substituteValueArgsInType(
       return {
         ...vt,
         operand: substituteValueArgsInType(vt.operand, bindings),
+      };
+    case "intersectionType":
+      return {
+        ...vt,
+        types: vt.types.map((m) => substituteValueArgsInType(m, bindings)),
       };
     case "indexedAccessType":
       return {

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -43,7 +43,8 @@ export type VariableType =
   | FunctionRefType
   | GenericType
   | KeyofType
-  | IndexedAccessType;
+  | IndexedAccessType
+  | IntersectionType;
 
 /**
  * A concrete generic-type usage: Record<string, number>, Container<string>, etc.
@@ -96,6 +97,19 @@ export type IndexedAccessType = {
   type: "indexedAccessType";
   objectType: VariableType;
   index: VariableType;
+  tags?: Tag[];
+};
+
+/**
+ * `A & B` — an n-ary intersection of object types. Same lifecycle as
+ * KeyofType: exists only between parse and resolution, where
+ * `evalIntersection` (lib/typeChecker/typeOperators.ts) merges the
+ * operands into a plain object type; downstream code never sees the
+ * node.
+ */
+export type IntersectionType = {
+  type: "intersectionType";
+  types: VariableType[];
   tags?: Tag[];
 };
 

--- a/packages/agency-lang/lib/utils/formatType.test.ts
+++ b/packages/agency-lang/lib/utils/formatType.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatTypeHint } from "./formatType.js";
+import { VariableType } from "@/types.js";
+
+const alias = (name: string): VariableType => ({
+  type: "typeAliasVariable",
+  aliasName: name,
+});
+
+describe("formatTypeHint array-element paren rules", () => {
+  // Each case must re-parse as written; the bare forms re-parse with
+  // the [] binding to the last operand only.
+  it("parenthesizes a union element: (A | B)[]", () => {
+    expect(
+      formatTypeHint({
+        type: "arrayType",
+        elementType: { type: "unionType", types: [alias("A"), alias("B")] },
+      }),
+    ).toBe("(A | B)[]");
+  });
+
+  it("parenthesizes an intersection element: (A & B)[]", () => {
+    expect(
+      formatTypeHint({
+        type: "arrayType",
+        elementType: {
+          type: "intersectionType",
+          types: [alias("A"), alias("B")],
+        },
+      }),
+    ).toBe("(A & B)[]");
+  });
+
+  it("parenthesizes a keyof element: (keyof A)[]", () => {
+    expect(
+      formatTypeHint({
+        type: "arrayType",
+        elementType: { type: "keyofType", operand: alias("A") },
+      }),
+    ).toBe("(keyof A)[]");
+  });
+
+  it("leaves a plain element bare: A[]", () => {
+    expect(
+      formatTypeHint({ type: "arrayType", elementType: alias("A") }),
+    ).toBe("A[]");
+  });
+});

--- a/packages/agency-lang/lib/utils/formatType.ts
+++ b/packages/agency-lang/lib/utils/formatType.ts
@@ -33,10 +33,14 @@ export function formatTypeHint(
     case "primitiveType":
       return primitiveAliases?.[vt.value] ?? vt.value;
     case "arrayType": {
-      // Parenthesize a keyof element: `(keyof User)[]` re-parses as
-      // written, while `keyof User[]` would re-parse as keyof (User[]).
+      // Parenthesize keyof and intersection elements: `(keyof User)[]`
+      // and `(A & B)[]` re-parse as written, while the unparenthesized
+      // forms re-parse as keyof (User[]) and A & (B[]).
       const el = recurse(vt.elementType);
-      return vt.elementType.type === "keyofType" ? `(${el})[]` : `${el}[]`;
+      return vt.elementType.type === "keyofType" ||
+        vt.elementType.type === "intersectionType"
+        ? `(${el})[]`
+        : `${el}[]`;
     }
     case "stringLiteralType":
       return `"${vt.value}"`;
@@ -83,11 +87,20 @@ export function formatTypeHint(
     }
     case "genericType":
       return `${vt.name}<${vt.typeArgs.map(recurse).join(", ")}>`;
+    case "intersectionType":
+      // A union member needs parens (`(A | B) & C`) because & binds
+      // tighter; an intersection inside a union needs none for the same
+      // reason.
+      return vt.types
+        .map((m) => (m.type === "unionType" ? `(${recurse(m)})` : recurse(m)))
+        .join(" & ");
     case "keyofType": {
-      // Parenthesize a union operand: `keyof (A | B)` must not print as
-      // `keyof A | B`, which re-parses as (keyof A) | B.
+      // Parenthesize union AND intersection operands: `keyof (A | B)` /
+      // `keyof (A & B)` must not print bare, which would re-parse as
+      // (keyof A) | B and (keyof A) & B.
       const op = recurse(vt.operand);
-      return vt.operand.type === "unionType"
+      return vt.operand.type === "unionType" ||
+        vt.operand.type === "intersectionType"
         ? `keyof (${op})`
         : `keyof ${op}`;
     }
@@ -98,7 +111,8 @@ export function formatTypeHint(
       const obj = recurse(vt.objectType);
       const wrapped =
         vt.objectType.type === "keyofType" ||
-        vt.objectType.type === "unionType"
+        vt.objectType.type === "unionType" ||
+        vt.objectType.type === "intersectionType"
           ? `(${obj})`
           : obj;
       return `${wrapped}[${recurse(vt.index)}]`;

--- a/packages/agency-lang/lib/utils/formatType.ts
+++ b/packages/agency-lang/lib/utils/formatType.ts
@@ -33,11 +33,13 @@ export function formatTypeHint(
     case "primitiveType":
       return primitiveAliases?.[vt.value] ?? vt.value;
     case "arrayType": {
-      // Parenthesize keyof and intersection elements: `(keyof User)[]`
-      // and `(A & B)[]` re-parse as written, while the unparenthesized
-      // forms re-parse as keyof (User[]) and A & (B[]).
+      // Parenthesize keyof, union, and intersection elements:
+      // `(keyof User)[]`, `(A | B)[]`, and `(A & B)[]` re-parse as
+      // written, while the unparenthesized forms re-parse as
+      // keyof (User[]), A | (B[]), and A & (B[]).
       const el = recurse(vt.elementType);
       return vt.elementType.type === "keyofType" ||
+        vt.elementType.type === "unionType" ||
         vt.elementType.type === "intersectionType"
         ? `(${el})[]`
         : `${el}[]`;

--- a/packages/agency-lang/tests/agency/intersection-type.agency
+++ b/packages/agency-lang/tests/agency/intersection-type.agency
@@ -1,0 +1,27 @@
+// A merged type's schema requires keys from BOTH sides. (Schema bound
+// to a variable first — #480.)
+type Named = {
+  name: string,
+}
+
+type Aged = {
+  age: number,
+}
+
+node accepts() {
+  const s = schema(Named & Aged)
+  const r = s.parseJSON("{\"name\": \"a\", \"age\": 3}")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "parse failed"
+}
+
+node rejects() {
+  const s = schema(Named & Aged)
+  const r = s.parseJSON("{\"name\": \"a\"}")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}

--- a/packages/agency-lang/tests/agency/intersection-type.test.json
+++ b/packages/agency-lang/tests/agency/intersection-type.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "accepts",
+      "input": "",
+      "expectedOutput": "{\"name\":\"a\",\"age\":3}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "complete merged object parses"
+    },
+    {
+      "nodeName": "rejects",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "missing right-side key rejected"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.agency
@@ -1,0 +1,14 @@
+type Named = {
+  name: string,
+}
+
+type Aged = {
+  age: number,
+}
+
+type Person = Named & Aged
+
+node main() {
+  const p: Person = { name: "a", age: 3 }
+  return p
+}

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -1,0 +1,293 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "agency-lang/zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import os from "os";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
+  RestoreSignal,
+  AgencyAbort,
+  deepClone as __deepClone,
+  deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  functionRefReviver as __functionRefReviver,
+  DeterministicClient as __DeterministicClient,
+  installFetchMock as __installFetchMock,
+  createLogger as __createLogger,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false,
+    observability: false
+  },
+  smoltalkDefaults: {
+    apiKey: {
+      openAi: __process.env["OPENAI_API_KEY"] || "",
+      google: __process.env["GEMINI_API_KEY"] || "",
+      anthropic: __process.env["ANTHROPIC_API_KEY"] || "",
+      openRouter: __process.env["OPENROUTER_API_KEY"] || "",
+      deepInfra: __process.env["DEEPINFRA_API_KEY"] || "",
+      liteLlm: __process.env["LITELLM_API_KEY"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_API_KEY"] || ""
+    },
+    baseUrl: {
+      liteLlm: __process.env["LITELLM_BASE_URL"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
+    },
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  logLevel: "info",
+  traceConfig: {
+    program: "intersectionTypes.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Handler result builtins and interrupt response constructors (unified types)
+export function approve(value?: any) { return { type: "approve" as const, value }; }
+export function reject(value?: any) { return { type: "reject" as const, value }; }
+function propagate() { return { type: "propagate" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, hasInterrupts, isDebugger };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
+export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+// Auto-activate the deterministic LLM client when AGENCY_LLM_MOCKS is set.
+// The test runner (lib/cli/util.ts) populates this env var as a JSON string
+// when AGENCY_USE_TEST_LLM_PROVIDER=1. Both the agency evaluate template
+// and the agency-js test.js paths import this module, so this single block
+// covers both code paths.
+if (__process.env.AGENCY_LLM_MOCKS) {
+  __globalCtx.setLLMClient(
+    new __DeterministicClient(JSON.parse(__process.env.AGENCY_LLM_MOCKS))
+  );
+}
+
+// Auto-activate fetch mocking when AGENCY_FETCH_MOCKS_FILE points at a mocks
+// file. The runner writes resolved mocks (returnFile bodies already inlined) to
+// a temp file and passes its path — a file, not an inline env value, so a large
+// response body can't blow the exec arg/env size limit (ARG_MAX). Independent of
+// AGENCY_LLM_MOCKS — a test may mock the network while using a real LLM, or vice
+// versa. Installed before any node runs, ahead of any http.ts / stdlib / interop
+// fetch.
+if (__process.env.AGENCY_FETCH_MOCKS_FILE) {
+  __installFetchMock(JSON.parse(readFileSync(__process.env.AGENCY_FETCH_MOCKS_FILE, "utf-8")));
+}
+
+// Share a single registry object across every compiled module. With
+// composite "module:name" keys, all modules' helpers — plus
+// runtime-created blocks registered by `AgencyFunction.create` while
+// a function is executing — stay reachable from `FunctionRefReviver`
+// no matter which module touched the registry last.
+export const __toolRegistry: Record<string, any> = (__functionRefReviver.registry ??= {} as any);
+
+function __registerTool(value: unknown, _aliasName?: string) {
+  // Composite "module:name" key keyed off the function's *own*
+  // identity, not the importing module's local alias — so different
+  // modules that import the same function don't shadow each other in
+  // the shared global registry that `FunctionRefReviver` reads from.
+  // `_aliasName` is kept in the signature for backwards compatibility
+  // with already-compiled callers that pass it.
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[`${value.module}:${value.name}`] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const _run = __AgencyFunction.create({ name: "_run", module: "__runtime", fn: __runtime_run_impl, params: [{ name: "compiled", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "node", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "args", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "wallClock", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "memory", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "ipcPayload", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "stdout", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "configOverrides", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "cwd", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "maxDepth", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+
+function registerTools(tools: any[]) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[`${tool.module}:${tool.name}`] = tool;
+    }
+  }
+}
+
+async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("intersectionTypes.agency")) {
+    return;
+  }
+  __ctx.globals.markInitialized("intersectionTypes.agency")
+}
+__registerGlobalsInit("intersectionTypes.agency", __initializeGlobals);
+async function __registerTopLevelCallbacks(__ctx) {
+  __ctx.topLevelCallbacks = [];
+}
+__functionRefReviver.registry = __toolRegistry;
+const Named = z.object({ "name": z.string() });
+type Named = z.infer<typeof Named>;
+const Aged = z.object({ "age": z.number() });
+type Aged = z.infer<typeof Aged>;
+const Person = z.object({ "name": z.string(), "age": z.number() });
+type Person = z.infer<typeof Person>;
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "intersectionTypes.agency", scopeName: "main", threads: __setupData.threads });
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __ctx.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.p = {
+          "name": `a`,
+          "age": 3
+        };
+      });
+      await runner.step(2, async (runner) => {
+runner.halt({
+          messages: __threads(),
+          data: __stack.locals.p
+        })
+return;
+      });
+    })
+    if (runner.halted) return runner.haltResult;
+    await runner.hook(3, async () => {
+await callHook({
+        name: "onNodeEnd",
+        data: {
+          nodeName: "main",
+          data: undefined
+        }
+      })
+    });
+    return {
+      messages: __threads(),
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof AgencyAbort) {
+      throw __error
+    }
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
+    return {
+      messages: __threads(),
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals,
+    registerTopLevelCallbacks: __registerTopLevelCallbacks,
+    moduleDir: __dirname
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    const __result = await main(initialState);
+    reportUnhandledInterrupts(__result)
+  } catch (__error: any) {
+    console.error(`
+Agent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"intersectionTypes.agency:main":{"1":{"line":11,"col":2},"2":{"line":12,"col":2}}};


### PR DESCRIPTION
Adds the `&` intersection operator, per the spec and reviewed plan on this branch. **This closes the type-system feature roadmap** started 2026-07-09:

- Shipped: utility types (#478), recursive aliases (#485), keyof + indexed access (#496), intersections (this PR).
- Deliberately killed: tuples (2 of 3 providers reject the schema, live-probed), typeof (needs value scopes at alias-resolution time — an architecture change), mapped/conditional types (fail the eager-evaluation litmus test).

## What

`A & B` merges object types — the mixin pattern at the type level:

```
type Named = { id: string, name: string }
type Aged = { id: string, age: number }
type Person = Named & Aged   // { id, name, age }
```

- **One parser precedence level** between union and its items: `&` binds tighter than `|`, looser than postfix/keyof (all TS parity, all pinned by parse tests). N-ary, newline-tolerant, single members pass through with no node.
- **A declarative merge pipeline** (`evalIntersection` in `typeOperators.ts`): RESOLVE every operand to an object type, GROUP all properties across all operands by key, COMBINE each group (shared keys intersect recursively via a three-rule ladder: identical keeps one, objects merge, anything else errors naming the key; tags merge so BOTH sides' validate chains apply), BUILD an ordinary object type. Grouping all operands at once makes n-ary merging associative by construction — tested, but structural.
- **Structural equality is injected**, not imported: the resolver branch passes a `typeKey`-based comparator built on the real alias table, so `typeOperators.ts` keeps its no-assignability-import cycle rule (plan-review finding).
- Eager evaluation as with the whole operator family: nothing downstream sees the node, no provider surface.

## Two findings from execution worth reviewer attention

1. **A latent parser bug, found and fixed.** The old `unionItemParser` ordered `objectTypeParser` before `arrayTypeParser`, which was only safe because the union parser's >=2-member gate discarded single-member matches. The intersection passthrough SUCCEEDS on single members, so the copied order committed to bare `{ n: string }` and stranded the `[]` suffix — `stdlib/memory.agency` stopped compiling, which is how it surfaced. The fix (arrayType before objectType in intersection items) also fixes the pre-existing union-member variant: `type X = { a: number | { n: string }[] }` failed to parse on main and parses now. Regression tests pin all three shapes.
2. **Parse-performance gate** (owner concern about backtracking): in-process benchmark, median of 7 runs — ui.agency 168.1ms (branch) vs 177.4ms (main); policy.agency 55.7ms vs 59.0ms. No regression; the marginal improvement is likely the item reorder short-circuiting earlier.

## Deliberate TS divergence

`A & never` ERRORS (`intersection expects an object type, got 'never'`) instead of absorbing to `never` — a silently never-typed schema is a debugging trap in a schema-producing language. Documented in the dev notes.

## Verification

7810 lib tests green; linter and make clean; fallback-proof codegen pins observed red first (`const Person = z.string()`) before the `deepResolveNode` routing; `hasAnyValidateTag` gate covered (validated shared key reaches the descriptor); fixture with zero churn elsewhere; accept/reject execution test; seven formatter round-trips including the three paren cases the plan review demanded (`keyof (A & B)`, `(A & B)[]`, `(A & B)["id"]`); re-runs of the keyof, utility-types, and recursive-types execution suites guarding the union-item restructure.

## Scope-outs

Non-object operands (including TS-style union distribution), located diagnostics for resolver errors (standing family follow-up, tripwire-pinned), user-facing guide docs (pending an owner call on where those should live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
