### PR TITLE
Fix builtin-name params losing their value in codegen (#453)

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -971,7 +971,16 @@ export class TypeScriptBuilder {
       case "variableName": {
         const importedOrUnknownScope =
           literal.scope === "imported" || !literal.scope;
-        const isBuiltinVar = BUILTIN_VARIABLES.includes(literal.value);
+        // A builtin name (e.g. `color`) is only the *fallback* meaning of the
+        // identifier. A real binding — a parameter, local, etc. — with a
+        // resolved scope shadows it, exactly like in any lexically-scoped
+        // language. Without this guard a parameter named `color` compiles to a
+        // bare JS identifier instead of `__stack.args.color`, so its default
+        // value (and any value restored on resume) is silently lost: the body
+        // reads the undefaulted local while the default lands in the stack
+        // slot. See issue #453.
+        const isBuiltinVar =
+          BUILTIN_VARIABLES.includes(literal.value) && importedOrUnknownScope;
         const isLoopVar = this.loopVars.includes(literal.value);
         if (importedOrUnknownScope || isBuiltinVar || isLoopVar) {
           // Agency imports may resolve to a `static const` in the source

--- a/packages/agency-lang/tests/agency/builtin-name-param-shadowing.agency
+++ b/packages/agency-lang/tests/agency/builtin-name-param-shadowing.agency
@@ -1,0 +1,33 @@
+// Regression (issue #453): a function parameter whose name collides with a
+// BUILTIN_VARIABLE (`color`) must shadow the builtin inside the function body.
+//
+// Before the fix, a reference to such a parameter compiled to a bare JS
+// identifier instead of `__stack.args.color`. The parameter default is applied
+// only to the stack slot (`__stack.args.color`), so the body read the
+// undefaulted local (the `__UNSET` sentinel) and the default was silently lost.
+// This surfaced as std::ui/layout `render(node)` stripping color on the default
+// `color: "auto"` path even in an interactive terminal.
+
+def useColor(color: string = "auto"): string {
+  return color
+}
+
+// A local (not a param) named `color` must also shadow the builtin.
+def localShadow(): string {
+  const color = "local-wins"
+  return color
+}
+
+node testDefaultUsed() {
+  // `color` omitted at the call site: the body must observe the applied
+  // default "auto", not the internal sentinel.
+  return useColor()
+}
+
+node testExplicitPassed() {
+  return useColor("explicit")
+}
+
+node testLocalShadow() {
+  return localShadow()
+}

--- a/packages/agency-lang/tests/agency/builtin-name-param-shadowing.test.json
+++ b/packages/agency-lang/tests/agency/builtin-name-param-shadowing.test.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+    {
+      "nodeName": "testDefaultUsed",
+      "input": "",
+      "expectedOutput": "\"auto\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "omitted `color` param sees its applied default, not the __UNSET sentinel"
+    },
+    {
+      "nodeName": "testExplicitPassed",
+      "input": "",
+      "expectedOutput": "\"explicit\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "explicitly passed `color` value flows through the body"
+    },
+    {
+      "nodeName": "testLocalShadow",
+      "input": "",
+      "expectedOutput": "\"local-wins\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "a local named `color` shadows the builtin inside the body"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #453. The reported symptom — `std::ui/layout` `render(node)` stripping ANSI color on the default `color: "auto"` path even in an interactive terminal — turned out **not** to be a TTY-detection problem. Inside the compiled program `process.stdout.isTTY === true` and `autoUseColor()` correctly returns `true`; the color was being stripped for a different reason.

## Root cause

`render`'s `color` parameter is the sole entry in `BUILTIN_VARIABLES` (`lib/config.ts`). In `generateLiteral` (`lib/backends/typescriptBuilder.ts`), any reference to a `BUILTIN_VARIABLE` was forced down the bare-identifier code path **even when the symbol table had resolved that reference to a real binding** (the preprocessor correctly tags it `scope: "args"`).

For a parameter with a default, codegen applies the default only to the stack slot:

```js
__stack.args["color"] = color2 === __UNSET ? "auto" : color2;
```

But the body reference compiled to the bare local `color2` instead of `__stack.args.color`. When the caller omits the argument, `color2` is still the `__UNSET` sentinel, so `_render` received `Symbol(UNSET)`; `color === "auto"` was false and it stripped. Confirmed by instrumenting `_render`:

```
[_render DEBUG] color=Symbol(UNSET) isAuto=false autoUseColor=true   ← render(panel)
[_render DEBUG] color=true           isAuto=false autoUseColor=true   ← render(panel, color: true)
```

The same bare-local read also broke argument restoration on interrupt/resume for any param/local named `color`. `render` was just the most visible victim.

## Fix

A resolved binding shadows a builtin, exactly as in any lexically-scoped language. `isBuiltinVar` now only forces the fallback path when the name is otherwise unresolved (`imported`/unknown scope). Bare builtin references are unaffected — they already take that path via `importedOrUnknownScope`.

```ts
const isBuiltinVar =
  BUILTIN_VARIABLES.includes(literal.value) && importedOrUnknownScope;
```

## Testing

- New regression test `tests/agency/builtin-name-param-shadowing.agency` covers the omitted-default, explicit-pass, and local-shadow cases. It **fails 2/3 without the fix** and passes with it.
- End-to-end under a real PTY (`script`): `render(panel)` now colors on a terminal and still strips when piped; `render(panel, color: true)` unchanged.
- No regressions: `typescriptBuilder`, `typescriptGenerator` fixtures, and `stdlib/layout` suites all pass (433 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
