### PR TITLE
Parse method chains on schema(...) expressions (#480)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-schema-chaining-review.md
+++ b/docs/superpowers/plans/2026-07-11-schema-chaining-review.md
@@ -1,0 +1,120 @@
+# Review: Schema Chaining plan (issue #480)
+
+**Plan:** `/Users/adityabhargava/agency-lang/docs/superpowers/plans/2026-07-11-schema-chaining.md`
+**Spec:** `/Users/adityabhargava/agency-lang/docs/superpowers/specs/2026-07-11-schema-chaining-design.md`
+**Reviewed:** 2026-07-11, against main (every claim below re-verified in code, not taken from the plan)
+
+## Verdict
+
+Strong plan. The `peek(".")` + `parseError` refinement over the spec's plain
+`many1` is a genuine improvement and follows an exact in-repo precedent.
+Approve after the three "should fix" items below — all are small test/gate
+adjustments, none change the architecture.
+
+## Verified facts — all check out
+
+I independently confirmed every entry in the plan's "Verified facts" section:
+
+- `peek`, `parseError`, and `captureCaptures` are all already imported in
+  `lib/parsers/parsers.ts` (import lines 13, 38, 39).
+- `parseAgency` catches `TarsecError` and converts it to a parse failure
+  carrying the message (`lib/parser.ts:313` region).
+- `angleBracketsArrayTypeParser` (parsers.ts:1107) is an exact precedent for
+  the proposed composition — `memo(seqC(..., captureCaptures(parseError(msg,
+  capture(...)))))` — so the snippet's combinator usage is proven shape, not
+  invention.
+- Definition-order/TDZ claim is right: `schemaExpressionParser` (2643) →
+  new parser → `baseAtom` (2656) works as a plain value reference; the
+  call-time reference from `_valueAccessParser` (2483, defined earlier) is
+  safe.
+- All four claimed test homes exist: `lib/parsers/expression.test.ts` (schema
+  parse tests start at line 380, matching the plan's ~384),
+  `lib/typeChecker/schemaType.test.ts`, `lib/backends/agencyGenerator.test.ts`,
+  and `tests/agency/schema-param-injection.js`.
+- Task 4's `isSuccess(r)` idiom is valid Agency AND typechecks: the checker
+  narrows on `isSuccess`/`isFailure` calls (`lib/typeChecker/narrowing.ts:227-237`),
+  so the `r.value` access inside the guard passes strict member access. Both
+  `isSuccess(r)` and `r is success(v)` appear in existing `tests/agency/` files.
+- Statement-position repro (functionCall named `schema` today) was verified
+  during the spec review by dumping the AST.
+
+## Should fix before execution
+
+### 1. `peek(char("."))` misses `?.` — gate on `dotParser` instead
+
+`dotParser` (parsers.ts:2355) accepts both `?.` and `.`, and every dot-led
+chain element goes through it. With the plan's `peek(char("."))`,
+`schema(number)?.parseJSON(x)` fails the peek, falls through to the bare
+schema atom, and dies with the old stranded-suffix failure — an inconsistency
+the spec's plain `many1` would not have had. The parser comment carves out
+non-dot heads (`[i]`, `(args)`) but is silent on `?.`, which is dot-led in
+every sense that matters.
+
+Fix: `peek(dotParser)` (already defined right above the chain parsers), so the
+commit gate matches exactly the set of inputs `dotMethodCallParser` accepts.
+If instead `?.` is deliberately excluded, say so explicitly in the comment and
+non-goals — silence reads as an oversight.
+
+### 2. Missing statement-position bare-schema pin (spec test row 1)
+
+The spec requires bare `schema(number)` pinned unchanged in **both**
+positions. Task 1 pins expression position; Task 2 only asserts the
+statement-position legacy shape in prose ("bare `schema(T)` statements still
+take the legacy functionCall path" — Step 4 Expected) with no test. This is
+precisely the behavior the peek gate exists to preserve, so pin it: one Task 2
+row asserting a bare statement-position `schema(number)` still parses as a
+`functionCall` named `schema`.
+
+### 3. Missing assignment-target pin (carried over from the spec review)
+
+Inserting `schemaAccessParser` into `_valueAccessParser` also changes what the
+assignment-target parser (parsers.ts:3590, `capture(_valueAccessParser,
+"target")`) sees: `schema(number).foo = 5` flips its target from
+functionCall-base to schemaExpression-base. Benign (semantic error either
+way), but the spec review asked for it to be named and cheaply pinned, and the
+plan doesn't carry it. Add one row to Task 2: the statement parses as an
+assignment whose target is a `valueAccess` with a `schemaExpression` base (or,
+equivalently, a checker pin that it errors cleanly).
+
+## Minor notes — no block, executor discretion
+
+- **Whitespace-before-dot loses nothing:** chain elements never allow leading
+  whitespace anywhere in the language (`dotParser` starts at the dot;
+  `_valueAccessParser` and `parenAccessParser` attach chains with no space
+  skip), so the peek gate does not newly break multiline fluent chains — they
+  were never supported for any base. Worth one line in the parser doc comment
+  so a future reader doesn't attribute this to the peek.
+- **Hard-commit safety:** I probed for a valid program containing `schema(T).`
+  where `many1(chainElementParser)` fails and found none — `schema` is in
+  `RESERVED_FUNCTION_NAMES`, and a postfix dot demands a chain element in
+  every expression context (including interpolations), so `parseError` can
+  only fire on genuinely invalid input. The comment could state this in one
+  sentence; it is the whole justification for the throw.
+- **Task 1 helper fields are also guesses:** the NOTE flags the chain-element
+  shapes and the failure-message field, but `parsed.result.nodes`,
+  `node.body`, and `type === "assignment"` for a `const` statement are equally
+  unverified. Extend the NOTE's verify-with-`pnpm run ast` instruction to the
+  whole helper skeleton.
+- **Lighter test harness available:** the existing schema tests at
+  `expression.test.ts:380` call `exprParser` directly on the bare expression
+  string. The expression-position rows could use that pattern and skip the
+  `parseAgency` + node-digging helper entirely; only the statement-position
+  and error-message rows need full-program parsing.
+- **Task 3 exactly-one-error assertion** may be brittle if `check()` surfaces
+  unrelated diagnostics on that snippet; fine as a pin, executor adjusts on
+  first run.
+- **Worktree setup:** add `git fetch origin` before `git worktree add ...
+  origin/main` so the branch bases on current main, not a stale ref.
+
+## Altitude check
+
+Right level. The plan reuses the two pieces of machinery the codebase already
+owns for exactly these semantics — the `parenAccessParser` chain-base idiom
+and the `angleBracketsArrayTypeParser` commit-then-`parseError` idiom — rather
+than inventing anything. The peek-commit is a real refinement over the spec
+(targeted error once user intent is unambiguous, zero behavior change for
+bare `schema(T)`), and the plan correctly records it as a plan-level deviation
+to surface in the PR body. Task sequencing (expression → statement → pins →
+fixtures → full verify) is red-first throughout, and Task 3's STOP-on-failure
+correctly treats a downstream failure as a spec falsification rather than
+something to patch silently.

--- a/docs/superpowers/plans/2026-07-11-schema-chaining.md
+++ b/docs/superpowers/plans/2026-07-11-schema-chaining.md
@@ -1,0 +1,443 @@
+# Schema Chaining (issue #480) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (inline execution — this owner does not use subagent-driven development). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `schema(number).parseJSON("[1]")` parse (issue #480) by letting a schema expression start an access chain, with a targeted `parseError` message once the chain is unambiguously intended.
+
+**Architecture:** One new parser, `schemaAccessParser` = `schemaExpressionParser` + `peek(dotParser)` commit + `parseError`-wrapped `many1(chainElementParser)`, producing an ordinary `ValueAccess`. Inserted at two sites: `baseAtom` (expression position) and `_valueAccessParser` (statement position). No AST, checker, or codegen changes — those paths are already generic over the base (verified in the spec). (Review fix: the gate is `peek(dotParser)`, not `peek(char("."))`, so `?.`-led chains commit too — `dotParser` at parsers.ts:2355 is the exact set of dot-led heads `dotMethodCallParser` accepts.)
+
+**Tech Stack:** TypeScript, tarsec parser combinators, vitest.
+
+**Spec:** `/Users/adityabhargava/agency-lang/docs/superpowers/specs/2026-07-11-schema-chaining-design.md`
+
+## Global Constraints
+
+- Commit messages: NO apostrophes; multi-line messages via file + `git commit -F`.
+- Save all test output to files; never rerun suites to re-read failures.
+- Do NOT run the full agency execution suite locally (CI does); running the two new agency tests individually is fine.
+- Agency syntax in tests must follow `docs/site/guide/basic-syntax.md` (parens + braces, `let`/`const`, `match` yield form).
+- No new benchmark gate (spec: `schema(`-anchored parser, no new backtracking level); the full parse-test suite + `make` (stdlib compile) are the guards.
+
+## Verified facts (2026-07-11, against main)
+
+- `peek` and `parseError` are ALREADY imported in `lib/parsers/parsers.ts` (lines 19-20 of the tarsec import). `parseError(msg, ...parsers)` runs `seqC(...parsers)` and THROWS `TarsecError` on failure (combinators.js:776) — a hard commit, no backtrack. `parseAgency` catches `TarsecError` (lib/parser.ts:313-314) and converts it to a parse failure carrying the message.
+- Precedent for the commit-anchor + parseError shape: `angleBracketsArrayTypeParser` (parsers.ts:1107) commits after `array<`.
+- `chainElementParser` (parsers.ts:2451) = dot-method / call / slice / index elements. `schemaExpressionParser` (parsers.ts:2643). `baseAtom` or() (parsers.ts:~2656) lists `schemaExpressionParser` BEFORE `lazy(() => valueAccessParser)` — the stranded-suffix cause. `_valueAccessParser` (parsers.ts:2483) tries `parenAccessParser` first, then bases `or(_functionCallParser, variableNameParser)`.
+- Statement-position `schema(T).method()` parses TODAY as a functionCall named `schema` with the chain attached (repro-verified) — Task 2 deliberately changes that shape.
+- `ValueAccess.base` is `AgencyNode` (lib/types/access.ts:13) — a schema base needs no type change. `parenAccessParser` (parsers.ts:2466) is the exact `map(seqC(capture(...), capture(many1(chainElementParser), "chain")))` idiom to mirror.
+- Module-init ordering: `schemaAccessParser` must be DEFINED after `schemaExpressionParser` (module-init value dependency — the known or()/seqC TDZ class); referencing it from `_valueAccessParser`'s function BODY (call-time) is safe even though that function is defined earlier in the file.
+- Existing test homes: schema parse assertions in `lib/parsers/expression.test.ts` (~line 384); checker schema tests in `lib/typeChecker/schemaType.test.ts`; formatter cases table in `lib/backends/agencyGenerator.test.ts`; execution-test convention `tests/agency/schema-param-injection.{agency,js,test.json}` (nodeName/input/expectedOutput/exact); codegen fixture convention `tests/typescriptGenerator/schemaAccess.{agency,mjs}` (regenerate via `make fixtures`, zero churn elsewhere).
+- (Review-verified) `dotParser` (parsers.ts:2355) = `?.` | `.`; chain elements never allow leading whitespace (for ANY base), so the peek gate does not newly break multiline chains. `isSuccess(r)`/`isFailure(r)` narrow (lib/typeChecker/narrowing.ts:227-237), so `.value` access inside the guard typechecks. No valid program contains `schema(T).`/`schema(T)?.` followed by a non-chain — `schema` is reserved and a postfix dot demands a chain element in every context — so the parseError hard commit can only fire on genuinely invalid input.
+
+## Worktree setup (before Task 1)
+
+```bash
+cd /Users/adityabhargava/agency-lang
+git fetch origin
+git worktree add .claude/worktrees/schema-chaining -b schema-chaining origin/main
+cd .claude/worktrees/schema-chaining && pnpm install
+cd packages/agency-lang && make > /tmp/i480-setup-make.log 2>&1
+```
+
+All paths below are inside `.claude/worktrees/schema-chaining/packages/agency-lang/` unless noted.
+
+---
+
+### Task 1: `schemaAccessParser` + expression position
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts` (define after `schemaExpressionParser` ~2654; insert into `baseAtom` ~2656)
+- Test: `lib/parsers/expression.test.ts`
+
+**Interfaces:**
+- Produces: `export const schemaAccessParser: Parser<ValueAccess>` — matches `schema(T)` followed by a `.`- or `?.`-led chain; throws `TarsecError` ("expected a method call after schema(...)…") when the dot is present but the chain is malformed; plain failure (backtracks) when there is no dot.
+
+- [ ] **Step 1: Write the failing tests** — append to `lib/parsers/expression.test.ts` (uses `parseAgency` directly; add the import if the file lacks it):
+
+```ts
+describe("schema(...) chaining (issue #480)", () => {
+  function rhsOfFirstConst(source: string): AgencyNode {
+    const parsed = parseAgency(`node main() {\n  ${source}\n  return 1\n}`, {}, false);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw new Error("unreachable");
+    const node = parsed.result.nodes.find((n) => n.type === "graphNode") as GraphNodeDefinition;
+    const assignment = node.body.find((n) => n.type === "assignment") as Assignment;
+    return assignment.value as AgencyNode;
+  }
+
+  it("parses a chained call in expression position", () => {
+    expect(rhsOfFirstConst('const r = schema(number).parseJSON("[1]")')).toMatchObject({
+      type: "valueAccess",
+      base: { type: "schemaExpression" },
+      chain: [{ kind: "method", name: "parseJSON" }],
+    });
+  });
+
+  it("accepts a type-grammar argument on the chained form", () => {
+    expect(rhsOfFirstConst('const r = schema(number[]).parseJSON("[1]")')).toMatchObject({
+      type: "valueAccess",
+      base: { type: "schemaExpression", typeArg: { type: "arrayType" } },
+    });
+  });
+
+  it("parses a two-element chain", () => {
+    const v = rhsOfFirstConst('const r = schema(number).parseJSON("5").value');
+    expect(v).toMatchObject({ type: "valueAccess", base: { type: "schemaExpression" } });
+    expect((v as ValueAccess).chain.length).toBe(2);
+  });
+
+  it("bare schema(T) in expression position is unchanged", () => {
+    expect(rhsOfFirstConst("const s = schema(number)")).toMatchObject({
+      type: "schemaExpression",
+    });
+  });
+
+  it("optional-chain head commits too", () => {
+    expect(rhsOfFirstConst('const r = schema(number)?.parseJSON("[1]")')).toMatchObject({
+      type: "valueAccess",
+      base: { type: "schemaExpression" },
+      chain: [{ kind: "method", name: "parseJSON", optional: true }],
+    });
+  });
+
+  it("a malformed chain after the dot is a targeted parse error", () => {
+    const parsed = parseAgency("node main() {\n  const r = schema(number).123\n  return r\n}", {}, false);
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.message).toContain("expected a method call after schema(...)");
+  });
+});
+```
+
+NOTE for the executor: the chain-element shape (`{ kind: "method", name: ... }`) is an educated guess — the real fields are `{ kind: "methodCall", functionCall: {...} }` per `AccessChainElement` (lib/types/access.ts:4-9); read one `chainElementParser` result or `pnpm run ast` the bind-first form and correct the `toMatchObject` shapes before running. The SAME applies to the whole helper skeleton (`parsed.result.nodes`, `node.body`, `type === "assignment"` for a `const` statement) and to `parsed.message` — verify each against a real parse before trusting the red run. Consider the lighter pattern used by the existing schema tests (expression.test.ts:380): call `exprParser` directly on the bare expression string for the expression-position rows; only the statement-position and error-message rows need full-program `parseAgency`. The assertion intent (targeted message reaches the user) must not be weakened.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run lib/parsers/expression.test.ts > /tmp/i480-task1-red.log 2>&1`
+Expected: the three chained-form tests FAIL (parse fails today: this is the issue); the bare-schema test PASSES; the parse-error test FAILS (today's message is the generic stranded-suffix failure, not the targeted one).
+
+- [ ] **Step 3: Implement.** In `lib/parsers/parsers.ts`, immediately AFTER `schemaExpressionParser` (so its module-init value dependency is initialized — the or()/seqC TDZ class):
+
+```ts
+/**
+ * `schema(T).method(...)...` — a schema expression as an access-chain base
+ * (issue #480). The peek(dotParser) gate — `.` or `?.`, exactly the heads
+ * dotMethodCallParser accepts — keeps bare `schema(T)` on its existing path
+ * in every position. Once a dot is seen the user unambiguously meant a
+ * chain (`schema` is reserved, and no valid program puts a postfix dot on
+ * schema(T) without a chain element), so a malformed tail is a hard,
+ * targeted parse error (parseError throws TarsecError; parseAgency converts
+ * it to a message) instead of a backtrack into the stranded-suffix
+ * "expected node body" failure. Mirrors parenAccessParser; the commit shape
+ * mirrors angleBracketsArrayTypeParser. Non-dot chain heads ([i], (args))
+ * stay non-committal by design and fall through to the bare atom. Chains
+ * never allow whitespace before the dot (dotParser starts at the dot, for
+ * every base), so the peek loses no multiline forms.
+ */
+export const schemaAccessParser: Parser<ValueAccess> = memo(
+  "schemaAccessParser",
+  map(
+    seqC(
+      capture(schemaExpressionParser, "base"),
+      peek(dotParser),
+      captureCaptures(
+        parseError(
+          "expected a method call after schema(...), e.g. schema(number).parseJSON(input)",
+          capture(many1(chainElementParser), "chain"),
+        ),
+      ),
+    ),
+    (result) =>
+      ({
+        type: "valueAccess" as const,
+        base: result.base as unknown as AgencyNode,
+        chain: result.chain,
+      }) as ValueAccess,
+  ),
+);
+```
+
+`dotParser` (parsers.ts:2355) is declared well above `schemaExpressionParser` (2643), so referencing it here has no module-init ordering issue.
+
+Then insert into `baseAtom`, directly BEFORE `schemaExpressionParser`:
+
+```ts
+  schemaAccessParser,
+  schemaExpressionParser,
+```
+
+If the produced node lacks a `loc` in the Step 1 assertions (compare the bind-first form), wrap the `map(...)` in `withLoc(...)` exactly as `valueAccessParser` (parsers.ts:2550) does.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run lib/parsers/expression.test.ts > /tmp/i480-task1-green.log 2>&1`
+Expected: PASS, including all pre-existing schemaExpression tests.
+
+- [ ] **Step 5: Parser-suite sweep** (the new alternative sits in `baseAtom` — everything routes through it):
+
+Run: `npx vitest run lib/parsers > /tmp/i480-task1-parsers.log 2>&1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/expression.test.ts
+git commit -m "Parse schema(T) as an access-chain base in expression position (issue 480)"
+```
+
+---
+
+### Task 2: Statement position (deliberate shape change)
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts:2483-2495` (`_valueAccessParser`)
+- Test: `lib/parsers/expression.test.ts`
+
+**Interfaces:**
+- Consumes: `schemaAccessParser` (Task 1).
+
+- [ ] **Step 1: Write the failing test** — append inside the Task 1 describe block:
+
+```ts
+  it("statement position: chain on schema(...) is a schemaExpression-based access, not a call to schema", () => {
+    // Parses TODAY as functionCall("schema") with the chain attached —
+    // wrong node kind (undefined function, wrong codegen). Deliberate
+    // shape change, spec section Design/site 2.
+    const parsed = parseAgency('node main() {\n  schema(number).parseJSON("[1]")\n  return 1\n}', {}, false);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw new Error("unreachable");
+    const node = parsed.result.nodes.find((n) => n.type === "graphNode") as GraphNodeDefinition;
+    const stmt = node.body.find((n) => n.type === "valueAccess" || n.type === "functionCall");
+    expect(stmt).toMatchObject({
+      type: "valueAccess",
+      base: { type: "schemaExpression" },
+    });
+  });
+
+  it("statement position: bare schema(T) keeps its legacy functionCall shape", () => {
+    // The peek(dotParser) gate exists to preserve exactly this: a chainless
+    // schema(T) statement still parses as a call to `schema` (checker flags
+    // it as reserved/undefined), NOT as a schemaExpression statement.
+    const parsed = parseAgency("node main() {\n  schema(number)\n  return 1\n}", {}, false);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw new Error("unreachable");
+    const node = parsed.result.nodes.find((n) => n.type === "graphNode") as GraphNodeDefinition;
+    const stmt = node.body.find((n) => n.type === "functionCall");
+    expect(stmt).toMatchObject({ type: "functionCall", functionName: "schema" });
+  });
+
+  it("assignment target: chained schema flips to a schemaExpression-based access", () => {
+    // The assignment-target parser (parsers.ts:~3590) consumes
+    // _valueAccessParser, so it sees the new shape too: the target of
+    // `schema(number).foo = 5` was functionCall-based before this change.
+    // Semantic nonsense either way (checker rejects); this pins the parse
+    // shape so the change is deliberate, not incidental.
+    const parsed = parseAgency("node main() {\n  schema(number).foo = 5\n  return 1\n}", {}, false);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw new Error("unreachable");
+    const node = parsed.result.nodes.find((n) => n.type === "graphNode") as GraphNodeDefinition;
+    const assignment = node.body.find((n) => n.type === "assignment") as Assignment;
+    expect(assignment.target ?? assignment.lhs).toMatchObject({
+      type: "valueAccess",
+      base: { type: "schemaExpression" },
+    });
+  });
+```
+
+NOTE for the executor: as in Task 1, verify the AST field names (`assignment.target` vs `lhs`, statement node types) against `pnpm run ast` output before running; the assertion intents must not be weakened.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run lib/parsers/expression.test.ts > /tmp/i480-task2-red.log 2>&1`
+Expected: the chained-statement test FAILS (parses today as `functionCall("schema")`, so the `toMatchObject` on `valueAccess` fails); the bare-statement pin PASSES already (it pins current behavior that must survive the change); the assignment-target pin FAILS (target is functionCall-based today).
+
+- [ ] **Step 3: Implement.** In `_valueAccessParser`, after the `parenAccessParser` attempt and before the general `seqC`:
+
+```ts
+  // Schema-with-chain must be tried before the general base parsers:
+  // `schema(number)` also matches _functionCallParser (as a call to an
+  // undefined function named `schema`), which would mis-tag the base.
+  // Call-time reference: schemaAccessParser is defined later in the module,
+  // which is safe inside a function body (module fully initialized before
+  // any parse runs) but would TDZ as a module-init value dependency.
+  const schemaResult = schemaAccessParser(input);
+  if (schemaResult.success) return schemaResult;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run lib/parsers/expression.test.ts lib/parsers > /tmp/i480-task2-green.log 2>&1`
+Expected: PASS across the parser suite (bare `schema(T)` statements still take the legacy functionCall path — only the chained form changed shape).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/expression.test.ts
+git commit -m "Statement-position schema chains parse as schemaExpression-based access"
+```
+
+---
+
+### Task 3: Checker pin + formatter round-trip
+
+**Files:**
+- Test: `lib/typeChecker/schemaType.test.ts`, `lib/backends/agencyGenerator.test.ts`
+
+**Interfaces:**
+- Consumes: parsing from Tasks 1-2. NO checker/formatter code changes expected — these pins prove the existing generic paths compose.
+
+- [ ] **Step 1: Checker pin** — append to `lib/typeChecker/schemaType.test.ts`, adapting to that file's existing parse+typeCheck helper (if none, use the `check(source)` shape from `lib/typeChecker/matchExpression.test.ts:8-13`):
+
+```ts
+it("chained schema(...).parseJSON types like the bind-first form (issue #480)", () => {
+  // One deliberate error pins that the chained call is Result-typed
+  // (a bare `any` would silently pass the annotation).
+  const errs = check(`node main() {
+  const chained = schema(number).parseJSON("5")
+  const s = schema(number)
+  const bound = s.parseJSON("5")
+  const n: number = schema(number).parseJSON("5")
+  return 1
+}`);
+  expect(errs.length).toBe(1);
+  expect(errs[0]).toMatch(/not assignable/);
+});
+```
+
+- [ ] **Step 2: Formatter round-trip** — add to the round-trip `testCases` table in `lib/backends/agencyGenerator.test.ts` (same shape as the intersection rows):
+
+```ts
+{
+  description: "schema chaining round-trips",
+  input: 'def f(x: string) { const r = schema(number).parseJSON(x) }',
+  expectedOutput: 'def f(x: string) {\nconst r = schema(number).parseJSON(x)\n}',
+},
+```
+
+- [ ] **Step 3: Run both**
+
+Run: `npx vitest run lib/typeChecker/schemaType.test.ts lib/backends/agencyGenerator.test.ts > /tmp/i480-task3.log 2>&1`
+Expected: PASS with zero production-code changes. If either fails, STOP and diagnose — a failure here means the spec's "downstream is ready" claim is wrong and the fix needs a checker/formatter case, which is a plan deviation to record.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/typeChecker/schemaType.test.ts lib/backends/agencyGenerator.test.ts
+git commit -m "Pin checker typing and formatter round-trip for chained schema access"
+```
+
+---
+
+### Task 4: Execution test + codegen fixture
+
+**Files:**
+- Create: `tests/agency/schema-chaining.agency`, `tests/agency/schema-chaining.test.json`
+- Create: `tests/typescriptGenerator/schemaChaining.agency` (+ generated `.mjs`)
+
+- [ ] **Step 1: Execution test.** Create `tests/agency/schema-chaining.agency`:
+
+```
+// Issue #480: method calls chained directly on schema(...) expressions.
+// The accept node uses a type-grammar argument (number[]) that could never
+// parse as a call argument, proving the chained form goes through the
+// schema atom. No LLM calls.
+
+node chainedAccept() {
+  const r = schema(number[]).parseJSON("[1,2,3]")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "failed"
+}
+
+node chainedReject() {
+  const r = schema(number).parseJSON("\"not a number\"")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}
+```
+
+And `tests/agency/schema-chaining.test.json`:
+
+```json
+{
+  "sourceFile": "schema-chaining.agency",
+  "tests": [
+    {
+      "nodeName": "chainedAccept",
+      "input": "",
+      "expectedOutput": "[1,2,3]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Chained parseJSON accepts and returns the parsed value"
+    },
+    {
+      "nodeName": "chainedReject",
+      "input": "",
+      "expectedOutput": "rejected",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Chained parseJSON rejects a type mismatch"
+    }
+  ]
+}
+```
+
+Mirror how sibling tests get their committed `.js` (schema-param-injection.js exists — check `docs/misc/TESTING.md` / `make fixtures` for whether it is generated or committed by hand) and produce it the same way.
+
+- [ ] **Step 2: Run the execution test**
+
+Run: `pnpm run agency test tests/agency/schema-chaining.agency > /tmp/i480-task4-exec.log 2>&1`
+Expected: both nodes PASS. (Single-file agency tests are fine locally; no LLM calls involved.)
+
+- [ ] **Step 3: Codegen fixture.** Create `tests/typescriptGenerator/schemaChaining.agency`:
+
+```
+node main() {
+  const r = schema(number).parseJSON("[1]")
+  print(r)
+}
+```
+
+Run `make fixtures > /tmp/i480-task4-fixtures.log 2>&1`, then `git status --porcelain tests/typescriptGenerator/` — expected: ONLY `schemaChaining.agency` + its new `.mjs` appear. Any other fixture churn is a regression; STOP and diagnose. Eyeball the generated `.mjs`: the chained call must appear as a schema construction with `.parseJSON(...)` on it, not a call to a function named `schema`.
+
+- [ ] **Step 4: Run the fixture suite**
+
+Run: `npx vitest run lib/backends > /tmp/i480-task4-backends.log 2>&1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/agency/schema-chaining.agency tests/agency/schema-chaining.test.json tests/agency/schema-chaining.js tests/typescriptGenerator/schemaChaining.agency tests/typescriptGenerator/schemaChaining.mjs
+git commit -m "Execution test and codegen fixture for chained schema access"
+```
+
+(Adjust the `git add` list to whatever artifacts the conventions actually produce.)
+
+---
+
+### Task 5: Full verification + PR
+
+- [ ] **Step 1: Build + linter + full lib suite**
+
+```bash
+make > /tmp/i480-task5-make.log 2>&1
+pnpm run lint:structure > /tmp/i480-task5-lint.log 2>&1
+npx vitest run lib > /tmp/i480-task5-tests.log 2>&1
+```
+Expected: all clean. `make` compiling the full stdlib is the strongest regression guard for the new `baseAtom` alternative. Revert any `docs/site/stdlib/data/usaspending.md` drift; delete any `a.vs.b.verdict.json`.
+
+- [ ] **Step 2: Commit spec + plan docs to the branch** (repo-root `docs/superpowers/{specs,plans}` copies, as in prior PRs).
+
+- [ ] **Step 3: Push and open the PR.** Body must include: `Fixes #480`; the two-site design and the `peek(".")`-commit rationale (bare schema untouched, dot = user intent, targeted `parseError` message with the exact text); the DELIBERATE statement-position shape change (functionCall("schema") → schemaExpression-based valueAccess) with its pin; the owner-requested parseError usage; scope-outs (`new Foo().bump()` sibling gap; non-dot chain heads on schema literals stay non-committal). Title: "Parse method chains on schema(...) expressions (#480)".
+
+---
+
+## Self-review notes
+
+- Spec coverage: design/two sites → Tasks 1-2; parseError (owner ask) → Task 1 (message + pin); deliberate statement shape change → Task 2; downstream-ready claims → Task 3 pins (with a STOP if wrong); tests 1-5 of the spec → Tasks 1-4; non-goals need no task.
+- The `peek(".")` commit is narrower than the spec's plain `many1` sketch — it is what makes the owner's parseError request safe (no hard failure on bare `schema(T)`); recorded here as the plan-level refinement of the spec, to be called out in the PR body.
+- Known transcription checkpoints flagged inline (chain-element field names, parse-failure message field, `.js` artifact convention, `withLoc`) — each has a concrete resolution instruction, not a TBD.
+- Type consistency: `schemaAccessParser` name and `Parser<ValueAccess>` shape consistent across Tasks 1-2; test helper names local to each file.
+- Review round (2026-07-11, `2026-07-11-schema-chaining-review.md`) incorporated: gate widened from `peek(char("."))` to `peek(dotParser)` so `?.` chains commit; statement-position bare-schema pin and assignment-target shape pin added to Task 2; helper-skeleton verification extended in the Task 1 NOTE; `git fetch origin` added to worktree setup; whitespace/hard-commit safety arguments recorded in the parser doc comment.

--- a/docs/superpowers/specs/2026-07-11-schema-chaining-design.md
+++ b/docs/superpowers/specs/2026-07-11-schema-chaining-design.md
@@ -30,26 +30,41 @@ as a base.
 ## Design (Approach A — approved)
 
 One new parser that COMPOSES the two existing ones, mirroring the established
-`parenAccessParser` idiom (`(expr).chain`):
+`parenAccessParser` idiom (`(expr).chain`). As-shipped (plan-level refinement,
+recorded in the plan self-review): the gate is `peek(dotParser)` rather than
+bare `many1`, and the chain is `parseError`-wrapped — once the dot is seen the
+user unambiguously meant a chain, so a malformed tail is a targeted hard error
+instead of the stranded-suffix failure. `withLoc` was added in PR review
+(expression position does not flow through `valueAccessParser`'s wrap):
 
 ```ts
-// `schema(T).method(...)...` — a schema expression used as an access-chain
-// base. many1 is the gate: bare `schema(T)` never matches here, so the plain
-// schemaExpressionParser alternatives (and everything that consumes them)
-// keep their exact current behavior. Mirrors parenAccessParser.
-const schemaAccessParser: Parser<ValueAccess> = map(
-  seqC(
-    capture(schemaExpressionParser, "base"),
-    capture(many1(chainElementParser), "chain"),
-  ),
-  (result) =>
-    ({
-      type: "valueAccess" as const,
-      base: result.base as unknown as AgencyNode,
-      chain: result.chain,
-    }) as ValueAccess,
+const schemaAccessParser: Parser<ValueAccess> = memo(
+  "schemaAccessParser",
+  withLoc(map(
+    seqC(
+      capture(schemaExpressionParser, "base"),
+      peek(dotParser),
+      captureCaptures(
+        parseError(
+          "expected a method call after schema(...), e.g. schema(number).parseJSON(input)",
+          capture(many1(chainElementParser), "chain"),
+        ),
+      ),
+    ),
+    (result) =>
+      ({
+        type: "valueAccess" as const,
+        base: result.base as unknown as AgencyNode,
+        chain: result.chain,
+      }) as ValueAccess,
+  )),
 );
 ```
+
+One consequence found during red-first execution and deliberately accepted
+(pinned): `const r = schema(number).123` previously parsed as two statements
+(`const r = schema(number)` followed by a bare float-literal statement
+`.123`); it is now the targeted parse error above.
 
 Inserted at exactly two sites:
 

--- a/docs/superpowers/specs/2026-07-11-schema-chaining-design.md
+++ b/docs/superpowers/specs/2026-07-11-schema-chaining-design.md
@@ -1,0 +1,138 @@
+# Chained method calls on `schema(...)` expressions (issue #480)
+
+**Issue:** #480 — `const r = schema(number).parseJSON("[1]")` fails to parse
+("expected node body"); the workaround is binding the schema to a variable
+first. Found while writing the utility-types execution tests (#478).
+
+## Root cause (verified by repro, 2026-07-11)
+
+Same failure class as the intersection-item parser bug fixed in #502: an
+`or()` alternative commits to a prefix and strands the suffix.
+
+- In the expression grammar's `baseAtom` (`lib/parsers/parsers.ts`),
+  `schemaExpressionParser` is ordered before `valueAccessParser`. For
+  `schema(number).parseJSON("[1]")` it succeeds on `schema(number)` and
+  returns, leaving `.parseJSON("[1]")` unconsumed — the enclosing statement
+  parse then fails.
+- The value-access machinery can't rescue it: `_valueAccessParser`'s base
+  alternatives are `_functionCallParser | variableNameParser`; a schema
+  expression is not an admissible chain base.
+
+`schema` cannot simply be parsed as a regular function call (owner question,
+settled during brainstorm): its argument is written in the TYPE grammar, not
+the value grammar. `schema(number[])`, `schema(string | null)`,
+`schema(Record<string, number>)`, and `schema({name: string, age?: number})`
+are all legal today and none of them parse as call arguments. `schema(...)`
+is a keyword form (like TS `typeof`), so the schema atom must exist
+regardless; this fix is about letting the existing chain machinery accept it
+as a base.
+
+## Design (Approach A — approved)
+
+One new parser that COMPOSES the two existing ones, mirroring the established
+`parenAccessParser` idiom (`(expr).chain`):
+
+```ts
+// `schema(T).method(...)...` — a schema expression used as an access-chain
+// base. many1 is the gate: bare `schema(T)` never matches here, so the plain
+// schemaExpressionParser alternatives (and everything that consumes them)
+// keep their exact current behavior. Mirrors parenAccessParser.
+const schemaAccessParser: Parser<ValueAccess> = map(
+  seqC(
+    capture(schemaExpressionParser, "base"),
+    capture(many1(chainElementParser), "chain"),
+  ),
+  (result) =>
+    ({
+      type: "valueAccess" as const,
+      base: result.base as unknown as AgencyNode,
+      chain: result.chain,
+    }) as ValueAccess,
+);
+```
+
+Inserted at exactly two sites:
+
+1. **`baseAtom`** — immediately BEFORE `schemaExpressionParser`, so
+   expression positions (assignment RHS, arguments, returns, pipe operands)
+   try the chained form first and fall back to the bare atom.
+2. **`_valueAccessParser`** — immediately after the `parenAccessParser`
+   attempt, so statement position works too (the body parser calls
+   `_valueAccessParser` directly, bypassing `baseAtom`). This is a DELIBERATE
+   behavior change to an already-parsing form (repro-verified 2026-07-11): a
+   statement-position `schema(T).method()` parses TODAY, but as a call to an
+   undefined function named `schema` with the chain hung off it — wrong node
+   kind, undefined-function diagnostics, wrong codegen. Schema-with-chain now
+   wins first and produces the correct `schemaExpression`-based access. A
+   parse pin covers the old-vs-new shape explicitly.
+
+No AST changes: `ValueAccess.base` is already `AgencyNode`
+(`lib/types/access.ts:13`). No parser return-type changes: a chained schema
+is always wrapped in `ValueAccess` (the `many1` gate guarantees it).
+
+### Why not the alternatives
+
+- **B (schema as a general value-access base):** the no-chain case would
+  return a bare `SchemaExpression` from `_valueAccessParser`, widening its
+  return union and silently changing what statement position, `try schema(...)`,
+  and the assignment-target parser see. All probably benign, each needing
+  audit + pins — a day of edge verification to avoid ~6 lines.
+- **C (general postfix-chain level over all atoms):** the textbook grammar
+  (would also fix the `new Foo().bump()` sibling gap, which today needs
+  parens), but it changes chaining behavior for every atom kind at once.
+  Out of proportion for this issue; the `new` gap stays a known non-goal.
+
+### Downstream (verified ready, pinned by tests rather than changed)
+
+- **Checker:** `synthValueAccess` resolves the base generically via
+  `synthType(expr.base, ...)`, and the `schemaExpression` case already
+  produces `Schema<T>`; the chain walk then types `.parse`/`.parseJSON` as it
+  does for a bound variable. Expected: chained and bind-first forms type
+  identically.
+- **Codegen:** `processValueAccess` (typescriptBuilder.ts) emits the base via
+  the generic expression path; `schemaExpression` has its own emit case.
+- **Flow/narrowing:** `asPathReference`/`narrowedPathPrefix` gate on
+  `base.type === "variableName"`, so a schema base simply never narrows —
+  safe by construction.
+- **Formatter:** `AgencyGenerator` prints `ValueAccess` generically and has a
+  `schemaExpression` case; a round-trip test pins the composition.
+
+### Performance
+
+`schemaAccessParser` is anchored on the literal `schema(` and fails within
+one token on all other input; `chainElementParser` is memoized. No benchmark
+gate needed (no new backtracking level); the full parse-test suite is the
+guard.
+
+## Non-goals
+
+- `new Foo().bump()` without parens (sibling gap, same class — file or fold
+  into a future postfix-level change if it ever hurts).
+- Any change to bare `schema(T)` parsing, in any position.
+- Schema-method TYPE improvements (e.g. what `.parseJSON` returns) — the
+  checker's existing behavior is pinned as-is, not extended.
+
+## Tests (red-first)
+
+1. **Parse pins** (new `lib/parsers/schemaChaining.test.ts` or appended to
+   the existing schema parse tests): chained call parses as `valueAccess`
+   with `schemaExpression` base + call chain — RED on main with the exact
+   "expected node body" class failure. Rows: `schema(number).parseJSON("[1]")`
+   (expression position), the same in statement position, a type-grammar arg
+   (`schema({a: number}).parse(x)`), a two-element chain
+   (`schema(number).parseJSON("5").value`), and bare `schema(number)`
+   unchanged (still a plain `schemaExpression`, both positions).
+2. **Checker pin:** the chained form synthesizes the same type as the
+   bind-first form (both `Result`-typed from `parseJSON`); no new
+   diagnostics.
+3. **Execution test** (`tests/agency/`): chained `parseJSON` accept AND
+   reject paths return the same Results as the bind-first form (no LLM
+   calls).
+4. **Codegen fixture** (`tests/typescriptGenerator/`): one golden file with
+   the chained form; zero churn elsewhere.
+5. **Formatter round-trip** (`agencyGenerator.test.ts`):
+   `schema(number).parseJSON("[1]")` prints back exactly.
+
+## Estimated size
+
+~15 lines of parser code, ~5 test files touched. Half a day including the PR.

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -130,6 +130,12 @@ describe("AgencyGenerator - Function Parameter Type Hints", () => {
         input: 'def f(x: (A & B)["id"]) { x }',
         expectedOutput: 'def f(x: (A & B)["id"]) {\nx\n}',
       },
+
+      {
+        description: "schema chaining round-trips (issue #480)",
+        input: 'def f(x: string) { const r = schema(number).parseJSON(x) }',
+        expectedOutput: 'def f(x: string) {\n  const r = schema(number).parseJSON(x)\n}',
+      },
     ];
 
     testCases.forEach(({ description, input, expectedOutput }) => {

--- a/packages/agency-lang/lib/parsers/expression.test.ts
+++ b/packages/agency-lang/lib/parsers/expression.test.ts
@@ -422,7 +422,20 @@ describe("exprParser", () => {
           base: { type: "schemaExpression", typeArg: { type: "primitiveType", value: "number" } },
           chain: [{ kind: "methodCall", functionCall: { functionName: "parseJSON" } }],
         });
+        // Unlike variable-base access, this path does not flow through
+        // valueAccessParser's withLoc wrap — schemaAccessParser carries its
+        // own. Without it, downstream diagnostics (e.g. Result-field guard
+        // errors on the chain) anchor to loc: undefined.
+        expect(result.result.loc).toBeDefined();
       }
+    });
+
+    it("try on a chained schema call parses as tryExpression", () => {
+      // Newly parses with this change (tryExpressionParser captures
+      // valueAccessParser, which now routes through the schema branch).
+      // Pinned so a future parser reshuffle cannot silently drop it.
+      const parsed = parseAgency('node main() {\n  const r = try schema(number).parseJSON("5")\n  return r\n}', {}, false);
+      expect(parsed.success).toBe(true);
     });
 
     it("accepts a type-grammar argument on the chained form", () => {

--- a/packages/agency-lang/lib/parsers/expression.test.ts
+++ b/packages/agency-lang/lib/parsers/expression.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { exprParser } from "./parsers.js";
+import { parseAgency } from "../parser.js";
 
 describe("exprParser", () => {
   describe("atoms", () => {
@@ -407,6 +408,66 @@ describe("exprParser", () => {
         if (result.result.type === "schemaExpression") {
           expect(result.result.typeArg.type).toBe("objectType");
         }
+      }
+    });
+  });
+
+  describe("schema(...) chaining (issue #480)", () => {
+    it("parses a chained call in expression position", () => {
+      const result = exprParser('schema(number).parseJSON("[1]")');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toMatchObject({
+          type: "valueAccess",
+          base: { type: "schemaExpression", typeArg: { type: "primitiveType", value: "number" } },
+          chain: [{ kind: "methodCall", functionCall: { functionName: "parseJSON" } }],
+        });
+      }
+    });
+
+    it("accepts a type-grammar argument on the chained form", () => {
+      const result = exprParser('schema(number[]).parseJSON("[1]")');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toMatchObject({
+          type: "valueAccess",
+          base: { type: "schemaExpression", typeArg: { type: "arrayType" } },
+        });
+      }
+    });
+
+    it("parses a two-element chain", () => {
+      const result = exprParser('schema(number).parseJSON("5").value');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toMatchObject({
+          type: "valueAccess",
+          base: { type: "schemaExpression" },
+        });
+        if (result.result.type === "valueAccess") {
+          expect(result.result.chain).toHaveLength(2);
+          expect(result.result.chain[1]).toMatchObject({ kind: "property", name: "value" });
+        }
+      }
+    });
+
+    it("commits on an optional-chain head too", () => {
+      const result = exprParser('schema(number)?.parseJSON("[1]")');
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toMatchObject({
+          type: "valueAccess",
+          base: { type: "schemaExpression" },
+          chain: [{ kind: "methodCall", optional: true, functionCall: { functionName: "parseJSON" } }],
+        });
+      }
+    });
+
+    it("a malformed chain after the dot is a targeted parse error", () => {
+      const parsed = parseAgency("node main() {\n  const r = schema(number).123\n  return r\n}", {}, false);
+      expect(parsed.success).toBe(false);
+      if (!parsed.success) {
+        expect(parsed.message).toContain("expected a method call after schema(...)");
       }
     });
   });

--- a/packages/agency-lang/lib/parsers/expression.test.ts
+++ b/packages/agency-lang/lib/parsers/expression.test.ts
@@ -470,6 +470,45 @@ describe("exprParser", () => {
         expect(parsed.message).toContain("expected a method call after schema(...)");
       }
     });
+
+    function mainBody(source: string) {
+      const parsed = parseAgency(`node main() {\n  ${source}\n  return 1\n}`, {}, false);
+      expect(parsed.success).toBe(true);
+      if (!parsed.success) throw new Error("unreachable");
+      const node = parsed.result.nodes.find((n) => n.type === "graphNode");
+      if (!node || node.type !== "graphNode") throw new Error("no graphNode");
+      return node.body;
+    }
+
+    it("statement position: chain on schema(...) is a schemaExpression-based access, not a call to schema", () => {
+      // Parsed as functionCall("schema") with the chain attached before this
+      // change — wrong node kind (undefined function, wrong codegen).
+      // Deliberate shape change, spec section Design/site 2.
+      const stmt = mainBody('schema(number).parseJSON("[1]")').find(
+        (n) => n.type === "valueAccess" || n.type === "functionCall",
+      );
+      expect(stmt).toMatchObject({
+        type: "valueAccess",
+        base: { type: "schemaExpression" },
+        chain: [{ kind: "methodCall", functionCall: { functionName: "parseJSON" } }],
+      });
+    });
+
+    it("statement position: bare schema(T) keeps its legacy functionCall shape", () => {
+      // The peek(dotParser) gate exists to preserve exactly this: a chainless
+      // schema(T) statement still parses as a call to `schema` (the checker
+      // flags it as reserved), NOT as a schemaExpression statement.
+      const stmt = mainBody("schema(number)").find((n) => n.type === "functionCall");
+      expect(stmt).toMatchObject({ type: "functionCall", functionName: "schema" });
+    });
+
+    it("assignment target: schema(T).foo = x still fails to parse", () => {
+      // The assignment parser rejects any non-variableName base ("assignment
+      // target must start with a variable name"), so this fails identically
+      // before and after schema chains became parseable.
+      const parsed = parseAgency("node main() {\n  schema(number).foo = 5\n  return 1\n}", {}, false);
+      expect(parsed.success).toBe(false);
+    });
   });
 
   describe("parens followed by an access chain", () => {

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2681,7 +2681,7 @@ export const schemaExpressionParser: Parser<SchemaExpression> = memo(
  */
 export const schemaAccessParser: Parser<ValueAccess> = memo(
   "schemaAccessParser",
-  map(
+  withLoc(map(
     seqC(
       capture(schemaExpressionParser, "base"),
       peek(dotParser),
@@ -2698,7 +2698,7 @@ export const schemaAccessParser: Parser<ValueAccess> = memo(
         base: result.base as unknown as AgencyNode,
         chain: result.chain,
       }) as ValueAccess,
-  ),
+  )),
 );
 
 const baseAtom: Parser<Expression> = or(

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2489,6 +2489,15 @@ export const _valueAccessParser: Parser<VariableNameLiteral | FunctionCall | Val
   const parenResult = parenAccessParser(input);
   if (parenResult.success) return parenResult;
 
+  // Schema-with-chain must be tried before the general base parsers:
+  // `schema(number)` also matches _functionCallParser (as a call to an
+  // undefined function named `schema`), which would mis-tag the base.
+  // Call-time reference: schemaAccessParser is defined later in the module,
+  // which is safe inside a function body (the module is fully initialized
+  // before any parse runs) but would TDZ as a module-init value dependency.
+  const schemaResult = schemaAccessParser(input);
+  if (schemaResult.success) return schemaResult;
+
   const parser = seqC(
     capture(or(_functionCallParser, variableNameParser), "base"),
     capture(many(chainElementParser), "chain"),

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2653,12 +2653,52 @@ export const schemaExpressionParser: Parser<SchemaExpression> = memo(
   ),
 );
 
+/**
+ * `schema(T).method(...)...` — a schema expression as an access-chain base
+ * (issue #480). The peek(dotParser) gate — `.` or `?.`, exactly the heads
+ * dotMethodCallParser accepts — keeps bare `schema(T)` on its existing path
+ * in every position. Once a dot is seen the user unambiguously meant a
+ * chain (`schema` is a reserved function name), so a malformed tail is a
+ * hard, targeted parse error (parseError throws TarsecError; parseAgency
+ * converts it to a message) instead of a backtrack into the stranded-suffix
+ * "expected node body" failure. The one form this newly rejects is
+ * `schema(T)` immediately followed by a leading-dot float statement
+ * (`schema(number).123` used to parse as two statements); the targeted
+ * error is the better outcome there. Mirrors parenAccessParser; the commit
+ * shape mirrors angleBracketsArrayTypeParser. Non-dot chain heads
+ * (`[i]`, `(args)`) stay non-committal and fall through to the bare atom.
+ * Chains never allow whitespace before the dot (dotParser starts at the
+ * dot, for every base), so the peek loses no multiline forms.
+ */
+export const schemaAccessParser: Parser<ValueAccess> = memo(
+  "schemaAccessParser",
+  map(
+    seqC(
+      capture(schemaExpressionParser, "base"),
+      peek(dotParser),
+      captureCaptures(
+        parseError(
+          "expected a method call after schema(...), e.g. schema(number).parseJSON(input)",
+          capture(many1(chainElementParser), "chain"),
+        ),
+      ),
+    ),
+    (result) =>
+      ({
+        type: "valueAccess" as const,
+        base: result.base as unknown as AgencyNode,
+        chain: result.chain,
+      }) as ValueAccess,
+  ),
+);
+
 const baseAtom: Parser<Expression> = or(
   unaryTypeofParser,
   unaryVoidParser,
   unaryNotParser,
   tryExpressionParser,
   newExpressionParser,
+  schemaAccessParser,
   schemaExpressionParser,
   lazy(() => interruptExprParser),
   lazy(() => agencyArrayParser),

--- a/packages/agency-lang/lib/typeChecker/schemaType.test.ts
+++ b/packages/agency-lang/lib/typeChecker/schemaType.test.ts
@@ -96,4 +96,38 @@ describe("Schema<T> type synthesis", () => {
     );
     expect(mismatch).toEqual([]);
   });
+
+  it("chained schema(...).parseJSON types like the bind-first form (issue #480)", () => {
+    // The chained form (no intermediate binding) must synth the same
+    // Result<number, any> the bind-first form does: assigning it to a
+    // Result binding is clean, and assigning it to a bare number errors
+    // (a silent `any` would pass both, so the error is the real pin).
+    const clean = errorsFrom(
+      [
+        "node main() {",
+        '  let chained: Result<number, any> = schema(number).parseJSON("5")',
+        "  let s = schema(number)",
+        '  let bound: Result<number, any> = s.parseJSON("5")',
+        "  print(chained)",
+        "  print(bound)",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    expect(clean.filter((e) => e.severity !== "warning")).toEqual([]);
+
+    const errors = errorsFrom(
+      [
+        "node main() {",
+        '  let n: number = schema(number).parseJSON("5")',
+        "  print(n)",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    const mismatch = errors.filter(
+      (e) => e.message.includes("Result") && e.message.includes("number"),
+    );
+    expect(mismatch.length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/agency-lang/tests/agency/schema-chaining.agency
+++ b/packages/agency-lang/tests/agency/schema-chaining.agency
@@ -1,0 +1,20 @@
+// Issue #480: method calls chained directly on schema(...) expressions.
+// The accept node uses a type-grammar argument (number[]) that could never
+// parse as a call argument, proving the chained form goes through the
+// schema atom. No LLM calls.
+
+node chainedAccept() {
+  const r = schema(number[]).parseJSON("[1,2,3]")
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "failed"
+}
+
+node chainedReject() {
+  const r = schema(number).parseJSON("\"not a number\"")
+  if (isFailure(r)) {
+    return "rejected"
+  }
+  return "accepted"
+}

--- a/packages/agency-lang/tests/agency/schema-chaining.test.json
+++ b/packages/agency-lang/tests/agency/schema-chaining.test.json
@@ -1,0 +1,19 @@
+{
+  "sourceFile": "schema-chaining.agency",
+  "tests": [
+    {
+      "nodeName": "chainedAccept",
+      "input": "",
+      "expectedOutput": "[1,2,3]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Chained parseJSON accepts and returns the parsed value"
+    },
+    {
+      "nodeName": "chainedReject",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Chained parseJSON rejects a type mismatch"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.agency
@@ -1,0 +1,4 @@
+node main() {
+  const r = schema(number).parseJSON("[1]")
+  print(r)
+}

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -1,0 +1,294 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "agency-lang/zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import os from "os";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
+  RestoreSignal,
+  AgencyAbort,
+  deepClone as __deepClone,
+  deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult, __eq,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  functionRefReviver as __functionRefReviver,
+  DeterministicClient as __DeterministicClient,
+  installFetchMock as __installFetchMock,
+  createLogger as __createLogger,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false,
+    observability: false
+  },
+  smoltalkDefaults: {
+    apiKey: {
+      openAi: __process.env["OPENAI_API_KEY"] || "",
+      google: __process.env["GEMINI_API_KEY"] || "",
+      anthropic: __process.env["ANTHROPIC_API_KEY"] || "",
+      openRouter: __process.env["OPENROUTER_API_KEY"] || "",
+      deepInfra: __process.env["DEEPINFRA_API_KEY"] || "",
+      liteLlm: __process.env["LITELLM_API_KEY"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_API_KEY"] || ""
+    },
+    baseUrl: {
+      liteLlm: __process.env["LITELLM_BASE_URL"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
+    },
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  logLevel: "info",
+  traceConfig: {
+    program: "schemaChaining.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Handler result builtins and interrupt response constructors (unified types)
+export function approve(value?: any) { return { type: "approve" as const, value }; }
+export function reject(value?: any) { return { type: "reject" as const, value }; }
+function propagate() { return { type: "propagate" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, hasInterrupts, isDebugger };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
+export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+// Auto-activate the deterministic LLM client when AGENCY_LLM_MOCKS is set.
+// The test runner (lib/cli/util.ts) populates this env var as a JSON string
+// when AGENCY_USE_TEST_LLM_PROVIDER=1. Both the agency evaluate template
+// and the agency-js test.js paths import this module, so this single block
+// covers both code paths.
+if (__process.env.AGENCY_LLM_MOCKS) {
+  __globalCtx.setLLMClient(
+    new __DeterministicClient(JSON.parse(__process.env.AGENCY_LLM_MOCKS))
+  );
+}
+
+// Auto-activate fetch mocking when AGENCY_FETCH_MOCKS_FILE points at a mocks
+// file. The runner writes resolved mocks (returnFile bodies already inlined) to
+// a temp file and passes its path — a file, not an inline env value, so a large
+// response body can't blow the exec arg/env size limit (ARG_MAX). Independent of
+// AGENCY_LLM_MOCKS — a test may mock the network while using a real LLM, or vice
+// versa. Installed before any node runs, ahead of any http.ts / stdlib / interop
+// fetch.
+if (__process.env.AGENCY_FETCH_MOCKS_FILE) {
+  __installFetchMock(JSON.parse(readFileSync(__process.env.AGENCY_FETCH_MOCKS_FILE, "utf-8")));
+}
+
+// Share a single registry object across every compiled module. With
+// composite "module:name" keys, all modules' helpers — plus
+// runtime-created blocks registered by `AgencyFunction.create` while
+// a function is executing — stay reachable from `FunctionRefReviver`
+// no matter which module touched the registry last.
+export const __toolRegistry: Record<string, any> = (__functionRefReviver.registry ??= {} as any);
+
+function __registerTool(value: unknown, _aliasName?: string) {
+  // Composite "module:name" key keyed off the function's *own*
+  // identity, not the importing module's local alias — so different
+  // modules that import the same function don't shadow each other in
+  // the shared global registry that `FunctionRefReviver` reads from.
+  // `_aliasName` is kept in the signature for backwards compatibility
+  // with already-compiled callers that pass it.
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[`${value.module}:${value.name}`] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const _run = __AgencyFunction.create({ name: "_run", module: "__runtime", fn: __runtime_run_impl, params: [{ name: "compiled", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "node", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "args", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "wallClock", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "memory", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "ipcPayload", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "stdout", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "configOverrides", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "cwd", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "maxDepth", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+
+function registerTools(tools: any[]) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[`${tool.module}:${tool.name}`] = tool;
+    }
+  }
+}
+
+async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("schemaChaining.agency")) {
+    return;
+  }
+  __ctx.globals.markInitialized("schemaChaining.agency")
+}
+__registerGlobalsInit("schemaChaining.agency", __initializeGlobals);
+async function __registerTopLevelCallbacks(__ctx) {
+  __ctx.topLevelCallbacks = [];
+}
+__functionRefReviver.registry = __toolRegistry;
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaChaining.agency", scopeName: "main", threads: __setupData.threads });
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __ctx.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.r = await __callMethod((new Schema(z.number())), "parseJSON", {
+          type: "positional",
+          args: [`[1]`]
+        });
+      });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.r]
+        });
+if (hasInterrupts(__funcResult)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
+    if (runner.halted) return runner.haltResult;
+    await runner.hook(3, async () => {
+await callHook({
+        name: "onNodeEnd",
+        data: {
+          nodeName: "main",
+          data: undefined
+        }
+      })
+    });
+    return {
+      messages: __threads(),
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof AgencyAbort) {
+      throw __error
+    }
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
+    return {
+      messages: __threads(),
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals,
+    registerTopLevelCallbacks: __registerTopLevelCallbacks,
+    moduleDir: __dirname
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    const __result = await main(initialState);
+    reportUnhandledInterrupts(__result)
+  } catch (__error: any) {
+    console.error(`
+Agent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"schemaChaining.agency:main":{"1":{"line":1,"col":2},"2":{"line":2,"col":2}}};


### PR DESCRIPTION
Fixes #480: `const r = schema(number).parseJSON("[1]")` failed to parse ("expected node body") because `baseAtom` committed to the bare `schema(T)` atom and stranded the chain. The workaround was binding the schema to a variable first.

## Design

One new parser, `schemaAccessParser`, composing two existing ones — mirroring the `parenAccessParser` idiom, with the commit shape of `angleBracketsArrayTypeParser`:

- `schemaExpressionParser` + `peek(dotParser)` + `parseError`-wrapped `many1(chainElementParser)`, producing an ordinary `ValueAccess`.
- The `peek(dotParser)` gate (`.` or `?.` — exactly the heads `dotMethodCallParser` accepts) keeps bare `schema(T)` on its existing path in every position.
- Once the dot is seen, the user unambiguously meant a chain (`schema` is a reserved function name), so a malformed tail is a hard, targeted parse error: `expected a method call after schema(...), e.g. schema(number).parseJSON(input)` — instead of the old stranded-suffix failure.

Inserted at two sites:

1. **`baseAtom`** (expression position) — tried before the bare `schemaExpressionParser` atom.
2. **`_valueAccessParser`** (statement position) — tried before the general `_functionCallParser | variableNameParser` bases, which would otherwise mis-tag the base as a call to an undefined function named `schema`.

No AST, checker, codegen, or formatter changes: `ValueAccess.base` is already `AgencyNode`, and all downstream paths resolve the base generically. Test pins prove this (zero production changes outside `parsers.ts`).

## Deliberate behavior changes

- **Statement position** (pinned): `schema(T).method()` used to parse as a `functionCall` named `schema` with the chain attached — wrong node kind, undefined-function diagnostics, wrong codegen. It now parses as a `schemaExpression`-based `ValueAccess`. Bare statement-position `schema(T)` keeps its legacy `functionCall` shape (pinned).
- **Degenerate float statement** (found during red-run, pinned): `const r = schema(number).123` used to parse as two statements — `const r = schema(number)` followed by a bare float-literal statement `.123`. It is now the targeted parse error above. The old parse was almost certainly never intended by anyone; the error is the better outcome.
- **Assignment targets**: `schema(T).foo = x` fails to parse both before and after (the assignment parser rejects any non-variableName base) — pinned.

## Non-goals

- `new Foo().bump()` without parens (sibling gap, same class — fold into a future postfix-level change if it ever hurts).
- Non-dot chain heads on a schema literal (`schema(T)[i]`, `schema(T)(args)`) stay non-committal and fall through to the bare atom.
- Schema-method type improvements (what `.parseJSON` returns is pinned as-is, not extended).

## Tests

- Parse pins (`lib/parsers/expression.test.ts`): chained call in expression and statement position, type-grammar argument (`schema(number[])`), two-element chain, `?.` head, bare-schema unchanged in both positions, assignment-target rejection, targeted error message.
- Checker pin (`lib/typeChecker/schemaType.test.ts`): chained form types identically to the bind-first form (`Result<number, any>`; deliberate mismatch errors).
- Formatter round-trip (`lib/backends/agencyGenerator.test.ts`).
- Execution test (`tests/agency/schema-chaining.agency`): chained `parseJSON` accept and reject paths, no LLM calls; the accept node uses a `number[]` type-grammar argument that could never parse as a call argument.
- Codegen fixture (`tests/typescriptGenerator/schemaChaining.{agency,mjs}`): emits `__callMethod((new Schema(z.number())), "parseJSON", ...)`; zero churn in other fixtures.

Full verification: `make`, `pnpm run lint:structure`, and the full `lib/` vitest suite (7919 passed) are clean.

Spec, plan, and plan review are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
