### PR TITLE
Normalize undefined→null at index and match value sites (#409)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-index-match-null-normalization.md
+++ b/docs/superpowers/plans/2026-07-11-index-match-null-normalization.md
@@ -1,0 +1,451 @@
+# Index/Match `undefined`→`null` Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make missing object-key lookups (`obj[key]`), out-of-bounds array indexing (`arr[i]`), and unmatched `match` expressions yield `null` instead of `undefined`, completing the value-side of Agency's "one nothing-value" invariant.
+
+**Architecture:** Add a tiny `__nn(x) => x ?? null` runtime helper, wired exactly like the existing `__eq` helper. Emit `__nn(...)` around two codegen sites in `typescriptBuilder.ts`: the index access chain element, and the `__matchval_<id>` read that consumes a match result. No type-checker changes — this is a runtime-value fix only.
+
+**Tech Stack:** TypeScript (compiler + runtime), typestache templates (`pnpm run templates`), vitest (unit + integration tests), Agency execution tests under `tests/agency-js/`.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-index-match-null-normalization-design.md`
+**Issue:** https://github.com/egonSchiele/agency-lang/issues/409
+
+## Global Constraints
+
+- All paths below are relative to `packages/agency-lang/` unless absolute.
+- **Never edit generated `.ts` templates.** `lib/templates/.../imports.ts` is auto-generated from `imports.mustache`; edit the `.mustache` and run `pnpm run templates`.
+- **Rebuild with `make`, not `pnpm run build`** before running Agency/agency-js tests (`pnpm run build` does not copy everything into `dist`).
+- **No dynamic imports. Use `type` not `interface`. Use arrays not sets, objects not maps.**
+- **Agency syntax:** `def foo(x: T): R { ... }`, `node main() { ... }`, `if (cond) { ... }`, declare with `let`/`const`. Verify snippets against `docs/site/guide/basic-syntax.md`.
+- **Do not run the full agency test suite locally** (slow/expensive). Run only the specific new agency-js tests named in this plan, and save output to a file.
+- Work happens on branch `undefined-to-null-indexing` (already created). Do not commit to `main`.
+
+---
+
+### Task 1: `__nn` runtime helper + wiring
+
+Add the nullish-normalize helper and make it importable in generated code. Self-contained and unit-testable before any codegen touches it.
+
+**Files:**
+- Create: `lib/runtime/nn.ts`
+- Create: `lib/runtime/nn.test.ts`
+- Modify: `lib/runtime/index.ts:151` (add export beside `__eq`)
+- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache:25` (add `__nn` to the import list)
+
+**Interfaces:**
+- Produces: `export function __nn<T>(x: T): T | null` — returns `null` for `null`/`undefined`, `x` unchanged otherwise. Later tasks emit it as `ts.call(ts.id("__nn"), [expr])`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `lib/runtime/nn.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { __nn } from "./nn.js";
+
+describe("__nn", () => {
+  it("collapses undefined and null to null", () => {
+    expect(__nn(undefined)).toBe(null);
+    expect(__nn(null)).toBe(null);
+  });
+
+  it("passes non-nullish values through unchanged, including falsy ones", () => {
+    expect(__nn(0)).toBe(0);
+    expect(__nn("")).toBe("");
+    expect(__nn(false)).toBe(false);
+    expect(__nn(5)).toBe(5);
+    expect(__nn("a")).toBe("a");
+    expect(Number.isNaN(__nn(NaN))).toBe(true);
+  });
+
+  it("returns the same object reference for objects", () => {
+    const obj = { x: 1 };
+    expect(__nn(obj)).toBe(obj);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run lib/runtime/nn.test.ts 2>&1 | tee /tmp/nn-test.log`
+Expected: FAIL — cannot resolve `./nn.js` (module does not exist yet).
+
+- [ ] **Step 3: Create the helper**
+
+Create `lib/runtime/nn.ts`:
+
+```ts
+/**
+ * Nullish-normalize: collapse `undefined` into Agency's single nothing-value,
+ * `null`. Wraps the value sites where the JS runtime produces `undefined`
+ * (missing object key, out-of-bounds index, unmatched `match`) so the
+ * "only null exists" invariant holds at the value level, not just at `__eq`.
+ *
+ * `x ?? null` returns `null` for `null`/`undefined` and `x` unchanged for every
+ * other value (including `0`, `""`, `false`, `NaN`). The operand is evaluated
+ * exactly once, so wrapping a side-effecting expression is safe.
+ *
+ * See docs/dev/null-and-undefined.md.
+ */
+export function __nn<T>(x: T): T | null {
+  return x ?? null;
+}
+```
+
+- [ ] **Step 4: Export it from the runtime barrel**
+
+In `lib/runtime/index.ts`, directly below the existing `export { __eq } from "./eq.js";` (line 151), add:
+
+```ts
+export { __nn } from "./nn.js";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run lib/runtime/nn.test.ts 2>&1 | tee /tmp/nn-test.log`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Add `__nn` to the generated-code import list**
+
+In `lib/templates/backends/typescriptGenerator/imports.mustache`, line 25 currently reads:
+
+```
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+```
+
+Change the trailing `__eq,` to `__eq, __nn,`:
+
+```
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+```
+
+- [ ] **Step 7: Regenerate the template and rebuild**
+
+Run: `pnpm run templates && make 2>&1 | tail -20 | tee /tmp/build.log`
+Then verify `__nn` landed in the generated import list:
+Run: `grep -n "__nn" lib/templates/backends/typescriptGenerator/imports.ts`
+Expected: one match, showing `__nn` in the destructured import from `agency-lang/runtime`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/runtime/nn.ts lib/runtime/nn.test.ts lib/runtime/index.ts \
+  lib/templates/backends/typescriptGenerator/imports.mustache \
+  lib/templates/backends/typescriptGenerator/imports.ts
+git commit -m "Add __nn nullish-normalize runtime helper (#409)"
+```
+
+---
+
+### Task 2: Coerce index reads to `null`
+
+Wrap the index access-chain codegen in `__nn(...)` so both `obj[key]` (missing key) and `arr[i]` (out of bounds) yield `null`.
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts:1107` (the `case "index":` in `processValueAccess`)
+- Create: `tests/agency-js/index-missing-key-null/agent.agency`
+- Create: `tests/agency-js/index-missing-key-null/test.js`
+- Create: `tests/agency-js/index-missing-key-null/fixture.json`
+
+**Interfaces:**
+- Consumes: `__nn` from Task 1, emitted as `ts.call(ts.id("__nn"), [ ... ])`.
+
+- [ ] **Step 1: Write the failing execution test**
+
+Create `tests/agency-js/index-missing-key-null/agent.agency`:
+
+```
+node lookups() {
+  const obj: Record<string, number> = { present: 42 }
+  const arr = [1, 2, 3]
+  const zero: Record<string, number> = { z: 0 }
+  return {
+    missingKey: obj["absent"],
+    presentKey: obj["present"],
+    outOfBounds: arr[10],
+    inBounds: arr[0],
+    falsyZero: zero["z"]
+  }
+}
+```
+
+Create `tests/agency-js/index-missing-key-null/test.js`:
+
+```js
+import { lookups } from "./agent.js";
+import { writeFileSync } from "fs";
+
+const r = (await lookups()).data;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      missingKeyIsNull: r.missingKey === null,
+      outOfBoundsIsNull: r.outOfBounds === null,
+      presentKeyValue: r.presentKey,
+      inBoundsValue: r.inBounds,
+      falsyZeroPreserved: r.falsyZero === 0,
+    },
+    null,
+    2,
+  ),
+);
+```
+
+Create `tests/agency-js/index-missing-key-null/fixture.json`:
+
+```json
+{
+  "missingKeyIsNull": true,
+  "outOfBoundsIsNull": true,
+  "presentKeyValue": 42,
+  "inBoundsValue": 1,
+  "falsyZeroPreserved": true
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/index-missing-key-null 2>&1 | tee /tmp/index-test.log`
+Expected: FAIL — `missingKeyIsNull` and `outOfBoundsIsNull` come back `false` (the raw value is `undefined`, and `undefined === null` is `false`), so `__result.json` differs from `fixture.json`.
+
+- [ ] **Step 3: Wrap the index codegen in `__nn`**
+
+In `lib/backends/typescriptBuilder.ts`, `processValueAccess`, the `case "index":` (line ~1107) currently reads:
+
+```ts
+        case "index":
+          result = ts.index(result, this.processNode(element.index), {
+            optional: element.optional,
+          });
+          break;
+```
+
+Change it to wrap the built index node in `__nn`:
+
+```ts
+        case "index":
+          result = ts.call(ts.id("__nn"), [
+            ts.index(result, this.processNode(element.index), {
+              optional: element.optional,
+            }),
+          ]);
+          break;
+```
+
+Leave the assignment-LHS index emitter (`lib/backends/typescriptBuilder/assignmentEmitter.ts:104`) untouched — it is a write target, not a value read.
+
+- [ ] **Step 4: Rebuild the compiler**
+
+Run: `make 2>&1 | tail -20 | tee /tmp/build.log`
+Expected: build succeeds.
+
+- [ ] **Step 5: Run the execution test to verify it passes**
+
+Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/index-missing-key-null 2>&1 | tee /tmp/index-test.log`
+Expected: PASS — `__result.json` matches `fixture.json` (all booleans `true`, values `42`/`1`).
+
+- [ ] **Step 6: Regenerate integration fixtures and review the diff**
+
+Run: `make fixtures 2>&1 | tail -20`
+Run: `git status --short tests/typescriptGenerator/ && git diff tests/typescriptGenerator/ | head -80`
+Expected: `.mjs` fixtures that use indexing now show index expressions wrapped as `__nn(...)`. Confirm the ONLY change is added `__nn(...)` wrappers around index/subscript expressions — no unrelated churn.
+
+- [ ] **Step 7: Run the codegen integration tests**
+
+Run: `pnpm exec vitest run lib/backends/typescriptGenerator.integration.test.ts lib/backends/typescriptBuilder.integration.test.ts 2>&1 | tee /tmp/integration.log`
+Expected: PASS (fixtures now match the new codegen).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder.ts tests/agency-js/index-missing-key-null tests/typescriptGenerator
+git commit -m "Coerce index reads to null via __nn (#409)"
+```
+
+---
+
+### Task 3: Coerce `match` results to `null`
+
+Coerce the single `__matchval_<id>` read chokepoint so every unmatched-`match` path yields `null`, and make a valueless `yield` emit `null` at the source.
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts:1024` (the `isMatchValName` read branch)
+- Modify: `lib/backends/typescriptBuilder.ts:1520` (valueless-`yield` fallback)
+- Create: `tests/agency-js/match-no-arm-null/agent.agency`
+- Create: `tests/agency-js/match-no-arm-null/test.js`
+- Create: `tests/agency-js/match-no-arm-null/fixture.json`
+
+**Interfaces:**
+- Consumes: `__nn` from Task 1.
+
+- [ ] **Step 1: Write the failing execution test**
+
+The design relies on the fact (confirmed in `lib/typeChecker/matchExhaustiveness.ts`, `missingCases`) that a `match` over an **open** type like `string` is never required to be exhaustive, so this compiles cleanly at the default `matchExhaustiveness: "error"` — no config override needed. At runtime the unmatched scrutinee falls through and (pre-fix) yields `undefined`.
+
+Create `tests/agency-js/match-no-arm-null/agent.agency`:
+
+```
+node classify(s: string) {
+  const result = match (s) {
+    "a" => "got-a"
+    "b" => "got-b"
+  }
+  return result
+}
+```
+
+Create `tests/agency-js/match-no-arm-null/test.js`:
+
+```js
+import { classify } from "./agent.js";
+import { writeFileSync } from "fs";
+
+const matched = (await classify("a")).data;
+const unmatched = (await classify("z")).data;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      matchedValue: matched,
+      unmatchedIsNull: unmatched === null,
+    },
+    null,
+    2,
+  ),
+);
+```
+
+Create `tests/agency-js/match-no-arm-null/fixture.json`:
+
+```json
+{
+  "matchedValue": "got-a",
+  "unmatchedIsNull": true
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/match-no-arm-null 2>&1 | tee /tmp/match-test.log`
+Expected: FAIL — `unmatchedIsNull` comes back `false` (the match result is `undefined`).
+
+- [ ] **Step 3: Coerce the match-result read**
+
+In `lib/backends/typescriptBuilder.ts`, the `isMatchValName` branch (line ~1024) currently reads:
+
+```ts
+          if (!isBuiltinVar && !isLoopVar && isMatchValName(literal.value)) {
+            return ts.scopedVar(literal.value, "local", this.moduleId);
+          }
+```
+
+Wrap the resolved read in `__nn`:
+
+```ts
+          if (!isBuiltinVar && !isLoopVar && isMatchValName(literal.value)) {
+            return ts.call(ts.id("__nn"), [
+              ts.scopedVar(literal.value, "local", this.moduleId),
+            ]);
+          }
+```
+
+- [ ] **Step 4: Make a valueless `yield` emit `null` at the source**
+
+In `lib/backends/typescriptBuilder.ts`, `processMatchYield` (line ~1520) currently reads:
+
+```ts
+    const value = node.value
+      ? this.processNode(node.value)
+      : ts.id("undefined");
+```
+
+Change the fallback from `undefined` to `null`:
+
+```ts
+    const value = node.value
+      ? this.processNode(node.value)
+      : ts.id("null");
+```
+
+- [ ] **Step 5: Rebuild the compiler**
+
+Run: `make 2>&1 | tail -20 | tee /tmp/build.log`
+Expected: build succeeds.
+
+- [ ] **Step 6: Run the execution test to verify it passes**
+
+Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/match-no-arm-null 2>&1 | tee /tmp/match-test.log`
+Expected: PASS — `matchedValue` is `"got-a"`, `unmatchedIsNull` is `true`.
+
+- [ ] **Step 7: Regenerate integration fixtures and review the diff**
+
+Run: `make fixtures 2>&1 | tail -20`
+Run: `git diff tests/typescriptGenerator/ | head -80`
+Expected: `.mjs` fixtures that read a match-expression result (e.g. `matchExpression.mjs`, `matchBlock.mjs`) now show the `__matchval_<id>` read wrapped as `__nn(...)`, and any valueless-yield fallback now emits `null`. Confirm no unrelated churn.
+
+- [ ] **Step 8: Run the codegen integration tests**
+
+Run: `pnpm exec vitest run lib/backends/typescriptGenerator.integration.test.ts lib/backends/typescriptBuilder.integration.test.ts 2>&1 | tee /tmp/integration.log`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder.ts tests/agency-js/match-no-arm-null tests/typescriptGenerator
+git commit -m "Coerce match results to null via __nn (#409)"
+```
+
+---
+
+### Task 4: Update documentation
+
+Record that index and match value sites are now normalized, so the "known and unfixed" leak list in the design doc no longer misstates the behavior.
+
+**Files:**
+- Modify: `docs/dev/null-and-undefined.md`
+
+- [ ] **Step 1: Update the leak-list note**
+
+In `docs/dev/null-and-undefined.md`, in the section "The key fact that constrains the design" (the bulleted list around lines 108-113 that begins "a missing object key reads as `undefined`"), add a sentence after the list noting that Agency now normalizes these two sites at the value level:
+
+```markdown
+As of the index/match normalization work (issue #409), the two most common of
+these — a missing object key / out-of-bounds index (`obj[key]`, `arr[i]`) and an
+unmatched `match` expression — are wrapped in the `__nn` runtime helper
+(`x ?? null`), so they yield `null` rather than `undefined` as an observable
+value. The remaining leak sites (optional chaining, destructuring a missing
+field, falling off a function without `return`, and TypeScript interop) are not
+yet normalized and are tracked as follow-ups.
+```
+
+- [ ] **Step 2: Note the value-side completion in the equality section**
+
+In the same doc, in the "Relationship to null safety" section, verify the text does not claim `undefined` is fully absorbed everywhere; if it overstates, adjust to reference `__nn` covering index/match value sites in addition to `__eq` covering comparisons. (If the existing wording is already accurate, leave it — no edit required.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/null-and-undefined.md
+git commit -m "Document index/match null normalization (#409)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `__nn` helper + wiring → Task 1. ✅
+- Fix 1, index reads (issue #1 object missing key + #2 array OOB, shared site) → Task 2. ✅
+- Fix 2, match no-arm (all three paths via the read chokepoint) + valueless-yield source → Task 3. ✅
+- Non-goal: no type-checker change → no task touches `lib/typeChecker/`. ✅
+- Non-goal: match-comparison `===` unchanged → not touched. ✅
+- Testing: falsy-passthrough guard (`0`/`""`/`false`/`NaN`) in Task 1 unit test + `falsyZero`/`presentKey` in Task 2; `=== null` JS observation (not `==`, which `__eq` blinds) in Tasks 2-3; matched-arm-still-returns-value in Task 3. ✅
+- Docs + fixture rebuild note → Task 4 + `make fixtures` steps in Tasks 2-3. ✅
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows full content. ✅
+
+**Type consistency:** `__nn<T>(x: T): T | null` defined in Task 1; emitted identically as `ts.call(ts.id("__nn"), [expr])` in Tasks 2-3. Test helper accessor `.data` matches the `categorize` agency-js precedent. ✅

--- a/docs/superpowers/plans/2026-07-11-index-match-null-normalization.md
+++ b/docs/superpowers/plans/2026-07-11-index-match-null-normalization.md
@@ -4,7 +4,11 @@
 
 **Goal:** Make missing object-key lookups (`obj[key]`), out-of-bounds array indexing (`arr[i]`), and unmatched `match` expressions yield `null` instead of `undefined`, completing the value-side of Agency's "one nothing-value" invariant.
 
-**Architecture:** Add a tiny `__nn(x) => x ?? null` runtime helper, wired exactly like the existing `__eq` helper. Emit `__nn(...)` around two codegen sites in `typescriptBuilder.ts`: the index access chain element, and the `__matchval_<id>` read that consumes a match result. No type-checker changes — this is a runtime-value fix only.
+**Architecture:** Add a tiny `__nn(x) => x ?? null` runtime helper, wired exactly like the existing `__eq` helper. Emit `__nn(...)` around two codegen sites in `typescriptBuilder.ts`: the **terminal** index read of an access chain (wrapped once, after the chain is built — NOT per index element), and the `__matchval_<id>` read that consumes a match result. No type-checker changes — this is a runtime-value fix only.
+
+**Why terminal-only for index reads:** Wrapping each `case "index"` element individually inserts `__nn` *between* an optional index and any following access, which captures JS optional-chain short-circuit and turns it into a thrown `TypeError`. Concretely, `a?.[b].c` with a null `a` currently yields `undefined` (whole-chain short-circuit); `__nn(a?.[b]).c` would evaluate `null.c` and throw. Wrapping only the completed chain when its last element is an index avoids this, still normalizes the terminal missing-key / out-of-bounds read to `null`, and emits one `__nn(...)` per read instead of nested `__nn(__nn(...))`.
+
+**Coercion caveat (intended):** `null` and `undefined` coerce differently in arithmetic (`undefined + 1` is `NaN`; `null + 1` is `1`) and string contexts (`` `${undefined}` `` is `"undefined"`; `` `${null}` `` is `"null"`). The string-context change is the fix the issue wants. The arithmetic change is a deliberate side effect of collapsing to one nothing-value; it is consistent with Agency's model (do not do math on a missing key) and introduces no new nullish value that was not already there.
 
 **Tech Stack:** TypeScript (compiler + runtime), typestache templates (`pnpm run templates`), vitest (unit + integration tests), Agency execution tests under `tests/agency-js/`.
 
@@ -138,12 +142,12 @@ git commit -m "Add __nn nullish-normalize runtime helper (#409)"
 
 ---
 
-### Task 2: Coerce index reads to `null`
+### Task 2: Coerce the terminal index read to `null`
 
-Wrap the index access-chain codegen in `__nn(...)` so both `obj[key]` (missing key) and `arr[i]` (out of bounds) yield `null`.
+Wrap the completed access chain in `__nn(...)` when its last element is an index, so both `obj[key]` (missing key) and `arr[i]` (out of bounds) yield `null` as a consumed value.
 
 **Files:**
-- Modify: `lib/backends/typescriptBuilder.ts:1107` (the `case "index":` in `processValueAccess`)
+- Modify: `lib/backends/typescriptBuilder.ts:1154` (the `return result;` tail of `processValueAccess`)
 - Create: `tests/agency-js/index-missing-key-null/agent.agency`
 - Create: `tests/agency-js/index-missing-key-null/test.js`
 - Create: `tests/agency-js/index-missing-key-null/fixture.json`
@@ -164,19 +168,34 @@ node lookups() {
     missingKey: obj["absent"],
     presentKey: obj["present"],
     outOfBounds: arr[10],
+    negativeIndex: arr[-1],
     inBounds: arr[0],
     falsyZero: zero["z"]
   }
+}
+
+// Regression guard for the terminal-only wrap decision (Step 3). `a` is null, so
+// `a?.["x"]` short-circuits and `["y"]` is never evaluated: with terminal-only
+// wrapping the whole chain is `__nn(a?.["x"]["y"])` → null (NO throw). If the fix
+// ever regresses to per-element wrapping it becomes `__nn(__nn(a?.["x"])["y"])` →
+// `null["y"]` → THROWS, and this node crashes the test.
+node optChainNoThrow() {
+  const a: Record<string, Record<string, number>> | null = null
+  return { deep: a?.["x"]["y"] }
 }
 ```
 
 Create `tests/agency-js/index-missing-key-null/test.js`:
 
 ```js
-import { lookups } from "./agent.js";
+import { lookups, optChainNoThrow } from "./agent.js";
 import { writeFileSync } from "fs";
 
 const r = (await lookups()).data;
+
+// Must not throw. With per-element wrapping this call crashes (null["y"]);
+// with terminal-only wrapping `deep` is null and this resolves cleanly.
+const opt = (await optChainNoThrow()).data;
 
 writeFileSync(
   "__result.json",
@@ -184,9 +203,11 @@ writeFileSync(
     {
       missingKeyIsNull: r.missingKey === null,
       outOfBoundsIsNull: r.outOfBounds === null,
+      negativeIndexIsNull: r.negativeIndex === null,
       presentKeyValue: r.presentKey,
       inBoundsValue: r.inBounds,
       falsyZeroPreserved: r.falsyZero === 0,
+      optChainDeepIsNull: opt.deep === null,
     },
     null,
     2,
@@ -200,42 +221,54 @@ Create `tests/agency-js/index-missing-key-null/fixture.json`:
 {
   "missingKeyIsNull": true,
   "outOfBoundsIsNull": true,
+  "negativeIndexIsNull": true,
   "presentKeyValue": 42,
   "inBoundsValue": 1,
-  "falsyZeroPreserved": true
+  "falsyZeroPreserved": true,
+  "optChainDeepIsNull": true
 }
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/index-missing-key-null 2>&1 | tee /tmp/index-test.log`
-Expected: FAIL — `missingKeyIsNull` and `outOfBoundsIsNull` come back `false` (the raw value is `undefined`, and `undefined === null` is `false`), so `__result.json` differs from `fixture.json`.
+Expected: FAIL — `missingKeyIsNull`, `outOfBoundsIsNull`, and `negativeIndexIsNull` come back `false` (the raw value is `undefined`, and `undefined === null` is `false`), so `__result.json` differs from `fixture.json`.
 
-- [ ] **Step 3: Wrap the index codegen in `__nn`**
+- [ ] **Step 3: Normalize the terminal index read to `null`**
 
-In `lib/backends/typescriptBuilder.ts`, `processValueAccess`, the `case "index":` (line ~1107) currently reads:
+Do NOT wrap inside `case "index":`. Wrapping each index element inserts `__nn` *between* an optional index and any following access, which captures JS optional-chain short-circuit and converts it to a thrown `TypeError` (e.g. `a?.[b].c` with a null `a` goes from `undefined` to `null.c` → throw). Instead, leave `case "index":` exactly as-is and normalize once, after the chain is built, when the chain's last element is an index (a value read).
 
-```ts
-        case "index":
-          result = ts.index(result, this.processNode(element.index), {
-            optional: element.optional,
-          });
-          break;
-```
-
-Change it to wrap the built index node in `__nn`:
+In `lib/backends/typescriptBuilder.ts`, `processValueAccess`, the chain loop currently ends (line ~1153-1154):
 
 ```ts
-        case "index":
-          result = ts.call(ts.id("__nn"), [
-            ts.index(result, this.processNode(element.index), {
-              optional: element.optional,
-            }),
-          ]);
-          break;
+      }
+    }
+    return result;
+  }
 ```
 
-Leave the assignment-LHS index emitter (`lib/backends/typescriptBuilder/assignmentEmitter.ts:104`) untouched — it is a write target, not a value read.
+Change the tail so a terminal index read is wrapped in `__nn`:
+
+```ts
+      }
+    }
+    const lastElement = node.chain[node.chain.length - 1];
+    if (lastElement?.kind === "index") {
+      return ts.call(ts.id("__nn"), [result]);
+    }
+    return result;
+  }
+```
+
+This normalizes the observable value of a terminal `obj[key]` / `arr[i]` read (missing key, out of bounds, negative) to `null`, while:
+- preserving JS short-circuit *within* the chain (no mid-chain `__nn`), so `a?.[b].c` is unchanged and does not throw;
+- leaving intermediate missing reads to throw exactly as today (`obj[a][b]` where `obj[a]` is missing throws before the terminal `__nn` runs);
+- emitting a single `__nn(...)` per read instead of nested `__nn(__nn(...))`.
+
+**Explicitly untouched (intentionally left raw):**
+- Property-terminal chains (`obj.foo`) are out of scope — the guard fires only when the last element is an `index`.
+- The assignment-LHS index emitter (`lib/backends/typescriptBuilder/assignmentEmitter.ts:105`) is a write target, not a value read.
+- The two compiler-internal `ts.index` sites — `stackBranches[branchKey]` (`typescriptBuilder.ts:398`) and the for-in `keys[i]` iterator (`typescriptBuilder.ts:3672`) — index known-present keys and never surface an observable `undefined`.
 
 - [ ] **Step 4: Rebuild the compiler**
 
@@ -251,7 +284,11 @@ Expected: PASS — `__result.json` matches `fixture.json` (all booleans `true`, 
 
 Run: `make fixtures 2>&1 | tail -20`
 Run: `git status --short tests/typescriptGenerator/ && git diff tests/typescriptGenerator/ | head -80`
-Expected: `.mjs` fixtures that use indexing now show index expressions wrapped as `__nn(...)`. Confirm the ONLY change is added `__nn(...)` wrappers around index/subscript expressions — no unrelated churn.
+Expected: `.mjs` fixtures that end a value read on an index now show that read wrapped as `__nn(...)`, exactly once per terminal read (no nested `__nn(__nn(...))`). Two guards to confirm in the diff:
+- No `__nn` appears *between* an optional index and a following access (grep the diff for `__nn(` immediately followed by `)?.` or `).` on a chain — there should be none). This is the regression the terminal-only wrap exists to avoid.
+- Property-terminal chains (`obj.foo`), assignment LHS (`arr[i] = ...`), and for-in `keys[i]` iterators are unchanged.
+
+Confirm no other unrelated churn.
 
 - [ ] **Step 7: Run the codegen integration tests**
 
@@ -283,7 +320,9 @@ Coerce the single `__matchval_<id>` read chokepoint so every unmatched-`match` p
 
 - [ ] **Step 1: Write the failing execution test**
 
-The design relies on the fact (confirmed in `lib/typeChecker/matchExhaustiveness.ts`, `missingCases`) that a `match` over an **open** type like `string` is never required to be exhaustive, so this compiles cleanly at the default `matchExhaustiveness: "error"` — no config override needed. At runtime the unmatched scrutinee falls through and (pre-fix) yields `undefined`.
+The design relies on the fact (confirmed in `lib/typeChecker/matchExhaustiveness.ts:181`, `missingCases` returns `[]` when `!caseSet.closed`) that a `match` over an **open** type like `string` is never required to be exhaustive, so this compiles cleanly at the default `matchExhaustiveness: "error"` — no config override needed. At runtime the unmatched scrutinee falls through and (pre-fix) yields `undefined`.
+
+Note: this **supersedes** the spec (case 4), which suggested setting `matchExhaustiveness: "warn"`. That override is unnecessary for an open scrutinee type — do not add it, and do not "fix" this test by adding one.
 
 Create `tests/agency-js/match-no-arm-null/agent.agency`:
 
@@ -295,16 +334,32 @@ node classify(s: string) {
   }
   return result
 }
+
+// Guards spec case 5: an arm that genuinely yields `null` must stay `null` (no
+// double-coercion surprise), and a real-valued arm passes through `__nn`
+// unchanged. `classifyNullable("z")` also exercises the no-arm path alongside an
+// explicit null arm so the two null sources are not conflated.
+node classifyNullable(s: string) {
+  const result = match (s) {
+    "a" => "got-a"
+    "n" => null
+  }
+  return result
+}
 ```
 
 Create `tests/agency-js/match-no-arm-null/test.js`:
 
 ```js
-import { classify } from "./agent.js";
+import { classify, classifyNullable } from "./agent.js";
 import { writeFileSync } from "fs";
 
 const matched = (await classify("a")).data;
 const unmatched = (await classify("z")).data;
+
+const realArm = (await classifyNullable("a")).data;
+const nullArm = (await classifyNullable("n")).data;
+const noArm = (await classifyNullable("z")).data;
 
 writeFileSync(
   "__result.json",
@@ -312,6 +367,9 @@ writeFileSync(
     {
       matchedValue: matched,
       unmatchedIsNull: unmatched === null,
+      realArmValue: realArm,
+      nullArmIsNull: nullArm === null,
+      noArmIsNull: noArm === null,
     },
     null,
     2,
@@ -324,14 +382,17 @@ Create `tests/agency-js/match-no-arm-null/fixture.json`:
 ```json
 {
   "matchedValue": "got-a",
-  "unmatchedIsNull": true
+  "unmatchedIsNull": true,
+  "realArmValue": "got-a",
+  "nullArmIsNull": true,
+  "noArmIsNull": true
 }
 ```
 
 - [ ] **Step 2: Run the test to verify it fails**
 
 Run: `AGENCY_USE_TEST_LLM_PROVIDER=1 pnpm run agency test js tests/agency-js/match-no-arm-null 2>&1 | tee /tmp/match-test.log`
-Expected: FAIL — `unmatchedIsNull` comes back `false` (the match result is `undefined`).
+Expected: FAIL — the two no-arm paths, `unmatchedIsNull` and `noArmIsNull`, come back `false` (their match result is `undefined`). Note `nullArmIsNull` and `realArmValue` already pass pre-fix (an explicit `null` arm is already `null`, and a real arm is unchanged) — they are passthrough guards proving the fix does not disturb matched values, not failing cases.
 
 - [ ] **Step 3: Coerce the match-result read**
 
@@ -439,12 +500,21 @@ git commit -m "Document index/match null normalization (#409)"
 
 **Spec coverage:**
 - `__nn` helper + wiring → Task 1. ✅
-- Fix 1, index reads (issue #1 object missing key + #2 array OOB, shared site) → Task 2. ✅
+- Fix 1, index reads (issue #1 object missing key + #2 array OOB + negative, shared terminal site) → Task 2. ✅
 - Fix 2, match no-arm (all three paths via the read chokepoint) + valueless-yield source → Task 3. ✅
 - Non-goal: no type-checker change → no task touches `lib/typeChecker/`. ✅
 - Non-goal: match-comparison `===` unchanged → not touched. ✅
 - Testing: falsy-passthrough guard (`0`/`""`/`false`/`NaN`) in Task 1 unit test + `falsyZero`/`presentKey` in Task 2; `=== null` JS observation (not `==`, which `__eq` blinds) in Tasks 2-3; matched-arm-still-returns-value in Task 3. ✅
+- Regression guard for the terminal-only decision: `optChainNoThrow` (`a?.["x"]["y"]` with null `a`) in Task 2 — CI-fails (throws) if the fix regresses to per-element wrapping. Emitted shape verified as a single chain `a?.["x"]["y"]` against a fresh build. ✅
+- Spec case 5 (arm genuinely yields `null`; real arm unchanged; no double-coercion) → `classifyNullable` in Task 3. ✅
+- Known coverage limits (accepted): the plain-mode / handler-body match read path funnels through the same `isMatchValName` chokepoint (verified — `processMatchExpressionPlain` writes `__matchval_<id>` that "the consumer reads"), so it is covered by the fix but exercised only indirectly. The valueless-`yield` source change (Task 3 Step 4) is masked by the read-site wrap and cannot be isolated by a runtime test; it is defense-in-depth, not independently asserted. ✅
 - Docs + fixture rebuild note → Task 4 + `make fixtures` steps in Tasks 2-3. ✅
+
+**Altitude / regression review:**
+- Index normalization is emitted once, at the **terminal** index read (chain tail), not per index element. This preserves JS optional-chain short-circuit inside a chain (`a?.[b].c` does not throw) and avoids nested `__nn(__nn(...))`. The "how" (nullish-normalize) stays encapsulated in the single `__nn` helper; the codegen only declares *where* to normalize. ✅
+- All four `ts.index(` emit sites accounted for: terminal user read (wrapped), assignment LHS + `stackBranches[branchKey]` + for-in `keys[i]` (intentionally raw, named in Task 2 Step 3). ✅
+- Coercion-profile change (`null` vs `undefined` in arithmetic/string) is a deliberate, documented consequence — Architecture "Coercion caveat". ✅
+- Divergence from spec case 4 (`matchExhaustiveness: "warn"`) is intentional and flagged in Task 3 Step 1. ✅
 
 **Placeholder scan:** No TBD/TODO/"handle edge cases"; every code step shows full content. ✅
 

--- a/docs/superpowers/specs/2026-07-11-index-match-null-normalization-design.md
+++ b/docs/superpowers/specs/2026-07-11-index-match-null-normalization-design.md
@@ -1,0 +1,207 @@
+# Normalize `undefined` → `null` at index and match value sites
+
+**Issue:** [#409](https://github.com/egonSchiele/agency-lang/issues/409) — "object lookup with missing key should yield null (not undefined)"
+
+**Status:** Design approved; ready for implementation plan.
+
+## Problem
+
+Agency has exactly one nothing-value: `null`. Users cannot write `undefined`, and
+`docs/dev/null-and-undefined.md` commits the language to *absorbing* any `undefined`
+that the JS runtime produces into `null` so it is "never a distinct concept a user has
+to reason about."
+
+That absorption was only ever finished on the **comparison** side: `==`/`!=`/`===`/`!==`
+lower to `__eq`, which makes `null == undefined`. The **value** side was left undone.
+So a missing lookup produces a literal `undefined` value that then flows through the
+program — printed, interpolated into strings, stored in threads, serialized to JSON,
+passed to tools — as `undefined`, not `null`:
+
+```ts
+const val = obj[key]   // key not in obj  ->  val === undefined  (should be null)
+```
+
+`__eq` hides this only at comparison sites. Everywhere else the raw `undefined` is
+observable, breaking the "only `null` exists" invariant.
+
+## Scope
+
+This fix covers the two value-leak sites the issue names (the lookup itself and its
+`match` companion):
+
+1. Object missing key — `obj[key]`
+2. Array out-of-bounds — `arr[i]` (shares the same codegen path as #1, so free)
+3. `match` expression with no matching arm (and no `_` wildcard)
+
+**Out of scope** (deferred to follow-up issues; listed in `null-and-undefined.md`):
+optional chaining `a?.b`, destructuring a missing field, a function that falls off the
+end without `return`, and TypeScript-interop returning `undefined`.
+
+## Non-goals
+
+- **No type-checker changes.** Index and match result *types* stay as they are. Making
+  them `T | null` and forcing narrowing is "Project 2" strict null checking
+  (`null-and-undefined.md`, "Relationship to null safety"), a separate effort. Because
+  the value at these sites was already `undefined` — an equally-nullish value — swapping
+  it for `null` introduces no new "possibly null" type errors and no regression.
+- **No change to match arm *comparison*.** Arms compare with raw `===`, so a `null`
+  scrutinee will not match an interop `undefined` case. That is a matching-semantics
+  concern, distinct from the result *value* this fix addresses, and stays as-is.
+
+## Design
+
+### Core mechanism: a `__nn` runtime helper
+
+Add a nullish-normalize helper that mirrors the existing `__eq` helper in structure and
+wiring.
+
+`lib/runtime/nn.ts`:
+
+```ts
+/**
+ * Nullish-normalize: collapse `undefined` into Agency's single nothing-value,
+ * `null`. Wraps the value sites where the JS runtime produces `undefined`
+ * (missing object key, out-of-bounds index, unmatched `match`) so the
+ * "only null exists" invariant holds at the value level, not just at `__eq`.
+ *
+ * `x ?? null` returns `null` for `null`/`undefined` and `x` unchanged for every
+ * other value (including `0`, `""`, `false`, `NaN`). The operand is evaluated
+ * exactly once, so wrapping a side-effecting expression is safe.
+ *
+ * See docs/dev/null-and-undefined.md.
+ */
+export function __nn<T>(x: T): T | null {
+  return x ?? null;
+}
+```
+
+Wiring (identical to `__eq`'s three touch points):
+
+- Export from `lib/runtime/index.ts` (`export { __nn } from "./nn.js";`).
+- Add `__nn` to the runtime import list in
+  `lib/templates/backends/typescriptGenerator/imports.ts`.
+- Emit at call sites as `ts.call(ts.id("__nn"), [expr])`.
+
+A helper is chosen over an inline `(expr ?? null)` for consistency with `__eq`: it is
+greppable, centralizes the semantics in one documented place, and reads in generated
+code the same way comparisons already do.
+
+### Fix 1 — index reads (issue sites #1 and #2)
+
+In `lib/backends/typescriptBuilder.ts`, `processValueAccess`, the `case "index"` at
+line ~1116:
+
+```ts
+// before
+result = ts.index(result, this.processNode(element.index), {
+  optional: element.optional,
+});
+
+// after
+result = ts.call(ts.id("__nn"), [
+  ts.index(result, this.processNode(element.index), {
+    optional: element.optional,
+  }),
+]);
+```
+
+Because object subscript `obj[key]` and array subscript `arr[i]` parse to the same
+`{ kind: "index" }` access-chain element and compile through this one branch, both the
+missing-key and out-of-bounds cases are fixed together.
+
+Intermediate steps in a longer chain are wrapped too — `obj[a][b]` becomes
+`__nn(__nn(obj[a])[b])`. This is harmless: if `obj[a]` is missing, `__nn` yields `null`
+and the subsequent `[b]` throws exactly as it would have thrown on `undefined`, only
+with a `null`-worded message. The optional form `obj?.[key]` is likewise wrapped, so a
+short-circuited optional index also normalizes to `null`.
+
+**Explicitly untouched:** the index in an assignment LHS chain
+(`lib/backends/typescriptBuilder/assignmentEmitter.ts:104`, `arr[i] = x`) is a write
+target, not a value read, and stays raw.
+
+### Fix 2 — `match` with no matching arm (companion)
+
+The exploration found three distinct paths that can produce `undefined` from a `match`
+expression, but they all funnel through a single **read** chokepoint: the
+`isMatchValName` branch in `typescriptBuilder.ts` (~line 1034) that resolves a
+`__matchval_<id>` reference to the frame-local where `runner.exitMatch` stored the arm
+value. Coercing there covers every path at once:
+
+```ts
+// before
+if (!isBuiltinVar && !isLoopVar && isMatchValName(literal.value)) {
+  return ts.scopedVar(literal.value, "local", this.moduleId);
+}
+
+// after
+if (!isBuiltinVar && !isLoopVar && isMatchValName(literal.value)) {
+  return ts.call(ts.id("__nn"), [
+    ts.scopedVar(literal.value, "local", this.moduleId),
+  ]);
+}
+```
+
+This single site handles:
+
+- the stepped match expression whose temp is never written because no arm matched;
+- the plain-mode (handler-body) expression match whose async IIFE returns `undefined`
+  when no branch matched, then stores that into the same temp;
+- the ordinary resolved read of a matched value (unchanged behavior — a real value
+  passes through `__nn` untouched; a matched `null` stays `null`).
+
+Additionally, change the valueless-`yield` emission at `typescriptBuilder.ts:1519` from
+`ts.id("undefined")` to `ts.id("null")`, so an explicit bare `yield` reads `null` at the
+source rather than relying only on the read-site coercion.
+
+This is a runtime safety net. A well-typed match is either exhaustive (no fallthrough
+possible) or carries a `_` arm (always matches); the no-arm-yields-`undefined` case only
+arises when `matchExhaustiveness` is set to `warn`/`off`. The fix ensures that even then,
+the leaked value is `null`.
+
+## Testing
+
+Agency execution tests (`tests/agency/`, `tests/agency-js/`) — no LLM calls required.
+
+The subtlety: `__eq` makes `null == undefined`, so the difference cannot be observed with
+Agency `==`. Tests must inspect the raw value another way:
+
+- **agency-js test** asserting the returned value is strictly `=== null` in JS. This is
+  the definitive check and the primary test vehicle.
+- **JSON-shape** cross-check where useful: `{ a: null }` survives `JSON.stringify` as
+  `{"a":null}`, whereas an `undefined`-valued key vanishes.
+
+Cases to cover:
+
+1. Object literal indexed by a key that is absent → `null`.
+2. Array indexed out of bounds (index ≥ length, and negative) → `null`.
+3. A present key / in-bounds index returns its real value unchanged (including
+   falsy values `0`, `""`, `false` — these must NOT be coerced to `null`).
+4. A non-exhaustive `match` expression with no `_` arm, evaluated with
+   `matchExhaustiveness: "warn"` so codegen runs, whose scrutinee matches no arm → the
+   match result is `null`.
+5. A `match` arm that genuinely yields `null` still yields `null` (no double-coercion
+   surprise), and an arm yielding a real value returns it unchanged.
+
+Add a `lib/runtime/nn.test.ts` unit test for `__nn` itself mirroring `eq.test.ts`:
+`undefined → null`, `null → null`, and the falsy values `0`/`""`/`false`/`NaN` pass
+through unchanged.
+
+## Files touched
+
+- `lib/runtime/nn.ts` (new) — the helper.
+- `lib/runtime/nn.test.ts` (new) — unit test.
+- `lib/runtime/index.ts` — export `__nn`.
+- `lib/templates/backends/typescriptGenerator/imports.ts` — add `__nn` to the emitted
+  import list.
+- `lib/backends/typescriptBuilder.ts` — wrap `case "index"` (~1116); wrap the
+  `isMatchValName` read (~1034); change valueless-yield `undefined`→`null` (~1519).
+- New execution/agency-js tests under `tests/`.
+- `docs/dev/null-and-undefined.md` — note that index and match value sites are now
+  normalized (updating the "known and unfixed" leak list).
+
+## Fixture / build note
+
+`__nn` newly appears in generated code, so integration fixtures under
+`tests/typescriptGenerator/` (and any golden output) that exercise indexing or `match`
+will shift. Rebuild fixtures with `make fixtures` and review the diff — the only expected
+change is index/match expressions gaining a `__nn(...)` wrapper.

--- a/packages/agency-lang/docs/dev/null-and-undefined.md
+++ b/packages/agency-lang/docs/dev/null-and-undefined.md
@@ -122,6 +122,21 @@ The design therefore does not *ignore* `undefined` — it **absorbs** it. `null`
 and `undefined` are made to behave identically everywhere a user can observe
 them, and `undefined` is normalized to `null` where it enters typed data.
 
+As of the index/match normalization work (issue #409), the two most common of
+these value leaks — a missing object key / out-of-bounds index (`obj[key]`,
+`arr[i]`) and an unmatched `match` expression — are normalized to `null` at the
+value level via the `__nn` runtime helper (`x ?? null`). A *terminal* index read
+of an access chain and the `__matchval_<id>` read that consumes a match result
+are wrapped in `__nn`, so they yield `null` rather than `undefined` as an
+observable value. This complements `__eq` (which unifies the two only at
+*comparison* sites) by unifying them at the *value* level too. The wrap is
+terminal-only and skipped for assignment/update targets, so JS optional-chain
+short-circuit is preserved (`a?.[b].c` stays `undefined`, does not throw) and
+lvalues (`x[i]++`, `x[i] += v`) stay valid. The remaining leak sites (optional
+chaining, destructuring a missing field, falling off a function without
+`return`, and TypeScript interop) are not yet normalized and are tracked as
+follow-ups.
+
 ## Alternatives considered
 
 ### A. Full TypeScript parity (keep both, distinct)

--- a/packages/agency-lang/docs/dev/null-and-undefined.md
+++ b/packages/agency-lang/docs/dev/null-and-undefined.md
@@ -132,10 +132,12 @@ observable value. This complements `__eq` (which unifies the two only at
 *comparison* sites) by unifying them at the *value* level too. The wrap is
 terminal-only and skipped for assignment/update targets, so JS optional-chain
 short-circuit is preserved (`a?.[b].c` stays `undefined`, does not throw) and
-lvalues (`x[i]++`, `x[i] += v`) stay valid. The remaining leak sites (optional
-chaining, destructuring a missing field, falling off a function without
-`return`, and TypeScript interop) are not yet normalized and are tracked as
-follow-ups.
+lvalues (`x[i]++`, `x[i] += v`) stay valid. An *optional* terminal index
+(`arr?.[i]`) is also left raw, so `?.[]` stays consistent with `?.` property
+access (both yield `undefined` on a null base) — optional chaining as a whole is
+deferred. The remaining leak sites (optional chaining, destructuring a missing
+field, falling off a function without `return`, and TypeScript interop) are not
+yet normalized and are tracked as follow-ups.
 
 ## Alternatives considered
 

--- a/packages/agency-lang/lib/agents/agency-agent/tests/capabilities.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/capabilities.test.json
@@ -154,7 +154,7 @@
     {
       "nodeName": "removeLastFieldDropsEntry",
       "input": "",
-      "expectedOutput": "\"undefined/undefined\"",
+      "expectedOutput": "\"null/null\"",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/lib/agents/agency-agent/tests/settings.test.json
+++ b/packages/agency-lang/lib/agents/agency-agent/tests/settings.test.json
@@ -94,7 +94,7 @@
     {
       "nodeName": "nullEntryAndReservedKeySurviveLoad",
       "input": "",
-      "expectedOutput": "\"undefined/true\"",
+      "expectedOutput": "\"null/true\"",
       "evaluationCriteria": [
         {
           "type": "exact"
@@ -104,7 +104,7 @@
     {
       "nodeName": "dropsBareEmbeddingSlotValue",
       "input": "",
-      "expectedOutput": "\"undefined/opus\"",
+      "expectedOutput": "\"null/opus\"",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1180,9 +1180,15 @@ export class TypeScriptBuilder {
     // `asLValue` skips the wrap when this access is emitted as an
     // assignment/update *target* (`x[i]++`, `x[i] += v`) — `__nn(x[i]) = ...`
     // is not a valid assignment target. Those targets stay raw lvalues.
+    //
+    // An *optional* terminal index (`arr?.[i]`) is left raw: optional chaining
+    // is deliberately deferred (see docs/dev/null-and-undefined.md), so `?.[]`
+    // stays consistent with `?.` property access — both yield `undefined` on a
+    // null base rather than `null`. Only a plain `[i]` — issue #409's actual
+    // target — is normalized.
     // See docs/dev/null-and-undefined.md and issue #409.
     const lastElement = node.chain[node.chain.length - 1];
-    if (!asLValue && lastElement?.kind === "index") {
+    if (!asLValue && lastElement?.kind === "index" && !lastElement.optional) {
       return ts.call(ts.id("__nn"), [result]);
     }
     return result;

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1087,7 +1087,7 @@ export class TypeScriptBuilder {
     return ts.template(parts);
   }
 
-  private processValueAccess(node: ValueAccess): TsNode {
+  private processValueAccess(node: ValueAccess, asLValue = false): TsNode {
     let result = this.processNode(node.base);
     // If the base is a function call, await it before accessing properties/methods
     // on the result. Without this, chaining like getGreeting().trim() would call
@@ -1160,7 +1160,34 @@ export class TypeScriptBuilder {
         }
       }
     }
+    // Normalize the observable value of a *terminal* index read (`obj[key]`,
+    // `arr[i]`) to `null` when the key is missing / index is out of bounds.
+    // Wrap only the completed chain, and only when its last element is an
+    // index: wrapping each `case "index"` element individually would insert
+    // `__nn` *between* an optional index and a following access, capturing JS
+    // optional-chain short-circuit and turning `a?.[b].c` (null `a` → whole-
+    // chain `undefined`) into `null.c` → a thrown TypeError. Intermediate
+    // missing reads still throw exactly as before (the terminal `__nn` runs
+    // last), and the emitted shape is a single `__nn(...)`, never nested.
+    //
+    // `asLValue` skips the wrap when this access is emitted as an
+    // assignment/update *target* (`x[i]++`, `x[i] += v`) — `__nn(x[i]) = ...`
+    // is not a valid assignment target. Those targets stay raw lvalues.
+    // See docs/dev/null-and-undefined.md and issue #409.
+    const lastElement = node.chain[node.chain.length - 1];
+    if (!asLValue && lastElement?.kind === "index") {
+      return ts.call(ts.id("__nn"), [result]);
+    }
     return result;
+  }
+
+  /** Emit an assignment/update *target*. A `valueAccess` target must stay a
+   *  raw lvalue (never `__nn`-wrapped); anything else goes through the normal
+   *  value path. Used by `++`/`--` and compound-assignment (`+=` etc.). */
+  private processAssignTarget(node: Expression): TsNode {
+    return node.type === "valueAccess"
+      ? this.processValueAccess(node, true)
+      : this.processNode(node);
   }
 
   private awaitChainCall(callExpr: TsNode, isLast: boolean): TsNode {
@@ -1180,7 +1207,7 @@ export class TypeScriptBuilder {
       return this.processRegexMatchExpression(node);
     }
     if (node.operator === "++" || node.operator === "--") {
-      return ts.postfix(this.processNode(node.left), node.operator);
+      return ts.postfix(this.processAssignTarget(node.left), node.operator);
     }
     if (node.operator === "typeof" || node.operator === "void") {
       return ts.unaryOp(node.operator, this.processNode(node.right));
@@ -1215,7 +1242,14 @@ export class TypeScriptBuilder {
         `((__v) => (${this.str(setCall)}, __v))(${this.str(newValueExpr)})`,
       );
     }
-    const leftNode = this.processNode(node.left);
+    // For a compound assignment (`x[i] += v`, `??=`, ...) the left operand is
+    // also the assignment target, so it must stay a raw lvalue — never wrapped
+    // in `__nn`. For every other binary operator the left is a plain value read
+    // and follows the normal (terminal-index-normalizing) path.
+    const leftNode =
+      COMPOUND_ASSIGN_TO_BINARY[node.operator] !== undefined
+        ? this.processAssignTarget(node.left)
+        : this.processNode(node.left);
     const rightNode = this.processNode(node.right);
     // All equality operators use unified nullish equality via the `__eq`
     // runtime helper (null and undefined compare equal). There is no strict

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1031,7 +1031,14 @@ export class TypeScriptBuilder {
           // var / builtin / agency import, and must resolve through the
           // normal paths untouched.
           if (!isBuiltinVar && !isLoopVar && isMatchValName(literal.value)) {
-            return ts.scopedVar(literal.value, "local", this.moduleId);
+            // A `match` expression with no matching arm (and no `_`) never
+            // writes `__matchval_<id>`, so the read is `undefined`. Normalize
+            // to Agency's single nothing-value, `null`. This one read site is
+            // the chokepoint for every match-result path (stepped no-arm and
+            // the plain-mode IIFE that returns `undefined`). See #409.
+            return ts.call(ts.id("__nn"), [
+              ts.scopedVar(literal.value, "local", this.moduleId),
+            ]);
           }
           return ts.id(literal.value);
         }
@@ -1560,7 +1567,7 @@ export class TypeScriptBuilder {
     this.assertMatchArmValueNotGraphNode(node.value);
     const value = node.value
       ? this.processNode(node.value)
-      : ts.id("undefined");
+      : ts.id("null");
     // Plain-mode (handler) match expressions wrap their arms in an async IIFE
     // (see processMatchExpressionPlain): a yield is a real `return` out of that
     // IIFE, not the stepped `runner.exitMatch` unwind — so the handler never

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -149,6 +149,7 @@ export type { ResultValue, ResultSuccess, ResultFailure, SkippedFunction } from 
 export { acceptsFailures } from "./failurePropagation.js";
 export { Schema, __validateType } from "./schema.js";
 export { __eq } from "./eq.js";
+export { __nn } from "./nn.js";
 export {
   __validateChain,
   __validateChainRecursive,

--- a/packages/agency-lang/lib/runtime/nn.test.ts
+++ b/packages/agency-lang/lib/runtime/nn.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { __nn } from "./nn.js";
+
+describe("__nn", () => {
+  it("collapses undefined and null to null", () => {
+    expect(__nn(undefined)).toBe(null);
+    expect(__nn(null)).toBe(null);
+  });
+
+  it("passes non-nullish values through unchanged, including falsy ones", () => {
+    expect(__nn(0)).toBe(0);
+    expect(__nn("")).toBe("");
+    expect(__nn(false)).toBe(false);
+    expect(__nn(5)).toBe(5);
+    expect(__nn("a")).toBe("a");
+    expect(Number.isNaN(__nn(NaN))).toBe(true);
+  });
+
+  it("returns the same object reference for objects", () => {
+    const obj = { x: 1 };
+    expect(__nn(obj)).toBe(obj);
+  });
+});

--- a/packages/agency-lang/lib/runtime/nn.ts
+++ b/packages/agency-lang/lib/runtime/nn.ts
@@ -1,0 +1,15 @@
+/**
+ * Nullish-normalize: collapse `undefined` into Agency's single nothing-value,
+ * `null`. Wraps the value sites where the JS runtime produces `undefined`
+ * (missing object key, out-of-bounds index, unmatched `match`) so the
+ * "only null exists" invariant holds at the value level, not just at `__eq`.
+ *
+ * `x ?? null` returns `null` for `null`/`undefined` and `x` unchanged for every
+ * other value (including `0`, `""`, `false`, `NaN`). The operand is evaluated
+ * exactly once, so wrapping a side-effecting expression is safe.
+ *
+ * See docs/dev/null-and-undefined.md.
+ */
+export function __nn<T>(x: T): T | null {
+  return x ?? null;
+}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -27,7 +27,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/agency-js/index-missing-key-null/agent.agency
+++ b/packages/agency-lang/tests/agency-js/index-missing-key-null/agent.agency
@@ -1,0 +1,23 @@
+node lookups() {
+  const obj: Record<string, number> = { present: 42 }
+  const arr = [1, 2, 3]
+  const zero: Record<string, number> = { z: 0 }
+  return {
+    missingKey: obj["absent"],
+    presentKey: obj["present"],
+    outOfBounds: arr[10],
+    negativeIndex: arr[-1],
+    inBounds: arr[0],
+    falsyZero: zero["z"]
+  }
+}
+
+// Regression guard for the terminal-only wrap decision (Step 3). `a` is null, so
+// `a?.["x"]` short-circuits and `["y"]` is never evaluated: with terminal-only
+// wrapping the whole chain is `__nn(a?.["x"]["y"])` → null (NO throw). If the fix
+// ever regresses to per-element wrapping it becomes `__nn(__nn(a?.["x"])["y"])` →
+// `null["y"]` → THROWS, and this node crashes the test.
+node optChainNoThrow() {
+  const a: Record<string, Record<string, number>> | null = null
+  return { deep: a?.["x"]["y"] }
+}

--- a/packages/agency-lang/tests/agency-js/index-missing-key-null/agent.agency
+++ b/packages/agency-lang/tests/agency-js/index-missing-key-null/agent.agency
@@ -17,7 +17,12 @@ node lookups() {
 // wrapping the whole chain is `__nn(a?.["x"]["y"])` → null (NO throw). If the fix
 // ever regresses to per-element wrapping it becomes `__nn(__nn(a?.["x"])["y"])` →
 // `null["y"]` → THROWS, and this node crashes the test.
+//
+// `optNull` guards the optional-terminal exclusion: an *optional* terminal index
+// (`a?.["x"]`) is NOT normalized — optional chaining is deferred, so `?.[]` on a
+// null base stays `undefined` (dropped from JSON), consistent with `?.` property
+// access. If that ever regresses to wrapping, `optNull` becomes null.
 node optChainNoThrow() {
   const a: Record<string, Record<string, number>> | null = null
-  return { deep: a?.["x"]["y"] }
+  return { deep: a?.["x"]["y"], optNull: a?.["x"] }
 }

--- a/packages/agency-lang/tests/agency-js/index-missing-key-null/fixture.json
+++ b/packages/agency-lang/tests/agency-js/index-missing-key-null/fixture.json
@@ -5,5 +5,6 @@
   "presentKeyValue": 42,
   "inBoundsValue": 1,
   "falsyZeroPreserved": true,
-  "optChainDeepIsNull": true
+  "optChainDeepIsNull": true,
+  "optNullIndexIsUndefined": true
 }

--- a/packages/agency-lang/tests/agency-js/index-missing-key-null/fixture.json
+++ b/packages/agency-lang/tests/agency-js/index-missing-key-null/fixture.json
@@ -1,0 +1,9 @@
+{
+  "missingKeyIsNull": true,
+  "outOfBoundsIsNull": true,
+  "negativeIndexIsNull": true,
+  "presentKeyValue": 42,
+  "inBoundsValue": 1,
+  "falsyZeroPreserved": true,
+  "optChainDeepIsNull": true
+}

--- a/packages/agency-lang/tests/agency-js/index-missing-key-null/test.js
+++ b/packages/agency-lang/tests/agency-js/index-missing-key-null/test.js
@@ -1,0 +1,25 @@
+import { lookups, optChainNoThrow } from "./agent.js";
+import { writeFileSync } from "fs";
+
+const r = (await lookups()).data;
+
+// Must not throw. With per-element wrapping this call crashes (null["y"]);
+// with terminal-only wrapping `deep` is null and this resolves cleanly.
+const opt = (await optChainNoThrow()).data;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      missingKeyIsNull: r.missingKey === null,
+      outOfBoundsIsNull: r.outOfBounds === null,
+      negativeIndexIsNull: r.negativeIndex === null,
+      presentKeyValue: r.presentKey,
+      inBoundsValue: r.inBounds,
+      falsyZeroPreserved: r.falsyZero === 0,
+      optChainDeepIsNull: opt.deep === null,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/index-missing-key-null/test.js
+++ b/packages/agency-lang/tests/agency-js/index-missing-key-null/test.js
@@ -18,6 +18,8 @@ writeFileSync(
       inBoundsValue: r.inBounds,
       falsyZeroPreserved: r.falsyZero === 0,
       optChainDeepIsNull: opt.deep === null,
+      // optional-terminal index on null stays undefined (not normalized) → dropped from JSON
+      optNullIndexIsUndefined: opt.optNull === undefined,
     },
     null,
     2,

--- a/packages/agency-lang/tests/agency-js/match-no-arm-null/agent.agency
+++ b/packages/agency-lang/tests/agency-js/match-no-arm-null/agent.agency
@@ -1,0 +1,19 @@
+node classify(s: string) {
+  const result = match (s) {
+    "a" => "got-a"
+    "b" => "got-b"
+  }
+  return result
+}
+
+// Guards spec case 5: an arm that genuinely yields `null` must stay `null` (no
+// double-coercion surprise), and a real-valued arm passes through `__nn`
+// unchanged. `classifyNullable("z")` also exercises the no-arm path alongside an
+// explicit null arm so the two null sources are not conflated.
+node classifyNullable(s: string) {
+  const result = match (s) {
+    "a" => "got-a"
+    "n" => null
+  }
+  return result
+}

--- a/packages/agency-lang/tests/agency-js/match-no-arm-null/fixture.json
+++ b/packages/agency-lang/tests/agency-js/match-no-arm-null/fixture.json
@@ -1,0 +1,7 @@
+{
+  "matchedValue": "got-a",
+  "unmatchedIsNull": true,
+  "realArmValue": "got-a",
+  "nullArmIsNull": true,
+  "noArmIsNull": true
+}

--- a/packages/agency-lang/tests/agency-js/match-no-arm-null/test.js
+++ b/packages/agency-lang/tests/agency-js/match-no-arm-null/test.js
@@ -1,0 +1,24 @@
+import { classify, classifyNullable } from "./agent.js";
+import { writeFileSync } from "fs";
+
+const matched = (await classify("a")).data;
+const unmatched = (await classify("z")).data;
+
+const realArm = (await classifyNullable("a")).data;
+const nullArm = (await classifyNullable("n")).data;
+const noArm = (await classifyNullable("z")).data;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      matchedValue: matched,
+      unmatchedIsNull: unmatched === null,
+      realArmValue: realArm,
+      nullArmIsNull: nullArm === null,
+      noArmIsNull: noArm === null,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -233,7 +233,7 @@ async function __initializeGlobals(__ctx) {
     type: "positional",
     args: [__globals()!.get("arrayAndObject.agency", "config")]
   })
-  __ctx.globals.set("arrayAndObject.agency", "firstNum", __globals()!.get("arrayAndObject.agency", "nums")[0])
+  __ctx.globals.set("arrayAndObject.agency", "firstNum", __nn(__globals()!.get("arrayAndObject.agency", "nums")[0]))
   await __call(print, {
     type: "positional",
     args: [__globals()!.get("arrayAndObject.agency", "firstNum")]

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -249,7 +249,7 @@ __stack.locals.right = __stack.locals.s.length - 1;
 await runner.ifElse(0, [
 
   {
-    condition: async () => !__eq(__stack.locals.s[__stack.locals.left], __stack.locals.s[__stack.locals.right]),
+    condition: async () => !__eq(__nn(__stack.locals.s[__stack.locals.left]), __nn(__stack.locals.s[__stack.locals.right])),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -490,7 +490,7 @@ await runner.whileLoop(2, async () => __stack.locals.j < 13, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.product = __stack.locals.product * await __call(toDigit, {
               type: "positional",
-              args: [__stack.locals.digits[__stack.locals.i + __stack.locals.j]]
+              args: [__nn(__stack.locals.digits[__stack.locals.i + __stack.locals.j])]
             });
           });
 await runner.step(1, async (runner) => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -37,7 +37,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -265,7 +265,7 @@ return;
           });
 }, { matchId: 1 });
       await runner.step(2, async (runner) => {
-__stack.locals.val = __stack.locals.__matchval_1;
+__stack.locals.val = __nn(__stack.locals.__matchval_1);
       });
       await runner.step(3, async (runner) => {
 runner.halt({

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
@@ -214,7 +214,7 @@ __stack.locals.votes = {
 __stack.locals.votes[`carol`] = `approve`;
       });
       await runner.step(3, async (runner) => {
-__stack.locals.v = __stack.locals.votes[`alice`];
+__stack.locals.v = __nn(__stack.locals.votes[`alice`]);
       });
       await runner.step(4, async (runner) => {
 const __funcResult = await __call(print, {

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -23,7 +23,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -22,7 +22,7 @@ import {
   __UNINIT_STATIC, __readStatic,
   __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
-  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,


### PR DESCRIPTION
## Summary

Fixes #409. Missing object-key lookups (`obj[key]`), out-of-bounds array indexing (`arr[i]`), and unmatched `match` expressions now yield `null` instead of `undefined`, completing the **value** side of Agency's "one nothing-value" invariant.

The language already committed to absorbing `undefined` into `null` (see `docs/dev/null-and-undefined.md`), but only the **comparison** side was finished — `__eq` makes `null == undefined`. The **value** side was unaddressed: a missing lookup produced a literal `undefined` that then flowed through the program (printed, interpolated, stored in threads, serialized) as `undefined`. This PR closes that gap for the two most common leak sites.

## Approach

- **`__nn` runtime helper** (`x ?? null`) — a nullish-normalize helper wired exactly like the existing `__eq` (`lib/runtime/nn.ts` → exported from `runtime/index.ts` → added to the generated-code import list via `imports.mustache` → emitted as `__nn(...)`).
- **Terminal index reads** — `processValueAccess` wraps the completed access chain in `__nn` when its last element is an index. Wrapping *terminally* (not per-element) preserves JS optional-chain short-circuit: `a?.[b].c` with null `a` stays `undefined` rather than throwing `null.c`. Covers `obj[key]`, `arr[i]`, and `arr[-1]` in one site.
- **Match results** — the single `__matchval_<id>` read chokepoint is wrapped in `__nn`, covering both the stepped no-arm path and the plain-mode IIFE that returns `undefined`. The valueless-`yield` fallback is also changed from `undefined` to `null` at the source.

## Beyond the plan: lvalue targets

`processValueAccess` turned out to also emit assignment/update **targets** (`x[i]++`, `x[i] += v`) via `processBinOpExpression` — a route the design missed. Naively wrapping produced invalid lvalues (`__nn(x[i]) = ...`) and broke the stdlib build. Fixed with an `asLValue` flag + `processAssignTarget` helper so targets stay raw lvalues while value reads are normalized. Verified in generated output: `arr[i] += 10` / `arr[i]++` stay raw; `arr[i] + 1` (a read) becomes `__nn(arr[i]) + 1`.

## Non-goals

- No type-checker changes — index/match result *types* are unchanged. Forcing narrowing on nullable access is "Project 2" strict null checking. Since the value at these sites was already `undefined` (equally nullish), there is no regression and no new "possibly null" errors.
- Deferred leak sites: optional chaining, destructuring a missing field, falling off a function without `return`, and TypeScript interop.

## Coercion caveat (intended)

`null` and `undefined` coerce differently in arithmetic (`undefined + 1` → `NaN`; `null + 1` → `1`) and string contexts (`` `${undefined}` `` → `"undefined"`; `` `${null}` `` → `"null"`). The string-context change is the fix the issue wants; the arithmetic change is a deliberate consequence of collapsing to one nothing-value, consistent with "don't do math on a missing key."

## Testing

- `lib/runtime/nn.test.ts` — unit test for `__nn`, incl. falsy passthrough (`0`/`""`/`false`/`NaN`).
- `tests/agency-js/index-missing-key-null` — missing key, out-of-bounds, negative index → `null`; falsy/present values preserved; plus `optChainNoThrow` (`a?.["x"]["y"]` with null `a`) which CI-fails if the wrap ever regresses to per-element.
- `tests/agency-js/match-no-arm-null` — no-arm match → `null`; matched arm unchanged; explicit `null` arm stays `null` (no double-coercion). Uses an open scrutinee type, so it compiles at the default `matchExhaustiveness: error` with no override.
- Full lib unit suite (8121 tests) and codegen integration fixtures pass; `null-and-undefined.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
