### PR TITLE
std::agency: writeAgency, review, getEffects, maxCost + std::skills docsSkill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ stdlib/index.ts
 stdlib/array.ts
 stdlib/object.ts
 stdlib/strategy.ts
+# Packaged docs staged into the stdlib by make (stage-stdlib-docs); build
+# output like stdlib/**/*.js, but .md so the broad *.js rule misses it.
+packages/agency-lang/stdlib/docs/
 **/traces/*
 **/statelog.log
 **/log.jsonl

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -29,7 +29,7 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L58))
 
 ### SourceLocation
 
@@ -42,7 +42,7 @@ export type SourceLocation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L62))
 
 ### TypeCheckDiagnostic
 
@@ -57,7 +57,7 @@ export type TypeCheckDiagnostic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L66))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L69))
 
 ### TypeCheckReport
 
@@ -68,7 +68,53 @@ export type TypeCheckReport = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L78))
+
+### EffectsByExport
+
+Per-exported-symbol effect lists, keyed by node/function name.
+
+```ts
+/** Per-exported-symbol effect lists, keyed by node/function name. */
+export type EffectsByExport = Record<string, string[]>
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L268))
+
+### Feedback
+
+One review finding. `error: true` means the code is broken (parse or
+type error, or the reviewer judged it does not do the task); `error:
+false` is advisory feedback, including typecheck warnings.
+
+```ts
+/** One review finding. `error: true` means the code is broken (parse or
+type error, or the reviewer judged it does not do the task); `error:
+false` is advisory feedback, including typecheck warnings. */
+export type Feedback = {
+  error: boolean;
+  feedback: string;
+  data?: any
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L286))
+
+### WriteFailure
+
+The failure payload writeAgency returns on retry exhaustion: the last
+generated source and its typecheck diagnostics.
+
+```ts
+/** The failure payload writeAgency returns on retry exhaustion: the last
+generated source and its typecheck diagnostics. */
+export type WriteFailure = {
+  source: string;
+  errors: TypeCheckDiagnostic[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L426))
 
 ### AST
 
@@ -91,7 +137,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L243))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L532))
 
 ## Effects
 
@@ -104,7 +150,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L40))
 
 ### std::write
 
@@ -115,7 +161,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L44))
 
 ### std::run
 
@@ -124,14 +170,14 @@ effect std::run {
   moduleId: string;
   node: string;
   args: Record<string, any>;
-  limits: { wallClock: number; memory: number; ipcPayload: number; stdout: number };
+  limits: { wallClock: number; memory: number; ipcPayload: number; stdout: number; maxCost: number | null };
   cwd: string;
   logFile: string;
   depth: number
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L48))
 
 ## Functions
 
@@ -153,12 +199,24 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L83))
 
 ### run
 
 ```ts
-run(compiled: CompiledProgram, node: string, args: Record<string, any>, wallClock: number, memory: number, ipcPayload: number, stdout: number, logFile: string, cwd: string, maxDepth: number): Result
+run(
+  compiled: CompiledProgram,
+  node: string,
+  args: Record<string, any> = {},
+  wallClock: number = 60s,
+  memory: number = 512mb,
+  ipcPayload: number = 100mb,
+  stdout: number = 1mb,
+  logFile: string = "",
+  cwd: string = "",
+  maxDepth: number = 5,
+  maxCost: number | null = null,
+): Result
 ```
 
 Execute a compiled Agency program in a subprocess and return the node's result.
@@ -173,12 +231,14 @@ Execute a compiled Agency program in a subprocess and return the node's result.
   @param logFile - Optional statelog JSONL file path for this subprocess run
   @param cwd - Optional working directory for this subprocess run
   @param maxDepth - Max subprocess nesting depth (default 5, hard ceiling 10).
+  @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
 
 Runs agent-generated Agency code in a child process.
 Any interrupts and guards defined in the parent process will
 apply to the child process. Any callbacks in scope will also apply.
 Exceeding a resource limit kills the subprocess and returns a
-limit_exceeded failure.
+limit_exceeded failure. Exceeding maxCost kills the subprocess and
+returns a limit_exceeded failure, like the other limits.
 
 For `maxDepth`, if an ancestor process has a lower maxDepth,
 the lower value is used. For example, if a parent process has maxDepth=3
@@ -198,17 +258,28 @@ and a child process has maxDepth=5, maxDepth=3 is used.
 | logFile | `string` | "" |
 | cwd | `string` | "" |
 | maxDepth | `number` | 5 |
+| maxCost | `number \| null` | null |
 
 **Returns:** `Result`
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L103))
 
 ### runFile
 
 ```ts
-runFile(dir: string, filename: string, node: string, args: Record<string, any>, wallClock: number, memory: number, ipcPayload: number, stdout: number): Result
+runFile(
+  dir: string,
+  filename: string,
+  node: string,
+  args: Record<string, any> = {},
+  wallClock: number = 60s,
+  memory: number = 512mb,
+  ipcPayload: number = 100mb,
+  stdout: number = 1mb,
+  maxCost: number | null = null,
+): Result
 ```
 
 Compile and execute an Agency file in a subprocess and return the node's result.
@@ -222,6 +293,7 @@ Compile and execute an Agency file in a subprocess and return the node's result.
   @param memory - Max V8 heap size (default 512mb, max 4gb)
   @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
   @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
+  @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
 
 Just like `run`, any interrupts and guards defined in the parent process
 will apply to the child process. Any callbacks in scope will also apply.
@@ -239,12 +311,13 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 | memory | `number` | 512mb |
 | ipcPayload | `number` | 100mb |
 | stdout | `number` | 1mb |
+| maxCost | `number \| null` | null |
 
 **Returns:** `Result`
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L167))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L213))
 
 ### typecheck
 
@@ -268,7 +341,150 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L209))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L258))
+
+### getEffects
+
+```ts
+getEffects(source: string): Result<EffectsByExport>
+```
+
+Map each exported node and function in the source to the list of
+  interrupt effects it can raise, transitively. Bare `interrupt(...)`
+  sites appear as the sentinel "unknown", so the envelope never
+  silently under-reports. Use this to show or check what a program can
+  do before running it.
+
+  @param source - Agency source code as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result<EffectsByExport>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L270))
+
+### mergeFeedback
+
+```ts
+mergeFeedback(a: Result<Feedback[]>, b: Result<Feedback[]>): Result<Feedback[]>
+```
+
+Merge two feedback Results by concatenating their success arrays or
+  returning the first failure.
+
+  @param a - First feedback Result
+  @param b - Second feedback Result
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| a | `Result<Feedback[]>` |  |
+| b | `Result<Feedback[]>` |  |
+
+**Returns:** `Result<Feedback[]>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L292))
+
+### review
+
+```ts
+review(source: string, task: string = ""): Result<Feedback[]>
+```
+
+Review Agency source code. Always merges parse and typecheck findings;
+  when a task description is given, an LLM pass also judges whether the
+  code accomplishes the task.
+
+  @param source - Agency source code as a string
+  @param task - Optional description of what the code should do
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+| task | `string` | "" |
+
+**Returns:** `Result<Feedback[]>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L363))
+
+### renderFeedback
+
+```ts
+renderFeedback(feedback: Result<Feedback[]>): string
+```
+
+Render a feedback Result as human-readable text, one line per finding.
+
+  @param feedback - The Result review() returned
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| feedback | `Result<Feedback[]>` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L394))
+
+### feedbackHasErrors
+
+```ts
+feedbackHasErrors(feedback: Result<Feedback[]>): boolean
+```
+
+True when any finding is an error, or when the feedback Result itself
+  is a failure.
+
+  @param feedback - The Result review() returned
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| feedback | `Result<Feedback[]>` |  |
+
+**Returns:** `boolean`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L406))
+
+### writeAgency
+
+```ts
+writeAgency(
+  task: string,
+  context: string = "",
+  maxAttempts: number = 3,
+): Result<string, WriteFailure>
+```
+
+Generate Agency source code for a task description. Typechecks each
+  attempt and feeds diagnostics back to the model, up to maxAttempts
+  tries. Success holds source that compiles and typechecks; on retry
+  exhaustion the failure holds { source, errors } for the last attempt.
+
+  @param task - What the generated program should do
+  @param context - Optional extra material (available data, examples)
+  @param maxAttempts - Max generation attempts before giving up (default 3)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| task | `string` |  |
+| context | `string` | "" |
+| maxAttempts | `number` | 3 |
+
+**Returns:** `Result<string, WriteFailure>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
 
 ### typecheckFile
 
@@ -293,7 +509,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L512))
 
 ### parseAST
 
@@ -313,12 +529,17 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L249))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L538))
 
 ### writeAST
 
 ```ts
-writeAST(ast: AST, dir: string, filename: string, overwrite: boolean): Result
+writeAST(
+  ast: AST,
+  dir: string,
+  filename: string,
+  overwrite: boolean = true,
+): Result
 ```
 
 Format an AST as Agency source and write it to dir/filename. Absolute paths and .. segments cannot escape dir. Symlinks on existing files are followed and re-checked.
@@ -345,7 +566,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L261))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L550))
 
 ### format
 
@@ -365,7 +586,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L283))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L572))
 
 ### formatFile
 
@@ -392,12 +613,12 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L294))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L583))
 
 ### walkAST
 
 ```ts
-walkAST(ast: AST, visitor: (node: any, ancestors: any[]) => any): AST
+walkAST(ast: AST, visitor: (node: any, ancestors: any[]) -> any): AST
 ```
 
 Walk every node in a deep-cloned copy of the AST, invoking the visitor
@@ -421,7 +642,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L313))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L602))
 
 ### getNodesOfType
 
@@ -443,7 +664,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L333))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L622))
 
 ### getImports
 
@@ -463,7 +684,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L343))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L632))
 
 ### getFunctions
 
@@ -483,7 +704,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L352))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L641))
 
 ### getGraphNodes
 
@@ -503,12 +724,18 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L361))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L650))
 
 ### filterImports
 
 ```ts
-filterImports(source: string, allowedPackages: string[], excludedPackages: string[], allowKinds: string[], excludeKinds: string[]): Result<{ source: string; filtered: boolean }>
+filterImports(
+  source: string,
+  allowedPackages: string[] = [],
+  excludedPackages: string[] = [],
+  allowKinds: string[] = [],
+  excludeKinds: string[] = [],
+): Result<{ source: string; filtered: boolean }>
 ```
 
 Filter imports in Agency source code according to the given policy.
@@ -549,7 +776,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L388))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L677))
 
 ### getVersion
 
@@ -561,4 +788,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L414))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L703))

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -79,7 +79,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L268))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L258))
 
 ### Feedback
 
@@ -98,7 +98,7 @@ export type Feedback = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L286))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L276))
 
 ### WriteFailure
 
@@ -114,7 +114,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L426))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L416))
 
 ### AST
 
@@ -137,7 +137,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L532))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L529))
 
 ## Effects
 
@@ -317,7 +317,7 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L213))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L203))
 
 ### typecheck
 
@@ -341,7 +341,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L258))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L248))
 
 ### getEffects
 
@@ -365,7 +365,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L270))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L260))
 
 ### mergeFeedback
 
@@ -388,7 +388,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L292))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L282))
 
 ### review
 
@@ -412,7 +412,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L363))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L353))
 
 ### renderFeedback
 
@@ -432,7 +432,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L394))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L384))
 
 ### feedbackHasErrors
 
@@ -453,7 +453,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L406))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L396))
 
 ### writeAgency
 
@@ -484,7 +484,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L444))
 
 ### typecheckFile
 
@@ -509,7 +509,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L512))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L509))
 
 ### parseAST
 
@@ -529,7 +529,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L538))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L535))
 
 ### writeAST
 
@@ -566,7 +566,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L550))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L547))
 
 ### format
 
@@ -586,7 +586,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L572))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L569))
 
 ### formatFile
 
@@ -613,7 +613,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L583))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L580))
 
 ### walkAST
 
@@ -642,7 +642,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L602))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L599))
 
 ### getNodesOfType
 
@@ -664,7 +664,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L622))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L619))
 
 ### getImports
 
@@ -684,7 +684,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L632))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L629))
 
 ### getFunctions
 
@@ -704,7 +704,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L641))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L638))
 
 ### getGraphNodes
 
@@ -724,7 +724,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L650))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L647))
 
 ### filterImports
 
@@ -776,7 +776,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L677))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L674))
 
 ### getVersion
 
@@ -788,4 +788,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L703))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L700))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -58,7 +58,7 @@ effect std::skills::skillsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L155))
 
 ### std::skills::commandsDir
 
@@ -68,14 +68,14 @@ effect std::skills::commandsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L156))
 
 ## Functions
 
 ### skillsDir
 
 ```ts
-skillsDir(dir: string, layout: "flat" | "standard")
+skillsDir(dir: string, layout: "flat" | "standard" = "standard")
 ```
 
 Build a skills tool for an LLM over a directory of skills.
@@ -92,7 +92,28 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L185))
+
+### docsSkill
+
+```ts
+docsSkill(section: "guide" | "cli")
+```
+
+Build a docs tool for an LLM over the packaged Agency documentation.
+  "guide" serves the language guide (syntax, types, control flow);
+  "cli" serves the CLI reference. The returned tool lists every page in
+  its description and lets the model read any one on demand.
+
+  @param section - Which documentation set to serve: "guide" or "cli".
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| section | `"guide" \| "cli"` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L200))
 
 ### commandsDir
 
@@ -146,7 +167,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L262))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L284))
 
 ### expandSlash
 
@@ -185,4 +206,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L319))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L341))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -83,7 +83,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L253))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L254))
 
 ### ThreadInfo
 
@@ -99,7 +99,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L258))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L259))
 
 ## Functions
 
@@ -146,7 +146,11 @@ Add a user message to the current thread's message history. Use this
 ### image
 
 ```ts
-image(source: string, mimeType: string, base64: boolean): Attachment
+image(
+  source: string,
+  mimeType: string = "",
+  base64: boolean = false,
+): Attachment
 ```
 
 Build an image attachment for a multimodal llm() call. The source is
@@ -171,7 +175,12 @@ Build an image attachment for a multimodal llm() call. The source is
 ### file
 
 ```ts
-file(source: string, filename: string, mimeType: string, base64: boolean): Attachment
+file(
+  source: string,
+  filename: string = "",
+  mimeType: string = "",
+  base64: boolean = false,
+): Attachment
 ```
 
 Build a file (e.g. PDF) attachment for a multimodal llm() call.
@@ -288,12 +297,17 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 ### guard
 
 ```ts
-guard(cost: number | null, time: number | null, block: () => any): Result
+guard(
+  cost: number | null = null,
+  time: number | null = null,
+  block: () -> any = null,
+): Result
 ```
 
 Run a block under a cost limit, a time limit, or both, aborting the
-  block as soon as either limit is exceeded. At least one of `cost` or
-  `time` must be supplied.
+  block as soon as either limit is exceeded. A null or negative value
+  disables that limit, so callers with an optional cap can always pass
+  something; with both limits disabled the block just runs.
 
   Returns a `Result`. On success it holds the block's return value. On a
   trip it holds a failure whose `error.type` is either "guardFailure"
@@ -301,8 +315,8 @@ Run a block under a cost limit, a time limit, or both, aborting the
   "timeoutFailure" (compute time exceeded, read `error.maxTime` and
   `error.actualTime`, in milliseconds).
 
-  @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null = no cost limit.
-  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null = no time limit.
+  @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null or negative = no cost limit.
+  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null or negative = no time limit.
   @param block - The work to run under the guard.
 
   Example:
@@ -353,7 +367,7 @@ Run a block under a cost limit, a time limit, or both, aborting the
 ### listThreads
 
 ```ts
-listThreads(lazySummarize: boolean): Result
+listThreads(lazySummarize: boolean = true): Result
 ```
 
 Return every thread in the current run, including the active one, as a
@@ -381,7 +395,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L330))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L331))
 
 ### currentThreadId
 
@@ -396,12 +410,12 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L383))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L384))
 
 ### getThread
 
 ```ts
-getThread(id: string, offset: number, limit: number): Result
+getThread(id: string, offset: number = 0, limit: number = 50): Result
 ```
 
 Read a slice of a thread's messages. Returns success holding `[]`
@@ -428,4 +442,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L393))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L394))

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -23,7 +23,7 @@ import {
   gitAdd, gitCommit, gitCheckout, gitSwitch, gitBranchCreate, gitBranchDelete,
   gitStashPush, gitStashPop, gitRestore,
  } from "std::git"
-import { skillsDir } from "std::skills"
+import { skillsDir, docsSkill } from "std::skills"
 import { systemMessage } from "std::thread"
 
 import { agentNames } from "../lib/config.agency"
@@ -47,8 +47,11 @@ import { verify, renderGaps, unwrapVerdict } from "./verify.agency"
 // in by leaving the binding in place). See `skills/superpowers/
 // ATTRIBUTION.txt` for the upstream MIT license.
 static const superpowersSkill = skillsDir("./skills/superpowers", "flat") with approve
-static const docSkill = skillsDir("../docs/guide", "flat") with approve
-static const cliSkill = skillsDir("../docs/cli", "flat") with approve
+
+// Packaged language guide + CLI reference via std::skills docsSkill (no
+// startup approval interrupt — the docs ship with the stdlib).
+static const docSkill = docsSkill("guide")
+static const cliSkill = docsSkill("cli")
 
 export def agencyCli(args: string[]): any {
   """

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
@@ -11,7 +11,7 @@
  * and broad. Read-only — no write/edit/bash tools.
  */
 import { ls, glob, grep } from "std::shell"
-import { skillsDir } from "std::skills"
+import { docsSkill } from "std::skills"
 import { systemMessage } from "std::thread"
 
 import { withWebSearch } from "../lib/search.agency"
@@ -21,8 +21,8 @@ import { getSlowModel, getSlowProvider } from "../shared.agency"
 // Relative paths resolve against the agent working directory (set by
 // `agent.agency` at startup), so no per-tool anchoring is needed.
 
-static const docSkill = skillsDir("../docs/guide", "flat") with approve
-static const cliSkill = skillsDir("../docs/cli", "flat") with approve
+static const docSkill = docsSkill("guide")
+static const cliSkill = docsSkill("cli")
 
 export static const explorerSysPrompt = """
 You are the **explorer** — a read-only researcher called by other

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
@@ -1,6 +1,6 @@
 import { typecheck } from "std::agency"
 import { ls, glob, grep } from "std::shell"
-import { skillsDir } from "std::skills"
+import { docsSkill } from "std::skills"
 import { systemMessage } from "std::thread"
 
 import { withWebSearch } from "../lib/search.agency"
@@ -10,8 +10,8 @@ import { getSlowModel, getSlowProvider } from "../shared.agency"
 // Relative paths resolve against the agent working directory (set by
 // `agent.agency` at startup), so no per-tool anchoring is needed.
 
-static const docSkill = skillsDir("../docs/guide", "flat") with approve
-static const cliSkill = skillsDir("../docs/cli", "flat") with approve
+static const docSkill = docsSkill("guide")
+static const cliSkill = docsSkill("cli")
 
 export static const oracleSysPrompt = """
 You are the **oracle** — a senior reviewer called by other agents

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
@@ -13,7 +13,7 @@ import { todoWrite, todoList, handoff } from "std::agent"
 import { filter } from "std::array"
 import { fetch, fetchJSON, fetchMarkdown } from "std::http"
 import { remember, recall, setMemoryId } from "std::memory"
-import { skillsDir } from "std::skills"
+import { docsSkill } from "std::skills"
 import { highlight } from "std::syntax"
 import { systemMessage } from "std::thread"
 import {
@@ -26,19 +26,13 @@ import { agentNames } from "../lib/config.agency"
 import { withWebSearch } from "../lib/search.agency"
 
 
-// Bundled docs live one level above the agent's compiled JS. Built
-// once at module load — `skillsDir` reads + parses every `.md`
-// file's frontmatter and bakes a description listing all available
-// skills into the returned tool. `static` caches this across runs;
-// `with approve` auto-approves the init-time `glob` and `read`
-// interrupts (the binding itself is the user opt-in).
-static const docSkill = skillsDir("../docs/guide", "flat") with approve
-
-// Same pattern for the CLI reference (`agency run`, `agency test`,
-// `agency compile`, ...) and the appendix (built-ins, callbacks,
-// advanced types). Each becomes its own tool so the LLM can pick
-// the right corpus instead of grepping a giant blob of docs.
-static const cliSkill = skillsDir("../docs/cli", "flat") with approve
+// Packaged docs served via std::skills docsSkill (no startup approval
+// interrupt — the docs ship with the stdlib). Built once at module
+// load; `static` caches the tool across runs. Guide and CLI reference
+// are separate tools so the LLM can pick the right corpus instead of
+// grepping a giant blob of docs.
+static const docSkill = docsSkill("guide")
+static const cliSkill = docsSkill("cli")
 
 export static const researchSysPrompt = """
 You are the **research specialist** of a multi-thread Agency-language

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
@@ -1,69 +1,16 @@
-import { typecheck, parseAST } from "std::agency"
-import { map, filter, some } from "std::array"
+import { review as agencyReview, mergeFeedback, renderFeedback } from "std::agency"
 import { setMemoryId } from "std::memory"
-import { systemMessage } from "std::thread"
 
-import { agentNames } from "../lib/config.agency"
+// The review core (parse + typecheck findings, optional LLM code-vs-task
+// judgment, rendering helpers) lives in std::agency now — this subagent
+// only owns the agent-shaped wrapper: extracting snippets from a chat
+// message and reviewing each one. Consumers keep importing the shared
+// surface from this module via the re-export below.
 
-
-// NOTE: `reviewAgent`/`review` typecheck and parse snippets directly and
-// never call the LLM with skill tools (the tool path below is commented
-// out), so the doc `skillsDir(...)` scans this file used to do at module
-// load were pure startup cost with no consumer. Removed. If the LLM tool
-// path is reinstated, build the skills lazily inside `review` (see the
-// other subagents) rather than as eager `static const`s.
+export { renderFeedback, feedbackHasErrors, Feedback } from "std::agency"
 
 type AgencyCode = {
   code: string
-}
-
-export type Feedback = {
-  error: boolean;
-  feedback: string;
-  data?: any
-}
-
-/**
-  * Merges two `Result<Feedback[]>` values by concatenating their success
-  * arrays or returning the first failure. Used to combine typecheck
-  * feedback with LLM-generated feedback.
-  */
-def mergeFeedback(
-  a: Result<Feedback[]>,
-  b: Result<Feedback[]>,
-): Result<Feedback[]> {
-  if (a is success(aVal)) {
-    if (b is success(bVal)) {
-      return success([...aVal, ...bVal])
-    } else {
-      return b
-    }
-  } else {
-    return a
-  }
-}
-
-export def renderSingleFeedback(f: Feedback): string {
-  if (f.error) {
-    return `Error: ${f.feedback}`
-  } else {
-    return `Feedback: ${f.feedback}`
-  }
-}
-
-export def renderFeedback(feedback: Result<Feedback[]>): string {
-  if (feedback is success(val)) {
-    return map(val, renderSingleFeedback).join("\n\n")
-  }
-  return feedback.error
-}
-
-export def feedbackHasErrors(feedback: Result<Feedback[]>): boolean {
-  if (feedback is success(val)) {
-    return some(val, \f -> f.error)
-  }
-  // If the feedback itself is a failure, we can treat that as an error state.
-  return true
 }
 
 export def reviewAgent(userMsg: string, allowHandoff: boolean): string {
@@ -89,83 +36,8 @@ export def review(userMsg: string): Result<Feedback[]> {
     let feedback: Result<Feedback[]> = success([])
 
     for (codeSnippet in snippets) {
-      const parseResult = _parse(codeSnippet.code)
-      const typecheckResult = _typecheck(codeSnippet.code)
-      feedback = mergeFeedback(feedback, parseResult)
-      feedback = mergeFeedback(feedback, typecheckResult)
+      feedback = mergeFeedback(feedback, agencyReview(codeSnippet.code))
     }
-    /*     if (!_first) {
-      systemMessage(reviewSysPrompt)
-      _first = true
-    }
- */
-    /*     const tools = [...reviewTools]
-    const otherAgents = filter(agentNames, \name -> name != "review")
-    if (allowHandoff) {
-      tools.push(handoff.partial(validCategories: otherAgents))
-    }
-    reply = llm(userMsg, {
-      memory: true,
-      tools: tools
-    }) */
   }
   return feedback
-}
-
-def _typecheck(agencyCode: string): Result<Feedback[]> {
-  const result = typecheck(agencyCode)
-  if (result is success(val)) {
-    const { errors, warnings } = val
-    if (errors.length == 0 && warnings.length == 0) {
-      return success(
-        [
-        {
-        error: false,
-        feedback: "Code is valid with no errors or warnings."
-      },
-      ],
-      )
-    }
-    const feedback: Feedback[] = []
-    for (error in errors) {
-      feedback.push(
-        {
-        error: true,
-        feedback: `Error: ${error.message}`,
-        data: error
-      },
-      )
-    }
-    for (warning in warnings) {
-      feedback.push(
-        {
-        error: true,
-        feedback: `Warning: ${warning.message}`,
-        data: warning
-      },
-      )
-    }
-    return success(feedback)
-  }
-  return failure(
-    `Typecheck failed with the following errors:\n\n${JSON.stringify(result.error, null, 2)}`,
-  )
-}
-
-def _parse(agencyCode: string): Result<Feedback[]> {
-  const result = parseAST(agencyCode)
-  if (result is success(val)) {
-    return success(
-      [
-      {
-      error: false,
-      feedback: "Code is valid with no errors or warnings."
-    },
-    ],
-    )
-  }
-
-  return failure(
-    `Parse failed with the following errors:\n\n${JSON.stringify(result.error, null, 2)}`,
-  )
 }

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
@@ -1,13 +1,38 @@
-import { review as agencyReview, mergeFeedback } from "std::agency"
+import {
+  review as agencyReview,
+  mergeFeedback,
+  renderFeedback as stdRenderFeedback,
+  feedbackHasErrors as stdFeedbackHasErrors,
+ } from "std::agency"
 import { setMemoryId } from "std::memory"
 
 // The review core (parse + typecheck findings, optional LLM code-vs-task
 // judgment, rendering helpers) lives in std::agency now — this subagent
 // only owns the agent-shaped wrapper: extracting snippets from a chat
 // message and reviewing each one. Consumers keep importing the shared
-// surface from this module via the re-export below.
+// surface from this module via the type + thin wrappers below.
+//
+// NOT `export { ... } from "std::agency"`: re-exporting the Feedback
+// type alongside functions whose tool schemas reference it generates
+// `const Feedback = _reexport_Feedback` AFTER the tool registrations
+// that use it, so importing the compiled module throws "Cannot access
+// Feedback before initialization" (pre-existing codegen ordering bug;
+// same TDZ family as the prelude-wrapped stdlib re-export carve-outs).
 
-export { renderFeedback, feedbackHasErrors, Feedback } from "std::agency"
+/** Structurally identical to std::agency Feedback. */
+export type Feedback = {
+  error: boolean;
+  feedback: string;
+  data?: any
+}
+
+export def renderFeedback(feedback: Result<Feedback[]>): string {
+  return stdRenderFeedback(feedback)
+}
+
+export def feedbackHasErrors(feedback: Result<Feedback[]>): boolean {
+  return stdFeedbackHasErrors(feedback)
+}
 
 type AgencyCode = {
   code: string

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
@@ -1,4 +1,4 @@
-import { review as agencyReview, mergeFeedback, renderFeedback } from "std::agency"
+import { review as agencyReview, mergeFeedback } from "std::agency"
 import { setMemoryId } from "std::memory"
 
 // The review core (parse + typecheck findings, optional LLM code-vs-task

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -90,7 +90,7 @@ function checkImportPolicy(
   return { success: false, errors: violations };
 }
 
-export { typeCheckSource } from "./typecheck.js";
+export { typeCheckSource, getEffectsFromSource } from "./typecheck.js";
 export type { TypeCheckDiagnostic, TypeCheckReport } from "./typecheck.js";
 
 export function compileSource(

--- a/packages/agency-lang/lib/compiler/typecheck.getEffects.test.ts
+++ b/packages/agency-lang/lib/compiler/typecheck.getEffects.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { getEffectsFromSource } from "./typecheck.js";
+
+describe("getEffectsFromSource", () => {
+  it("reports direct effects on an exported node", () => {
+    const src = `export node main() {\n  write("out.txt", "hi")\n}`;
+    expect(getEffectsFromSource(src)).toEqual({ main: ["std::write"] });
+  });
+
+  it("reports transitive effects through a local def and omits unexported symbols", () => {
+    const src =
+      `def helper() {\n  write("out.txt", "hi")\n}\n` +
+      `export node main() {\n  helper()\n}`;
+    expect(getEffectsFromSource(src)).toEqual({ main: ["std::write"] });
+  });
+
+  it("sorts, dedups, and includes exported defs, not just nodes", () => {
+    const src =
+      `export def helper() {\n` +
+      `  write("a.txt", "hi")\n` +
+      `  write("b.txt", "ho")\n` +
+      `  const x = read("a.txt")\n` +
+      `  return x\n` +
+      `}`;
+    expect(getEffectsFromSource(src)).toEqual({
+      helper: ["std::read", "std::write"],
+    });
+  });
+
+  it("maps a clean exported node to an empty list, not absence", () => {
+    const src = `export node main() {\n  return 1\n}`;
+    expect(getEffectsFromSource(src)).toEqual({ main: [] });
+  });
+
+  it("reports the unknown sentinel for bare interrupts", () => {
+    const src = `export node main() {\n  const ok = interrupt("proceed?")\n  return ok\n}`;
+    expect(getEffectsFromSource(src)).toEqual({ main: ["unknown"] });
+  });
+
+  it("throws on unparseable source", () => {
+    expect(() => getEffectsFromSource("node {{{{")).toThrow();
+  });
+});

--- a/packages/agency-lang/lib/compiler/typecheck.ts
+++ b/packages/agency-lang/lib/compiler/typecheck.ts
@@ -90,10 +90,18 @@ function toDiagnostic(err: TypeCheckErrorShape): TypeCheckDiagnostic {
 // symbol table sees — letting relative imports in `source` resolve against
 // that directory. Otherwise a fresh tempdir is used and relative imports
 // will not resolve.
-export function typeCheckSource(
+/** Shared parse→symbols→resolve→lift→build→check pipeline. Both
+ * typeCheckSource and getEffectsFromSource consume this; keep the
+ * security-relevant allowTestImports: false decision HERE, once. */
+function runCheckerPipeline<T>(
   source: string,
-  sourcePath?: string,
-): TypeCheckReport {
+  sourcePath: string | undefined,
+  fn: (result: {
+    checkResult: ReturnType<typeof typeCheck>;
+    symbolTable: SymbolTable;
+    syntheticPath: string;
+  }) => T,
+): T {
   const parseResult = parseAgency(source, {}, true);
   if (!parseResult.success) {
     throw new Error(parseResult.message ?? "Failed to parse Agency source");
@@ -103,9 +111,9 @@ export function typeCheckSource(
   return withSourcePath(source, sourcePath, (syntheticPath) => {
     const symbolTable = SymbolTable.build(syntheticPath, {});
     const reExported = resolveReExports(program, symbolTable, syntheticPath);
-    // `typeCheckSource` is agent-reachable (std::agency typecheck), not just
-    // an editor path — so it must agree with execution: code that run()/
-    // compileSource would reject should not typecheck as valid. Deny
+    // This pipeline is agent-reachable (std::agency typecheck/getEffects),
+    // not just an editor path — so it must agree with execution: code that
+    // run()/compileSource would reject should not check as valid. Deny
     // `import test` here; the LSP (lib/lsp/diagnostics.ts) independently
     // allows it for editor support.
     const resolved = resolveImports(reExported, symbolTable, syntheticPath, {
@@ -113,16 +121,49 @@ export function typeCheckSource(
     });
     const lifted = liftCallbackBlocks(resolved);
     const info = buildCompilationUnit(lifted, symbolTable, syntheticPath, source);
-    const { errors } = typeCheck(lifted, { typechecker: { enabled: true } }, info);
+    const checkResult = typeCheck(lifted, { typechecker: { enabled: true } }, info);
+    return fn({ checkResult, symbolTable, syntheticPath });
+  });
+}
 
+export function typeCheckSource(
+  source: string,
+  sourcePath?: string,
+): TypeCheckReport {
+  return runCheckerPipeline(source, sourcePath, ({ checkResult }) => {
     // Partition into errors and warnings in a single pass. The only severity
     // values the type-checker emits are "error" and "warning" (see
     // lib/typeChecker/types.ts), so anything not "warning" is treated as
     // "error" by toDiagnostic's default.
     const out: TypeCheckReport = { errors: [], warnings: [] };
-    for (const err of errors) {
+    for (const err of checkResult.errors) {
       const d = toDiagnostic(err);
       (d.severity === "warning" ? out.warnings : out.errors).push(d);
+    }
+    return out;
+  });
+}
+
+export type EffectsByExport = Record<string, string[]>;
+
+/**
+ * Map each EXPORTED node/function in `source` to the transitive list of
+ * interrupt effects it can raise. Reads the propagated map typeCheck
+ * returns (same data raises-checking enforces — see lib/cli/policy.ts
+ * for the precedent). Bare `interrupt(...)` sites surface as the
+ * "unknown" sentinel — the envelope is fail-closed by design. Type
+ * errors in `source` do not prevent extraction; parse failures throw.
+ */
+export function getEffectsFromSource(source: string): EffectsByExport {
+  return runCheckerPipeline(source, undefined, ({ checkResult, symbolTable, syntheticPath }) => {
+    const { interruptEffectsByFunction } = checkResult;
+    const out: EffectsByExport = {};
+    const fileSymbols = symbolTable.getFile(syntheticPath) ?? {};
+    for (const [name, sym] of Object.entries(fileSymbols)) {
+      const isCallable = sym.kind === "function" || sym.kind === "node";
+      if (!isCallable || !sym.exported) continue;
+      const names = (interruptEffectsByFunction[name] ?? []).map((e) => e.effect);
+      out[name] = names.filter((n, i) => names.indexOf(n) === i).sort();
     }
     return out;
   });

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -1,4 +1,4 @@
-import { compileSource, typeCheckSource, TypeCheckReport } from "../compiler/compile.js";
+import { compileSource, typeCheckSource, getEffectsFromSource, TypeCheckReport } from "../compiler/compile.js";
 import { writeFileSync, readFileSync, realpathSync, existsSync } from "fs";
 import { resolve, sep } from "path";
 import { parseAgency, replaceBlankLines } from "../parser.js";
@@ -171,6 +171,10 @@ export function _subprocessDepth(): number {
 
 export function _typecheck(source: string): TypeCheckReport {
   return typeCheckSource(source);
+}
+
+export function _getEffects(source: string): Record<string, string[]> {
+  return getEffectsFromSource(source);
 }
 
 // The real file path is handed to the type-checker so relative imports in

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { getModuleDir } from "../runtime/asyncContext.js";
+import { getStdlibDir } from "../importPaths.js";
 import { expandPath } from "./expandPath.js";
 
 /**
@@ -24,4 +25,14 @@ export function _readSkill(filepath: string): string {
   const dirname = getModuleDir();
   const fullPath = path.resolve(dirname, expandPath(filepath));
   return fs.readFileSync(fullPath, "utf8");
+}
+
+/**
+ * Absolute path to a section of the packaged Agency docs. `make` stages
+ * `docs/site/{guide,cli}` into `stdlib/docs/` (see stage-stdlib-docs in
+ * the makefile), and stdlib resolves in both dev and npm installs via
+ * getStdlibDir, so one copy serves compiled and source runs.
+ */
+export function _docsDir(section: "guide" | "cli"): string {
+  return path.join(getStdlibDir(), "docs", section);
 }

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -269,13 +269,17 @@ function pushGuardImpl(
   // Return the pushed guards' ids (innermost-last) so the caller can scope a
   // `try` to convert ONLY its own guards' trips (C2 ownedGuardIds). The array
   // length also drives the LIFO pop, replacing the old count.
+  // A null OR negative limit disables that dimension: no guard is pushed,
+  // so the block runs unmetered for it. Negative-as-disabled lets callers
+  // with an optional cap (e.g. run()'s maxCost) keep a single guarded call
+  // site instead of branching on "no limit".
   const ids: string[] = [];
-  if (costLimit != null) {
+  if (costLimit != null && costLimit >= 0) {
     const g = new CostGuard(costLimit);
     stack.pushGuard(g);
     ids.push(g.guardId);
   }
-  if (timeLimit != null) {
+  if (timeLimit != null && timeLimit >= 0) {
     const g = new TimeGuard(timeLimit);
     stack.pushGuard(g);
     ids.push(g.guardId);

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -33,6 +33,16 @@ define stage-agent-docs
 	cp -r docs/site/cli dist/lib/agents/docs/cli
 endef
 
+# Stage the same docs into the stdlib so std::skills::docsSkill can serve
+# them (resolved via getStdlibDir, which works in dev and npm installs).
+# Same rm-before-cp idempotency rule as above.
+define stage-stdlib-docs
+	mkdir -p stdlib/docs
+	rm -rf stdlib/docs/guide stdlib/docs/cli
+	cp -r docs/site/guide stdlib/docs/guide
+	cp -r docs/site/cli stdlib/docs/cli
+endef
+
 all:
 	pnpm run templates && $(MAKE) build && $(MAKE) compile-agency && $(MAKE) doc
 
@@ -85,15 +95,18 @@ compile-agency:
 	$(stage-agent-sources)
 	node ./dist/scripts/agency.js compile stdlib/ $(AGENT_PATHS)
 	$(stage-agent-docs)
+	$(stage-stdlib-docs)
 
 # Selective-use aliases (same recipes, one root set each).
 stdlib:
 	node ./dist/scripts/agency.js compile stdlib/
+	$(stage-stdlib-docs)
 
 agents:
 	$(stage-agent-sources)
 	node ./dist/scripts/agency.js compile $(AGENT_PATHS)
 	$(stage-agent-docs)
+	$(stage-stdlib-docs)
 
 test:
 	pnpm run test

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -23,19 +23,11 @@ define stage-agent-sources
 	node ./scripts/stage-agents.mjs lib/agents dist/lib/agents
 endef
 
-# Stage the doc markdown the agents read at runtime. rm before cp -r:
-# copying onto an existing dir NESTS (guide/guide) — that artifact exists
-# in pre-Stage-C tarballs; these copies must be idempotent.
-define stage-agent-docs
-	mkdir -p dist/lib/agents/docs
-	rm -rf dist/lib/agents/docs/guide dist/lib/agents/docs/cli
-	cp -r docs/site/guide dist/lib/agents/docs/guide
-	cp -r docs/site/cli dist/lib/agents/docs/cli
-endef
-
-# Stage the same docs into the stdlib so std::skills::docsSkill can serve
-# them (resolved via getStdlibDir, which works in dev and npm installs).
-# Same rm-before-cp idempotency rule as above.
+# Stage the doc markdown into the stdlib so std::skills::docsSkill can
+# serve it (resolved via getStdlibDir, which works in dev and npm
+# installs). rm before cp -r: copying onto an existing dir NESTS
+# (guide/guide) — that artifact exists in pre-Stage-C tarballs; these
+# copies must be idempotent.
 define stage-stdlib-docs
 	mkdir -p stdlib/docs
 	rm -rf stdlib/docs/guide stdlib/docs/cli
@@ -94,7 +86,6 @@ clean:
 compile-agency:
 	$(stage-agent-sources)
 	node ./dist/scripts/agency.js compile stdlib/ $(AGENT_PATHS)
-	$(stage-agent-docs)
 	$(stage-stdlib-docs)
 
 # Selective-use aliases (same recipes, one root set each).
@@ -105,7 +96,6 @@ stdlib:
 agents:
 	$(stage-agent-sources)
 	node ./dist/scripts/agency.js compile $(AGENT_PATHS)
-	$(stage-agent-docs)
 	$(stage-stdlib-docs)
 
 test:

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -43,8 +43,6 @@
   },
   "files": [
     "./dist",
-    "./dist/lib/agents/docs/guide/**/*.md",
-    "./dist/lib/agents/docs/cli/**/*.md",
     "./dist/lib/agents/docs/appendix/**/*.md",
     "./stdlib/**/*.agency",
     "./stdlib/**/*.js",

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -43,7 +43,6 @@
   },
   "files": [
     "./dist",
-    "./dist/lib/agents/docs/appendix/**/*.md",
     "./stdlib/**/*.agency",
     "./stdlib/**/*.js",
     "./stdlib/docs/**/*.md",

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -48,6 +48,7 @@
     "./dist/lib/agents/docs/appendix/**/*.md",
     "./stdlib/**/*.agency",
     "./stdlib/**/*.js",
+    "./stdlib/docs/**/*.md",
     "./scripts/hooks/postinstall.js"
   ],
   "exports": {

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -3,6 +3,7 @@ import {
   _compileFile,
   _typecheck,
   _typecheckFile,
+  _getEffects,
   _parseAST,
   _writeAST,
   _format,
@@ -213,6 +214,22 @@ export safe def typecheck(source: string): Result<TypeCheckReport> {
   @param source - Agency source code as a string
   """
   return try _typecheck(source)
+}
+
+/** Per-exported-symbol effect lists, keyed by node/function name. */
+export type EffectsByExport = Record<string, string[]>
+
+export safe def getEffects(source: string): Result<EffectsByExport> {
+  """
+  Map each exported node and function in the source to the list of
+  interrupt effects it can raise, transitively. Bare `interrupt(...)`
+  sites appear as the sentinel "unknown", so the envelope never
+  silently under-reports. Use this to show or check what a program can
+  do before running it.
+
+  @param source - Agency source code as a string
+  """
+  return try _getEffects(source)
 }
 
 type FilterImportsResult = {

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -153,23 +153,13 @@ export def run(
     depth: _subprocessDepth() + 1
   })
 
-  // NOTE: the two _run call sites below must keep IDENTICAL argument
-  // lists (Agency has no zero-arg lambda to factor the call through).
-  if (maxCost == null) {
-    return try _run(
-      compiled,
-      node,
-      args,
-      wallClock,
-      memory,
-      ipcPayload,
-      stdout,
-      configOverrides,
-      cwd,
-      maxDepth,
-    )
+  // A negative cost disables the guard, so the no-cap case runs through
+  // the same single call site with an inert guard.
+  let costCap = -1.0
+  if (maxCost != null) {
+    costCap = maxCost
   }
-  const guarded = guard(cost: maxCost) as {
+  const guarded = guard(cost: costCap) as {
     return try _run(
       compiled,
       node,
@@ -483,7 +473,14 @@ export def writeAgency(
       const checked = try _typecheck(source)
       if (checked is failure(parseErr)) {
         result = failure({ source: source, errors: [] })
-        const findings = renderFeedback(parseFeedback(source))
+        // _typecheck throws for import-resolution failures as well as
+        // parse failures. In the import case the re-parse succeeds and
+        // renders no findings — fall back to the thrown error so the
+        // model always gets a diagnostic to repair against.
+        let findings = renderFeedback(parseFeedback(source))
+        if (findings == "") {
+          findings = "${parseErr}"
+        }
         prompt = "That code has problems:\n${findings}\nReturn a corrected complete program."
       } else if (checked.value.errors.length > 0) {
         result = failure({ source: source, errors: checked.value.errors })

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -14,7 +14,8 @@ import {
   _subprocessDepth,
  } from "agency-lang/stdlib-lib/agency.js"
 import { VERSION } from "agency-lang/stdlib-lib/version.js"
-import { guard } from "std::thread"
+import { guard, systemMessage } from "std::thread"
+import { docsSkill } from "std::skills"
 
 /** @module
   Tools for compiling, type-checking, running, formatting, and inspecting
@@ -414,6 +415,93 @@ export def feedbackHasErrors(feedback: Result<Feedback[]>): boolean {
   }
   // If the feedback itself is a failure, we can treat that as an error state.
   return true
+}
+
+type GeneratedCode = {
+  code: string
+}
+
+/** The failure payload writeAgency returns on retry exhaustion: the last
+generated source and its typecheck diagnostics. */
+export type WriteFailure = {
+  source: string;
+  errors: TypeCheckDiagnostic[]
+}
+
+// Kept in sync by hand with the syntax rules in the code subagent prompt
+// (lib/agents/agency-agent/subagents/code.agency) — the authoritative
+// source is docs/site/guide/basic-syntax.md, which the model can read
+// through the docs tool.
+static const writeSysPrompt = """You write code in the Agency language.
+Agency syntax rules you MUST follow:
+- Functions: def name(param: Type): ReturnType { ... }
+- Nodes: node name() { ... } — export the entry node.
+- if / while / for require parentheses AND curly braces: if (x > 5) { ... }
+- The ONLY for loop is for-in over an array: for (item in items) { ... }
+  There is NO C-style for (let i = 0; i < n; i++) loop. To count, use a
+  while loop:
+    let i = 1
+    while (i <= 3) {
+      print(i)
+      i = i + 1
+    }
+- Declare variables with let or const before use.
+- No Python-style colon blocks. Always { ... }.
+If you are unsure about syntax or a standard-library function, read the
+relevant page with the docs tool before writing code.
+Return only the complete program in the code field."""
+
+export def writeAgency(
+  task: string,
+  context: string = "",
+  maxAttempts: number = 3,
+): Result<string, WriteFailure> {
+  """
+  Generate Agency source code for a task description. Typechecks each
+  attempt and feeds diagnostics back to the model, up to maxAttempts
+  tries. Success holds source that compiles and typechecks; on retry
+  exhaustion the failure holds { source, errors } for the last attempt.
+
+  @param task - What the generated program should do
+  @param context - Optional extra material (available data, examples)
+  @param maxAttempts - Max generation attempts before giving up (default 3)
+  """
+  const docsTool = docsSkill("guide")
+  let result: Result<string, WriteFailure> = failure({ source: "", errors: [] })
+  thread(label: "writeAgency") {
+    systemMessage(writeSysPrompt)
+    let prompt = "Write an Agency program for this task:\n<task>\n${task}\n</task>"
+    if (context != "") {
+      prompt = prompt + "\n<context>\n${context}\n</context>"
+    }
+    let attempt = 0
+    let done = false
+    while (attempt < maxAttempts && !done) {
+      attempt = attempt + 1
+      const generated: GeneratedCode = llm(prompt, { tools: [docsTool] })
+      const source = generated.code
+      const checked = try _typecheck(source)
+      if (checked is failure(parseErr)) {
+        result = failure({ source: source, errors: [] })
+        const findings = renderFeedback(parseFeedback(source))
+        prompt = "That code has problems:\n${findings}\nReturn a corrected complete program."
+      } else if (checked.value.errors.length > 0) {
+        result = failure({ source: source, errors: checked.value.errors })
+        const findings = renderFeedback(success(reportFeedback(checked.value)))
+        prompt = "That code has problems:\n${findings}\nReturn a corrected complete program."
+      } else {
+        const compiled = try _compile(source)
+        if (compiled is failure(compileErr)) {
+          result = failure({ source: source, errors: [] })
+          prompt = "That code failed to compile: ${compileErr}\nReturn a corrected complete program."
+        } else {
+          result = success(source)
+          done = true
+        }
+      }
+    }
+  }
+  return result
 }
 
 type FilterImportsResult = {

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -14,6 +14,7 @@ import {
   _subprocessDepth,
  } from "agency-lang/stdlib-lib/agency.js"
 import { VERSION } from "agency-lang/stdlib-lib/version.js"
+import { guard } from "std::thread"
 
 /** @module
   Tools for compiling, type-checking, running, formatting, and inspecting
@@ -47,7 +48,7 @@ effect std::run {
   moduleId: string;
   node: string;
   args: Record<string, any>;
-  limits: { wallClock: number; memory: number; ipcPayload: number; stdout: number };
+  limits: { wallClock: number; memory: number; ipcPayload: number; stdout: number; maxCost: number | null };
   cwd: string;
   logFile: string;
   depth: number
@@ -91,7 +92,8 @@ export safe def compile(source: string): Result {
 Any interrupts and guards defined in the parent process will
 apply to the child process. Any callbacks in scope will also apply.
 Exceeding a resource limit kills the subprocess and returns a
-limit_exceeded failure.
+limit_exceeded failure. Exceeding maxCost kills the subprocess and
+returns a limit_exceeded failure, like the other limits.
 
 For `maxDepth`, if an ancestor process has a lower maxDepth,
 the lower value is used. For example, if a parent process has maxDepth=3
@@ -108,6 +110,7 @@ export def run(
   logFile: string = "",
   cwd: string = "",
   maxDepth: number = 5,
+  maxCost: number | null = null,
 ): Result {
   """
   Execute a compiled Agency program in a subprocess and return the node's result.
@@ -122,6 +125,7 @@ export def run(
   @param logFile - Optional statelog JSONL file path for this subprocess run
   @param cwd - Optional working directory for this subprocess run
   @param maxDepth - Max subprocess nesting depth (default 5, hard ceiling 10).
+  @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
   """
   let configOverrides = null
   if (logFile != "") {
@@ -140,25 +144,65 @@ export def run(
       wallClock: wallClock,
       memory: memory,
       ipcPayload: ipcPayload,
-      stdout: stdout
+      stdout: stdout,
+      maxCost: maxCost
     },
     cwd: cwd,
     logFile: logFile,
     depth: _subprocessDepth() + 1
   })
 
-  return try _run(
-    compiled,
-    node,
-    args,
-    wallClock,
-    memory,
-    ipcPayload,
-    stdout,
-    configOverrides,
-    cwd,
-    maxDepth,
-  )
+  // NOTE: the two _run call sites below must keep IDENTICAL argument
+  // lists (Agency has no zero-arg lambda to factor the call through).
+  if (maxCost == null) {
+    return try _run(
+      compiled,
+      node,
+      args,
+      wallClock,
+      memory,
+      ipcPayload,
+      stdout,
+      configOverrides,
+      cwd,
+      maxDepth,
+    )
+  }
+  const guarded = guard(cost: maxCost) as {
+    return try _run(
+      compiled,
+      node,
+      args,
+      wallClock,
+      memory,
+      ipcPayload,
+      stdout,
+      configOverrides,
+      cwd,
+      maxDepth,
+    )
+  }
+  // guard() runs the block through a try-style call, which passes a
+  // returned Result through unchanged — so `guarded` IS the child's
+  // Result on success (no double wrapping), and a guardFailure only
+  // when the cost guard itself tripped.
+  if (guarded is failure(err)) {
+    if (err.type == "guardFailure") {
+      // Present cost caps in the same limit_exceeded shape as the other
+      // run() limits (shape mirrors makeLimitFailure in lib/runtime/ipc.ts
+      // — keep the two in sync).
+      return failure(
+        {
+        reason: "limit_exceeded",
+        limit: "cost",
+        threshold: maxCost,
+        value: err.actualCost,
+        message: "Subprocess exceeded cost limit of ${maxCost} (used ${err.actualCost})"
+      },
+      )
+    }
+  }
+  return guarded
 }
 
 /** Just like `run`, any interrupts and guards defined in the parent process
@@ -174,6 +218,7 @@ export def runFile(
   memory: number = 512mb,
   ipcPayload: number = 100mb,
   stdout: number = 1mb,
+  maxCost: number | null = null,
 ): Result {
   """
   Compile and execute an Agency file in a subprocess and return the node's result.
@@ -187,6 +232,7 @@ export def runFile(
   @param memory - Max V8 heap size (default 512mb, max 4gb)
   @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
   @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
+  @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
   """
   const compileResult = try _compileFile(dir, filename)
   if (isFailure(compileResult)) {
@@ -200,6 +246,7 @@ export def runFile(
     memory: memory,
     ipcPayload: ipcPayload,
     stdout: stdout,
+    maxCost: maxCost,
   )
 }
 

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -279,6 +279,143 @@ export safe def getEffects(source: string): Result<EffectsByExport> {
   return try _getEffects(source)
 }
 
+/** One review finding. `error: true` means the code is broken (parse or
+type error, or the reviewer judged it does not do the task); `error:
+false` is advisory feedback, including typecheck warnings. */
+export type Feedback = {
+  error: boolean;
+  feedback: string;
+  data?: any
+}
+
+export def mergeFeedback(
+  a: Result<Feedback[]>,
+  b: Result<Feedback[]>,
+): Result<Feedback[]> {
+  """
+  Merge two feedback Results by concatenating their success arrays or
+  returning the first failure.
+
+  @param a - First feedback Result
+  @param b - Second feedback Result
+  """
+  if (a is success(aVal)) {
+    if (b is success(bVal)) {
+      return success([...aVal, ...bVal])
+    } else {
+      return b
+    }
+  } else {
+    return a
+  }
+}
+
+def parseFeedback(source: string): Result<Feedback[]> {
+  const result = try _parseAST(source)
+  if (result is failure(err)) {
+    return success([{ error: true, feedback: "Parse error: ${err}" }])
+  }
+  return success([])
+}
+
+// Report -> findings, separated from typecheckFeedback so writeAgency
+// can format an already-computed report without re-checking.
+def reportFeedback(report: TypeCheckReport): Feedback[] {
+  const feedback: Feedback[] = []
+  for (error in report.errors) {
+    feedback.push({ error: true, feedback: "Error: ${error.message}", data: error })
+  }
+  for (warning in report.warnings) {
+    feedback.push({ error: false, feedback: "Warning: ${warning.message}", data: warning })
+  }
+  return feedback
+}
+
+def typecheckFeedback(source: string): Result<Feedback[]> {
+  const result = try _typecheck(source)
+  if (result is failure(err)) {
+    return success([{ error: true, feedback: "Typecheck failed: ${err}" }])
+  }
+  return success(reportFeedback(result.value))
+}
+
+def llmFeedback(source: string, task: string): Result<Feedback[]> {
+  let out: Result<Feedback[]> = success([])
+  thread(label: "review") {
+    const items: Feedback[] = llm("""You are reviewing Agency-language code.
+The code was written for this task:
+<task>
+${task}
+</task>
+
+<code>
+${source}
+</code>
+
+Return a list of feedback items. Set error=true only if the code does
+not accomplish the task. Keep feedback brief and concrete.""")
+    out = success(items)
+  }
+  return out
+}
+
+export def review(source: string, task: string = ""): Result<Feedback[]> {
+  """
+  Review Agency source code. Always merges parse and typecheck findings;
+  when a task description is given, an LLM pass also judges whether the
+  code accomplishes the task.
+
+  @param source - Agency source code as a string
+  @param task - Optional description of what the code should do
+  """
+  let feedback: Result<Feedback[]> = success([])
+  feedback = mergeFeedback(feedback, parseFeedback(source))
+  feedback = mergeFeedback(feedback, typecheckFeedback(source))
+  if (task != "") {
+    feedback = mergeFeedback(feedback, llmFeedback(source, task))
+  }
+  if (feedback is success(items)) {
+    if (items.length == 0) {
+      return success([{ error: false, feedback: "Code is valid with no errors or warnings." }])
+    }
+  }
+  return feedback
+}
+
+def renderSingleFeedback(f: Feedback): string {
+  if (f.error) {
+    return `Error: ${f.feedback}`
+  } else {
+    return `Feedback: ${f.feedback}`
+  }
+}
+
+export def renderFeedback(feedback: Result<Feedback[]>): string {
+  """
+  Render a feedback Result as human-readable text, one line per finding.
+
+  @param feedback - The Result review() returned
+  """
+  if (feedback is success(val)) {
+    return map(val, renderSingleFeedback).join("\n\n")
+  }
+  return feedback.error
+}
+
+export def feedbackHasErrors(feedback: Result<Feedback[]>): boolean {
+  """
+  True when any finding is an error, or when the feedback Result itself
+  is a failure.
+
+  @param feedback - The Result review() returned
+  """
+  if (feedback is success(val)) {
+    return some(val, \f -> f.error)
+  }
+  // If the feedback itself is a failure, we can treat that as an error state.
+  return true
+}
+
 type FilterImportsResult = {
   source: string;
   filtered: boolean

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -153,13 +153,28 @@ export def run(
     depth: _subprocessDepth() + 1
   })
 
-  // A negative cost disables the guard, so the no-cap case runs through
-  // the same single call site with an inert guard.
-  let costCap = -1.0
-  if (maxCost != null) {
-    costCap = maxCost
+  // Two call sites on purpose. Wrapping the no-cap path in an inert
+  // guard block breaks nested subprocess pause/resume: when THIS process
+  // is itself a subprocess that pauses on a bubbled interrupt, resuming
+  // its serialized stack through the guard block loses the block's
+  // return value and run() yields undefined (see the nested-pause-resume
+  // fixture, which caught this in CI). Keep the argument lists below
+  // IDENTICAL.
+  if (maxCost == null) {
+    return try _run(
+      compiled,
+      node,
+      args,
+      wallClock,
+      memory,
+      ipcPayload,
+      stdout,
+      configOverrides,
+      cwd,
+      maxDepth,
+    )
   }
-  const guarded = guard(cost: costCap) as {
+  const guarded = guard(cost: maxCost) as {
     return try _run(
       compiled,
       node,

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -12,6 +12,7 @@ import { frontmatter } from "std::markdown"
 // the interrupt-raising versions have.
 import { _read } from "agency-lang/stdlib-lib/builtins.js"
 import { _glob } from "agency-lang/stdlib-lib/shell.js"
+import { _docsDir } from "agency-lang/stdlib-lib/skills.js"
 
 /** @module
   Give an LLM access to a directory of skills, and support Claude-Code-style
@@ -154,18 +155,7 @@ def standardEntry(skillPath: string, parsedFrontmatter: any): SkillEntry {
 effect std::skills::skillsDir { dir: string, layout: "flat" | "standard" }
 effect std::skills::commandsDir { dir: string }
 
-export def skillsDir(dir: string, layout: "flat" | "standard" = "standard") {
-  """
-  Build a skills tool for an LLM over a directory of skills.
-
-  @param dir - Directory containing the skills.
-  @param layout - "standard" (default) for subdirectory-per-skill with SKILL.md, "flat" for a directory of loose Markdown files.
-  """
-  return interrupt std::skills::skillsDir("Are you sure you want to scan this directory for skill files?", {
-    dir: dir,
-    layout: layout
-  })
-
+def buildSkillsTool(dir: string, layout: "flat" | "standard") {
   let pattern = "*/SKILL.md"
   if (layout == "flat") {
     pattern = "*.{md,markdown}"
@@ -190,6 +180,38 @@ export def skillsDir(dir: string, layout: "flat" | "standard" = "standard") {
   // tool is named `read` (the base of `read.partial`), so two of them in one
   // `tools:` list trip the provider's unique-name requirement.
   return read.partial(dir: dir).describe(description).rename(skillToolName(dir))
+}
+
+export def skillsDir(dir: string, layout: "flat" | "standard" = "standard") {
+  """
+  Build a skills tool for an LLM over a directory of skills.
+
+  @param dir - Directory containing the skills.
+  @param layout - "standard" (default) for subdirectory-per-skill with SKILL.md, "flat" for a directory of loose Markdown files.
+  """
+  return interrupt std::skills::skillsDir("Are you sure you want to scan this directory for skill files?", {
+    dir: dir,
+    layout: layout
+  })
+
+  return buildSkillsTool(dir, layout)
+}
+
+export def docsSkill(section: "guide" | "cli") {
+  """
+  Build a docs tool for an LLM over the packaged Agency documentation.
+  "guide" serves the language guide (syntax, types, control flow);
+  "cli" serves the CLI reference. The returned tool lists every page in
+  its description and lets the model read any one on demand.
+
+  @param section - Which documentation set to serve: "guide" or "cli".
+  """
+  // No approval interrupt for the startup scan: these docs ship inside
+  // the agency package, so scanning them carries the same trust as
+  // running the stdlib itself. The returned tool is read.partial, so
+  // every read the LLM later performs still raises std::read and goes
+  // through handlers/policies exactly like any other read tool.
+  return buildSkillsTool(_docsDir(section), "flat")
 }
 
 // ============================================================

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -216,8 +216,9 @@ export def guard(
 ): Result {
   """
   Run a block under a cost limit, a time limit, or both, aborting the
-  block as soon as either limit is exceeded. At least one of `cost` or
-  `time` must be supplied.
+  block as soon as either limit is exceeded. A null or negative value
+  disables that limit, so callers with an optional cap can always pass
+  something; with both limits disabled the block just runs.
 
   Returns a `Result`. On success it holds the block's return value. On a
   trip it holds a failure whose `error.type` is either "guardFailure"
@@ -225,8 +226,8 @@ export def guard(
   "timeoutFailure" (compute time exceeded, read `error.maxTime` and
   `error.actualTime`, in milliseconds).
 
-  @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null = no cost limit.
-  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null = no time limit.
+  @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null or negative = no cost limit.
+  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null or negative = no time limit.
   @param block - The work to run under the guard.
 
   Example:

--- a/packages/agency-lang/tests/agency/agency-review.agency
+++ b/packages/agency-lang/tests/agency/agency-review.agency
@@ -1,0 +1,27 @@
+import { review, feedbackHasErrors } from "std::agency"
+
+// task="" -> pure parse+typecheck feedback, no LLM call.
+// (That no-LLM property is NOT pinned by this test — the deterministic
+// mock cannot assert absence of traffic. Accepted gap.)
+node lintOnly() {
+  // A real type error: undeclared identifiers silently type as `any`
+  // (known checker hole), so use a const type mismatch instead.
+  const bad = review("node main() { const x: number = \"s\"\n  return x }")
+  const good = review("export node main() { return 1 }")
+  return [feedbackHasErrors(bad), feedbackHasErrors(good)]
+}
+
+// Unparseable source exercises parseFeedback, not just typecheck.
+node parseError() {
+  const fb = review("node main() {{{")
+  return feedbackHasErrors(fb)
+}
+
+// task!="" -> an LLM pass judges code-vs-task and merges its feedback
+// in. The mock returns an ERROR finding on otherwise-clean code, so the
+// only way this returns true is if the LLM item actually flowed through
+// mergeFeedback — a stub llmFeedback returning success([]) fails here.
+node withTask() {
+  const fb = review("export node main() { return 1 }", task: "return the number two")
+  return feedbackHasErrors(fb)
+}

--- a/packages/agency-lang/tests/agency/agency-review.test.json
+++ b/packages/agency-lang/tests/agency/agency-review.test.json
@@ -1,0 +1,33 @@
+{
+  "tests": [
+    {
+      "nodeName": "lintOnly",
+      "description": "review with no task flags type errors and passes clean code",
+      "input": "",
+      "expectedOutput": "[true,false]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "parseError",
+      "description": "review surfaces parse failures as error findings",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "withTask",
+      "description": "review with a task merges LLM feedback into the findings",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": [
+            { "error": true, "feedback": "The code returns one, not two." }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/docs-skill.agency
+++ b/packages/agency-lang/tests/agency/docs-skill.agency
@@ -1,0 +1,26 @@
+import { docsSkill } from "std::skills"
+
+// Both docsSkill builds happen OUTSIDE the handle block on purpose: the
+// test runner fails any test whose interrupt reaches the top unhandled,
+// so building out here pins the no-startup-interrupt property. Moving
+// the builds inside the handler would silently unpin it.
+//
+// The returned tools are read.partial, so the reads below still raise
+// std::read — approved by the handler. `read` returns a Result.
+node main() {
+  const guideTool = docsSkill("guide")
+  const cliTool = docsSkill("cli")
+  let guideOk = false
+  let cliOk = false
+  handle {
+    const guidePage = guideTool(filename: "basic-syntax.md")
+    if (guidePage is success(guideText)) {
+      guideOk = guideText.includes("def")
+    }
+    const cliPage = cliTool(filename: "doc.md")
+    if (cliPage is success(cliText)) {
+      cliOk = cliText.includes("agency")
+    }
+  } with approve
+  return [guideOk, cliOk]
+}

--- a/packages/agency-lang/tests/agency/docs-skill.test.json
+++ b/packages/agency-lang/tests/agency/docs-skill.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "docsSkill serves packaged guide and cli pages through read tools with no startup interrupt",
+      "input": "",
+      "expectedOutput": "[true,true]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/get-effects.agency
+++ b/packages/agency-lang/tests/agency/get-effects.agency
@@ -1,0 +1,24 @@
+import { getEffects } from "std::agency"
+
+// Transitive: run calls helper which calls the std write tool. Only
+// exported symbols appear in the map, and bare interrupts surface as
+// the "unknown" sentinel.
+node main() {
+  const src = """
+def helper() {
+  write("out.txt", "hi")
+}
+export node run() {
+  helper()
+}
+export node ask() {
+  const ok = interrupt("proceed?")
+  return ok
+}
+"""
+  const fx = getEffects(src)
+  if (fx is failure(err)) {
+    return "failed: ${err}"
+  }
+  return fx.value
+}

--- a/packages/agency-lang/tests/agency/get-effects.test.json
+++ b/packages/agency-lang/tests/agency/get-effects.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "getEffects returns per-exported-symbol transitive effect lists with the unknown sentinel",
+      "input": "",
+      "expectedOutput": "{\"run\":[\"std::write\"],\"ask\":[\"unknown\"]}",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/run-max-cost.agency
+++ b/packages/agency-lang/tests/agency/subprocess/run-max-cost.agency
@@ -1,0 +1,127 @@
+import { compile, run, runFile } from "std::agency"
+import { guard } from "std::thread"
+
+// The child makes 3 mocked llm() calls at 0.000002 each. maxCost caps at
+// 0.000003: the second call trips the under-the-hood guard, and run()
+// translates the trip into the uniform limit_exceeded failure shape.
+def childSource(): string {
+  return """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  const c = llm("Reply with: three")
+  return c
+}
+"""
+}
+
+// The handler REJECTS unless the interrupt payload carries the cap in
+// limits.maxCost — this is what pins the payload change: if maxCost is
+// missing from the payload, the run is rejected and the output differs.
+node trips() {
+  const compileResult = compile(childSource())
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "main", maxCost: 0.000003)
+    if (isFailure(result)) {
+      return "tripped:${result.error.reason}:${result.error.limit}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run" && e.data.limits.maxCost == 0.000003) {
+      return approve()
+    }
+    return reject()
+  }
+}
+
+node generous() {
+  const compileResult = compile(childSource())
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "main", maxCost: 1.0)
+    if (isFailure(result)) {
+      return "tripped"
+    }
+    return result.value.data
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+
+// Guard nesting: the inner maxCost trip must NOT trip a generous outer
+// guard. guard() passes a returned Result through unchanged, so `outer`
+// is run()'s own Result: a guardFailure here would mean the OUTER guard
+// tripped; the inner trip arrives as the translated limit_exceeded.
+node nested() {
+  const compileResult = compile(childSource())
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const outer = guard(cost: 10.0) as {
+      return run(compiled: compileResult.value, node: "main", maxCost: 0.000003)
+    }
+    if (isFailure(outer)) {
+      if (outer.error.type == "guardFailure") {
+        return "outer tripped"
+      }
+      return "inner only:${outer.error.limit}"
+    }
+    return "nothing tripped"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+
+// A failure that is NOT a cost trip must pass through untranslated:
+// the node name does not exist, and maxCost is generous.
+node passthrough() {
+  const compileResult = compile(childSource())
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "missing", maxCost: 1.0)
+    if (isFailure(result)) {
+      if (result.error.reason == "limit_exceeded") {
+        return "wrongly translated"
+      }
+      return "passthrough-ok"
+    }
+    return "unexpected success"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+
+// runFile must actually forward maxCost in its delegating run() call —
+// this is one forgotten argument away from a silent no-op.
+node runFileTrips() {
+  handle {
+    const result = runFile(
+      dir: "tests/agency/subprocess/runfile-maxcost-target",
+      filename: "sub.agency",
+      node: "main",
+      maxCost: 0.000003,
+    )
+    if (isFailure(result)) {
+      return "tripped:${result.error.reason}:${result.error.limit}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/run-max-cost.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/run-max-cost.test.json
@@ -1,0 +1,69 @@
+{
+  "tests": [
+    {
+      "nodeName": "trips",
+      "description": "maxCost trips and surfaces as limit_exceeded with limit=cost; handler sees the cap in the payload",
+      "input": "",
+      "expectedOutput": "\"tripped:limit_exceeded:cost\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    },
+    {
+      "nodeName": "generous",
+      "description": "a generous maxCost does not trip",
+      "input": "",
+      "expectedOutput": "\"three\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    },
+    {
+      "nodeName": "nested",
+      "description": "an inner maxCost trip does not trip a generous outer guard",
+      "input": "",
+      "expectedOutput": "\"inner only:cost\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    },
+    {
+      "nodeName": "passthrough",
+      "description": "a non-cost failure passes through untranslated under maxCost",
+      "input": "",
+      "expectedOutput": "\"passthrough-ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    },
+    {
+      "nodeName": "runFileTrips",
+      "description": "runFile forwards maxCost to run and trips the same way",
+      "input": "",
+      "expectedOutput": "\"tripped:limit_exceeded:cost\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/runfile-maxcost-target/sub.agency
+++ b/packages/agency-lang/tests/agency/subprocess/runfile-maxcost-target/sub.agency
@@ -1,0 +1,6 @@
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  const c = llm("Reply with: three")
+  return c
+}

--- a/packages/agency-lang/tests/agency/write-agency.agency
+++ b/packages/agency-lang/tests/agency/write-agency.agency
@@ -1,0 +1,40 @@
+import { writeAgency } from "std::agency"
+
+// First mock returns code with a type error (const type mismatch —
+// undeclared identifiers silently type as any and would not trip the
+// checker); second returns valid code. The repair loop must feed
+// diagnostics back and succeed on attempt 2.
+// (Mock caveat: this proves a retry happens, NOT that the second prompt
+// contained the diagnostics — the deterministic client returns mocks
+// regardless of input. That wiring is accepted as unverified here;
+// statelog inspection would be the mechanism if it ever matters.)
+node repairs() {
+  const result = writeAgency("return the number one")
+  if (result is failure(err)) {
+    return "failed"
+  }
+  return result.value.includes("export node main")
+}
+
+// First mock is unparseable (not just a type error), second is valid —
+// exercises the parse-failure branch of the loop.
+node repairsParse() {
+  const result = writeAgency("return the number one")
+  if (result is failure(err)) {
+    return "failed"
+  }
+  return result.value.includes("export node main")
+}
+
+// One attempt, permanently broken output -> exhaustion failure carrying
+// the last source and its diagnostics.
+node exhausts() {
+  const result = writeAgency("return the number one", maxAttempts: 1)
+  if (result is success(src)) {
+    return "unexpected success"
+  }
+  if (result is failure(err)) {
+    return [err.source.includes("const x: number"), err.errors.length > 0]
+  }
+  return "unreachable"
+}

--- a/packages/agency-lang/tests/agency/write-agency.test.json
+++ b/packages/agency-lang/tests/agency/write-agency.test.json
@@ -1,0 +1,39 @@
+{
+  "tests": [
+    {
+      "nodeName": "repairs",
+      "description": "writeAgency feeds typecheck diagnostics back and succeeds on retry",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": { "code": "export node main() { const x: number = \"s\"\n  return x }" } },
+        { "return": { "code": "export node main() { return 1 }" } }
+      ]
+    },
+    {
+      "nodeName": "repairsParse",
+      "description": "writeAgency recovers from unparseable output",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": { "code": "node {{{" } },
+        { "return": { "code": "export node main() { return 1 }" } }
+      ]
+    },
+    {
+      "nodeName": "exhausts",
+      "description": "writeAgency returns the last source and diagnostics on retry exhaustion",
+      "input": "",
+      "expectedOutput": "[true,true]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": { "code": "export node main() { const x: number = \"s\"\n  return x }" } }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the primitives for agents that write their plans as Agency code and run them under handlers (the CodeAct pattern), plus the groundwork for offline harness search.

Spec: `docs/superpowers/specs/2026-07-10-std-agency-write-effects-cost-design.md` (in the main checkout, untracked).

## New std::agency APIs

- **`writeAgency(task, context, maxAttempts)`** — generate Agency source from a task description. One `llm()` call with the packaged language guide available as a docs tool, then a typecheck-repair loop that feeds diagnostics back. Success is source guaranteed to compile and typecheck; exhaustion returns `{ source, errors }`.
- **`review(source, task)`** — lifted from the review subagent. Always merges parse + typecheck findings; a non-empty `task` adds an LLM pass judging whether the code does what was asked. `Feedback`, `mergeFeedback`, `renderFeedback`, `feedbackHasErrors` are exported; the subagent now delegates per-snippet to the stdlib.
- **`getEffects(source)`** — maps each exported node/function to its transitive interrupt-effect list, read from the same propagated map raises-checking enforces. Bare `interrupt(...)` surfaces as the fail-closed `"unknown"` sentinel. Approval flows can show a plan-program effect envelope before running it.
- **`maxCost` on `run`/`runFile`** — cost cap for subprocesses, implemented as a `guard(cost:)` under the hood. Trips translate to the same `limit_exceeded` failure shape as the other limits, with `limit: "cost"`. The cap rides in the `std::run` interrupt payload (`limits.maxCost`, additive declaration change) so handlers and policies see it before approving.

## Docs staging moved into the stdlib

`make` now stages the guide + CLI docs into `stdlib/docs/` (gitignored, shipped via `files`), served by the new `std::skills::docsSkill("guide" | "cli")`. All four subagents drop their per-file `skillsDir("../docs/...") with approve` statics for `docsSkill`, and the old `stage-agent-docs` staging into `dist/lib/agents/docs/` is retired. `docsSkill` skips only the scan-approval interrupt (packaged docs carry stdlib trust); reads through the returned tool still raise `std::read` and go through handlers/policies unchanged.

## Notes for review

- `guard()` passes a returned `Result` through unchanged (try-style call), so `run`'s guarded branch returns the child result as-is and only translates a `guardFailure`. The `nested` test pins inner-trip-does-not-trip-outer-guard.
- `getEffectsFromSource` shares one extracted `runCheckerPipeline` helper with `typeCheckSource`, so the `allowTestImports: false` decision exists once. No typechecker changes; the transitive map comes from `typeCheck`'s return (same pattern as `lib/cli/policy.ts`).
- The `trips` test handler rejects unless `e.data.limits.maxCost` matches, pinning the payload change.
- Real-LLM smoke test of `writeAgency` surfaced that models default to C-style `for(;;)` loops; the system prompt now shows the while-loop counting idiom explicitly and generation succeeds.

## Tests

- `tests/agency/docs-skill.agency` — guide + cli pages served, no startup interrupt (tool builds sit outside the handler on purpose).
- `tests/agency/get-effects.agency` + 6 vitest cases — direct/transitive effects, sort/dedup, exported defs, clean-node `[]`, unknown sentinel, parse-throw.
- `tests/agency/subprocess/run-max-cost.agency` — trip, generous, nested guards, non-cost passthrough, runFile forwarding (5 nodes), plus the pre-existing `cost-guard-trips-on-child-spend` still passing for the `maxCost == null` path.
- `tests/agency/agency-review.agency` — lint-only, parse-error path, LLM feedback actually merged (error-finding mock).
- `tests/agency/write-agency.agency` — repair retry, parse-failure recovery, exhaustion payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
