### PR TITLE
Automate typeAt memo invalidation with a Scope generation counter (#471 part 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-10-flowenv-generation-counter-review.md
+++ b/docs/superpowers/plans/2026-07-10-flowenv-generation-counter-review.md
@@ -1,0 +1,148 @@
+# Review: FlowEnvironment Generation Counter Plan
+
+**Plan:** `docs/superpowers/plans/2026-07-10-flowenv-generation-counter.md`
+**Reviewer basis:** every "Verified fact" re-checked against main (2026-07-10); bench script actually executed; all `declare`/`declareLocal`/`child()` call sites re-enumerated.
+
+**Verdict:** Sound design at the right altitude, with one sequencing blocker (Task 2 cannot go green as written) and one missed contract site (handlerParamTyping.ts) that contradicts the PR's own story if left untouched. Fix those two and the smaller items below; no structural rework needed.
+
+---
+
+## Blocker
+
+### 1. Task 2 cannot compile: the manual reset is a fifth `memo` write site
+
+Task 2 Step 3 says to fix four construction sites and claims "there should be none beyond these four." Wrong: `matchExprTypes.ts:127` does
+
+```ts
+ctx.flowEnv.memo = new WeakMap();
+```
+
+The moment `FlowEnvironment.memo` becomes `FlowMemo`, this line is a type error. Task 2 Step 3's `tsc --noEmit` and Step 7's "PASS across the typeChecker suite" both fail, but the plan defers touching this line to Task 3.
+
+**Fix:** in Task 2 Step 3, convert the reset to an in-place interim flush that respects the new box contract:
+
+```ts
+ctx.flowEnv.memo.map = new WeakMap();
+```
+
+(Belt-and-braces during the transition; Task 3 then deletes it exactly as planned. Do NOT use `ctx.flowEnv.memo = freshMemo()` — replacing the box is the pattern the FlowMemo comment forbids, and the first commit that models it would undermine the comment.)
+
+---
+
+## Should fix
+
+### 2. Task 5 bench instructions are broken as written (verified by running them)
+
+"Write this script to the scratchpad as `bench-typecheck.mjs` and run it from the worktree package dir" does not work: Node resolves the `./dist/...` imports relative to the **script file's location**, not the cwd. Ran it verbatim from the package dir with the script in the scratchpad → `ERR_MODULE_NOT_FOUND`.
+
+**Fix:** either hardcode absolute import paths per checkout (two script copies, or a `ROOT` const edited per run), or place the script inside each `packages/agency-lang` dir and delete it before committing. Note `readFileSync("stdlib/ui.agency")` is cwd-relative, so the run-from-package-dir instruction must stay either way.
+
+With absolute imports the script body works: **main median = 23.2 ms** (parse succeeds with `applyTemplate: false`, `typeCheck(parsed.result)` signature is correct — `config` and `info` are optional).
+
+### 3. The perf gate is inside measurement noise
+
+5% of a 23 ms median is ~1 ms. Seven iterations with no warmup means the gate can flap on JIT/GC noise alone and "fail" a perfectly good branch (or pass a bad one).
+
+**Fix:** discard 3 warmup iterations, then time ~25; or run the whole script 3× and compare best-of medians. Cheap change, makes the gate meaningful.
+
+### 4. Task 3's comment sweep misses handlerParamTyping.ts — the third home of the contract being deleted
+
+The plan updates the ordering story in `index.ts` and the narrowing README, but `handlerParamTyping.ts:92-100` contains a **load-bearing runtime assertion**:
+
+```ts
+// ORDERING ASSERTION (load-bearing — see TypeChecker.check()): this pass
+// MUTATES scope types, so it must run BEFORE buildFlowGraphs seeds the
+// typeAt memo. Running after would require the memo-reset contract this
+// ordering exists to avoid; a reorder would silently produce stale types.
+if (ctx.flowEnv) { throw new Error("refineInlineHandlerParams must run before buildFlowGraphs ..."); }
+```
+
+plus a trailing "No flow-env memo reset needed: this pass runs BEFORE `buildFlowGraphs`..." comment at the end of the function. After this PR, "a reorder would silently produce stale types" is **false** — the pass's `declare()` at line 121 would bump the generation and the memo would self-invalidate. Leaving the assertion's rationale untouched ships a PR whose index.ts comment says "ordering is a clarity choice now" while another file still throws with a comment saying ordering is a soundness cliff.
+
+**Fix (add to Task 3):** keep the throw if you want the ordering preserved for oracle-seeding quality (reasonable), but rewrite its justification to match the new world; update the trailing comment likewise. Deleting the assertion is also defensible — make it an explicit decision either way.
+
+### 5. Add the two missed call sites to Verified Facts (conclusions survive, the executor shouldn't rediscover them)
+
+The plan's inventory of `declare` sites omits:
+
+- `handlerParamTyping.ts:121` — `info.scope.declare(...)` on the **main** tree, but it runs before `buildFlowGraphs` (enforced by the assertion in item 4), so it bumps before the memo exists. Harmless; should be listed.
+- `narrowing.ts:431` — `childScope.declareLocal(...)` inside `applyNarrowing`, on the `walkWithNarrowing` detached child. Covered by the detached carve-out; should be listed since it's the second production `declareLocal` caller.
+
+Confirmed the load-bearing facts the plan does state: all `ScopeInfo` scopes chain to one `topLevelScope` (`scopes.ts:32`/`scopes.ts:67`), so the tree-wide counter read from `env.scope` is consistent with the `at.scope` reads in `computeTypeAt`; `checkScopes` (`checker.ts`) never calls `declare`/`declareLocal`/`child()`; lazy `inferReturnTypeFor` declares only into its standalone tree (`inference.ts:56`); the spread-copy sites are `synthesizer.ts:284-287` and `:832` as claimed.
+
+---
+
+## Minor
+
+6. **`root()` doc comment "depth <= 3" is wrong.** `walkWithNarrowing` creates a child scope per narrowed branch and nested ifs chain them (`child.child()...`), so parent chains are arbitrarily deep. The cost is still fine — `functionScope()` already walks the same chain on every `declare` today, and the hot `typeAt` path reads generation through `ctx.flowEnv.scope`, which is the parent-less top-level scope (O(1)). Just fix the comment, e.g. "O(parent-chain depth); the flow env's scope is the root, so the hot path is O(1)."
+
+7. **`flowBuilder.ts:394` fallback root.** With an empty `scopes` list, `ctx.flowEnv.scope = new Scope("global")` is an orphan root whose generation never moves. No flow nodes exist in that case, so it's harmless — worth a one-line note so nobody "fixes" it later.
+
+8. **The FlowMemo comment slightly overpromises.** "Invalidation is AUTOMATIC" is true for Scope mutations only. In-place FlowNode patches (`assignFlow.type = ...`) remain invisible to the counter and still require the paired consumer re-declare — the plan knows this (the second pin exists precisely to pin it) but the FlowMemo/typeAt comments should say it in one sentence: "Automatic for Scope mutations; a FlowNode patched in place still needs a paired declare() bump (see matchConsumerAssignFlows)." Otherwise the next person who patches a flow node without a declare reads "automatic" and ships a stale-memo bug.
+
+9. **Task 2 Step 3 wording** — after fixing item 1, update "none beyond these four" to five sites (four constructions + the interim in-place reset).
+
+---
+
+## Verified with no findings
+
+- Altitude is right: the codebase currently enforces one invariant ("scope mutated after memo seeded ⇒ stale typeAt") via **two different mechanisms** (manual reset in matchExprTypes, throw-on-reorder in handlerParamTyping) plus prose in three files. Centralizing it as data on `Scope` is the correct move, and `Scope` is the correct owner (the mutation site, not the cache site).
+- Task 1 tests exercise the real semantics: `declare` from a detached child delegates through `functionScope()` and bumps; `declareLocal` on detached skips. Checked against `scope.ts:25-43`/`:80-89`.
+- The four Task 2 pins are correct against `computeTypeAt`: the assign-node pin's `toBe("any")` matches the exact-ref early return; the identity pin's fresh-object assumption holds (`uniteTypes` builds a new union object for 2+ members) and the plan already names the limitation.
+- The detached-root assertion is safely placed (first statement of the `for (const info of scopes)` loop; the test's ctx stub works because `getTypeAliases()` is called before the loop). Production `ScopeInfo` scopes are never `child()`-created, so it's purely defensive — as intended.
+- Test-helper anchors check out: `flow.test.ts:65-67` (`env`), `flow.test.ts:~320` (bare env), `flowBuilder.test.ts:~28-33` (`freshEnv`).
+- The box-shared-by-reference design correctly handles the spread-copied envs; mutating `memo.map`/`memo.gen` in place keeps all copies coherent, including copies taken before an invalidation.
+- Interim state after Task 1 (counter exists, nothing reads it) is inert. Commit sequencing otherwise fine.
+- Spec file exists; issue #471's title matches the part-1/part-2 framing; `stdlib/ui.agency` exists; `parseAgency`/`typeCheck` import paths in dist are real.
+
+---
+
+## Anti-pattern audit (against `docs/dev/anti-patterns.md`)
+
+**Headline: the plan is a net anti-pattern FIX, not a violation.** Today's design is a textbook instance of the "Imperative code everywhere" + "Leaky abstractions" entries: `FlowEnvironment.memo`'s soundness contract is prose that instructs every scope-mutating pass to reach into the env and imperatively replace the memo (`ctx.flowEnv.memo = new WeakMap()`), and a second pass (handlerParamTyping) enforces the same invariant with a throw-on-reorder. The "how" of cache invalidation leaks into every "what" site. The plan moves the how behind two interfaces: producers bump implicitly inside `declare()`/`declareLocal()` (client passes just declare — the what), and the single consumer (`typeAt`) owns the check-and-flush. The `detached` flag likewise turns "callers must know whether their child scope endangers the memo" into a property fixed at construction. That is exactly the declarative encapsulation the catalog asks for.
+
+Two places where the plan still relies on prose contracts instead of interfaces, and could go further:
+
+- **The "never replace the box" rule is comment-enforced.** The FlowMemo doc says "Mutate the box fields in place; never replace a memo field on one env" — a human contract of exactly the species this PR exists to delete. Make it structural: declare the field `readonly memo: FlowMemo` in `FlowEnvironment`. Object-literal construction still works, spread copies still work, `memo.map`/`memo.gen` in-place mutation still works — but `env.memo = ...` (the old reset, and any future regression) becomes a compile error. Verified feasible: the only assignment site on main is `matchExprTypes.ts:127`, which this PR removes. Recommend adding to Task 2.
+- **The paired patch+declare in matchExprTypes phase 2 stays imperative-and-adjacent.** `info.scope.declare(...)` and `assignFlow.type = type` must travel together (the counter only sees the first), and the plan keeps them as two statements plus a comment. Optional: a small helper (e.g. `rebindMatchConsumer(scope, node, type, flowNode)`) that owns the pairing would make the invariant an interface instead of a convention. Single caller today, so reasonable to skip — but then the FlowMemo comment must carry the warning (item 8 above).
+
+Line-level entries, checked against every code block in the plan:
+
+- **One-line if statements (violation, minor):** the new `declareLocal` body uses `if (!this.detached) this.bumpGeneration();` — the catalog explicitly bans one-line ifs. Brace it. (The `if (isConst) target.consts[name] = true;` line is pre-existing code the plan quotes verbatim — leave that to the file's current style.) Same nit in the bench script's `if (!parsed.success) throw ...`.
+- **Magic numbers (nit, bench only):** `7` iterations and `times[3]` as the median index are paired magic numbers — if one changes the other silently breaks. `const RUNS = 7; ... times[Math.floor(RUNS / 2)]`. Folds into review item 3 (which raises RUNS anyway).
+- **Single-character names:** the pins use `e` for the env — matches the existing convention in `flow.test.ts` (`const e: FlowEnvironment` at ~:320), so consistency with the file wins here. No change.
+- **Duplicating existing code:** none — `root()` doesn't exist on `Scope` today (`functionScope()` is a different walk: it stops at function boundaries); `freshMemo()` centralizes what are currently four copy-pasted `new WeakMap()` literals, which also cures an "Inconsistent patterns" seed.
+- **Order-dependent mutable state:** the check-then-flush-then-stamp in `typeAt` is 3 lines of ordered mutation, but it is confined inside the one function that owns the cache — this is the encapsulation the entry asks for, not a violation. The counter itself is mutable state by necessity (it is a cache-invalidation clock) and is private with a single mutation path.
+- **Useless special cases / nested ternaries / silent try-catch / dynamic requires / nested type objects:** none present. `freshMemo()`'s `gen: -1` sentinel is a justified special value (documented, guarantees the first query stamps) rather than a useless branch.
+
+---
+
+## Test-plan review
+
+**Verdict:** The pins are unusually well-designed — they are mutually covering for the two halves of the check-and-stamp, and the red-check procedures prove they detect the exact bug class. Two structural gaps: the box-shared-by-reference design (the plan's own headline subtlety) has **zero** test, and integration coverage of the production flush point is *recorded* but not *guaranteed*. Plus three cheap unit pins worth adding.
+
+### Do the planned tests test what they claim? (verified by simulation against the proposed code)
+
+**Task 1 scope tests — yes.** Traced each against the proposed `declare`/`declareLocal`/`functionScope`/`root` wiring: bump-on-declare lands on the root and is readable from any scope (catches a per-scope-storage regression: both assertions fail if `generation` is bumped or read on the wrong instance); the detached carve-out and the declare-still-delegates-and-bumps cases pin the two sides of detachment. Step 2's red is trivially real (methods don't exist).
+
+**Task 2 pins — yes, and they complement each other correctly:**
+
+- **Pin 1** (fresh type after mutation) and **pin 2** (patch+declare pairing) test *invalidation*. If the generation check is removed or the flush half breaks (`gen` stamped, map kept), both return stale types and fail. Step 6's comment-out red-check proves this empirically. Note: pin 2's first assertion (`toBe("any")`) is load-bearing — it seeds the memo before the patch; verified `computeTypeAt`'s exact-ref assign case returns `at.type` directly, so the setup is real.
+- **Pin 3** (identity-based memo hit) tests *caching*. It catches the failure modes pins 1–2 are blind to: stamp-half broken (`map` flushed but `gen` never stamped → flushes every call → identity fails) and memoization removed entirely (pins 1–2 pass vacuously green in both cases, since recomputing always yields the fresh type). It also catches a detached-scope regression (a bump from `declareLocal` on a child would flush and break identity). The fresh-object assumption behind `toBe` is verified: `uniteTypes` builds a new union object for 2+ members.
+- **Pin 4** deliberately pins whole-map lazy invalidation so granularity changes show up as a test diff. It is red on main (memo hit → `not.toBe` fails), so it also participates in the red-proof.
+- **flowBuilder assertion test** — real: without the assertion, `buildFlowGraphs` on an empty body completes without throwing, so `toThrow` fails.
+
+### Breakages NO planned test catches
+
+1. **Box replacement / spread-copy desync — the design's central subtlety is untested.** Every pin uses a single env object, so reverting `FlowMemo` to a per-env value, or writing `env.memo = freshMemo()` on one env, passes the entire planned suite while silently desyncing the synthesizer's spread copies (`synthesizer.ts:284-287`, `:832`). Add a pin: memoize through env A, `scope.declare(...)`, query through a spread copy `{ ...A, typeAliases }` and assert the fresh type; and the converse identity-hit (no mutation → same object through the copy). Pairs with the `readonly memo` suggestion — one enforces at compile time, the other pins the runtime semantics.
+2. **Wrong-root generation reads.** Every pin builds `env.scope` and the `start` node from the same `Scope`, so a bug where `typeAt` consults a scope outside the mutated tree (e.g. the `flowBuilder.ts:394` fallback root wired into `ctx.flowEnv` wrongly) never invalidates and no pin notices. Unit pins can't realistically cover this — it's what integration coverage is for → item 3.
+3. **Integration coverage is conditional, not guaranteed.** Task 3 Step 4 *records* whether any match-expression integration test goes red with the check disabled — good experiment, wrong ending. A candidate exists (`matchExpression.test.ts:228`, "unannotated consumer flows the match union to downstream uses" — its `const n: number = label` diagnostic depends on the consumer's post-phase-2 type), but whether phase-1 yield synthesis memoizes the consumer's node *before* phase 2 rebinds it is exactly the open question. **Change Step 4: if no integration test fails, add one that does** (e.g. a second match whose scrutinee reads the first consumer, forcing a typeAt query during phase 1). Otherwise the only guard on the real production flush point is synthetic-graph pins.
+4. **Same-type re-declare must still bump.** Phase 2 re-declares the consumer with the computed union, which can equal the already-declared type. A plausible future "optimization" — skip the bump when the type is unchanged — would break the paired assign-node-patch contract (pin 2 declares a *different* type, so it wouldn't notice... actually pin 2 declares STR over "any", so it passes under that optimization only if types differ — the same-type case is uncovered). One-line scope test: declare the same name/type twice → generation +2.
+5. **Nested detached chains.** `walkWithNarrowing` nests children per nested if, so `fn.child().child()` chains are real. Cheap Task 1 additions: `declareLocal` through two detached levels doesn't bump; `declare` through two detached levels does.
+6. **Standalone-tree isolation (perf claim).** "Bumps in `inferReturnTypeFor`'s standalone tree never flush the main memo" is guarded only by the noisy benchmark. Cheap identity pin: memoize via the main env, `declare` into an unrelated `new Scope(...)` tree, assert the memo hit survives.
+
+### Accepted residuals (fine to leave untested, but say so)
+
+- **Mid-walk mutations:** `gen` is stamped before computing, so a scope mutation occurring *during* a recursive typeAt walk goes unnoticed for entries computed earlier in that walk. The design's stated invariant ("nothing mutates scopes mid-walk") makes this moot today; it's the right call to not test it, but the typeAt comment should name it as an invariant rather than an observation.
+- **The perf gate as a test** is currently inside noise (item 3 above) — until fixed, it cannot fail meaningfully in either direction.
+- The red-checks (Task 2 Step 6, Task 3 Step 4) prove test power once, at execution time. That's inherent to comment-out proofs; the durable artifacts are the pins themselves, which is why items 1 and 3 matter.

--- a/docs/superpowers/plans/2026-07-10-flowenv-generation-counter.md
+++ b/docs/superpowers/plans/2026-07-10-flowenv-generation-counter.md
@@ -1,0 +1,690 @@
+# FlowEnvironment Generation Counter Implementation Plan (rev 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (inline execution — this owner does not use subagent-driven development). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Rev 2** applies all findings from
+> `docs/superpowers/plans/2026-07-10-flowenv-generation-counter-review.md`:
+> blocker 1 (interim in-place flush in Task 2), bench script placement + warmup
+> (items 2-3), handlerParamTyping contract site (item 4), Verified Facts
+> additions (item 5), comment fixes (items 6-8), `readonly memo` + braced ifs +
+> bench constants (anti-pattern audit), and all six test gaps (spread-copy
+> pins, guaranteed integration pin, same-type bump, nested detached chains,
+> standalone-tree isolation).
+
+**Goal:** Automate `FlowEnvironment.memo` invalidation with a Scope-tree generation counter, deleting the human-enforced "discard the memo if scope contents change" contract (issue #471 part 2; part 1 descoped — see spec header).
+
+**Architecture:** `Scope` gains a tree-wide mutation counter (single integer on the root scope; `declare()` bumps it). The memo becomes a shared box `{ gen, map }` behind a `readonly` field; `typeAt` compares the box generation against the tree generation on entry and lazily rebuilds the map on mismatch. Throwaway `child()` scopes are marked `detached` and skip the bump (they are never flow-reachable — asserted in `buildFlowGraphs`).
+
+**Tech Stack:** TypeScript, vitest. All paths below are relative to `packages/agency-lang/` unless they start with `docs/superpowers/`.
+
+**Spec:** `/Users/adityabhargava/agency-lang/docs/superpowers/specs/2026-07-10-flowenv-generation-counter-design.md`
+
+## Global Constraints
+
+- Repo rules: use types not interfaces, objects not maps, arrays not sets; no dynamic imports; never hold per-run state in a TS module global (the counter lives on Scope instances, per check run); no one-line if statements (brace all bodies).
+- Commit messages must contain NO apostrophes (shell quoting breaks); write multi-line messages to a file and use `git commit -F`.
+- Save all test-run output to files (e.g. `> /tmp/genctr-task1.log 2>&1`); never rerun a suite just to re-read its failures.
+- Do NOT run the agency execution test suite locally; CI runs it on the PR.
+- Perf gate (spec): ui.agency typecheck benchmark, branch vs main, 3 warmup + 25 timed iterations, branch median ≤ main median × 1.05. Reviewer-measured main median: ~23.2 ms.
+
+## Verified facts (grep/read against main 2026-07-10; re-verified by external review)
+
+- Memo WRITE sites: `flowBuilder.ts:373` (construction), `matchExprTypes.ts:127` (`ctx.flowEnv.memo = new WeakMap()` — the manual reset, ALSO a type-break site for the box change), `flow.test.ts:66` + `flow.test.ts:323`, `flowBuilder.test.ts:32` (test env helpers). Five sites total.
+- Memo consumption: `flow.ts:169/175` inside `typeAt` only. Spread-copied envs (`{ ...ctx.flowEnv, typeAliases }`) at `synthesizer.ts:284-287` and `synthesizer.ts:832` share the memo **by reference** — the box must be mutated in place, never replaced.
+- `scope.declare` sites that run AFTER `buildFlowGraphs` on the main tree: only `matchExprTypes.ts:113`. `handlerParamTyping.ts:121` declares on the main tree but runs BEFORE the flow build (enforced by a load-bearing throw + comment at `handlerParamTyping.ts:92-100` — a third home of the old contract, updated in Task 3). Lazy `inferReturnTypeFor` declares only into a standalone `new Scope(defScopeKey)` tree (`inference.ts:56`) whose bumps never touch the main root.
+- `declareLocal` production callers: `synthesizer.ts:1201-1203` (callback params on a `child()` scope) and `narrowing.ts:431` (`applyNarrowing`, on the `walkWithNarrowing` child). Both detached under this change. `walkWithNarrowing` NESTS children (`child().child()` chains for nested ifs) — parent chains are arbitrarily deep, so no "depth <= 3" claims.
+- All `ScopeInfo` scopes chain to one `topLevelScope` (`scopes.ts:32`/`:67`); `ctx.flowEnv.scope` is that parent-less root (`flowBuilder.ts:394-395`), so the hot-path generation read is O(1). `checkScopes` never calls `declare`/`declareLocal`/`child()`.
+- Benchmark: `dist/lib/parser.js` exports `parseAgency`; `dist/lib/typeChecker/index.js` exports `typeCheck` (config/info args optional); ui.agency parses with `applyTemplate: false`. Node resolves `./dist/...` imports relative to the SCRIPT FILE location — the script must live inside each `packages/agency-lang` dir (not the scratchpad) and be deleted before committing.
+
+## File structure
+
+- Modify `lib/typeChecker/scope.ts` — generation counter, `detached` flag, `child()` marks detached. Test: `lib/typeChecker/scope.test.ts`.
+- Modify `lib/typeChecker/flow.ts` — `FlowMemo` box type + `freshMemo()`, generation check in `typeAt`, rewritten contract comments. Test: `lib/typeChecker/flow.test.ts`.
+- Modify `lib/typeChecker/flowBuilder.ts` — use `freshMemo()`, assert non-detached flow roots, fallback-root note. Test: `lib/typeChecker/flowBuilder.test.ts`.
+- Modify `lib/typeChecker/matchExprTypes.ts` — interim in-place flush (Task 2), then delete it (Task 3). Test: `lib/typeChecker/matchExpression.test.ts` (integration pin).
+- Modify `lib/typeChecker/handlerParamTyping.ts` + `lib/typeChecker/index.ts` — contract comments.
+- Modify `docs/dev/typechecker/narrowing/README.md` — status + memo sections.
+
+## Worktree setup (before Task 1)
+
+```bash
+cd /Users/adityabhargava/agency-lang
+git worktree add .claude/worktrees/flow-memo-generation -b flow-memo-generation origin/main
+cd .claude/worktrees/flow-memo-generation && pnpm install
+cd packages/agency-lang && make > /tmp/genctr-setup-make.log 2>&1
+```
+
+All subsequent paths are inside `.claude/worktrees/flow-memo-generation/packages/agency-lang/`.
+
+---
+
+### Task 1: Scope generation counter + detached child scopes
+
+**Files:**
+- Modify: `lib/typeChecker/scope.ts`
+- Test: `lib/typeChecker/scope.test.ts`
+
+**Interfaces:**
+- Produces: `Scope.currentGeneration(): number` (tree-wide, readable from any scope in the tree); `Scope.detached: boolean` (readonly, true for `child()` scopes); bump semantics: `declare()` always bumps (even re-declaring the same name/type), `declareLocal()` bumps unless `this.detached`.
+
+- [ ] **Step 1: Write the failing tests** — append to `lib/typeChecker/scope.test.ts`:
+
+```ts
+describe("generation counter", () => {
+  it("declare bumps the tree-wide generation, readable from any scope", () => {
+    const root = new Scope("global");
+    const fn = new Scope("fn", root, true);
+    const g0 = fn.currentGeneration();
+    fn.declare("x", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+    expect(root.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("re-declaring the same name and type still bumps", () => {
+    // computeMatchExprTypes phase 2 re-declares consumers with a type that can
+    // equal the existing entry; the paired assign-node patch relies on the
+    // bump regardless. Pins against a skip-if-unchanged "optimization".
+    const fn = new Scope("fn");
+    fn.declare("x", "any");
+    const g0 = fn.currentGeneration();
+    fn.declare("x", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("declareLocal on a detached child() scope does not bump", () => {
+    const fn = new Scope("fn");
+    const child = fn.child();
+    expect(child.detached).toBe(true);
+    const g0 = fn.currentGeneration();
+    child.declareLocal("cbParam", "any");
+    expect(fn.currentGeneration()).toBe(g0);
+  });
+
+  it("declareLocal through a NESTED detached chain does not bump", () => {
+    // walkWithNarrowing nests children per nested if — chains are real.
+    const fn = new Scope("fn");
+    const grandchild = fn.child().child();
+    const g0 = fn.currentGeneration();
+    grandchild.declareLocal("cbParam", "any");
+    expect(fn.currentGeneration()).toBe(g0);
+  });
+
+  it("declare from a detached child bumps (delegates to the function scope)", () => {
+    const fn = new Scope("fn");
+    const child = fn.child();
+    const g0 = fn.currentGeneration();
+    child.declare("real", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("declare through a NESTED detached chain bumps", () => {
+    const fn = new Scope("fn");
+    const grandchild = fn.child().child();
+    const g0 = fn.currentGeneration();
+    grandchild.declare("real", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("declareLocal on an attached scope bumps", () => {
+    const fn = new Scope("fn");
+    const g0 = fn.currentGeneration();
+    fn.declareLocal("x", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run lib/typeChecker/scope.test.ts > /tmp/genctr-task1-red.log 2>&1`
+Expected: FAIL — `currentGeneration is not a function` / `detached` undefined.
+
+- [ ] **Step 3: Implement in `lib/typeChecker/scope.ts`**
+
+Add fields/methods (constructor gains a 4th param; existing call sites are unaffected by the default):
+
+```ts
+export class Scope {
+  readonly key: string;
+  readonly parent?: Scope;
+  /**
+   * True for throwaway child() scopes (synthesizer callback params, legacy
+   * branch narrowing). Detached scopes are never flow-reachable — no flow
+   * `start` node may be built over one (asserted in buildFlowGraphs) — so
+   * their local writes do not bump the generation counter. This is the perf
+   * carve-out that keeps lambda synthesis in checkScopes from flushing the
+   * typeAt memo on every call.
+   */
+  readonly detached: boolean;
+  // ... existing vars/consts/isFunctionBoundary fields ...
+  /**
+   * Tree-wide mutation counter, stored on the ROOT scope only. typeAt
+   * (flow.ts) compares it against its memo generation and discards stale
+   * entries automatically — the mechanism that replaced the manual
+   * "discard the memo if scope contents change" contract.
+   */
+  private generation = 0;
+
+  constructor(
+    key: string,
+    parent?: Scope,
+    isFunctionBoundary: boolean = false,
+    detached: boolean = false,
+  ) {
+    this.key = key;
+    this.parent = parent;
+    this.isFunctionBoundary = isFunctionBoundary;
+    this.detached = detached;
+  }
+
+  private root(): Scope {
+    return this.parent ? this.parent.root() : this;
+  }
+
+  /**
+   * The tree-wide mutation count. O(parent-chain depth) in general (narrowing
+   * child chains can nest arbitrarily); the hot path (typeAt) reads through
+   * the flow env scope, which is the parent-less top-level scope — O(1).
+   */
+  currentGeneration(): number {
+    return this.root().generation;
+  }
+
+  private bumpGeneration(): void {
+    this.root().generation++;
+  }
+  // ...
+}
+```
+
+Wire the bumps and the child flag:
+
+```ts
+  declare(name: string, type: ScopeType, isConst: boolean = false): void {
+    const target = this.functionScope();
+    target.vars[name] = type;
+    if (isConst) target.consts[name] = true;
+    target.bumpGeneration();
+  }
+
+  declareLocal(name: string, type: ScopeType): void {
+    this.vars[name] = type;
+    if (!this.detached) {
+      this.bumpGeneration();
+    }
+  }
+
+  child(key: string = this.key): Scope {
+    return new Scope(key, this, false, true);
+  }
+```
+
+(The `if (isConst) ...` one-liner is pre-existing code quoted verbatim — leave it in the file's current style.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run lib/typeChecker/scope.test.ts > /tmp/genctr-task1-green.log 2>&1`
+Expected: PASS (all pre-existing scope tests too).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/typeChecker/scope.ts lib/typeChecker/scope.test.ts
+git commit -m "Scope generation counter: declare bumps tree-wide, child scopes are detached"
+```
+
+---
+
+### Task 2: FlowMemo box + typeAt auto-invalidation
+
+**Files:**
+- Modify: `lib/typeChecker/flow.ts:87-120` (FlowEnvironment), `flow.ts:167-182` (typeAt)
+- Modify: `lib/typeChecker/flowBuilder.ts:371-403` (buildFlowGraphs)
+- Modify: `lib/typeChecker/matchExprTypes.ts:127` (interim in-place flush — deleted in Task 3)
+- Test: `lib/typeChecker/flow.test.ts` (env helper at :66, bare env at :323, new pins), `lib/typeChecker/flowBuilder.test.ts` (env helper at :32, assert test)
+
+**Interfaces:**
+- Consumes: `Scope.currentGeneration()`, `Scope.detached` (Task 1).
+- Produces: `export type FlowMemo = { gen: number; map: WeakMap<FlowNode, Record<string, ScopeType>> }`; `export function freshMemo(): FlowMemo`; `FlowEnvironment.memo: readonly FlowMemo` (readonly FIELD — replacement is a compile error; in-place `memo.map`/`memo.gen` mutation is the only path).
+
+- [ ] **Step 1: Change the memo type** in `lib/typeChecker/flow.ts`. Add above `FlowEnvironment`:
+
+```ts
+/**
+ * The typeAt memo plus the scope-tree generation it was filled under. A BOX
+ * shared by reference across every env that wraps the same check run —
+ * including the spread copies the synthesizer makes ({ ...ctx.flowEnv,
+ * typeAliases }) — so an invalidation made through any env is visible to all.
+ * Mutate the box fields in place; the `readonly` on FlowEnvironment.memo
+ * makes replacing the box itself a compile error.
+ */
+export type FlowMemo = {
+  gen: number;
+  map: WeakMap<FlowNode, Record<string, ScopeType>>;
+};
+
+/** A fresh memo box. gen -1 guarantees the first typeAt query stamps it. */
+export function freshMemo(): FlowMemo {
+  return { gen: -1, map: new WeakMap() };
+}
+```
+
+Replace the `memo` field and its SOUNDNESS CONTRACT comment in `FlowEnvironment`:
+
+```ts
+  /**
+   * Per-flow-node, per-reference-key memo for typeAt. WeakMap because keys are
+   * FlowNode identities; without it, nested joins/loops re-walk super-linearly.
+   *
+   * Invalidation is AUTOMATIC for Scope mutations: `start` nodes read
+   * `scope.lookup(...)` live, so any scope mutation stales the cache — typeAt
+   * compares `memo.gen` against the scope tree generation
+   * (Scope.currentGeneration) on entry and rebuilds the map on mismatch.
+   * Passes that retype scope entries (e.g. computeMatchExprTypes) need no
+   * manual reset: their declare() calls bump the generation. A FlowNode
+   * patched IN PLACE (assignFlow.type = ...) is invisible to the counter and
+   * still needs a paired declare() bump — see matchConsumerAssignFlows.
+   */
+  readonly memo: FlowMemo;
+```
+
+- [ ] **Step 2: Add the generation check to `typeAt`** (flow.ts:167). Replace the body's memo access:
+
+```ts
+export function typeAt(ref: Reference, at: FlowNode, env: FlowEnvironment): ScopeType {
+  // Auto-invalidation: a mismatch means some attached scope mutated since the
+  // memo was filled (see FlowMemo). Every entry is suspect — start nodes read
+  // scopes live — so drop the whole map (lazy full invalidation, the same
+  // semantics as the manual resets this replaced). INVARIANT: nothing mutates
+  // scopes mid-walk — gen is stamped before computing, so a mid-walk mutation
+  // would go unnoticed for entries computed earlier in the same walk.
+  // Recursive typeAt calls re-check harmlessly under that invariant.
+  const gen = env.scope.currentGeneration();
+  if (env.memo.gen !== gen) {
+    env.memo.map = new WeakMap();
+    env.memo.gen = gen;
+  }
+  const key = referenceKey(ref);
+  let perNode = env.memo.map.get(at);
+  if (perNode === undefined) {
+    // (existing null-prototype comment unchanged)
+    perNode = Object.create(null) as Record<string, ScopeType>;
+    env.memo.map.set(at, perNode);
+  }
+  const cached = perNode[key];
+  if (cached !== undefined) return cached;
+  const result = computeTypeAt(ref, key, at, env);
+  perNode[key] = result;
+  return result;
+}
+```
+
+- [ ] **Step 3: Fix the five memo write sites.**
+  1. `flowBuilder.ts:373`: `const memo = freshMemo();` (import `freshMemo` from `./flow.js`).
+  2. `matchExprTypes.ts:127`: the manual reset is now a type error against the box (and would violate `readonly`). Interim in-place flush that respects the box contract — do NOT use `freshMemo()` here (replacing the box is the forbidden pattern):
+     ```ts
+     ctx.flowEnv.memo.map = new WeakMap();
+     ```
+     (Belt-and-braces during the transition; Task 3 deletes it.)
+  3. `flow.test.ts:66` and `:323`, `flowBuilder.test.ts:32`: replace `memo: new WeakMap()` with `memo: freshMemo()` (add imports).
+
+  Then run `npx tsc --noEmit -p . > /tmp/genctr-task2-tsc.log 2>&1` — clean, no remaining `memo` errors.
+
+- [ ] **Step 4: Add the detached-root assertion + fallback note** in `flowBuilder.ts`. Inside the `for (const info of scopes)` loop, first statement:
+
+```ts
+    if (info.scope.detached) {
+      throw new Error(
+        `buildFlowGraphs: scope for ${info.scopeKey} is a detached child scope. Flow start nodes must be built over function/top-level scopes only - detached scopes do not bump the generation counter, so a start node over one would silently un-protect the typeAt memo.`,
+      );
+    }
+```
+
+At the fallback root (`flowBuilder.ts:394`), add above the line:
+
+```ts
+  // Empty scopes list fallback: an orphan root whose generation never moves.
+  // Harmless — no flow nodes exist to memoize against in that case.
+```
+
+- [ ] **Step 5: Write the pins** — append to `lib/typeChecker/flow.test.ts` (module already defines `env`, `ref`, `STR`, `NUM`, `Scope`, flow-node literals):
+
+```ts
+describe("memo auto-invalidation (generation counter)", () => {
+  it("returns the fresh type after a scope mutation (stale on main)", () => {
+    const scope = new Scope("fn");
+    scope.declare("x", NUM);
+    const start: FlowNode = { kind: "start", scope };
+    const e = env(scope);
+    expect(typeAt(ref("x"), start, e)).toEqual(NUM); // memoized
+    scope.declare("x", STR); // a later pass retypes x
+    expect(typeAt(ref("x"), start, e)).toEqual(STR);
+  });
+
+  it("a declare bump also covers a paired in-place assign-node patch", () => {
+    // Pins the computeMatchExprTypes phase-2 contract: patch assignFlow.type
+    // AND re-declare the consumer; the declare bump invalidates entries
+    // derived from the old snapshot.
+    const scope = new Scope("fn");
+    scope.declare("x", "any");
+    const start: FlowNode = { kind: "start", scope };
+    const assign: Extract<FlowNode, { kind: "assign" }> = {
+      kind: "assign",
+      prev: start,
+      ref: ref("x"),
+      type: "any",
+    };
+    const e = env(scope);
+    expect(typeAt(ref("x"), assign, e)).toBe("any"); // memoized under old gen
+    assign.type = STR;
+    scope.declare("x", STR);
+    expect(typeAt(ref("x"), assign, e)).toEqual(STR);
+  });
+
+  it("an invalidation is visible through a spread-copied env (shared box)", () => {
+    // The synthesizer queries through { ...ctx.flowEnv, typeAliases } copies
+    // (synthesizer.ts:284, :832). The box is shared by reference, so a flush
+    // triggered through ANY env must be visible through every copy.
+    const scope = new Scope("fn");
+    scope.declare("x", NUM);
+    const start: FlowNode = { kind: "start", scope };
+    const e = env(scope);
+    expect(typeAt(ref("x"), start, e)).toEqual(NUM); // memoize via original
+    scope.declare("x", STR);
+    const copy = { ...e, typeAliases: {} };
+    expect(typeAt(ref("x"), start, copy)).toEqual(STR); // read via the COPY
+  });
+
+  it("a memo hit survives through a spread copy (no mutation)", () => {
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    const copy = { ...e, typeAliases: {} };
+    expect(typeAt(ref("x"), join, copy)).toBe(first); // identity => shared memo
+  });
+
+  it("declareLocal on a detached child does not flush the memo (identity pin)", () => {
+    // Recomputing this join constructs a FRESH union object (uniteTypes), so
+    // object identity across queries proves a memo hit. Guards the perf
+    // carve-out: lambda-param child scopes must not flush the memo.
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    scope.child().declareLocal("cbParam", STR); // the synthesizer pattern
+    expect(typeAt(ref("x"), join, e)).toBe(first); // same object => memo hit
+  });
+
+  it("a declare into an UNRELATED standalone scope tree does not flush", () => {
+    // Lazy inferReturnTypeFor declares into its own new Scope(...) tree
+    // mid-checkScopes; those bumps must not touch the main tree memo.
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    const standalone = new Scope("inference");
+    standalone.declare("y", NUM);
+    expect(typeAt(ref("x"), join, e)).toBe(first); // memo hit survives
+  });
+
+  it("an unrelated attached declare flushes the whole memo (lazy semantics)", () => {
+    // Deliberate pin of whole-memo (not per-name) invalidation, so a future
+    // change to finer granularity is a conscious decision with a test diff.
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    scope.declare("unrelated", NUM);
+    const second = typeAt(ref("x"), join, e);
+    expect(second).toEqual(first);
+    expect(second).not.toBe(first); // recomputed => memo was flushed
+  });
+});
+```
+
+And to `lib/typeChecker/flowBuilder.test.ts` (import `buildFlowGraphs`, and `ScopeInfo`/`TypeCheckerContext` types from `./types.js`):
+
+```ts
+it("rejects a detached child scope as a flow root", () => {
+  const detachedScope = new Scope("fn").child();
+  const info = {
+    scope: detachedScope,
+    body: [],
+    name: "f",
+    scopeKey: "fn:f",
+    file: "",
+  } as ScopeInfo;
+  const ctx = { getTypeAliases: () => ({}) } as unknown as TypeCheckerContext;
+  expect(() => buildFlowGraphs([info], ctx)).toThrow(/detached/);
+});
+```
+
+- [ ] **Step 6: Red check.** With the Step 2 generation check temporarily commented out, run `npx vitest run lib/typeChecker/flow.test.ts > /tmp/genctr-task2-red.log 2>&1`. Expected RED: the staleness pin, the assign-patch pin, the spread-copy invalidation pin, and the lazy-semantics pin (its `not.toBe` fails on a memo hit). Expected GREEN even without the check: the identity pins (they test caching, which exists on main). Restore the block.
+
+- [ ] **Step 7: Full green.**
+
+Run: `npx vitest run lib/typeChecker > /tmp/genctr-task2-green.log 2>&1`
+Expected: PASS across the typeChecker suite.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/typeChecker/flow.ts lib/typeChecker/flowBuilder.ts lib/typeChecker/matchExprTypes.ts lib/typeChecker/flow.test.ts lib/typeChecker/flowBuilder.test.ts
+git commit -m "FlowMemo box + generation check in typeAt: memo self-invalidates on scope mutation"
+```
+
+---
+
+### Task 3: Delete the manual reset; guaranteed integration pin; update all three contract homes
+
+**Files:**
+- Modify: `lib/typeChecker/matchExprTypes.ts` (delete the interim flush from Task 2)
+- Modify: `lib/typeChecker/index.ts:323-335` (two comments)
+- Modify: `lib/typeChecker/handlerParamTyping.ts:92-100` + trailing comment (the third contract home — re-read the file first, anchors may have drifted)
+- Modify: `lib/typeChecker/flow.ts:110-119` (`matchConsumerAssignFlows` doc)
+- Test: `lib/typeChecker/matchExpression.test.ts`
+
+**Interfaces:**
+- Consumes: automatic invalidation from Task 2.
+
+- [ ] **Step 1: Add the integration pin FIRST** (green on main semantics, red if the counter fails to carry the contract). Append to `lib/typeChecker/matchExpression.test.ts`, adapting to that file's existing typecheck helper if one exists (otherwise `parseAgency` + `typeCheck` directly, as its sibling tests do):
+
+```ts
+it("stale phase-1 memo entries do not suppress downstream diagnostics", () => {
+  // Two sequential expression-matches. The second match has the higher id, so
+  // computeMatchExprTypes phase 1 processes it FIRST and synthesizes its
+  // yield `first` — a typeAt query that memoizes the PRE-patch "any" at the
+  // flow node after the first consumer assignment. Phase 2 then patches
+  // `first` to string. The `const n: number = first` check in checkScopes
+  // resolves `first` through that same flow path: with a stale memo the
+  // cached "any" propagates (any is assignable to number — diagnostic
+  // SUPPRESSED); with invalidation (manual reset on main, generation counter
+  // now) the diagnostic fires. Pins the production flush point end-to-end.
+  const src = [
+    "def f(v: number): string {",
+    '  const first = match (v) { 1 => "a"',
+    '    _ => "b" }',
+    '  const second = match (v) { 1 => first',
+    '    _ => "z" }',
+    "  const n: number = first",
+    "  return second",
+    "}",
+  ].join("\n");
+  const parsed = parseAgency(src, {}, false);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) {
+    throw new Error("unreachable");
+  }
+  const result = typeCheck(parsed.result);
+  const messages = result.errors.map((e) => e.message).join("\n");
+  expect(messages).toContain("not assignable");
+  expect(messages).toContain("number");
+});
+```
+
+Verify it is GREEN before touching the reset (main behavior, reset still present as the Task 2 interim flush). If the match syntax above misparses, debug with `pnpm run ast` on the snippet before proceeding — do not weaken the assertion.
+
+- [ ] **Step 2: Delete the interim flush.** In `matchExprTypes.ts`, replace the trailing comment block + `ctx.flowEnv.memo.map = new WeakMap()` (inside its `if (ctx.flowEnv)`) with:
+
+```ts
+  // Scope entries and flow-node types were rebound above. The declare() calls
+  // bumped the scope-tree generation, so typeAt discards its stale memo on the
+  // next query (see FlowMemo, flow.ts) — no manual reset needed.
+```
+
+- [ ] **Step 3: Update the other two contract homes.**
+
+`index.ts` at the `buildFlowGraphs` call (~line 323) — replace "Build the flow graph AFTER the param retype, so its `typeAt` oracle is seeded with the refined `e` (no stale-memo reset needed)." with:
+
+```ts
+    // Build the flow graph AFTER the param retype so the oracle is seeded with
+    // the refined `e` from the start. (Ordering kept for oracle-seeding
+    // quality; since the generation counter, a post-flow retype would also be
+    // sound — the declare would bump the generation and the memo would
+    // self-invalidate.)
+```
+
+`index.ts` at the `computeMatchExprTypes` call comment (~line 330): delete the trailing clause ", then resets the typeAt memo (per the FlowEnvironment soundness contract) so no stale entry survives", ending the sentence at "...with the computed union.".
+
+`handlerParamTyping.ts:92-100`: the ORDERING ASSERTION throw stays (ordering is kept — no reason to pay a whole-memo flush for a retype that can simply run first), but its justification is now false ("a reorder would silently produce stale types" — it would not; the declare at :121 bumps). Rewrite the comment to:
+
+```ts
+  // ORDERING ASSERTION: this pass runs BEFORE buildFlowGraphs so the typeAt
+  // oracle is seeded with the refined `e` from its first query. Since the
+  // Scope generation counter (FlowMemo, flow.ts) a reorder would no longer
+  // produce stale types — the declare below bumps the generation and the memo
+  // self-invalidates — but running first is still strictly better: it avoids
+  // a whole-memo flush and keeps every pass reading the same refined types.
+```
+
+Update the trailing "No flow-env memo reset needed: this pass runs BEFORE `buildFlowGraphs`..." comment at the end of the function to match (one sentence: pre-flow ordering means the memo does not exist yet; were it reordered, the counter would cover it).
+
+`flow.ts` `matchConsumerAssignFlows` doc: append one sentence to the existing (still-true) text: "The paired consumer re-declare bumps the generation, so the memo needs no manual reset."
+
+- [ ] **Step 4: Green check.**
+
+Run: `npx vitest run lib/typeChecker/matchExpression.test.ts lib/typeChecker/matchArmNarrowing.test.ts lib/typeChecker/matchExhaustiveness.test.ts lib/typeChecker/flow.test.ts lib/typeChecker/flowNarrowing.test.ts > /tmp/genctr-task3-green.log 2>&1`
+Expected: PASS.
+
+- [ ] **Step 5: Red-proof that the counter now carries the contract.** Temporarily comment out the generation check in `typeAt` (the reset is deleted), run the same suites to `/tmp/genctr-task3-redproof.log`. Expected RED: the Step 1 integration pin (guaranteed — this is the production flush point end-to-end) plus the Task 2 unit pins. Record in the PR body whether any PRE-EXISTING match test also went red (tells us whether the old manual reset had independent coverage before this PR). Restore the check, re-run, confirm green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/typeChecker/matchExprTypes.ts lib/typeChecker/index.ts lib/typeChecker/handlerParamTyping.ts lib/typeChecker/flow.ts lib/typeChecker/matchExpression.test.ts
+git commit -m "Delete the manual typeAt memo reset; generation counter carries the contract in all three homes"
+```
+
+---
+
+### Task 4: Narrowing README refresh
+
+**Files:**
+- Modify: `docs/dev/typechecker/narrowing/README.md`: status blockquote (lines 12-21), H1 "Memo reset" bullet (~line 258)
+
+- [ ] **Step 1: Rewrite the stale status blockquote** (it predates the flow-checker series #359-#386 and claims "the flow graph itself has not [landed]"). Replace the whole `> **Status — mid-migration.**` blockquote with:
+
+```markdown
+> **Status — dual model, flow-typed primary.** The flow graph and the
+> `typeAt(reference, flowNode)` oracle have LANDED (the #359–#386 series):
+> every diagnostic pass (`checkScopes`, exhaustiveness, definite returns)
+> resolves types through the flow model, and `FlowEnvironment.memo`
+> invalidation is automatic (a Scope-tree generation counter — see
+> `FlowMemo` in `lib/typeChecker/flow.ts`). The scope-chain model documented
+> below survives for ONE job: declaration-time inference during
+> `buildScopes`, which runs before the flow graph exists. Both models share
+> fact production (`analyzeCondition`) and fact application
+> (`narrowByRefine`), so a new narrowing form lands in both automatically.
+> Fusing the walks and deleting the scope-chain path was assessed and
+> deliberately deferred (issue #471): the duplication is inert and the
+> precision delta was not worth the rebuild.
+```
+
+- [ ] **Step 2: Update the H1 "Memo reset" bullet** (under "Handler param `.effect` typing"). Replace the bullet's text with:
+
+```markdown
+- **Ordering.** The pass runs before `buildFlowGraphs` so the oracle is
+  seeded with the refined `e` from the start. Historically this ordering was
+  load-bearing (a post-flow retype required a manual memo reset); since the
+  generation counter, the memo self-invalidates on `declare()` and the
+  ordering is an oracle-seeding-quality choice, not a soundness cliff.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/typechecker/narrowing/README.md
+git commit -m "Narrowing README: flow model has landed, memo invalidation is automatic"
+```
+
+---
+
+### Task 5: Full verification, perf gate, issue update, PR
+
+- [ ] **Step 1: Build + linter + full lib suite.**
+
+```bash
+make > /tmp/genctr-task5-make.log 2>&1
+pnpm run lint:structure > /tmp/genctr-task5-lint.log 2>&1
+npx vitest run lib > /tmp/genctr-task5-tests.log 2>&1
+```
+Expected: all clean (~7,820+ tests). If `make` drifted `docs/site/stdlib/data/usaspending.md`, revert it; delete any `a.vs.b.verdict.json`.
+
+- [ ] **Step 2: Perf gate.** Write this script as `bench-typecheck.mjs` INSIDE `packages/agency-lang/` of BOTH checkouts (Node resolves the `./dist/...` imports relative to the script file, and `readFileSync` is cwd-relative — so file in package dir, run from package dir). DELETE both copies before committing. For the main-checkout run use `/Users/adityabhargava/agency-lang/packages/agency-lang` after `make` — verify `git status` shows no typeChecker modifications there first; do NOT use git stash (breaks the incremental build).
+
+```js
+// bench-typecheck.mjs — run from packages/agency-lang after make. DELETE before committing.
+import { readFileSync } from "node:fs";
+import { parseAgency } from "./dist/lib/parser.js";
+import { typeCheck } from "./dist/lib/typeChecker/index.js";
+
+const WARMUP = 3;
+const RUNS = 25;
+const src = readFileSync("stdlib/ui.agency", "utf8");
+const parsed = parseAgency(src, {}, false);
+if (!parsed.success) {
+  throw new Error("parse failed");
+}
+for (let i = 0; i < WARMUP; i++) {
+  typeCheck(parsed.result);
+}
+const times = [];
+for (let i = 0; i < RUNS; i++) {
+  const t0 = performance.now();
+  typeCheck(parsed.result);
+  times.push(performance.now() - t0);
+}
+times.sort((a, b) => a - b);
+console.log("median typecheck ms:", times[Math.floor(RUNS / 2)].toFixed(1));
+```
+
+Gate: branch median ≤ main median × 1.05 (expect ~23 ms on main per the review's measurement). Diagnostics from unresolved `std::` imports are identical on both sides — the comparison is valid. If the gate fails, profile before proceeding: the expected flush points are only `computeMatchExprTypes` phase 2, same as the manual reset today.
+
+- [ ] **Step 3: Comment on issue #471** (body via file, `gh issue comment 471 --repo egonSchiele/agency-lang -F <file>`): part 2 (memo automation) is implemented in this PR; part 1 (delete the scope-chain path / fuse the walks) is deliberately deferred with a two-sentence summary of the owner decision (duplication is inert — shared `analyzeCondition` + `narrowByRefine`; ~150 lines and unrequested precision not worth 2-3 weeks; revisit if a passes-disagree bug materializes or a narrowing feature cannot live in the dual model). Do NOT close the issue.
+
+- [ ] **Step 4: Push and open the PR.** Body (via file): what the counter is (three-sentence mechanism), the detached carve-out and its assertion, what was deleted (manual reset, the soundness-cliff framing in all three contract homes), reviewer pointers (the box-shared-by-reference subtlety + `readonly memo`; the identity-based memo-hit pins; the integration pin and how it exercises the production flush point), the red-proof result from Task 3 Step 5 (including whether pre-existing tests covered the reset), benchmark numbers, and the #471 descope note. Title: "Automate typeAt memo invalidation with a Scope generation counter (#471 part 2)".
+
+---
+
+## Self-review notes (rev 2)
+
+- All review findings applied: blocker 1 → Task 2 Step 3.2; item 2-3 → Task 5 Step 2 (script placement, warmup, RUNS const, computed median index); item 4 → Task 3 Step 3 (handlerParamTyping kept-but-rewritten); item 5 → Verified Facts; items 6-8 → comment texts in Tasks 1-2; anti-pattern audit → `readonly memo`, braced `declareLocal` if, braced bench throw; test gaps 1-6 → spread-copy pins + guaranteed integration pin (Task 3 Step 1, replacing the conditional experiment) + same-type bump + nested chains + standalone-tree pin.
+- The rebindMatchConsumer helper suggested as optional in the review is deliberately skipped (single caller); the pairing warning lives in the FlowMemo + matchConsumerAssignFlows comments instead, per review item 8.
+- Type consistency: `FlowMemo`/`freshMemo` (Task 2 Step 1) consumed in Steps 3/5 and Task 3; `currentGeneration()`/`detached` (Task 1) consumed in Task 2 Steps 2/4/5. Integration pin uses `parseAgency(src, {}, false)` + `typeCheck(parsed.result)` — signatures verified on main.

--- a/docs/superpowers/specs/2026-07-10-flowenv-generation-counter-design.md
+++ b/docs/superpowers/specs/2026-07-10-flowenv-generation-counter-design.md
@@ -1,5 +1,12 @@
 # FlowEnvironment memo auto-invalidation via a Scope generation counter
 
+> **Errata (point-in-time record; see the plan rev-2 header for the corrected
+> versions):** two claims below were superseded by later review rounds —
+> "O(depth) (depth ≤ 3)" (narrowing child chains nest arbitrarily; the shipped
+> `scope.ts` comment has the corrected wording, and the hot-path read is O(1)
+> via the parent-less flow-env root) and "median of 7" in the Tests section
+> (the shipped perf gate is 3 warmup + 25 timed iterations).
+
 **Issue:** #471 (part 2). Part 1 of that issue — fusing flow-graph construction
 into the scope walk and deleting the legacy child-scope narrowing path — is
 **deliberately descoped** after owner review (2026-07-10): its remaining unique

--- a/docs/superpowers/specs/2026-07-10-flowenv-generation-counter-design.md
+++ b/docs/superpowers/specs/2026-07-10-flowenv-generation-counter-design.md
@@ -1,0 +1,140 @@
+# FlowEnvironment memo auto-invalidation via a Scope generation counter
+
+**Issue:** #471 (part 2). Part 1 of that issue — fusing flow-graph construction
+into the scope walk and deleting the legacy child-scope narrowing path — is
+**deliberately descoped** after owner review (2026-07-10): its remaining unique
+benefits (unrequested precision gains, ~150 deleted lines, conceptual
+cleanliness) do not justify 2–3 weeks. The dual "where to apply narrowing"
+logic is inert — both paths share `analyzeCondition` (fact production) and
+`narrowByRefine` (fact application), so a new narrowing form lands in both
+automatically. This spec covers the part that has actually caused repeated
+work: the human-enforced `FlowEnvironment.memo` soundness contract.
+
+## Problem
+
+`typeAt` (lib/typeChecker/flow.ts) memoizes per (flow node, reference key).
+`start` nodes read `scope.lookup(...)` live, so a memoized answer embeds scope
+state at query time. Any pass that mutates a scope after answers were cached
+makes the cache stale, silently. The current protection is a doc comment
+("SOUNDNESS CONTRACT: ... discard the memo") enforced by vigilance. Two passes
+have independently paid for it:
+
+- `handlerParamTyping` was moved ahead of `buildFlowGraphs` (index.ts) solely
+  to avoid needing a reset.
+- `computeMatchExprTypes` must remember `ctx.flowEnv.memo = new WeakMap()`
+  after patching consumer scope entries and `assign` flow nodes.
+
+## Mechanism
+
+One integer per check run — the **generation** — owned by the `Scope` tree.
+
+1. **`Scope` gets a `generation` counter.** `declare()` bumps it, propagating
+   the bump up the parent chain to the root (`topLevelScope`), so any scope can
+   read the tree-wide current generation in O(depth) (depth ≤ 3). The root's
+   counter is the single source of truth.
+2. **The memo becomes a shared box:** `FlowEnvironment.memo` changes from
+   `WeakMap<FlowNode, Record<string, ScopeType>>` to
+   `{ gen: number; map: WeakMap<FlowNode, Record<string, ScopeType>> }`.
+   The box is shared **by reference** across the per-scope build envs and the
+   spread-copied envs in the synthesizer (`{ ...ctx.flowEnv, typeAliases }`),
+   so a reset made through any env is visible to all. (Replacing a `memo`
+   field on one env object would not be — this is why the box exists.)
+3. **`typeAt` checks on entry:** if `box.gen !== scope tree's current
+   generation`, set `box.map = new WeakMap()` and `box.gen = current`, then
+   proceed. Lazy whole-memo invalidation — identical semantics to today's
+   manual resets, but automatic.
+
+### Detached child scopes do not bump (the perf carve-out)
+
+`Scope.child()` creates throwaway scopes for two callers: the synthesizer's
+callback-parameter scopes (`xs.map(\(x) -> …)`, scope.ts `declareLocal`) and
+the legacy narrowing path. These are created constantly during `checkScopes`;
+if their `declareLocal` writes bumped the generation, every lambda synthesis
+would flush the whole memo and typeAt memoization would be near-useless in
+exactly the pass that needs it.
+
+They don't need to bump: a memo entry can only go stale if the mutated scope
+is reachable from a flow node, and flow `start` nodes are built exclusively
+over `ScopeInfo` scopes (function/node/top-level scopes, `buildFlowGraphs`) —
+never over `child()` scopes. Make that a by-construction rule rather than
+vigilance:
+
+- `Scope.child()` marks the child `detached: true` (readonly field).
+- `declareLocal()` on a detached scope does not bump. (`declare()` from inside
+  a detached child delegates to `functionScope()`, which is attached and DOES
+  bump — correct, that mutation is flow-visible.)
+- `buildFlowGraphs` asserts `!info.scope.detached` before building a `start`
+  node, so a future misuse fails loudly instead of silently un-protecting the
+  memo.
+
+## What gets deleted / relaxed
+
+- `computeMatchExprTypes`: the trailing manual memo reset. Its phase-2 patch
+  loop already calls `info.scope.declare(...)` for every consumer it patches
+  (matchExprTypes.ts:113), and that bump also covers the paired in-place
+  `assignFlow.type` patch — any memo entry derived from the old snapshot was
+  computed under the pre-bump generation. The **ordering assertion**
+  (`flowEnv` must exist) stays: yield synthesis still genuinely requires the
+  flow graph; only the memo half of the contract is automated.
+- `FlowEnvironment.memo`'s SOUNDNESS CONTRACT doc comment: rewritten to
+  describe the automatic mechanism.
+- The pass-ordering *hazard* class in index.ts: `handlerParamTyping` stays
+  where it is (it must still precede `checkScopes` for H3), but its position
+  relative to `buildFlowGraphs` is no longer a correctness cliff; comments at
+  both sites updated to say so.
+- Audit for any other manual `memo = new WeakMap()` sites (grep during
+  execution); delete each one the counter covers.
+
+## What stays (non-goals)
+
+- `matchConsumerAssignFlows` and the two-phase patch structure of
+  `computeMatchExprTypes`: cross-scope consumers (module-level
+  `const x = match(...)` lowering into a synthesized init function) genuinely
+  require patching after all scopes are processed. The counter automates the
+  *memo* consequence of the patch, not the patch itself.
+- `strictMemberAccessSeverity`'s `!ctx.flowEnv → silent` gate: unchanged.
+- The legacy child-scope narrowing path (`walkWithNarrowing` etc.): unchanged;
+  descoped per the header. Issue #471 gets a comment recording the decision
+  and shrinking its scope to this spec + docs refresh, with the fusion noted
+  as "revisit if a passes-disagree bug materializes or a narrowing feature
+  cannot live in the dual model."
+- `inferReturnTypeFor`'s standalone scopes: they form their own tiny tree
+  (no parent), so their bumps never touch the main tree's generation — and
+  they never appear in flow nodes, so that is correct, not a gap.
+
+## Docs refresh (same PR)
+
+`docs/dev/typechecker/narrowing/README.md` still says the flow graph "has not
+landed" (its status blurb predates the flow-checker series, #359–#386).
+Rewrite the status section to describe the current dual model accurately:
+flow-typed narrowing + `typeAt` are the primary path consulted by all
+diagnostic passes; the scope-chain child-scope path survives only for
+declaration-time inference during `buildScopes`; memo invalidation is
+automatic (this change).
+
+## Tests (red-first)
+
+1. **Staleness pin (red on main):** flow.test.ts — memoize a start-rooted
+   `typeAt` query, `scope.declare` the same name with a different type,
+   re-query → must return the new type. On main this returns the stale cached
+   type (this is the exact bug class).
+2. **Bump propagation:** the declare happens on a *def* scope chained to the
+   root; a query through an env holding the root still invalidates.
+3. **Detached carve-out:** `declareLocal` on a `child()` scope does NOT
+   invalidate (memoized entry survives, by identity) — pins the perf
+   carve-out so a future "simplify: always bump" doesn't silently regress
+   checkScopes performance. Plus: `buildFlowGraphs` over a detached scope
+   throws (the assertion).
+4. **Reset deletion is load-bearing:** delete `computeMatchExprTypes`' manual
+   reset; the existing match-expression narrowing tests must stay green.
+   Red-proof during execution: with the counter reverted but the reset still
+   deleted, those tests fail — proving the counter now carries the contract.
+5. **Perf gate:** in-process compile benchmark on ui.agency (median of 7),
+   branch vs main, expectation: within noise. The counter only invalidates
+   when a pass actually mutates an attached scope — the same points where
+   manual resets fire today.
+
+## Estimated size
+
+~20 lines of mechanism (Scope counter + box + typeAt check + assert),
+~30 lines of deletions/comment rewrites, tests, README refresh. 1–2 days.

--- a/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
+++ b/packages/agency-lang/docs/dev/typechecker/narrowing/README.md
@@ -9,14 +9,19 @@ Agency's goal of giving agents *compile-time* feedback on the programs they writ
 The narrowing engine lives in `lib/typeChecker/narrowing.ts` (fact production) and
 is applied during scope building in `lib/typeChecker/scopes.ts`.
 
-> **Status — mid-migration.** Narrowing is moving from the **scope-chain** model
-> documented below to a **flow-typed** model where a single `typeAt(reference,
-> flowNode)` oracle answers "what is this variable's type at this program point"
-> for every pass. The bottom type `never` (the first prerequisite) has landed; the
-> flow graph itself has not. This page documents the **current** implementation
-> accurately, plus a capabilities matrix and the **planned** architecture. As each
-> flow-checker increment lands, the per-topic pages listed at the bottom get
-> filled in. See the design spec:
+> **Status — dual model, flow-typed primary.** The flow graph and the
+> `typeAt(reference, flowNode)` oracle have LANDED (the #359–#386 series):
+> every diagnostic pass (`checkScopes`, exhaustiveness, definite returns)
+> resolves types through the flow model, and `FlowEnvironment.memo`
+> invalidation is automatic (a Scope-tree generation counter — see
+> `FlowMemo` in `lib/typeChecker/flow.ts`). The scope-chain model documented
+> below survives for ONE job: declaration-time inference during
+> `buildScopes`, which runs before the flow graph exists. Both models share
+> fact production (`analyzeCondition`) and fact application
+> (`narrowByRefine`), so a new narrowing form lands in both automatically.
+> Fusing the walks and deleting the scope-chain path was assessed and
+> deliberately deferred (issue #471): the duplication is inert and the
+> precision delta was not worth the rebuild. Original design spec:
 > [`docs/superpowers/specs/2026-06-29-flow-typed-checker-design.md`](../../../superpowers/specs/2026-06-29-flow-typed-checker-design.md).
 
 ## Capabilities & limitations (current)
@@ -256,10 +261,11 @@ interrupt object. The raisable set is computed by `collectRaisableEffects`
 unhandled-interrupt check agree on "what can be raised."
 
 Two subtleties:
-- **Memo reset.** The pass mutates scope types after the flow graph + its
-  `typeAt` memo were built, so it discards `ctx.flowEnv.memo` (the flow env's
-  documented soundness contract) — otherwise `synthType(e.effect)` returns the
-  stale pre-refinement `any`.
+- **Ordering.** The pass runs before `buildFlowGraphs` so the oracle is
+  seeded with the refined `e` from the start. Historically this ordering was
+  load-bearing (a post-flow retype required a manual memo reset); since the
+  generation counter, the memo self-invalidates on `declare()` and the
+  ordering is an oracle-seeding-quality choice, not a soundness cliff.
 - **Not a breaking change.** Field-access checking runs in `checkScopes`, before
   this pass, so the refined object type only reaches `checkMatchExhaustiveness`;
   no `e.<field>` read is re-checked against the closed object.

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -10,6 +10,7 @@ import {
   flowHasNarrowFor,
   isPrefixOf,
   segKey,
+  freshMemo,
   type FlowNode,
   type FlowEnvironment,
 } from "./flow.js";
@@ -63,7 +64,7 @@ describe("uniteTypes", () => {
 });
 
 function env(scope: Scope): FlowEnvironment {
-  return { scope, flowOf: new WeakMap(), typeAliases: {}, memo: new WeakMap() };
+  return { scope, flowOf: new WeakMap(), typeAliases: {}, memo: freshMemo() };
 }
 const ref = (variable: string) => ({ variable, chain: [] as PathSegment[] });
 
@@ -320,7 +321,7 @@ describe("typeAt — property paths (M1)", () => {
     const e: FlowEnvironment = {
       scope: s,
       flowOf: new WeakMap(),
-      memo: new WeakMap(),
+      memo: freshMemo(),
       typeAliases: { Box: { body: boxType } },
     };
     expect(typeAt(pathRef("box", "r"), { kind: "start", scope: s }, e)).toEqual(RESULT);
@@ -536,5 +537,113 @@ describe("PathSegment helpers + index resolution (M2)", () => {
     const reassigned: FlowNode = { kind: "assign", prev: narrowed, ref: { variable: "arr", chain: [idx(0)] }, type: RESULT };
     const after = typeAt({ variable: "arr", chain: [idx(0)] }, reassigned, env(s));
     expect(typeof after === "object" && after.type).toBe("resultType");
+  });
+});
+
+describe("memo auto-invalidation (generation counter)", () => {
+  it("returns the fresh type after a scope mutation (stale on main)", () => {
+    const scope = new Scope("fn");
+    scope.declare("x", NUM);
+    const start: FlowNode = { kind: "start", scope };
+    const e = env(scope);
+    expect(typeAt(ref("x"), start, e)).toEqual(NUM); // memoized
+    scope.declare("x", STR); // a later pass retypes x
+    expect(typeAt(ref("x"), start, e)).toEqual(STR);
+  });
+
+  it("a declare bump also covers a paired in-place assign-node patch", () => {
+    // Pins the computeMatchExprTypes phase-2 contract: patch assignFlow.type
+    // AND re-declare the consumer; the declare bump invalidates entries
+    // derived from the old snapshot.
+    const scope = new Scope("fn");
+    scope.declare("x", "any");
+    const start: FlowNode = { kind: "start", scope };
+    const assign: Extract<FlowNode, { kind: "assign" }> = {
+      kind: "assign",
+      prev: start,
+      ref: ref("x"),
+      type: "any",
+    };
+    const e = env(scope);
+    expect(typeAt(ref("x"), assign, e)).toBe("any"); // memoized under old gen
+    assign.type = STR;
+    scope.declare("x", STR);
+    expect(typeAt(ref("x"), assign, e)).toEqual(STR);
+  });
+
+  it("an invalidation is visible through a spread-copied env (shared box)", () => {
+    // The synthesizer queries through { ...ctx.flowEnv, typeAliases } copies
+    // (synthesizer.ts). The box is shared by reference, so a flush triggered
+    // through ANY env must be visible through every copy.
+    const scope = new Scope("fn");
+    scope.declare("x", NUM);
+    const start: FlowNode = { kind: "start", scope };
+    const e = env(scope);
+    expect(typeAt(ref("x"), start, e)).toEqual(NUM); // memoize via original
+    scope.declare("x", STR);
+    const copy = { ...e, typeAliases: {} };
+    expect(typeAt(ref("x"), start, copy)).toEqual(STR); // read via the COPY
+  });
+
+  it("a memo hit survives through a spread copy (no mutation)", () => {
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    const copy = { ...e, typeAliases: {} };
+    expect(typeAt(ref("x"), join, copy)).toBe(first); // identity => shared memo
+  });
+
+  it("declareLocal on a detached child does not flush the memo (identity pin)", () => {
+    // Recomputing this join constructs a FRESH union object (uniteTypes), so
+    // object identity across queries proves a memo hit. Guards the perf
+    // carve-out: lambda-param child scopes must not flush the memo.
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    scope.child().declareLocal("cbParam", STR); // the synthesizer pattern
+    expect(typeAt(ref("x"), join, e)).toBe(first); // same object => memo hit
+  });
+
+  it("a declare into an UNRELATED standalone scope tree does not flush", () => {
+    // Lazy inferReturnTypeFor declares into its own new Scope(...) tree
+    // mid-checkScopes; those bumps must not touch the main tree memo.
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    const standalone = new Scope("inference");
+    standalone.declare("y", NUM);
+    expect(typeAt(ref("x"), join, e)).toBe(first); // memo hit survives
+  });
+
+  it("an unrelated attached declare flushes the whole memo (lazy semantics)", () => {
+    // Deliberate pin of whole-memo (not per-name) invalidation, so a future
+    // change to finer granularity is a conscious decision with a test diff.
+    const scope = new Scope("fn");
+    scope.declare("x", STR);
+    const start: FlowNode = { kind: "start", scope };
+    const a1: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: STR };
+    const a2: FlowNode = { kind: "assign", prev: start, ref: ref("x"), type: NUM };
+    const join: FlowNode = { kind: "join", prev: [a1, a2] };
+    const e = env(scope);
+    const first = typeAt(ref("x"), join, e);
+    scope.declare("unrelated", NUM);
+    const second = typeAt(ref("x"), join, e);
+    expect(second).toEqual(first);
+    expect(second).not.toBe(first); // recomputed => memo was flushed
   });
 });

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -541,7 +541,7 @@ describe("PathSegment helpers + index resolution (M2)", () => {
 });
 
 describe("memo auto-invalidation (generation counter)", () => {
-  it("returns the fresh type after a scope mutation (stale on main)", () => {
+  it("returns the fresh type after a scope mutation (stale without the generation check)", () => {
     const scope = new Scope("fn");
     scope.declare("x", NUM);
     const start: FlowNode = { kind: "start", scope };

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -133,7 +133,9 @@ export type FlowEnvironment = {
    * which runs AFTER `buildFlowGraphs` (so yield synthesis sees narrowing) and
    * therefore must patch the eagerly-snapshotted `type` on this node with the
    * computed union — otherwise downstream reads of `x` resolve through typeAt
-   * to the stale "any" recorded at build time. Optional: bare envs in tests.
+   * to the stale "any" recorded at build time. The paired consumer re-declare
+   * bumps the generation, so the memo needs no manual reset. Optional: bare
+   * envs in tests.
    */
   matchConsumerAssignFlows?: WeakMap<AgencyNode, FlowNode>;
 };

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -84,6 +84,24 @@ export type FlowNode =
   | { kind: "loop"; prev: FlowNode; widened: Record<string, ScopeType> }
   | { kind: "exit" };
 
+/**
+ * The typeAt memo plus the scope-tree generation it was filled under. A BOX
+ * shared by reference across every env that wraps the same check run —
+ * including the spread copies the synthesizer makes ({ ...ctx.flowEnv,
+ * typeAliases }) — so an invalidation made through any env is visible to all.
+ * Mutate the box fields in place; the `readonly` on FlowEnvironment.memo
+ * makes replacing the box itself a compile error.
+ */
+export type FlowMemo = {
+  gen: number;
+  map: WeakMap<FlowNode, Record<string, ScopeType>>;
+};
+
+/** A fresh memo box. gen -1 guarantees the first typeAt query stamps it. */
+export function freshMemo(): FlowMemo {
+  return { gen: -1, map: new WeakMap() };
+}
+
 export type FlowEnvironment = {
   scope: Scope;
   flowOf: WeakMap<AgencyNode, FlowNode>;
@@ -92,15 +110,16 @@ export type FlowEnvironment = {
    * Per-flow-node, per-reference-key memo for typeAt. WeakMap because keys are
    * FlowNode identities; without it, nested joins/loops re-walk super-linearly.
    *
-   * SOUNDNESS CONTRACT: a `FlowEnvironment` is valid only for a single
-   * type-check pass. The cache is keyed by FlowNode identity, but `start` nodes
-   * read `scope.lookup(...)` — if the underlying `Scope` mutates (a new
-   * declaration is added, a type is rebound) after a `start`-rooted query has
-   * been memoized, the cache will return stale results. Discard the env (or
-   * call `env.memo = new WeakMap()`) at any point where the scope contents
-   * could have changed.
+   * Invalidation is AUTOMATIC for Scope mutations: `start` nodes read
+   * `scope.lookup(...)` live, so any scope mutation stales the cache — typeAt
+   * compares `memo.gen` against the scope tree generation
+   * (Scope.currentGeneration) on entry and rebuilds the map on mismatch.
+   * Passes that retype scope entries (e.g. computeMatchExprTypes) need no
+   * manual reset: their declare() calls bump the generation. A FlowNode
+   * patched IN PLACE (assignFlow.type = ...) is invisible to the counter and
+   * still needs a paired declare() bump — see matchConsumerAssignFlows.
    */
-  memo: WeakMap<FlowNode, Record<string, ScopeType>>;
+  readonly memo: FlowMemo;
   /**
    * The end-of-body flow node per scopeKey, populated by `buildFlowGraphs`.
    * `exit` means every path through that scope diverges (returns). Consumed by
@@ -165,14 +184,26 @@ export function applyRefine(
  * Memoized per (flow node, reference key).
  */
 export function typeAt(ref: Reference, at: FlowNode, env: FlowEnvironment): ScopeType {
+  // Auto-invalidation: a mismatch means some attached scope mutated since the
+  // memo was filled (see FlowMemo). Every entry is suspect — start nodes read
+  // scopes live — so drop the whole map (lazy full invalidation, the same
+  // semantics as the manual resets this replaced). INVARIANT: nothing mutates
+  // scopes mid-walk — gen is stamped before computing, so a mid-walk mutation
+  // would go unnoticed for entries computed earlier in the same walk.
+  // Recursive typeAt calls re-check harmlessly under that invariant.
+  const gen = env.scope.currentGeneration();
+  if (env.memo.gen !== gen) {
+    env.memo.map = new WeakMap();
+    env.memo.gen = gen;
+  }
   const key = referenceKey(ref);
-  let perNode = env.memo.get(at);
+  let perNode = env.memo.map.get(at);
   if (perNode === undefined) {
     // Null-prototype dict: keys are source identifiers (variable names), so a
     // ref named "__proto__" / "toString" / "constructor" must not collide with
     // Object.prototype on read. Mirrors scope.ts's own-property discipline.
     perNode = Object.create(null) as Record<string, ScopeType>;
-    env.memo.set(at, perNode);
+    env.memo.map.set(at, perNode);
   }
   const cached = perNode[key];
   if (cached !== undefined) return cached;

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { parseAgency } from "../parser.js";
 import { Scope } from "./scope.js";
-import { typeAt, type FlowEnvironment, type FlowNode, type PathSegment } from "./flow.js";
-import { buildFlowGraph } from "./flowBuilder.js";
+import { typeAt, freshMemo, type FlowEnvironment, type FlowNode, type PathSegment } from "./flow.js";
+import { buildFlowGraph, buildFlowGraphs } from "./flowBuilder.js";
 import { walkNodes } from "../utils/node.js";
 import type { AgencyNode, VariableType } from "../types.js";
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
 
 const NUM: VariableType = { type: "primitiveType", value: "number" };
 const STR: VariableType = { type: "primitiveType", value: "string" };
@@ -29,7 +30,7 @@ function freshEnv(
   scope: Scope,
   typeAliases: FlowEnvironment["typeAliases"] = {},
 ): FlowEnvironment {
-  return { scope, flowOf: new WeakMap(), typeAliases, memo: new WeakMap() };
+  return { scope, flowOf: new WeakMap(), typeAliases, memo: freshMemo() };
 }
 
 const ref = (variable: string) => ({ variable, chain: [] as PathSegment[] });
@@ -265,4 +266,17 @@ describe("attachExpressionsToFlow — short-circuit", () => {
     const rightU = find([andExpr.right as AgencyNode], (n) => n.type === "valueAccess");
     expect(typeAt(ref("u"), env.flowOf.get(rightU)!, env)).toEqual(memberA);
   });
+});
+
+it("rejects a detached child scope as a flow root", () => {
+  const detachedScope = new Scope("fn").child();
+  const info = {
+    scope: detachedScope,
+    body: [],
+    name: "f",
+    scopeKey: "fn:f",
+    file: "",
+  } as ScopeInfo;
+  const ctx = { getTypeAliases: () => ({}) } as unknown as TypeCheckerContext;
+  expect(() => buildFlowGraphs([info], ctx)).toThrow(/detached/);
 });

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -12,6 +12,7 @@ import {
   widenAtLoopBackEdge,
   chainToSegments,
   declaredPathType,
+  freshMemo,
 } from "./flow.js";
 
 /**
@@ -378,7 +379,7 @@ export function buildFlowGraph(
  */
 export function buildFlowGraphs(scopes: ScopeInfo[], ctx: TypeCheckerContext): void {
   const flowOf: WeakMap<AgencyNode, FlowNode> = new WeakMap();
-  const memo: WeakMap<FlowNode, Record<string, ScopeType>> = new WeakMap();
+  const memo = freshMemo();
   const matchConsumerAssignFlows: WeakMap<AgencyNode, FlowNode> = new WeakMap();
   const typeAliases = ctx.getTypeAliases();
   // Null-prototype: scopeKeys derive from user-controlled function/node names, so
@@ -386,6 +387,11 @@ export function buildFlowGraphs(scopes: ScopeInfo[], ctx: TypeCheckerContext): v
   // Object.prototype on write or read (mirrors the flow memo dicts in flow.ts).
   const scopeTerminals: Record<string, FlowNode> = Object.create(null);
   for (const info of scopes) {
+    if (info.scope.detached) {
+      throw new Error(
+        `buildFlowGraphs: scope for ${info.scopeKey} is a detached child scope. Flow start nodes must be built over function/top-level scopes only - detached scopes do not bump the generation counter, so a start node over one would silently un-protect the typeAt memo.`,
+      );
+    }
     const env: FlowEnvironment = {
       scope: info.scope,
       flowOf,
@@ -399,6 +405,8 @@ export function buildFlowGraphs(scopes: ScopeInfo[], ctx: TypeCheckerContext): v
       env,
     );
   }
+  // Empty scopes list fallback: an orphan root whose generation never moves.
+  // Harmless — no flow nodes exist to memoize against in that case.
   const rootScope = scopes[0]?.scope ?? new Scope("global");
   ctx.flowEnv = {
     scope: rootScope,

--- a/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerParamTyping.ts
@@ -89,10 +89,12 @@ export function refineInlineHandlerParams(
   ctx: TypeCheckerContext,
   registry: Record<string, ObjectType>,
 ): void {
-  // ORDERING ASSERTION (load-bearing — see TypeChecker.check()): this pass
-  // MUTATES scope types, so it must run BEFORE buildFlowGraphs seeds the
-  // typeAt memo. Running after would require the memo-reset contract this
-  // ordering exists to avoid; a reorder would silently produce stale types.
+  // ORDERING ASSERTION: this pass runs BEFORE buildFlowGraphs so the typeAt
+  // oracle is seeded with the refined `e` from its first query. Since the
+  // Scope generation counter (FlowMemo, flow.ts) a reorder would no longer
+  // produce stale types — the declare below bumps the generation and the memo
+  // self-invalidates — but running first is still strictly better: it avoids
+  // a whole-memo flush and keeps every pass reading the same refined types.
   if (ctx.flowEnv) {
     throw new Error(
       "refineInlineHandlerParams must run before buildFlowGraphs (ctx.flowEnv is already set)",
@@ -122,7 +124,7 @@ export function refineInlineHandlerParams(
       }
     });
   }
-  // No flow-env memo reset needed: this pass runs BEFORE `buildFlowGraphs`, so
-  // the flow graph's `typeAt` oracle is seeded from the refined scope from the
-  // start — there is no stale `e`-is-`any` cache to discard.
+  // Pre-flow ordering means the typeAt memo does not exist yet, so there is
+  // nothing to invalidate here; were this pass ever reordered after the flow
+  // build, the generation counter would cover it (see FlowMemo, flow.ts).
 }

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -323,8 +323,11 @@ export class TypeChecker {
     // MUST run before checkScopes so `e.data` usage sites narrow correctly.
     refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, effectRegistry);
 
-    // Build the flow graph AFTER the param retype, so its `typeAt` oracle is
-    // seeded with the refined `e` (no stale-memo reset needed).
+    // Build the flow graph AFTER the param retype so the oracle is seeded with
+    // the refined `e` from the start. (Ordering kept for oracle-seeding
+    // quality; since the generation counter, a post-flow retype would also be
+    // sound — the declare would bump the generation and the memo would
+    // self-invalidate.)
     buildFlowGraphs(scopes, ctx);
 
     // Compute the value type of every expression-position `match` (union of
@@ -333,8 +336,7 @@ export class TypeChecker {
     // and before checkScopes so the `__matchval_<id>` synth hook and the
     // `matchExprSource` assignment check can read the results. Patches each
     // consumer variable's scope entry AND its eagerly-snapshotted `assign` flow
-    // node with the computed union, then resets the typeAt memo (per the
-    // FlowEnvironment soundness contract) so no stale entry survives.
+    // node with the computed union.
     computeMatchExprTypes(scopes, ctx);
 
     // Check function calls, return types, and expressions. `e.data` is now

--- a/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
@@ -124,7 +124,7 @@ export function computeMatchExprTypes(
   // pass (yield synthesis walks the flow graph) may now be stale. Drop the
   // memo — checkScopes recomputes on demand.
   if (ctx.flowEnv) {
-    ctx.flowEnv.memo = new WeakMap();
+    ctx.flowEnv.memo.map = new WeakMap();
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
@@ -119,13 +119,9 @@ export function computeMatchExprTypes(
     });
   }
 
-  // Scope entries and flow-node types were rebound above; per the
-  // FlowEnvironment soundness contract, any typeAt result memoized during this
-  // pass (yield synthesis walks the flow graph) may now be stale. Drop the
-  // memo — checkScopes recomputes on demand.
-  if (ctx.flowEnv) {
-    ctx.flowEnv.memo.map = new WeakMap();
-  }
+  // Scope entries and flow-node types were rebound above. The declare() calls
+  // bumped the scope-tree generation, so typeAt discards its stale memo on the
+  // next query (see FlowMemo, flow.ts) — no manual reset needed.
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/matchExpression.test.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExpression.test.ts
@@ -268,3 +268,33 @@ describe("computeMatchExprTypes ordering assertion", () => {
     );
   });
 });
+
+describe("memo invalidation across computeMatchExprTypes phases", () => {
+  it("stale phase-1 memo entries do not suppress downstream diagnostics", () => {
+    // Two sequential expression-matches. The second match has the higher id,
+    // so computeMatchExprTypes phase 1 processes it FIRST and synthesizes its
+    // yield `first` — a typeAt query that memoizes the PRE-patch "any" at the
+    // flow node after the first consumer assignment. Phase 2 then patches
+    // `first` to string. The `const n: number = first` check in checkScopes
+    // resolves `first` through that same flow path: with a stale memo the
+    // cached "any" propagates (any is assignable to number — diagnostic
+    // SUPPRESSED); with invalidation (the generation counter; previously the
+    // manual memo reset) the diagnostic fires. Pins the production flush
+    // point end-to-end.
+    const errs = check(`def f(v: number): string {
+  const first = match(v) {
+    1 => "a"
+    _ => "b"
+  }
+  const second = match(v) {
+    1 => first
+    _ => "z"
+  }
+  const n: number = first
+  return second
+}`);
+    const messages = errs.join("\n");
+    expect(messages).toContain("not assignable");
+    expect(messages).toContain("number");
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/scope.test.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.test.ts
@@ -81,3 +81,66 @@ describe("Scope", () => {
     expect(scope.lookup("toString")).toBeUndefined();
   });
 });
+
+describe("generation counter", () => {
+  it("declare bumps the tree-wide generation, readable from any scope", () => {
+    const root = new Scope("global");
+    const fn = new Scope("fn", root, true);
+    const g0 = fn.currentGeneration();
+    fn.declare("x", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+    expect(root.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("re-declaring the same name and type still bumps", () => {
+    // computeMatchExprTypes phase 2 re-declares consumers with a type that can
+    // equal the existing entry; the paired assign-node patch relies on the
+    // bump regardless. Pins against a skip-if-unchanged "optimization".
+    const fn = new Scope("fn");
+    fn.declare("x", "any");
+    const g0 = fn.currentGeneration();
+    fn.declare("x", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("declareLocal on a detached child() scope does not bump", () => {
+    const fn = new Scope("fn");
+    const child = fn.child();
+    expect(child.detached).toBe(true);
+    const g0 = fn.currentGeneration();
+    child.declareLocal("cbParam", "any");
+    expect(fn.currentGeneration()).toBe(g0);
+  });
+
+  it("declareLocal through a NESTED detached chain does not bump", () => {
+    // walkWithNarrowing nests children per nested if — chains are real.
+    const fn = new Scope("fn");
+    const grandchild = fn.child().child();
+    const g0 = fn.currentGeneration();
+    grandchild.declareLocal("cbParam", "any");
+    expect(fn.currentGeneration()).toBe(g0);
+  });
+
+  it("declare from a detached child bumps (delegates to the function scope)", () => {
+    const fn = new Scope("fn");
+    const child = fn.child();
+    const g0 = fn.currentGeneration();
+    child.declare("real", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("declare through a NESTED detached chain bumps", () => {
+    const fn = new Scope("fn");
+    const grandchild = fn.child().child();
+    const g0 = fn.currentGeneration();
+    grandchild.declare("real", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+
+  it("declareLocal on an attached scope bumps", () => {
+    const fn = new Scope("fn");
+    const g0 = fn.currentGeneration();
+    fn.declareLocal("x", "any");
+    expect(fn.currentGeneration()).toBe(g0 + 1);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/scope.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.ts
@@ -5,17 +5,56 @@ export type ScopeType = VariableType | "any";
 export class Scope {
   readonly key: string;
   readonly parent?: Scope;
+  /**
+   * True for throwaway child() scopes (synthesizer callback params, legacy
+   * branch narrowing). Detached scopes are never flow-reachable — no flow
+   * `start` node may be built over one (asserted in buildFlowGraphs) — so
+   * their local writes do not bump the generation counter. This is the perf
+   * carve-out that keeps lambda synthesis in checkScopes from flushing the
+   * typeAt memo on every call.
+   */
+  readonly detached: boolean;
   // Null-prototype dictionaries: variable names are user-controlled, and on
   // a plain `{}` assigning the key "__proto__" invokes the prototype setter
   // (losing the binding and mutating the map) instead of storing an entry.
   private readonly vars: Record<string, ScopeType> = Object.create(null);
   private readonly consts: Record<string, boolean> = Object.create(null);
   private readonly isFunctionBoundary: boolean;
+  /**
+   * Tree-wide mutation counter, stored on the ROOT scope only. typeAt
+   * (flow.ts) compares it against its memo generation and discards stale
+   * entries automatically — the mechanism that replaced the manual
+   * "discard the memo if scope contents change" contract.
+   */
+  private generation = 0;
 
-  constructor(key: string, parent?: Scope, isFunctionBoundary: boolean = false) {
+  constructor(
+    key: string,
+    parent?: Scope,
+    isFunctionBoundary: boolean = false,
+    detached: boolean = false,
+  ) {
     this.key = key;
     this.parent = parent;
     this.isFunctionBoundary = isFunctionBoundary;
+    this.detached = detached;
+  }
+
+  private root(): Scope {
+    return this.parent ? this.parent.root() : this;
+  }
+
+  /**
+   * The tree-wide mutation count. O(parent-chain depth) in general (narrowing
+   * child chains can nest arbitrarily); the hot path (typeAt) reads through
+   * the flow env scope, which is the parent-less top-level scope — O(1).
+   */
+  currentGeneration(): number {
+    return this.root().generation;
+  }
+
+  private bumpGeneration(): void {
+    this.root().generation++;
   }
 
   /**
@@ -26,6 +65,7 @@ export class Scope {
     const target = this.functionScope();
     target.vars[name] = type;
     if (isConst) target.consts[name] = true;
+    target.bumpGeneration();
   }
 
   /**
@@ -40,6 +80,9 @@ export class Scope {
    */
   declareLocal(name: string, type: ScopeType): void {
     this.vars[name] = type;
+    if (!this.detached) {
+      this.bumpGeneration();
+    }
   }
 
   lookup(name: string): ScopeType | undefined {
@@ -78,7 +121,7 @@ export class Scope {
   }
 
   child(key: string = this.key): Scope {
-    return new Scope(key, this);
+    return new Scope(key, this, false, true);
   }
 
   private functionScope(): Scope {


### PR DESCRIPTION
Implements issue #471 part 2, per the spec and reviewed plan on this branch (part 1, the walk fusion, is deliberately deferred — decision recorded on the issue and in the narrowing README).

## What

`typeAt` memoizes per (flow node, reference key), but `start` nodes read scopes live — so any pass that mutates a scope after answers were cached made the memo silently stale. The protection was a prose contract ("discard the memo if scope contents change") enforced in three separate homes: a manual reset in `computeMatchExprTypes`, a throw-on-reorder in `handlerParamTyping`, and vigilance. This PR makes invalidation automatic:

- **`Scope` gains a tree-wide generation counter** (single integer on the root scope; `declare()` bumps it, O(1) to read from the flow env).
- **The memo becomes a box** (`FlowMemo = { gen, map }`) behind a `readonly` field. `typeAt` compares the box generation to the tree generation on entry and lazily rebuilds the map on mismatch — the same semantics as the manual resets, with no human in the loop.
- **Throwaway `child()` scopes are `detached` and skip the bump.** They are never flow-reachable (now asserted in `buildFlowGraphs`), and bumping on them would flush the memo on every lambda synthesis in `checkScopes`.

Deleted/relaxed: the manual reset in `computeMatchExprTypes` (its phase-2 `declare()` calls ARE the bump, covering the paired in-place `assignFlow.type` patch), and the soundness-cliff framing in `handlerParamTyping` + `index.ts` (the pre-flow ordering is kept — it avoids a whole-memo flush — but a reorder is no longer silently unsound).

## Reviewer attention

1. **The box is shared by reference** across the per-scope build envs AND the synthesizer's spread copies (`{ ...ctx.flowEnv, typeAliases }`). Invalidation mutates `memo.map`/`memo.gen` in place; the `readonly` on the field makes replacing the box (the old reset pattern) a compile error. Two pins cover the copies explicitly (invalidation visible through a copy; memo hit shared through a copy).
2. **Identity-based pins.** The "does NOT flush" tests assert object identity (`toBe`) on a join result — recomputing constructs a fresh union object via `uniteTypes`, so identity proves a memo hit. Noted limitation: if `uniteTypes` ever memoizes internally, those pins need a new observable.
3. **The integration pin** (`matchExpression.test.ts`) exercises the production flush point end-to-end: two sequential expression-matches where phase 1 memoizes the first consumer's pre-patch `any`, and a downstream `const n: number = first` whose diagnostic is suppressed by the stale entry. It fails with invalidation disabled.

## Red-proof finding

With the generation check disabled and the manual reset deleted, exactly the 5 new pins fail — **zero pre-existing tests** detect the staleness. The old manual reset had no independent test coverage before this PR; the contract was enforced purely by the comment.

## Verification

Full lib suite green; `make` + structural linter clean; `tsc --noEmit` clean. Perf gate (ui.agency typecheck, 3 warmup + 25 timed, median): branch 23.6 / 23.9 ms vs main 24.1 / 23.1 ms across two rounds (within noise, gate passed) — the counter only invalidates where the manual reset fired before, so steady-state flush behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
