### PR TITLE
agency run: make --interactive a user endpoint, not a chain handler

### DIFF
--- a/packages/agency-lang/docs/site/guide/policies.md
+++ b/packages/agency-lang/docs/site/guide/policies.md
@@ -85,16 +85,9 @@ Notes:
 
 - The built-in names are `recommended`, `minimal`, `with-writes`, and `approve-all`.
 - `--approve` and `--reject` take comma-separated [effect](/guide/effects) names. Reject takes precedence, so if you have an effect in both approve and reject, it gets rejected.
-- The [rules of handlers](/guide/handlers.md#the-rules-of-handlers) still apply. Think of the policy's explicit rules as just another handler: a `--reject` beats a handler's approve, and a handler's reject beats an `--approve`.
-- Effects the policy doesn't mention are left entirely to your program's handlers. The policy only steps in again for interrupts that *surface* — ones no handler settled, or ones a handler explicitly `propagate`d.
+- The [rules of handlers](/guide/handlers.md#the-rules-of-handlers) still apply. Think of this as just another handler.
 
 ### The `--interactive` flag
 
-An interrupt that nothing settles — no handler in your program approves or rejects it, and no explicit policy rule covers it — *surfaces to the user*, the same way it would surface to a TypeScript caller as a returned `Interrupt[]`. What happens then depends on how you ran the program:
-
-- With `--interactive` (or `-i` for short), you become that user: the CLI prompts you to approve or reject each surfaced interrupt, then resumes the run with your answer. Answering `aa` (approve-always) or `rr` (reject-always) remembers the decision for the rest of the run.
-- With a policy but no `--interactive`, surfaced interrupts are rejected and the run continues.
-- With no policy flags at all, a surfaced interrupt crashes the run with a pointer to the [handlers guide](/guide/handlers.md).
-
-Interrupts your program already handles never surface, so `--interactive` never re-asks about them. A handler that `propagate`s does the opposite — it forces the interrupt to surface, so it always reaches the prompt.
+By default, any interrupts that aren't addressed by your policy, and aren't handled by your agent, will cause a crash. Run with the `--interactive` flag if you want to be prompted to approve or reject those interrupts instead.
 

--- a/packages/agency-lang/docs/site/guide/policies.md
+++ b/packages/agency-lang/docs/site/guide/policies.md
@@ -85,9 +85,16 @@ Notes:
 
 - The built-in names are `recommended`, `minimal`, `with-writes`, and `approve-all`.
 - `--approve` and `--reject` take comma-separated [effect](/guide/effects) names. Reject takes precedence, so if you have an effect in both approve and reject, it gets rejected.
-- The [rules of handlers](/guide/handlers.md#the-rules-of-handlers) still apply. Think of this as just another handler.
+- The [rules of handlers](/guide/handlers.md#the-rules-of-handlers) still apply. Think of the policy's explicit rules as just another handler: a `--reject` beats a handler's approve, and a handler's reject beats an `--approve`.
+- Effects the policy doesn't mention are left entirely to your program's handlers. The policy only steps in again for interrupts that *surface* — ones no handler settled, or ones a handler explicitly `propagate`d.
 
 ### The `--interactive` flag
 
-By default, any interrupts that aren't addressed by your policy, and aren't handled by your agent, will cause a crash. Run with the `--interactive` flag if you want to be prompted to approve or reject those interrupts instead.
+An interrupt that nothing settles — no handler in your program approves or rejects it, and no explicit policy rule covers it — *surfaces to the user*, the same way it would surface to a TypeScript caller as a returned `Interrupt[]`. What happens then depends on how you ran the program:
+
+- With `--interactive` (or `-i` for short), you become that user: the CLI prompts you to approve or reject each surfaced interrupt, then resumes the run with your answer. Answering `aa` (approve-always) or `rr` (reject-always) remembers the decision for the rest of the run.
+- With a policy but no `--interactive`, surfaced interrupts are rejected and the run continues.
+- With no policy flags at all, a surfaced interrupt crashes the run with a pointer to the [handlers guide](/guide/handlers.md).
+
+Interrupts your program already handles never surface, so `--interactive` never re-asks about them. A handler that `propagate`s does the opposite — it forces the interrupt to surface, so it always reaches the prompt.
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -4308,11 +4308,20 @@ export class TypeScriptBuilder {
                 "__result",
                 ts.await(ts.call(ts.id("main"), [ts.id("initialState")])),
               ),
-              // Running `main` directly from the CLI: if it returned an
-              // unhandled interrupt, tell the user instead of exiting
-              // silently. Skipped when imported from TS (guard above is
-              // false), where the caller handles interrupts itself.
-              ts.call(ts.id("reportUnhandledInterrupts"), [ts.id("__result")]),
+              // Running `main` directly from the CLI: interrupts that no
+              // handler settled have surfaced to the user. resolveCliInterrupts
+              // is that user endpoint — under a run policy it decides each one
+              // (prompting with --interactive, rejecting otherwise) and resumes
+              // via respondToInterrupts; without a policy it reports the
+              // unhandled interrupt and exits non-zero. Skipped when imported
+              // from TS (guard above is false), where the caller handles
+              // interrupts itself.
+              ts.await(
+                ts.call(ts.id("resolveCliInterrupts"), [
+                  ts.id("__result"),
+                  ts.id("respondToInterrupts"),
+                ]),
+              ),
             ]),
             ts.statements([
               ts.consoleError(

--- a/packages/agency-lang/lib/cli/runPolicy.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/runPolicy.spawn.test.ts
@@ -33,9 +33,22 @@ const FIXTURE = `node main() {
 }
 `;
 
-function makeDir(): string {
+// Same write, but the program handles the interrupt itself. The policy layer
+// must NOT override or prompt for an interrupt the code already settled.
+const HANDLED_FIXTURE = `node main() {
+  handle {
+    const r = write(filename: "policy-spawn-out.txt", content: "x", dir: ".")
+    match (r) {
+      success(_) => print("WRITE_OK")
+      failure(_) => print("WRITE_REJECTED")
+    }
+  } with approve
+}
+`;
+
+function makeDir(fixture: string = FIXTURE): string {
   const dir = mkdtempSync(path.join(tmpdir(), "runpol-spawn-"));
-  writeFileSync(path.join(dir, "writer.agency"), FIXTURE);
+  writeFileSync(path.join(dir, "writer.agency"), fixture);
   return dir;
 }
 
@@ -75,6 +88,37 @@ describe.skipIf(!existsSync(CLI))("agency run --policy flags (end-to-end)", () =
       expect(code).toBe(0);
       expect(stdout).toMatch(/WRITE_OK/);
       expect(stdout).not.toMatch(/WRITE_REJECTED/);
+    } finally {
+      rmTemp(dir);
+    }
+  });
+
+  it("an interrupt the code handles itself is NOT re-decided by --interactive", async () => {
+    // The program's own `with approve` settles the interrupt, so it never
+    // surfaces to the user endpoint. (Pre-endpoint behavior: the interactive
+    // handler joined the chain, prompted on non-TTY stdin, and fail-closed
+    // to reject — clobbering the code's approval.)
+    const dir = makeDir(HANDLED_FIXTURE);
+    try {
+      const { stdout, code } = await runCli(dir, ["--interactive"]);
+      expect(code).toBe(0);
+      expect(stdout).toMatch(/WRITE_OK/);
+      expect(stdout).not.toMatch(/WRITE_REJECTED/);
+    } finally {
+      rmTemp(dir);
+    }
+  });
+
+  it("a surfaced interrupt the policy does not cover is rejected and the run resumes", async () => {
+    // --approve std::read covers nothing here; std::write surfaces to the
+    // user endpoint, which (non-interactive) rejects it and resumes the run —
+    // the program observes the failure Result and exits cleanly.
+    const dir = makeDir();
+    try {
+      const { stdout, code } = await runCli(dir, ["--approve", "std::read"]);
+      expect(code).toBe(0);
+      expect(stdout).toMatch(/WRITE_REJECTED/);
+      expect(stdout).not.toMatch(/WRITE_OK/);
     } finally {
       rmTemp(dir);
     }

--- a/packages/agency-lang/lib/cli/runPolicy.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/runPolicy.spawn.test.ts
@@ -193,7 +193,9 @@ describe.skipIf(!existsSync(CLI))("agency run --policy flags (end-to-end)", () =
     } finally {
       rmLocal(dir);
     }
-  });
+    // Compile + fork + pause + endpoint decision + nested resume: ~5s locally,
+    // slower on CI runners — well past vitest's 5s default.
+  }, 90_000);
 
   it("without any policy flag, an uncovered interrupt still reports unhandled", async () => {
     // No handler is installed when no flag is set (resolveRunPolicy returns null),

--- a/packages/agency-lang/lib/cli/runPolicy.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/runPolicy.spawn.test.ts
@@ -46,10 +46,66 @@ const HANDLED_FIXTURE = `node main() {
 }
 `;
 
+// A std::agency::run child whose interrupt nothing handles. The child's
+// bash interrupt relays through the root chain (silent — the policy only
+// covers std::run), the child pauses, and the interrupt bubbles up to the
+// root CLI endpoint. There it is rejected (non-interactive), the child
+// resumes with a failure Result — a rejection is not an abort — and returns
+// a marker naming which decision it observed.
+const SUBPROCESS_FIXTURE = `import { compile, run } from "std::agency"
+
+node main() {
+  const source = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo hi")
+  if (isFailure(r)) {
+    return "child-saw-rejection"
+  }
+  return "child-saw-approval"
+}
+"""
+  const compiled = compile(source)
+  if (isFailure(compiled)) {
+    print("COMPILE_FAILED")
+    return ""
+  }
+  const result = run(compiled: compiled.value, node: "main")
+  if (isSuccess(result)) {
+    print("CHILD_RESULT: " + result.value.data)
+  } else {
+    print("CHILD_RUN_FAILED")
+  }
+}
+`;
+
 function makeDir(fixture: string = FIXTURE): string {
   const dir = mkdtempSync(path.join(tmpdir(), "runpol-spawn-"));
   writeFileSync(path.join(dir, "writer.agency"), fixture);
   return dir;
+}
+
+// The subprocess fixture must live INSIDE the package dir: the nested
+// std::agency::run child materializes its compiled script under the parent's
+// cwd, and from os.tmpdir() that script cannot resolve the `agency-lang`
+// package (the CLI's resolver shim only covers the direct child).
+function makeLocalDir(fixture: string): string {
+  const dir = mkdtempSync(path.join(process.cwd(), ".runpol-spawn-"));
+  writeFileSync(path.join(dir, "writer.agency"), fixture);
+  return dir;
+}
+
+// Companion guard to rmTemp for makeLocalDir: only remove a direct
+// `.runpol-spawn-*` child of the package dir.
+function rmLocal(dir: string): void {
+  const root = realpathSync(process.cwd());
+  const resolved = realpathSync(dir);
+  if (
+    path.dirname(resolved) === root &&
+    path.basename(resolved).startsWith(".runpol-spawn-")
+  ) {
+    rmSync(resolved, { recursive: true, force: true });
+  }
 }
 
 async function runCli(dir: string, args: string[]) {
@@ -121,6 +177,21 @@ describe.skipIf(!existsSync(CLI))("agency run --policy flags (end-to-end)", () =
       expect(stdout).not.toMatch(/WRITE_OK/);
     } finally {
       rmTemp(dir);
+    }
+  });
+
+  it("a subprocess interrupt nothing handles surfaces to the endpoint too", async () => {
+    // std::agency::run child hits a bash interrupt with no handler anywhere;
+    // the policy approves only std::run. The child interrupt must bubble to
+    // the root endpoint (rejected here, prompted under --interactive), resume
+    // the child with the rejection, and let the whole tree finish cleanly.
+    const dir = makeLocalDir(SUBPROCESS_FIXTURE);
+    try {
+      const { stdout, code } = await runCli(dir, ["--approve", "std::run"]);
+      expect(code).toBe(0);
+      expect(stdout).toMatch(/CHILD_RESULT: child-saw-rejection/);
+    } finally {
+      rmLocal(dir);
     }
   });
 

--- a/packages/agency-lang/lib/runtime/agencyInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/agencyInterrupt.ts
@@ -117,6 +117,10 @@ export type InterruptOpts<T = unknown> = {
    *  Optional — interrupts that carry no payload (e.g. a bare
    *  "needs user attention") can omit it. */
   data?: T;
+  /** Declare that the caller will USE the approval value (the TS analog of
+   *  an assignment-position raise, `const x = raise …`). Surfaces as
+   *  `Interrupt.expectsValue` so approvers know to provide one. */
+  expectsValue?: boolean;
 };
 
 export async function interrupt<T = unknown>(
@@ -168,6 +172,7 @@ export async function interrupt<T = unknown>(
     origin,
     ctx,
     stack,
+    { expectsValue: opts.expectsValue },
   );
 
   if (isRejected(handlerResult)) return handlerResult;

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -87,7 +87,9 @@ export {
   respondToInterrupts,
 } from "./interrupts.js";
 
-export { checkPolicy, validatePolicy } from "./policy.js";
+export { checkPolicy, checkPolicyExplicit, validatePolicy } from "./policy.js";
+
+export { resolveCliInterrupts } from "./runPolicyHandler.js";
 
 export { isGenerator, handleStreamingResponse } from "./streaming.js";
 

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -107,6 +107,54 @@ describe("interruptWithHandlers resolvedBy attribution (IPC mode)", () => {
   });
 });
 
+describe("interruptWithHandlers expectsValue", () => {
+  const makeCtx = (handlers: any[]): RuntimeContext<any> => {
+    const ctx = new RuntimeContext({
+      statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+      smoltalkDefaults: {},
+      dirname: process.cwd(),
+    });
+    ctx.handlers = handlers;
+    // The surfaced path stamps the run id onto the Interrupt (renderVerdict →
+    // ctx.getRunId()), which a real run sets when the exec context is created.
+    ctx.runId = "test-run";
+    return ctx;
+  };
+
+  it("a surfaced assignment-position interrupt carries expectsValue", async () => {
+    const verdict = await interruptWithHandlers(
+      "unknown", "Question for user", {}, "o", makeCtx([]), undefined,
+      { expectsValue: true },
+    );
+    expect(Array.isArray(verdict)).toBe(true);
+    expect((verdict as any)[0].expectsValue).toBe(true);
+  });
+
+  it("a statement-position interrupt does NOT carry expectsValue", async () => {
+    const verdict = await interruptWithHandlers(
+      "std::error", "m", {}, "o", makeCtx([]),
+    );
+    expect(Array.isArray(verdict)).toBe(true);
+    expect((verdict as any)[0].expectsValue).toBeUndefined();
+  });
+
+  it("handlers see expectsValue on the interrupt they are deciding", async () => {
+    const seen: any[] = [];
+    const ctx = makeCtx([
+      async (intr: any) => {
+        seen.push(intr.expectsValue);
+        return { type: "approve", value: "Adit" };
+      },
+    ]);
+    const verdict = await interruptWithHandlers(
+      "unknown", "Question for user", {}, "o", ctx, undefined,
+      { expectsValue: true },
+    );
+    expect(verdict).toEqual({ type: "approve", value: "Adit" });
+    expect(seen).toEqual([true]);
+  });
+});
+
 describe("mergeChainOutcomes", () => {
   const approvedA = { kind: "approved", value: "a" } as const;
   const approvedB = { kind: "approved", value: "b" } as const;

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -66,6 +66,11 @@ export type Interrupt<T = any> = {
   checkpoint?: Checkpoint;
   state?: InterruptState; // kept for backward compat migration shim
   runId: string; // unique ID for the agent run, persists across interrupt pauses/resumes
+  // True when the raise site ASSIGNS the approval value (`const x = raise …`):
+  // whoever approves this interrupt is expected to provide a value, and a
+  // plain approve resolves the variable to `true`. Set by the compiler; absent
+  // (falsy) on statement-position raises.
+  expectsValue?: boolean;
 };
 
 export function interrupt<T = any>(opts: {
@@ -75,6 +80,7 @@ export function interrupt<T = any>(opts: {
   origin: string;
   runId: string;
   interruptId?: string;
+  expectsValue?: boolean;
 }): Interrupt<T> {
   return {
     type: "interrupt",
@@ -84,6 +90,7 @@ export function interrupt<T = any>(opts: {
     interruptId: opts.interruptId || nanoid(),
     data: opts.data,
     runId: opts.runId,
+    ...(opts.expectsValue ? { expectsValue: true } : {}),
   };
 }
 
@@ -160,6 +167,17 @@ export type HandlerChainOutcome =
   | { kind: "propagated" }
   | { kind: "noResponse" };
 
+/** The interrupt fields visible to handlers and relayed between processes:
+ * everything identifying WHAT is being decided, without the per-dispatch
+ * bookkeeping (ids, checkpoints) the origin process owns. */
+export type InterruptInfo = {
+  effect: string;
+  message: string;
+  data: any;
+  origin: string;
+  expectsValue?: boolean;
+};
+
 /** Maximum nested-dispatch depth for `runHandlerChain`. Each dispatch descends
  *  one level in `handlerChainDepthALS`; exceeding this limit throws
  *  `HandlerRecursionError`. Picked to be well above any plausible legitimate
@@ -194,7 +212,7 @@ async function runHandlerChain(
   ctx: RuntimeContext<any>,
   stack: StateStack | undefined,
   interruptId: string,
-  interruptObj: { effect: string; message: string; data: any; origin: string },
+  interruptObj: InterruptInfo,
 ): Promise<HandlerChainOutcome> {
   // Descend one level in the CURRENT async lineage (see
   // `handlerChainDepthALS`). Concurrent sibling dispatches each read the same
@@ -316,7 +334,7 @@ export function mergeChainOutcomes(
  * evaluating a child's interrupt) contribute only handlerDecision events
  * to the shared trace. */
 export async function gatherChainOutcome(
-  interruptObj: { effect: string; message: string; data: any; origin: string },
+  interruptObj: InterruptInfo,
   ctx: RuntimeContext<any>,
   stack: StateStack | undefined,
   interruptId: string,
@@ -345,7 +363,7 @@ function renderVerdict(
   merged: HandlerChainOutcome,
   ctx: RuntimeContext<any>,
   interruptId: string,
-  interruptObj: { effect: string; message: string; data: any; origin: string },
+  interruptObj: InterruptInfo,
   resolvedBy: "ipc" | "handler",
 ): Interrupt[] | Approved | Rejected {
   const { effect, message, data, origin } = interruptObj;
@@ -374,7 +392,15 @@ function renderVerdict(
   // interrupts will have interruptThrown but no matching checkpointCreated
   // from the runtime. A future improvement could add checkpoint events to
   // the generated templates.
-  const intr = interrupt({ effect, message, data, origin, runId: ctx.getRunId(), interruptId });
+  const intr = interrupt({
+    effect,
+    message,
+    data,
+    origin,
+    runId: ctx.getRunId(),
+    interruptId,
+    expectsValue: interruptObj.expectsValue,
+  });
   ctx.statelogClient.interruptThrown({
     interruptId: intr.interruptId,
     interruptData: data,
@@ -389,8 +415,14 @@ export async function interruptWithHandlers<T = any>(
   origin: string,
   ctx: RuntimeContext<any>,
   stack?: StateStack,
+  // `expectsValue: true` marks an assignment-position raise (`const x = raise
+  // …`): handlers and the surfaced Interrupt see that an approval value is
+  // expected. Optional trailing object so already-compiled 6-arg calls keep
+  // working.
+  opts?: { expectsValue?: boolean },
 ): Promise<Interrupt<T>[] | Approved | Rejected> {
-  const interruptObj = { effect, message, data, origin };
+  const interruptObj: InterruptInfo = { effect, message, data, origin };
+  if (opts?.expectsValue) interruptObj.expectsValue = true;
   const interruptId = nanoid();
   // The origin dispatch of the distributed chain: gatherChainOutcome walks
   // the local segment and — in IPC mode — consults the parent and merges

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -184,6 +184,7 @@ export type IpcInterruptMessage = {
     message: string;
     data: any;
     origin: string;
+    expectsValue?: boolean;
   };
 };
 
@@ -336,6 +337,7 @@ export async function sendInterruptToParent(
     message: string;
     data: any;
     origin: string;
+    expectsValue?: boolean;
   },
   interruptId: string,
 ): Promise<HandlerChainOutcome> {
@@ -752,7 +754,7 @@ function attachStdoutForwarder(
 }
 
 async function handleInterruptMessage(s: RunSession, msg: any): Promise<void> {
-  const { effect, message, data, origin } = msg.interrupt;
+  const { effect, message, data, origin, expectsValue } = msg.interrupt;
   try {
     // Report this process's chain OUTCOME; the child merges and decides.
     // The child's interruptId is relayed into the chain walk so this
@@ -767,7 +769,7 @@ async function handleInterruptMessage(s: RunSession, msg: any): Promise<void> {
     const { outcome } = await s.ctx.statelogClient.runInBranchContext(
       s.ctx.statelogClient.snapshotStack(),
       () => gatherChainOutcome(
-        { effect, message, data, origin },
+        { effect, message, data, origin, expectsValue },
         s.ctx,
         s.stateStack,
         msg.interruptId,

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -21,6 +21,18 @@ export function checkPolicy(
   policy: Policy,
   interrupt: { effect: string; message: string; data: any; origin: string },
 ): PolicyResult {
+  return checkPolicyExplicit(policy, interrupt) ?? { type: "propagate" };
+}
+
+/** Like `checkPolicy`, but returns null when NO rule matched — callers that
+ * need to distinguish an explicit `propagate` rule from plain fall-through
+ * (e.g. the run-policy chain handler, which must stay silent on effects the
+ * policy never mentions) use this; everyone else keeps `checkPolicy`'s
+ * fall-through-is-propagate contract. */
+export function checkPolicyExplicit(
+  policy: Policy,
+  interrupt: { effect: string; message: string; data: any; origin: string },
+): PolicyResult | null {
   // Effect-specific rules take precedence over the wildcard.
   const rules = policy[interrupt.effect];
   if (rules) {
@@ -34,7 +46,7 @@ export function checkPolicy(
   // Wildcard catch-all: the `"*"` effect key applies to any interrupt whose
   // own effect had no matching rule. This is how an "approve-all" policy
   // covers effects it doesn't enumerate (a plain per-effect map would
-  // `propagate` — i.e. prompt — on anything unlisted).
+  // `propagate` — i.e. surface to the user — on anything unlisted).
   const wildcard = policy["*"];
   if (wildcard) {
     for (const rule of wildcard) {
@@ -44,7 +56,7 @@ export function checkPolicy(
     }
   }
 
-  return { type: "propagate" };
+  return null;
 }
 
 // picomatch fails to match patterns starting with `./` when combined

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
@@ -124,6 +124,17 @@ describe("formatInterruptPrompt", () => {
     );
     expect(out).toContain("─".repeat(50));
   });
+
+  it("does not throw on unserializable data (circular, BigInt)", () => {
+    const circular: any = { name: "loop" };
+    circular.self = circular;
+    for (const data of [circular, { n: BigInt(1) }]) {
+      const out = plain(
+        formatInterruptPrompt({ effect: "e", message: "m", data, origin: "t" }),
+      );
+      expect(out).toContain("[object Object]"); // best-effort String() fallback
+    }
+  });
 });
 
 describe("terminalPrompt", () => {
@@ -174,26 +185,26 @@ async function withEnv(
 }
 
 describe("installRunPolicyHandler", () => {
-  it("pushes a handler when AGENCY_RUN_POLICY is set (root process)", () => {
-    withEnv({ [AGENCY_RUN_POLICY]: READ_OK, AGENCY_IPC: undefined }, () => {
+  it("pushes a handler when AGENCY_RUN_POLICY is set (root process)", async () => {
+    await withEnv({ [AGENCY_RUN_POLICY]: READ_OK, AGENCY_IPC: undefined }, () => {
       const pushed: unknown[] = [];
       installRunPolicyHandler({ pushHandler: (h) => pushed.push(h) });
       expect(pushed).toHaveLength(1);
     });
   });
 
-  it("is a no-op when AGENCY_RUN_POLICY is unset", () => {
-    withEnv({ [AGENCY_RUN_POLICY]: undefined, AGENCY_IPC: undefined }, () => {
+  it("is a no-op when AGENCY_RUN_POLICY is unset", async () => {
+    await withEnv({ [AGENCY_RUN_POLICY]: undefined, AGENCY_IPC: undefined }, () => {
       const pushed: unknown[] = [];
       installRunPolicyHandler({ pushHandler: (h) => pushed.push(h) });
       expect(pushed).toHaveLength(0);
     });
   });
 
-  it("is a no-op in an IPC subprocess even when the policy env is set", () => {
+  it("is a no-op in an IPC subprocess even when the policy env is set", async () => {
     // isIpcMode() reads AGENCY_IPC === "1". The policy lives at the root; a
     // subprocess forwards its interrupts up, so it must NOT install its own.
-    withEnv({ [AGENCY_RUN_POLICY]: READ_OK, AGENCY_IPC: "1" }, () => {
+    await withEnv({ [AGENCY_RUN_POLICY]: READ_OK, AGENCY_IPC: "1" }, () => {
       const pushed: unknown[] = [];
       installRunPolicyHandler({ pushHandler: (h) => pushed.push(h) });
       expect(pushed).toHaveLength(0);

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect, vi } from "vitest";
 import {
   makeRunPolicyHandler,
   terminalPrompt,
+  terminalValuePrompt,
   parsePromptAnswer,
+  parseValueAnswer,
   installRunPolicyHandler,
   resolveCliInterrupts,
   formatInterruptPrompt,
   type PromptFn,
+  type ValuePromptFn,
 } from "./runPolicyHandler.js";
 import type { Interrupt, InterruptResponse } from "./interrupts.js";
 import {
@@ -73,6 +76,19 @@ describe("parsePromptAnswer", () => {
     expect(parsePromptAnswer("")).toBe("reject");
     expect(parsePromptAnswer("yes")).toBe("reject");
     expect(parsePromptAnswer("maybe")).toBe("reject");
+  });
+});
+
+describe("parseValueAnswer", () => {
+  it("typed text becomes the approval value verbatim", () => {
+    expect(parseValueAnswer("Adit")).toEqual({ type: "approve", value: "Adit" });
+    // Even text that looks like a decision keyword IS the answer.
+    expect(parseValueAnswer("r")).toEqual({ type: "approve", value: "r" });
+  });
+
+  it("an empty or whitespace-only line rejects (incl. the EOF fallback)", () => {
+    expect(parseValueAnswer("").type).toBe("reject");
+    expect(parseValueAnswer("   ").type).toBe("reject");
   });
 });
 
@@ -153,6 +169,14 @@ describe("terminalPrompt", () => {
         origin: "t",
       });
       expect(d).toBe("reject");
+      const v = await terminalValuePrompt({
+        effect: "myapp::foo",
+        message: "m",
+        data: {},
+        origin: "t",
+        expectsValue: true,
+      });
+      expect(v.type).toBe("reject");
     } finally {
       Object.defineProperty(process.stdin, "isTTY", {
         value: prev,
@@ -229,8 +253,17 @@ describe("resolveCliInterrupts", () => {
     messages: {} as any,
     data: effects.map(surfaced),
   });
+  const valueInterrupt = (effect: string): Interrupt => ({
+    ...surfaced(effect),
+    expectsValue: true,
+  });
   const promptWith = (answers: string[]): PromptFn => {
     return async () => answers.shift() as any;
+  };
+  const INTERACTIVE_ENV = {
+    [AGENCY_RUN_POLICY]: READ_OK,
+    [AGENCY_RUN_POLICY_INTERACTIVE]: AGENCY_RUN_POLICY_INTERACTIVE_ON,
+    AGENCY_IPC: undefined,
   };
 
   it("returns the result untouched when there are no interrupts", async () => {
@@ -333,6 +366,82 @@ describe("resolveCliInterrupts", () => {
           2,
           [surfaced("myapp::foo")],
           [{ type: "approve", value: undefined }],
+        );
+      },
+    );
+  });
+
+  it("interactive: a value-expecting interrupt gets the value prompt, not a/r", async () => {
+    await withEnv(INTERACTIVE_ENV, async () => {
+      const respond = vi.fn(async () => done);
+      const prompt = vi.fn();
+      const valuePrompt: ValuePromptFn = vi.fn(async () => ({
+        type: "approve",
+        value: "Adit",
+      } as any));
+      const result = await resolveCliInterrupts(
+        { messages: {} as any, data: [valueInterrupt("std::input")] },
+        respond,
+        { prompt: prompt as any, valuePrompt },
+      );
+      expect(result).toBe(done);
+      expect(prompt).not.toHaveBeenCalled();
+      expect(valuePrompt).toHaveBeenCalledTimes(1);
+      expect(respond).toHaveBeenCalledWith(
+        [valueInterrupt("std::input")],
+        [{ type: "approve", value: "Adit" }],
+      );
+    });
+  });
+
+  it("value-expecting interrupts bypass remembered 'always' decisions", async () => {
+    await withEnv(INTERACTIVE_ENV, async () => {
+      // Round 1: a statement interrupt of effect E answered approve-always.
+      // Round 2: a VALUE interrupt of the same effect E — must still hit the
+      // value prompt (a standing approve can't answer a question).
+      const rounds = [
+        { messages: {} as any, data: [valueInterrupt("myapp::foo")] },
+        done,
+      ];
+      const respond = vi.fn(async () => rounds.shift()!);
+      const valuePrompt: ValuePromptFn = vi.fn(async () => ({
+        type: "approve",
+        value: "42",
+      } as any));
+      const result = await resolveCliInterrupts(
+        withInterrupts("myapp::foo"),
+        respond,
+        { prompt: promptWith(["approve-always"]), valuePrompt },
+      );
+      expect(result).toBe(done);
+      expect(valuePrompt).toHaveBeenCalledTimes(1);
+      expect(respond).toHaveBeenNthCalledWith(
+        2,
+        [valueInterrupt("myapp::foo")],
+        [{ type: "approve", value: "42" }],
+      );
+    });
+  });
+
+  it("non-interactive: a value-expecting interrupt is rejected without prompting", async () => {
+    await withEnv(
+      {
+        [AGENCY_RUN_POLICY]: READ_OK,
+        [AGENCY_RUN_POLICY_INTERACTIVE]: undefined,
+        AGENCY_IPC: undefined,
+      },
+      async () => {
+        const respond = vi.fn(async () => done);
+        const valuePrompt = vi.fn();
+        await resolveCliInterrupts(
+          { messages: {} as any, data: [valueInterrupt("std::input")] },
+          respond,
+          { valuePrompt: valuePrompt as any },
+        );
+        expect(valuePrompt).not.toHaveBeenCalled();
+        expect(respond).toHaveBeenCalledWith(
+          [valueInterrupt("std::input")],
+          [{ type: "reject", value: undefined }],
         );
       },
     );

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.test.ts
@@ -1,12 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   makeRunPolicyHandler,
   terminalPrompt,
   parsePromptAnswer,
   installRunPolicyHandler,
+  resolveCliInterrupts,
+  formatInterruptPrompt,
   type PromptFn,
 } from "./runPolicyHandler.js";
-import { AGENCY_RUN_POLICY } from "@/constants.js";
+import type { Interrupt, InterruptResponse } from "./interrupts.js";
+import {
+  AGENCY_RUN_POLICY,
+  AGENCY_RUN_POLICY_INTERACTIVE,
+  AGENCY_RUN_POLICY_INTERACTIVE_ON,
+} from "@/constants.js";
 
 const intr = (effect: string, data: any = {}) => ({
   effect,
@@ -14,67 +21,30 @@ const intr = (effect: string, data: any = {}) => ({
   data,
   origin: "test",
 });
-const neverPrompt: PromptFn = async () => {
-  throw new Error("prompt should not be called");
-};
 
 describe("makeRunPolicyHandler", () => {
   it("approves an effect the policy approves", async () => {
-    const h = makeRunPolicyHandler(
-      { "std::read": [{ action: "approve" }] },
-      { interactive: false, prompt: neverPrompt },
-    );
+    const h = makeRunPolicyHandler({ "std::read": [{ action: "approve" }] });
     expect(await h(intr("std::read"))).toEqual({ type: "approve", value: undefined });
   });
 
   it("rejects an effect the policy rejects", async () => {
-    const h = makeRunPolicyHandler(
-      { "std::write": [{ action: "reject" }] },
-      { interactive: false, prompt: neverPrompt },
-    );
+    const h = makeRunPolicyHandler({ "std::write": [{ action: "reject" }] });
     expect((await h(intr("std::write")))!.type).toBe("reject");
   });
 
-  it("fail-closed: unmatched effect rejects in non-interactive mode", async () => {
-    const h = makeRunPolicyHandler({}, { interactive: false, prompt: neverPrompt });
-    expect((await h(intr("myapp::foo")))!.type).toBe("reject");
+  it("stays silent on an unmatched effect (the chain decides)", async () => {
+    const h = makeRunPolicyHandler({ "std::read": [{ action: "approve" }] });
+    expect(await h(intr("myapp::foo"))).toBeUndefined();
   });
 
-  it("interactive: prompts on an unmatched effect", async () => {
-    const prompt: PromptFn = async () => "approve";
-    const h = makeRunPolicyHandler({}, { interactive: true, prompt });
-    expect((await h(intr("myapp::foo")))!.type).toBe("approve");
-  });
-
-  it("interactive: 'approve-always' is remembered for the run", async () => {
-    let calls = 0;
-    const prompt: PromptFn = async () => {
-      calls++;
-      return "approve-always";
-    };
-    const h = makeRunPolicyHandler({}, { interactive: true, prompt });
-    expect((await h(intr("myapp::foo")))!.type).toBe("approve");
-    expect((await h(intr("myapp::foo")))!.type).toBe("approve");
-    expect(calls).toBe(1); // second call served from memory
-  });
-
-  it("interactive: 'reject-always' is remembered for the run", async () => {
-    let calls = 0;
-    const prompt: PromptFn = async () => {
-      calls++;
-      return "reject-always";
-    };
-    const h = makeRunPolicyHandler({}, { interactive: true, prompt });
-    expect((await h(intr("myapp::foo")))!.type).toBe("reject");
-    expect((await h(intr("myapp::foo")))!.type).toBe("reject");
-    expect(calls).toBe(1); // second call served from a remembered reject rule
+  it("returns propagate for an explicit propagate rule", async () => {
+    const h = makeRunPolicyHandler({ "std::write": [{ action: "propagate" }] });
+    expect((await h(intr("std::write")))!.type).toBe("propagate");
   });
 
   it("honors the '*' wildcard", async () => {
-    const h = makeRunPolicyHandler(
-      { "*": [{ action: "approve" }] },
-      { interactive: false, prompt: neverPrompt },
-    );
+    const h = makeRunPolicyHandler({ "*": [{ action: "approve" }] });
     expect((await h(intr("anything::at::all")))!.type).toBe("approve");
   });
 });
@@ -106,6 +76,56 @@ describe("parsePromptAnswer", () => {
   });
 });
 
+describe("formatInterruptPrompt", () => {
+  // Strip ANSI codes so assertions read the visible text, not escape bytes.
+  const plain = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+  it("shows effect, a rule, and the message", () => {
+    const out = plain(
+      formatInterruptPrompt({
+        effect: "std::error",
+        message: "This is a test error",
+        data: {},
+        origin: "t",
+      }),
+    );
+    expect(out).toContain("std::error\n");
+    expect(out).toContain("─".repeat(36));
+    expect(out).toContain("This is a test error");
+  });
+
+  it("omits data when it is an empty object or null", () => {
+    for (const data of [{}, null, undefined]) {
+      const out = plain(
+        formatInterruptPrompt({ effect: "e", message: "m", data, origin: "t" }),
+      );
+      expect(out).not.toContain("{}");
+      expect(out).not.toContain("null");
+      expect(out).not.toContain("undefined");
+    }
+  });
+
+  it("pretty-prints data when present", () => {
+    const out = plain(
+      formatInterruptPrompt({
+        effect: "std::edit",
+        message: "m",
+        data: { path: "/tmp/x", mode: "w" },
+        origin: "t",
+      }),
+    );
+    expect(out).toContain(JSON.stringify({ path: "/tmp/x", mode: "w" }, null, 2));
+  });
+
+  it("extends the rule to cover a long effect name", () => {
+    const effect = "a".repeat(50);
+    const out = plain(
+      formatInterruptPrompt({ effect, message: "m", data: {}, origin: "t" }),
+    );
+    expect(out).toContain("─".repeat(50));
+  });
+});
+
 describe("terminalPrompt", () => {
   it("returns 'reject' when stdin is not a TTY (fail-closed, no hang)", async () => {
     const prev = process.stdin.isTTY;
@@ -131,26 +151,29 @@ describe("terminalPrompt", () => {
   });
 });
 
-describe("installRunPolicyHandler", () => {
-  const READ_OK = JSON.stringify({ "std::read": [{ action: "approve" }] });
+const READ_OK = JSON.stringify({ "std::read": [{ action: "approve" }] });
 
-  function withEnv(vars: Record<string, string | undefined>, fn: () => void) {
-    const prev: Record<string, string | undefined> = {};
-    for (const k of Object.keys(vars)) {
-      prev[k] = process.env[k];
-      if (vars[k] === undefined) delete process.env[k];
-      else process.env[k] = vars[k];
-    }
-    try {
-      fn();
-    } finally {
-      for (const k of Object.keys(prev)) {
-        if (prev[k] === undefined) delete process.env[k];
-        else process.env[k] = prev[k];
-      }
+async function withEnv(
+  vars: Record<string, string | undefined>,
+  fn: () => void | Promise<void>,
+) {
+  const prev: Record<string, string | undefined> = {};
+  for (const k of Object.keys(vars)) {
+    prev[k] = process.env[k];
+    if (vars[k] === undefined) delete process.env[k];
+    else process.env[k] = vars[k];
+  }
+  try {
+    await fn();
+  } finally {
+    for (const k of Object.keys(prev)) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
     }
   }
+}
 
+describe("installRunPolicyHandler", () => {
   it("pushes a handler when AGENCY_RUN_POLICY is set (root process)", () => {
     withEnv({ [AGENCY_RUN_POLICY]: READ_OK, AGENCY_IPC: undefined }, () => {
       const pushed: unknown[] = [];
@@ -175,5 +198,152 @@ describe("installRunPolicyHandler", () => {
       installRunPolicyHandler({ pushHandler: (h) => pushed.push(h) });
       expect(pushed).toHaveLength(0);
     });
+  });
+});
+
+describe("resolveCliInterrupts", () => {
+  // A minimal surfaced interrupt — enough shape for hasInterrupts and the
+  // decision loop, no checkpoint needed since `respond` is a fake.
+  const surfaced = (effect: string): Interrupt => ({
+    type: "interrupt",
+    effect,
+    message: "m",
+    origin: "test",
+    interruptId: `id-${effect}`,
+    data: {},
+    runId: "run",
+  });
+  const done = { messages: {} as any, data: "final" };
+  const withInterrupts = (...effects: string[]) => ({
+    messages: {} as any,
+    data: effects.map(surfaced),
+  });
+  const promptWith = (answers: string[]): PromptFn => {
+    return async () => answers.shift() as any;
+  };
+
+  it("returns the result untouched when there are no interrupts", async () => {
+    const respond = vi.fn();
+    const result = await resolveCliInterrupts(done, respond);
+    expect(result).toBe(done);
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it("without a policy env, reports unhandled and exits (historical path)", async () => {
+    await withEnv({ [AGENCY_RUN_POLICY]: undefined, AGENCY_IPC: undefined }, async () => {
+      const exit = vi
+        .spyOn(process, "exit")
+        .mockImplementation((() => undefined) as any);
+      const err = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const respond = vi.fn();
+        await resolveCliInterrupts(withInterrupts("std::write"), respond);
+        expect(exit).toHaveBeenCalledWith(1);
+        expect(respond).not.toHaveBeenCalled();
+      } finally {
+        exit.mockRestore();
+        err.mockRestore();
+      }
+    });
+  });
+
+  it("non-interactive: rejects every surfaced interrupt and resumes", async () => {
+    await withEnv(
+      {
+        [AGENCY_RUN_POLICY]: READ_OK,
+        [AGENCY_RUN_POLICY_INTERACTIVE]: undefined,
+        AGENCY_IPC: undefined,
+      },
+      async () => {
+        const seen: InterruptResponse[][] = [];
+        const respond = vi.fn(async (_i: Interrupt[], r: InterruptResponse[]) => {
+          seen.push(r);
+          return done;
+        });
+        const result = await resolveCliInterrupts(
+          withInterrupts("myapp::foo", "myapp::bar"),
+          respond,
+        );
+        expect(result).toBe(done);
+        expect(seen).toEqual([[
+          { type: "reject", value: undefined },
+          { type: "reject", value: undefined },
+        ]]);
+      },
+    );
+  });
+
+  it("interactive: prompts and applies the answer", async () => {
+    await withEnv(
+      {
+        [AGENCY_RUN_POLICY]: READ_OK,
+        [AGENCY_RUN_POLICY_INTERACTIVE]: AGENCY_RUN_POLICY_INTERACTIVE_ON,
+        AGENCY_IPC: undefined,
+      },
+      async () => {
+        const respond = vi.fn(async () => done);
+        await resolveCliInterrupts(withInterrupts("myapp::foo"), respond, {
+          prompt: promptWith(["approve"]),
+        });
+        expect(respond).toHaveBeenCalledWith(
+          [surfaced("myapp::foo")],
+          [{ type: "approve", value: undefined }],
+        );
+      },
+    );
+  });
+
+  it("interactive: loops until the run finishes, remembering 'always' answers", async () => {
+    await withEnv(
+      {
+        [AGENCY_RUN_POLICY]: READ_OK,
+        [AGENCY_RUN_POLICY_INTERACTIVE]: AGENCY_RUN_POLICY_INTERACTIVE_ON,
+        AGENCY_IPC: undefined,
+      },
+      async () => {
+        // Round 1 surfaces foo (answered approve-always); round 2 surfaces
+        // foo again — served from memory, prompt NOT called a second time.
+        const rounds = [withInterrupts("myapp::foo"), done];
+        const respond = vi.fn(async () => rounds.shift()!);
+        let promptCalls = 0;
+        const prompt: PromptFn = async () => {
+          promptCalls++;
+          return "approve-always";
+        };
+        const result = await resolveCliInterrupts(
+          withInterrupts("myapp::foo"),
+          respond,
+          { prompt },
+        );
+        expect(result).toBe(done);
+        expect(promptCalls).toBe(1);
+        expect(respond).toHaveBeenCalledTimes(2);
+        expect(respond).toHaveBeenNthCalledWith(
+          2,
+          [surfaced("myapp::foo")],
+          [{ type: "approve", value: undefined }],
+        );
+      },
+    );
+  });
+
+  it("in an IPC subprocess, never prompts or resumes (parent owns the user)", async () => {
+    await withEnv(
+      { [AGENCY_RUN_POLICY]: READ_OK, AGENCY_IPC: "1" },
+      async () => {
+        const exit = vi
+          .spyOn(process, "exit")
+          .mockImplementation((() => undefined) as any);
+        const err = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+          const respond = vi.fn();
+          await resolveCliInterrupts(withInterrupts("std::write"), respond);
+          expect(respond).not.toHaveBeenCalled();
+        } finally {
+          exit.mockRestore();
+          err.mockRestore();
+        }
+      },
+    );
   });
 });

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.ts
@@ -107,7 +107,15 @@ export function formatInterruptPrompt(intr: Intr): string {
     intr.data != null &&
     !(typeof intr.data === "object" && Object.keys(intr.data).length === 0);
   if (hasData) {
-    lines.push(JSON.stringify(intr.data, null, 2));
+    // Best-effort: interrupt data is program-controlled and may not be
+    // serializable (circular references, BigInt). The prompt must still
+    // render — a throw here would crash the run right as it asks for a
+    // decision.
+    try {
+      lines.push(JSON.stringify(intr.data, null, 2));
+    } catch {
+      lines.push(String(intr.data));
+    }
   }
   lines.push("");
   return lines.join("\n");

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.ts
@@ -17,7 +17,13 @@ import {
 import readline from "readline";
 import { color } from "@/utils/termcolors.js";
 
-type Intr = { effect: string; message: string; data: any; origin: string };
+type Intr = {
+  effect: string;
+  message: string;
+  data: any;
+  origin: string;
+  expectsValue?: boolean;
+};
 
 export type PromptDecision =
   | "approve"
@@ -26,6 +32,10 @@ export type PromptDecision =
   | "reject-always";
 
 export type PromptFn = (intr: Intr) => Promise<PromptDecision>;
+
+// Prompt for a value-expecting interrupt (`const x = raise …`): returns the
+// full response (approve carries the typed answer) rather than a decision.
+export type ValuePromptFn = (intr: Intr) => Promise<InterruptResponse>;
 
 // How each prompt decision resolves: the immediate action, and whether to
 // remember it for the rest of the run.
@@ -76,18 +86,49 @@ export function parsePromptAnswer(raw: string): PromptDecision {
 // per-run state.
 let promptQueue: Promise<unknown> = Promise.resolve();
 
-// Terminal prompt used by installRunPolicyHandler. Falls back to reject
-// (fail-closed) when stdin is not a TTY rather than hanging. Exported so the
-// non-TTY fallback is unit-testable.
-export async function terminalPrompt(intr: Intr): Promise<PromptDecision> {
-  if (!process.stdin.isTTY) return "reject";
-  const run = promptQueue.then(() => promptOnce(intr));
+// Serialize a prompt through the terminal queue (see promptQueue above).
+function queuePrompt<T>(fn: () => Promise<T>): Promise<T> {
+  const run = promptQueue.then(fn);
   // Keep the chain alive whether or not this prompt resolves cleanly.
   promptQueue = run.then(
     () => undefined,
     () => undefined,
   );
   return run;
+}
+
+// Terminal approve/reject prompt used by resolveCliInterrupts. Falls back to
+// reject (fail-closed) when stdin is not a TTY rather than hanging. Exported
+// so the non-TTY fallback is unit-testable.
+export async function terminalPrompt(intr: Intr): Promise<PromptDecision> {
+  if (!process.stdin.isTTY) return "reject";
+  return queuePrompt(async () =>
+    parsePromptAnswer(
+      await askLine(
+        formatInterruptPrompt(intr) +
+          `(a)pprove / (r)eject / (aa) approve-always / (rr) reject-always: `,
+      ),
+    ),
+  );
+}
+
+// Terminal prompt for a value-expecting interrupt: the interrupt message IS
+// the question, and the typed line becomes the approval value. Same non-TTY
+// fail-closed contract as terminalPrompt.
+export async function terminalValuePrompt(intr: Intr): Promise<InterruptResponse> {
+  if (!process.stdin.isTTY) return reject();
+  return queuePrompt(async () =>
+    parseValueAnswer(
+      await askLine(formatInterruptPrompt(intr) + `answer (empty line rejects): `),
+    ),
+  );
+}
+
+// Map a typed line to a response for a value-expecting interrupt: the text is
+// the approval value verbatim; an empty/whitespace-only line (including stdin
+// EOF, which askLine surfaces as "") rejects. Pure and exported for tests.
+export function parseValueAnswer(raw: string): InterruptResponse {
+  return raw.trim() === "" ? reject() : approve(raw);
 }
 
 // Render the interrupt banner shown above the approve/reject question:
@@ -121,25 +162,21 @@ export function formatInterruptPrompt(intr: Intr): string {
   return lines.join("\n");
 }
 
-async function promptOnce(intr: Intr): Promise<PromptDecision> {
+// Ask one question on the terminal and return the typed line. Stdin EOF (^D,
+// or a closed pipe) while the question is pending would otherwise leave the
+// promise unsettled forever — the process would die with an "unsettled
+// top-level await" instead of a decision — so it resolves to "" (which every
+// caller parses to a safe reject).
+async function askLine(question: string): Promise<string> {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stderr,
   });
   try {
-    const answer: string = await new Promise((resolve) => {
-      // Stdin EOF (^D, or a closed pipe) while the question is pending would
-      // otherwise leave this promise unsettled forever — the process would
-      // die with an "unsettled top-level await" instead of a decision. Treat
-      // it as an empty answer, which parses to a safe reject.
+    return await new Promise((resolve) => {
       rl.once("close", () => resolve(""));
-      rl.question(
-        formatInterruptPrompt(intr) +
-          `(a)pprove / (r)eject / (aa) approve-always / (rr) reject-always: `,
-        resolve,
-      );
+      rl.question(question, resolve);
     });
-    return parsePromptAnswer(answer);
   } finally {
     rl.close();
   }
@@ -189,16 +226,20 @@ export function installRunPolicyHandler(execCtx: {
 //
 // Decisions: `--interactive` prompts on the terminal ("always" answers are
 // remembered for the rest of the run); without it every surfaced interrupt
-// is rejected (the documented default). Without any policy flag at all, this
-// falls back to reportUnhandledInterrupts — print the handlers-guide message
-// and exit non-zero, exactly the historical no-flag behavior.
+// is rejected (the documented default). Value-expecting interrupts
+// (`const x = raise …`, expectsValue) get the answer prompt instead — the
+// typed line becomes the approval value — and skip the remembered map both
+// ways: a standing approve/reject can't answer a question, and answering a
+// question shouldn't create a standing rule. Without any policy flag at all,
+// this falls back to reportUnhandledInterrupts — print the handlers-guide
+// message and exit non-zero, exactly the historical no-flag behavior.
 export async function resolveCliInterrupts(
   result: RunNodeResult<any>,
   respond: (
     interrupts: Interrupt[],
     responses: InterruptResponse[],
   ) => Promise<RunNodeResult<any>>,
-  opts?: { prompt?: PromptFn },
+  opts?: { prompt?: PromptFn; valuePrompt?: ValuePromptFn },
 ): Promise<RunNodeResult<any>> {
   if (!hasInterrupts(result.data)) return result;
   // No policy flag (or an IPC subprocess, which never owns the terminal):
@@ -211,6 +252,7 @@ export async function resolveCliInterrupts(
   const interactive =
     process.env[AGENCY_RUN_POLICY_INTERACTIVE] === AGENCY_RUN_POLICY_INTERACTIVE_ON;
   const prompt = opts?.prompt ?? terminalPrompt;
+  const valuePrompt = opts?.valuePrompt ?? terminalValuePrompt;
   // Standing user decisions from "(aa)/(rr)" answers, keyed by effect.
   // Null-prototype so a program-controlled effect name (e.g. "__proto__")
   // is just an ordinary string key.
@@ -221,6 +263,10 @@ export async function resolveCliInterrupts(
     const interrupts: Interrupt[] = result.data;
     const responses: InterruptResponse[] = [];
     for (const intr of interrupts) {
+      if (intr.expectsValue) {
+        responses.push(interactive ? await valuePrompt(intr) : reject());
+        continue;
+      }
       let action = remembered[intr.effect];
       if (!action && interactive) {
         const outcome = DECISIONS[await prompt(intr)];

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.ts
@@ -1,7 +1,13 @@
-import type { Policy, PolicyRule } from "./policy.js";
-import { checkPolicy, validatePolicy } from "./policy.js";
-import { approve, reject } from "./interrupts.js";
-import type { HandlerFn } from "./types.js";
+import type { Policy } from "./policy.js";
+import { checkPolicyExplicit, validatePolicy } from "./policy.js";
+import {
+  approve,
+  reject,
+  hasInterrupts,
+  reportUnhandledInterrupts,
+} from "./interrupts.js";
+import type { Interrupt, InterruptResponse } from "./interrupts.js";
+import type { HandlerFn, RunNodeResult } from "./types.js";
 import { isIpcMode } from "./subprocessRunInfo.js";
 import {
   AGENCY_RUN_POLICY,
@@ -9,6 +15,7 @@ import {
   AGENCY_RUN_POLICY_INTERACTIVE_ON,
 } from "@/constants.js";
 import readline from "readline";
+import { color } from "@/utils/termcolors.js";
 
 type Intr = { effect: string; message: string; data: any; origin: string };
 
@@ -21,8 +28,7 @@ export type PromptDecision =
 export type PromptFn = (intr: Intr) => Promise<PromptDecision>;
 
 // How each prompt decision resolves: the immediate action, and whether to
-// remember a rule for the rest of the run. Declarative so the four branches
-// don't each hand-roll the same array surgery.
+// remember it for the rest of the run.
 const DECISIONS: Record<
   PromptDecision,
   { action: "approve" | "reject"; remember: boolean }
@@ -33,37 +39,20 @@ const DECISIONS: Record<
   "reject-always": { action: "reject", remember: true },
 };
 
-// Build the outermost policy handler for a CLI-driven run. `policy` is the
-// base; interactive "always" decisions accumulate into a working clone so
-// checkPolicy serves them without re-prompting.
-export function makeRunPolicyHandler(
-  policy: Policy,
-  opts: { interactive: boolean; prompt: PromptFn },
-): HandlerFn {
-  // Null-prototype so indexing/writing by an untrusted, program-controlled
-  // `intr.effect` (e.g. "__proto__", "constructor") can't reach or mutate a
-  // prototype — it's just an ordinary string key on a bare object.
-  const working: Policy = Object.assign(
-    Object.create(null) as Policy,
-    JSON.parse(JSON.stringify(policy)),
-  );
-
-  // Prepend a catch-all rule for `effect` so checkPolicy serves it first.
-  const remember = (effect: string, action: PolicyRule["action"]): void => {
-    working[effect] = [{ action }, ...(working[effect] ?? [])];
-  };
-
+// Build the root policy handler for a CLI-driven run. It participates in the
+// handler chain like any other handler — but ONLY for effects the policy
+// explicitly matches. Effects the policy never mentions get no response, so
+// the chain resolves by the program's own handlers; what nothing settles
+// surfaces to the user endpoint (resolveCliInterrupts) instead of being
+// decided here.
+export function makeRunPolicyHandler(policy: Policy): HandlerFn {
   return async (intr: Intr) => {
-    const decision = checkPolicy(working, intr);
+    const decision = checkPolicyExplicit(policy, intr);
+    if (decision === null) return undefined;
     if (decision.type === "approve") return approve();
     if (decision.type === "reject") return reject();
-
-    // Unmatched (checkPolicy fell through to "propagate").
-    if (!opts.interactive) return reject();
-
-    const outcome = DECISIONS[await opts.prompt(intr)];
-    if (outcome.remember) remember(intr.effect, outcome.action);
-    return outcome.action === "approve" ? approve() : reject();
+    // An explicit `propagate` rule: force the interrupt to the user.
+    return { type: "propagate" };
   };
 }
 
@@ -101,24 +90,70 @@ export async function terminalPrompt(intr: Intr): Promise<PromptDecision> {
   return run;
 }
 
+// Render the interrupt banner shown above the approve/reject question:
+// effect name over a horizontal rule (both cyan), then the message in bold,
+// then the interrupt's data pretty-printed — omitted entirely when there is
+// none (null/undefined or an empty object). Exported for unit tests.
+export function formatInterruptPrompt(intr: Intr): string {
+  const rule = "─".repeat(Math.max(intr.effect.length, 36));
+  const lines = [
+    "",
+    color.cyan(intr.effect),
+    color.cyan(rule),
+    "",
+    color.bold(intr.message),
+  ];
+  const hasData =
+    intr.data != null &&
+    !(typeof intr.data === "object" && Object.keys(intr.data).length === 0);
+  if (hasData) {
+    lines.push(JSON.stringify(intr.data, null, 2));
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
 async function promptOnce(intr: Intr): Promise<PromptDecision> {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stderr,
   });
   try {
-    const dataStr = JSON.stringify(intr.data);
-    const answer: string = await new Promise((resolve) =>
+    const answer: string = await new Promise((resolve) => {
+      // Stdin EOF (^D, or a closed pipe) while the question is pending would
+      // otherwise leave this promise unsettled forever — the process would
+      // die with an "unsettled top-level await" instead of a decision. Treat
+      // it as an empty answer, which parses to a safe reject.
+      rl.once("close", () => resolve(""));
       rl.question(
-        `\nInterrupt "${intr.effect}": ${intr.message}\n  ${dataStr}\n` +
+        formatInterruptPrompt(intr) +
           `(a)pprove / (r)eject / (aa) approve-always / (rr) reject-always: `,
         resolve,
-      ),
-    );
+      );
+    });
     return parsePromptAnswer(answer);
   } finally {
     rl.close();
   }
+}
+
+// Parse and validate the run policy from the environment. Returns null when
+// no policy was passed (the run was launched without any policy flag).
+function loadEnvPolicy(): Policy | null {
+  const raw = process.env[AGENCY_RUN_POLICY];
+  if (!raw) return null;
+
+  let policy: unknown;
+  try {
+    policy = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`${AGENCY_RUN_POLICY} is not valid JSON: ${String(e)}`);
+  }
+  const valid = validatePolicy(policy);
+  if (!valid.success) {
+    throw new Error(`${AGENCY_RUN_POLICY} is not a valid policy: ${valid.error}`);
+  }
+  return policy as Policy;
 }
 
 // Install the root policy handler on `execCtx` when the run was launched
@@ -131,25 +166,63 @@ export function installRunPolicyHandler(execCtx: {
   pushHandler: (h: HandlerFn) => void;
 }): void {
   if (isIpcMode()) return;
-  const raw = process.env[AGENCY_RUN_POLICY];
-  if (!raw) return;
+  const policy = loadEnvPolicy();
+  if (!policy) return;
+  execCtx.pushHandler(makeRunPolicyHandler(policy));
+}
 
-  let policy: unknown;
-  try {
-    policy = JSON.parse(raw);
-  } catch (e) {
-    throw new Error(`${AGENCY_RUN_POLICY} is not valid JSON: ${String(e)}`);
-  }
-  const valid = validatePolicy(policy);
-  if (!valid.success) {
-    throw new Error(`${AGENCY_RUN_POLICY} is not a valid policy: ${valid.error}`);
+// The user endpoint for a CLI-driven run: called by the generated bootstrap
+// after the top-level node returns. The handler chain has already had its
+// say — anything still in `result.data` is an interrupt the program's own
+// handlers (and the policy's explicit rules) did NOT settle, i.e. it has
+// surfaced to the user. This loop plays the role that a TypeScript caller
+// would: decide each interrupt, then resume via `respond` (the module-bound
+// respondToInterrupts) until the run finishes.
+//
+// Decisions: `--interactive` prompts on the terminal ("always" answers are
+// remembered for the rest of the run); without it every surfaced interrupt
+// is rejected (the documented default). Without any policy flag at all, this
+// falls back to reportUnhandledInterrupts — print the handlers-guide message
+// and exit non-zero, exactly the historical no-flag behavior.
+export async function resolveCliInterrupts(
+  result: RunNodeResult<any>,
+  respond: (
+    interrupts: Interrupt[],
+    responses: InterruptResponse[],
+  ) => Promise<RunNodeResult<any>>,
+  opts?: { prompt?: PromptFn },
+): Promise<RunNodeResult<any>> {
+  if (!hasInterrupts(result.data)) return result;
+  // No policy flag (or an IPC subprocess, which never owns the terminal):
+  // preserve the historical behavior — report and exit(1).
+  if (isIpcMode() || !loadEnvPolicy()) {
+    reportUnhandledInterrupts(result);
+    return result;
   }
 
   const interactive =
     process.env[AGENCY_RUN_POLICY_INTERACTIVE] === AGENCY_RUN_POLICY_INTERACTIVE_ON;
-  const handler = makeRunPolicyHandler(policy as Policy, {
-    interactive,
-    prompt: terminalPrompt,
-  });
-  execCtx.pushHandler(handler);
+  const prompt = opts?.prompt ?? terminalPrompt;
+  // Standing user decisions from "(aa)/(rr)" answers, keyed by effect.
+  // Null-prototype so a program-controlled effect name (e.g. "__proto__")
+  // is just an ordinary string key.
+  const remembered: Record<string, "approve" | "reject"> =
+    Object.create(null);
+
+  while (hasInterrupts(result.data)) {
+    const interrupts: Interrupt[] = result.data;
+    const responses: InterruptResponse[] = [];
+    for (const intr of interrupts) {
+      let action = remembered[intr.effect];
+      if (!action && interactive) {
+        const outcome = DECISIONS[await prompt(intr)];
+        if (outcome.remember) remembered[intr.effect] = outcome.action;
+        action = outcome.action;
+      }
+      // Non-interactive (or fail-closed): reject what would have surfaced.
+      responses.push(action === "approve" ? approve() : reject());
+    }
+    result = await respond(interrupts, responses);
+  }
+  return result;
 }

--- a/packages/agency-lang/lib/runtime/types.ts
+++ b/packages/agency-lang/lib/runtime/types.ts
@@ -37,7 +37,15 @@ export type Approved = { type: "approve"; value?: any };
 export type Propagated = { type: "propagate" };
 
 export type HandlerFn = (
-  interrupt: { effect: string; message: string; data: any; origin: string },
+  interrupt: {
+    effect: string;
+    message: string;
+    data: any;
+    origin: string;
+    // True for assignment-position raises (`const x = raise …`) — an
+    // approval value is expected. See Interrupt.expectsValue.
+    expectsValue?: boolean;
+  },
 ) => Promise<Approved | Rejected | Propagated | undefined>;
 
 /* tokenstats

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -16,7 +16,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
@@ -19,7 +19,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
+  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack(), { expectsValue: true });
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
@@ -24,7 +24,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
+  const __handlerResult = await interruptWithHandlers({{{effect}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack(), { expectsValue: true });
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -295,8 +295,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
         "Comma-separated interrupt effects to auto-reject",
       )
       .option(
-        "--interactive",
-        "Prompt on effects the policy does not cover (default: reject)",
+        "-i, --interactive",
+        "Prompt on interrupts that surface unhandled (default: reject them)",
       );
   }
 

--- a/packages/agency-lang/tests/agency-js/run-policy/agent.agency
+++ b/packages/agency-lang/tests/agency-js/run-policy/agent.agency
@@ -6,8 +6,8 @@ node writeIt(args: { dir: string, filename: string }): any {
   return write(filename: args.filename, content: "WROTE_IT", dir: args.dir)
 }
 
-// Input-style interrupt (effect "unknown"): a policy yields only approve/reject,
-// never a free-text value. Pins spec non-goal #2 / behavior note #2.
+// Input-style interrupt (effect "unknown", assignment position): under an
+// empty policy it surfaces to the caller carrying expectsValue: true.
 node inputIt(): any {
   const answer = interrupt("Where should I write?")
   return answer

--- a/packages/agency-lang/tests/agency-js/run-policy/fixture.json
+++ b/packages/agency-lang/tests/agency-js/run-policy/fixture.json
@@ -1,6 +1,6 @@
 {
   "readApproved": true,
   "writeRejected": true,
-  "failClosedRejected": true,
-  "inputRejected": true
+  "unlistedSurfaced": true,
+  "inputSurfacedExpectsValue": true
 }

--- a/packages/agency-lang/tests/agency-js/run-policy/test.js
+++ b/packages/agency-lang/tests/agency-js/run-policy/test.js
@@ -24,24 +24,30 @@ const writeRejected =
   !Array.isArray(writeRes.data) &&
   /reject/i.test(s(writeRes.data));
 
-// Scenario 2: empty policy — fail-closed. Write is unlisted → rejected.
-// "handled (not an Interrupt[]) AND no file" together rule out both fail-open
-// (would create the file) and unhandled (would leave data as an array).
+// Scenario 2: empty policy — effects the policy does not mention are left to
+// the program (and ultimately the caller). Write is unlisted → the chain stays
+// silent and the interrupt SURFACES to this TS caller as an Interrupt[], with
+// no file created. (The reject-what-surfaces default lives in the CLI endpoint,
+// resolveCliInterrupts — not here.)
 process.env.AGENCY_RUN_POLICY = "{}";
 const dir2 = mkdtempSync(join(tmpdir(), "runpol-"));
 const writeRes2 = await writeIt({ dir: dir2, filename: "out.txt" });
-const failClosedRejected =
-  !Array.isArray(writeRes2.data) && !existsSync(join(dir2, "out.txt"));
+const unlistedSurfaced =
+  Array.isArray(writeRes2.data) &&
+  writeRes2.data[0].effect === "std::write" &&
+  !existsSync(join(dir2, "out.txt"));
 
-// Scenario 3: input-style interrupt under empty policy → reject, not a value.
+// Scenario 3: input-style interrupt (assignment position) under empty policy →
+// surfaces too, and carries expectsValue so the caller knows an approval value
+// is expected.
 const inputRes = await inputIt();
-const inputRejected =
-  !Array.isArray(inputRes.data) && /reject/i.test(s(inputRes.data));
+const inputSurfacedExpectsValue =
+  Array.isArray(inputRes.data) && inputRes.data[0].expectsValue === true;
 
 writeFileSync(
   "__result.json",
   JSON.stringify(
-    { readApproved, writeRejected, failClosedRejected, inputRejected },
+    { readApproved, writeRejected, unlistedSurfaced, inputSurfacedExpectsValue },
     null,
     2,
   ),

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -286,7 +286,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -12,7 +12,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -592,7 +592,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -297,7 +297,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -337,7 +337,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -286,7 +286,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -464,7 +464,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -297,7 +297,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -467,7 +467,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -447,7 +447,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -431,7 +431,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -283,7 +283,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -480,7 +480,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -503,7 +503,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -301,7 +301,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -469,7 +469,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -289,7 +289,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -304,7 +304,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -288,7 +288,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -480,7 +480,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -617,7 +617,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -290,7 +290,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -502,7 +502,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -582,7 +582,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -307,7 +307,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -502,7 +502,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -340,7 +340,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -1250,7 +1250,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -555,7 +555,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -741,7 +741,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -459,7 +459,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -367,7 +367,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -374,7 +374,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -444,7 +444,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -26,7 +26,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -480,7 +480,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -491,7 +491,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -314,7 +314,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -300,7 +300,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -336,7 +336,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -223,7 +223,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers("unknown", `What is your name?`, {}, "./interrupt-assignment.agency", __ctx, __stateStack());
+  const __handlerResult = await interruptWithHandlers("unknown", `What is your name?`, {}, "./interrupt-assignment.agency", __ctx, __stateStack(), { expectsValue: true });
   if (isRejected(__handlerResult)) {
     
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -282,7 +282,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -328,7 +328,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -659,7 +659,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -331,7 +331,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -336,7 +336,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -504,7 +504,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -494,7 +494,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -297,7 +297,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -300,7 +300,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -780,7 +780,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -306,7 +306,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -399,7 +399,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -273,7 +273,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -298,7 +298,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -12,7 +12,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -288,7 +288,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -283,7 +283,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -710,7 +710,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -12,7 +12,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -304,7 +304,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -297,7 +297,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -290,7 +290,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -275,7 +275,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -444,7 +444,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -290,7 +290,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -266,7 +266,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -744,7 +744,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -334,7 +334,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -282,7 +282,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -302,7 +302,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -332,7 +332,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -304,7 +304,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -302,7 +302,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -291,7 +291,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -539,7 +539,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -306,7 +306,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -306,7 +306,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -448,7 +448,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -302,7 +302,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
       data: {}
     };
     const __result = await main(initialState);
-    reportUnhandledInterrupts(__result)
+    await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
     console.error(`
 Agent crashed: ${__error.message}`)


### PR DESCRIPTION
## Problem

`agency run --interactive` (and the non-interactive default-reject) was implemented as a root handler in the chain. Per the rules of handlers, every handler runs on every interrupt — so the CLI prompted (or rejected) interrupts the program had already settled with its own `handle ... with approve`. Example:

```
node main() {
  handle {
    raise std::error("This is a test error", { a: 1, b: 2 })
    print("This will not be printed if rejected")
  } with approve
}
```

Running this with `--interactive` prompted the user even though the code approves the interrupt itself.

## Semantics change

`--interactive` is now the **user endpoint** — it models what happens when an interrupt surfaces to a TypeScript caller as a returned `Interrupt[]`, rather than acting as another handler:

- **Explicit policy rules** (`--approve X`, `--reject X`, policy-file rules incl. `*` wildcards) still participate as a root chain handler, unchanged: a `--reject` beats a code approve and vice versa, per the rules of handlers.
- For effects the policy does **not** match, the handler now stays silent (previously: prompt/reject), leaving the decision to the program's own handlers.
- Interrupts that **nothing settles** — or that a handler explicitly `propagate`s — surface to a new `resolveCliInterrupts` endpoint in the generated CLI bootstrap. With `--interactive` it prompts and resumes the run via the module-bound `respondToInterrupts` (the same loop `agency serve` and `agency evaluate` use); `aa`/`rr` answers are remembered for the rest of the run. Without `--interactive`, surfaced interrupts are rejected and the run continues. With no policy flags at all, the historical `reportUnhandledInterrupts` crash is unchanged.

One deliberate behavior change beyond the prompt: with a non-interactive policy, an uncovered effect no longer clobbers a code-level approve with an in-chain reject — the default reject now applies only to interrupts that actually surface.

## Also in this PR

- `-i` shorthand for `--interactive`.
- Nicer prompt: effect name over a cyan horizontal rule, message in bold, interrupt data pretty-printed (omitted when empty).
- Fail-closed reject when stdin hits EOF while a prompt is pending (previously the process died with an unsettled top-level await, exit 13).

## Implementation

- `lib/runtime/policy.ts`: new `checkPolicyExplicit` returning `null` on fall-through; `checkPolicy`'s public propagate-on-fallthrough contract (re-exported via `std::policy`) is untouched.
- `lib/runtime/runPolicyHandler.ts`: chain handler reduced to explicit matches (explicit `propagate` rules now return a real `propagate`); new `resolveCliInterrupts` endpoint loop; prompt banner + EOF handling.
- `lib/backends/typescriptBuilder.ts` + `imports.mustache`: the bootstrap now runs `await resolveCliInterrupts(__result, respondToInterrupts)` instead of `reportUnhandledInterrupts(__result)`. All codegen fixtures rebuilt (the bulk of the diff: 2 lines x 93 fixture files).
- Docs: rewrote the `--interactive` section of the policies guide around the surfacing model.

## Testing

- Unit tests for the explicit-only handler, the endpoint loop (prompting, remembering, non-interactive reject, no-policy fallback, IPC guard), and the prompt formatter.
- New e2e spawn tests: a code-handled interrupt is not re-decided under `--interactive`; an uncovered surfaced interrupt is rejected and the run resumes to a clean exit.
- Verified live through a PTY: approve/reject/EOF answers, and the nested case — a `runCode` child raising an unhandled interrupt pauses, bubbles to the root CLI, prompts there, and resumes correctly down the subprocess tree on approve.
- 1667 tests pass across `lib/runtime`, `lib/cli`, and codegen suites; structural lint clean.


## Round 2: value-expecting interrupts (`expectsValue`)

An assignment-position raise (`const answer = raise interrupt("Question for user")`) expects its approver to provide a value — but nothing on the `Interrupt` said so. Now:

- **New `Interrupt.expectsValue: true` property**, set by the compiler for assignment-position raises (via a new trailing options arg to `interruptWithHandlers`; old 6-arg compiled calls keep working). Visible to handlers (`with (e) { e.expectsValue }`), across the IPC relay for nested runs, on surfaced `Interrupt` objects, and declarable from TS via `agency.interrupt({ expectsValue: true })`.
- **`--interactive` answers questions directly**: a surfaced value-expecting interrupt shows the banner and an `answer (empty line rejects):` prompt — the typed line becomes the approval value (assigned to the variable), an empty line or stdin EOF rejects. Statement raises keep the a/r/aa/rr prompt. Value interrupts bypass remembered `aa`/`rr` decisions both ways: a standing approve cannot answer a question.
- Verified via PTY: typed answer flows into the variable (`Hello, Adit!`), empty line rejects, and a mixed run shows both prompt styles in sequence. 2069 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
