### PR TITLE
agency doc: render raises + wrap long signatures via the generator

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -964,10 +964,16 @@ export class AgencyGenerator {
     return ` raises ${this.effectSetTypeToString(raises)}`;
   }
 
-  protected processFunctionDefinition(node: FunctionDefinition): string {
-    const tags = this.formatAttachedTags(node);
-    const { functionName, body, parameters } = node;
-
+  /** Build the signature line(s) for a `def`/`node` — the given `prefix`,
+   *  wrapped params, return type, and `raises` clause — with `opener`
+   *  appended (`" {"` for a full definition, `""` for a signature-only
+   *  render). The params wrap onto their own lines via `wrapList` when they
+   *  don't fit. */
+  private buildSignature(
+    prefix: string,
+    node: FunctionDefinition | GraphNodeDefinition,
+    opener: string,
+  ): string {
     const returnTypeBang = node.returnTypeValidated ? "!" : "";
     const returnTypeStr = node.returnType
       ? ": " +
@@ -975,21 +981,34 @@ export class AgencyGenerator {
         returnTypeBang
       : "";
     const raisesStr = this.formatRaisesClause(node.raises);
+    return this.wrapList(
+      this.renderParams(node.parameters),
+      prefix,
+      "(",
+      ")",
+      `${returnTypeStr}${raisesStr}${opener}`,
+    );
+  }
+
+  /** The signature of a `def`/`node` with no keyword and no body — just
+   *  `name(params): ReturnType raises <...>` — used by `agency doc`. Params
+   *  wrap onto their own lines the same way the formatter wraps source, and
+   *  the declared `raises` clause is included. */
+  signatureOf(node: FunctionDefinition | GraphNodeDefinition): string {
+    const name = node.type === "function" ? node.functionName : node.nodeName;
+    return this.buildSignature(name, node, "");
+  }
+
+  protected processFunctionDefinition(node: FunctionDefinition): string {
+    const tags = this.formatAttachedTags(node);
+    const { body } = node;
 
     const prefixes: string[] = [];
     if (node.exported) prefixes.push("export");
     if (node.safe) prefixes.push("safe");
     prefixes.push("def");
-
-    const prefix = `${prefixes.join(" ")} ${functionName}`;
-    const renderedParams = this.renderParams(parameters);
-    const signature = this.wrapList(
-      renderedParams,
-      prefix,
-      "(",
-      ")",
-      `${returnTypeStr}${raisesStr} {`,
-    );
+    const prefix = `${prefixes.join(" ")} ${node.functionName}`;
+    const signature = this.buildSignature(prefix, node, " {");
 
     let result = this.indentStr(`${signature}\n`);
 
@@ -1487,24 +1506,9 @@ export class AgencyGenerator {
 
   protected processGraphNode(node: GraphNodeDefinition): string {
     const tags = this.formatAttachedTags(node);
-    const { nodeName, body, parameters } = node;
-    const returnTypeBang = node.returnTypeValidated ? "!" : "";
-    const returnTypeStr = node.returnType
-      ? ": " +
-        variableTypeToString(node.returnType, this.typeAliases, true) +
-        returnTypeBang
-      : "";
-    const raisesStr = this.formatRaisesClause(node.raises);
-    const exportPrefix = node.exported ? "export " : "";
-    const prefix = `${exportPrefix}node ${nodeName}`;
-    const renderedParams = this.renderParams(parameters);
-    const signature = this.wrapList(
-      renderedParams,
-      prefix,
-      "(",
-      ")",
-      `${returnTypeStr}${raisesStr} {`,
-    );
+    const { body } = node;
+    const prefix = `${node.exported ? "export " : ""}node ${node.nodeName}`;
+    const signature = this.buildSignature(prefix, node, " {");
 
     let result = this.indentStr(`${signature}\n`);
 

--- a/packages/agency-lang/lib/backends/signatureOf.test.ts
+++ b/packages/agency-lang/lib/backends/signatureOf.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { AgencyGenerator } from "./agencyGenerator.js";
+import { parseAgency } from "../parser.js";
+
+function sigOf(src: string): string {
+  const parsed = parseAgency(src, {}, false);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) return "";
+  const node = parsed.result.nodes.find(
+    (n: any) => n.type === "function" || n.type === "graphNode",
+  );
+  return new AgencyGenerator().signatureOf(node as any);
+}
+
+describe("AgencyGenerator.signatureOf (for docs)", () => {
+  it("is name-only: no def/export/safe keyword and no body", () => {
+    expect(sigOf("export def greet(name: string): string { return name }")).toBe(
+      "greet(name: string): string",
+    );
+  });
+
+  it("includes the raises clause (inline set)", () => {
+    expect(sigOf("def f(x: number): number raises <std::read> { return x }")).toBe(
+      "f(x: number): number raises <std::read>",
+    );
+  });
+
+  it("includes a named-set raises clause", () => {
+    expect(sigOf("def f(): number raises Fs { return 1 }")).toBe("f(): number raises Fs");
+  });
+
+  it("wraps a long parameter list onto separate lines", () => {
+    const sig = sigOf(
+      "def readConfig(path: string, encoding: string, fallback: string, retries: number): string raises <std::read> { return read(path) }",
+    );
+    expect(sig).toBe(
+      "readConfig(\n" +
+        "  path: string,\n" +
+        "  encoding: string,\n" +
+        "  fallback: string,\n" +
+        "  retries: number,\n" +
+        "): string raises <std::read>",
+    );
+  });
+
+  it("works for nodes (name-only, no `node` keyword)", () => {
+    expect(sigOf("export node run(input: string): string { return input }")).toBe(
+      "run(input: string): string",
+    );
+  });
+});

--- a/packages/agency-lang/lib/cli/doc.test.ts
+++ b/packages/agency-lang/lib/cli/doc.test.ts
@@ -14,6 +14,25 @@ afterEach(() => {
 });
 
 describe("generateDoc", () => {
+  it("renders a function's raises clause and wraps a long signature", () => {
+    const inputDir = path.join(tmpDir, "input-raises");
+    const outputDir = path.join(tmpDir, "output-raises");
+    fs.mkdirSync(inputDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(inputDir, "cfg.agency"),
+      "export def load(path: string, encoding: string, fallback: string, retries: number): string raises <std::read> {\n" +
+        "  return read(path)\n}\n",
+    );
+
+    generateDoc({}, path.join(inputDir, "cfg.agency"), outputDir);
+    const output = fs.readFileSync(path.join(outputDir, "cfg.md"), "utf-8");
+
+    // The declared raises clause is rendered in the signature.
+    expect(output).toContain("raises <std::read>");
+    // The long signature wraps one param per line (not one long line).
+    expect(output).toContain("load(\n  path: string,");
+  });
+
   it("generates docs for a file with types, functions, and nodes", () => {
     const inputDir = path.join(tmpDir, "input");
     const outputDir = path.join(tmpDir, "output");

--- a/packages/agency-lang/lib/cli/doc.ts
+++ b/packages/agency-lang/lib/cli/doc.ts
@@ -252,22 +252,6 @@ function sourceLink(
   return `([source](${ctx.baseUrl}/${toPosixPath(ctx.sourceRelPath)}#L${loc.line + 1}))`;
 }
 
-function formatSignature(
-  name: string,
-  params: FunctionParameter[],
-  returnType?: VariableType | null,
-): string {
-  const paramStr = params
-    .map((p) => {
-      const prefix = p.variadic ? "..." : "";
-      const typeStr = p.typeHint ? `: ${formatType(p.typeHint)}` : "";
-      return `${prefix}${p.name}${typeStr}`;
-    })
-    .join(", ");
-  const retStr = returnType ? `: ${formatType(returnType)}` : "";
-  return `${name}(${paramStr})${retStr}`;
-}
-
 const generator = new AgencyGenerator();
 
 function formatDefaultValue(node: FunctionParameter["defaultValue"]): string {
@@ -437,7 +421,7 @@ function generateFunctionSection(
   if (fns.length === 0) return null;
   const _parts = fns.map((fn) => {
     if (!fn.exported) return null; // skip non-exported functions
-    const sig = formatSignature(fn.functionName, fn.parameters, fn.returnType);
+    const sig = generator.signatureOf(fn);
     return section(
       heading(3, fn.functionName),
       codeFence(sig),
@@ -462,11 +446,7 @@ function generateNodeSection(
 ): string | null {
   if (nodes.length === 0) return null;
   const parts = nodes.map((node) => {
-    const sig = formatSignature(
-      node.nodeName,
-      node.parameters,
-      node.returnType,
-    );
+    const sig = generator.signatureOf(node);
     return section(
       heading(3, node.nodeName),
       codeFence(sig),


### PR DESCRIPTION
## What

`agency doc` rendered function/node signatures with a hand-rolled one-line formatter that:
1. **never showed the declared `raises` clause**, and
2. **put the entire signature on one line** — hard to read for functions with several params.

This reuses the `AgencyGenerator` to format signatures instead, so docs match how the formatter renders source.

## Before / after

```
# before
readConfig(path: string, encoding: string, fallback: string, retries: number): string

# after
readConfig(
  path: string,
  encoding: string,
  fallback: string,
  retries: number,
): string raises <std::read>
```

## How

- Factored the generator's signature-building into a shared `buildSignature(prefix, node, opener)` (used by `processFunctionDefinition` / `processGraphNode` with `" {"`).
- Added a public, keyword-less `signatureOf(node)` for docs (`name(params): Ret raises <...>`, no `def`/`node`/`export`, no body).
- `doc.ts` now calls `generator.signatureOf(...)` and drops its own `formatSignature`.

Params wrap one-per-line past 80 columns via the same `wrapList` the source formatter uses, and the `raises` clause is included.

## Compatibility

Short, non-raising signatures render **byte-identically** to before (name-only style preserved), so existing doc output only changes where it was already unreadable or missing `raises`.

## Testing

- New `signatureOf.test.ts`: name-only output, `raises` (inline + named set), long-signature wrapping, nodes.
- New `doc.test.ts` case: a raising function's generated doc shows `raises <std::read>` and wraps. Mutation-tested (removing the `raises` render fails it).
- Formatter round-trip (`agencyGenerator.test.ts`, `raisesFormat.test.ts`, `function.test.ts`) and full doc suite green; `tsc` clean. (The 11 spawn/pack tests that failed on a stale build all pass after `make build && make stdlib` — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
