### PR TITLE
Diagnostic explanations: agency explain, generated docs, agent knowledge

### DIFF
--- a/packages/agency-lang/docs/site/diagnostics/checking.md
+++ b/packages/agency-lang/docs/site/diagnostics/checking.md
@@ -4,6 +4,8 @@ name: "Assignability and checking"
 
 # Assignability and checking
 
+<a id="ag2001"></a>
+
 ## AG2001 — Type '{actual}' is not assignable to type '{expected}' ({context}).
 
 *Default severity: error.*
@@ -11,6 +13,8 @@ name: "Assignability and checking"
 Agency assigns each value a type and checks that it fits where you use it. This is the assignability error with the surrounding context named (a return, an argument, a field) — the value's type does not fit that slot.
 
 **How to fix:** change one side so they line up — convert the value, widen the declared type, or fix the expression that produced the wrong type. If the value can legitimately be several types, declare the slot as a union.
+
+<a id="ag2002"></a>
 
 ## AG2002 — Type '{actual}' is not assignable to type 'boolean' (condition).
 
@@ -20,6 +24,8 @@ The condition of an `if` or `while` must be a boolean. Agency does not treat non
 
 **How to fix:** compare explicitly — e.g. `count > 0` instead of `count`, or `name != ""` instead of `name`.
 
+<a id="ag2003"></a>
+
 ## AG2003 — Unknown property '{key}' on type '{expected}' ({context}).
 
 *Default severity: error.*
@@ -28,6 +34,8 @@ An object literal (or similar structured value) included a key that the target t
 
 **How to fix:** remove the stray key, fix a typo in the key name, or add the field to the target type if it belongs there.
 
+<a id="ag2004"></a>
+
 ## AG2004 — Variable '{name}' has no type annotation (strict mode).
 
 *Default severity: error.*
@@ -35,6 +43,8 @@ An object literal (or similar structured value) included a key that the target t
 In strict mode every variable needs a type annotation; this one has none and its type could not be inferred with certainty. Strict mode trades a little verbosity for catching type mistakes early.
 
 **How to fix:** add an annotation, e.g. `let total: number = …`, or turn strict mode off if you do not want this requirement.
+
+<a id="ag2005"></a>
 
 ## AG2005 — Type '{actual}' is not assignable to type '{expected}'.
 
@@ -55,6 +65,8 @@ node main() {
 }
 ```
 
+<a id="ag2006"></a>
+
 ## AG2006 — For-loop iterable must be an array or Record, got '{actual}'.
 
 *Default severity: error.*
@@ -72,6 +84,8 @@ node main() {
 }
 ```
 
+<a id="ag2007"></a>
+
 ## AG2007 — {kind} '{name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'.
 
 *Default severity: error.*
@@ -80,6 +94,8 @@ A parameter marked with `!` validation can short-circuit the call with a failure
 
 **How to fix:** change the return type to `Result<...>`, or remove the `!` validation from the parameters if the call cannot fail.
 
+<a id="ag2008"></a>
+
 ## AG2008 — Property '{field}' is not available on every member of '{union}'; narrow the value (e.g. with a guard) before accessing it.
 
 *Default severity: error.*
@@ -87,6 +103,8 @@ A parameter marked with `!` validation can short-circuit the call with a failure
 The value has a union type, and the field you accessed exists on some members of the union but not all. Reading it directly would be unsafe on the members that lack it.
 
 **How to fix:** narrow the value first — for example with a guard that establishes which member you have — then access the field inside that narrowed branch.
+
+<a id="ag2009"></a>
 
 ## AG2009 — '.{field}' is only available on a {branch} Result; guard with 'if (isSuccess(r))' / 'if (isFailure(r))', use 'r catch …', or 'match (r) {{ … }}'.
 
@@ -105,6 +123,8 @@ node main() {
 }
 ```
 
+<a id="ag2010"></a>
+
 ## AG2010 — Cannot {op} values of different dimensions ({leftDim} and {rightDim}): '{left}' and '{right}'.
 
 *Default severity: error.*
@@ -113,6 +133,8 @@ Agency tracks physical dimensions (like duration versus size) on some values and
 
 **How to fix:** operate on values of the same dimension, or convert one so both agree before combining them.
 
+<a id="ag2011"></a>
+
 ## AG2011 — Property '{property}' does not exist on type '{type}'.
 
 *Default severity: error.*
@@ -120,6 +142,8 @@ Agency tracks physical dimensions (like duration versus size) on some values and
 The property you accessed is not declared on the value's type. The checker knows the type's shape and only allows the fields it declares.
 
 **How to fix:** fix a typo in the property name, access a field the type actually has, or add the field to the type if it belongs there.
+
+<a id="ag2012"></a>
 
 ## AG2012 — Not all code paths return a value in '{fn}'.
 

--- a/packages/agency-lang/docs/site/diagnostics/checking.md
+++ b/packages/agency-lang/docs/site/diagnostics/checking.md
@@ -6,7 +6,7 @@ name: "Assignability and checking"
 
 <a id="ag2001"></a>
 
-## AG2001 — Type '{actual}' is not assignable to type '{expected}' ({context}).
+## AG2001 — Type '&#123;actual&#125;' is not assignable to type '&#123;expected&#125;' (&#123;context&#125;).
 
 *Default severity: error.*
 
@@ -16,7 +16,7 @@ Agency assigns each value a type and checks that it fits where you use it. This 
 
 <a id="ag2002"></a>
 
-## AG2002 — Type '{actual}' is not assignable to type 'boolean' (condition).
+## AG2002 — Type '&#123;actual&#125;' is not assignable to type 'boolean' (condition).
 
 *Default severity: error.*
 
@@ -26,7 +26,7 @@ The condition of an `if` or `while` must be a boolean. Agency does not treat non
 
 <a id="ag2003"></a>
 
-## AG2003 — Unknown property '{key}' on type '{expected}' ({context}).
+## AG2003 — Unknown property '&#123;key&#125;' on type '&#123;expected&#125;' (&#123;context&#125;).
 
 *Default severity: error.*
 
@@ -36,7 +36,7 @@ An object literal (or similar structured value) included a key that the target t
 
 <a id="ag2004"></a>
 
-## AG2004 — Variable '{name}' has no type annotation (strict mode).
+## AG2004 — Variable '&#123;name&#125;' has no type annotation (strict mode).
 
 *Default severity: error.*
 
@@ -46,7 +46,7 @@ In strict mode every variable needs a type annotation; this one has none and its
 
 <a id="ag2005"></a>
 
-## AG2005 — Type '{actual}' is not assignable to type '{expected}'.
+## AG2005 — Type '&#123;actual&#125;' is not assignable to type '&#123;expected&#125;'.
 
 *Default severity: error.*
 
@@ -67,7 +67,7 @@ node main() {
 
 <a id="ag2006"></a>
 
-## AG2006 — For-loop iterable must be an array or Record, got '{actual}'.
+## AG2006 — For-loop iterable must be an array or Record, got '&#123;actual&#125;'.
 
 *Default severity: error.*
 
@@ -86,7 +86,7 @@ node main() {
 
 <a id="ag2007"></a>
 
-## AG2007 — {kind} '{name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'.
+## AG2007 — &#123;kind&#125; '&#123;name&#125;' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result&lt;...&gt;'.
 
 *Default severity: error.*
 
@@ -96,7 +96,7 @@ A parameter marked with `!` validation can short-circuit the call with a failure
 
 <a id="ag2008"></a>
 
-## AG2008 — Property '{field}' is not available on every member of '{union}'; narrow the value (e.g. with a guard) before accessing it.
+## AG2008 — Property '&#123;field&#125;' is not available on every member of '&#123;union&#125;'; narrow the value (e.g. with a guard) before accessing it.
 
 *Default severity: error.*
 
@@ -106,7 +106,7 @@ The value has a union type, and the field you accessed exists on some members of
 
 <a id="ag2009"></a>
 
-## AG2009 — '.{field}' is only available on a {branch} Result; guard with 'if (isSuccess(r))' / 'if (isFailure(r))', use 'r catch …', or 'match (r) {{ … }}'.
+## AG2009 — '.&#123;field&#125;' is only available on a &#123;branch&#125; Result; guard with 'if (isSuccess(r))' / 'if (isFailure(r))', use 'r catch …', or 'match (r) &#123; … &#125;'.
 
 *Default severity: error.*
 
@@ -125,7 +125,7 @@ node main() {
 
 <a id="ag2010"></a>
 
-## AG2010 — Cannot {op} values of different dimensions ({leftDim} and {rightDim}): '{left}' and '{right}'.
+## AG2010 — Cannot &#123;op&#125; values of different dimensions (&#123;leftDim&#125; and &#123;rightDim&#125;): '&#123;left&#125;' and '&#123;right&#125;'.
 
 *Default severity: error.*
 
@@ -135,7 +135,7 @@ Agency tracks physical dimensions (like duration versus size) on some values and
 
 <a id="ag2011"></a>
 
-## AG2011 — Property '{property}' does not exist on type '{type}'.
+## AG2011 — Property '&#123;property&#125;' does not exist on type '&#123;type&#125;'.
 
 *Default severity: error.*
 
@@ -145,7 +145,7 @@ The property you accessed is not declared on the value's type. The checker knows
 
 <a id="ag2012"></a>
 
-## AG2012 — Not all code paths return a value in '{fn}'.
+## AG2012 — Not all code paths return a value in '&#123;fn&#125;'.
 
 *Default severity: error.*
 

--- a/packages/agency-lang/docs/site/diagnostics/checking.md
+++ b/packages/agency-lang/docs/site/diagnostics/checking.md
@@ -1,0 +1,130 @@
+---
+name: "Assignability and checking"
+---
+
+# Assignability and checking
+
+## AG2001 — Type '{actual}' is not assignable to type '{expected}' ({context}).
+
+*Default severity: error.*
+
+Agency assigns each value a type and checks that it fits where you use it. This is the assignability error with the surrounding context named (a return, an argument, a field) — the value's type does not fit that slot.
+
+**How to fix:** change one side so they line up — convert the value, widen the declared type, or fix the expression that produced the wrong type. If the value can legitimately be several types, declare the slot as a union.
+
+## AG2002 — Type '{actual}' is not assignable to type 'boolean' (condition).
+
+*Default severity: error.*
+
+The condition of an `if` or `while` must be a boolean. Agency does not treat non-boolean values as truthy or falsy, so a number or string here is an error rather than a silent coercion.
+
+**How to fix:** compare explicitly — e.g. `count > 0` instead of `count`, or `name != ""` instead of `name`.
+
+## AG2003 — Unknown property '{key}' on type '{expected}' ({context}).
+
+*Default severity: error.*
+
+An object literal (or similar structured value) included a key that the target type does not declare. The checker knows the exact shape the context expects and rejects keys outside it.
+
+**How to fix:** remove the stray key, fix a typo in the key name, or add the field to the target type if it belongs there.
+
+## AG2004 — Variable '{name}' has no type annotation (strict mode).
+
+*Default severity: error.*
+
+In strict mode every variable needs a type annotation; this one has none and its type could not be inferred with certainty. Strict mode trades a little verbosity for catching type mistakes early.
+
+**How to fix:** add an annotation, e.g. `let total: number = …`, or turn strict mode off if you do not want this requirement.
+
+## AG2005 — Type '{actual}' is not assignable to type '{expected}'.
+
+*Default severity: error.*
+
+Agency assigns each value a type and checks that the value you store, return, or pass matches the type the destination expects. This error fires when they disagree — for example putting a `string` where a `number` is required.
+
+**How to fix:** change one side so they line up — convert the value, widen the declared type, or fix the expression that produced the wrong type. If the value can legitimately be one of several types, declare the destination as a union.
+
+```agency
+def half(n: number): number {
+  return n / 2
+}
+
+node main() {
+  const count: number = 3
+  half(count)
+}
+```
+
+## AG2006 — For-loop iterable must be an array or Record, got '{actual}'.
+
+*Default severity: error.*
+
+A `for (x in xs)` loop iterates an array or a Record; the value after `in` here is neither. The checker needs a container it knows how to walk.
+
+**How to fix:** iterate an array or Record, or convert the value into one before the loop.
+
+```agency
+node main() {
+  const names = ["ada", "grace"]
+  for (name in names) {
+    print(name)
+  }
+}
+```
+
+## AG2007 — {kind} '{name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'.
+
+*Default severity: error.*
+
+A parameter marked with `!` validation can short-circuit the call with a failure when the data does not pass. A function that can fail must advertise it in its return type, so its return type must be a `Result`.
+
+**How to fix:** change the return type to `Result<...>`, or remove the `!` validation from the parameters if the call cannot fail.
+
+## AG2008 — Property '{field}' is not available on every member of '{union}'; narrow the value (e.g. with a guard) before accessing it.
+
+*Default severity: error.*
+
+The value has a union type, and the field you accessed exists on some members of the union but not all. Reading it directly would be unsafe on the members that lack it.
+
+**How to fix:** narrow the value first — for example with a guard that establishes which member you have — then access the field inside that narrowed branch.
+
+## AG2009 — '.{field}' is only available on a {branch} Result; guard with 'if (isSuccess(r))' / 'if (isFailure(r))', use 'r catch …', or 'match (r) {{ … }}'.
+
+*Default severity: error.*
+
+A `Result` is either a success or a failure, and the field you accessed only exists on one of those branches. Reading it without first checking which branch you have would be unsafe.
+
+**How to fix:** guard with `if (isSuccess(r))` or `if (isFailure(r))`, use `r catch …`, or handle both arms with `match`.
+
+```agency
+node main() {
+  const r = compute()
+  if (isSuccess(r)) {
+    print(r.value)
+  }
+}
+```
+
+## AG2010 — Cannot {op} values of different dimensions ({leftDim} and {rightDim}): '{left}' and '{right}'.
+
+*Default severity: error.*
+
+Agency tracks physical dimensions (like duration versus size) on some values and refuses arithmetic that mixes incompatible ones, the way you cannot add seconds to bytes. This caught an operation on two different dimensions.
+
+**How to fix:** operate on values of the same dimension, or convert one so both agree before combining them.
+
+## AG2011 — Property '{property}' does not exist on type '{type}'.
+
+*Default severity: error.*
+
+The property you accessed is not declared on the value's type. The checker knows the type's shape and only allows the fields it declares.
+
+**How to fix:** fix a typo in the property name, access a field the type actually has, or add the field to the type if it belongs there.
+
+## AG2012 — Not all code paths return a value in '{fn}'.
+
+*Default severity: error.*
+
+The function declares a return type, so every path through its body must produce a value — but at least one path (often a missing `else`, or a fall-through past a loop) reaches the end without returning.
+
+**How to fix:** add a `return` on the path that is missing one, or a final `return` that covers the fall-through.

--- a/packages/agency-lang/docs/site/diagnostics/effects.md
+++ b/packages/agency-lang/docs/site/diagnostics/effects.md
@@ -4,6 +4,8 @@ name: "Interrupts, effects, and handlers"
 
 # Interrupts, effects, and handlers
 
+<a id="ag3001"></a>
+
 ## AG3001 — The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.
 
 *Default severity: error.*
@@ -11,6 +13,8 @@ name: "Interrupts, effects, and handlers"
 Handler parameters carry the payload of an interrupt, and the `!` validation syntax is not allowed on them. Validation there would run at a point in the flow where a failure has nowhere safe to go.
 
 **How to fix:** drop the `!` from the handler parameter and validate the data inside the handler body if you need to.
+
+<a id="ag3002"></a>
 
 ## AG3002 — Effect '{effect}' is declared more than once in the same file.
 
@@ -20,6 +24,8 @@ An effect was declared more than once in the same file. Each effect name should 
 
 **How to fix:** remove the duplicate declaration.
 
+<a id="ag3003"></a>
+
 ## AG3003 — Conflicting payload types for effect '{effect}'. All declarations of an effect must agree on its payload.
 
 *Default severity: error.*
@@ -27,6 +33,8 @@ An effect was declared more than once in the same file. Each effect name should 
 Two declarations of the same effect disagree about its payload type. Every declaration of an effect must agree on the data it carries.
 
 **How to fix:** make the declarations match, or consolidate them into one.
+
+<a id="ag3004"></a>
 
 ## AG3004 — Named arguments are not allowed on 'raise'/'interrupt'. Pass the data positionally.
 
@@ -36,6 +44,8 @@ Two declarations of the same effect disagree about its payload type. Every decla
 
 **How to fix:** pass the data positionally, e.g. `raise MyEffect(payload)`.
 
+<a id="ag3005"></a>
+
 ## AG3005 — Effect '{effect}' expects data {payload}, but none was supplied.
 
 *Default severity: error.*
@@ -43,6 +53,8 @@ Two declarations of the same effect disagree about its payload type. Every decla
 The effect declares a payload, but this `raise`/`interrupt` supplied none. A declared payload is required at the raise site.
 
 **How to fix:** pass the data the effect expects.
+
+<a id="ag3006"></a>
 
 ## AG3006 — Effect '{effect}' data field '{field}' is missing.
 
@@ -52,6 +64,8 @@ The effect's payload is a structured type, and a required field of it was not su
 
 **How to fix:** add the missing field to the payload you pass.
 
+<a id="ag3007"></a>
+
 ## AG3007 — Effect '{effect}' data field '{field}' has the wrong type.
 
 *Default severity: error.*
@@ -59,6 +73,8 @@ The effect's payload is a structured type, and a required field of it was not su
 A field of the effect's payload was supplied with a value whose type does not match what the effect declares for that field.
 
 **How to fix:** pass a value of the declared type for that field.
+
+<a id="ag3008"></a>
 
 ## AG3008 — Effect '{effect}' data does not match the declared {payload}.
 
@@ -68,6 +84,8 @@ The payload supplied at the raise site does not match the shape the effect decla
 
 **How to fix:** construct the payload to match the effect's declared type.
 
+<a id="ag3009"></a>
+
 ## AG3009 — Function '{fn}' may throw interrupts [{effects}] but is not inside a handler.
 
 *Default severity: warning.*
@@ -75,6 +93,8 @@ The payload supplied at the raise site does not match the shape the effect decla
 This function may raise interrupts, but it is called from a place that is not inside a matching handler. An unhandled interrupt at runtime has no `handle` block to receive it. This is a warning because the handler may be installed dynamically at a point the checker cannot see.
 
 **How to fix:** wrap the call in a `handle` block for the effects it may raise, or confirm a handler is installed higher up.
+
+<a id="ag3010"></a>
 
 ## AG3010 — Handler {handler} may raise interrupts [{effects}]. That would re-enter the handler chain (the dispatcher visits every handler, even the one currently running) and recurse until `HandlerRecursionError` fires at runtime. Restructure so the handler doesn't call interrupt-raising code (e.g. hoist file I/O out of the handler), or suppress this error with `// @tc-ignore` on the line above the `handle` block.
 
@@ -84,6 +104,8 @@ A handler that itself raises interrupts would re-enter the handler chain — the
 
 **How to fix:** restructure so the handler does not call interrupt-raising code (for example, hoist file I/O out of the handler). If you are certain it is safe, suppress with `// @tc-ignore` on the line above the `handle` block.
 
+<a id="ag3011"></a>
+
 ## AG3011 — `interrupt` is not allowed inside a callback body (callback registered on '{hook}' may raise [{effects}]). Callbacks fire as side effects; their body cannot pause execution to ask the user a question. Move the `interrupt` into the calling node/function instead, or use a runtime guard if you wanted budget enforcement.
 
 *Default severity: error.*
@@ -91,6 +113,8 @@ A handler that itself raises interrupts would re-enter the handler chain — the
 Callbacks fire as side effects at points where execution cannot pause, so their body may not `interrupt` — an interrupt would need to stop the run to ask the user something, which a callback has no way to do.
 
 **How to fix:** move the `interrupt` into the calling node or function. If you only wanted a runtime budget check, use a runtime guard instead.
+
+<a id="ag3012"></a>
 
 ## AG3012 — 'raises {ref}' is not an effect set. Declare '{ref}' with 'effectSet' (not 'type'), or use an inline set like '<...>'.
 
@@ -100,6 +124,8 @@ A `raises` clause must name an effect set, but the reference given is declared a
 
 **How to fix:** declare the reference with `effectSet` instead of `type`, or use an inline effect set in angle brackets.
 
+<a id="ag3013"></a>
+
 ## AG3013 — {kind} '{name}' raises effect '{effect}', which exceeds its declared 'raises {declared}'. Add '{effect}' to the clause.
 
 *Default severity: error.*
@@ -108,6 +134,8 @@ The function or node raises an effect that its own `raises` clause does not list
 
 **How to fix:** add the effect to the `raises` clause, or stop raising it.
 
+<a id="ag3014"></a>
+
 ## AG3014 — {who} may raise any effect (its type has no 'raises' clause), which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add a 'raises' clause to the value's type.
 
 *Default severity: error.*
@@ -115,6 +143,8 @@ The function or node raises an effect that its own `raises` clause does not list
 A value is being used where the target type limits which effects may be raised, but the value's own type has no `raises` clause — so it could raise anything, which exceeds that limit.
 
 **How to fix:** add a `raises` clause to the value's type so the checker can see it stays within bounds.
+
+<a id="ag3015"></a>
 
 ## AG3015 — {who} raises effect '{effect}', which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add '{effect}' to the clause, or use a target type that allows it.
 

--- a/packages/agency-lang/docs/site/diagnostics/effects.md
+++ b/packages/agency-lang/docs/site/diagnostics/effects.md
@@ -1,0 +1,125 @@
+---
+name: "Interrupts, effects, and handlers"
+---
+
+# Interrupts, effects, and handlers
+
+## AG3001 — The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.
+
+*Default severity: error.*
+
+Handler parameters carry the payload of an interrupt, and the `!` validation syntax is not allowed on them. Validation there would run at a point in the flow where a failure has nowhere safe to go.
+
+**How to fix:** drop the `!` from the handler parameter and validate the data inside the handler body if you need to.
+
+## AG3002 — Effect '{effect}' is declared more than once in the same file.
+
+*Default severity: error.*
+
+An effect was declared more than once in the same file. Each effect name should be introduced by a single declaration so its payload shape has one definition.
+
+**How to fix:** remove the duplicate declaration.
+
+## AG3003 — Conflicting payload types for effect '{effect}'. All declarations of an effect must agree on its payload.
+
+*Default severity: error.*
+
+Two declarations of the same effect disagree about its payload type. Every declaration of an effect must agree on the data it carries.
+
+**How to fix:** make the declarations match, or consolidate them into one.
+
+## AG3004 — Named arguments are not allowed on 'raise'/'interrupt'. Pass the data positionally.
+
+*Default severity: error.*
+
+`raise` and `interrupt` take their payload positionally, not as named arguments. Their data is a single positional value.
+
+**How to fix:** pass the data positionally, e.g. `raise MyEffect(payload)`.
+
+## AG3005 — Effect '{effect}' expects data {payload}, but none was supplied.
+
+*Default severity: error.*
+
+The effect declares a payload, but this `raise`/`interrupt` supplied none. A declared payload is required at the raise site.
+
+**How to fix:** pass the data the effect expects.
+
+## AG3006 — Effect '{effect}' data field '{field}' is missing.
+
+*Default severity: error.*
+
+The effect's payload is a structured type, and a required field of it was not supplied at the raise site.
+
+**How to fix:** add the missing field to the payload you pass.
+
+## AG3007 — Effect '{effect}' data field '{field}' has the wrong type.
+
+*Default severity: error.*
+
+A field of the effect's payload was supplied with a value whose type does not match what the effect declares for that field.
+
+**How to fix:** pass a value of the declared type for that field.
+
+## AG3008 — Effect '{effect}' data does not match the declared {payload}.
+
+*Default severity: error.*
+
+The payload supplied at the raise site does not match the shape the effect declares. The whole value, not just one field, is off.
+
+**How to fix:** construct the payload to match the effect's declared type.
+
+## AG3009 — Function '{fn}' may throw interrupts [{effects}] but is not inside a handler.
+
+*Default severity: warning.*
+
+This function may raise interrupts, but it is called from a place that is not inside a matching handler. An unhandled interrupt at runtime has no `handle` block to receive it. This is a warning because the handler may be installed dynamically at a point the checker cannot see.
+
+**How to fix:** wrap the call in a `handle` block for the effects it may raise, or confirm a handler is installed higher up.
+
+## AG3010 — Handler {handler} may raise interrupts [{effects}]. That would re-enter the handler chain (the dispatcher visits every handler, even the one currently running) and recurse until `HandlerRecursionError` fires at runtime. Restructure so the handler doesn't call interrupt-raising code (e.g. hoist file I/O out of the handler), or suppress this error with `// @tc-ignore` on the line above the `handle` block.
+
+*Default severity: error.*
+
+A handler that itself raises interrupts would re-enter the handler chain — the dispatcher visits every handler, including the one currently running — and recurse until the runtime aborts with a recursion error.
+
+**How to fix:** restructure so the handler does not call interrupt-raising code (for example, hoist file I/O out of the handler). If you are certain it is safe, suppress with `// @tc-ignore` on the line above the `handle` block.
+
+## AG3011 — `interrupt` is not allowed inside a callback body (callback registered on '{hook}' may raise [{effects}]). Callbacks fire as side effects; their body cannot pause execution to ask the user a question. Move the `interrupt` into the calling node/function instead, or use a runtime guard if you wanted budget enforcement.
+
+*Default severity: error.*
+
+Callbacks fire as side effects at points where execution cannot pause, so their body may not `interrupt` — an interrupt would need to stop the run to ask the user something, which a callback has no way to do.
+
+**How to fix:** move the `interrupt` into the calling node or function. If you only wanted a runtime budget check, use a runtime guard instead.
+
+## AG3012 — 'raises {ref}' is not an effect set. Declare '{ref}' with 'effectSet' (not 'type'), or use an inline set like '<...>'.
+
+*Default severity: error.*
+
+A `raises` clause must name an effect set, but the reference given is declared as a plain `type`, not an `effectSet`. The two are different: only an effect set enumerates raisable effects.
+
+**How to fix:** declare the reference with `effectSet` instead of `type`, or use an inline effect set in angle brackets.
+
+## AG3013 — {kind} '{name}' raises effect '{effect}', which exceeds its declared 'raises {declared}'. Add '{effect}' to the clause.
+
+*Default severity: error.*
+
+The function or node raises an effect that its own `raises` clause does not list. The clause is a contract: it must cover every effect the body can raise.
+
+**How to fix:** add the effect to the `raises` clause, or stop raising it.
+
+## AG3014 — {who} may raise any effect (its type has no 'raises' clause), which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add a 'raises' clause to the value's type.
+
+*Default severity: error.*
+
+A value is being used where the target type limits which effects may be raised, but the value's own type has no `raises` clause — so it could raise anything, which exceeds that limit.
+
+**How to fix:** add a `raises` clause to the value's type so the checker can see it stays within bounds.
+
+## AG3015 — {who} raises effect '{effect}', which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add '{effect}' to the clause, or use a target type that allows it.
+
+*Default severity: error.*
+
+A value raises an effect that the target type's `raises` clause does not allow. The target restricts the effect set, and this value steps outside it.
+
+**How to fix:** add the effect to the target type's clause, or use a target type that permits it.

--- a/packages/agency-lang/docs/site/diagnostics/effects.md
+++ b/packages/agency-lang/docs/site/diagnostics/effects.md
@@ -16,7 +16,7 @@ Handler parameters carry the payload of an interrupt, and the `!` validation syn
 
 <a id="ag3002"></a>
 
-## AG3002 — Effect '{effect}' is declared more than once in the same file.
+## AG3002 — Effect '&#123;effect&#125;' is declared more than once in the same file.
 
 *Default severity: error.*
 
@@ -26,7 +26,7 @@ An effect was declared more than once in the same file. Each effect name should 
 
 <a id="ag3003"></a>
 
-## AG3003 — Conflicting payload types for effect '{effect}'. All declarations of an effect must agree on its payload.
+## AG3003 — Conflicting payload types for effect '&#123;effect&#125;'. All declarations of an effect must agree on its payload.
 
 *Default severity: error.*
 
@@ -46,7 +46,7 @@ Two declarations of the same effect disagree about its payload type. Every decla
 
 <a id="ag3005"></a>
 
-## AG3005 — Effect '{effect}' expects data {payload}, but none was supplied.
+## AG3005 — Effect '&#123;effect&#125;' expects data &#123;payload&#125;, but none was supplied.
 
 *Default severity: error.*
 
@@ -56,7 +56,7 @@ The effect declares a payload, but this `raise`/`interrupt` supplied none. A dec
 
 <a id="ag3006"></a>
 
-## AG3006 — Effect '{effect}' data field '{field}' is missing.
+## AG3006 — Effect '&#123;effect&#125;' data field '&#123;field&#125;' is missing.
 
 *Default severity: error.*
 
@@ -66,7 +66,7 @@ The effect's payload is a structured type, and a required field of it was not su
 
 <a id="ag3007"></a>
 
-## AG3007 — Effect '{effect}' data field '{field}' has the wrong type.
+## AG3007 — Effect '&#123;effect&#125;' data field '&#123;field&#125;' has the wrong type.
 
 *Default severity: error.*
 
@@ -76,7 +76,7 @@ A field of the effect's payload was supplied with a value whose type does not ma
 
 <a id="ag3008"></a>
 
-## AG3008 — Effect '{effect}' data does not match the declared {payload}.
+## AG3008 — Effect '&#123;effect&#125;' data does not match the declared &#123;payload&#125;.
 
 *Default severity: error.*
 
@@ -86,7 +86,7 @@ The payload supplied at the raise site does not match the shape the effect decla
 
 <a id="ag3009"></a>
 
-## AG3009 — Function '{fn}' may throw interrupts [{effects}] but is not inside a handler.
+## AG3009 — Function '&#123;fn&#125;' may throw interrupts [&#123;effects&#125;] but is not inside a handler.
 
 *Default severity: warning.*
 
@@ -96,7 +96,7 @@ This function may raise interrupts, but it is called from a place that is not in
 
 <a id="ag3010"></a>
 
-## AG3010 — Handler {handler} may raise interrupts [{effects}]. That would re-enter the handler chain (the dispatcher visits every handler, even the one currently running) and recurse until `HandlerRecursionError` fires at runtime. Restructure so the handler doesn't call interrupt-raising code (e.g. hoist file I/O out of the handler), or suppress this error with `// @tc-ignore` on the line above the `handle` block.
+## AG3010 — Handler &#123;handler&#125; may raise interrupts [&#123;effects&#125;]. That would re-enter the handler chain (the dispatcher visits every handler, even the one currently running) and recurse until `HandlerRecursionError` fires at runtime. Restructure so the handler doesn't call interrupt-raising code (e.g. hoist file I/O out of the handler), or suppress this error with `// @tc-ignore` on the line above the `handle` block.
 
 *Default severity: error.*
 
@@ -106,7 +106,7 @@ A handler that itself raises interrupts would re-enter the handler chain — the
 
 <a id="ag3011"></a>
 
-## AG3011 — `interrupt` is not allowed inside a callback body (callback registered on '{hook}' may raise [{effects}]). Callbacks fire as side effects; their body cannot pause execution to ask the user a question. Move the `interrupt` into the calling node/function instead, or use a runtime guard if you wanted budget enforcement.
+## AG3011 — `interrupt` is not allowed inside a callback body (callback registered on '&#123;hook&#125;' may raise [&#123;effects&#125;]). Callbacks fire as side effects; their body cannot pause execution to ask the user a question. Move the `interrupt` into the calling node/function instead, or use a runtime guard if you wanted budget enforcement.
 
 *Default severity: error.*
 
@@ -116,7 +116,7 @@ Callbacks fire as side effects at points where execution cannot pause, so their 
 
 <a id="ag3012"></a>
 
-## AG3012 — 'raises {ref}' is not an effect set. Declare '{ref}' with 'effectSet' (not 'type'), or use an inline set like '<...>'.
+## AG3012 — 'raises &#123;ref&#125;' is not an effect set. Declare '&#123;ref&#125;' with 'effectSet' (not 'type'), or use an inline set like '&lt;...&gt;'.
 
 *Default severity: error.*
 
@@ -126,7 +126,7 @@ A `raises` clause must name an effect set, but the reference given is declared a
 
 <a id="ag3013"></a>
 
-## AG3013 — {kind} '{name}' raises effect '{effect}', which exceeds its declared 'raises {declared}'. Add '{effect}' to the clause.
+## AG3013 — &#123;kind&#125; '&#123;name&#125;' raises effect '&#123;effect&#125;', which exceeds its declared 'raises &#123;declared&#125;'. Add '&#123;effect&#125;' to the clause.
 
 *Default severity: error.*
 
@@ -136,7 +136,7 @@ The function or node raises an effect that its own `raises` clause does not list
 
 <a id="ag3014"></a>
 
-## AG3014 — {who} may raise any effect (its type has no 'raises' clause), which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add a 'raises' clause to the value's type.
+## AG3014 — &#123;who&#125; may raise any effect (its type has no 'raises' clause), which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add a 'raises' clause to the value's type.
 
 *Default severity: error.*
 
@@ -146,7 +146,7 @@ A value is being used where the target type limits which effects may be raised, 
 
 <a id="ag3015"></a>
 
-## AG3015 — {who} raises effect '{effect}', which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add '{effect}' to the clause, or use a target type that allows it.
+## AG3015 — &#123;who&#125; raises effect '&#123;effect&#125;', which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add '&#123;effect&#125;' to the clause, or use a target type that allows it.
 
 *Default severity: error.*
 

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -1,0 +1,127 @@
+---
+name: "Diagnostics"
+---
+
+# Diagnostic codes
+
+Every type-checker error and warning carries a stable `AG####` code.
+Look one up with `agency explain <code>` (e.g. `agency explain AG2005`),
+or suppress one on the next line with `// @tc-ignore AG####`.
+
+## Types and aliases
+
+| Code | Message |
+| --- | --- |
+| [AG1001](types-aliases.md#ag1001) | Type parameter '{param}' (no default) must come before parameters that have defaults in '{alias}'. |
+| [AG1002](types-aliases.md#ag1002) | Type '{alias}' is not a value-parameterized type but was given {count} value {argumentWord} (referenced in '{context}'). |
+| [AG1003](types-aliases.md#ag1003) | {alias} expects at most {max} value {argumentWord}, got {count} (referenced in '{context}'). |
+| [AG1004](types-aliases.md#ag1004) | '{alias}' is a value-parameterized type and requires value arguments — write '{alias}({formals})' (referenced in '{context}'). |
+| [AG1005](types-aliases.md#ag1005) | {alias} requires at least {min} value {argumentWord} (referenced in '{context}'). |
+| [AG1006](types-aliases.md#ag1006) | Type alias '{alias}' is not defined (referenced in '{context}'). |
+| [AG1007](types-aliases.md#ag1007) | Generic type '{alias}' requires type arguments (referenced in '{context}'). |
+| [AG1008](types-aliases.md#ag1008) | {alias} expects {expected} type {argumentWord}, got {count} (referenced in '{context}'). |
+| [AG1009](types-aliases.md#ag1009) | Unknown generic type '{alias}' (referenced in '{context}'). |
+| [AG1010](types-aliases.md#ag1010) | Type '{alias}' is not a generic type (referenced in '{context}'). |
+| [AG1011](types-aliases.md#ag1011) | {alias} expects at most {max} type {argumentWord}, got {count} (referenced in '{context}'). |
+| [AG1012](types-aliases.md#ag1012) | {alias} requires at least {min} type {argumentWord} (referenced in '{context}'). |
+
+## Assignability and checking
+
+| Code | Message |
+| --- | --- |
+| [AG2001](checking.md#ag2001) | Type '{actual}' is not assignable to type '{expected}' ({context}). |
+| [AG2002](checking.md#ag2002) | Type '{actual}' is not assignable to type 'boolean' (condition). |
+| [AG2003](checking.md#ag2003) | Unknown property '{key}' on type '{expected}' ({context}). |
+| [AG2004](checking.md#ag2004) | Variable '{name}' has no type annotation (strict mode). |
+| [AG2005](checking.md#ag2005) | Type '{actual}' is not assignable to type '{expected}'. |
+| [AG2006](checking.md#ag2006) | For-loop iterable must be an array or Record, got '{actual}'. |
+| [AG2007](checking.md#ag2007) | {kind} '{name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'. |
+| [AG2008](checking.md#ag2008) | Property '{field}' is not available on every member of '{union}'; narrow the value (e.g. with a guard) before accessing it. |
+| [AG2009](checking.md#ag2009) | '.{field}' is only available on a {branch} Result; guard with 'if (isSuccess(r))' / 'if (isFailure(r))', use 'r catch …', or 'match (r) {{ … }}'. |
+| [AG2010](checking.md#ag2010) | Cannot {op} values of different dimensions ({leftDim} and {rightDim}): '{left}' and '{right}'. |
+| [AG2011](checking.md#ag2011) | Property '{property}' does not exist on type '{type}'. |
+| [AG2012](checking.md#ag2012) | Not all code paths return a value in '{fn}'. |
+
+## Interrupts, effects, and handlers
+
+| Code | Message |
+| --- | --- |
+| [AG3001](effects.md#ag3001) | The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed. |
+| [AG3002](effects.md#ag3002) | Effect '{effect}' is declared more than once in the same file. |
+| [AG3003](effects.md#ag3003) | Conflicting payload types for effect '{effect}'. All declarations of an effect must agree on its payload. |
+| [AG3004](effects.md#ag3004) | Named arguments are not allowed on 'raise'/'interrupt'. Pass the data positionally. |
+| [AG3005](effects.md#ag3005) | Effect '{effect}' expects data {payload}, but none was supplied. |
+| [AG3006](effects.md#ag3006) | Effect '{effect}' data field '{field}' is missing. |
+| [AG3007](effects.md#ag3007) | Effect '{effect}' data field '{field}' has the wrong type. |
+| [AG3008](effects.md#ag3008) | Effect '{effect}' data does not match the declared {payload}. |
+| [AG3009](effects.md#ag3009) | Function '{fn}' may throw interrupts [{effects}] but is not inside a handler. |
+| [AG3010](effects.md#ag3010) | Handler {handler} may raise interrupts [{effects}]. That would re-enter the handler chain (the dispatcher visits every handler, even the one currently running) and recurse until `HandlerRecursionError` fires at runtime. Restructure so the handler doesn't call interrupt-raising code (e.g. hoist file I/O out of the handler), or suppress this error with `// @tc-ignore` on the line above the `handle` block. |
+| [AG3011](effects.md#ag3011) | `interrupt` is not allowed inside a callback body (callback registered on '{hook}' may raise [{effects}]). Callbacks fire as side effects; their body cannot pause execution to ask the user a question. Move the `interrupt` into the calling node/function instead, or use a runtime guard if you wanted budget enforcement. |
+| [AG3012](effects.md#ag3012) | 'raises {ref}' is not an effect set. Declare '{ref}' with 'effectSet' (not 'type'), or use an inline set like '<...>'. |
+| [AG3013](effects.md#ag3013) | {kind} '{name}' raises effect '{effect}', which exceeds its declared 'raises {declared}'. Add '{effect}' to the clause. |
+| [AG3014](effects.md#ag3014) | {who} may raise any effect (its type has no 'raises' clause), which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add a 'raises' clause to the value's type. |
+| [AG3015](effects.md#ag3015) | {who} raises effect '{effect}', which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add '{effect}' to the clause, or use a target type that allows it. |
+
+## Names, scope, and reserved words
+
+| Code | Message |
+| --- | --- |
+| [AG4001](names.md#ag4001) | '{name}' shadows an imported function. |
+| [AG4002](names.md#ag4002) | '{name}' is a reserved built-in; cannot be redefined. |
+| [AG4003](names.md#ag4003) | '{name}' is a reserved built-in type; cannot be redefined. |
+| [AG4004](names.md#ag4004) | Function '{name}' is not defined. |
+| [AG4005](names.md#ag4005) | Cannot reassign to constant '{name}'. |
+| [AG4006](names.md#ag4006) | `{keyword}` is a reserved block keyword. Write `{keyword} {{ ... }}` or `{keyword}(args) {{ ... }}` directly — the `as` keyword is not supported on {keyword} blocks (there's nothing to bind). |
+| [AG4007](names.md#ag4007) | Variable '{name}' is not defined. |
+
+## Match and narrowing
+
+| Code | Message |
+| --- | --- |
+| [AG5002](match.md#ag5002) | match is not exhaustive: missing {missing}. |
+
+## Calls, tools, and LLM usage
+
+| Code | Message |
+| --- | --- |
+| [AG6001](tools.md#ag6001) | 'regex' cannot appear in an llm() structured-output type ({context}); LLMs can't return regex values through JSON. |
+| [AG6002](tools.md#ag6002) | Cannot interpolate parameter '{param}' in doc string — parameter values are not known when the tool description is sent to the LLM. Use a global variable instead. |
+| [AG6003](tools.md#ag6003) | .partial() requires named arguments, e.g. fn.partial(a: 5). |
+| [AG6004](tools.md#ag6004) | Unknown parameter '{name}' in .partial() call. '{fn}' has parameters: {params}. |
+| [AG6005](tools.md#ag6005) | Argument type '{actual}' is not assignable to parameter type '{expected}' in .partial() call to '{fn}'. |
+| [AG6006](tools.md#ag6006) | Named arguments are not supported on built-in method '.{method}()'. |
+| [AG6007](tools.md#ag6007) | Method '.{method}()' expects {expected} argument(s), got {count}. |
+| [AG6008](tools.md#ag6008) | Method '.{method}()' expects at least {min} argument(s), got {count}. |
+| [AG6009](tools.md#ag6009) | Method '.{method}()' expects {min}–{max} argument(s), got {count}. |
+| [AG6010](tools.md#ag6010) | Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '.{method}()'. |
+| [AG6011](tools.md#ag6011) | Named arguments can only be used with Agency-defined functions, not '{fn}'. |
+| [AG6012](tools.md#ag6012) | '{fn}' does not accept the named argument '{name}'. Allowed: {allowed}. |
+| [AG6013](tools.md#ag6013) | Duplicate named argument '{name}' in call to '{fn}'. |
+| [AG6014](tools.md#ag6014) | Named argument '{name}' on '{fn}' expects type '{expected}', got '{actual}'. |
+| [AG6015](tools.md#ag6015) | '{fn}' does not accept a block argument. |
+| [AG6016](tools.md#ag6016) | Expected {expected} argument(s) for '{fn}', but got {count}. |
+| [AG6017](tools.md#ag6017) | Expected at least {min} argument(s) for '{fn}', but got {count}. |
+| [AG6018](tools.md#ag6018) | Expected {min}-{max} argument(s) for '{fn}', but got {count}. |
+| [AG6019](tools.md#ag6019) | Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'. |
+| [AG6020](tools.md#ag6020) | Splat argument must be an array, got '{actual}' in call to '{fn}'. |
+| [AG6021](tools.md#ag6021) | Splat element type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'. |
+| [AG6022](tools.md#ag6022) | Type '{actual}' is not assignable to pipe slot of type '{expected}'. |
+| [AG6023](tools.md#ag6023) | Splat argument cannot follow a named argument in call to '{fn}'. |
+| [AG6024](tools.md#ag6024) | Positional argument cannot follow a named argument in call to '{fn}'. |
+| [AG6025](tools.md#ag6025) | Unknown named argument '{name}' in call to '{fn}'. |
+| [AG6026](tools.md#ag6026) | Named argument '{name}' conflicts with positional argument at position {position} in call to '{fn}'. |
+| [AG6027](tools.md#ag6027) | Positional argument cannot feed variadic parameter '{param}' when it is also bound by name in call to '{fn}'. |
+| [AG6028](tools.md#ag6028) | Tool '{tool}' has required function-typed parameter '{param}' is unbound. Bind it with .partial({param}: <value>) before passing as a tool. |
+| [AG6029](tools.md#ag6029) | Tool '{tool}' has required function-typed parameter '{param}' is unbound ({type}). Bind it with .partial({param}: <value>) before passing as a tool. |
+| [AG6030](tools.md#ag6030) | Tool '{tool}' will be exposed to the LLM without optional function-typed parameter(s): {params}. The function body must be prepared to run with the declared default for each. |
+
+## Static init, config, and imports
+
+| Code | Message |
+| --- | --- |
+| [AG7001](static-init.md#ag7001) | Only 'static const' declarations can be exported. Use 'export static const {name} = ...' instead. |
+| [AG7002](static-init.md#ag7002) | {contextLabel} cannot call `{builtin}(...)` — {reason}, but static initializers run once at process startup before any per-run state exists. Move this call into a node or a function called from a node. |
+| [AG7003](static-init.md#ag7003) | {contextLabel} cannot `interrupt(...)` — interrupts pause the per-run execution stack, but static initializers run once at process startup before any agent run has begun. Move this into a node body. |
+| [AG7004](static-init.md#ag7004) | Cannot reassign static `{name}` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
+| [AG7005](static-init.md#ag7005) | Cannot mutate static `{name}` via `.{method}(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
+| [AG7006](static-init.md#ag7006) | Function '{name}' cannot be both destructive and idempotent — those markers are contradictory. Pick one. |

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -12,116 +12,116 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 
 | Code | Message |
 | --- | --- |
-| [AG1001](types-aliases.md#ag1001) | Type parameter '{param}' (no default) must come before parameters that have defaults in '{alias}'. |
-| [AG1002](types-aliases.md#ag1002) | Type '{alias}' is not a value-parameterized type but was given {count} value {argumentWord} (referenced in '{context}'). |
-| [AG1003](types-aliases.md#ag1003) | {alias} expects at most {max} value {argumentWord}, got {count} (referenced in '{context}'). |
-| [AG1004](types-aliases.md#ag1004) | '{alias}' is a value-parameterized type and requires value arguments — write '{alias}({formals})' (referenced in '{context}'). |
-| [AG1005](types-aliases.md#ag1005) | {alias} requires at least {min} value {argumentWord} (referenced in '{context}'). |
-| [AG1006](types-aliases.md#ag1006) | Type alias '{alias}' is not defined (referenced in '{context}'). |
-| [AG1007](types-aliases.md#ag1007) | Generic type '{alias}' requires type arguments (referenced in '{context}'). |
-| [AG1008](types-aliases.md#ag1008) | {alias} expects {expected} type {argumentWord}, got {count} (referenced in '{context}'). |
-| [AG1009](types-aliases.md#ag1009) | Unknown generic type '{alias}' (referenced in '{context}'). |
-| [AG1010](types-aliases.md#ag1010) | Type '{alias}' is not a generic type (referenced in '{context}'). |
-| [AG1011](types-aliases.md#ag1011) | {alias} expects at most {max} type {argumentWord}, got {count} (referenced in '{context}'). |
-| [AG1012](types-aliases.md#ag1012) | {alias} requires at least {min} type {argumentWord} (referenced in '{context}'). |
+| [AG1001](types-aliases.md#ag1001) | Type parameter '&#123;param&#125;' (no default) must come before parameters that have defaults in '&#123;alias&#125;'. |
+| [AG1002](types-aliases.md#ag1002) | Type '&#123;alias&#125;' is not a value-parameterized type but was given &#123;count&#125; value &#123;argumentWord&#125; (referenced in '&#123;context&#125;'). |
+| [AG1003](types-aliases.md#ag1003) | &#123;alias&#125; expects at most &#123;max&#125; value &#123;argumentWord&#125;, got &#123;count&#125; (referenced in '&#123;context&#125;'). |
+| [AG1004](types-aliases.md#ag1004) | '&#123;alias&#125;' is a value-parameterized type and requires value arguments — write '&#123;alias&#125;(&#123;formals&#125;)' (referenced in '&#123;context&#125;'). |
+| [AG1005](types-aliases.md#ag1005) | &#123;alias&#125; requires at least &#123;min&#125; value &#123;argumentWord&#125; (referenced in '&#123;context&#125;'). |
+| [AG1006](types-aliases.md#ag1006) | Type alias '&#123;alias&#125;' is not defined (referenced in '&#123;context&#125;'). |
+| [AG1007](types-aliases.md#ag1007) | Generic type '&#123;alias&#125;' requires type arguments (referenced in '&#123;context&#125;'). |
+| [AG1008](types-aliases.md#ag1008) | &#123;alias&#125; expects &#123;expected&#125; type &#123;argumentWord&#125;, got &#123;count&#125; (referenced in '&#123;context&#125;'). |
+| [AG1009](types-aliases.md#ag1009) | Unknown generic type '&#123;alias&#125;' (referenced in '&#123;context&#125;'). |
+| [AG1010](types-aliases.md#ag1010) | Type '&#123;alias&#125;' is not a generic type (referenced in '&#123;context&#125;'). |
+| [AG1011](types-aliases.md#ag1011) | &#123;alias&#125; expects at most &#123;max&#125; type &#123;argumentWord&#125;, got &#123;count&#125; (referenced in '&#123;context&#125;'). |
+| [AG1012](types-aliases.md#ag1012) | &#123;alias&#125; requires at least &#123;min&#125; type &#123;argumentWord&#125; (referenced in '&#123;context&#125;'). |
 
 ## Assignability and checking
 
 | Code | Message |
 | --- | --- |
-| [AG2001](checking.md#ag2001) | Type '{actual}' is not assignable to type '{expected}' ({context}). |
-| [AG2002](checking.md#ag2002) | Type '{actual}' is not assignable to type 'boolean' (condition). |
-| [AG2003](checking.md#ag2003) | Unknown property '{key}' on type '{expected}' ({context}). |
-| [AG2004](checking.md#ag2004) | Variable '{name}' has no type annotation (strict mode). |
-| [AG2005](checking.md#ag2005) | Type '{actual}' is not assignable to type '{expected}'. |
-| [AG2006](checking.md#ag2006) | For-loop iterable must be an array or Record, got '{actual}'. |
-| [AG2007](checking.md#ag2007) | {kind} '{name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'. |
-| [AG2008](checking.md#ag2008) | Property '{field}' is not available on every member of '{union}'; narrow the value (e.g. with a guard) before accessing it. |
-| [AG2009](checking.md#ag2009) | '.{field}' is only available on a {branch} Result; guard with 'if (isSuccess(r))' / 'if (isFailure(r))', use 'r catch …', or 'match (r) {{ … }}'. |
-| [AG2010](checking.md#ag2010) | Cannot {op} values of different dimensions ({leftDim} and {rightDim}): '{left}' and '{right}'. |
-| [AG2011](checking.md#ag2011) | Property '{property}' does not exist on type '{type}'. |
-| [AG2012](checking.md#ag2012) | Not all code paths return a value in '{fn}'. |
+| [AG2001](checking.md#ag2001) | Type '&#123;actual&#125;' is not assignable to type '&#123;expected&#125;' (&#123;context&#125;). |
+| [AG2002](checking.md#ag2002) | Type '&#123;actual&#125;' is not assignable to type 'boolean' (condition). |
+| [AG2003](checking.md#ag2003) | Unknown property '&#123;key&#125;' on type '&#123;expected&#125;' (&#123;context&#125;). |
+| [AG2004](checking.md#ag2004) | Variable '&#123;name&#125;' has no type annotation (strict mode). |
+| [AG2005](checking.md#ag2005) | Type '&#123;actual&#125;' is not assignable to type '&#123;expected&#125;'. |
+| [AG2006](checking.md#ag2006) | For-loop iterable must be an array or Record, got '&#123;actual&#125;'. |
+| [AG2007](checking.md#ag2007) | &#123;kind&#125; '&#123;name&#125;' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result&lt;...&gt;'. |
+| [AG2008](checking.md#ag2008) | Property '&#123;field&#125;' is not available on every member of '&#123;union&#125;'; narrow the value (e.g. with a guard) before accessing it. |
+| [AG2009](checking.md#ag2009) | '.&#123;field&#125;' is only available on a &#123;branch&#125; Result; guard with 'if (isSuccess(r))' / 'if (isFailure(r))', use 'r catch …', or 'match (r) &#123; … &#125;'. |
+| [AG2010](checking.md#ag2010) | Cannot &#123;op&#125; values of different dimensions (&#123;leftDim&#125; and &#123;rightDim&#125;): '&#123;left&#125;' and '&#123;right&#125;'. |
+| [AG2011](checking.md#ag2011) | Property '&#123;property&#125;' does not exist on type '&#123;type&#125;'. |
+| [AG2012](checking.md#ag2012) | Not all code paths return a value in '&#123;fn&#125;'. |
 
 ## Interrupts, effects, and handlers
 
 | Code | Message |
 | --- | --- |
 | [AG3001](effects.md#ag3001) | The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed. |
-| [AG3002](effects.md#ag3002) | Effect '{effect}' is declared more than once in the same file. |
-| [AG3003](effects.md#ag3003) | Conflicting payload types for effect '{effect}'. All declarations of an effect must agree on its payload. |
+| [AG3002](effects.md#ag3002) | Effect '&#123;effect&#125;' is declared more than once in the same file. |
+| [AG3003](effects.md#ag3003) | Conflicting payload types for effect '&#123;effect&#125;'. All declarations of an effect must agree on its payload. |
 | [AG3004](effects.md#ag3004) | Named arguments are not allowed on 'raise'/'interrupt'. Pass the data positionally. |
-| [AG3005](effects.md#ag3005) | Effect '{effect}' expects data {payload}, but none was supplied. |
-| [AG3006](effects.md#ag3006) | Effect '{effect}' data field '{field}' is missing. |
-| [AG3007](effects.md#ag3007) | Effect '{effect}' data field '{field}' has the wrong type. |
-| [AG3008](effects.md#ag3008) | Effect '{effect}' data does not match the declared {payload}. |
-| [AG3009](effects.md#ag3009) | Function '{fn}' may throw interrupts [{effects}] but is not inside a handler. |
-| [AG3010](effects.md#ag3010) | Handler {handler} may raise interrupts [{effects}]. That would re-enter the handler chain (the dispatcher visits every handler, even the one currently running) and recurse until `HandlerRecursionError` fires at runtime. Restructure so the handler doesn't call interrupt-raising code (e.g. hoist file I/O out of the handler), or suppress this error with `// @tc-ignore` on the line above the `handle` block. |
-| [AG3011](effects.md#ag3011) | `interrupt` is not allowed inside a callback body (callback registered on '{hook}' may raise [{effects}]). Callbacks fire as side effects; their body cannot pause execution to ask the user a question. Move the `interrupt` into the calling node/function instead, or use a runtime guard if you wanted budget enforcement. |
-| [AG3012](effects.md#ag3012) | 'raises {ref}' is not an effect set. Declare '{ref}' with 'effectSet' (not 'type'), or use an inline set like '<...>'. |
-| [AG3013](effects.md#ag3013) | {kind} '{name}' raises effect '{effect}', which exceeds its declared 'raises {declared}'. Add '{effect}' to the clause. |
-| [AG3014](effects.md#ag3014) | {who} may raise any effect (its type has no 'raises' clause), which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add a 'raises' clause to the value's type. |
-| [AG3015](effects.md#ag3015) | {who} raises effect '{effect}', which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add '{effect}' to the clause, or use a target type that allows it. |
+| [AG3005](effects.md#ag3005) | Effect '&#123;effect&#125;' expects data &#123;payload&#125;, but none was supplied. |
+| [AG3006](effects.md#ag3006) | Effect '&#123;effect&#125;' data field '&#123;field&#125;' is missing. |
+| [AG3007](effects.md#ag3007) | Effect '&#123;effect&#125;' data field '&#123;field&#125;' has the wrong type. |
+| [AG3008](effects.md#ag3008) | Effect '&#123;effect&#125;' data does not match the declared &#123;payload&#125;. |
+| [AG3009](effects.md#ag3009) | Function '&#123;fn&#125;' may throw interrupts [&#123;effects&#125;] but is not inside a handler. |
+| [AG3010](effects.md#ag3010) | Handler &#123;handler&#125; may raise interrupts [&#123;effects&#125;]. That would re-enter the handler chain (the dispatcher visits every handler, even the one currently running) and recurse until `HandlerRecursionError` fires at runtime. Restructure so the handler doesn't call interrupt-raising code (e.g. hoist file I/O out of the handler), or suppress this error with `// @tc-ignore` on the line above the `handle` block. |
+| [AG3011](effects.md#ag3011) | `interrupt` is not allowed inside a callback body (callback registered on '&#123;hook&#125;' may raise [&#123;effects&#125;]). Callbacks fire as side effects; their body cannot pause execution to ask the user a question. Move the `interrupt` into the calling node/function instead, or use a runtime guard if you wanted budget enforcement. |
+| [AG3012](effects.md#ag3012) | 'raises &#123;ref&#125;' is not an effect set. Declare '&#123;ref&#125;' with 'effectSet' (not 'type'), or use an inline set like '&lt;...&gt;'. |
+| [AG3013](effects.md#ag3013) | &#123;kind&#125; '&#123;name&#125;' raises effect '&#123;effect&#125;', which exceeds its declared 'raises &#123;declared&#125;'. Add '&#123;effect&#125;' to the clause. |
+| [AG3014](effects.md#ag3014) | &#123;who&#125; may raise any effect (its type has no 'raises' clause), which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add a 'raises' clause to the value's type. |
+| [AG3015](effects.md#ag3015) | &#123;who&#125; raises effect '&#123;effect&#125;', which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add '&#123;effect&#125;' to the clause, or use a target type that allows it. |
 
 ## Names, scope, and reserved words
 
 | Code | Message |
 | --- | --- |
-| [AG4001](names.md#ag4001) | '{name}' shadows an imported function. |
-| [AG4002](names.md#ag4002) | '{name}' is a reserved built-in; cannot be redefined. |
-| [AG4003](names.md#ag4003) | '{name}' is a reserved built-in type; cannot be redefined. |
-| [AG4004](names.md#ag4004) | Function '{name}' is not defined. |
-| [AG4005](names.md#ag4005) | Cannot reassign to constant '{name}'. |
-| [AG4006](names.md#ag4006) | `{keyword}` is a reserved block keyword. Write `{keyword} {{ ... }}` or `{keyword}(args) {{ ... }}` directly — the `as` keyword is not supported on {keyword} blocks (there's nothing to bind). |
-| [AG4007](names.md#ag4007) | Variable '{name}' is not defined. |
+| [AG4001](names.md#ag4001) | '&#123;name&#125;' shadows an imported function. |
+| [AG4002](names.md#ag4002) | '&#123;name&#125;' is a reserved built-in; cannot be redefined. |
+| [AG4003](names.md#ag4003) | '&#123;name&#125;' is a reserved built-in type; cannot be redefined. |
+| [AG4004](names.md#ag4004) | Function '&#123;name&#125;' is not defined. |
+| [AG4005](names.md#ag4005) | Cannot reassign to constant '&#123;name&#125;'. |
+| [AG4006](names.md#ag4006) | `&#123;keyword&#125;` is a reserved block keyword. Write `&#123;keyword&#125; &#123; ... &#125;` or `&#123;keyword&#125;(args) &#123; ... &#125;` directly — the `as` keyword is not supported on &#123;keyword&#125; blocks (there's nothing to bind). |
+| [AG4007](names.md#ag4007) | Variable '&#123;name&#125;' is not defined. |
 
 ## Match and narrowing
 
 | Code | Message |
 | --- | --- |
-| [AG5002](match.md#ag5002) | match is not exhaustive: missing {missing}. |
+| [AG5002](match.md#ag5002) | match is not exhaustive: missing &#123;missing&#125;. |
 
 ## Calls, tools, and LLM usage
 
 | Code | Message |
 | --- | --- |
-| [AG6001](tools.md#ag6001) | 'regex' cannot appear in an llm() structured-output type ({context}); LLMs can't return regex values through JSON. |
-| [AG6002](tools.md#ag6002) | Cannot interpolate parameter '{param}' in doc string — parameter values are not known when the tool description is sent to the LLM. Use a global variable instead. |
+| [AG6001](tools.md#ag6001) | 'regex' cannot appear in an llm() structured-output type (&#123;context&#125;); LLMs can't return regex values through JSON. |
+| [AG6002](tools.md#ag6002) | Cannot interpolate parameter '&#123;param&#125;' in doc string — parameter values are not known when the tool description is sent to the LLM. Use a global variable instead. |
 | [AG6003](tools.md#ag6003) | .partial() requires named arguments, e.g. fn.partial(a: 5). |
-| [AG6004](tools.md#ag6004) | Unknown parameter '{name}' in .partial() call. '{fn}' has parameters: {params}. |
-| [AG6005](tools.md#ag6005) | Argument type '{actual}' is not assignable to parameter type '{expected}' in .partial() call to '{fn}'. |
-| [AG6006](tools.md#ag6006) | Named arguments are not supported on built-in method '.{method}()'. |
-| [AG6007](tools.md#ag6007) | Method '.{method}()' expects {expected} argument(s), got {count}. |
-| [AG6008](tools.md#ag6008) | Method '.{method}()' expects at least {min} argument(s), got {count}. |
-| [AG6009](tools.md#ag6009) | Method '.{method}()' expects {min}–{max} argument(s), got {count}. |
-| [AG6010](tools.md#ag6010) | Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '.{method}()'. |
-| [AG6011](tools.md#ag6011) | Named arguments can only be used with Agency-defined functions, not '{fn}'. |
-| [AG6012](tools.md#ag6012) | '{fn}' does not accept the named argument '{name}'. Allowed: {allowed}. |
-| [AG6013](tools.md#ag6013) | Duplicate named argument '{name}' in call to '{fn}'. |
-| [AG6014](tools.md#ag6014) | Named argument '{name}' on '{fn}' expects type '{expected}', got '{actual}'. |
-| [AG6015](tools.md#ag6015) | '{fn}' does not accept a block argument. |
-| [AG6016](tools.md#ag6016) | Expected {expected} argument(s) for '{fn}', but got {count}. |
-| [AG6017](tools.md#ag6017) | Expected at least {min} argument(s) for '{fn}', but got {count}. |
-| [AG6018](tools.md#ag6018) | Expected {min}-{max} argument(s) for '{fn}', but got {count}. |
-| [AG6019](tools.md#ag6019) | Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'. |
-| [AG6020](tools.md#ag6020) | Splat argument must be an array, got '{actual}' in call to '{fn}'. |
-| [AG6021](tools.md#ag6021) | Splat element type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'. |
-| [AG6022](tools.md#ag6022) | Type '{actual}' is not assignable to pipe slot of type '{expected}'. |
-| [AG6023](tools.md#ag6023) | Splat argument cannot follow a named argument in call to '{fn}'. |
-| [AG6024](tools.md#ag6024) | Positional argument cannot follow a named argument in call to '{fn}'. |
-| [AG6025](tools.md#ag6025) | Unknown named argument '{name}' in call to '{fn}'. |
-| [AG6026](tools.md#ag6026) | Named argument '{name}' conflicts with positional argument at position {position} in call to '{fn}'. |
-| [AG6027](tools.md#ag6027) | Positional argument cannot feed variadic parameter '{param}' when it is also bound by name in call to '{fn}'. |
-| [AG6028](tools.md#ag6028) | Tool '{tool}' has required function-typed parameter '{param}' is unbound. Bind it with .partial({param}: <value>) before passing as a tool. |
-| [AG6029](tools.md#ag6029) | Tool '{tool}' has required function-typed parameter '{param}' is unbound ({type}). Bind it with .partial({param}: <value>) before passing as a tool. |
-| [AG6030](tools.md#ag6030) | Tool '{tool}' will be exposed to the LLM without optional function-typed parameter(s): {params}. The function body must be prepared to run with the declared default for each. |
+| [AG6004](tools.md#ag6004) | Unknown parameter '&#123;name&#125;' in .partial() call. '&#123;fn&#125;' has parameters: &#123;params&#125;. |
+| [AG6005](tools.md#ag6005) | Argument type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in .partial() call to '&#123;fn&#125;'. |
+| [AG6006](tools.md#ag6006) | Named arguments are not supported on built-in method '.&#123;method&#125;()'. |
+| [AG6007](tools.md#ag6007) | Method '.&#123;method&#125;()' expects &#123;expected&#125; argument(s), got &#123;count&#125;. |
+| [AG6008](tools.md#ag6008) | Method '.&#123;method&#125;()' expects at least &#123;min&#125; argument(s), got &#123;count&#125;. |
+| [AG6009](tools.md#ag6009) | Method '.&#123;method&#125;()' expects &#123;min&#125;–&#123;max&#125; argument(s), got &#123;count&#125;. |
+| [AG6010](tools.md#ag6010) | Argument type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in call to '.&#123;method&#125;()'. |
+| [AG6011](tools.md#ag6011) | Named arguments can only be used with Agency-defined functions, not '&#123;fn&#125;'. |
+| [AG6012](tools.md#ag6012) | '&#123;fn&#125;' does not accept the named argument '&#123;name&#125;'. Allowed: &#123;allowed&#125;. |
+| [AG6013](tools.md#ag6013) | Duplicate named argument '&#123;name&#125;' in call to '&#123;fn&#125;'. |
+| [AG6014](tools.md#ag6014) | Named argument '&#123;name&#125;' on '&#123;fn&#125;' expects type '&#123;expected&#125;', got '&#123;actual&#125;'. |
+| [AG6015](tools.md#ag6015) | '&#123;fn&#125;' does not accept a block argument. |
+| [AG6016](tools.md#ag6016) | Expected &#123;expected&#125; argument(s) for '&#123;fn&#125;', but got &#123;count&#125;. |
+| [AG6017](tools.md#ag6017) | Expected at least &#123;min&#125; argument(s) for '&#123;fn&#125;', but got &#123;count&#125;. |
+| [AG6018](tools.md#ag6018) | Expected &#123;min&#125;-&#123;max&#125; argument(s) for '&#123;fn&#125;', but got &#123;count&#125;. |
+| [AG6019](tools.md#ag6019) | Argument type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in call to '&#123;fn&#125;'. |
+| [AG6020](tools.md#ag6020) | Splat argument must be an array, got '&#123;actual&#125;' in call to '&#123;fn&#125;'. |
+| [AG6021](tools.md#ag6021) | Splat element type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in call to '&#123;fn&#125;'. |
+| [AG6022](tools.md#ag6022) | Type '&#123;actual&#125;' is not assignable to pipe slot of type '&#123;expected&#125;'. |
+| [AG6023](tools.md#ag6023) | Splat argument cannot follow a named argument in call to '&#123;fn&#125;'. |
+| [AG6024](tools.md#ag6024) | Positional argument cannot follow a named argument in call to '&#123;fn&#125;'. |
+| [AG6025](tools.md#ag6025) | Unknown named argument '&#123;name&#125;' in call to '&#123;fn&#125;'. |
+| [AG6026](tools.md#ag6026) | Named argument '&#123;name&#125;' conflicts with positional argument at position &#123;position&#125; in call to '&#123;fn&#125;'. |
+| [AG6027](tools.md#ag6027) | Positional argument cannot feed variadic parameter '&#123;param&#125;' when it is also bound by name in call to '&#123;fn&#125;'. |
+| [AG6028](tools.md#ag6028) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound. Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
+| [AG6029](tools.md#ag6029) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound (&#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
+| [AG6030](tools.md#ag6030) | Tool '&#123;tool&#125;' will be exposed to the LLM without optional function-typed parameter(s): &#123;params&#125;. The function body must be prepared to run with the declared default for each. |
 
 ## Static init, config, and imports
 
 | Code | Message |
 | --- | --- |
-| [AG7001](static-init.md#ag7001) | Only 'static const' declarations can be exported. Use 'export static const {name} = ...' instead. |
-| [AG7002](static-init.md#ag7002) | {contextLabel} cannot call `{builtin}(...)` — {reason}, but static initializers run once at process startup before any per-run state exists. Move this call into a node or a function called from a node. |
-| [AG7003](static-init.md#ag7003) | {contextLabel} cannot `interrupt(...)` — interrupts pause the per-run execution stack, but static initializers run once at process startup before any agent run has begun. Move this into a node body. |
-| [AG7004](static-init.md#ag7004) | Cannot reassign static `{name}` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
-| [AG7005](static-init.md#ag7005) | Cannot mutate static `{name}` via `.{method}(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
-| [AG7006](static-init.md#ag7006) | Function '{name}' cannot be both destructive and idempotent — those markers are contradictory. Pick one. |
+| [AG7001](static-init.md#ag7001) | Only 'static const' declarations can be exported. Use 'export static const &#123;name&#125; = ...' instead. |
+| [AG7002](static-init.md#ag7002) | &#123;contextLabel&#125; cannot call `&#123;builtin&#125;(...)` — &#123;reason&#125;, but static initializers run once at process startup before any per-run state exists. Move this call into a node or a function called from a node. |
+| [AG7003](static-init.md#ag7003) | &#123;contextLabel&#125; cannot `interrupt(...)` — interrupts pause the per-run execution stack, but static initializers run once at process startup before any agent run has begun. Move this into a node body. |
+| [AG7004](static-init.md#ag7004) | Cannot reassign static `&#123;name&#125;` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
+| [AG7005](static-init.md#ag7005) | Cannot mutate static `&#123;name&#125;` via `.&#123;method&#125;(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value. |
+| [AG7006](static-init.md#ag7006) | Function '&#123;name&#125;' cannot be both destructive and idempotent — those markers are contradictory. Pick one. |

--- a/packages/agency-lang/docs/site/diagnostics/match.md
+++ b/packages/agency-lang/docs/site/diagnostics/match.md
@@ -4,6 +4,8 @@ name: "Match and narrowing"
 
 # Match and narrowing
 
+<a id="ag5002"></a>
+
 ## AG5002 — match is not exhaustive: missing {missing}.
 
 *Default severity: error.*

--- a/packages/agency-lang/docs/site/diagnostics/match.md
+++ b/packages/agency-lang/docs/site/diagnostics/match.md
@@ -1,0 +1,23 @@
+---
+name: "Match and narrowing"
+---
+
+# Match and narrowing
+
+## AG5002 — match is not exhaustive: missing {missing}.
+
+*Default severity: error.*
+
+A `match` over a union or Result must handle every case the scrutinee can take; the checker computes the set of arms you covered and reports the ones missing. An unhandled case would fall through at runtime with no branch to run.
+
+**How to fix:** add an arm for each listed missing case, or add a wildcard `_` arm if a catch-all is genuinely what you want.
+
+```agency
+node main() {
+  const r = compute()
+  match (r) {
+    is success(v) { print(v) }
+    is failure(e) { print(e) }
+  }
+}
+```

--- a/packages/agency-lang/docs/site/diagnostics/match.md
+++ b/packages/agency-lang/docs/site/diagnostics/match.md
@@ -6,7 +6,7 @@ name: "Match and narrowing"
 
 <a id="ag5002"></a>
 
-## AG5002 — match is not exhaustive: missing {missing}.
+## AG5002 — match is not exhaustive: missing &#123;missing&#125;.
 
 *Default severity: error.*
 

--- a/packages/agency-lang/docs/site/diagnostics/names.md
+++ b/packages/agency-lang/docs/site/diagnostics/names.md
@@ -1,0 +1,69 @@
+---
+name: "Names, scope, and reserved words"
+---
+
+# Names, scope, and reserved words
+
+## AG4001 — '{name}' shadows an imported function.
+
+*Default severity: warning.*
+
+A local name here has the same name as a function you imported, so the local shadows the import within this scope. That is legal but often unintended, so it is flagged as a warning.
+
+**How to fix:** rename the local if you meant to keep using the import, or ignore the warning if the shadow is deliberate.
+
+## AG4002 — '{name}' is a reserved built-in; cannot be redefined.
+
+*Default severity: error.*
+
+The name is a reserved built-in and cannot be redefined. Built-ins are part of the language surface; redefining one would make its ordinary uses ambiguous.
+
+**How to fix:** choose a different name for your definition.
+
+## AG4003 — '{name}' is a reserved built-in type; cannot be redefined.
+
+*Default severity: error.*
+
+The name is a reserved built-in type and cannot be redefined for the same reason built-in functions cannot: its ordinary uses must stay unambiguous.
+
+**How to fix:** pick a different type name.
+
+## AG4004 — Function '{name}' is not defined.
+
+*Default severity: error.*
+
+A function was called that has no definition in scope and is not a built-in. The checker resolves every call against the functions visible in the file plus its imports.
+
+**How to fix:** define the function, import it from the module that provides it, or fix a typo in the call.
+
+## AG4005 — Cannot reassign to constant '{name}'.
+
+*Default severity: error.*
+
+A `const` binding is fixed after its initial value: it cannot be reassigned. This assignment targets a name that was declared `const`.
+
+**How to fix:** declare it with `let` if it needs to change, or assign to a different variable.
+
+```agency
+node main() {
+  let count = 0
+  const limit = 10
+  count = count + 1
+}
+```
+
+## AG4006 — `{keyword}` is a reserved block keyword. Write `{keyword} {{ ... }}` or `{keyword}(args) {{ ... }}` directly — the `as` keyword is not supported on {keyword} blocks (there's nothing to bind).
+
+*Default severity: error.*
+
+This keyword introduces a block directly — you write it followed by braces (or parentheses then braces) — and it does not support an `as` binding, because there is nothing to bind. The `as` here is not valid on this block form.
+
+**How to fix:** write the block without `as`, e.g. the keyword followed immediately by its `{ ... }` body.
+
+## AG4007 — Variable '{name}' is not defined.
+
+*Default severity: error.*
+
+The type checker walks every scope — nodes, function bodies, blocks — and resolves each name to a declaration. This error means a name was used with no `let`, `const`, parameter, or import that introduces it in reach.
+
+**How to fix:** declare it before use (`let x = …` / `const x = …`), fix a typo in the name, or import it if it lives in another module. Agency has no implicit variables: a bare assignment like `x = 5` without a prior `let`/`const` is not a declaration.

--- a/packages/agency-lang/docs/site/diagnostics/names.md
+++ b/packages/agency-lang/docs/site/diagnostics/names.md
@@ -6,7 +6,7 @@ name: "Names, scope, and reserved words"
 
 <a id="ag4001"></a>
 
-## AG4001 — '{name}' shadows an imported function.
+## AG4001 — '&#123;name&#125;' shadows an imported function.
 
 *Default severity: warning.*
 
@@ -16,7 +16,7 @@ A local name here has the same name as a function you imported, so the local sha
 
 <a id="ag4002"></a>
 
-## AG4002 — '{name}' is a reserved built-in; cannot be redefined.
+## AG4002 — '&#123;name&#125;' is a reserved built-in; cannot be redefined.
 
 *Default severity: error.*
 
@@ -26,7 +26,7 @@ The name is a reserved built-in and cannot be redefined. Built-ins are part of t
 
 <a id="ag4003"></a>
 
-## AG4003 — '{name}' is a reserved built-in type; cannot be redefined.
+## AG4003 — '&#123;name&#125;' is a reserved built-in type; cannot be redefined.
 
 *Default severity: error.*
 
@@ -36,7 +36,7 @@ The name is a reserved built-in type and cannot be redefined for the same reason
 
 <a id="ag4004"></a>
 
-## AG4004 — Function '{name}' is not defined.
+## AG4004 — Function '&#123;name&#125;' is not defined.
 
 *Default severity: error.*
 
@@ -46,7 +46,7 @@ A function was called that has no definition in scope and is not a built-in. The
 
 <a id="ag4005"></a>
 
-## AG4005 — Cannot reassign to constant '{name}'.
+## AG4005 — Cannot reassign to constant '&#123;name&#125;'.
 
 *Default severity: error.*
 
@@ -64,7 +64,7 @@ node main() {
 
 <a id="ag4006"></a>
 
-## AG4006 — `{keyword}` is a reserved block keyword. Write `{keyword} {{ ... }}` or `{keyword}(args) {{ ... }}` directly — the `as` keyword is not supported on {keyword} blocks (there's nothing to bind).
+## AG4006 — `&#123;keyword&#125;` is a reserved block keyword. Write `&#123;keyword&#125; &#123; ... &#125;` or `&#123;keyword&#125;(args) &#123; ... &#125;` directly — the `as` keyword is not supported on &#123;keyword&#125; blocks (there's nothing to bind).
 
 *Default severity: error.*
 
@@ -74,7 +74,7 @@ This keyword introduces a block directly — you write it followed by braces (or
 
 <a id="ag4007"></a>
 
-## AG4007 — Variable '{name}' is not defined.
+## AG4007 — Variable '&#123;name&#125;' is not defined.
 
 *Default severity: error.*
 

--- a/packages/agency-lang/docs/site/diagnostics/names.md
+++ b/packages/agency-lang/docs/site/diagnostics/names.md
@@ -4,6 +4,8 @@ name: "Names, scope, and reserved words"
 
 # Names, scope, and reserved words
 
+<a id="ag4001"></a>
+
 ## AG4001 — '{name}' shadows an imported function.
 
 *Default severity: warning.*
@@ -11,6 +13,8 @@ name: "Names, scope, and reserved words"
 A local name here has the same name as a function you imported, so the local shadows the import within this scope. That is legal but often unintended, so it is flagged as a warning.
 
 **How to fix:** rename the local if you meant to keep using the import, or ignore the warning if the shadow is deliberate.
+
+<a id="ag4002"></a>
 
 ## AG4002 — '{name}' is a reserved built-in; cannot be redefined.
 
@@ -20,6 +24,8 @@ The name is a reserved built-in and cannot be redefined. Built-ins are part of t
 
 **How to fix:** choose a different name for your definition.
 
+<a id="ag4003"></a>
+
 ## AG4003 — '{name}' is a reserved built-in type; cannot be redefined.
 
 *Default severity: error.*
@@ -28,6 +34,8 @@ The name is a reserved built-in type and cannot be redefined for the same reason
 
 **How to fix:** pick a different type name.
 
+<a id="ag4004"></a>
+
 ## AG4004 — Function '{name}' is not defined.
 
 *Default severity: error.*
@@ -35,6 +43,8 @@ The name is a reserved built-in type and cannot be redefined for the same reason
 A function was called that has no definition in scope and is not a built-in. The checker resolves every call against the functions visible in the file plus its imports.
 
 **How to fix:** define the function, import it from the module that provides it, or fix a typo in the call.
+
+<a id="ag4005"></a>
 
 ## AG4005 — Cannot reassign to constant '{name}'.
 
@@ -52,6 +62,8 @@ node main() {
 }
 ```
 
+<a id="ag4006"></a>
+
 ## AG4006 — `{keyword}` is a reserved block keyword. Write `{keyword} {{ ... }}` or `{keyword}(args) {{ ... }}` directly — the `as` keyword is not supported on {keyword} blocks (there's nothing to bind).
 
 *Default severity: error.*
@@ -59,6 +71,8 @@ node main() {
 This keyword introduces a block directly — you write it followed by braces (or parentheses then braces) — and it does not support an `as` binding, because there is nothing to bind. The `as` here is not valid on this block form.
 
 **How to fix:** write the block without `as`, e.g. the keyword followed immediately by its `{ ... }` body.
+
+<a id="ag4007"></a>
 
 ## AG4007 — Variable '{name}' is not defined.
 

--- a/packages/agency-lang/docs/site/diagnostics/static-init.md
+++ b/packages/agency-lang/docs/site/diagnostics/static-init.md
@@ -6,7 +6,7 @@ name: "Static init, config, and imports"
 
 <a id="ag7001"></a>
 
-## AG7001 — Only 'static const' declarations can be exported. Use 'export static const {name} = ...' instead.
+## AG7001 — Only 'static const' declarations can be exported. Use 'export static const &#123;name&#125; = ...' instead.
 
 *Default severity: error.*
 
@@ -16,7 +16,7 @@ Only `static const` declarations can be exported from a module. A plain `const`,
 
 <a id="ag7002"></a>
 
-## AG7002 — {contextLabel} cannot call `{builtin}(...)` — {reason}, but static initializers run once at process startup before any per-run state exists. Move this call into a node or a function called from a node.
+## AG7002 — &#123;contextLabel&#125; cannot call `&#123;builtin&#125;(...)` — &#123;reason&#125;, but static initializers run once at process startup before any per-run state exists. Move this call into a node or a function called from a node.
 
 *Default severity: error.*
 
@@ -26,7 +26,7 @@ Static initializers run once at process startup, before any per-run state exists
 
 <a id="ag7003"></a>
 
-## AG7003 — {contextLabel} cannot `interrupt(...)` — interrupts pause the per-run execution stack, but static initializers run once at process startup before any agent run has begun. Move this into a node body.
+## AG7003 — &#123;contextLabel&#125; cannot `interrupt(...)` — interrupts pause the per-run execution stack, but static initializers run once at process startup before any agent run has begun. Move this into a node body.
 
 *Default severity: error.*
 
@@ -36,7 +36,7 @@ Interrupts pause the per-run execution stack, but static initializers run once a
 
 <a id="ag7004"></a>
 
-## AG7004 — Cannot reassign static `{name}` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
+## AG7004 — Cannot reassign static `&#123;name&#125;` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
 
 *Default severity: error.*
 
@@ -46,7 +46,7 @@ Statics are immutable after they initialize, so a static cannot be reassigned at
 
 <a id="ag7005"></a>
 
-## AG7005 — Cannot mutate static `{name}` via `.{method}(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
+## AG7005 — Cannot mutate static `&#123;name&#125;` via `.&#123;method&#125;(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
 
 *Default severity: error.*
 
@@ -56,7 +56,7 @@ Statics are deep-frozen after initialization, so mutating one through a method (
 
 <a id="ag7006"></a>
 
-## AG7006 — Function '{name}' cannot be both destructive and idempotent — those markers are contradictory. Pick one.
+## AG7006 — Function '&#123;name&#125;' cannot be both destructive and idempotent — those markers are contradictory. Pick one.
 
 *Default severity: error.*
 

--- a/packages/agency-lang/docs/site/diagnostics/static-init.md
+++ b/packages/agency-lang/docs/site/diagnostics/static-init.md
@@ -1,0 +1,53 @@
+---
+name: "Static init, config, and imports"
+---
+
+# Static init, config, and imports
+
+## AG7001 — Only 'static const' declarations can be exported. Use 'export static const {name} = ...' instead.
+
+*Default severity: error.*
+
+Only `static const` declarations can be exported from a module. A plain `const`, `let`, or other declaration is per-run state and is not part of a module's public surface.
+
+**How to fix:** declare the exported value as `static const`, or remove the `export`.
+
+## AG7002 — {contextLabel} cannot call `{builtin}(...)` — {reason}, but static initializers run once at process startup before any per-run state exists. Move this call into a node or a function called from a node.
+
+*Default severity: error.*
+
+Static initializers run once at process startup, before any per-run state exists — so they may not call built-ins that need a running agent (LLM calls, I/O, and similar). This static init calls one of those.
+
+**How to fix:** move the call into a node, or into a function called from a node, where per-run state is available.
+
+## AG7003 — {contextLabel} cannot `interrupt(...)` — interrupts pause the per-run execution stack, but static initializers run once at process startup before any agent run has begun. Move this into a node body.
+
+*Default severity: error.*
+
+Interrupts pause the per-run execution stack, but static initializers run once at startup before any run has begun — there is no stack to pause. So `interrupt(...)` is not allowed in a static initializer.
+
+**How to fix:** move the `interrupt` into a node body.
+
+## AG7004 — Cannot reassign static `{name}` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
+
+*Default severity: error.*
+
+Statics are immutable after they initialize, so a static cannot be reassigned at module top level. Reassigning one would break the guarantee that its value is fixed for the whole process.
+
+**How to fix:** use a global (`const` or `let` without `static`) if you need a value that changes.
+
+## AG7005 — Cannot mutate static `{name}` via `.{method}(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
+
+*Default severity: error.*
+
+Statics are deep-frozen after initialization, so mutating one through a method (like `.push(...)`) at module top level is not allowed — the frozen value rejects the change.
+
+**How to fix:** use a global (`const` or `let` without `static`) if you need a mutable value.
+
+## AG7006 — Function '{name}' cannot be both destructive and idempotent — those markers are contradictory. Pick one.
+
+*Default severity: error.*
+
+A function was marked both `destructive` and `idempotent`, but those markers contradict each other: destructive means a retry can cause additional effects, while idempotent means a retry is safe to repeat. A function cannot be both.
+
+**How to fix:** keep the one marker that describes the function and remove the other.

--- a/packages/agency-lang/docs/site/diagnostics/static-init.md
+++ b/packages/agency-lang/docs/site/diagnostics/static-init.md
@@ -4,6 +4,8 @@ name: "Static init, config, and imports"
 
 # Static init, config, and imports
 
+<a id="ag7001"></a>
+
 ## AG7001 — Only 'static const' declarations can be exported. Use 'export static const {name} = ...' instead.
 
 *Default severity: error.*
@@ -11,6 +13,8 @@ name: "Static init, config, and imports"
 Only `static const` declarations can be exported from a module. A plain `const`, `let`, or other declaration is per-run state and is not part of a module's public surface.
 
 **How to fix:** declare the exported value as `static const`, or remove the `export`.
+
+<a id="ag7002"></a>
 
 ## AG7002 — {contextLabel} cannot call `{builtin}(...)` — {reason}, but static initializers run once at process startup before any per-run state exists. Move this call into a node or a function called from a node.
 
@@ -20,6 +24,8 @@ Static initializers run once at process startup, before any per-run state exists
 
 **How to fix:** move the call into a node, or into a function called from a node, where per-run state is available.
 
+<a id="ag7003"></a>
+
 ## AG7003 — {contextLabel} cannot `interrupt(...)` — interrupts pause the per-run execution stack, but static initializers run once at process startup before any agent run has begun. Move this into a node body.
 
 *Default severity: error.*
@@ -27,6 +33,8 @@ Static initializers run once at process startup, before any per-run state exists
 Interrupts pause the per-run execution stack, but static initializers run once at startup before any run has begun — there is no stack to pause. So `interrupt(...)` is not allowed in a static initializer.
 
 **How to fix:** move the `interrupt` into a node body.
+
+<a id="ag7004"></a>
 
 ## AG7004 — Cannot reassign static `{name}` at module top level — statics are immutable after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
 
@@ -36,6 +44,8 @@ Statics are immutable after they initialize, so a static cannot be reassigned at
 
 **How to fix:** use a global (`const` or `let` without `static`) if you need a value that changes.
 
+<a id="ag7005"></a>
+
 ## AG7005 — Cannot mutate static `{name}` via `.{method}(...)` at module top level — statics are deep-frozen after initialization. Use a global (`const`/`let` without `static`) if you need a mutable value.
 
 *Default severity: error.*
@@ -43,6 +53,8 @@ Statics are immutable after they initialize, so a static cannot be reassigned at
 Statics are deep-frozen after initialization, so mutating one through a method (like `.push(...)`) at module top level is not allowed — the frozen value rejects the change.
 
 **How to fix:** use a global (`const` or `let` without `static`) if you need a mutable value.
+
+<a id="ag7006"></a>
 
 ## AG7006 — Function '{name}' cannot be both destructive and idempotent — those markers are contradictory. Pick one.
 

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -4,6 +4,8 @@ name: "Calls, tools, and LLM usage"
 
 # Calls, tools, and LLM usage
 
+<a id="ag6001"></a>
+
 ## AG6001 — 'regex' cannot appear in an llm() structured-output type ({context}); LLMs can't return regex values through JSON.
 
 *Default severity: error.*
@@ -11,6 +13,8 @@ name: "Calls, tools, and LLM usage"
 An `llm()` call returns its result as structured JSON, and a `regex` value has no JSON representation the model can produce — so `regex` may not appear anywhere in an `llm()` output type.
 
 **How to fix:** return the matched text as a `string` (or another JSON-friendly type) and build the regex yourself afterward.
+
+<a id="ag6002"></a>
 
 ## AG6002 — Cannot interpolate parameter '{param}' in doc string — parameter values are not known when the tool description is sent to the LLM. Use a global variable instead.
 
@@ -20,6 +24,8 @@ A function's doc string becomes the tool description sent to the LLM, and that d
 
 **How to fix:** reference a global variable instead of a parameter, or reword the doc string to not depend on per-call values.
 
+<a id="ag6003"></a>
+
 ## AG6003 — .partial() requires named arguments, e.g. fn.partial(a: 5).
 
 *Default severity: error.*
@@ -27,6 +33,8 @@ A function's doc string becomes the tool description sent to the LLM, and that d
 `.partial()` binds arguments by name so it is unambiguous which parameters you are fixing. It does not accept positional arguments.
 
 **How to fix:** name the arguments, e.g. `fn.partial(a: 5)`.
+
+<a id="ag6004"></a>
 
 ## AG6004 — Unknown parameter '{name}' in .partial() call. '{fn}' has parameters: {params}.
 
@@ -36,6 +44,8 @@ A `.partial()` call named a parameter that the function does not have. Binding a
 
 **How to fix:** bind one of the function's real parameters (the message lists them), or fix a typo.
 
+<a id="ag6005"></a>
+
 ## AG6005 — Argument type '{actual}' is not assignable to parameter type '{expected}' in .partial() call to '{fn}'.
 
 *Default severity: error.*
@@ -43,6 +53,8 @@ A `.partial()` call named a parameter that the function does not have. Binding a
 An argument passed to `.partial()` has a type that does not match the parameter it binds. A partially-applied argument must still satisfy the parameter's type.
 
 **How to fix:** pass a value of the parameter's declared type.
+
+<a id="ag6006"></a>
 
 ## AG6006 — Named arguments are not supported on built-in method '.{method}()'.
 
@@ -52,6 +64,8 @@ Built-in methods take their arguments positionally; named arguments are only sup
 
 **How to fix:** pass the arguments positionally.
 
+<a id="ag6007"></a>
+
 ## AG6007 — Method '.{method}()' expects {expected} argument(s), got {count}.
 
 *Default severity: error.*
@@ -59,6 +73,8 @@ Built-in methods take their arguments positionally; named arguments are only sup
 A built-in method was called with the wrong number of arguments; this method takes an exact count.
 
 **How to fix:** pass exactly the number of arguments the message names.
+
+<a id="ag6008"></a>
 
 ## AG6008 — Method '.{method}()' expects at least {min} argument(s), got {count}.
 
@@ -68,6 +84,8 @@ A built-in method was called with too few arguments; it requires at least a mini
 
 **How to fix:** supply at least the number of arguments the message names.
 
+<a id="ag6009"></a>
+
 ## AG6009 — Method '.{method}()' expects {min}–{max} argument(s), got {count}.
 
 *Default severity: error.*
@@ -75,6 +93,8 @@ A built-in method was called with too few arguments; it requires at least a mini
 A built-in method accepts a range of argument counts, and this call fell outside it.
 
 **How to fix:** pass a number of arguments within the range the message names.
+
+<a id="ag6010"></a>
 
 ## AG6010 — Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '.{method}()'.
 
@@ -84,6 +104,8 @@ An argument to a built-in method has a type that does not match the parameter it
 
 **How to fix:** pass a value of the expected type.
 
+<a id="ag6011"></a>
+
 ## AG6011 — Named arguments can only be used with Agency-defined functions, not '{fn}'.
 
 *Default severity: error.*
@@ -91,6 +113,8 @@ An argument to a built-in method has a type that does not match the parameter it
 Named arguments work only with functions defined in Agency. The target here is not one of those (for example a built-in or an imported host function), so its arguments must be positional.
 
 **How to fix:** pass the arguments positionally.
+
+<a id="ag6012"></a>
 
 ## AG6012 — '{fn}' does not accept the named argument '{name}'. Allowed: {allowed}.
 
@@ -100,6 +124,8 @@ A named argument was supplied that the function does not declare. The checker kn
 
 **How to fix:** use one of the function's declared parameter names (the message lists the allowed ones), or fix a typo.
 
+<a id="ag6013"></a>
+
 ## AG6013 — Duplicate named argument '{name}' in call to '{fn}'.
 
 *Default severity: error.*
@@ -107,6 +133,8 @@ A named argument was supplied that the function does not declare. The checker kn
 The same named argument was supplied twice in one call. Each parameter can be bound at most once.
 
 **How to fix:** remove the duplicate.
+
+<a id="ag6014"></a>
 
 ## AG6014 — Named argument '{name}' on '{fn}' expects type '{expected}', got '{actual}'.
 
@@ -116,6 +144,8 @@ A named argument's value has a type that does not match the parameter's declared
 
 **How to fix:** pass a value of the expected type for that parameter.
 
+<a id="ag6015"></a>
+
 ## AG6015 — '{fn}' does not accept a block argument.
 
 *Default severity: error.*
@@ -123,6 +153,8 @@ A named argument's value has a type that does not match the parameter's declared
 A block argument (a trailing `{ ... }`) was passed to a function that does not declare a block parameter.
 
 **How to fix:** remove the block, or call a function that takes one.
+
+<a id="ag6016"></a>
 
 ## AG6016 — Expected {expected} argument(s) for '{fn}', but got {count}.
 
@@ -132,6 +164,8 @@ A function was called with the wrong number of positional arguments; it takes an
 
 **How to fix:** pass exactly the number of arguments the message names.
 
+<a id="ag6017"></a>
+
 ## AG6017 — Expected at least {min} argument(s) for '{fn}', but got {count}.
 
 *Default severity: error.*
@@ -139,6 +173,8 @@ A function was called with the wrong number of positional arguments; it takes an
 A function was called with too few positional arguments; it requires at least a minimum number.
 
 **How to fix:** supply at least the number of arguments the message names.
+
+<a id="ag6018"></a>
 
 ## AG6018 — Expected {min}-{max} argument(s) for '{fn}', but got {count}.
 
@@ -148,6 +184,8 @@ A function accepts a range of argument counts (some parameters have defaults or 
 
 **How to fix:** pass a number of arguments within the range the message names.
 
+<a id="ag6019"></a>
+
 ## AG6019 — Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'.
 
 *Default severity: error.*
@@ -155,6 +193,8 @@ A function accepts a range of argument counts (some parameters have defaults or 
 A positional argument's type does not match the parameter it fills. Each argument must be assignable to its parameter's type.
 
 **How to fix:** pass a value of the expected type, or adjust the parameter's type if the call is correct.
+
+<a id="ag6020"></a>
 
 ## AG6020 — Splat argument must be an array, got '{actual}' in call to '{fn}'.
 
@@ -164,6 +204,8 @@ A splat argument (`...xs`) spreads an array's elements into positional arguments
 
 **How to fix:** splat an array, or convert the value into one first.
 
+<a id="ag6021"></a>
+
 ## AG6021 — Splat element type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'.
 
 *Default severity: error.*
@@ -171,6 +213,8 @@ A splat argument (`...xs`) spreads an array's elements into positional arguments
 The array being splatted has an element type that does not match the parameters the elements would fill.
 
 **How to fix:** splat an array whose element type matches the target parameters.
+
+<a id="ag6022"></a>
 
 ## AG6022 — Type '{actual}' is not assignable to pipe slot of type '{expected}'.
 
@@ -180,6 +224,8 @@ A pipe feeds its left-hand value into a slot on the right, and that value's type
 
 **How to fix:** pipe a value of the slot's type, or transform it before the pipe.
 
+<a id="ag6023"></a>
+
 ## AG6023 — Splat argument cannot follow a named argument in call to '{fn}'.
 
 *Default severity: error.*
@@ -187,6 +233,8 @@ A pipe feeds its left-hand value into a slot on the right, and that value's type
 A splat argument cannot come after a named argument in a call. The splat fills positional slots, and those are resolved before names.
 
 **How to fix:** move the splat ahead of any named arguments.
+
+<a id="ag6024"></a>
 
 ## AG6024 — Positional argument cannot follow a named argument in call to '{fn}'.
 
@@ -196,6 +244,8 @@ Once a call uses a named argument, every following argument must also be named �
 
 **How to fix:** move positional arguments before the named ones, or name them too.
 
+<a id="ag6025"></a>
+
 ## AG6025 — Unknown named argument '{name}' in call to '{fn}'.
 
 *Default severity: error.*
@@ -203,6 +253,8 @@ Once a call uses a named argument, every following argument must also be named �
 A named argument in this call does not correspond to any parameter of the function.
 
 **How to fix:** use a declared parameter name, or fix a typo.
+
+<a id="ag6026"></a>
 
 ## AG6026 — Named argument '{name}' conflicts with positional argument at position {position} in call to '{fn}'.
 
@@ -212,6 +264,8 @@ A parameter was filled both positionally and by name in the same call, so it is 
 
 **How to fix:** supply the argument once — either positionally or by name, not both.
 
+<a id="ag6027"></a>
+
 ## AG6027 — Positional argument cannot feed variadic parameter '{param}' when it is also bound by name in call to '{fn}'.
 
 *Default severity: error.*
@@ -219,6 +273,8 @@ A parameter was filled both positionally and by name in the same call, so it is 
 A positional argument would feed a variadic parameter that is also being bound by name in the same call. The parameter cannot collect positionals and take a named value at once.
 
 **How to fix:** bind the variadic parameter one way — either by name or with positional arguments.
+
+<a id="ag6028"></a>
 
 ## AG6028 — Tool '{tool}' has required function-typed parameter '{param}' is unbound. Bind it with .partial({param}: <value>) before passing as a tool.
 
@@ -228,6 +284,8 @@ A function passed as a tool has a required function-typed parameter that is stil
 
 **How to fix:** bind it first with `.partial(...)` — e.g. `fn.partial(callback: myImpl)` — then pass the result as the tool.
 
+<a id="ag6029"></a>
+
 ## AG6029 — Tool '{tool}' has required function-typed parameter '{param}' is unbound ({type}). Bind it with .partial({param}: <value>) before passing as a tool.
 
 *Default severity: error.*
@@ -235,6 +293,8 @@ A function passed as a tool has a required function-typed parameter that is stil
 This is the same problem as an unbound required function-typed tool parameter, with the parameter's function type shown. The LLM cannot provide a function value, so the parameter must be bound before the function is used as a tool.
 
 **How to fix:** bind it with `.partial(...)` before passing the function as a tool.
+
+<a id="ag6030"></a>
 
 ## AG6030 — Tool '{tool}' will be exposed to the LLM without optional function-typed parameter(s): {params}. The function body must be prepared to run with the declared default for each.
 

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -6,7 +6,7 @@ name: "Calls, tools, and LLM usage"
 
 <a id="ag6001"></a>
 
-## AG6001 — 'regex' cannot appear in an llm() structured-output type ({context}); LLMs can't return regex values through JSON.
+## AG6001 — 'regex' cannot appear in an llm() structured-output type (&#123;context&#125;); LLMs can't return regex values through JSON.
 
 *Default severity: error.*
 
@@ -16,7 +16,7 @@ An `llm()` call returns its result as structured JSON, and a `regex` value has n
 
 <a id="ag6002"></a>
 
-## AG6002 — Cannot interpolate parameter '{param}' in doc string — parameter values are not known when the tool description is sent to the LLM. Use a global variable instead.
+## AG6002 — Cannot interpolate parameter '&#123;param&#125;' in doc string — parameter values are not known when the tool description is sent to the LLM. Use a global variable instead.
 
 *Default severity: error.*
 
@@ -36,7 +36,7 @@ A function's doc string becomes the tool description sent to the LLM, and that d
 
 <a id="ag6004"></a>
 
-## AG6004 — Unknown parameter '{name}' in .partial() call. '{fn}' has parameters: {params}.
+## AG6004 — Unknown parameter '&#123;name&#125;' in .partial() call. '&#123;fn&#125;' has parameters: &#123;params&#125;.
 
 *Default severity: error.*
 
@@ -46,7 +46,7 @@ A `.partial()` call named a parameter that the function does not have. Binding a
 
 <a id="ag6005"></a>
 
-## AG6005 — Argument type '{actual}' is not assignable to parameter type '{expected}' in .partial() call to '{fn}'.
+## AG6005 — Argument type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in .partial() call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -56,7 +56,7 @@ An argument passed to `.partial()` has a type that does not match the parameter 
 
 <a id="ag6006"></a>
 
-## AG6006 — Named arguments are not supported on built-in method '.{method}()'.
+## AG6006 — Named arguments are not supported on built-in method '.&#123;method&#125;()'.
 
 *Default severity: error.*
 
@@ -66,7 +66,7 @@ Built-in methods take their arguments positionally; named arguments are only sup
 
 <a id="ag6007"></a>
 
-## AG6007 — Method '.{method}()' expects {expected} argument(s), got {count}.
+## AG6007 — Method '.&#123;method&#125;()' expects &#123;expected&#125; argument(s), got &#123;count&#125;.
 
 *Default severity: error.*
 
@@ -76,7 +76,7 @@ A built-in method was called with the wrong number of arguments; this method tak
 
 <a id="ag6008"></a>
 
-## AG6008 — Method '.{method}()' expects at least {min} argument(s), got {count}.
+## AG6008 — Method '.&#123;method&#125;()' expects at least &#123;min&#125; argument(s), got &#123;count&#125;.
 
 *Default severity: error.*
 
@@ -86,7 +86,7 @@ A built-in method was called with too few arguments; it requires at least a mini
 
 <a id="ag6009"></a>
 
-## AG6009 — Method '.{method}()' expects {min}–{max} argument(s), got {count}.
+## AG6009 — Method '.&#123;method&#125;()' expects &#123;min&#125;–&#123;max&#125; argument(s), got &#123;count&#125;.
 
 *Default severity: error.*
 
@@ -96,7 +96,7 @@ A built-in method accepts a range of argument counts, and this call fell outside
 
 <a id="ag6010"></a>
 
-## AG6010 — Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '.{method}()'.
+## AG6010 — Argument type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in call to '.&#123;method&#125;()'.
 
 *Default severity: error.*
 
@@ -106,7 +106,7 @@ An argument to a built-in method has a type that does not match the parameter it
 
 <a id="ag6011"></a>
 
-## AG6011 — Named arguments can only be used with Agency-defined functions, not '{fn}'.
+## AG6011 — Named arguments can only be used with Agency-defined functions, not '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -116,7 +116,7 @@ Named arguments work only with functions defined in Agency. The target here is n
 
 <a id="ag6012"></a>
 
-## AG6012 — '{fn}' does not accept the named argument '{name}'. Allowed: {allowed}.
+## AG6012 — '&#123;fn&#125;' does not accept the named argument '&#123;name&#125;'. Allowed: &#123;allowed&#125;.
 
 *Default severity: error.*
 
@@ -126,7 +126,7 @@ A named argument was supplied that the function does not declare. The checker kn
 
 <a id="ag6013"></a>
 
-## AG6013 — Duplicate named argument '{name}' in call to '{fn}'.
+## AG6013 — Duplicate named argument '&#123;name&#125;' in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -136,7 +136,7 @@ The same named argument was supplied twice in one call. Each parameter can be bo
 
 <a id="ag6014"></a>
 
-## AG6014 — Named argument '{name}' on '{fn}' expects type '{expected}', got '{actual}'.
+## AG6014 — Named argument '&#123;name&#125;' on '&#123;fn&#125;' expects type '&#123;expected&#125;', got '&#123;actual&#125;'.
 
 *Default severity: error.*
 
@@ -146,7 +146,7 @@ A named argument's value has a type that does not match the parameter's declared
 
 <a id="ag6015"></a>
 
-## AG6015 — '{fn}' does not accept a block argument.
+## AG6015 — '&#123;fn&#125;' does not accept a block argument.
 
 *Default severity: error.*
 
@@ -156,7 +156,7 @@ A block argument (a trailing `{ ... }`) was passed to a function that does not d
 
 <a id="ag6016"></a>
 
-## AG6016 — Expected {expected} argument(s) for '{fn}', but got {count}.
+## AG6016 — Expected &#123;expected&#125; argument(s) for '&#123;fn&#125;', but got &#123;count&#125;.
 
 *Default severity: error.*
 
@@ -166,7 +166,7 @@ A function was called with the wrong number of positional arguments; it takes an
 
 <a id="ag6017"></a>
 
-## AG6017 — Expected at least {min} argument(s) for '{fn}', but got {count}.
+## AG6017 — Expected at least &#123;min&#125; argument(s) for '&#123;fn&#125;', but got &#123;count&#125;.
 
 *Default severity: error.*
 
@@ -176,7 +176,7 @@ A function was called with too few positional arguments; it requires at least a 
 
 <a id="ag6018"></a>
 
-## AG6018 — Expected {min}-{max} argument(s) for '{fn}', but got {count}.
+## AG6018 — Expected &#123;min&#125;-&#123;max&#125; argument(s) for '&#123;fn&#125;', but got &#123;count&#125;.
 
 *Default severity: error.*
 
@@ -186,7 +186,7 @@ A function accepts a range of argument counts (some parameters have defaults or 
 
 <a id="ag6019"></a>
 
-## AG6019 — Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'.
+## AG6019 — Argument type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -196,7 +196,7 @@ A positional argument's type does not match the parameter it fills. Each argumen
 
 <a id="ag6020"></a>
 
-## AG6020 — Splat argument must be an array, got '{actual}' in call to '{fn}'.
+## AG6020 — Splat argument must be an array, got '&#123;actual&#125;' in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -206,7 +206,7 @@ A splat argument (`...xs`) spreads an array's elements into positional arguments
 
 <a id="ag6021"></a>
 
-## AG6021 — Splat element type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'.
+## AG6021 — Splat element type '&#123;actual&#125;' is not assignable to parameter type '&#123;expected&#125;' in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -216,7 +216,7 @@ The array being splatted has an element type that does not match the parameters 
 
 <a id="ag6022"></a>
 
-## AG6022 — Type '{actual}' is not assignable to pipe slot of type '{expected}'.
+## AG6022 — Type '&#123;actual&#125;' is not assignable to pipe slot of type '&#123;expected&#125;'.
 
 *Default severity: error.*
 
@@ -226,7 +226,7 @@ A pipe feeds its left-hand value into a slot on the right, and that value's type
 
 <a id="ag6023"></a>
 
-## AG6023 — Splat argument cannot follow a named argument in call to '{fn}'.
+## AG6023 — Splat argument cannot follow a named argument in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -236,7 +236,7 @@ A splat argument cannot come after a named argument in a call. The splat fills p
 
 <a id="ag6024"></a>
 
-## AG6024 — Positional argument cannot follow a named argument in call to '{fn}'.
+## AG6024 — Positional argument cannot follow a named argument in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -246,7 +246,7 @@ Once a call uses a named argument, every following argument must also be named �
 
 <a id="ag6025"></a>
 
-## AG6025 — Unknown named argument '{name}' in call to '{fn}'.
+## AG6025 — Unknown named argument '&#123;name&#125;' in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -256,7 +256,7 @@ A named argument in this call does not correspond to any parameter of the functi
 
 <a id="ag6026"></a>
 
-## AG6026 — Named argument '{name}' conflicts with positional argument at position {position} in call to '{fn}'.
+## AG6026 — Named argument '&#123;name&#125;' conflicts with positional argument at position &#123;position&#125; in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -266,7 +266,7 @@ A parameter was filled both positionally and by name in the same call, so it is 
 
 <a id="ag6027"></a>
 
-## AG6027 — Positional argument cannot feed variadic parameter '{param}' when it is also bound by name in call to '{fn}'.
+## AG6027 — Positional argument cannot feed variadic parameter '&#123;param&#125;' when it is also bound by name in call to '&#123;fn&#125;'.
 
 *Default severity: error.*
 
@@ -276,7 +276,7 @@ A positional argument would feed a variadic parameter that is also being bound b
 
 <a id="ag6028"></a>
 
-## AG6028 — Tool '{tool}' has required function-typed parameter '{param}' is unbound. Bind it with .partial({param}: <value>) before passing as a tool.
+## AG6028 — Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound. Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool.
 
 *Default severity: error.*
 
@@ -286,7 +286,7 @@ A function passed as a tool has a required function-typed parameter that is stil
 
 <a id="ag6029"></a>
 
-## AG6029 — Tool '{tool}' has required function-typed parameter '{param}' is unbound ({type}). Bind it with .partial({param}: <value>) before passing as a tool.
+## AG6029 — Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound (&#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool.
 
 *Default severity: error.*
 
@@ -296,7 +296,7 @@ This is the same problem as an unbound required function-typed tool parameter, w
 
 <a id="ag6030"></a>
 
-## AG6030 — Tool '{tool}' will be exposed to the LLM without optional function-typed parameter(s): {params}. The function body must be prepared to run with the declared default for each.
+## AG6030 — Tool '&#123;tool&#125;' will be exposed to the LLM without optional function-typed parameter(s): &#123;params&#125;. The function body must be prepared to run with the declared default for each.
 
 *Default severity: warning.*
 

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -1,0 +1,245 @@
+---
+name: "Calls, tools, and LLM usage"
+---
+
+# Calls, tools, and LLM usage
+
+## AG6001 — 'regex' cannot appear in an llm() structured-output type ({context}); LLMs can't return regex values through JSON.
+
+*Default severity: error.*
+
+An `llm()` call returns its result as structured JSON, and a `regex` value has no JSON representation the model can produce — so `regex` may not appear anywhere in an `llm()` output type.
+
+**How to fix:** return the matched text as a `string` (or another JSON-friendly type) and build the regex yourself afterward.
+
+## AG6002 — Cannot interpolate parameter '{param}' in doc string — parameter values are not known when the tool description is sent to the LLM. Use a global variable instead.
+
+*Default severity: error.*
+
+A function's doc string becomes the tool description sent to the LLM, and that description is fixed before any call happens — so a parameter's runtime value is not available to interpolate into it.
+
+**How to fix:** reference a global variable instead of a parameter, or reword the doc string to not depend on per-call values.
+
+## AG6003 — .partial() requires named arguments, e.g. fn.partial(a: 5).
+
+*Default severity: error.*
+
+`.partial()` binds arguments by name so it is unambiguous which parameters you are fixing. It does not accept positional arguments.
+
+**How to fix:** name the arguments, e.g. `fn.partial(a: 5)`.
+
+## AG6004 — Unknown parameter '{name}' in .partial() call. '{fn}' has parameters: {params}.
+
+*Default severity: error.*
+
+A `.partial()` call named a parameter that the function does not have. Binding an unknown parameter has no meaning.
+
+**How to fix:** bind one of the function's real parameters (the message lists them), or fix a typo.
+
+## AG6005 — Argument type '{actual}' is not assignable to parameter type '{expected}' in .partial() call to '{fn}'.
+
+*Default severity: error.*
+
+An argument passed to `.partial()` has a type that does not match the parameter it binds. A partially-applied argument must still satisfy the parameter's type.
+
+**How to fix:** pass a value of the parameter's declared type.
+
+## AG6006 — Named arguments are not supported on built-in method '.{method}()'.
+
+*Default severity: error.*
+
+Built-in methods take their arguments positionally; named arguments are only supported on Agency-defined functions. This call used names on a built-in method.
+
+**How to fix:** pass the arguments positionally.
+
+## AG6007 — Method '.{method}()' expects {expected} argument(s), got {count}.
+
+*Default severity: error.*
+
+A built-in method was called with the wrong number of arguments; this method takes an exact count.
+
+**How to fix:** pass exactly the number of arguments the message names.
+
+## AG6008 — Method '.{method}()' expects at least {min} argument(s), got {count}.
+
+*Default severity: error.*
+
+A built-in method was called with too few arguments; it requires at least a minimum number.
+
+**How to fix:** supply at least the number of arguments the message names.
+
+## AG6009 — Method '.{method}()' expects {min}–{max} argument(s), got {count}.
+
+*Default severity: error.*
+
+A built-in method accepts a range of argument counts, and this call fell outside it.
+
+**How to fix:** pass a number of arguments within the range the message names.
+
+## AG6010 — Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '.{method}()'.
+
+*Default severity: error.*
+
+An argument to a built-in method has a type that does not match the parameter it fills.
+
+**How to fix:** pass a value of the expected type.
+
+## AG6011 — Named arguments can only be used with Agency-defined functions, not '{fn}'.
+
+*Default severity: error.*
+
+Named arguments work only with functions defined in Agency. The target here is not one of those (for example a built-in or an imported host function), so its arguments must be positional.
+
+**How to fix:** pass the arguments positionally.
+
+## AG6012 — '{fn}' does not accept the named argument '{name}'. Allowed: {allowed}.
+
+*Default severity: error.*
+
+A named argument was supplied that the function does not declare. The checker knows the function's parameter names and rejects names outside that set.
+
+**How to fix:** use one of the function's declared parameter names (the message lists the allowed ones), or fix a typo.
+
+## AG6013 — Duplicate named argument '{name}' in call to '{fn}'.
+
+*Default severity: error.*
+
+The same named argument was supplied twice in one call. Each parameter can be bound at most once.
+
+**How to fix:** remove the duplicate.
+
+## AG6014 — Named argument '{name}' on '{fn}' expects type '{expected}', got '{actual}'.
+
+*Default severity: error.*
+
+A named argument's value has a type that does not match the parameter's declared type.
+
+**How to fix:** pass a value of the expected type for that parameter.
+
+## AG6015 — '{fn}' does not accept a block argument.
+
+*Default severity: error.*
+
+A block argument (a trailing `{ ... }`) was passed to a function that does not declare a block parameter.
+
+**How to fix:** remove the block, or call a function that takes one.
+
+## AG6016 — Expected {expected} argument(s) for '{fn}', but got {count}.
+
+*Default severity: error.*
+
+A function was called with the wrong number of positional arguments; it takes an exact count.
+
+**How to fix:** pass exactly the number of arguments the message names.
+
+## AG6017 — Expected at least {min} argument(s) for '{fn}', but got {count}.
+
+*Default severity: error.*
+
+A function was called with too few positional arguments; it requires at least a minimum number.
+
+**How to fix:** supply at least the number of arguments the message names.
+
+## AG6018 — Expected {min}-{max} argument(s) for '{fn}', but got {count}.
+
+*Default severity: error.*
+
+A function accepts a range of argument counts (some parameters have defaults or are variadic), and this call fell outside that range.
+
+**How to fix:** pass a number of arguments within the range the message names.
+
+## AG6019 — Argument type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'.
+
+*Default severity: error.*
+
+A positional argument's type does not match the parameter it fills. Each argument must be assignable to its parameter's type.
+
+**How to fix:** pass a value of the expected type, or adjust the parameter's type if the call is correct.
+
+## AG6020 — Splat argument must be an array, got '{actual}' in call to '{fn}'.
+
+*Default severity: error.*
+
+A splat argument (`...xs`) spreads an array's elements into positional arguments, so the splatted value must be an array. This value is not.
+
+**How to fix:** splat an array, or convert the value into one first.
+
+## AG6021 — Splat element type '{actual}' is not assignable to parameter type '{expected}' in call to '{fn}'.
+
+*Default severity: error.*
+
+The array being splatted has an element type that does not match the parameters the elements would fill.
+
+**How to fix:** splat an array whose element type matches the target parameters.
+
+## AG6022 — Type '{actual}' is not assignable to pipe slot of type '{expected}'.
+
+*Default severity: error.*
+
+A pipe feeds its left-hand value into a slot on the right, and that value's type does not match the slot's type.
+
+**How to fix:** pipe a value of the slot's type, or transform it before the pipe.
+
+## AG6023 — Splat argument cannot follow a named argument in call to '{fn}'.
+
+*Default severity: error.*
+
+A splat argument cannot come after a named argument in a call. The splat fills positional slots, and those are resolved before names.
+
+**How to fix:** move the splat ahead of any named arguments.
+
+## AG6024 — Positional argument cannot follow a named argument in call to '{fn}'.
+
+*Default severity: error.*
+
+Once a call uses a named argument, every following argument must also be named — a positional argument cannot come after a named one.
+
+**How to fix:** move positional arguments before the named ones, or name them too.
+
+## AG6025 — Unknown named argument '{name}' in call to '{fn}'.
+
+*Default severity: error.*
+
+A named argument in this call does not correspond to any parameter of the function.
+
+**How to fix:** use a declared parameter name, or fix a typo.
+
+## AG6026 — Named argument '{name}' conflicts with positional argument at position {position} in call to '{fn}'.
+
+*Default severity: error.*
+
+A parameter was filled both positionally and by name in the same call, so it is bound twice.
+
+**How to fix:** supply the argument once — either positionally or by name, not both.
+
+## AG6027 — Positional argument cannot feed variadic parameter '{param}' when it is also bound by name in call to '{fn}'.
+
+*Default severity: error.*
+
+A positional argument would feed a variadic parameter that is also being bound by name in the same call. The parameter cannot collect positionals and take a named value at once.
+
+**How to fix:** bind the variadic parameter one way — either by name or with positional arguments.
+
+## AG6028 — Tool '{tool}' has required function-typed parameter '{param}' is unbound. Bind it with .partial({param}: <value>) before passing as a tool.
+
+*Default severity: error.*
+
+A function passed as a tool has a required function-typed parameter that is still unbound. The LLM cannot supply a function value, so a required function parameter must be fixed before the function becomes a tool.
+
+**How to fix:** bind it first with `.partial(...)` — e.g. `fn.partial(callback: myImpl)` — then pass the result as the tool.
+
+## AG6029 — Tool '{tool}' has required function-typed parameter '{param}' is unbound ({type}). Bind it with .partial({param}: <value>) before passing as a tool.
+
+*Default severity: error.*
+
+This is the same problem as an unbound required function-typed tool parameter, with the parameter's function type shown. The LLM cannot provide a function value, so the parameter must be bound before the function is used as a tool.
+
+**How to fix:** bind it with `.partial(...)` before passing the function as a tool.
+
+## AG6030 — Tool '{tool}' will be exposed to the LLM without optional function-typed parameter(s): {params}. The function body must be prepared to run with the declared default for each.
+
+*Default severity: warning.*
+
+A function passed as a tool has optional function-typed parameters that the LLM cannot fill, so they are dropped and the tool runs with each parameter's declared default. This is a warning, not an error, because a default exists — but the body must be prepared to run without those functions.
+
+**How to fix:** confirm the defaults are correct for the tool use, or bind the parameters explicitly with `.partial(...)` if you need specific implementations.

--- a/packages/agency-lang/docs/site/diagnostics/types-aliases.md
+++ b/packages/agency-lang/docs/site/diagnostics/types-aliases.md
@@ -4,6 +4,8 @@ name: "Types and aliases"
 
 # Types and aliases
 
+<a id="ag1001"></a>
+
 ## AG1001 — Type parameter '{param}' (no default) must come before parameters that have defaults in '{alias}'.
 
 *Default severity: error.*
@@ -11,6 +13,8 @@ name: "Types and aliases"
 A type alias lists its type parameters left to right, and — like default function arguments — every parameter with a default must come after the parameters that have none. Otherwise a caller who omits a middle argument leaves a later, required one with no way to be positioned.
 
 **How to fix:** reorder the type parameters so all defaulted ones are last.
+
+<a id="ag1002"></a>
 
 ## AG1002 — Type '{alias}' is not a value-parameterized type but was given {count} value {argumentWord} (referenced in '{context}').
 
@@ -20,6 +24,8 @@ Some type aliases take *value* arguments in parentheses (like a validated length
 
 **How to fix:** drop the parenthesized arguments, or point at the alias you actually meant to parameterize.
 
+<a id="ag1003"></a>
+
 ## AG1003 — {alias} expects at most {max} value {argumentWord}, got {count} (referenced in '{context}').
 
 *Default severity: error.*
@@ -27,6 +33,8 @@ Some type aliases take *value* arguments in parentheses (like a validated length
 A value-parameterized alias accepts a fixed maximum number of value arguments, and you supplied more than it declares.
 
 **How to fix:** remove the extra arguments, or check whether you meant a different alias with more parameters.
+
+<a id="ag1004"></a>
 
 ## AG1004 — '{alias}' is a value-parameterized type and requires value arguments — write '{alias}({formals})' (referenced in '{context}').
 
@@ -36,6 +44,8 @@ This alias is value-parameterized: it needs its value arguments supplied in pare
 
 **How to fix:** call it with its arguments, following the form the message shows for that alias.
 
+<a id="ag1005"></a>
+
 ## AG1005 — {alias} requires at least {min} value {argumentWord} (referenced in '{context}').
 
 *Default severity: error.*
@@ -43,6 +53,8 @@ This alias is value-parameterized: it needs its value arguments supplied in pare
 A value-parameterized alias requires at least some minimum number of value arguments, and you supplied fewer.
 
 **How to fix:** add the missing arguments; the message names how many the alias needs.
+
+<a id="ag1006"></a>
 
 ## AG1006 — Type alias '{alias}' is not defined (referenced in '{context}').
 
@@ -52,6 +64,8 @@ A type name was used that has no `type` declaration in scope and is not a built-
 
 **How to fix:** declare the alias, import it from the module that defines it, or fix a typo in the name.
 
+<a id="ag1007"></a>
+
 ## AG1007 — Generic type '{alias}' requires type arguments (referenced in '{context}').
 
 *Default severity: error.*
@@ -59,6 +73,8 @@ A type name was used that has no `type` declaration in scope and is not a built-
 This is a generic type — it is parameterized by other types (like the element type of a list) — and it cannot be used bare. The type arguments are required.
 
 **How to fix:** supply the type arguments in angle brackets, e.g. write the element type the generic wraps.
+
+<a id="ag1008"></a>
 
 ## AG1008 — {alias} expects {expected} type {argumentWord}, got {count} (referenced in '{context}').
 
@@ -68,6 +84,8 @@ A built-in generic type (such as an array or Record) was given the wrong number 
 
 **How to fix:** supply exactly the number of type arguments the message names.
 
+<a id="ag1009"></a>
+
 ## AG1009 — Unknown generic type '{alias}' (referenced in '{context}').
 
 *Default severity: error.*
@@ -75,6 +93,8 @@ A built-in generic type (such as an array or Record) was given the wrong number 
 A generic type name was used with type arguments, but no generic type by that name is defined or imported.
 
 **How to fix:** define or import the generic, or fix the name.
+
+<a id="ag1010"></a>
 
 ## AG1010 — Type '{alias}' is not a generic type (referenced in '{context}').
 
@@ -84,6 +104,8 @@ Type arguments in angle brackets were applied to a name that is not a generic ty
 
 **How to fix:** remove the type arguments, or reference the generic type you meant.
 
+<a id="ag1011"></a>
+
 ## AG1011 — {alias} expects at most {max} type {argumentWord}, got {count} (referenced in '{context}').
 
 *Default severity: error.*
@@ -91,6 +113,8 @@ Type arguments in angle brackets were applied to a name that is not a generic ty
 A generic type accepts a fixed maximum number of type arguments, and you supplied more than it declares.
 
 **How to fix:** remove the extra type arguments.
+
+<a id="ag1012"></a>
 
 ## AG1012 — {alias} requires at least {min} type {argumentWord} (referenced in '{context}').
 

--- a/packages/agency-lang/docs/site/diagnostics/types-aliases.md
+++ b/packages/agency-lang/docs/site/diagnostics/types-aliases.md
@@ -1,0 +1,101 @@
+---
+name: "Types and aliases"
+---
+
+# Types and aliases
+
+## AG1001 — Type parameter '{param}' (no default) must come before parameters that have defaults in '{alias}'.
+
+*Default severity: error.*
+
+A type alias lists its type parameters left to right, and — like default function arguments — every parameter with a default must come after the parameters that have none. Otherwise a caller who omits a middle argument leaves a later, required one with no way to be positioned.
+
+**How to fix:** reorder the type parameters so all defaulted ones are last.
+
+## AG1002 — Type '{alias}' is not a value-parameterized type but was given {count} value {argumentWord} (referenced in '{context}').
+
+*Default severity: error.*
+
+Some type aliases take *value* arguments in parentheses (like a validated length), and some take none. This fires when you passed value arguments to an alias that accepts none.
+
+**How to fix:** drop the parenthesized arguments, or point at the alias you actually meant to parameterize.
+
+## AG1003 — {alias} expects at most {max} value {argumentWord}, got {count} (referenced in '{context}').
+
+*Default severity: error.*
+
+A value-parameterized alias accepts a fixed maximum number of value arguments, and you supplied more than it declares.
+
+**How to fix:** remove the extra arguments, or check whether you meant a different alias with more parameters.
+
+## AG1004 — '{alias}' is a value-parameterized type and requires value arguments — write '{alias}({formals})' (referenced in '{context}').
+
+*Default severity: error.*
+
+This alias is value-parameterized: it needs its value arguments supplied in parentheses before it can be used as a type. Writing the bare name leaves those parameters unfilled.
+
+**How to fix:** call it with its arguments, following the form the message shows for that alias.
+
+## AG1005 — {alias} requires at least {min} value {argumentWord} (referenced in '{context}').
+
+*Default severity: error.*
+
+A value-parameterized alias requires at least some minimum number of value arguments, and you supplied fewer.
+
+**How to fix:** add the missing arguments; the message names how many the alias needs.
+
+## AG1006 — Type alias '{alias}' is not defined (referenced in '{context}').
+
+*Default severity: error.*
+
+A type name was used that has no `type` declaration in scope and is not a built-in type. The checker resolves every type name against the aliases visible in the file plus its imports.
+
+**How to fix:** declare the alias, import it from the module that defines it, or fix a typo in the name.
+
+## AG1007 — Generic type '{alias}' requires type arguments (referenced in '{context}').
+
+*Default severity: error.*
+
+This is a generic type — it is parameterized by other types (like the element type of a list) — and it cannot be used bare. The type arguments are required.
+
+**How to fix:** supply the type arguments in angle brackets, e.g. write the element type the generic wraps.
+
+## AG1008 — {alias} expects {expected} type {argumentWord}, got {count} (referenced in '{context}').
+
+*Default severity: error.*
+
+A built-in generic type (such as an array or Record) was given the wrong number of type arguments. Each built-in generic takes an exact count.
+
+**How to fix:** supply exactly the number of type arguments the message names.
+
+## AG1009 — Unknown generic type '{alias}' (referenced in '{context}').
+
+*Default severity: error.*
+
+A generic type name was used with type arguments, but no generic type by that name is defined or imported.
+
+**How to fix:** define or import the generic, or fix the name.
+
+## AG1010 — Type '{alias}' is not a generic type (referenced in '{context}').
+
+*Default severity: error.*
+
+Type arguments in angle brackets were applied to a name that is not a generic type, so it has no parameters to fill.
+
+**How to fix:** remove the type arguments, or reference the generic type you meant.
+
+## AG1011 — {alias} expects at most {max} type {argumentWord}, got {count} (referenced in '{context}').
+
+*Default severity: error.*
+
+A generic type accepts a fixed maximum number of type arguments, and you supplied more than it declares.
+
+**How to fix:** remove the extra type arguments.
+
+## AG1012 — {alias} requires at least {min} type {argumentWord} (referenced in '{context}').
+
+*Default severity: error.*
+
+A generic type requires at least some minimum number of type arguments, and you supplied fewer.
+
+**How to fix:** add the missing type arguments; the message names how many are needed.

--- a/packages/agency-lang/docs/site/diagnostics/types-aliases.md
+++ b/packages/agency-lang/docs/site/diagnostics/types-aliases.md
@@ -6,7 +6,7 @@ name: "Types and aliases"
 
 <a id="ag1001"></a>
 
-## AG1001 — Type parameter '{param}' (no default) must come before parameters that have defaults in '{alias}'.
+## AG1001 — Type parameter '&#123;param&#125;' (no default) must come before parameters that have defaults in '&#123;alias&#125;'.
 
 *Default severity: error.*
 
@@ -16,7 +16,7 @@ A type alias lists its type parameters left to right, and — like default funct
 
 <a id="ag1002"></a>
 
-## AG1002 — Type '{alias}' is not a value-parameterized type but was given {count} value {argumentWord} (referenced in '{context}').
+## AG1002 — Type '&#123;alias&#125;' is not a value-parameterized type but was given &#123;count&#125; value &#123;argumentWord&#125; (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -26,7 +26,7 @@ Some type aliases take *value* arguments in parentheses (like a validated length
 
 <a id="ag1003"></a>
 
-## AG1003 — {alias} expects at most {max} value {argumentWord}, got {count} (referenced in '{context}').
+## AG1003 — &#123;alias&#125; expects at most &#123;max&#125; value &#123;argumentWord&#125;, got &#123;count&#125; (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -36,7 +36,7 @@ A value-parameterized alias accepts a fixed maximum number of value arguments, a
 
 <a id="ag1004"></a>
 
-## AG1004 — '{alias}' is a value-parameterized type and requires value arguments — write '{alias}({formals})' (referenced in '{context}').
+## AG1004 — '&#123;alias&#125;' is a value-parameterized type and requires value arguments — write '&#123;alias&#125;(&#123;formals&#125;)' (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -46,7 +46,7 @@ This alias is value-parameterized: it needs its value arguments supplied in pare
 
 <a id="ag1005"></a>
 
-## AG1005 — {alias} requires at least {min} value {argumentWord} (referenced in '{context}').
+## AG1005 — &#123;alias&#125; requires at least &#123;min&#125; value &#123;argumentWord&#125; (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -56,7 +56,7 @@ A value-parameterized alias requires at least some minimum number of value argum
 
 <a id="ag1006"></a>
 
-## AG1006 — Type alias '{alias}' is not defined (referenced in '{context}').
+## AG1006 — Type alias '&#123;alias&#125;' is not defined (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -66,7 +66,7 @@ A type name was used that has no `type` declaration in scope and is not a built-
 
 <a id="ag1007"></a>
 
-## AG1007 — Generic type '{alias}' requires type arguments (referenced in '{context}').
+## AG1007 — Generic type '&#123;alias&#125;' requires type arguments (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -76,7 +76,7 @@ This is a generic type — it is parameterized by other types (like the element 
 
 <a id="ag1008"></a>
 
-## AG1008 — {alias} expects {expected} type {argumentWord}, got {count} (referenced in '{context}').
+## AG1008 — &#123;alias&#125; expects &#123;expected&#125; type &#123;argumentWord&#125;, got &#123;count&#125; (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -86,7 +86,7 @@ A built-in generic type (such as an array or Record) was given the wrong number 
 
 <a id="ag1009"></a>
 
-## AG1009 — Unknown generic type '{alias}' (referenced in '{context}').
+## AG1009 — Unknown generic type '&#123;alias&#125;' (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -96,7 +96,7 @@ A generic type name was used with type arguments, but no generic type by that na
 
 <a id="ag1010"></a>
 
-## AG1010 — Type '{alias}' is not a generic type (referenced in '{context}').
+## AG1010 — Type '&#123;alias&#125;' is not a generic type (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -106,7 +106,7 @@ Type arguments in angle brackets were applied to a name that is not a generic ty
 
 <a id="ag1011"></a>
 
-## AG1011 — {alias} expects at most {max} type {argumentWord}, got {count} (referenced in '{context}').
+## AG1011 — &#123;alias&#125; expects at most &#123;max&#125; type &#123;argumentWord&#125;, got &#123;count&#125; (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 
@@ -116,7 +116,7 @@ A generic type accepts a fixed maximum number of type arguments, and you supplie
 
 <a id="ag1012"></a>
 
-## AG1012 — {alias} requires at least {min} type {argumentWord} (referenced in '{context}').
+## AG1012 — &#123;alias&#125; requires at least &#123;min&#125; type &#123;argumentWord&#125; (referenced in '&#123;context&#125;').
 
 *Default severity: error.*
 

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -97,21 +97,23 @@ Build a skills tool for an LLM over a directory of skills.
 ### docsSkill
 
 ```ts
-docsSkill(section: "guide" | "cli")
+docsSkill(section: "guide" | "cli" | "diagnostics")
 ```
 
 Build a docs tool for an LLM over the packaged Agency documentation.
   "guide" serves the language guide (syntax, types, control flow);
-  "cli" serves the CLI reference. The returned tool lists every page in
-  its description and lets the model read any one on demand.
+  "cli" serves the CLI reference; "diagnostics" serves the type-checker
+  diagnostic codes (AG####) with explanations and fixes. The returned tool
+  lists every page in its description and lets the model read any one on
+  demand.
 
-  @param section - Which documentation set to serve: "guide" or "cli".
+  @param section - Which documentation set to serve: "guide", "cli", or "diagnostics".
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| section | `"guide" \| "cli"` |  |
+| section | `"guide" \| "cli" \| "diagnostics"` |  |
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L200))
 
@@ -167,7 +169,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L284))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L286))
 
 ### expandSlash
 
@@ -206,4 +208,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L341))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L343))

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -52,6 +52,7 @@ static const superpowersSkill = skillsDir("./skills/superpowers", "flat") with a
 // startup approval interrupt — the docs ship with the stdlib).
 static const docSkill = docsSkill("guide")
 static const cliSkill = docsSkill("cli")
+static const diagnosticsSkill = docsSkill("diagnostics")
 
 export def agencyCli(args: string[]): any {
   """
@@ -81,6 +82,9 @@ call the bundled docs tools — they are authoritative for Agency:
   * `docSkill` — the language guide (syntax, types, error handling,
                  built-ins, callbacks, advanced types)
   * `cliSkill` — the CLI reference (`agency run`, `agency test`, ...)
+  * `diagnosticsSkill` — type-checker diagnostic codes (AG####) with
+                 explanations and fixes; consult it when `typecheck` reports
+                 an error code you want to understand or resolve
 Pick whichever matches the question rather than guessing.
 
 **Stay focused on the current task.** Most follow-ups ("can you make it
@@ -360,6 +364,7 @@ export static const codeTools: any[] = [
   superpowersSkill,
   docSkill,
   cliSkill,
+  diagnosticsSkill,
   todoWrite,
   todoList,
   oracleAgent.partial(allowHandoff: false),

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
@@ -23,6 +23,7 @@ import { getSlowModel, getSlowProvider } from "../shared.agency"
 
 static const docSkill = docsSkill("guide")
 static const cliSkill = docsSkill("cli")
+static const diagnosticsSkill = docsSkill("diagnostics")
 
 export static const explorerSysPrompt = """
 You are the **explorer** — a read-only researcher called by other
@@ -108,6 +109,7 @@ export static const explorerTools: any[] = [
   grep.partial(useAgentCwd: true),
   docSkill,
   cliSkill,
+  diagnosticsSkill,
 ]
 
 // only add system message the first time

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/oracle.agency
@@ -12,6 +12,7 @@ import { getSlowModel, getSlowProvider } from "../shared.agency"
 
 static const docSkill = docsSkill("guide")
 static const cliSkill = docsSkill("cli")
+static const diagnosticsSkill = docsSkill("diagnostics")
 
 export static const oracleSysPrompt = """
 You are the **oracle** — a senior reviewer called by other agents
@@ -76,6 +77,7 @@ export static const oracleTools: any[] = [
   typecheck,
   docSkill,
   cliSkill,
+  diagnosticsSkill,
 ]
 
 // only add system message the first time

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
@@ -33,6 +33,7 @@ import { withWebSearch } from "../lib/search.agency"
 // grepping a giant blob of docs.
 static const docSkill = docsSkill("guide")
 static const cliSkill = docsSkill("cli")
+static const diagnosticsSkill = docsSkill("diagnostics")
 
 export static const researchSysPrompt = """
 You are the **research specialist** of a multi-thread Agency-language
@@ -61,6 +62,8 @@ When you need information:
                         built-ins, callbacks, advanced types
     * `cliSkill`      — CLI reference (`agency run`, `agency test`,
                         `agency compile`, ...)
+    * `diagnosticsSkill` — type-checker diagnostic codes (AG####)
+                        with explanations and fixes
   Pick whichever matches the question rather than guessing.
 
 - For **general knowledge**, prefer the lighter tools first:
@@ -120,6 +123,7 @@ underlining, and properly highlighted code fences.
 export static const researchTools: any[] = [
   docSkill,
   cliSkill,
+  diagnosticsSkill,
   wikipediaSearch.rename("wikipedia_search"),
   wikipediaSummary.rename("wikipedia_summary"),
   wikipediaArticle.rename("wikipedia_article"),

--- a/packages/agency-lang/lib/cli/diagnosticsDocs.test.ts
+++ b/packages/agency-lang/lib/cli/diagnosticsDocs.test.ts
@@ -18,10 +18,13 @@ describe("generateDiagnosticsPages", () => {
     }
   });
 
-  it("index lists every code exactly once", () => {
+  it("index links every code exactly once", () => {
+    // Count LINK occurrences, not raw substring: the intro prose contains a
+    // legitimate `agency explain AG2005` example, so a bare-substring count
+    // would read 2. The invariant is one table-row link per code.
     const index = byPath["index.md"];
     for (const code of codes) {
-      expect(index.split(code).length - 1, code).toBeGreaterThanOrEqual(1);
+      expect(index.split(`[${code}](`).length - 1, code).toBe(1);
     }
   });
 
@@ -34,6 +37,19 @@ describe("generateDiagnosticsPages", () => {
         if (other.slug === cat.slug) continue;
         expect(byPath[`${other.slug}.md`].includes(`## ${entry.code}`)).toBe(false);
       }
+    }
+  });
+
+  it("every index link resolves to an explicit anchor on its category page", () => {
+    // VitePress slugifies headings from full text, so the index's #ag#### must
+    // land on an explicit <a id="ag####"> we emit, not on the heading itself.
+    const index = byPath["index.md"];
+    const links = [...index.matchAll(/\]\((\S+?\.md)#(\S+?)\)/g)];
+    expect(links.length).toBeGreaterThan(0);
+    for (const [, file, anchor] of links) {
+      const page = byPath[file];
+      expect(page, `linked page missing: ${file}`).toBeTruthy();
+      expect(page.includes(`<a id="${anchor}"></a>`), `${file}#${anchor}`).toBe(true);
     }
   });
 

--- a/packages/agency-lang/lib/cli/diagnosticsDocs.test.ts
+++ b/packages/agency-lang/lib/cli/diagnosticsDocs.test.ts
@@ -53,6 +53,15 @@ describe("generateDiagnosticsPages", () => {
     }
   });
 
+  it("emits no `{{` — VitePress would parse it as a Vue interpolation", () => {
+    // The docs are built by VitePress (Vue), which reads `{{ … }}` as a
+    // template expression and hard-fails the build. Message templates use it
+    // as the literal-brace escape, so the generator must neutralize it.
+    for (const { relPath, contents } of pages) {
+      expect(contents.includes("{{"), relPath).toBe(false);
+    }
+  });
+
   it("has unique heading anchors within each page", () => {
     for (const { contents } of pages) {
       const headings = [...contents.matchAll(/^## (.+)$/gm)].map((m) => m[1]);

--- a/packages/agency-lang/lib/cli/diagnosticsDocs.test.ts
+++ b/packages/agency-lang/lib/cli/diagnosticsDocs.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { generateDiagnosticsPages } from "./diagnosticsDocs.js";
+import {
+  DIAGNOSTICS,
+  DIAGNOSTIC_CATEGORIES,
+  categoryForCode,
+} from "@/typeChecker/diagnostics.js";
+
+const pages = generateDiagnosticsPages();
+const byPath = Object.fromEntries(pages.map((p) => [p.relPath, p.contents]));
+const codes = Object.values(DIAGNOSTICS).map((e) => e.code);
+
+describe("generateDiagnosticsPages", () => {
+  it("emits index.md plus one page per category", () => {
+    expect(byPath["index.md"]).toBeTruthy();
+    for (const cat of DIAGNOSTIC_CATEGORIES) {
+      expect(byPath[`${cat.slug}.md`], cat.slug).toBeTruthy();
+    }
+  });
+
+  it("index lists every code exactly once", () => {
+    const index = byPath["index.md"];
+    for (const code of codes) {
+      expect(index.split(code).length - 1, code).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("each code appears on exactly its own category page", () => {
+    for (const entry of Object.values(DIAGNOSTICS)) {
+      const cat = categoryForCode(entry.code)!;
+      const page = byPath[`${cat.slug}.md`];
+      expect(page.includes(`## ${entry.code}`), `${entry.code} on ${cat.slug}`).toBe(true);
+      for (const other of DIAGNOSTIC_CATEGORIES) {
+        if (other.slug === cat.slug) continue;
+        expect(byPath[`${other.slug}.md`].includes(`## ${entry.code}`)).toBe(false);
+      }
+    }
+  });
+
+  it("has unique heading anchors within each page", () => {
+    for (const { contents } of pages) {
+      const headings = [...contents.matchAll(/^## (.+)$/gm)].map((m) => m[1]);
+      expect(new Set(headings).size).toBe(headings.length);
+    }
+  });
+});

--- a/packages/agency-lang/lib/cli/diagnosticsDocs.ts
+++ b/packages/agency-lang/lib/cli/diagnosticsDocs.ts
@@ -1,0 +1,67 @@
+import {
+  DIAGNOSTICS,
+  DIAGNOSTIC_CATEGORIES,
+  categoryForCode,
+} from "@/typeChecker/diagnostics.js";
+import { DIAGNOSTIC_EXPLANATIONS } from "@/typeChecker/diagnosticExplanations.js";
+
+type Page = { relPath: string; contents: string };
+
+function codesForCategory(prefix: string) {
+  return Object.entries(DIAGNOSTICS)
+    .filter(([, e]) => categoryForCode(e.code)?.prefix === prefix)
+    .sort(([, a], [, b]) => a.code.localeCompare(b.code));
+}
+
+function escapeCell(s: string): string {
+  return s.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function indexPage(): string {
+  const lines = [
+    "---",
+    'name: "Diagnostics"',
+    "---",
+    "",
+    "# Diagnostic codes",
+    "",
+    "Every type-checker error and warning carries a stable `AG####` code.",
+    "Look one up with `agency explain <code>` (e.g. `agency explain AG2005`),",
+    "or suppress one on the next line with `// @tc-ignore AG####`.",
+    "",
+  ];
+  for (const cat of DIAGNOSTIC_CATEGORIES) {
+    const entries = codesForCategory(cat.prefix);
+    if (entries.length === 0) continue;
+    lines.push(`## ${cat.title}`, "");
+    lines.push("| Code | Message |", "| --- | --- |");
+    for (const [, e] of entries) {
+      const anchor = e.code.toLowerCase();
+      lines.push(`| [${e.code}](${cat.slug}.md#${anchor}) | ${escapeCell(e.message)} |`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function categoryPage(cat: (typeof DIAGNOSTIC_CATEGORIES)[number]): string {
+  const lines = ["---", `name: "${cat.title}"`, "---", "", `# ${cat.title}`, ""];
+  for (const [name, e] of codesForCategory(cat.prefix)) {
+    lines.push(`## ${e.code} — ${e.message}`, "");
+    lines.push(`*Default severity: ${e.severity}.*`, "");
+    lines.push(DIAGNOSTIC_EXPLANATIONS[name as keyof typeof DIAGNOSTIC_EXPLANATIONS], "");
+  }
+  return lines.join("\n");
+}
+
+/** All diagnostics pages as in-memory {relPath, contents}. The build script
+ *  writes them; tests assert on them without touching the filesystem. */
+export function generateDiagnosticsPages(): Page[] {
+  return [
+    { relPath: "index.md", contents: indexPage() },
+    ...DIAGNOSTIC_CATEGORIES.map((cat) => ({
+      relPath: `${cat.slug}.md`,
+      contents: categoryPage(cat),
+    })),
+  ];
+}

--- a/packages/agency-lang/lib/cli/diagnosticsDocs.ts
+++ b/packages/agency-lang/lib/cli/diagnosticsDocs.ts
@@ -17,6 +17,25 @@ function escapeCell(s: string): string {
   return s.replace(/\|/g, "\\|").replace(/\n/g, " ");
 }
 
+/**
+ * Render a message template as literal text for a VitePress page. Templates
+ * contain characters VitePress/Vue would otherwise interpret: `{{ … }}` reads
+ * as a Vue interpolation (hard build error) and `<...>` reads as an HTML tag.
+ * Collapse the template's literal-brace escape (`{{ }}` -> `{ }`) so the real
+ * braces show, then HTML-escape every metacharacter so the whole string is
+ * inert text. Order matters: escape `&` before introducing entities.
+ */
+function messageForMd(msg: string): string {
+  return msg
+    .replace(/\{\{/g, "{")
+    .replace(/\}\}/g, "}")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\{/g, "&#123;")
+    .replace(/\}/g, "&#125;");
+}
+
 function indexPage(): string {
   const lines = [
     "---",
@@ -37,7 +56,7 @@ function indexPage(): string {
     lines.push("| Code | Message |", "| --- | --- |");
     for (const [, e] of entries) {
       const anchor = e.code.toLowerCase();
-      lines.push(`| [${e.code}](${cat.slug}.md#${anchor}) | ${escapeCell(e.message)} |`);
+      lines.push(`| [${e.code}](${cat.slug}.md#${anchor}) | ${escapeCell(messageForMd(e.message))} |`);
     }
     lines.push("");
   }
@@ -51,7 +70,7 @@ function categoryPage(cat: (typeof DIAGNOSTIC_CATEGORIES)[number]): string {
     // text ("## AG2001 — Type ..."), so the index's `#ag2001` fragment would
     // not match. This bare-code anchor is what the index links resolve to.
     lines.push(`<a id="${e.code.toLowerCase()}"></a>`, "");
-    lines.push(`## ${e.code} — ${e.message}`, "");
+    lines.push(`## ${e.code} — ${messageForMd(e.message)}`, "");
     lines.push(`*Default severity: ${e.severity}.*`, "");
     lines.push(DIAGNOSTIC_EXPLANATIONS[name as keyof typeof DIAGNOSTIC_EXPLANATIONS], "");
   }

--- a/packages/agency-lang/lib/cli/diagnosticsDocs.ts
+++ b/packages/agency-lang/lib/cli/diagnosticsDocs.ts
@@ -47,6 +47,10 @@ function indexPage(): string {
 function categoryPage(cat: (typeof DIAGNOSTIC_CATEGORIES)[number]): string {
   const lines = ["---", `name: "${cat.title}"`, "---", "", `# ${cat.title}`, ""];
   for (const [name, e] of codesForCategory(cat.prefix)) {
+    // Explicit anchor: VitePress slugifies heading IDs from the FULL heading
+    // text ("## AG2001 — Type ..."), so the index's `#ag2001` fragment would
+    // not match. This bare-code anchor is what the index links resolve to.
+    lines.push(`<a id="${e.code.toLowerCase()}"></a>`, "");
     lines.push(`## ${e.code} — ${e.message}`, "");
     lines.push(`*Default severity: ${e.severity}.*`, "");
     lines.push(DIAGNOSTIC_EXPLANATIONS[name as keyof typeof DIAGNOSTIC_EXPLANATIONS], "");

--- a/packages/agency-lang/lib/cli/explain.test.ts
+++ b/packages/agency-lang/lib/cli/explain.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { renderDiagnosticText, renderDiagnosticList } from "./explain.js";
+import { DIAGNOSTICS } from "@/typeChecker/diagnostics.js";
+
+// termcolors colors unconditionally; strip ANSI to assert on text.
+// (Same pattern as lib/typeChecker/formatErrors.test.ts:10.)
+const plain = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+describe("renderDiagnosticText", () => {
+  it("resolves a code and its registry name to the same text", () => {
+    const byCode = renderDiagnosticText("AG2005");
+    const byName = renderDiagnosticText("typeNotAssignable");
+    expect(byCode.found).toBe(true);
+    expect(plain(byCode.text)).toBe(plain(byName.text));
+  });
+
+  it("is case-insensitive on the code", () => {
+    expect(renderDiagnosticText("ag2005").found).toBe(true);
+  });
+
+  it("includes the message template and the explanation", () => {
+    const { text } = renderDiagnosticText("AG2005");
+    expect(plain(text)).toContain(DIAGNOSTICS.typeNotAssignable.message);
+    expect(plain(text)).toContain("not assignable"); // from the explanation prose
+  });
+
+  it("returns found:false with a suggestion for an unknown code", () => {
+    const { text, found } = renderDiagnosticText("AG9999");
+    expect(found).toBe(false);
+    expect(plain(text)).toContain("AG9999");
+    expect(plain(text)).toContain("agency explain --list");
+  });
+});
+
+describe("renderDiagnosticList", () => {
+  it("lists every code exactly once", () => {
+    const listed = plain(renderDiagnosticList());
+    for (const entry of Object.values(DIAGNOSTICS)) {
+      const occurrences = listed.split(entry.code).length - 1;
+      expect(occurrences, entry.code).toBe(1);
+    }
+  });
+});

--- a/packages/agency-lang/lib/cli/explain.test.ts
+++ b/packages/agency-lang/lib/cli/explain.test.ts
@@ -30,6 +30,14 @@ describe("renderDiagnosticText", () => {
     expect(plain(text)).toContain("AG9999");
     expect(plain(text)).toContain("agency explain --list");
   });
+
+  it("does not resolve inherited Object keys as diagnostics", () => {
+    // `toString`/`constructor` are on the prototype; an `in` check would
+    // match them and then crash on `entry.code`. Must be treated as unknown.
+    for (const key of ["toString", "constructor", "hasOwnProperty"]) {
+      expect(renderDiagnosticText(key).found, key).toBe(false);
+    }
+  });
 });
 
 describe("renderDiagnosticList", () => {

--- a/packages/agency-lang/lib/cli/explain.ts
+++ b/packages/agency-lang/lib/cli/explain.ts
@@ -9,7 +9,10 @@ import { color } from "@/utils/termcolors.js";
 
 function lookup(codeOrName: string): DiagnosticName | undefined {
   const q = codeOrName.trim();
-  if (q in DIAGNOSTICS) return q as DiagnosticName;
+  // Own-property check, not `in`: `q` is user input, so an inherited key
+  // like "toString"/"constructor" must not resolve via the prototype chain
+  // (it would then crash on `entry.code`). Same guard as lib/optimize/registry.ts.
+  if (Object.hasOwn(DIAGNOSTICS, q)) return q as DiagnosticName;
   const upper = q.toUpperCase();
   for (const [name, entry] of Object.entries(DIAGNOSTICS)) {
     if (entry.code.toUpperCase() === upper) return name as DiagnosticName;

--- a/packages/agency-lang/lib/cli/explain.ts
+++ b/packages/agency-lang/lib/cli/explain.ts
@@ -1,0 +1,58 @@
+import {
+  DIAGNOSTICS,
+  DIAGNOSTIC_CATEGORIES,
+  categoryForCode,
+  type DiagnosticName,
+} from "@/typeChecker/diagnostics.js";
+import { DIAGNOSTIC_EXPLANATIONS } from "@/typeChecker/diagnosticExplanations.js";
+import { color } from "@/utils/termcolors.js";
+
+function lookup(codeOrName: string): DiagnosticName | undefined {
+  const q = codeOrName.trim();
+  if (q in DIAGNOSTICS) return q as DiagnosticName;
+  const upper = q.toUpperCase();
+  for (const [name, entry] of Object.entries(DIAGNOSTICS)) {
+    if (entry.code.toUpperCase() === upper) return name as DiagnosticName;
+  }
+  return undefined;
+}
+
+/** Rendered detail for one diagnostic. `found:false` carries the not-found
+ *  message with a suggestion; the caller prints it and exits 1. */
+export function renderDiagnosticText(codeOrName: string): {
+  text: string;
+  found: boolean;
+} {
+  const name = lookup(codeOrName);
+  if (!name) {
+    return {
+      found: false,
+      text: `Unknown diagnostic code '${codeOrName}'. Run 'agency explain --list' to see all codes.`,
+    };
+  }
+  const entry = DIAGNOSTICS[name];
+  const lines = [
+    `${color.bold(entry.code)} ${color.dim(name)}`,
+    `${color.dim("severity:")} ${entry.severity}`,
+    "",
+    entry.message,
+    "",
+    DIAGNOSTIC_EXPLANATIONS[name],
+  ];
+  return { found: true, text: lines.join("\n") };
+}
+
+/** Every code, grouped under its category title, with the message template
+ *  as the one-line summary. Codes sort within a category. */
+export function renderDiagnosticList(): string {
+  const blocks: string[] = [];
+  for (const cat of DIAGNOSTIC_CATEGORIES) {
+    const rows = Object.entries(DIAGNOSTICS)
+      .filter(([, e]) => categoryForCode(e.code)?.prefix === cat.prefix)
+      .sort(([, a], [, b]) => a.code.localeCompare(b.code))
+      .map(([, e]) => `  ${color.bold(e.code)}  ${e.message}`);
+    if (rows.length === 0) continue;
+    blocks.push([color.underline(cat.title), ...rows].join("\n"));
+  }
+  return blocks.join("\n\n");
+}

--- a/packages/agency-lang/lib/compiler/buildSession.ts
+++ b/packages/agency-lang/lib/compiler/buildSession.ts
@@ -23,7 +23,7 @@ import { resolveReExports } from "@/preprocessors/resolveReExports.js";
 import { liftCallbackBlocks } from "@/preprocessors/liftCallbacks.js";
 import { buildCompilationUnit, CompilationUnit } from "@/compilationUnit.js";
 import { SymbolTable } from "@/symbolTable.js";
-import { formatErrors, typeCheck } from "@/typeChecker/index.js";
+import { formatErrors, formatDiagnosticsHint, typeCheck } from "@/typeChecker/index.js";
 import {
   agencyImportTargets,
   buildCompiledClosure,
@@ -644,12 +644,16 @@ function runTypecheck(
   const tcEndTime = performance.now();
   logTime({ label: `Type checked ${absoluteInputFile}`, start: tcStartTime, end: tcEndTime, verbose });
   if (errors.length === 0) return;
+  const hint = formatDiagnosticsHint(errors);
   if (tc?.strict) {
     console.error(formatErrors(errors));
+    if (hint) console.error(hint);
     const hasFatal = errors.some((e) => e.severity === "error");
     if (hasFatal) process.exit(1);
   } else {
     console.warn(formatErrors(errors));
+    // warn-mode output is warnings-first; a hint only fires on error severity
+    if (hint) console.warn(hint);
   }
 }
 

--- a/packages/agency-lang/lib/stdlib/skills.test.ts
+++ b/packages/agency-lang/lib/stdlib/skills.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { _readSkill } from "./skills.js";
+import { _readSkill, _docsDir } from "./skills.js";
 
 describe("_readSkill", () => {
   let fakeHome: string;
@@ -52,5 +52,13 @@ describe("_readSkill", () => {
     } finally {
       fs.rmSync(targetPath, { force: true });
     }
+  });
+});
+
+describe("_docsDir", () => {
+  it("resolves the diagnostics section under docs/", () => {
+    // Guards the union widening ("guide" | "cli" | "diagnostics"). Pure path
+    // math — does not depend on the staged docs being present.
+    expect(_docsDir("diagnostics").endsWith(path.join("docs", "diagnostics"))).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -33,6 +33,6 @@ export function _readSkill(filepath: string): string {
  * the makefile), and stdlib resolves in both dev and npm installs via
  * getStdlibDir, so one copy serves compiled and source runs.
  */
-export function _docsDir(section: "guide" | "cli"): string {
+export function _docsDir(section: "guide" | "cli" | "diagnostics"): string {
   return path.join(getStdlibDir(), "docs", section);
 }

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.test.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { DIAGNOSTICS, type DiagnosticName } from "./diagnostics.js";
+import { DIAGNOSTIC_EXPLANATIONS } from "./diagnosticExplanations.js";
+import { parseAgency } from "../parser.js";
+
+const names = Object.keys(DIAGNOSTICS) as DiagnosticName[];
+
+describe("diagnostic explanations", () => {
+  it("has one entry per diagnostic (exhaustive)", () => {
+    // The Record type guarantees this at compile time; this pins it at
+    // runtime and guards against an accidental `as any` cast.
+    for (const name of names) {
+      expect(DIAGNOSTIC_EXPLANATIONS[name], `missing explanation: ${name}`).toBeTruthy();
+    }
+    expect(Object.keys(DIAGNOSTIC_EXPLANATIONS).sort()).toEqual([...names].sort());
+  });
+
+  it("every explanation is substantial (no stubs)", () => {
+    for (const name of names) {
+      expect(DIAGNOSTIC_EXPLANATIONS[name].trim().length, name).toBeGreaterThanOrEqual(100);
+    }
+  });
+
+  it("no explanation leaks a TS interpolation", () => {
+    for (const name of names) {
+      expect(DIAGNOSTIC_EXPLANATIONS[name], name).not.toContain("${");
+    }
+  });
+
+  it("no unrendered {placeholder} outside a code span", () => {
+    // Reuse the registry's brace rule: strip fenced/inline code, then any
+    // remaining {word} is an accidental raw-template quote.
+    for (const name of names) {
+      const withoutCode = DIAGNOSTIC_EXPLANATIONS[name]
+        .replace(/```[\s\S]*?```/g, "")
+        .replace(/`[^`]*`/g, "");
+      const withoutEscapes = withoutCode.replace(/\{\{|\}\}/g, "");
+      expect(withoutEscapes.replace(/\{\w+\}/g, ""), name).not.toMatch(/[{}]/);
+    }
+  });
+
+  it("every ```agency fenced snippet parses", () => {
+    for (const name of names) {
+      const blocks = extractAgencyBlocks(DIAGNOSTIC_EXPLANATIONS[name]);
+      for (const block of blocks) {
+        expect(() => parseAgency(block), `${name} snippet failed to parse`).not.toThrow();
+      }
+    }
+  });
+});
+
+function extractAgencyBlocks(md: string): string[] {
+  const out: string[] = [];
+  const re = /```agency\n([\s\S]*?)```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(md)) !== null) out.push(m[1]);
+  return out;
+}

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -1,0 +1,410 @@
+import type { DiagnosticName } from "./diagnostics.js";
+
+/**
+ * Long-form explanation per diagnostic, in Markdown.
+ *
+ * EXHAUSTIVE BY TYPE: `Record<DiagnosticName, string>` — adding a registry
+ * entry without an explanation here is a COMPILE error, not a test failure.
+ * That is the whole point; never weaken this to Partial or Record<string,…>.
+ *
+ * A retired/deprecated registry entry STILL needs an explanation here — the
+ * docs keep explaining a code a user may still see from an older compiler.
+ * Do not "clean up" an entry when a diagnostic is retired.
+ *
+ * Convention per entry: one short what/why paragraph, then fix guidance.
+ * 2-4 sentences for most; longer for high-traffic codes (assignability,
+ * undefined names, strict member access, exhaustiveness). A small Agency
+ * example is welcome but MUST parse — fence it as ```agency and it is
+ * verified by diagnosticExplanations.test.ts. A snippet that shows WRONG
+ * code must NOT be tagged ```agency (use a plain fence) so the parser gate
+ * skips it. Do NOT quote a raw message template with live {placeholders};
+ * write concrete values instead, and keep any braces inside a code span
+ * (the leak test rejects an unrendered {word} outside code).
+ */
+export const DIAGNOSTIC_EXPLANATIONS: Record<DiagnosticName, string> = {
+  // ---- AG1: types and aliases ----
+  typeParamDefaultOrder: `A type alias lists its type parameters left to right, and — like default function arguments — every parameter with a default must come after the parameters that have none. Otherwise a caller who omits a middle argument leaves a later, required one with no way to be positioned.
+
+**How to fix:** reorder the type parameters so all defaulted ones are last.`,
+
+  notValueParameterized: `Some type aliases take *value* arguments in parentheses (like a validated length), and some take none. This fires when you passed value arguments to an alias that accepts none.
+
+**How to fix:** drop the parenthesized arguments, or point at the alias you actually meant to parameterize.`,
+
+  tooManyValueArgs: `A value-parameterized alias accepts a fixed maximum number of value arguments, and you supplied more than it declares.
+
+**How to fix:** remove the extra arguments, or check whether you meant a different alias with more parameters.`,
+
+  valueArgsRequired: `This alias is value-parameterized: it needs its value arguments supplied in parentheses before it can be used as a type. Writing the bare name leaves those parameters unfilled.
+
+**How to fix:** call it with its arguments, following the form the message shows for that alias.`,
+
+  tooFewValueArgs: `A value-parameterized alias requires at least some minimum number of value arguments, and you supplied fewer.
+
+**How to fix:** add the missing arguments; the message names how many the alias needs.`,
+
+  unknownTypeAlias: `A type name was used that has no \`type\` declaration in scope and is not a built-in type. The checker resolves every type name against the aliases visible in the file plus its imports.
+
+**How to fix:** declare the alias, import it from the module that defines it, or fix a typo in the name.`,
+
+  genericRequiresTypeArgs: `This is a generic type — it is parameterized by other types (like the element type of a list) — and it cannot be used bare. The type arguments are required.
+
+**How to fix:** supply the type arguments in angle brackets, e.g. write the element type the generic wraps.`,
+
+  builtinGenericArity: `A built-in generic type (such as an array or Record) was given the wrong number of type arguments. Each built-in generic takes an exact count.
+
+**How to fix:** supply exactly the number of type arguments the message names.`,
+
+  unknownGenericType: `A generic type name was used with type arguments, but no generic type by that name is defined or imported.
+
+**How to fix:** define or import the generic, or fix the name.`,
+
+  notGenericType: `Type arguments in angle brackets were applied to a name that is not a generic type, so it has no parameters to fill.
+
+**How to fix:** remove the type arguments, or reference the generic type you meant.`,
+
+  tooManyTypeArgs: `A generic type accepts a fixed maximum number of type arguments, and you supplied more than it declares.
+
+**How to fix:** remove the extra type arguments.`,
+
+  tooFewTypeArgs: `A generic type requires at least some minimum number of type arguments, and you supplied fewer.
+
+**How to fix:** add the missing type arguments; the message names how many are needed.`,
+
+  // ---- AG2: assignability and checking ----
+  typeNotAssignableInContext: `Agency assigns each value a type and checks that it fits where you use it. This is the assignability error with the surrounding context named (a return, an argument, a field) — the value's type does not fit that slot.
+
+**How to fix:** change one side so they line up — convert the value, widen the declared type, or fix the expression that produced the wrong type. If the value can legitimately be several types, declare the slot as a union.`,
+
+  conditionNotBoolean: `The condition of an \`if\` or \`while\` must be a boolean. Agency does not treat non-boolean values as truthy or falsy, so a number or string here is an error rather than a silent coercion.
+
+**How to fix:** compare explicitly — e.g. \`count > 0\` instead of \`count\`, or \`name != ""\` instead of \`name\`.`,
+
+  unknownProperty: `An object literal (or similar structured value) included a key that the target type does not declare. The checker knows the exact shape the context expects and rejects keys outside it.
+
+**How to fix:** remove the stray key, fix a typo in the key name, or add the field to the target type if it belongs there.`,
+
+  missingAnnotationStrictMode: `In strict mode every variable needs a type annotation; this one has none and its type could not be inferred with certainty. Strict mode trades a little verbosity for catching type mistakes early.
+
+**How to fix:** add an annotation, e.g. \`let total: number = …\`, or turn strict mode off if you do not want this requirement.`,
+
+  typeNotAssignable: `Agency assigns each value a type and checks that the value you store, return, or pass matches the type the destination expects. This error fires when they disagree — for example putting a \`string\` where a \`number\` is required.
+
+**How to fix:** change one side so they line up — convert the value, widen the declared type, or fix the expression that produced the wrong type. If the value can legitimately be one of several types, declare the destination as a union.
+
+\`\`\`agency
+def half(n: number): number {
+  return n / 2
+}
+
+node main() {
+  const count: number = 3
+  half(count)
+}
+\`\`\``,
+
+  forLoopIterableType: `A \`for (x in xs)\` loop iterates an array or a Record; the value after \`in\` here is neither. The checker needs a container it knows how to walk.
+
+**How to fix:** iterate an array or Record, or convert the value into one before the loop.
+
+\`\`\`agency
+node main() {
+  const names = ["ada", "grace"]
+  for (name in names) {
+    print(name)
+  }
+}
+\`\`\``,
+
+  validatedParamsRequireResult: `A parameter marked with \`!\` validation can short-circuit the call with a failure when the data does not pass. A function that can fail must advertise it in its return type, so its return type must be a \`Result\`.
+
+**How to fix:** change the return type to \`Result<...>\`, or remove the \`!\` validation from the parameters if the call cannot fail.`,
+
+  docStringParamInterpolation: `A function's doc string becomes the tool description sent to the LLM, and that description is fixed before any call happens — so a parameter's runtime value is not available to interpolate into it.
+
+**How to fix:** reference a global variable instead of a parameter, or reword the doc string to not depend on per-call values.`,
+
+  unionFieldNotOnEveryMember: `The value has a union type, and the field you accessed exists on some members of the union but not all. Reading it directly would be unsafe on the members that lack it.
+
+**How to fix:** narrow the value first — for example with a guard that establishes which member you have — then access the field inside that narrowed branch.`,
+
+  resultBranchFieldAccess: `A \`Result\` is either a success or a failure, and the field you accessed only exists on one of those branches. Reading it without first checking which branch you have would be unsafe.
+
+**How to fix:** guard with \`if (isSuccess(r))\` or \`if (isFailure(r))\`, use \`r catch …\`, or handle both arms with \`match\`.
+
+\`\`\`agency
+node main() {
+  const r = compute()
+  if (isSuccess(r)) {
+    print(r.value)
+  }
+}
+\`\`\``,
+
+  dimensionMismatch: `Agency tracks physical dimensions (like duration versus size) on some values and refuses arithmetic that mixes incompatible ones, the way you cannot add seconds to bytes. This caught an operation on two different dimensions.
+
+**How to fix:** operate on values of the same dimension, or convert one so both agree before combining them.`,
+
+  propertyDoesNotExist: `The property you accessed is not declared on the value's type. The checker knows the type's shape and only allows the fields it declares.
+
+**How to fix:** fix a typo in the property name, access a field the type actually has, or add the field to the type if it belongs there.`,
+
+  notAllPathsReturn: `The function declares a return type, so every path through its body must produce a value — but at least one path (often a missing \`else\`, or a fall-through past a loop) reaches the end without returning.
+
+**How to fix:** add a \`return\` on the path that is missing one, or a final \`return\` that covers the fall-through.`,
+
+  // ---- AG3: interrupts, effects, and handlers ----
+  handlerParamValidated: `Handler parameters carry the payload of an interrupt, and the \`!\` validation syntax is not allowed on them. Validation there would run at a point in the flow where a failure has nowhere safe to go.
+
+**How to fix:** drop the \`!\` from the handler parameter and validate the data inside the handler body if you need to.`,
+
+  effectDeclaredTwice: `An effect was declared more than once in the same file. Each effect name should be introduced by a single declaration so its payload shape has one definition.
+
+**How to fix:** remove the duplicate declaration.`,
+
+  effectPayloadConflict: `Two declarations of the same effect disagree about its payload type. Every declaration of an effect must agree on the data it carries.
+
+**How to fix:** make the declarations match, or consolidate them into one.`,
+
+  namedArgsOnRaise: `\`raise\` and \`interrupt\` take their payload positionally, not as named arguments. Their data is a single positional value.
+
+**How to fix:** pass the data positionally, e.g. \`raise MyEffect(payload)\`.`,
+
+  effectDataMissing: `The effect declares a payload, but this \`raise\`/\`interrupt\` supplied none. A declared payload is required at the raise site.
+
+**How to fix:** pass the data the effect expects.`,
+
+  effectDataFieldMissing: `The effect's payload is a structured type, and a required field of it was not supplied at the raise site.
+
+**How to fix:** add the missing field to the payload you pass.`,
+
+  effectDataFieldWrongType: `A field of the effect's payload was supplied with a value whose type does not match what the effect declares for that field.
+
+**How to fix:** pass a value of the declared type for that field.`,
+
+  effectDataMismatch: `The payload supplied at the raise site does not match the shape the effect declares. The whole value, not just one field, is off.
+
+**How to fix:** construct the payload to match the effect's declared type.`,
+
+  unhandledInterrupts: `This function may raise interrupts, but it is called from a place that is not inside a matching handler. An unhandled interrupt at runtime has no \`handle\` block to receive it. This is a warning because the handler may be installed dynamically at a point the checker cannot see.
+
+**How to fix:** wrap the call in a \`handle\` block for the effects it may raise, or confirm a handler is installed higher up.`,
+
+  handlerBodyRaises: `A handler that itself raises interrupts would re-enter the handler chain — the dispatcher visits every handler, including the one currently running — and recurse until the runtime aborts with a recursion error.
+
+**How to fix:** restructure so the handler does not call interrupt-raising code (for example, hoist file I/O out of the handler). If you are certain it is safe, suppress with \`// @tc-ignore\` on the line above the \`handle\` block.`,
+
+  interruptInCallback: `Callbacks fire as side effects at points where execution cannot pause, so their body may not \`interrupt\` — an interrupt would need to stop the run to ask the user something, which a callback has no way to do.
+
+**How to fix:** move the \`interrupt\` into the calling node or function. If you only wanted a runtime budget check, use a runtime guard instead.`,
+
+  raisesNotAnEffectSet: `A \`raises\` clause must name an effect set, but the reference given is declared as a plain \`type\`, not an \`effectSet\`. The two are different: only an effect set enumerates raisable effects.
+
+**How to fix:** declare the reference with \`effectSet\` instead of \`type\`, or use an inline effect set in angle brackets.`,
+
+  raisesExceeded: `The function or node raises an effect that its own \`raises\` clause does not list. The clause is a contract: it must cover every effect the body can raise.
+
+**How to fix:** add the effect to the \`raises\` clause, or stop raising it.`,
+
+  valueMayRaiseAnyEffect: `A value is being used where the target type limits which effects may be raised, but the value's own type has no \`raises\` clause — so it could raise anything, which exceeds that limit.
+
+**How to fix:** add a \`raises\` clause to the value's type so the checker can see it stays within bounds.`,
+
+  valueEffectExceedsRaises: `A value raises an effect that the target type's \`raises\` clause does not allow. The target restricts the effect set, and this value steps outside it.
+
+**How to fix:** add the effect to the target type's clause, or use a target type that permits it.`,
+
+  // ---- AG4: names, scope, and reserved words ----
+  shadowsImportedFunction: `A local name here has the same name as a function you imported, so the local shadows the import within this scope. That is legal but often unintended, so it is flagged as a warning.
+
+**How to fix:** rename the local if you meant to keep using the import, or ignore the warning if the shadow is deliberate.`,
+
+  reservedBuiltinRedefined: `The name is a reserved built-in and cannot be redefined. Built-ins are part of the language surface; redefining one would make its ordinary uses ambiguous.
+
+**How to fix:** choose a different name for your definition.`,
+
+  reservedBuiltinTypeRedefined: `The name is a reserved built-in type and cannot be redefined for the same reason built-in functions cannot: its ordinary uses must stay unambiguous.
+
+**How to fix:** pick a different type name.`,
+
+  undefinedFunction: `A function was called that has no definition in scope and is not a built-in. The checker resolves every call against the functions visible in the file plus its imports.
+
+**How to fix:** define the function, import it from the module that provides it, or fix a typo in the call.`,
+
+  reassignToConst: `A \`const\` binding is fixed after its initial value: it cannot be reassigned. This assignment targets a name that was declared \`const\`.
+
+**How to fix:** declare it with \`let\` if it needs to change, or assign to a different variable.
+
+\`\`\`agency
+node main() {
+  let count = 0
+  const limit = 10
+  count = count + 1
+}
+\`\`\``,
+
+  reservedBlockKeyword: `This keyword introduces a block directly — you write it followed by braces (or parentheses then braces) — and it does not support an \`as\` binding, because there is nothing to bind. The \`as\` here is not valid on this block form.
+
+**How to fix:** write the block without \`as\`, e.g. the keyword followed immediately by its \`{ ... }\` body.`,
+
+  undefinedVariable: `The type checker walks every scope — nodes, function bodies, blocks — and resolves each name to a declaration. This error means a name was used with no \`let\`, \`const\`, parameter, or import that introduces it in reach.
+
+**How to fix:** declare it before use (\`let x = …\` / \`const x = …\`), fix a typo in the name, or import it if it lives in another module. Agency has no implicit variables: a bare assignment like \`x = 5\` without a prior \`let\`/\`const\` is not a declaration.`,
+
+  // ---- AG5: match and narrowing ----
+  matchNotExhaustive: `A \`match\` over a union or Result must handle every case the scrutinee can take; the checker computes the set of arms you covered and reports the ones missing. An unhandled case would fall through at runtime with no branch to run.
+
+**How to fix:** add an arm for each listed missing case, or add a wildcard \`_\` arm if a catch-all is genuinely what you want.
+
+\`\`\`agency
+node main() {
+  const r = compute()
+  match (r) {
+    is success(v) { print(v) }
+    is failure(e) { print(e) }
+  }
+}
+\`\`\``,
+
+  // ---- AG6: calls, tools, and LLM usage ----
+  regexInStructuredOutput: `An \`llm()\` call returns its result as structured JSON, and a \`regex\` value has no JSON representation the model can produce — so \`regex\` may not appear anywhere in an \`llm()\` output type.
+
+**How to fix:** return the matched text as a \`string\` (or another JSON-friendly type) and build the regex yourself afterward.`,
+
+  partialRequiresNamedArgs: `\`.partial()\` binds arguments by name so it is unambiguous which parameters you are fixing. It does not accept positional arguments.
+
+**How to fix:** name the arguments, e.g. \`fn.partial(a: 5)\`.`,
+
+  unknownPartialParameter: `A \`.partial()\` call named a parameter that the function does not have. Binding an unknown parameter has no meaning.
+
+**How to fix:** bind one of the function's real parameters (the message lists them), or fix a typo.`,
+
+  partialArgNotAssignable: `An argument passed to \`.partial()\` has a type that does not match the parameter it binds. A partially-applied argument must still satisfy the parameter's type.
+
+**How to fix:** pass a value of the parameter's declared type.`,
+
+  namedArgsOnBuiltinMethod: `Built-in methods take their arguments positionally; named arguments are only supported on Agency-defined functions. This call used names on a built-in method.
+
+**How to fix:** pass the arguments positionally.`,
+
+  methodArityExact: `A built-in method was called with the wrong number of arguments; this method takes an exact count.
+
+**How to fix:** pass exactly the number of arguments the message names.`,
+
+  methodArityAtLeast: `A built-in method was called with too few arguments; it requires at least a minimum number.
+
+**How to fix:** supply at least the number of arguments the message names.`,
+
+  methodArityRange: `A built-in method accepts a range of argument counts, and this call fell outside it.
+
+**How to fix:** pass a number of arguments within the range the message names.`,
+
+  builtinMethodArgNotAssignable: `An argument to a built-in method has a type that does not match the parameter it fills.
+
+**How to fix:** pass a value of the expected type.`,
+
+  namedArgsOnlyAgencyFunctions: `Named arguments work only with functions defined in Agency. The target here is not one of those (for example a built-in or an imported host function), so its arguments must be positional.
+
+**How to fix:** pass the arguments positionally.`,
+
+  namedArgNotAccepted: `A named argument was supplied that the function does not declare. The checker knows the function's parameter names and rejects names outside that set.
+
+**How to fix:** use one of the function's declared parameter names (the message lists the allowed ones), or fix a typo.`,
+
+  duplicateNamedArg: `The same named argument was supplied twice in one call. Each parameter can be bound at most once.
+
+**How to fix:** remove the duplicate.`,
+
+  namedArgTypeMismatch: `A named argument's value has a type that does not match the parameter's declared type.
+
+**How to fix:** pass a value of the expected type for that parameter.`,
+
+  blockArgNotAccepted: `A block argument (a trailing \`{ ... }\`) was passed to a function that does not declare a block parameter.
+
+**How to fix:** remove the block, or call a function that takes one.`,
+
+  callArityExact: `A function was called with the wrong number of positional arguments; it takes an exact count.
+
+**How to fix:** pass exactly the number of arguments the message names.`,
+
+  callArityAtLeast: `A function was called with too few positional arguments; it requires at least a minimum number.
+
+**How to fix:** supply at least the number of arguments the message names.`,
+
+  callArityRange: `A function accepts a range of argument counts (some parameters have defaults or are variadic), and this call fell outside that range.
+
+**How to fix:** pass a number of arguments within the range the message names.`,
+
+  argNotAssignable: `A positional argument's type does not match the parameter it fills. Each argument must be assignable to its parameter's type.
+
+**How to fix:** pass a value of the expected type, or adjust the parameter's type if the call is correct.`,
+
+  splatMustBeArray: `A splat argument (\`...xs\`) spreads an array's elements into positional arguments, so the splatted value must be an array. This value is not.
+
+**How to fix:** splat an array, or convert the value into one first.`,
+
+  splatElementNotAssignable: `The array being splatted has an element type that does not match the parameters the elements would fill.
+
+**How to fix:** splat an array whose element type matches the target parameters.`,
+
+  pipeSlotNotAssignable: `A pipe feeds its left-hand value into a slot on the right, and that value's type does not match the slot's type.
+
+**How to fix:** pipe a value of the slot's type, or transform it before the pipe.`,
+
+  splatAfterNamedArg: `A splat argument cannot come after a named argument in a call. The splat fills positional slots, and those are resolved before names.
+
+**How to fix:** move the splat ahead of any named arguments.`,
+
+  positionalAfterNamedArg: `Once a call uses a named argument, every following argument must also be named — a positional argument cannot come after a named one.
+
+**How to fix:** move positional arguments before the named ones, or name them too.`,
+
+  unknownNamedArg: `A named argument in this call does not correspond to any parameter of the function.
+
+**How to fix:** use a declared parameter name, or fix a typo.`,
+
+  namedArgConflictsPositional: `A parameter was filled both positionally and by name in the same call, so it is bound twice.
+
+**How to fix:** supply the argument once — either positionally or by name, not both.`,
+
+  positionalFeedsNamedVariadic: `A positional argument would feed a variadic parameter that is also being bound by name in the same call. The parameter cannot collect positionals and take a named value at once.
+
+**How to fix:** bind the variadic parameter one way — either by name or with positional arguments.`,
+
+  toolRequiredParamUnbound: `A function passed as a tool has a required function-typed parameter that is still unbound. The LLM cannot supply a function value, so a required function parameter must be fixed before the function becomes a tool.
+
+**How to fix:** bind it first with \`.partial(...)\` — e.g. \`fn.partial(callback: myImpl)\` — then pass the result as the tool.`,
+
+  toolRequiredParamUnboundTyped: `This is the same problem as an unbound required function-typed tool parameter, with the parameter's function type shown. The LLM cannot provide a function value, so the parameter must be bound before the function is used as a tool.
+
+**How to fix:** bind it with \`.partial(...)\` before passing the function as a tool.`,
+
+  toolOptionalParamsDropped: `A function passed as a tool has optional function-typed parameters that the LLM cannot fill, so they are dropped and the tool runs with each parameter's declared default. This is a warning, not an error, because a default exists — but the body must be prepared to run without those functions.
+
+**How to fix:** confirm the defaults are correct for the tool use, or bind the parameters explicitly with \`.partial(...)\` if you need specific implementations.`,
+
+  // ---- AG7: static init, config, and imports ----
+  exportRequiresStaticConst: `Only \`static const\` declarations can be exported from a module. A plain \`const\`, \`let\`, or other declaration is per-run state and is not part of a module's public surface.
+
+**How to fix:** declare the exported value as \`static const\`, or remove the \`export\`.`,
+
+  bannedBuiltinInStaticInit: `Static initializers run once at process startup, before any per-run state exists — so they may not call built-ins that need a running agent (LLM calls, I/O, and similar). This static init calls one of those.
+
+**How to fix:** move the call into a node, or into a function called from a node, where per-run state is available.`,
+
+  interruptInStaticInit: `Interrupts pause the per-run execution stack, but static initializers run once at startup before any run has begun — there is no stack to pause. So \`interrupt(...)\` is not allowed in a static initializer.
+
+**How to fix:** move the \`interrupt\` into a node body.`,
+
+  staticReassignedAtTopLevel: `Statics are immutable after they initialize, so a static cannot be reassigned at module top level. Reassigning one would break the guarantee that its value is fixed for the whole process.
+
+**How to fix:** use a global (\`const\` or \`let\` without \`static\`) if you need a value that changes.`,
+
+  staticMutatedViaMethod: `Statics are deep-frozen after initialization, so mutating one through a method (like \`.push(...)\`) at module top level is not allowed — the frozen value rejects the change.
+
+**How to fix:** use a global (\`const\` or \`let\` without \`static\`) if you need a mutable value.`,
+
+  conflictingMarkers: `A function was marked both \`destructive\` and \`idempotent\`, but those markers contradict each other: destructive means a retry can cause additional effects, while idempotent means a retry is safe to repeat. A function cannot be both.
+
+**How to fix:** keep the one marker that describes the function and remove the other.`,
+};

--- a/packages/agency-lang/lib/typeChecker/diagnostics.test.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { DIAGNOSTICS, diagnostic, renderMessage } from "./diagnostics.js";
+import {
+  DIAGNOSTICS,
+  DIAGNOSTIC_CATEGORIES,
+  categoryForCode,
+  diagnostic,
+  renderMessage,
+} from "./diagnostics.js";
 import {
   formatOptionalUnboundWarning,
   formatRequiredUnboundError,
@@ -33,6 +39,21 @@ describe("diagnostic registry invariants", () => {
       const withoutEscapes = entry.message.replace(/\{\{|\}\}/g, "");
       expect(withoutEscapes.replace(/\{\w+\}/g, "")).not.toMatch(/[{}]/);
     }
+  });
+
+  it("every code maps to exactly one category", () => {
+    for (const [name, entry] of entries) {
+      const cat = categoryForCode(entry.code);
+      expect(
+        cat,
+        `${name} (${entry.code}) has no DIAGNOSTIC_CATEGORIES entry for prefix '${entry.code.slice(0, 3)}' — add one`,
+      ).toBeDefined();
+    }
+  });
+
+  it("no two categories share a prefix", () => {
+    const prefixes = DIAGNOSTIC_CATEGORIES.map((c) => c.prefix);
+    expect(new Set(prefixes).size).toBe(prefixes.length);
   });
 });
 

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -6,11 +6,9 @@ import type { TypeCheckError } from "./types.js";
  *
  * APPEND-ONLY: a shipped code is never renumbered or reused. A retired
  * diagnostic keeps its entry with `retired: true` so the code stays reserved.
- * Codes are AG#### with category ranges (documentation, not machinery):
- *   AG1xxx types/aliases          AG2xxx assignability/checking
- *   AG3xxx interrupts/effects     AG4xxx names/scope/reserved/const
- *   AG5xxx match/narrowing        AG6xxx tools/llm/blocks
- *   AG7xxx static-init/config/imports
+ * Codes are AG#### (append-only). Category ranges live in
+ * DIAGNOSTIC_CATEGORIES below — the single source for the docs generator
+ * and the `agency explain --list` grouping.
  *
  * Message templates use {param} placeholders. Templates are extracted
  * VERBATIM from the legacy inline strings — rendered output must be
@@ -496,6 +494,30 @@ export const DIAGNOSTICS = {
 } as const;
 
 export type DiagnosticName = keyof typeof DIAGNOSTICS;
+
+/**
+ * Category ranges as data (they were prose in the DIAGNOSTICS header comment).
+ * The CLI `explain --list` grouping and the docs generator both key off this
+ * single source. Append-only, like the codes: a new AG8xxx range means a new
+ * entry here. `slug` is the docs filename; `title` is the human heading.
+ */
+export const DIAGNOSTIC_CATEGORIES = [
+  { prefix: "AG1", slug: "types-aliases", title: "Types and aliases" },
+  { prefix: "AG2", slug: "checking", title: "Assignability and checking" },
+  { prefix: "AG3", slug: "effects", title: "Interrupts, effects, and handlers" },
+  { prefix: "AG4", slug: "names", title: "Names, scope, and reserved words" },
+  { prefix: "AG5", slug: "match", title: "Match and narrowing" },
+  { prefix: "AG6", slug: "tools", title: "Calls, tools, and LLM usage" },
+  { prefix: "AG7", slug: "static-init", title: "Static init, config, and imports" },
+] as const;
+
+/** The category a code belongs to, by its AG# prefix, or undefined if none. */
+export function categoryForCode(
+  code: string,
+): (typeof DIAGNOSTIC_CATEGORIES)[number] | undefined {
+  const prefix = code.slice(0, 3);
+  return DIAGNOSTIC_CATEGORIES.find((c) => c.prefix === prefix);
+}
 
 /**
  * The {placeholder} names of a template, as a string-literal union.

--- a/packages/agency-lang/lib/typeChecker/formatErrors.test.ts
+++ b/packages/agency-lang/lib/typeChecker/formatErrors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatErrors, typeCheck } from "./index.js";
+import { formatErrors, formatDiagnosticsHint, typeCheck } from "./index.js";
 import { diagnostic } from "./diagnostics.js";
 import { parseAgency } from "../parser.js";
 import { buildCompilationUnit } from "../compilationUnit.js";
@@ -85,5 +85,32 @@ describe("end-to-end file stamping + formatting", () => {
     expect(lines[0]).toMatch(
       /^\/tmp\/stamp-test\.agency:\d+:\d+ - error AG\d{4}: /,
     );
+  });
+});
+
+describe("formatDiagnosticsHint", () => {
+  const err = (code: string, severity: "error" | "warning") => ({
+    code,
+    name: "x" as never,
+    message: "m",
+    severity,
+    params: {},
+    loc: null,
+  });
+
+  it("names the first ERROR-severity code, not errors[0]", () => {
+    const hint = formatDiagnosticsHint([
+      err("AG3009", "warning"),
+      err("AG2005", "error"),
+    ]);
+    expect(hint).not.toBeNull();
+    expect(hint!).toContain("AG2005");
+    expect(hint!).not.toContain("AG3009");
+    expect(hint!).toContain("agency explain");
+  });
+
+  it("returns null when there are no error-severity diagnostics", () => {
+    expect(formatDiagnosticsHint([err("AG3009", "warning")])).toBeNull();
+    expect(formatDiagnosticsHint([])).toBeNull();
   });
 });

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -523,3 +523,16 @@ export function formatErrors(errors: TypeCheckError[]): string {
     })
     .join("\n");
 }
+
+/**
+ * One-line discovery hint printed AFTER the error block, naming the first
+ * error-severity diagnostic. Returns null when no error-severity diagnostic
+ * is present (warnings-only output gets no hint). Kept OUT of formatErrors
+ * so programmatic consumers (compile.ts, serve.ts) are untouched — only the
+ * human/agent-facing print sites append it.
+ */
+export function formatDiagnosticsHint(errors: TypeCheckError[]): string | null {
+  const first = errors.find((e) => e.severity === "error");
+  if (!first) return null;
+  return `Run 'agency explain ${first.code}' for an explanation.`;
+}

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -1,4 +1,4 @@
-.PHONY: all test stdlib agents doc packages-doc refresh-action-pins build clean publish compile-agency
+.PHONY: all test stdlib agents doc diagnostics-docs packages-doc refresh-action-pins build clean publish compile-agency
 
 # Resolve tsc/tsc-alias from the workspace, not from whatever happens to
 # be global. Historically `make build` was only ever reached via
@@ -30,13 +30,14 @@ endef
 # copies must be idempotent.
 define stage-stdlib-docs
 	mkdir -p stdlib/docs
-	rm -rf stdlib/docs/guide stdlib/docs/cli
+	rm -rf stdlib/docs/guide stdlib/docs/cli stdlib/docs/diagnostics
 	cp -r docs/site/guide stdlib/docs/guide
 	cp -r docs/site/cli stdlib/docs/cli
+	cp -r docs/site/diagnostics stdlib/docs/diagnostics
 endef
 
 all:
-	pnpm run templates && $(MAKE) build && $(MAKE) compile-agency && $(MAKE) doc
+	pnpm run templates && $(MAKE) build && $(MAKE) diagnostics-docs && $(MAKE) compile-agency && $(MAKE) doc
 
 # Build the dist/ tree. Invoked by `pnpm run build`. Kept here (rather
 # than as a chain in package.json) so the steps remain readable and easy
@@ -124,6 +125,12 @@ doc:
 	  rm -rf docs/site/stdlib/ && node ./dist/scripts/agency.js doc stdlib -o docs/site/stdlib/ && \
 	  mkdir -p .agency-build && echo "$$STAMP" > .agency-build/doc.stamp; \
 	fi
+
+# Regenerate docs/site/diagnostics/ from the diagnostics registry. Cheap
+# (one node invocation), so no stamp. Must run BEFORE compile-agency stages
+# docs into stdlib/, so `all` sequences it right after build.
+diagnostics-docs:
+	node ./dist/scripts/generateDiagnosticsDocs.js docs/site/diagnostics/
 
 # Documentable packages: each has an index.agency that `agency doc` reads.
 # (brave-search / tui / examples have no library source, so they're skipped.)

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -24,6 +24,7 @@ import { evalExtract } from "@/cli/evalExtract.js";
 import { evalJudge } from "@/cli/evalJudge.js";
 import { evalRun } from "@/cli/eval/run.js";
 import { evalOptimize } from "@/cli/eval/optimize.js";
+import { renderDiagnosticText, renderDiagnosticList } from "@/cli/explain.js";
 import {
   AgencyConfig,
   applyCliFlags,
@@ -880,6 +881,25 @@ export function createProgram(deps: CliDependencies = {}): Command {
         }
       }
       if (hasErrors) process.exit(1);
+    });
+
+  program
+    .command("explain")
+    .description("Explain a type-checker diagnostic code (e.g. AG2005)")
+    .argument("[code]", "An AG#### code or registry name; omit to list all")
+    .option("--list", "List every diagnostic code")
+    .action((code: string | undefined, opts: { list?: boolean }) => {
+      if (!code || opts.list) {
+        console.log(renderDiagnosticList());
+        return;
+      }
+      const { text, found } = renderDiagnosticText(code);
+      if (found) {
+        console.log(text);
+      } else {
+        console.error(text);
+        process.exit(1);
+      }
     });
 
   program

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -36,7 +36,7 @@ import { _parseAgency } from "@/parser.js";
 import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
 import { buildCompilationUnit } from "@/compilationUnit.js";
 import { SymbolTable } from "@/symbolTable.js";
-import { formatErrors, typeCheck } from "@/typeChecker/index.js";
+import { formatErrors, formatDiagnosticsHint, typeCheck } from "@/typeChecker/index.js";
 import { Command, InvalidArgumentError } from "commander";
 import * as fs from "fs";
 import { color } from "@/utils/termcolors.js";
@@ -858,6 +858,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
         const { errors } = typeCheck(parsedProgram, config, info);
         if (errors.length > 0) {
           console.error(formatErrors(errors));
+          const hint = formatDiagnosticsHint(errors);
+          if (hint) console.error(hint);
           if (errors.some((e) => e.severity === "error")) {
             hasErrors = true;
           }

--- a/packages/agency-lang/scripts/generateDiagnosticsDocs.ts
+++ b/packages/agency-lang/scripts/generateDiagnosticsDocs.ts
@@ -1,0 +1,23 @@
+// Regenerates docs/site/diagnostics/ from the diagnostics registry +
+// explanations table. A BUILD script (compiled to dist/scripts/ like
+// stdlib-stamp), invoked from the Makefile — never a user command. One fast
+// node invocation, no stamp machinery: it wipes and rewrites the whole dir.
+import * as fs from "fs";
+import * as path from "path";
+import { generateDiagnosticsPages } from "@/cli/diagnosticsDocs.js";
+
+const outDir = process.argv[2];
+if (!outDir) {
+  console.error("usage: generateDiagnosticsDocs <output-dir>");
+  process.exit(1);
+}
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+const pages = generateDiagnosticsPages();
+for (const { relPath, contents } of pages) {
+  fs.writeFileSync(
+    path.join(outDir, relPath),
+    contents.endsWith("\n") ? contents : contents + "\n",
+  );
+}
+console.log(`Wrote ${pages.length} diagnostics pages to ${outDir}`);

--- a/packages/agency-lang/scripts/generateDiagnosticsDocs.ts
+++ b/packages/agency-lang/scripts/generateDiagnosticsDocs.ts
@@ -5,13 +5,22 @@
 import * as fs from "fs";
 import * as path from "path";
 import { generateDiagnosticsPages } from "@/cli/diagnosticsDocs.js";
+import { safeDeleteDirectory } from "@/utils.js";
 
 const outDir = process.argv[2];
 if (!outDir) {
   console.error("usage: generateDiagnosticsDocs <output-dir>");
   process.exit(1);
 }
-fs.rmSync(outDir, { recursive: true, force: true });
+// safeDeleteDirectory confines deletes to the project root (checkInsideProject),
+// so a mistyped argv[2] can't wipe an arbitrary path. Fail fast if it refuses.
+if (fs.existsSync(outDir)) {
+  const del = safeDeleteDirectory(outDir, false);
+  if (!del.success) {
+    console.error(`Refusing to regenerate '${outDir}': ${del.message}`);
+    process.exit(1);
+  }
+}
 fs.mkdirSync(outDir, { recursive: true });
 const pages = generateDiagnosticsPages();
 for (const { relPath, contents } of pages) {

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -197,14 +197,16 @@ export def skillsDir(dir: string, layout: "flat" | "standard" = "standard") {
   return buildSkillsTool(dir, layout)
 }
 
-export def docsSkill(section: "guide" | "cli") {
+export def docsSkill(section: "guide" | "cli" | "diagnostics") {
   """
   Build a docs tool for an LLM over the packaged Agency documentation.
   "guide" serves the language guide (syntax, types, control flow);
-  "cli" serves the CLI reference. The returned tool lists every page in
-  its description and lets the model read any one on demand.
+  "cli" serves the CLI reference; "diagnostics" serves the type-checker
+  diagnostic codes (AG####) with explanations and fixes. The returned tool
+  lists every page in its description and lets the model read any one on
+  demand.
 
-  @param section - Which documentation set to serve: "guide" or "cli".
+  @param section - Which documentation set to serve: "guide", "cli", or "diagnostics".
   """
   // No approval interrupt for the startup scan: these docs ship inside
   // the agency package, so scanning them carries the same trust as


### PR DESCRIPTION
Follow-on to #474 / #517 (the diagnostic codes + registry). Implements the spec and plan committed under `docs/superpowers/`. Serves a long-form explanation for every type-checker diagnostic three ways, plus a one-line discovery hint on failed type checks.

## What you get

```
$ agency typecheck bad.agency
bad.agency:2:3 - error AG2001: Type '"nope"' is not assignable to type 'number' (assignment to 'x').
Run 'agency explain AG2001' for an explanation.

$ agency explain AG2001
AG2001 typeNotAssignableInContext
severity: error

Type '{actual}' is not assignable to type '{expected}' ({context}).

Agency assigns each value a type and checks that it fits where you use it. ...
```

Three surfaces, all driven by one authored piece of new content per code (the long explanation) alongside the message template that already lives in the registry:

1. **CLI** — `agency explain <code>` (accepts an `AG####` code, case-insensitive, or a registry name like `typeNotAssignable`) and `agency explain --list` (every code grouped by category). Rendering lives in a testable `lib/cli/explain.ts`; the command is a thin wrapper. Named `explain`, not `diagnostics`, because `agency diagnostics` already exists as a VSCode-facing parse command.
2. **Docs** — a build script (`make diagnostics-docs` → `docs/site/diagnostics/`) generates an index plus one page per category from the registry + explanations. Pure generation lives in `lib/cli/diagnosticsDocs.ts` and is unit-tested in memory; `stage-stdlib-docs` copies the pages into `stdlib/docs` for the agent.
3. **Agent** — `docsSkill` gains a `"diagnostics"` section, wired into all four docsSkill-bearing subagents (oracle, research, **code**, explorer); the code subagent runs `typecheck` and is the primary consumer.

## Design choices

- **Explanations are an exhaustive `Record<DiagnosticName, string>`** in `lib/typeChecker/diagnosticExplanations.ts` — coverage is a compile guarantee, not a test. Adding a registry entry without an explanation fails `tsc` (this caught the four codes added after #517: the three tool-unbound entries and `conflictingMarkers`). 86 codes explained.
- **Category ranges became data** (`DIAGNOSTIC_CATEGORIES` + `categoryForCode` in `diagnostics.ts`) — they were prose in the registry header; now the CLI `--list` grouping and the docs generator share one source. A registry-suite invariant pins that every code's prefix maps to exactly one category, so a future AG8xxx code without a category entry fails there with an actionable message.
- **The hint targets the first error-severity diagnostic** (`errors.find(e => e.severity === "error")`, not `errors[0]`), so a warning-led error list still names the error. `formatDiagnosticsHint` lives next to `formatErrors` and is wired only at the two human/agent-facing print sites (typecheck action + buildSession failure), on the same stream as the error block — never inside `formatErrors`, so programmatic consumers stay clean. Warnings-only output gets no hint.

## Tests

- Coverage/quality: every explanation is substantial, leaks no `${...}` or unrendered `{placeholder}` outside code spans, and **every fenced `agency` snippet is run through `parseAgency`** — turning the authoring convention into a mechanical gate (this repo has a documented history of prose-syntax mistakes).
- CLI helper: code↔name resolve identically, unknown code returns the suggestion, list contains every code once.
- Generator invariants: index lists every code once with a link, each code appears on exactly its own category page, unique anchors.
- Hint: names the first error-severity code with a warning-first discriminating case; null on success/warnings-only.
- `_docsDir` union pin.

`tsc --noEmit` clean; 1647 tests pass across `lib/typeChecker` + `lib/cli` locally with no regressions. (The pre-existing warn-mode `settings.agency` fixture warning is unrelated.)

## Non-goals (unchanged from #474/#517)

Parser errors stay code-less; no message-template rewording (that is #518); no `agency doc` integration (these docs are generated from our registry by our build, never user-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
