### PR TITLE
Error on Agency imports that don't resolve (AG4008/AG4009)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-strict-imports-check-review.md
+++ b/docs/superpowers/plans/2026-07-12-strict-imports-check-review.md
@@ -1,0 +1,180 @@
+# Review: strict-imports-check implementation plan
+
+**Reviews:** `docs/superpowers/plans/2026-07-12-strict-imports-check.md`
+
+**Date:** 2026-07-12
+
+**Verdict:** Strong, plan-ready with one fix. It cleanly incorporated the spec review (scope narrowed to plain imports; `export from` and unresolvable `pkg::` excluded because they already throw in `build`; the `pkg::` throw folded into a `try/catch`; the hard-error decision now carries a rationale). Every load-bearing code claim was verified against the source. One medium finding on sweep scope, two low findings on test coverage/cosmetics; otherwise correct.
+
+## Verification (all confirmed against code)
+
+- `TypeCheckerContext` has `programNodes` (`types.ts:89`), `errors` (98), `symbolTable?` (125), `currentFile?` (130). The pass uses exactly these.
+- `diagnostic(name, params, loc, overrides?)` (`diagnostics.ts:563`) returns `TypeCheckError` with `.name` set to the registry key — so the tests' `err.name === "importNameNotFound"` works. `renderMessage` interpolates `{name}`-style placeholders (`diagnostics.ts:543`); the plan's `{name}`/`{module}` params match.
+- Wiring point: `checkUndefinedFunctions(scopes, ctx)` at `index.ts:337`; `ctx.programNodes = this.program.nodes` (127), `ctx.currentFile = resolved.fromFile` (107). Inserting the call after 337 is correct.
+- AST: `importStatement.isAgencyImport`/`importedNames` (`importStatement.ts:5,7`); `namedImport.importedNames` holds the **original** names, aliases kept separately in `.aliases` (18, 24) — so pushing `...nameType.importedNames` checks the original name, matching the spec and the alias test. `importNodeStatement.agencyFile`/`importedNodes` (55–56).
+- Node symbols are stored in `FileSymbols` keyed by node name (`classifySymbols`, `symbolTable.ts:361`), so the `import node` presence check via `hasOwnProperty` is sound.
+- Re-exports are merged into the re-exporter's `FileSymbols` during `build` (`mergeExportsFrom`), so `import { x }` where the target re-exports `x` won't false-positive.
+- `AG4008`/`AG4009` are unused; the classifier's `try/catch` correctly maps a `resolvePkgAgencyPath` throw to `missing`.
+
+## Findings
+
+### 1. [Medium] The rollout sweep is scoped too narrowly — it skips the highest-risk path
+
+Task 3 sweeps only `stdlib`, `tests/agency`, and `tests/typescriptGenerator`. It omits `tests/pkg-imports` — and `pkg::` resolution is the exact path the spec calls out as highest-risk (it can throw, which the classifier turns into `importModuleNotFound`). It also omits `tests/agency-js`, `tests/typescriptPreprocessor`, and any other `.agency` under `tests/`. Consequences:
+
+- A false-positive class in `pkg::` handling (e.g. a package that resolves in CI's context but is classified `missing` during the sweep, or vice versa) would go undiscovered by the very sweep the spec designed to catch it.
+- Any now-erroring import in an un-swept fixture surfaces only in CI (the full suite can't be run locally per the repo rules), not during the sweep.
+
+This feature builds directly on #525's directory typecheck, so the sweep can simply be `pnpm run agency tc tests` (whole tree) plus `pnpm run agency tc stdlib`, instead of two hand-picked subdirs. At minimum add `tests/pkg-imports`. Note that a whole-tree sweep will hit intentionally-broken fixtures — but those parse-fail to `notLoaded` (silent) or already assert errors, and the plan's per-finding decision rule already handles the noise. Recommend broadening Step 2–3 and recording the wider sweep's findings.
+
+### 2. [Low] No positive test for a valid `import node { }` or a valid re-exported import
+
+The `import node` test only asserts the negative (`ghostNode` absent → error). Correctness for a *valid* node import depends on the non-obvious fact that nodes live in `FileSymbols` keyed by name — verified here, but unguarded by a test. Likewise there's no test that `import { x }` of a name the target **re-exports** stays clean (also verified, also unguarded). Add one positive `import node { realNode }` case and one re-exported-name case so a future refactor of symbol storage or the merge path can't silently regress into false positives.
+
+### 3. [Low/cosmetic] Integration-test case number collides with existing `29-bundle`
+
+Task 3 Step 5 labels the new case `29-tc-missing-import`, but `29-bundle` already exists in `test.mjs` (and #525 added `28a`–`28d`). Labels are distinct strings so nothing breaks, but the numbering is misleading. Use the next genuinely free number and keep it in the `// tc` section.
+
+## Anti-pattern check (`docs/dev/anti-patterns.md`)
+
+Overall the plan's architecture already does the declarative-encapsulation the catalog asks for: `resolveImportModule` hides all the "how" (path resolution, the `fs` check, the `pkg::` throw) behind the flat tagged union `ImportModuleResolution`, and `reportModule` consumes it declaratively by dispatching on `.kind`. That is the good pattern. Three localized lapses:
+
+### 4. [Low-Medium — "Imperative code everywhere"] the name-collection loop
+
+Task 2, Step 4 uses a mutable accumulator + for-loop + `push`, which is almost line-for-line the catalog's *Bad* example:
+
+```ts
+const names: string[] = [];
+for (const nameType of node.importedNames) {
+  if (nameType.type !== "namedImport") continue;
+  names.push(...nameType.importedNames);
+}
+```
+
+Declarative equivalent — says *what* ("the original names of the named imports"):
+
+```ts
+const names = node.importedNames
+  .filter((nameType) => nameType.type === "namedImport")
+  .flatMap((nameType) => nameType.importedNames);
+```
+
+### 5. [Low — encapsulate the imperative extraction] duplicated AST-shape knowledge across the two `reportModule` call sites
+
+`checkMissingImports` pulls `(modulePath, names, loc)` out of `importStatement` and `importNodeStatement` in two separate branches. Splitting the *what* (which imports to check) from the *how* (per-node-kind field access) via a small normalizer removes the duplication and folds in finding 4:
+
+```ts
+type ImportSpec = { modulePath: string; names: readonly string[]; loc: SourceLocation | null };
+
+function toImportSpec(node: AgencyNode): ImportSpec | null {
+  if (node.type === "importStatement" && node.isAgencyImport) {
+    const names = node.importedNames
+      .filter((n) => n.type === "namedImport")
+      .flatMap((n) => n.importedNames);
+    return { modulePath: node.modulePath, names, loc: node.loc ?? null };
+  }
+  if (node.type === "importNodeStatement") {
+    return { modulePath: node.agencyFile, names: node.importedNodes, loc: node.loc ?? null };
+  }
+  return null;
+}
+
+// checkMissingImports body:
+for (const node of ctx.programNodes) {
+  const spec = toImportSpec(node);
+  if (spec) reportModule(ctx, spec, currentFile);
+}
+```
+
+Optional — two branches isn't egregious and YAGNI applies — but it's the one spot where the pass *doesn't yet* encapsulate the imperative bit behind a declarative interface, and it easily could.
+
+### 6. [Medium — "try-catch without logging anything in the catch block"] the empty catch in `resolveImportModule`
+
+Task 1, Step 3:
+
+```ts
+try {
+  resolved = path.resolve(resolveAgencyImportPath(modulePath, fromFile));
+} catch {
+  return { kind: "missing" };
+}
+```
+
+No binding, no log. Beyond tripping the listed anti-pattern, it collapses *every* throw to `"missing"`, so an **unexpected** resolution error (a malformed path, an internal `resolveAgencyImportPath` bug) is silently reported to the user as "Cannot find module" instead of its real cause.
+
+The fix is not a blind `console.error` — an unresolvable `pkg::` throwing is the *expected* path, and logging every such case would be noise. Gate it under verbose, matching how `SymbolTable.build` already logs:
+
+```ts
+} catch (e) {
+  if (config?.verbose) console.error(`[resolveImportModule] ${modulePath} failed to resolve:`, e);
+  return { kind: "missing" };
+}
+```
+
+This means threading `config` into the method (or capturing it on the `SymbolTable` instance) — worth a line in the plan either way.
+
+### Rest of the catalog: clean
+
+No duplicated code (it reuses `resolveAgencyImportPath`/`getFile`), no order-dependent mutable state, no leaky nested-object types (the tagged union is exemplary), no useless special cases, no nested ternaries, no magic numbers, no dynamic requires. The `ctx.errors.push(...)` mutation and the guard-clause one-liners (`if (!x) return;`) technically brush the "one-line if" entry, but they match the prevailing style in `checkUndefinedFunctions` and the symbol table — matching them beats the catalog's generic example, since "Inconsistent patterns" is itself an anti-pattern.
+
+## Test review — do the tests fail when the code breaks?
+
+Mostly yes, but two tests are weaker than they look and one behavior is unguarded. (Diagnostic-name assertions like `err.name === "importNameNotFound"` are valid — `diagnostic()` sets `.name` to the registry key.)
+
+**Genuinely guard their target:** Task 1 Tests 1–3 (each asserts a distinct `.kind`); Task 1 Test 4 (`pkg::`) — **verified** that `findPkgDir` re-throws `MODULE_NOT_FOUND` for `@no/such-package` (`importPaths.ts:408`), so deleting the `catch` makes `resolveImportModule` throw and the test fails; Task 2 Tests 1/2/4/6 (assert specific diagnostic name + message; Test 2 specifically guards "check the *original* name, not the alias"); Task 3 integration (`expectFail` + `AG4008` + `missingFn`).
+
+**Weaker than they look:**
+
+7. **[Medium] Task 2 Test 3 (missing node import) is green even if node handling is entirely broken.** It only asserts that an *absent* node name errors. If the pass looked nodes up in the wrong place and never matched any node, this test still passes — while every *valid* `import node { realNode }` would false-positive. It can't distinguish "correctly rejects a missing node" from "rejects all nodes." Needs the positive counterpart (missing test #2 below).
+
+8. **[Low] Task 2 Test 5 (silent on parse failure) is coupled to the parser.** It relies on `"def def def not valid agency"` failing to parse so `broken.agency` stays unloaded. The failure mode is *safe* (a lenient parse turns it red, not falsely green), but it's brittle — add a comment noting the dependency, or use a more obviously-unparseable body.
+
+## Missing test cases
+
+Ranked by regression risk:
+
+1. **[High] JS import is skipped.** The `if (!node.isAgencyImport) continue` guard is load-bearing — remove it and every `.js` import gets flagged. Nothing tests it:
+   ```ts
+   it("ignores JavaScript imports", () => {
+     const errors = check(
+       { "use.agency": 'import { anything } from "./helper.js"\n\nnode u(): string {\n  return "y"\n}\n' },
+       "use.agency",
+     );
+     expect(errors.find((e) => e.name === "importNameNotFound")).toBeUndefined();
+     expect(errors.find((e) => e.name === "importModuleNotFound")).toBeUndefined();
+   });
+   ```
+
+2. **[High] A *valid* node import passes cleanly** — the positive case Test 3 lacks. Only this catches a broken node-symbol lookup:
+   ```ts
+   it("accepts a valid node import", () => {
+     const errors = check(
+       {
+         "lib.agency": "export node helperNode(): string {\n  return \"n\"\n}\n",
+         "use.agency": 'import node { helperNode } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+       },
+       "use.agency",
+     );
+     expect(errors.find((e) => e.name === "importNameNotFound")).toBeUndefined();
+   });
+   ```
+   (Confirm the `export node` syntax against a fixture; adjust if nodes aren't `export`-marked that way.)
+
+3. **[Medium] Mixed valid + invalid names in one statement.** `import { realFn, missingFn }` → exactly one `importNameNotFound` naming `missingFn`, with `realFn` untouched. Guards per-name reporting and no collateral flagging.
+
+4. **[Medium] A multi-name missing *module* yields exactly one error.** The plan explicitly claims "one module error per statement, not per name," but no test asserts the count. `import { a, b } from "./ghost.agency"` → assert exactly one `importModuleNotFound`.
+
+5. **[Medium] A valid re-exported import passes.** The pass relies on re-exports being merged into the target's `FileSymbols`. `import { x }` from a file that does `export { x } from "./real.agency"` should be clean; a regression in the merge would false-positive, and nothing guards it.
+
+6. **[Low-Med] A valid `std::` import passes.** `std::` resolves through a different branch; one positive case guards it beyond the rollout sweep.
+
+**Coverage-boundary note:** every Task 2 test routes through `check()`, whose fidelity depends on `SymbolTable.build(entryPath)` crawling the entry's imports so the target ends up `loaded`. These are therefore integration tests of build+typeCheck, not unit tests of the pass in isolation — a `notLoaded` false-positive from the pass could only be caught by Test 5's specific parse-failure setup. Acceptable given the codebase style; just know the boundary.
+
+## Minor notes (no action required)
+
+- The pass no-ops when `ctx.currentFile` is absent, so `agency tc -` (stdin, no path anchor) skips import checking. That's an acceptable limitation and matches the spec, but worth a one-line mention in the docs or a code comment.
+- `reportModule` re-reads `ctx.symbolTable!` with a non-null assertion; safe because `checkMissingImports` guards it, and the plan says so. Fine as-is.
+
+## Bottom line
+
+Fix finding 1 (broaden the sweep — it's the difference between the rollout catching a `pkg::` false-positive class and shipping one) and finding 6 (the empty catch masks unexpected errors). Findings 2–3 are cheap test/cosmetic adds; 4–5 are declarative-style cleanups the catalog calls for (4 is a near-exact match of its *Bad* example). Findings 7–8 flag two weak existing tests, and the six missing test cases above should be added before implementation is called done — especially the two [High] ones (JS-import-skipped and a valid node import), which guard load-bearing behavior nothing currently covers. No correctness defects found in the pass, diagnostics, or wiring.

--- a/docs/superpowers/plans/2026-07-12-strict-imports-check.md
+++ b/docs/superpowers/plans/2026-07-12-strict-imports-check.md
@@ -1,0 +1,667 @@
+# Strict Imports Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `agency` error when a plain import names something that doesn't exist — a name a loaded Agency file doesn't define, or a module path that resolves to no file.
+
+**Architecture:** Add a `resolveImportModule` helper to `SymbolTable` that classifies an import's target as missing / not-loaded / loaded. Add a new typechecker pass `checkMissingImports` that walks the file's `import { ... }` and `import node { ... }` statements, uses that helper plus a per-name presence check, and emits two new hard-error diagnostics. Wire the pass into the typechecker beside `checkUndefinedFunctions`.
+
+**Tech Stack:** TypeScript, vitest (unit), the Node integration harness (`tests/integration/cli-main/test.mjs`).
+
+## Global Constraints
+
+- NEVER commit to `main`. All work happens on branch `worktree-strict-imports-check` in the worktree at `/Users/adityabhargava/agency-lang/.claude/worktrees/strict-imports-check`. Re-check `git branch --show-current` before every commit.
+- NEVER use dynamic imports. Use types, not interfaces. Use arrays, not sets. Use objects, not maps.
+- All non-absolute paths below are relative to `packages/agency-lang/`.
+- **Scope:** plain imports only — `import { ... }` (with `isAgencyImport === true`) and `import node { ... }`. Skip JavaScript imports (`isAgencyImport === false`), `export { } from` (already throws in `SymbolTable.build`), and unresolvable `pkg::` (already throws in `build`). See the spec's "What is already handled" section.
+- **Severity:** both new diagnostics are always errors. No config knob. Do not touch `undefinedFunctions`.
+- **Safeguard:** never error when the target file exists on disk but was not loaded into the symbol table (`getFile` returns `undefined`). That is a partial-view case (a parse failure in the target, or a single-file editor check), and the target's own error is the real diagnostic.
+- Reference: design spec at `docs/superpowers/specs/2026-07-12-strict-imports-check-design.md`.
+
+---
+
+### Task 1: `SymbolTable.resolveImportModule` classifier
+
+Add a method that resolves an import's module path and reports whether it is missing, exists-but-not-loaded, or loaded (with its symbols). This is the single place that touches the filesystem and path resolution, so the pass in Task 2 stays pure logic.
+
+**Files:**
+- Modify: `lib/symbolTable.ts` (add a type + method near the existing `getFile`, around line 246)
+- Test: `lib/symbolTable.importModule.test.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `type ImportModuleResolution = { kind: "missing" } | { kind: "notLoaded" } | { kind: "loaded"; symbols: FileSymbols }`
+  - `SymbolTable.resolveImportModule(modulePath: string, fromFile: string, config?: AgencyConfig): ImportModuleResolution`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `lib/symbolTable.importModule.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { SymbolTable } from "./symbolTable.js";
+
+function makeDir(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-immod-"));
+  for (const [name, src] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), src);
+  }
+  return dir;
+}
+
+describe("SymbolTable.resolveImportModule", () => {
+  it("returns loaded with symbols for a crawled Agency file", () => {
+    const dir = makeDir({
+      "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+      "use.agency": 'import { realFn } from "./lib.agency"\n\nnode u(): string {\n  return realFn()\n}\n',
+    });
+    const usePath = path.join(dir, "use.agency");
+    const table = SymbolTable.build(usePath);
+    const result = table.resolveImportModule("./lib.agency", usePath);
+    expect(result.kind).toBe("loaded");
+    if (result.kind === "loaded") {
+      expect(Object.prototype.hasOwnProperty.call(result.symbols, "realFn")).toBe(true);
+    }
+  });
+
+  it("returns missing for a module path that does not exist", () => {
+    const dir = makeDir({
+      "use.agency": 'import { x } from "./ghost.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+    });
+    const usePath = path.join(dir, "use.agency");
+    const table = SymbolTable.build(usePath);
+    expect(table.resolveImportModule("./ghost.agency", usePath).kind).toBe("missing");
+  });
+
+  it("returns notLoaded for a file that exists on disk but was never crawled", () => {
+    const dir = makeDir({
+      "use.agency": 'node u(): string {\n  return "y"\n}\n',
+      "other.agency": "export def helper(): string {\n  return \"h\"\n}\n",
+    });
+    const usePath = path.join(dir, "use.agency");
+    // build seeded from use.agency, which imports nothing → other.agency is
+    // never loaded, though it exists on disk.
+    const table = SymbolTable.build(usePath);
+    expect(table.resolveImportModule("./other.agency", usePath).kind).toBe("notLoaded");
+  });
+
+  it("returns missing when path resolution throws (unresolvable pkg::)", () => {
+    const dir = makeDir({
+      "use.agency": 'node u(): string {\n  return "y"\n}\n',
+    });
+    const usePath = path.join(dir, "use.agency");
+    const table = SymbolTable.build(usePath);
+    expect(table.resolveImportModule("pkg::@no/such-package", usePath).kind).toBe("missing");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run lib/symbolTable.importModule.test.ts`
+Expected: FAIL — `resolveImportModule` is not a function.
+
+- [ ] **Step 3: Implement the classifier**
+
+In `lib/symbolTable.ts`, immediately after the `getFile` method (ends at line 248), insert:
+
+```ts
+  /**
+   * Classify an import's target module for the strict-imports check.
+   * - `missing`   — the path resolves to nothing on disk, or resolution threw
+   *                 (e.g. an unresolvable `pkg::`).
+   * - `notLoaded` — the file exists on disk but was never crawled into this
+   *                 table (a parse failure in it, or a partial single-file
+   *                 check). The caller must stay silent: the view is incomplete.
+   * - `loaded`    — the file was crawled; `symbols` is its FileSymbols.
+   */
+  resolveImportModule(
+    modulePath: string,
+    fromFile: string,
+    config?: AgencyConfig,
+  ): ImportModuleResolution {
+    let resolved: string;
+    try {
+      resolved = path.resolve(resolveAgencyImportPath(modulePath, fromFile));
+    } catch (e) {
+      // An unresolvable `pkg::` throwing is the EXPECTED path here, so we
+      // report it as `missing` rather than crashing. But don't swallow the
+      // error entirely: an unexpected resolution bug (malformed path, internal
+      // fault) would otherwise be silently mislabelled "Cannot find module".
+      // Surface it under verbose, matching how `build` logs.
+      if (config?.verbose) {
+        console.error(`[resolveImportModule] '${modulePath}' failed to resolve:`, e);
+      }
+      return { kind: "missing" };
+    }
+    if (!fs.existsSync(resolved)) {
+      return { kind: "missing" };
+    }
+    const symbols = this.getFile(resolved);
+    if (symbols === undefined) {
+      return { kind: "notLoaded" };
+    }
+    return { kind: "loaded", symbols };
+  }
+```
+
+`AgencyConfig` is already imported at the top of `lib/symbolTable.ts` (line 4). Then add the result type. Place it next to the exported `FileSymbols` type near the top of the file (right after the `FileSymbols` definition at line 100):
+
+```ts
+export type ImportModuleResolution =
+  | { kind: "missing" }
+  | { kind: "notLoaded" }
+  | { kind: "loaded"; symbols: FileSymbols };
+```
+
+`path`, `fs`, and `resolveAgencyImportPath` are already imported in this file (used by `build`). Do not add duplicate imports.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run lib/symbolTable.importModule.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/symbolTable.ts lib/symbolTable.importModule.test.ts
+git commit -m "Add SymbolTable.resolveImportModule classifier for strict imports"
+```
+
+---
+
+### Task 2: `checkMissingImports` pass + diagnostics + wiring
+
+Add the two error diagnostics, the pass that emits them, and register it in the typechecker. Test the behavior end-to-end through `typeCheck` on temp multi-file fixtures.
+
+**Files:**
+- Modify: `lib/typeChecker/diagnostics.ts` (add two registry entries near `undefinedFunction`, line 434)
+- Create: `lib/typeChecker/missingImportDiagnostic.ts`
+- Modify: `lib/typeChecker/index.ts` (import + call the pass near line 337)
+- Test: `lib/typeChecker/missingImportDiagnostic.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `SymbolTable.resolveImportModule` from Task 1; `diagnostic` from `./diagnostics.js`; `TypeCheckerContext` from `./types.js`; `SourceLocation` from `../types/base.js`. The pass reads the AST field `node.isAgencyImport` directly (no helper import needed).
+- Produces: `checkMissingImports(ctx: TypeCheckerContext): void`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/typeChecker/missingImportDiagnostic.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+function check(files: Record<string, string>, entry: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-miss-"));
+  try {
+    for (const [name, src] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), src);
+    }
+    const entryPath = path.join(dir, entry);
+    const src = files[entry];
+    const parsed = parseAgency(src);
+    if (!parsed.success) {
+      throw new Error(`parse failed: ${(parsed as { message?: string }).message}`);
+    }
+    const symbols = SymbolTable.build(entryPath);
+    const info = buildCompilationUnit(parsed.result, symbols, entryPath, src);
+    return typeCheck(parsed.result, {}, info).errors;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("checkMissingImports", () => {
+  it("errors on a name the target file does not define", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { missingFn } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importNameNotFound");
+    expect(e).toBeDefined();
+    expect(e?.message).toContain("missingFn");
+  });
+
+  it("names the original name for an aliased import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { missingFn as m } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importNameNotFound");
+    expect(e?.message).toContain("missingFn");
+  });
+
+  it("errors on a missing node import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import node { ghostNode } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeDefined();
+  });
+
+  it("errors on a module path that does not exist", () => {
+    const errors = check(
+      {
+        "use.agency": 'import { x } from "./ghost.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importModuleNotFound");
+    expect(e).toBeDefined();
+    expect(e?.message).toContain("./ghost.agency");
+  });
+
+  it("stays silent when the target exists but failed to load (parse error)", () => {
+    // This test depends on `broken.agency` failing to parse, so `build` skips
+    // it and `getFile` returns undefined → `notLoaded` → silent. The dependency
+    // is on the parser: if the parser ever accepts this body, the target would
+    // load and the test would turn RED (name absent → error), not falsely green.
+    // So the coupling is safe — it can only over-report, never miss a real bug.
+    const errors = check(
+      {
+        "broken.agency": "def def def { { { <<< not valid agency\n",
+        "use.agency": 'import { anything } from "./broken.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("accepts a real cross-file import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { realFn } from "./lib.agency"\n\nnode u(): string {\n  return realFn()\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("ignores JavaScript imports", () => {
+    // The `if (!node.isAgencyImport)` guard is load-bearing: the checker can't
+    // read a .js file's exports. Remove the guard and this .js import gets flagged.
+    const errors = check(
+      {
+        "use.agency": 'import { anything } from "./helper.js"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("accepts a valid node import", () => {
+    // Positive counterpart to the missing-node test: guards that nodes are
+    // looked up in the right place (FileSymbols keyed by node name).
+    const errors = check(
+      {
+        "lib.agency": "export node helperNode(): string {\n  return \"n\"\n}\n",
+        "use.agency": 'import node { helperNode } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("reports only the missing name in a mixed import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { realFn, missingFn } from "./lib.agency"\n\nnode u(): string {\n  return realFn()\n}\n',
+      },
+      "use.agency",
+    );
+    const nameErrors = errors.filter((err) => err.name === "importNameNotFound");
+    expect(nameErrors).toHaveLength(1);
+    expect(nameErrors[0].message).toContain("missingFn");
+    expect(nameErrors[0].message).not.toContain("realFn");
+  });
+
+  it("reports exactly one module error for a multi-name missing module", () => {
+    const errors = check(
+      {
+        "use.agency": 'import { a, b } from "./ghost.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.filter((err) => err.name === "importModuleNotFound")).toHaveLength(1);
+  });
+
+  it("accepts an import of a re-exported name", () => {
+    // Relies on mergeExportsFrom merging `deep` into barrel.agency's FileSymbols
+    // during build. A regression in the merge would false-positive here.
+    const errors = check(
+      {
+        "real.agency": "export def deep(): string {\n  return \"d\"\n}\n",
+        "barrel.agency": 'export { deep } from "./real.agency"\n',
+        "use.agency": 'import { deep } from "./barrel.agency"\n\nnode u(): string {\n  return deep()\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("accepts a valid std:: import", () => {
+    // std:: resolves through a different branch of resolveAgencyImportPath.
+    // `bash` is a real export of std::shell (verified). We only assert the
+    // absence of import diagnostics, so any unrelated marker warning is ignored.
+    const errors = check(
+      {
+        "use.agency": 'import { bash } from "std::shell"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run lib/typeChecker/missingImportDiagnostic.test.ts`
+Expected: FAIL — no `importNameNotFound` / `importModuleNotFound` diagnostics exist yet.
+
+- [ ] **Step 3: Add the two diagnostics**
+
+In `lib/typeChecker/diagnostics.ts`, immediately after the `undefinedFunction` entry (ends at line 438), insert:
+
+```ts
+  importNameNotFound: {
+    code: "AG4008",
+    severity: "error",
+    message: "'{name}' is not defined in '{module}'.",
+  },
+  importModuleNotFound: {
+    code: "AG4009",
+    severity: "error",
+    message: "Cannot find module '{module}'.",
+  },
+```
+
+`DiagnosticName` is `keyof typeof DIAGNOSTICS`, so these codes become usable by `diagnostic(...)` automatically. AG4008 and AG4009 are unused (the AG40xx range currently stops at AG4007).
+
+- [ ] **Step 4: Write the pass**
+
+Create `lib/typeChecker/missingImportDiagnostic.ts`:
+
+```ts
+import { diagnostic } from "./diagnostics.js";
+import type { TypeCheckerContext } from "./types.js";
+import type { SourceLocation } from "../types/base.js";
+import type { AgencyNode } from "../types.js";
+
+/** A plain Agency import, normalized so the checker doesn't care which node
+ *  kind it came from. */
+type ImportSpec = {
+  modulePath: string;
+  names: readonly string[];
+  loc: SourceLocation | null;
+};
+
+/**
+ * The "what": which plain Agency imports to check, and the names each brings in.
+ * Returns null for anything out of scope (JS imports, non-import nodes). Keeps
+ * the per-node-kind field access (the "how") in one place.
+ */
+function toImportSpec(node: AgencyNode): ImportSpec | null {
+  if (node.type === "importStatement" && node.isAgencyImport) {
+    const names = node.importedNames
+      .filter((nameType) => nameType.type === "namedImport")
+      .flatMap((nameType) => nameType.importedNames);
+    return { modulePath: node.modulePath, names, loc: node.loc ?? null };
+  }
+  if (node.type === "importNodeStatement") {
+    return { modulePath: node.agencyFile, names: node.importedNodes, loc: node.loc ?? null };
+  }
+  return null;
+}
+
+/**
+ * Error on plain imports that don't resolve to a real export:
+ *   - a name a loaded Agency file doesn't define  → importNameNotFound
+ *   - a module path that resolves to no file       → importModuleNotFound
+ *
+ * Covers `import { ... }` (Agency only) and `import node { ... }`. Skips JS
+ * imports, `export { } from`, and unresolvable `pkg::` (the latter two already
+ * throw in SymbolTable.build). Stays silent when the target exists but wasn't
+ * loaded — that is a partial view, and the target's own error is the real one.
+ */
+export function checkMissingImports(ctx: TypeCheckerContext): void {
+  const { symbolTable, currentFile } = ctx;
+  if (!symbolTable || !currentFile) return;
+
+  for (const node of ctx.programNodes) {
+    const spec = toImportSpec(node);
+    if (!spec) continue;
+
+    const resolution = symbolTable.resolveImportModule(
+      spec.modulePath,
+      currentFile,
+      ctx.config,
+    );
+    if (resolution.kind === "missing") {
+      // One module error per statement, not one per imported name.
+      ctx.errors.push(diagnostic("importModuleNotFound", { module: spec.modulePath }, spec.loc));
+      continue;
+    }
+    if (resolution.kind === "notLoaded") {
+      continue;
+    }
+    for (const name of spec.names) {
+      if (!Object.prototype.hasOwnProperty.call(resolution.symbols, name)) {
+        ctx.errors.push(
+          diagnostic("importNameNotFound", { name, module: spec.modulePath }, spec.loc),
+        );
+      }
+    }
+  }
+}
+```
+
+`AgencyNode` is the top-level node union (`../types.js`). `ctx.config` is the `AgencyConfig` already carried by the checker context (used e.g. by `checkUndefinedFunctions`).
+
+- [ ] **Step 5: Wire the pass into the typechecker**
+
+In `lib/typeChecker/index.ts`, add the import next to the other pass imports (near line 51):
+
+```ts
+import { checkMissingImports } from "./missingImportDiagnostic.js";
+```
+
+Then, immediately after the `checkUndefinedFunctions(scopes, ctx);` call (line 337), add:
+
+```ts
+    // Error on plain imports that don't resolve to a real export.
+    checkMissingImports(ctx);
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run lib/typeChecker/missingImportDiagnostic.test.ts`
+Expected: PASS (12 tests).
+
+- [ ] **Step 7: Run the broader typechecker unit tests for regressions**
+
+Run: `pnpm exec vitest run lib/typeChecker/`
+Expected: PASS. If any existing typechecker test now fails because a fixture imports a name that a loaded file doesn't define, that is a real find — fix the fixture's import. If a failure is a false positive from the new pass, stop and diagnose before continuing (do not weaken the pass to make a test pass without understanding why).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/typeChecker/diagnostics.ts lib/typeChecker/missingImportDiagnostic.ts lib/typeChecker/index.ts lib/typeChecker/missingImportDiagnostic.test.ts
+git commit -m "Add checkMissingImports pass: error on imports that don't resolve"
+```
+
+---
+
+### Task 3: Rollout sweep + CLI integration test
+
+Build the CLI, run the new check across the stdlib and the `.agency` fixtures to surface pre-existing bad imports, fix genuine violations, and add one end-to-end integration case proving `agency tc` exits non-zero.
+
+**Files:**
+- Modify: `tests/integration/cli-main/test.mjs` (add a case in the `// tc` section)
+- Modify: any `stdlib/*.agency` or `tests/**/*.agency` files with genuinely bad imports found by the sweep (unknown in advance)
+
+- [ ] **Step 1: Build the CLI**
+
+```bash
+make
+```
+
+Expected: exit 0. (`make` is required after changing any stdlib or lib file.)
+
+- [ ] **Step 2: Sweep the stdlib and the whole test tree**
+
+Because this builds on #525's directory typecheck, `agency tc` accepts a directory and checks every `.agency` under it. Sweep the stdlib and the *entire* `tests/` tree in one pass each — a whole-tree sweep is what exercises the highest-risk resolution paths (`pkg::` under `tests/pkg-imports`, plus `tests/agency`, `tests/agency-js`, `tests/typescriptGenerator`, `tests/typescriptPreprocessor`, and every other fixture):
+
+```bash
+pnpm run agency tc stdlib > /tmp/sweep-stdlib.log 2>&1; echo "stdlib exit: $?"
+pnpm run agency tc tests   > /tmp/sweep-tests.log  2>&1; echo "tests exit: $?"
+```
+
+Read both logs. For each `AG4008` (name not defined) or `AG4009` (cannot find module):
+- If it's a genuine bad import (a typo, a renamed export, a stale path) → fix the importing `.agency` file.
+- If it's a false positive → STOP. Diagnose why `resolveImportModule` misclassified it (a resolution corner such as a re-export, a `std::`/`pkg::` path, or a load-order issue). Record the case and adjust `resolveImportModule` or the pass, then re-run. Do not suppress it blindly.
+- Some fixtures import from non-existent modules on purpose (to exercise error paths) or fail to parse. A parse-failing target lands in `notLoaded` (silent), so it won't show up. A genuinely-bad-but-intentional import that IS flagged should be pointed at a real file, unless a test consciously asserts a different error on it — record that decision per file.
+
+Record the findings (counts per log, files touched, any pass adjustment) in the commit message for this task. Note: the full `pnpm test:run` suite is not run locally (repo rule) — CI runs it — so the whole-tree sweep here is the local safety net for fixtures that would otherwise only surface in CI.
+
+- [ ] **Step 3: Rebuild after any stdlib fix**
+
+```bash
+make
+```
+
+Expected: exit 0. (Skip only if Step 2 changed no stdlib file.)
+
+- [ ] **Step 4: Write the failing integration test**
+
+In `tests/integration/cli-main/test.mjs`, find the `// tc` section (the block that runs `tc` cases) and add, immediately after the last `tc` case in that section:
+
+```ts
+  // tc: a directory where a file imports a name its target does not define (#438 follow-up)
+  const tcBadImportDir = join(dir, "tc-bad-import");
+  mkdirSync(tcBadImportDir, { recursive: true });
+  writeFileSync(
+    join(tcBadImportDir, "lib.agency"),
+    `export def realFn(): string {
+  return "x"
+}
+`,
+  );
+  writeFileSync(
+    join(tcBadImportDir, "use.agency"),
+    `import { missingFn } from "./lib.agency"
+
+node u(): string {
+  return "y"
+}
+`,
+  );
+  const tcBadImportOut = stripAnsi(
+    runAgency("28e-tc-missing-import", ["tc", "tc-bad-import"], { expectFail: true }),
+  );
+  assertIncludes(tcBadImportOut, "AG4008");
+  assertIncludes(tcBadImportOut, "missingFn");
+```
+
+(The `28a`–`28d` cases from #525 sit just above in the `// tc` section, and `29-bundle` is already taken; `28e` keeps this in the `tc` series without colliding. `stripAnsi`, `assertIncludes`, `mkdirSync`, `writeFileSync`, `join`, and `runAgency` are already available in this harness.)
+
+- [ ] **Step 5: Pack and run the integration harness**
+
+```bash
+npm pack && node tests/integration/cli-main/test.mjs ./agency-lang-*.tgz > /tmp/integration.log 2>&1; echo "exit: $?"
+```
+
+Expected: exit 0 (all cases pass, including the new `28e-tc-missing-import`). The `expectFail: true` case confirms `agency tc` exits non-zero on a bad import.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/integration/cli-main/test.mjs stdlib tests
+git commit -m "Sweep stdlib+fixtures for bad imports; add tc integration case (strict imports)"
+```
+
+(Only `git add` the stdlib/tests paths that the sweep actually changed. If the sweep changed nothing there, add just `tests/integration/cli-main/test.mjs`.)
+
+---
+
+### Task 4: Documentation
+
+Document that Agency imports must resolve to a real export, and note the two new error codes.
+
+**Files:**
+- Modify: `docs/site/cli/typecheck.md`
+
+- [ ] **Step 1: Add a note to the typecheck CLI page**
+
+Open `docs/site/cli/typecheck.md`. After the existing options/description content, add a new section:
+
+```markdown
+## Imports must resolve
+
+The type checker verifies that every Agency import names something real. Two mistakes are hard errors:
+
+- `AG4008` — the target file exists but does not define the imported name (for example, `import { missingFn } from "./lib.agency"` when `lib.agency` has no `missingFn`).
+- `AG4009` — the import path resolves to no file (for example, a typo in `import { x } from "./libb.agency"`).
+
+Unlike a call to an undefined function (a warning that might be an uncatalogued JavaScript global), an unresolved Agency import is unambiguous, so it always errors.
+
+Import checking needs a file path to resolve relative imports against, so it is skipped when input comes from stdin without a path (`agency tc -`). Pass files or a directory to have imports checked.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/site/cli/typecheck.md
+git commit -m "docs: document strict-import errors AG4008/AG4009"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Missing name (loaded file lacks the name) → Task 2 (`importNameNotFound`), tests in Task 2 Step 1. ✓
+- Missing module (relative/`std::` path resolves to no file) → Task 2 (`importModuleNotFound`); classifier in Task 1. ✓
+- Aliased imports check the original name → Task 2 pass (uses `nameType.importedNames`, not aliases) + test. ✓
+- `import node { }` covered → Task 2 pass + test. ✓
+- Silent when not loaded (parse failure / partial view) → Task 1 (`notLoaded`) + Task 2 pass + "stays silent" test. ✓
+- `try/catch` around resolution in the core flow → Task 1 `resolveImportModule` + `pkg::` unit test. ✓
+- Always error, no config knob → Task 2 registry entries (severity `error`, no override). ✓
+- Skips JS imports, `export from`, unresolvable `pkg::` → Task 2 `toImportSpec` (`isAgencyImport` guard; only `importStatement`/`importNodeStatement` normalized) + "ignores JavaScript imports" test + Global Constraints. ✓
+- One module error per statement (not per name) → Task 2 pass structure + "exactly one module error for a multi-name missing module" test. ✓
+- Positive cases guarded (valid cross-file, valid node import, re-exported name, `std::` import, mixed valid+invalid) → Task 2 tests. ✓
+- Unexpected resolution throw not masked → Task 1 verbose-gated log in the catch (finding 6). ✓
+- Rollout sweep over stdlib + the whole `tests/` tree (includes `tests/pkg-imports`, the highest-risk path) → Task 3 Step 2. ✓
+- Export-visibility asymmetry (non-goal) → not implemented; presence check ignores the `exported` flag (Task 2 uses `hasOwnProperty` on symbols). ✓
+- Docs → Task 4. ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows complete code. The sweep (Task 3) is investigative by nature, but its steps give exact commands and an explicit decision rule for each finding. ✓
+
+**Type consistency:** `ImportModuleResolution` (`missing` / `notLoaded` / `loaded` + `symbols`) is produced in Task 1 and consumed unchanged in Task 2's `checkMissingImports` loop. `resolveImportModule(modulePath, fromFile, config?)` and `checkMissingImports(ctx)` are named identically across tasks; the pass passes `ctx.config` as the third argument. The `toImportSpec` normalizer's `{ modulePath, names, loc }` shape is consumed only within the same function. Diagnostic names `importNameNotFound` / `importModuleNotFound` match between the registry (Task 2 Step 3), the pass (Task 2 Step 4), and the tests. ✓

--- a/docs/superpowers/specs/2026-07-12-strict-imports-check-design.md
+++ b/docs/superpowers/specs/2026-07-12-strict-imports-check-design.md
@@ -1,0 +1,145 @@
+# Design: error on plain imports that don't resolve to a real export
+
+**Date:** 2026-07-12
+
+**Related:** follow-up to #438 / PR #525 (directory typecheck). That PR made `agency tc <dir>` seed the `SymbolTable` from every file, so a directory check now loads every file. This design builds on that completeness.
+
+**Revised** after review (`2026-07-12-strict-imports-check-review.md`). The review found that `export { } from` and `pkg::` imports already error today, so this design narrows to the genuinely-silent cases.
+
+## Problem
+
+Agency is not TypeScript. In TypeScript an import can name a declaration the checker hasn't seen. In Agency, an import should name something that actually exists. For **plain imports** (`import { ... }` and `import node { ... }`), it doesn't have to.
+
+Two plain-import mistakes are silent today:
+
+1. **Missing name.** A file imports a name from a target Agency file that exists and is loaded, but that file doesn't define the name.
+2. **Missing module.** A file imports from a relative or `std::` path that resolves to no file on disk.
+
+Example of the missing-name case:
+
+```
+// lib.agency  — note: no `missingFn` here
+export def realFn(): string { return "x" }
+```
+
+```
+// use.agency
+import { missingFn } from "./lib.agency"
+
+node u(): string {
+  return missingFn()
+}
+```
+
+Running `agency tc` on both files reports `No type errors found.`
+
+### Why it is silent today
+
+Scope building declares every imported name unconditionally. For each import statement, `lib/typeChecker/scopes.ts:403` calls `scope.declare(name, "any")` for each imported name, whether or not the target file defines it. So `missingFn` becomes a known binding of type `any`. The later call to `missingFn()` resolves to that binding, so it does not trip the undefined-function check (`AG4004`), and because its type is `any`, its arguments aren't checked either. Nothing verifies that `lib.agency` really exports `missingFn`.
+
+Cross-file resolution lives in `SymbolTable.resolveImport` (`lib/symbolTable.ts:281`). It looks up `this.files[targetPath]?.[name]` and simply skips (`symbolTable.ts:289`) when the entry is absent. It never distinguishes "the target was loaded and lacks the name" from "the target was never loaded", so it can't raise an error on its own.
+
+For contrast, a bare call to a name that exists nowhere already warns (`bad.agency:2:10 - warning AG4004: Function 'totallyUndefinedFn' is not defined.`). So the gap is specific to plain imports.
+
+### What is already handled (and out of scope here)
+
+The review confirmed two neighboring cases are **not** silent — they already throw inside `SymbolTable.build`, before any typechecker pass runs:
+
+- **`export { name } from "./mod"`** — `mergeExportsFrom` (`symbolTable.ts:461`) throws when the name is missing (`symbolTable.ts:490`) or not exported (`symbolTable.ts:494`).
+- **`pkg::` imports that don't resolve** — `resolvePkgAgencyPath` (`importPaths.ts:448`) throws when the package or its `agency` entry is missing, and `resolveAgencyImportPath` propagates it.
+
+These already fail, but as ugly uncaught throws rather than clean diagnostics. Converting them into registry diagnostics is worthwhile but is a **separate follow-up**: it would change `SymbolTable.build`'s contract from "throw" to "collect and report", which many callers depend on. This PR leaves them as-is.
+
+## Key insight
+
+The symbol table records which files it loaded. `SymbolTable.getFile(absPath)` returns that file's symbols, or `undefined` when the file was never loaded. Combined with a filesystem existence check, that separates a real mistake from an incomplete view:
+
+- Module path does not exist on disk → **missing module**. Error.
+- Module exists on disk but `getFile` returns `undefined` (loaded nothing — e.g. a parse failure in the target, or an editor checking one file without its dependency) → **silent**. The checker's view is incomplete, and the target's own error is the real diagnostic.
+- Module loaded, and the name is absent → **missing name**. Error.
+
+A normal `agency tc` run loads every imported file, because `SymbolTable.build` crawls imports transitively. So the silent branch is rare in practice, and real mistakes are caught. Module resolution reuses `resolveAgencyImportPath` (`lib/importPaths.ts`), the same function the compiler uses.
+
+## Design
+
+### A new typechecker pass
+
+Add `checkMissingImports`, a pass mirroring `checkUndefinedFunctions` (`lib/typeChecker/undefinedFunctionDiagnostic.ts`). It walks the plain import statements in the file being checked and validates each imported Agency name against the symbol table. It runs only when the checker has both `ctx.symbolTable` and `ctx.currentFile`; without them it does nothing.
+
+### What it checks, per imported name
+
+For each **Agency** plain import (`import { x }`, `import { x as y }`, `import node { x }`):
+
+1. Resolve the module path. Wrap `resolveAgencyImportPath(modulePath, currentFile)` in a `try/catch`; a throw (e.g. an unresolvable path) becomes an `importModuleNotFound` error rather than a crash. In practice `build` resolves these first, but the guard keeps the pass robust if the two ever diverge.
+2. If the resolved path does not exist on disk → **`importModuleNotFound`** error at the import statement.
+3. Else look up `symbolTable.getFile(resolvedPath)`:
+   - `undefined` (exists but not loaded) → silent.
+   - defined, name present → OK.
+   - defined, name absent → **`importNameNotFound`** error at the import statement.
+
+Aliased imports (`x as y`) check the **original** name `x`, since that is what the target must define. `import node { x }` checks node symbols the same way; they live in the same `FileSymbols` map (`kind: "node"`).
+
+Presence uses "the name appears in the file's symbols", ignoring the `exported` flag (see the export-visibility note below).
+
+### What it skips
+
+- **`export { } from`** — already validated (throws in `build`). Not handled here.
+- **`pkg::` that fails to resolve** — already throws in `build` before this pass runs. A `pkg::` import that *does* resolve is checked normally, so a missing name in a resolved package file is caught.
+- **JavaScript imports** (`import { x } from "./helpers.js"`) — the checker can't read a `.js` file's exports. `isAgencyImport(modulePath)` distinguishes these; the pass ignores non-Agency imports.
+
+### Severity: always error, no config knob
+
+Both new diagnostics are always errors:
+
+- `importNameNotFound` — "'<name>' is not defined in '<module>'."
+- `importModuleNotFound` — "Cannot find module '<module>'."
+
+There is no config knob, and this does not reuse `undefinedFunctions`. The asymmetry with `undefinedFunctions` (a call to an unknown name is a silenceable *warning*) is deliberate and reflects **confidence**. A plain Agency import names one specific Agency file, so "the name isn't there" is certain. A bare call like `foo()` might be an uncatalogued JavaScript global (`parseInt`, `atob`, …), which Agency permits without an import, so the checker can't be certain and only warns.
+
+Flipping undefined **calls** to errors is a possible fast follow-up, once the sweep confirms the JS-globals registry is complete enough. It is not part of this PR.
+
+## Edge cases
+
+- **`std::` imports.** Map to bundled stdlib files that exist and get loaded. They resolve cleanly. A typo'd `std::` path resolves to a non-existent file → `importModuleNotFound`, which is desirable.
+- **Target file fails to parse.** `build` skips it, so `getFile` returns `undefined` → silent. The target's parse error surfaces on its own. No double-reporting.
+- **Auto-injected `std::index` prelude.** Resolves to a real, loaded stdlib file; passes cleanly.
+
+## Export-visibility asymmetry (named, not fixed)
+
+The existing `export { } from` path enforces `export` visibility: it throws on a defined-but-not-`export`ed name (`symbolTable.ts:494`). This pass does **not** enforce that for plain imports. Net user-visible result:
+
+- `import { x }` of a defined-but-not-exported `x` → **silent** (the name is present in the file's symbols, so the pass treats it as defined).
+- `export { x } from` of the same `x` → **errors** (existing build behavior).
+
+This inconsistency is defensible for now. Plain-import visibility enforcement would require consulting the `exported` flag in both `resolveImport` and this pass, and would widen the rollout sweep. It is called out here as a known asymmetry and a candidate follow-up, not a goal of this PR.
+
+## Testing
+
+Execution and unit coverage, no LLM calls:
+
+- Missing name: a directory where `use.agency` imports a name `lib.agency` doesn't define → `importNameNotFound`, exit 1.
+- Aliased missing name: `import { missingFn as m }` → error names `missingFn`.
+- `import node { }` missing name → error.
+- Missing relative module: `import { x } from "./nope.agency"` (no such file) → `importModuleNotFound`, exit 1.
+- Missing `std::` module: `import { x } from "std::nosuchmodule"` → `importModuleNotFound`.
+- Resolvable `pkg::` with a missing name (package installed, file lacks the name) → `importNameNotFound`. An *unresolvable* `pkg::` is out of scope — it throws in `build`.
+- Silent when not loaded: check a single file whose imported target has a parse error → the target's parse error only, no `importNameNotFound` piled on.
+- Valid imports (a real cross-file import and a real `std::` import) → no new errors.
+- Unit tests for the symbol-table classification helper: resolved / module-missing / exists-but-not-loaded / loaded-but-name-absent.
+
+## Rollout sweep
+
+As a hard error with no opt-out, this can surface pre-existing bad imports. Before shipping:
+
+1. Run `agency tc` across `stdlib/` and the test fixtures under `tests/`.
+2. Fix genuine bad imports.
+3. Diagnose any false positive and adjust the pass.
+
+The plan lists this sweep as an explicit task with its findings recorded, so nothing is silently suppressed.
+
+## Non-goals
+
+- Converting the existing `export { } from` and `pkg::` build-time throws into clean diagnostics (separate follow-up).
+- Flipping undefined function **calls** from warning to error (possible fast follow-up).
+- Enforcing `export` visibility on plain imports (named asymmetry above).
+- Checking `.js` import existence or exports.

--- a/docs/superpowers/specs/2026-07-12-strict-imports-check-review.md
+++ b/docs/superpowers/specs/2026-07-12-strict-imports-check-review.md
@@ -1,0 +1,56 @@
+# Review: strict-imports-check design
+
+**Reviews:** `docs/superpowers/specs/2026-07-12-strict-imports-check-design.md`
+
+**Date:** 2026-07-12
+
+**Verdict:** The core idea is real and worth doing, and the spec is unusually well-grounded in the code (the `getFile` loaded-vs-defined insight is exactly right). But it has one factual hole that makes part of the design dead code, plus an unresolved altitude question about severity. Revise before writing the plan. Every claim below was verified against the source in the `strict-imports-check` worktree. Findings are ranked by severity.
+
+---
+
+## 1. [Blocker] The `export { } from` case is already validated — and the spec's handling of it is unreachable
+
+The spec's premise is "two mistakes go unreported," and it lists `export { missing } from "./lib.agency"` as a silent case to newly catch (Design line 80, test line 110). **That case is not silent.** `mergeExportsFrom` (`lib/symbolTable.ts:461`) throws during `SymbolTable.build`:
+
+- `symbolTable.ts:490` — `Symbol '<name>' is not defined in '<module>'`
+- `symbolTable.ts:494` — `<kind> '<name>' … is not exported`
+
+It is called at `symbolTable.ts:229` inside `build`, with no surrounding try/catch, and `agency tc` calls `SymbolTable.build` *before* it runs any typechecker pass. Consequences:
+
+- The premise "Running `agency tc` … reports `No type errors found`" is **false** for `export from` (today it throws — arguably too hard, an unhandled crash rather than a clean diagnostic).
+- The new pass's `export { } from` branch is **dead code**: `build` throws before `checkMissingImports` ever runs.
+- The test on line 110 would surface a thrown `Error` (or a crash), not `importNameNotFound`.
+
+**Recommendation:** Either drop `export from` from this pass entirely (already covered), or — more valuable — retarget the work to convert those *thrown* re-export errors into clean registry diagnostics aligned with #474. That is a genuinely useful cleanup, but a different framing than "catch a silent mistake," and the spec should say which it is doing. As written it appears unaware the throw path exists.
+
+## 2. [Altitude] "Always an error, no config knob" conflicts with the existing `undefinedFunctions` knob
+
+The spec's closest sibling, `checkUndefinedFunctions`, has **config-controlled severity** (`config.typechecker.undefinedFunctions`, `undefinedFunctionDiagnostic.ts:18`) defaulting to *warning* — which is why the spec's own example (line 45) shows `warning AG4004`. The spec then proposes the new import diagnostics be **always errors with no knob** (lines 94, 131).
+
+That is incoherent from a user's mental model: `missingFn()` (a call to a name that exists nowhere) is a silenceable, default-*warning*, but `import { missingFn }` would be an un-silenceable *error*. Someone who sets `undefinedFunctions: "off"` still gets hard failures on imports. The codebase already owns "how strict are undefined-name diagnostics." The spec should reuse `undefinedFunctions`, or add a parallel `unresolvedImports` knob, and justify the default against the existing one rather than asserting strictness by fiat.
+
+## 3. [Design gap] The `pkg::` throw is not in the main algorithm
+
+The spec correctly flags `pkg::` as highest-risk (line 99), but treats the throw as an edge note. Verified: `resolvePkgAgencyPath` throws in multiple cases (`importPaths.ts:455-483`), and `resolveAgencyImportPath` propagates it. So the design's happy path — "resolve the path (step 1), then `existsSync` (step 2)" — **crashes** on an absent package before it can reach the existence check. The `try/catch` that maps a resolution throw to `importModuleNotFound` belongs in the core per-name flow (the "What it checks" section), not the edge-cases section.
+
+## 4. [Minor] Scope/premise wording
+
+- Line 13 is garbled: "imports a name that the target Agency file exists but does not define." Rewrite.
+- After findings 1–2, state the *actually novel* gap precisely: plain `import { name }` of a non-existent name, and plain imports from a non-existent module. That is the real, verified silent case (`resolveImport` skips at `symbolTable.ts:289`; `scopes.ts:403` declares it `"any"`). It is a good catch — lead with it.
+
+## 5. [Minor] Make the export-visibility asymmetry explicit
+
+The existing re-export path enforces `export` visibility (throws on non-exported, `symbolTable.ts:494`), but the spec makes export-visibility a non-goal for plain imports. Net user-visible result: `import { x }` of a *defined-but-not-exported* name stays silent, while `export { x } from` of the same name errors. That inconsistency is defensible but should be named in the spec, not left implicit.
+
+---
+
+## What's solid
+
+- The `getFile` loaded-vs-not-loaded distinction is the right primitive and correctly reasoned.
+- Staying silent on parse-failed targets avoids double-reporting.
+- Mirroring `checkUndefinedFunctions` as a new pass is the right altitude for the *plain-import* case.
+- The rollout sweep over `stdlib/` + fixtures is exactly right for a new hard error.
+
+## Bottom line
+
+Fix finding 1 (it changes what the feature even is for re-exports), resolve finding 2 (severity/altitude — likely a product call), and fold finding 3 into the algorithm. Findings 4–5 are wording. After that it is plan-ready.

--- a/packages/agency-lang/docs/site/cli/typecheck.md
+++ b/packages/agency-lang/docs/site/cli/typecheck.md
@@ -19,14 +19,3 @@ You can also pass a literal `-` to read from stdin explicitly, and mix it with f
 ## Options
 
 - `--strict` — enable strict mode. In strict mode, untyped variables are errors rather than being inferred. Use this if you want every variable to have an explicit type annotation.
-
-## Imports must resolve
-
-The type checker verifies that every Agency import names something real. Two mistakes are hard errors:
-
-- `AG4008` — the target file exists but does not define the imported name (for example, `import { missingFn } from "./lib.agency"` when `lib.agency` has no `missingFn`).
-- `AG4009` — the import path resolves to no file (for example, a typo in `import { x } from "./libb.agency"`).
-
-Unlike a call to an undefined function (a warning that might be an uncatalogued JavaScript global), an unresolved Agency import is unambiguous, so it always errors.
-
-Import checking needs a file path to resolve relative imports against, so it is skipped when input comes from stdin without a path (`agency tc -`). Pass files or a directory to have imports checked.

--- a/packages/agency-lang/docs/site/cli/typecheck.md
+++ b/packages/agency-lang/docs/site/cli/typecheck.md
@@ -19,3 +19,14 @@ You can also pass a literal `-` to read from stdin explicitly, and mix it with f
 ## Options
 
 - `--strict` — enable strict mode. In strict mode, untyped variables are errors rather than being inferred. Use this if you want every variable to have an explicit type annotation.
+
+## Imports must resolve
+
+The type checker verifies that every Agency import names something real. Two mistakes are hard errors:
+
+- `AG4008` — the target file exists but does not define the imported name (for example, `import { missingFn } from "./lib.agency"` when `lib.agency` has no `missingFn`).
+- `AG4009` — the import path resolves to no file (for example, a typo in `import { x } from "./libb.agency"`).
+
+Unlike a call to an undefined function (a warning that might be an uncatalogued JavaScript global), an unresolved Agency import is unambiguous, so it always errors.
+
+Import checking needs a file path to resolve relative imports against, so it is skipped when input comes from stdin without a path (`agency tc -`). Pass files or a directory to have imports checked.

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -73,6 +73,8 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG4005](names.md#ag4005) | Cannot reassign to constant '&#123;name&#125;'. |
 | [AG4006](names.md#ag4006) | `&#123;keyword&#125;` is a reserved block keyword. Write `&#123;keyword&#125; &#123; ... &#125;` or `&#123;keyword&#125;(args) &#123; ... &#125;` directly — the `as` keyword is not supported on &#123;keyword&#125; blocks (there's nothing to bind). |
 | [AG4007](names.md#ag4007) | Variable '&#123;name&#125;' is not defined. |
+| [AG4008](names.md#ag4008) | '&#123;name&#125;' is not defined in '&#123;module&#125;'. |
+| [AG4009](names.md#ag4009) | Cannot find module '&#123;module&#125;'. |
 
 ## Match and narrowing
 

--- a/packages/agency-lang/docs/site/diagnostics/names.md
+++ b/packages/agency-lang/docs/site/diagnostics/names.md
@@ -81,3 +81,23 @@ This keyword introduces a block directly — you write it followed by braces (or
 The type checker walks every scope — nodes, function bodies, blocks — and resolves each name to a declaration. This error means a name was used with no `let`, `const`, parameter, or import that introduces it in reach.
 
 **How to fix:** declare it before use (`let x = …` / `const x = …`), fix a typo in the name, or import it if it lives in another module. Agency has no implicit variables: a bare assignment like `x = 5` without a prior `let`/`const` is not a declaration.
+
+<a id="ag4008"></a>
+
+## AG4008 — '&#123;name&#125;' is not defined in '&#123;module&#125;'.
+
+*Default severity: error.*
+
+An import names a symbol that its target Agency module does not define. The checker resolves every `import { ... }` (and `import node { ... }`) against the actual exports of the file it points to, so a name the file never declares — often a typo, or a symbol that was renamed or removed — is an error.
+
+**How to fix:** import a name the module actually defines, correct the spelling, or add the missing definition to the target file. Unlike an undefined bare call (which might be an uncatalogued JavaScript global), an Agency import is unambiguous, so this always errors.
+
+<a id="ag4009"></a>
+
+## AG4009 — Cannot find module '&#123;module&#125;'.
+
+*Default severity: error.*
+
+An import points at a module that does not resolve to any file. The path — a relative `./…` path, a `std::` module, or a `pkg::` package — was resolved the same way the compiler resolves it, and nothing exists there.
+
+**How to fix:** correct the path, create the missing file, or install the package that provides it. Agency imports must resolve to a real module.

--- a/packages/agency-lang/lib/symbolTable.importModule.test.ts
+++ b/packages/agency-lang/lib/symbolTable.importModule.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { SymbolTable } from "./symbolTable.js";
+
+function makeDir(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-immod-"));
+  for (const [name, src] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), src);
+  }
+  return dir;
+}
+
+describe("SymbolTable.resolveImportModule", () => {
+  it("returns loaded with symbols for a crawled Agency file", () => {
+    const dir = makeDir({
+      "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+      "use.agency": 'import { realFn } from "./lib.agency"\n\nnode u(): string {\n  return realFn()\n}\n',
+    });
+    const usePath = path.join(dir, "use.agency");
+    const table = SymbolTable.build(usePath);
+    const result = table.resolveImportModule("./lib.agency", usePath);
+    expect(result.kind).toBe("loaded");
+    if (result.kind === "loaded") {
+      expect(Object.prototype.hasOwnProperty.call(result.symbols, "realFn")).toBe(true);
+    }
+  });
+
+  it("returns missing for a module path that does not exist", () => {
+    const dir = makeDir({
+      "use.agency": 'import { x } from "./ghost.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+    });
+    const usePath = path.join(dir, "use.agency");
+    const table = SymbolTable.build(usePath);
+    expect(table.resolveImportModule("./ghost.agency", usePath).kind).toBe("missing");
+  });
+
+  it("returns notLoaded for a file that exists on disk but was never crawled", () => {
+    const dir = makeDir({
+      "use.agency": 'node u(): string {\n  return "y"\n}\n',
+      "other.agency": "export def helper(): string {\n  return \"h\"\n}\n",
+    });
+    const usePath = path.join(dir, "use.agency");
+    // build seeded from use.agency, which imports nothing → other.agency is
+    // never loaded, though it exists on disk.
+    const table = SymbolTable.build(usePath);
+    expect(table.resolveImportModule("./other.agency", usePath).kind).toBe("notLoaded");
+  });
+
+  it("returns missing when path resolution throws (unresolvable pkg::)", () => {
+    const dir = makeDir({
+      "use.agency": 'node u(): string {\n  return "y"\n}\n',
+    });
+    const usePath = path.join(dir, "use.agency");
+    const table = SymbolTable.build(usePath);
+    expect(table.resolveImportModule("pkg::@no/such-package", usePath).kind).toBe("missing");
+  });
+});

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -99,6 +99,11 @@ export type SymbolKind = SymbolInfo["kind"];
 /** Maps symbol name → info for a single file. */
 export type FileSymbols = Record<string, SymbolInfo>;
 
+export type ImportModuleResolution =
+  | { kind: "missing" }
+  | { kind: "notLoaded" }
+  | { kind: "loaded"; symbols: FileSymbols };
+
 /**
  * One named symbol resolved through an import: where it lives, what name
  * the importing file uses, and what it actually is.
@@ -245,6 +250,44 @@ export class SymbolTable {
 
   getFile(absPath: string): FileSymbols | undefined {
     return this.files[absPath];
+  }
+
+  /**
+   * Classify an import's target module for the strict-imports check.
+   * - `missing`   — the path resolves to nothing on disk, or resolution threw
+   *                 (e.g. an unresolvable `pkg::`).
+   * - `notLoaded` — the file exists on disk but was never crawled into this
+   *                 table (a parse failure in it, or a partial single-file
+   *                 check). The caller must stay silent: the view is incomplete.
+   * - `loaded`    — the file was crawled; `symbols` is its FileSymbols.
+   */
+  resolveImportModule(
+    modulePath: string,
+    fromFile: string,
+    config?: AgencyConfig,
+  ): ImportModuleResolution {
+    let resolved: string;
+    try {
+      resolved = path.resolve(resolveAgencyImportPath(modulePath, fromFile));
+    } catch (e) {
+      // An unresolvable `pkg::` throwing is the EXPECTED path here, so we
+      // report it as `missing` rather than crashing. But don't swallow the
+      // error entirely: an unexpected resolution bug (malformed path, internal
+      // fault) would otherwise be silently mislabelled "Cannot find module".
+      // Surface it under verbose, matching how `build` logs.
+      if (config?.verbose) {
+        console.error(`[resolveImportModule] '${modulePath}' failed to resolve:`, e);
+      }
+      return { kind: "missing" };
+    }
+    if (!fs.existsSync(resolved)) {
+      return { kind: "missing" };
+    }
+    const symbols = this.getFile(resolved);
+    if (symbols === undefined) {
+      return { kind: "notLoaded" };
+    }
+    return { kind: "loaded", symbols };
   }
 
   /** Every effect declaration reachable in the closure, tagged with its

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -231,6 +231,14 @@ node main() {
 
 **How to fix:** define the function, import it from the module that provides it, or fix a typo in the call.`,
 
+  importNameNotFound: `An import names a symbol that its target Agency module does not define. The checker resolves every \`import { ... }\` (and \`import node { ... }\`) against the actual exports of the file it points to, so a name the file never declares — often a typo, or a symbol that was renamed or removed — is an error.
+
+**How to fix:** import a name the module actually defines, correct the spelling, or add the missing definition to the target file. Unlike an undefined bare call (which might be an uncatalogued JavaScript global), an Agency import is unambiguous, so this always errors.`,
+
+  importModuleNotFound: `An import points at a module that does not resolve to any file. The path — a relative \`./…\` path, a \`std::\` module, or a \`pkg::\` package — was resolved the same way the compiler resolves it, and nothing exists there.
+
+**How to fix:** correct the path, create the missing file, or install the package that provides it. Agency imports must resolve to a real module.`,
+
   reassignToConst: `A \`const\` binding is fixed after its initial value: it cannot be reassigned. This assignment targets a name that was declared \`const\`.
 
 **How to fix:** declare it with \`let\` if it needs to change, or assign to a different variable.

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -434,6 +434,16 @@ export const DIAGNOSTICS = {
     severity: "error",
     message: "Function '{name}' is not defined.",
   },
+  importNameNotFound: {
+    code: "AG4008",
+    severity: "error",
+    message: "'{name}' is not defined in '{module}'.",
+  },
+  importModuleNotFound: {
+    code: "AG4009",
+    severity: "error",
+    message: "Cannot find module '{module}'.",
+  },
   reservedBlockKeyword: {
     code: "AG4006",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/fixtureTypeCheck.integration.test.ts
+++ b/packages/agency-lang/lib/typeChecker/fixtureTypeCheck.integration.test.ts
@@ -17,6 +17,9 @@ const SKIP_TYPECHECK = new Set([
   "blockParams",        // calls append() which doesn't exist (should use .push())
   "ifElse",             // calls undefined isReady(), uses undeclared variables
   "setLLMClient",       // setLLMClient() is runtime-injected, not visible to typechecker
+  "imports",            // exercises import SYNTAX/codegen with intentionally-dangling
+                        // modules (./foo.agency etc. don't exist); strict imports (AG4009)
+                        // now flags them, which is correct for real code but not this fixture
 ]);
 
 // Stdlib files with known warnings from typechecker limitations

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -49,6 +49,7 @@ import { refineInlineHandlerParams } from "./handlerParamTyping.js";
 import { checkEffectPayloads, buildEffectRegistry } from "./effectPayloadCheck.js";
 import type { SymbolTable } from "../symbolTable.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
+import { checkMissingImports } from "./missingImportDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
 import { checkToolBlockBindings } from "./toolBlockBinding.js";
 import { RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
@@ -335,6 +336,9 @@ export class TypeChecker {
 
     // Check for undefined function calls (config-controlled severity).
     checkUndefinedFunctions(scopes, ctx);
+
+    // Error on plain imports that don't resolve to a real export.
+    checkMissingImports(ctx);
 
     // Check for undefined variable references (config-controlled severity).
     checkUndefinedVariables(scopes, ctx);

--- a/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+function check(files: Record<string, string>, entry: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-miss-"));
+  try {
+    for (const [name, src] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), src);
+    }
+    const entryPath = path.join(dir, entry);
+    const src = files[entry];
+    const parsed = parseAgency(src);
+    if (!parsed.success) {
+      throw new Error(`parse failed: ${(parsed as { message?: string }).message}`);
+    }
+    const symbols = SymbolTable.build(entryPath);
+    const info = buildCompilationUnit(parsed.result, symbols, entryPath, src);
+    return typeCheck(parsed.result, {}, info).errors;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("checkMissingImports", () => {
+  it("errors on a name the target file does not define", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { missingFn } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importNameNotFound");
+    expect(e).toBeDefined();
+    expect(e?.message).toContain("missingFn");
+  });
+
+  it("names the original name for an aliased import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { missingFn as m } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importNameNotFound");
+    expect(e?.message).toContain("missingFn");
+  });
+
+  it("errors on a missing node import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import node { ghostNode } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeDefined();
+  });
+
+  it("errors on a module path that does not exist", () => {
+    const errors = check(
+      {
+        "use.agency": 'import { x } from "./ghost.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importModuleNotFound");
+    expect(e).toBeDefined();
+    expect(e?.message).toContain("./ghost.agency");
+  });
+
+  it("stays silent when the target exists but failed to load (parse error)", () => {
+    // This test depends on `broken.agency` failing to parse, so `build` skips
+    // it and `getFile` returns undefined → `notLoaded` → silent. The dependency
+    // is on the parser: if the parser ever accepts this body, the target would
+    // load and the test would turn RED (name absent → error), not falsely green.
+    // So the coupling is safe — it can only over-report, never miss a real bug.
+    const errors = check(
+      {
+        "broken.agency": "def def def { { { <<< not valid agency\n",
+        "use.agency": 'import { anything } from "./broken.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("accepts a real cross-file import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { realFn } from "./lib.agency"\n\nnode u(): string {\n  return realFn()\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("ignores JavaScript imports", () => {
+    // The `if (!node.isAgencyImport)` guard is load-bearing: the checker can't
+    // read a .js file's exports. Remove the guard and this .js import gets flagged.
+    const errors = check(
+      {
+        "use.agency": 'import { anything } from "./helper.js"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("accepts a valid node import", () => {
+    // Positive counterpart to the missing-node test: guards that nodes are
+    // looked up in the right place (FileSymbols keyed by node name).
+    const errors = check(
+      {
+        "lib.agency": "export node helperNode(): string {\n  return \"n\"\n}\n",
+        "use.agency": 'import node { helperNode } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("reports only the missing name in a mixed import", () => {
+    const errors = check(
+      {
+        "lib.agency": "export def realFn(): string {\n  return \"x\"\n}\n",
+        "use.agency": 'import { realFn, missingFn } from "./lib.agency"\n\nnode u(): string {\n  return realFn()\n}\n',
+      },
+      "use.agency",
+    );
+    const nameErrors = errors.filter((err) => err.name === "importNameNotFound");
+    expect(nameErrors).toHaveLength(1);
+    expect(nameErrors[0].message).toContain("missingFn");
+    expect(nameErrors[0].message).not.toContain("realFn");
+  });
+
+  it("reports exactly one module error for a multi-name missing module", () => {
+    const errors = check(
+      {
+        "use.agency": 'import { a, b } from "./ghost.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.filter((err) => err.name === "importModuleNotFound")).toHaveLength(1);
+  });
+
+  it("accepts an import of a re-exported name", () => {
+    // Relies on mergeExportsFrom merging `deep` into barrel.agency's FileSymbols
+    // during build. A regression in the merge would false-positive here.
+    const errors = check(
+      {
+        "real.agency": "export def deep(): string {\n  return \"d\"\n}\n",
+        "barrel.agency": 'export { deep } from "./real.agency"\n',
+        "use.agency": 'import { deep } from "./barrel.agency"\n\nnode u(): string {\n  return deep()\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+
+  it("accepts a valid std:: import", () => {
+    // std:: resolves through a different branch of resolveAgencyImportPath.
+    // `bash` is a real export of std::shell (verified). We only assert the
+    // absence of import diagnostics, so any unrelated marker warning is ignored.
+    const errors = check(
+      {
+        "use.agency": 'import { bash } from "std::shell"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.ts
@@ -1,0 +1,71 @@
+import { diagnostic } from "./diagnostics.js";
+import type { TypeCheckerContext } from "./types.js";
+import type { SourceLocation } from "../types/base.js";
+import type { AgencyNode } from "../types.js";
+
+/** A plain Agency import, normalized so the checker doesn't care which node
+ *  kind it came from. */
+type ImportSpec = {
+  modulePath: string;
+  names: readonly string[];
+  loc: SourceLocation | null;
+};
+
+/**
+ * The "what": which plain Agency imports to check, and the names each brings in.
+ * Returns null for anything out of scope (JS imports, non-import nodes). Keeps
+ * the per-node-kind field access (the "how") in one place.
+ */
+function toImportSpec(node: AgencyNode): ImportSpec | null {
+  if (node.type === "importStatement" && node.isAgencyImport) {
+    const names = node.importedNames
+      .filter((nameType) => nameType.type === "namedImport")
+      .flatMap((nameType) => nameType.importedNames);
+    return { modulePath: node.modulePath, names, loc: node.loc ?? null };
+  }
+  if (node.type === "importNodeStatement") {
+    return { modulePath: node.agencyFile, names: node.importedNodes, loc: node.loc ?? null };
+  }
+  return null;
+}
+
+/**
+ * Error on plain imports that don't resolve to a real export:
+ *   - a name a loaded Agency file doesn't define  → importNameNotFound
+ *   - a module path that resolves to no file       → importModuleNotFound
+ *
+ * Covers `import { ... }` (Agency only) and `import node { ... }`. Skips JS
+ * imports, `export { } from`, and unresolvable `pkg::` (the latter two already
+ * throw in SymbolTable.build). Stays silent when the target exists but wasn't
+ * loaded — that is a partial view, and the target's own error is the real one.
+ */
+export function checkMissingImports(ctx: TypeCheckerContext): void {
+  const { symbolTable, currentFile } = ctx;
+  if (!symbolTable || !currentFile) return;
+
+  for (const node of ctx.programNodes) {
+    const spec = toImportSpec(node);
+    if (!spec) continue;
+
+    const resolution = symbolTable.resolveImportModule(
+      spec.modulePath,
+      currentFile,
+      ctx.config,
+    );
+    if (resolution.kind === "missing") {
+      // One module error per statement, not one per imported name.
+      ctx.errors.push(diagnostic("importModuleNotFound", { module: spec.modulePath }, spec.loc));
+      continue;
+    }
+    if (resolution.kind === "notLoaded") {
+      continue;
+    }
+    for (const name of spec.names) {
+      if (!Object.prototype.hasOwnProperty.call(resolution.symbols, name)) {
+        ctx.errors.push(
+          diagnostic("importNameNotFound", { name, module: spec.modulePath }, spec.loc),
+        );
+      }
+    }
+  }
+}

--- a/packages/agency-lang/tests/integration/cli-main/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-main/test.mjs
@@ -654,6 +654,31 @@ node beeMain(): string {
     "No .agency files found",
   );
 
+  // tc: a directory where a file imports a name its target does not define (#438 follow-up)
+  const tcBadImportDir = join(dir, "tc-bad-import");
+  mkdirSync(tcBadImportDir, { recursive: true });
+  writeFileSync(
+    join(tcBadImportDir, "lib.agency"),
+    `export def realFn(): string {
+  return "x"
+}
+`,
+  );
+  writeFileSync(
+    join(tcBadImportDir, "use.agency"),
+    `import { missingFn } from "./lib.agency"
+
+node u(): string {
+  return "y"
+}
+`,
+  );
+  const tcBadImportOut = stripAnsi(
+    runAgency("28e-tc-missing-import", ["tc", "tc-bad-import"], { expectFail: true }),
+  );
+  assertIncludes(tcBadImportOut, "AG4008");
+  assertIncludes(tcBadImportOut, "missingFn");
+
   // bundle and unbundle
 
   console.log("--- bundle/unbundle ---");


### PR DESCRIPTION
## Summary

Makes the type checker **error** when a plain Agency import names something that doesn't exist. Follow-up to #438 / PR #525.

Two mistakes were silent before and are now hard errors:

- **`AG4008`** — the target Agency file exists and is loaded, but doesn't define the imported name.
- **`AG4009`** — the import path resolves to no file.

```
// lib.agency has no `missingFn`
import { missingFn } from "./lib.agency"   // AG4008
import { x } from "./ghost.agency"         // AG4009
```

Previously both type-checked clean. An imported name is declared into scope as `any` unconditionally (`scopes.ts`), so nothing verified the target actually exports it.

## Why this is safe to make a hard error

The check only fires when it is **certain**. The symbol table records which files it loaded, so:

- module path doesn't exist on disk → error (missing module)
- module loaded, name absent → error (missing name)
- module exists on disk but wasn't loaded (a parse failure in it, or a single-file editor check) → **silent** — the view is incomplete, and the target's own error is the real one

This asymmetry with undefined *calls* (a silenceable warning) is deliberate: a bare `foo()` might be an uncatalogued JavaScript global, which Agency permits without an import, so the checker can't be sure. An Agency import is unambiguous.

## Scope

- Covers `import { ... }` (Agency only) and `import node { ... }`, including aliases.
- Skips JavaScript imports (can't read a `.js` file's exports).
- `export { } from` and unresolvable `pkg::` already throw in `SymbolTable.build`, so they're out of scope here (documented as a possible follow-up to convert those throws into clean diagnostics).
- Non-goal: enforcing `export` visibility on plain imports.

## Implementation

- `SymbolTable.resolveImportModule(modulePath, fromFile, config?)` — classifies the target as `missing` / `notLoaded` / `loaded`, hiding path resolution, the `fs` check, and the `pkg::` throw behind a tagged union. Verbose-gated logging in the catch so an unexpected resolution error isn't silently mislabelled.
- `checkMissingImports(ctx)` — a new typechecker pass beside `checkUndefinedFunctions`, using a small `toImportSpec` normalizer so it doesn't care which node kind an import came from.
- Two registry diagnostics (AG4008/AG4009) plus their required `agency explain` entries.

## Rollout sweep

Ran the check across the whole codebase before shipping the hard error:

- `agency tc stdlib` → **0** import errors.
- `agency tc tests` → only two fixtures with intentionally-dangling imports, both intentional and not type-checked by CI (`typescriptGenerator/imports.agency`, an import-syntax fixture now excluded from the fixtureTypeCheck vitest; `formatter/roundtrip.agency`, only formatted, never type-checked).

No real, stdlib, or production import needed fixing.

## Tests

- Unit tests for the classifier (loaded / missing / notLoaded / pkg-throws).
- 12 pass tests: missing name, aliased, missing node, missing module, silent-on-parse-failure, valid cross-file, **JS import skipped**, **valid node import**, mixed valid+invalid (one error), multi-name missing module (one error), re-exported name, valid `std::`.
- cli-main integration case `28e-tc-missing-import` (expectFail, asserts AG4008), proving `agency tc` exits non-zero.

Verified locally: full typechecker vitest suite (1318 pass), the two new unit files (16 pass), the cli-main integration harness (exit 0), structural linter clean, and direct CLI exercise of AG4008 + AG4009 end-to-end.

## Process docs

The design spec, implementation plan, and both external reviews are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
