### PR TITLE
Unwrap tool-call Results for the LLM and add std::agency runCode

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -79,7 +79,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L370))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L378))
 
 ### Feedback
 
@@ -98,7 +98,7 @@ export type Feedback = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L388))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L396))
 
 ### WriteFailure
 
@@ -114,7 +114,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L528))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L536))
 
 ### AST
 
@@ -137,7 +137,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L641))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L649))
 
 ## Effects
 
@@ -326,10 +326,10 @@ runCode(
   source: string,
   node: string = "main",
   args: Record<string, any> = {},
-  wallClockSeconds: number = 60,
-  memoryMb: number = 512,
-  ipcPayloadMb: number = 100,
-  stdoutMb: number = 1,
+  wallClock: number = 60s,
+  memory: number = 512mb,
+  ipcPayload: number = 100mb,
+  stdout: number = 1mb,
   maxCost: number | null = null,
 ): Result
 ```
@@ -343,10 +343,10 @@ Compile Agency source code and execute one of its nodes in a subprocess,
   @param source - Agency source code as a string
   @param node - Which exported node to run (default "main")
   @param args - Arguments to pass to the node
-  @param wallClockSeconds - Max wall-clock SECONDS before the subprocess is killed (default 60, max 3600). Omit for the default.
-  @param memoryMb - Max V8 heap size in MEGABYTES (default 512, max 4096). Omit for the default.
-  @param ipcPayloadMb - Max single IPC message size in MEGABYTES (default 100, max 1024). Omit for the default.
-  @param stdoutMb - Max combined stdout+stderr output in MEGABYTES (default 1, max 100). Omit for the default.
+  @param wallClock - Max wall-clock time in MILLISECONDS before SIGKILL (default 60000 = 60s, max 3600000 = 1h). Pass null for the default.
+  @param memory - Max V8 heap size in BYTES (default 536870912 = 512mb, max 4294967296 = 4gb). Pass null for the default.
+  @param ipcPayload - Max single IPC message size in BYTES (default 104857600 = 100mb, max 1073741824 = 1gb). Pass null for the default.
+  @param stdout - Max combined stdout+stderr output in BYTES (default 1048576 = 1mb, max 104857600 = 100mb). Pass null for the default.
   @param maxCost - Max subprocess LLM spend in dollars (e.g. 0.50). null = no cost limit.
 
 Just like `run`, any interrupts and guards defined in the parent process
@@ -357,10 +357,6 @@ Designed for LLM tool use: compile() returns a CompiledProgram the model
 would have to echo back into run() verbatim (it will not — see the
 compile→run "CompiledProgram has no code" failure mode). runCode takes
 the source directly, so nothing large round-trips through the model.
-Unlike `run`/`runFile` (which take canonical milliseconds/bytes and are
-what unit literals like `60s`/`512mb` produce), runCode takes human
-units — seconds and megabytes — because models fill numeric parameters
-from the docs and reliably pick human units.
 
 Declared `safe` (= okay to retry, see the LLM guide) so its pre-execution
 failures — bad limits, code that does not compile — reach a tool-calling
@@ -375,17 +371,17 @@ re-raises std::run and the child's own effects re-prompt.
 | source | `string` |  |
 | node | `string` | "main" |
 | args | `Record<string, any>` | {} |
-| wallClockSeconds | `number` | 60 |
-| memoryMb | `number` | 512 |
-| ipcPayloadMb | `number` | 100 |
-| stdoutMb | `number` | 1 |
+| wallClock | `number` | 60s |
+| memory | `number` | 512mb |
+| ipcPayload | `number` | 100mb |
+| stdout | `number` | 1mb |
 | maxCost | `number \| null` | null |
 
 **Returns:** `Result`
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L291))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L300))
 
 ### typecheck
 
@@ -409,7 +405,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L360))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L368))
 
 ### getEffects
 
@@ -433,7 +429,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L372))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L380))
 
 ### mergeFeedback
 
@@ -456,7 +452,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L394))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L402))
 
 ### review
 
@@ -480,7 +476,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L465))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L473))
 
 ### renderFeedback
 
@@ -500,7 +496,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L496))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L504))
 
 ### feedbackHasErrors
 
@@ -521,7 +517,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L508))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L516))
 
 ### writeAgency
 
@@ -552,7 +548,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L556))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L564))
 
 ### typecheckFile
 
@@ -577,7 +573,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L621))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L629))
 
 ### parseAST
 
@@ -597,7 +593,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L647))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L655))
 
 ### writeAST
 
@@ -634,7 +630,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L659))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L667))
 
 ### format
 
@@ -654,7 +650,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L681))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L689))
 
 ### formatFile
 
@@ -681,7 +677,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L692))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L700))
 
 ### walkAST
 
@@ -710,7 +706,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L711))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L719))
 
 ### getNodesOfType
 
@@ -732,7 +728,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L731))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L739))
 
 ### getImports
 
@@ -752,7 +748,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L741))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L749))
 
 ### getFunctions
 
@@ -772,7 +768,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L750))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L758))
 
 ### getGraphNodes
 
@@ -792,7 +788,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L759))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L767))
 
 ### filterImports
 
@@ -844,7 +840,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L786))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L794))
 
 ### getVersion
 
@@ -856,4 +852,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L812))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L820))

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -29,7 +29,7 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L59))
 
 ### SourceLocation
 
@@ -42,7 +42,7 @@ export type SourceLocation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L63))
 
 ### TypeCheckDiagnostic
 
@@ -57,7 +57,7 @@ export type TypeCheckDiagnostic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L70))
 
 ### TypeCheckReport
 
@@ -68,7 +68,7 @@ export type TypeCheckReport = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L79))
 
 ### EffectsByExport
 
@@ -79,7 +79,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L273))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L370))
 
 ### Feedback
 
@@ -98,7 +98,7 @@ export type Feedback = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L291))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L388))
 
 ### WriteFailure
 
@@ -114,7 +114,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L431))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L528))
 
 ### AST
 
@@ -137,7 +137,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L544))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L641))
 
 ## Effects
 
@@ -150,7 +150,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L41))
 
 ### std::write
 
@@ -161,7 +161,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L44))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L45))
 
 ### std::run
 
@@ -177,7 +177,7 @@ effect std::run {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L49))
 
 ## Functions
 
@@ -199,7 +199,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L84))
 
 ### run
 
@@ -224,10 +224,10 @@ Execute a compiled Agency program in a subprocess and return the node's result.
   @param compiled - A compiled Agency program
   @param node - Which exported node to run
   @param args - Arguments to pass to the node
-  @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
-  @param memory - Max V8 heap size (default 512mb, max 4gb)
-  @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
-  @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
+  @param wallClock - Max wall-clock time in MILLISECONDS before SIGKILL (default 60000 = 60s, max 1h). Pass null for the default.
+  @param memory - Max V8 heap size in BYTES (default 536870912 = 512mb, max 4gb). Pass null for the default.
+  @param ipcPayload - Max single IPC message size in BYTES (default 104857600 = 100mb, max 1gb). Pass null for the default.
+  @param stdout - Max combined stdout+stderr output in BYTES (default 1048576 = 1mb, max 100mb). Pass null for the default.
   @param logFile - Optional statelog JSONL file path for this subprocess run
   @param cwd - Optional working directory for this subprocess run
   @param maxDepth - Max subprocess nesting depth (default 5, hard ceiling 10).
@@ -264,7 +264,7 @@ and a child process has maxDepth=5, maxDepth=3 is used.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L104))
 
 ### runFile
 
@@ -289,10 +289,10 @@ Compile and execute an Agency file in a subprocess and return the node's result.
   @param filename - The agency file to compile and run
   @param node - Which node to run
   @param args - Arguments to pass to the node
-  @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
-  @param memory - Max V8 heap size (default 512mb, max 4gb)
-  @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
-  @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
+  @param wallClock - Max wall-clock time in MILLISECONDS before SIGKILL (default 60000 = 60s, max 1h). Pass null for the default.
+  @param memory - Max V8 heap size in BYTES (default 536870912 = 512mb, max 4gb). Pass null for the default.
+  @param ipcPayload - Max single IPC message size in BYTES (default 104857600 = 100mb, max 1gb). Pass null for the default.
+  @param stdout - Max combined stdout+stderr output in BYTES (default 1048576 = 1mb, max 100mb). Pass null for the default.
   @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
 
 Just like `run`, any interrupts and guards defined in the parent process
@@ -317,7 +317,75 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L218))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L219))
+
+### runCode
+
+```ts
+runCode(
+  source: string,
+  node: string = "main",
+  args: Record<string, any> = {},
+  wallClockSeconds: number = 60,
+  memoryMb: number = 512,
+  ipcPayloadMb: number = 100,
+  stdoutMb: number = 1,
+  maxCost: number | null = null,
+): Result
+```
+
+Compile Agency source code and execute one of its nodes in a subprocess,
+  returning the value the node returned. Prefer this over separate
+  compile() and run() calls. Only standard-library (`std::`) imports are
+  allowed in the source. Compile errors are returned as a failure without
+  running anything; fix the source and call again.
+
+  @param source - Agency source code as a string
+  @param node - Which exported node to run (default "main")
+  @param args - Arguments to pass to the node
+  @param wallClockSeconds - Max wall-clock SECONDS before the subprocess is killed (default 60, max 3600). Omit for the default.
+  @param memoryMb - Max V8 heap size in MEGABYTES (default 512, max 4096). Omit for the default.
+  @param ipcPayloadMb - Max single IPC message size in MEGABYTES (default 100, max 1024). Omit for the default.
+  @param stdoutMb - Max combined stdout+stderr output in MEGABYTES (default 1, max 100). Omit for the default.
+  @param maxCost - Max subprocess LLM spend in dollars (e.g. 0.50). null = no cost limit.
+
+Just like `run`, any interrupts and guards defined in the parent process
+will apply to the child process. Any callbacks in scope will also apply.
+Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` failure.
+
+Designed for LLM tool use: compile() returns a CompiledProgram the model
+would have to echo back into run() verbatim (it will not — see the
+compile→run "CompiledProgram has no code" failure mode). runCode takes
+the source directly, so nothing large round-trips through the model.
+Unlike `run`/`runFile` (which take canonical milliseconds/bytes and are
+what unit literals like `60s`/`512mb` produce), runCode takes human
+units — seconds and megabytes — because models fill numeric parameters
+from the docs and reliably pick human units.
+
+Declared `safe` (= okay to retry, see the LLM guide) so its pre-execution
+failures — bad limits, code that does not compile — reach a tool-calling
+model as RETRYABLE and it can correct itself instead of losing the tool.
+Re-running the child is handler-gated like any run(): each attempt
+re-raises std::run and the child's own effects re-prompt.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+| node | `string` | "main" |
+| args | `Record<string, any>` | {} |
+| wallClockSeconds | `number` | 60 |
+| memoryMb | `number` | 512 |
+| ipcPayloadMb | `number` | 100 |
+| stdoutMb | `number` | 1 |
+| maxCost | `number \| null` | null |
+
+**Returns:** `Result`
+
+**Throws:** `std::run`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L291))
 
 ### typecheck
 
@@ -341,7 +409,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L263))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L360))
 
 ### getEffects
 
@@ -365,7 +433,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L275))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L372))
 
 ### mergeFeedback
 
@@ -388,7 +456,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L297))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L394))
 
 ### review
 
@@ -412,7 +480,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L368))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L465))
 
 ### renderFeedback
 
@@ -432,7 +500,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L399))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L496))
 
 ### feedbackHasErrors
 
@@ -453,7 +521,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L411))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L508))
 
 ### writeAgency
 
@@ -484,7 +552,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L459))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L556))
 
 ### typecheckFile
 
@@ -509,7 +577,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L524))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L621))
 
 ### parseAST
 
@@ -529,7 +597,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L550))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L647))
 
 ### writeAST
 
@@ -566,7 +634,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L562))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L659))
 
 ### format
 
@@ -586,7 +654,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L584))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L681))
 
 ### formatFile
 
@@ -613,7 +681,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L595))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L692))
 
 ### walkAST
 
@@ -642,7 +710,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L614))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L711))
 
 ### getNodesOfType
 
@@ -664,7 +732,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L634))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L731))
 
 ### getImports
 
@@ -684,7 +752,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L644))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L741))
 
 ### getFunctions
 
@@ -704,7 +772,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L653))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L750))
 
 ### getGraphNodes
 
@@ -724,7 +792,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L662))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L759))
 
 ### filterImports
 
@@ -776,7 +844,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L689))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L786))
 
 ### getVersion
 
@@ -788,4 +856,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L715))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L812))

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -9,6 +9,7 @@ const {
   capToolResultForLlm,
   assertUniqueToolNames,
   unwrapToolResultForLlm,
+  toolErrorMessage,
 } = _internal;
 
 describe("assertUniqueToolNames", () => {
@@ -77,6 +78,18 @@ describe("unwrapToolResultForLlm", () => {
   it("passes a failure Result through unchanged (handled upstream)", () => {
     const fail = { __type: "resultType", success: false, error: "boom" };
     expect(unwrapToolResultForLlm(fail, "myTool")).toBe(fail);
+  });
+});
+
+describe("toolErrorMessage", () => {
+  it("passes string errors through", () => {
+    expect(toolErrorMessage("boom")).toBe("boom");
+  });
+
+  it("JSON-stringifies object errors instead of [object Object]", () => {
+    expect(toolErrorMessage({ source: "x", errors: [] })).toBe(
+      '{"source":"x","errors":[]}',
+    );
   });
 });
 

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -8,6 +8,7 @@ const {
   stringifyToolResult,
   capToolResultForLlm,
   assertUniqueToolNames,
+  unwrapToolResultForLlm,
 } = _internal;
 
 describe("assertUniqueToolNames", () => {
@@ -38,6 +39,44 @@ describe("assertUniqueToolNames", () => {
     expect(() =>
       assertUniqueToolNames([{ name: "x" }, { name: "x" }]),
     ).toThrow(/\.rename\(/);
+  });
+});
+
+describe("unwrapToolResultForLlm", () => {
+  const success = (value: unknown) => ({
+    __type: "resultType",
+    success: true,
+    value,
+  });
+
+  it("unwraps a success Result to its value (string)", () => {
+    expect(unwrapToolResultForLlm(success("hi"), "myTool")).toBe("hi");
+  });
+
+  it("unwraps a success Result to its value (object)", () => {
+    expect(
+      unwrapToolResultForLlm(success({ moduleId: "x" }), "myTool"),
+    ).toEqual({ moduleId: "x" });
+  });
+
+  it("substitutes the no-value message when a success holds null/undefined", () => {
+    expect(unwrapToolResultForLlm(success(null), "myTool")).toBe(
+      "myTool ran successfully but did not return a value",
+    );
+    expect(unwrapToolResultForLlm(success(undefined), "myTool")).toBe(
+      "myTool ran successfully but did not return a value",
+    );
+  });
+
+  it("passes plain values through unchanged", () => {
+    expect(unwrapToolResultForLlm("plain", "myTool")).toBe("plain");
+    const obj = { a: 1 };
+    expect(unwrapToolResultForLlm(obj, "myTool")).toBe(obj);
+  });
+
+  it("passes a failure Result through unchanged (handled upstream)", () => {
+    const fail = { __type: "resultType", success: false, error: "boom" };
+    expect(unwrapToolResultForLlm(fail, "myTool")).toBe(fail);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/prompt.test.ts
+++ b/packages/agency-lang/lib/runtime/prompt.test.ts
@@ -69,6 +69,12 @@ describe("unwrapToolResultForLlm", () => {
     );
   });
 
+  it("preserves legitimate falsy success values (false, 0, empty string)", () => {
+    expect(unwrapToolResultForLlm(success(false), "myTool")).toBe(false);
+    expect(unwrapToolResultForLlm(success(0), "myTool")).toBe(0);
+    expect(unwrapToolResultForLlm(success(""), "myTool")).toBe("");
+  });
+
   it("passes plain values through unchanged", () => {
     expect(unwrapToolResultForLlm("plain", "myTool")).toBe("plain");
     const obj = { a: 1 };

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -194,6 +194,14 @@ function unwrapToolResultForLlm(result: any, toolName: string): any {
   );
 }
 
+/** Render a failure Result's error for the model. String errors pass
+ *  through; structured errors (e.g. writeAgency's `{source, errors}`)
+ *  JSON-stringify — `String(error)` would send the useless
+ *  "[object Object]". */
+function toolErrorMessage(error: any): string {
+  return typeof error === "string" ? error : stringifyToolResult(error);
+}
+
 /** Truncate a tool result for the LLM if its serialized form exceeds
  *  `cap` characters. Returns the ORIGINAL value untouched when within
  *  the cap (so smoltalk serializes it exactly as before) or when the cap
@@ -442,6 +450,7 @@ export const _internal = {
   capToolResultForLlm,
   assertUniqueToolNames,
   unwrapToolResultForLlm,
+  toolErrorMessage,
   armCallTimeout,
   runWithRetry,
   dropNullDefaultedArgs,
@@ -1098,10 +1107,7 @@ export async function runPrompt(args: {
       }
 
       if (isFailure(toolResult)) {
-        const errorMessage =
-          typeof toolResult.error === "string"
-            ? toolResult.error
-            : String(toolResult.error);
+        const errorMessage = toolErrorMessage(toolResult.error);
         // Cap only what the LLM sees; statelog keeps the full message.
         const cappedError = String(
           capToolResultForLlm(errorMessage, toolResultCap),

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1182,8 +1182,10 @@ export async function runPrompt(args: {
       // branch cache keeps the FULL value (Agency code may match on a
       // Result); the model-facing message gets the unwrapped success
       // value via unwrapToolResultForLlm inside the push helper.
+      // Nullish, NOT ||: legitimate falsy returns (false, 0, "") must
+      // reach the model and the branch cache as-is.
       toolResult =
-        toolResult ||
+        toolResult ??
         `${handler.name} ran successfully but did not return a value`;
       stack.setResultOnBranch(branchKey, toolResult);
       pushSuccessToolMessage({ toolResult, toolCall, handler, branchStack });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -30,7 +30,7 @@ import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
 // See docs/dev/promptRunner.md for the control-flow abstraction used here.
 import { PromptBailout, PromptRunner } from "./promptRunner.js";
-import { failure, isFailure } from "./result.js";
+import { failure, isFailure, isSuccess } from "./result.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { LlmDefaults } from "../stdlib/llm.js";
@@ -176,6 +176,22 @@ function stringifyToolResult(result: any): string {
   } catch {
     return String(result);
   }
+}
+
+/** Unwrap a SUCCESS Result before it goes back to the model: the LLM
+ *  should see the tool's value, not the `{__type, success, value}`
+ *  envelope (a wrapped envelope makes the model re-derive `.value` and,
+ *  worse, reconstruct wrapped objects when echoing them into later tool
+ *  arguments — the compile→run CompiledProgram bug). Only the LLM-facing
+ *  message unwraps; the Result cached on the branch for Agency code is
+ *  untouched. Failures/rejections never reach this point (handled
+ *  upstream in the invoke path), but pass through unchanged
+ *  defensively. */
+function unwrapToolResultForLlm(result: any, toolName: string): any {
+  if (!isSuccess(result)) return result;
+  return (
+    result.value ?? `${toolName} ran successfully but did not return a value`
+  );
 }
 
 /** Truncate a tool result for the LLM if its serialized form exceeds
@@ -425,6 +441,7 @@ export const _internal = {
   stringifyToolResult,
   capToolResultForLlm,
   assertUniqueToolNames,
+  unwrapToolResultForLlm,
   armCallTimeout,
   runWithRetry,
   dropNullDefaultedArgs,
@@ -1155,7 +1172,10 @@ export async function runPrompt(args: {
       }
 
       // Success: cache the result, push tool message (extracted helper
-      // keeps this arrow inside the max-lines-per-function budget).
+      // keeps this arrow inside the max-lines-per-function budget). The
+      // branch cache keeps the FULL value (Agency code may match on a
+      // Result); the model-facing message gets the unwrapped success
+      // value via unwrapToolResultForLlm inside the push helper.
       toolResult =
         toolResult ||
         `${handler.name} ran successfully but did not return a value`;
@@ -1196,7 +1216,10 @@ export async function runPrompt(args: {
           // returns `any` (an under-cap structured result passes through
           // unstringified) and ToolMessage accepts it at runtime.
           appendReplyMarker(
-            capToolResultForLlm(toolResult, toolResultCap),
+            capToolResultForLlm(
+              unwrapToolResultForLlm(toolResult, handler.name),
+              toolResultCap,
+            ),
             replyMarker,
             stringifyToolResult,
           ) as any,

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -19,6 +19,7 @@ import {
 } from "../types/function.js";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { AgencyFunction } from "../runtime/agencyFunction.js";
+import { failure, type ResultFailure } from "../runtime/result.js";
 
 const VALID_CALLBACK_NAME_SET: ReadonlySet<string> = new Set(VALID_CALLBACK_NAMES);
 
@@ -175,6 +176,17 @@ export function _typecheck(source: string): TypeCheckReport {
 
 export function _getEffects(source: string): Record<string, string[]> {
   return getEffectsFromSource(source);
+}
+
+/**
+ * Build a RETRYABLE failure Result. Agency-level `failure(...)` and `try`
+ * both produce non-retryable failures, and the LLM tool loop removes a
+ * tool after a non-retryable failure — fatal for runCode, whose failure
+ * modes (bad limits, code that does not compile) are exactly the ones the
+ * model should fix and retry.
+ */
+export function _retryableFailure(error: any): ResultFailure {
+  return failure(error, { retryable: true });
 }
 
 // The real file path is handed to the type-checker so relative imports in

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -257,14 +257,27 @@ export def runFile(
   )
 }
 
-// Ceilings for runCode's human-unit limit params, mirroring
-// LIMIT_CEILINGS in lib/runtime/ipc.ts (keep in sync).
-def checkRunCodeLimit(name: string, value: number, max: number, unit: string): string {
-  if (value <= 0) {
-    return "${name} must be a positive number of ${unit} (got ${value})."
-  }
-  if (value > max) {
-    return "${name} is too large: ${value} ${unit} exceeds the maximum of ${max} ${unit}."
+// Reject out-of-range limit values with a message the model can act on.
+// Ceilings mirror LIMIT_CEILINGS in lib/runtime/ipc.ts (keep in sync).
+def checkRunCodeLimits(
+  wallClock: number,
+  memory: number,
+  ipcPayload: number,
+  stdout: number,
+): string {
+  const checks = [
+    { name: "wallClock", value: wallClock, max: 3600s, unit: "milliseconds" },
+    { name: "memory", value: memory, max: 4096mb, unit: "bytes" },
+    { name: "ipcPayload", value: ipcPayload, max: 1024mb, unit: "bytes" },
+    { name: "stdout", value: stdout, max: 100mb, unit: "bytes" },
+  ]
+  for (check in checks) {
+    if (check.value <= 0) {
+      return "${check.name} must be a positive number of ${check.unit} (got ${check.value})."
+    }
+    if (check.value > check.max) {
+      return "${check.name} is too large: ${check.value} ${check.unit} exceeds the maximum of ${check.max} ${check.unit}."
+    }
   }
   return ""
 }
@@ -277,10 +290,6 @@ Designed for LLM tool use: compile() returns a CompiledProgram the model
 would have to echo back into run() verbatim (it will not — see the
 compile→run "CompiledProgram has no code" failure mode). runCode takes
 the source directly, so nothing large round-trips through the model.
-Unlike `run`/`runFile` (which take canonical milliseconds/bytes and are
-what unit literals like `60s`/`512mb` produce), runCode takes human
-units — seconds and megabytes — because models fill numeric parameters
-from the docs and reliably pick human units.
 
 Declared `safe` (= okay to retry, see the LLM guide) so its pre-execution
 failures — bad limits, code that does not compile — reach a tool-calling
@@ -292,10 +301,10 @@ export safe def runCode(
   source: string,
   node: string = "main",
   args: Record<string, any> = {},
-  wallClockSeconds: number = 60,
-  memoryMb: number = 512,
-  ipcPayloadMb: number = 100,
-  stdoutMb: number = 1,
+  wallClock: number = 60s,
+  memory: number = 512mb,
+  ipcPayload: number = 100mb,
+  stdout: number = 1mb,
   maxCost: number | null = null,
 ): Result {
   """
@@ -308,39 +317,31 @@ export safe def runCode(
   @param source - Agency source code as a string
   @param node - Which exported node to run (default "main")
   @param args - Arguments to pass to the node
-  @param wallClockSeconds - Max wall-clock SECONDS before the subprocess is killed (default 60, max 3600). Omit for the default.
-  @param memoryMb - Max V8 heap size in MEGABYTES (default 512, max 4096). Omit for the default.
-  @param ipcPayloadMb - Max single IPC message size in MEGABYTES (default 100, max 1024). Omit for the default.
-  @param stdoutMb - Max combined stdout+stderr output in MEGABYTES (default 1, max 100). Omit for the default.
+  @param wallClock - Max wall-clock time in MILLISECONDS before SIGKILL (default 60000 = 60s, max 3600000 = 1h). Pass null for the default.
+  @param memory - Max V8 heap size in BYTES (default 536870912 = 512mb, max 4294967296 = 4gb). Pass null for the default.
+  @param ipcPayload - Max single IPC message size in BYTES (default 104857600 = 100mb, max 1073741824 = 1gb). Pass null for the default.
+  @param stdout - Max combined stdout+stderr output in BYTES (default 1048576 = 1mb, max 104857600 = 100mb). Pass null for the default.
   @param maxCost - Max subprocess LLM spend in dollars (e.g. 0.50). null = no cost limit.
   """
-  let limitError = checkRunCodeLimit("wallClockSeconds", wallClockSeconds, 3600, "seconds")
-  if (limitError == "") {
-    limitError = checkRunCodeLimit("memoryMb", memoryMb, 4096, "megabytes")
-  }
-  if (limitError == "") {
-    limitError = checkRunCodeLimit("ipcPayloadMb", ipcPayloadMb, 1024, "megabytes")
-  }
-  if (limitError == "") {
-    limitError = checkRunCodeLimit("stdoutMb", stdoutMb, 100, "megabytes")
-  }
+  const limitError = checkRunCodeLimits(wallClock, memory, ipcPayload, stdout)
   if (limitError != "") {
     return _retryableFailure(limitError)
   }
   const compileResult = try _compile(source)
   if (compileResult is failure(compileErr)) {
     // Re-wrap as retryable: the model should fix the source and call
-    // again, not lose the tool.
+    // again, not lose the tool. (`safe` alone is not enough — try-born
+    // failures start retryable:false; safe only preserves the bit.)
     return _retryableFailure(compileErr)
   }
   const result = run(
     compiled: compileResult.value,
     node: node,
     args: args,
-    wallClock: wallClockSeconds * 1000,
-    memory: memoryMb * 1048576,
-    ipcPayload: ipcPayloadMb * 1048576,
-    stdout: stdoutMb * 1048576,
+    wallClock: wallClock,
+    memory: memory,
+    ipcPayload: ipcPayload,
+    stdout: stdout,
     maxCost: maxCost,
   )
   // run() succeeds with a subprocess envelope ({ data, tokens, ... }).
@@ -349,6 +350,13 @@ export safe def runCode(
   // the node's value. Callers who want the envelope use run().
   if (result is success(envelope)) {
     return success(envelope.data)
+  }
+  if (result is failure(runErr)) {
+    // Runtime failures (child crash, timeout, cost trip) are retryable
+    // at the tool level too: the model fixes the source or raises a
+    // limit and calls again, and every attempt re-raises std::run, so
+    // retries stay handler-gated.
+    return _retryableFailure(runErr)
   }
   return result
 }
@@ -553,7 +561,7 @@ If you are unsure about syntax or a standard-library function, read the
 relevant page with the docs tool before writing code.
 Return only the complete program in the code field."""
 
-export def writeAgency(
+export safe def writeAgency(
   task: string,
   context: string = "",
   maxAttempts: number = 3,
@@ -569,7 +577,7 @@ export def writeAgency(
   @param maxAttempts - Max generation attempts before giving up (default 3)
   """
   const docsTool = docsSkill("guide")
-  let result: Result<string, WriteFailure> = failure({ source: "", errors: [] })
+  let result: Result<string, WriteFailure> = _retryableFailure({ source: "", errors: [] })
   thread(label: "writeAgency") {
     systemMessage(writeSysPrompt)
     let prompt = "Write an Agency program for this task:\n<task>\n${task}\n</task>"
@@ -584,7 +592,7 @@ export def writeAgency(
       const source = generated.code
       const checked = try _typecheck(source)
       if (checked is failure(parseErr)) {
-        result = failure({ source: source, errors: [] })
+        result = _retryableFailure({ source: source, errors: [] })
         // _typecheck throws for import-resolution failures as well as
         // parse failures. In the import case the re-parse succeeds and
         // renders no findings — fall back to the thrown error so the
@@ -595,13 +603,13 @@ export def writeAgency(
         }
         prompt = "That code has problems:\n${findings}\nReturn a corrected complete program."
       } else if (checked.value.errors.length > 0) {
-        result = failure({ source: source, errors: checked.value.errors })
+        result = _retryableFailure({ source: source, errors: checked.value.errors })
         const findings = renderFeedback(success(reportFeedback(checked.value)))
         prompt = "That code has problems:\n${findings}\nReturn a corrected complete program."
       } else {
         const compiled = try _compile(source)
         if (compiled is failure(compileErr)) {
-          result = failure({ source: source, errors: [] })
+          result = _retryableFailure({ source: source, errors: [] })
           prompt = "That code failed to compile: ${compileErr}\nReturn a corrected complete program."
         } else {
           result = success(source)

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -256,6 +256,56 @@ export def runFile(
   )
 }
 
+/** Just like `run`, any interrupts and guards defined in the parent process
+will apply to the child process. Any callbacks in scope will also apply.
+Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` failure.
+
+Designed for LLM tool use: compile() returns a CompiledProgram the model
+would have to echo back into run() verbatim (it will not — see the
+compile→run "CompiledProgram has no code" failure mode). runCode takes
+the source directly, so nothing large round-trips through the model.
+*/
+export def runCode(
+  source: string,
+  node: string = "main",
+  args: Record<string, any> = {},
+  wallClock: number = 60s,
+  memory: number = 512mb,
+  ipcPayload: number = 100mb,
+  stdout: number = 1mb,
+  maxCost: number | null = null,
+): Result {
+  """
+  Compile Agency source code and execute one of its nodes in a subprocess,
+  returning the node's result. Prefer this over separate compile() and
+  run() calls. Only standard-library (`std::`) imports are allowed in the
+  source. Compile errors are returned as a failure without running anything.
+
+  @param source - Agency source code as a string
+  @param node - Which exported node to run (default "main")
+  @param args - Arguments to pass to the node
+  @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
+  @param memory - Max V8 heap size (default 512mb, max 4gb)
+  @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
+  @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
+  @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
+  """
+  const compileResult = try _compile(source)
+  if (isFailure(compileResult)) {
+    return compileResult
+  }
+  return run(
+    compiled: compileResult.value,
+    node: node,
+    args: args,
+    wallClock: wallClock,
+    memory: memory,
+    ipcPayload: ipcPayload,
+    stdout: stdout,
+    maxCost: maxCost,
+  )
+}
+
 /** Unlike some of the other functions in this module,
 `typecheck` does not restrict imports to the standard library only.
 Relative imports (./foo.agency) cannot be resolved from a source string.

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -4,6 +4,7 @@ import {
   _typecheck,
   _typecheckFile,
   _getEffects,
+  _retryableFailure,
   _parseAST,
   _writeAST,
   _format,
@@ -119,10 +120,10 @@ export def run(
   @param compiled - A compiled Agency program
   @param node - Which exported node to run
   @param args - Arguments to pass to the node
-  @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
-  @param memory - Max V8 heap size (default 512mb, max 4gb)
-  @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
-  @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
+  @param wallClock - Max wall-clock time in MILLISECONDS before SIGKILL (default 60000 = 60s, max 1h). Pass null for the default.
+  @param memory - Max V8 heap size in BYTES (default 536870912 = 512mb, max 4gb). Pass null for the default.
+  @param ipcPayload - Max single IPC message size in BYTES (default 104857600 = 100mb, max 1gb). Pass null for the default.
+  @param stdout - Max combined stdout+stderr output in BYTES (default 1048576 = 1mb, max 100mb). Pass null for the default.
   @param logFile - Optional statelog JSONL file path for this subprocess run
   @param cwd - Optional working directory for this subprocess run
   @param maxDepth - Max subprocess nesting depth (default 5, hard ceiling 10).
@@ -234,10 +235,10 @@ export def runFile(
   @param filename - The agency file to compile and run
   @param node - Which node to run
   @param args - Arguments to pass to the node
-  @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
-  @param memory - Max V8 heap size (default 512mb, max 4gb)
-  @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
-  @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
+  @param wallClock - Max wall-clock time in MILLISECONDS before SIGKILL (default 60000 = 60s, max 1h). Pass null for the default.
+  @param memory - Max V8 heap size in BYTES (default 536870912 = 512mb, max 4gb). Pass null for the default.
+  @param ipcPayload - Max single IPC message size in BYTES (default 104857600 = 100mb, max 1gb). Pass null for the default.
+  @param stdout - Max combined stdout+stderr output in BYTES (default 1048576 = 1mb, max 100mb). Pass null for the default.
   @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
   """
   const compileResult = try _compileFile(dir, filename)
@@ -256,6 +257,18 @@ export def runFile(
   )
 }
 
+// Ceilings for runCode's human-unit limit params, mirroring
+// LIMIT_CEILINGS in lib/runtime/ipc.ts (keep in sync).
+def checkRunCodeLimit(name: string, value: number, max: number, unit: string): string {
+  if (value <= 0) {
+    return "${name} must be a positive number of ${unit} (got ${value})."
+  }
+  if (value > max) {
+    return "${name} is too large: ${value} ${unit} exceeds the maximum of ${max} ${unit}."
+  }
+  return ""
+}
+
 /** Just like `run`, any interrupts and guards defined in the parent process
 will apply to the child process. Any callbacks in scope will also apply.
 Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` failure.
@@ -264,46 +277,80 @@ Designed for LLM tool use: compile() returns a CompiledProgram the model
 would have to echo back into run() verbatim (it will not — see the
 compile→run "CompiledProgram has no code" failure mode). runCode takes
 the source directly, so nothing large round-trips through the model.
+Unlike `run`/`runFile` (which take canonical milliseconds/bytes and are
+what unit literals like `60s`/`512mb` produce), runCode takes human
+units — seconds and megabytes — because models fill numeric parameters
+from the docs and reliably pick human units.
+
+Declared `safe` (= okay to retry, see the LLM guide) so its pre-execution
+failures — bad limits, code that does not compile — reach a tool-calling
+model as RETRYABLE and it can correct itself instead of losing the tool.
+Re-running the child is handler-gated like any run(): each attempt
+re-raises std::run and the child's own effects re-prompt.
 */
-export def runCode(
+export safe def runCode(
   source: string,
   node: string = "main",
   args: Record<string, any> = {},
-  wallClock: number = 60s,
-  memory: number = 512mb,
-  ipcPayload: number = 100mb,
-  stdout: number = 1mb,
+  wallClockSeconds: number = 60,
+  memoryMb: number = 512,
+  ipcPayloadMb: number = 100,
+  stdoutMb: number = 1,
   maxCost: number | null = null,
 ): Result {
   """
   Compile Agency source code and execute one of its nodes in a subprocess,
-  returning the node's result. Prefer this over separate compile() and
-  run() calls. Only standard-library (`std::`) imports are allowed in the
-  source. Compile errors are returned as a failure without running anything.
+  returning the value the node returned. Prefer this over separate
+  compile() and run() calls. Only standard-library (`std::`) imports are
+  allowed in the source. Compile errors are returned as a failure without
+  running anything; fix the source and call again.
 
   @param source - Agency source code as a string
   @param node - Which exported node to run (default "main")
   @param args - Arguments to pass to the node
-  @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
-  @param memory - Max V8 heap size (default 512mb, max 4gb)
-  @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
-  @param stdout - Max combined stdout+stderr bytes (default 1mb, max 100mb)
-  @param maxCost - Max subprocess LLM spend in dollars (e.g. $0.50). null = no cost limit.
+  @param wallClockSeconds - Max wall-clock SECONDS before the subprocess is killed (default 60, max 3600). Omit for the default.
+  @param memoryMb - Max V8 heap size in MEGABYTES (default 512, max 4096). Omit for the default.
+  @param ipcPayloadMb - Max single IPC message size in MEGABYTES (default 100, max 1024). Omit for the default.
+  @param stdoutMb - Max combined stdout+stderr output in MEGABYTES (default 1, max 100). Omit for the default.
+  @param maxCost - Max subprocess LLM spend in dollars (e.g. 0.50). null = no cost limit.
   """
-  const compileResult = try _compile(source)
-  if (isFailure(compileResult)) {
-    return compileResult
+  let limitError = checkRunCodeLimit("wallClockSeconds", wallClockSeconds, 3600, "seconds")
+  if (limitError == "") {
+    limitError = checkRunCodeLimit("memoryMb", memoryMb, 4096, "megabytes")
   }
-  return run(
+  if (limitError == "") {
+    limitError = checkRunCodeLimit("ipcPayloadMb", ipcPayloadMb, 1024, "megabytes")
+  }
+  if (limitError == "") {
+    limitError = checkRunCodeLimit("stdoutMb", stdoutMb, 100, "megabytes")
+  }
+  if (limitError != "") {
+    return _retryableFailure(limitError)
+  }
+  const compileResult = try _compile(source)
+  if (compileResult is failure(compileErr)) {
+    // Re-wrap as retryable: the model should fix the source and call
+    // again, not lose the tool.
+    return _retryableFailure(compileErr)
+  }
+  const result = run(
     compiled: compileResult.value,
     node: node,
     args: args,
-    wallClock: wallClock,
-    memory: memory,
-    ipcPayload: ipcPayload,
-    stdout: stdout,
+    wallClock: wallClockSeconds * 1000,
+    memory: memoryMb * 1048576,
+    ipcPayload: ipcPayloadMb * 1048576,
+    stdout: stdoutMb * 1048576,
     maxCost: maxCost,
   )
+  // run() succeeds with a subprocess envelope ({ data, tokens, ... }).
+  // runCode is built for LLM tool use, where the envelope reads as noise
+  // (token stats first, the actual result buried in .data) — return just
+  // the node's value. Callers who want the envelope use run().
+  if (result is success(envelope)) {
+    return success(envelope.data)
+  }
+  return result
 }
 
 /** Unlike some of the other functions in this module,

--- a/packages/agency-lang/tests/agency/subprocess/run-code.agency
+++ b/packages/agency-lang/tests/agency/subprocess/run-code.agency
@@ -26,7 +26,8 @@ node main() {
   handle {
     const result = runCode(source)
     if (isSuccess(result)) {
-      return result.value.data
+      // runCode unwraps the run() envelope: value IS the node's result.
+      return result.value
     }
     return "run failed"
   } with (e) {
@@ -36,12 +37,24 @@ node main() {
   }
 }
 
-// A compile failure comes back as the compile Result, no subprocess and
-// no std::run interrupt (nothing to approve — the handler would reject).
+// A compile failure comes back as a RETRYABLE failure (the tool loop
+// keeps the tool so the model can fix the source and call again), with
+// no subprocess spawned and no std::run interrupt raised.
 node compileFailure() {
   const result = runCode("node {{{")
   if (isFailure(result)) {
-    return "compile failed as expected"
+    return ["compile failed as expected", result.retryable]
+  }
+  return "unexpected success"
+}
+
+// Limit params are human units (seconds / megabytes) with ceilings; a
+// too-large value is a retryable failure naming the limit and maximum.
+node tooLarge() {
+  const result = runCode("node main() { return 1 }", wallClockSeconds: 999999)
+  if (isFailure(result)) {
+    const message = "${result.error}"
+    return [result.retryable, message.includes("3600")]
   }
   return "unexpected success"
 }

--- a/packages/agency-lang/tests/agency/subprocess/run-code.agency
+++ b/packages/agency-lang/tests/agency/subprocess/run-code.agency
@@ -1,0 +1,70 @@
+import { runCode } from "std::agency"
+
+// runCode = compile + run in one call, designed for LLM tool use: the
+// model hands over source and never round-trips a CompiledProgram.
+node basic() {
+  const source = """
+def fib(n: number): number {
+  if (n <= 1) {
+    return n
+  }
+  let a = 0
+  let b = 1
+  let i = 2
+  while (i <= n) {
+    const next = a + b
+    a = b
+    b = next
+    i = i + 1
+  }
+  return b
+}
+node main() {
+  return fib(5)
+}
+"""
+  handle {
+    const result = runCode(source)
+    if (isSuccess(result)) {
+      return result.value.data
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+
+// A compile failure comes back as the compile Result, no subprocess and
+// no std::run interrupt (nothing to approve — the handler would reject).
+node compileFailure() {
+  const result = runCode("node {{{")
+  if (isFailure(result)) {
+    return "compile failed as expected"
+  }
+  return "unexpected success"
+}
+
+// maxCost forwards to run(): the mocked child trips at the second call.
+node maxCostTrips() {
+  const source = """
+node main() {
+  const a = llm("Reply with: one")
+  const b = llm("Reply with: two")
+  const c = llm("Reply with: three")
+  return c
+}
+"""
+  handle {
+    const result = runCode(source, maxCost: 0.000003)
+    if (isFailure(result)) {
+      return "tripped:${result.error.reason}:${result.error.limit}"
+    }
+    return "did not trip"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/run-code.agency
+++ b/packages/agency-lang/tests/agency/subprocess/run-code.agency
@@ -48,15 +48,35 @@ node compileFailure() {
   return "unexpected success"
 }
 
-// Limit params are human units (seconds / megabytes) with ceilings; a
-// too-large value is a retryable failure naming the limit and maximum.
+// Limit params are canonical units (ms / bytes, same as unit literals)
+// with ceilings; a too-large value is a retryable failure naming the
+// limit and maximum.
 node tooLarge() {
-  const result = runCode("node main() { return 1 }", wallClockSeconds: 999999)
+  const result = runCode("node main() { return 1 }", wallClock: 999999999)
   if (isFailure(result)) {
     const message = "${result.error}"
-    return [result.retryable, message.includes("3600")]
+    return [result.retryable, message.includes("3600000")]
   }
   return "unexpected success"
+}
+
+// A run()-level failure (here: the requested node does not exist; same
+// path as child module-init crashes) is retryable too: the model fixes
+// the source or node name and calls again, rather than losing the tool.
+// (A crash INSIDE the child node is different: the child converts it to
+// a failure Result and run() succeeds with it as the node's value.)
+node runtimeFailure() {
+  handle {
+    const result = runCode("node main() { return 1 }", node: "missing")
+    if (isFailure(result)) {
+      return ["runtime failure", result.retryable]
+    }
+    return "unexpected success"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
 }
 
 // maxCost forwards to run(): the mocked child trips at the second call.

--- a/packages/agency-lang/tests/agency/subprocess/run-code.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/run-code.test.json
@@ -9,9 +9,16 @@
     },
     {
       "nodeName": "compileFailure",
-      "description": "runCode surfaces compile failures without spawning a subprocess",
+      "description": "runCode surfaces compile failures as retryable, without spawning a subprocess",
       "input": "",
-      "expectedOutput": "\"compile failed as expected\"",
+      "expectedOutput": "[\"compile failed as expected\",true]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "tooLarge",
+      "description": "runCode rejects over-ceiling limits with a retryable failure naming the max",
+      "input": "",
+      "expectedOutput": "[true,true]",
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {

--- a/packages/agency-lang/tests/agency/subprocess/run-code.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/run-code.test.json
@@ -1,0 +1,31 @@
+{
+  "tests": [
+    {
+      "nodeName": "basic",
+      "description": "runCode compiles and runs source in one call, returning the node result",
+      "input": "",
+      "expectedOutput": "5",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "compileFailure",
+      "description": "runCode surfaces compile failures without spawning a subprocess",
+      "input": "",
+      "expectedOutput": "\"compile failed as expected\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
+      "nodeName": "maxCostTrips",
+      "description": "runCode forwards maxCost to run",
+      "input": "",
+      "expectedOutput": "\"tripped:limit_exceeded:cost\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" },
+        { "return": "three" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/run-code.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/run-code.test.json
@@ -22,6 +22,13 @@
       "evaluationCriteria": [{ "type": "exact" }]
     },
     {
+      "nodeName": "runtimeFailure",
+      "description": "runCode surfaces child runtime crashes as retryable failures",
+      "input": "",
+      "expectedOutput": "[\"runtime failure\",true]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    },
+    {
       "nodeName": "maxCostTrips",
       "description": "runCode forwards maxCost to run",
       "input": "",

--- a/packages/agency-lang/tests/agency/write-agency.agency
+++ b/packages/agency-lang/tests/agency/write-agency.agency
@@ -34,7 +34,9 @@ node exhausts() {
     return "unexpected success"
   }
   if (result is failure(err)) {
-    return [err.source.includes("const x: number"), err.errors.length > 0]
+    // retryable: the tool loop must keep writeAgency available so the
+    // model can call it again after exhaustion.
+    return [err.source.includes("const x: number"), err.errors.length > 0, result.retryable]
   }
   return "unreachable"
 }

--- a/packages/agency-lang/tests/agency/write-agency.test.json
+++ b/packages/agency-lang/tests/agency/write-agency.test.json
@@ -26,9 +26,9 @@
     },
     {
       "nodeName": "exhausts",
-      "description": "writeAgency returns the last source and diagnostics on retry exhaustion",
+      "description": "writeAgency returns the last source and diagnostics on retry exhaustion, retryable",
       "input": "",
-      "expectedOutput": "[true,true]",
+      "expectedOutput": "[true,true,true]",
       "evaluationCriteria": [{ "type": "exact" }],
       "useTestLLMProvider": true,
       "llmMocks": [


### PR DESCRIPTION
Fixes the agents-write-and-run-code flow (`writeAgency` + `runCode` as `llm()` tools), which failed end-to-end for four distinct reasons. Each was diagnosed from a real-LLM transcript via statelog and fixed with tests.

## 1. Tool results now unwrap success Results

Tool calls returned the raw `{__type: "resultType", success: true, value}` envelope to the model. The model had to fish values out of `.value` and, worse, reconstruct wrapped objects when echoing them into later tool arguments — it passed `compile()`s CompiledProgram back to `run()` without the `code` field, failing every compile-then-run flow. The success path now sends `.value` (LLM-facing only; the Result cached for Agency code is untouched). Failures already unwrapped.

## 2. `runCode`: compile + run in one call, built for tool use

New `std::agency::runCode(source, node = "main", ...)` compiles and runs source directly, so nothing large round-trips through the model. Design points, each earned by a real-LLM failure observed during verification:

- **Human-unit limit params with ceilings.** The model copied docstring defaults like "60s" / "512mb" as `60` / `512` — which the runtime reads as 60 ms and 512 bytes; the 512-byte heap became `--max-old-space-size=1` and the child died at V8 startup. `runCode` takes `wallClockSeconds` / `memoryMb` / `ipcPayloadMb` / `stdoutMb` (converted internally, ceilings mirroring LIMIT_CEILINGS, over-ceiling rejected with a message naming the max). `run`/`runFile` keep canonical units — unit literals like `60s` already produce those, and reinterpreting them would silently break existing call sites; their docstrings now state the units explicitly.
- **Declared `safe`, with pre-execution failures born retryable.** A non-retryable tool failure removes the tool from the conversation, so one bad generation ended the whole repair loop. `safe` (the documented okay-to-retry marker) stops codegen from force-clearing the retryable bit, and bad-limit/compile failures are constructed retryable via a small `_retryableFailure` extern — the model fixes its source and calls again. Each re-run still raises `std::run` and the child effects re-prompt, so nothing bypasses handlers.
- **Returns the node's value, not the run envelope.** The envelope leads with zero-filled token stats; the model read that as "no output" and thrashed. `run()` keeps the envelope for Agency callers.

## 3. Structured tool errors stringify

The failure branch did `String(error)`, so structured errors (e.g. `writeAgency`'s `{source, errors}`) reached the model as `Error: [object Object]`. Now JSON-stringified.

## Verification

- Unit tests for the new `unwrapToolResultForLlm` / `toolErrorMessage` helpers (`_internal` pattern); full `lib/runtime` vitest suite green.
- `tests/agency/subprocess/run-code.agency`: basic run, retryable compile failure, over-ceiling limit rejection, maxCost forwarding (4 nodes).
- Real-LLM e2e of the original failing flow: the model now generates, runs, reads "did not return a value" when its program printed instead of returning, self-corrects, re-runs, and reports `5`. Transcript verified via statelog.
- Existing subprocess suites (nested-pause-resume, run-max-cost, cost-guard) re-run green; structural lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
