### PR TITLE
Retire the "any" string sentinel in favor of ANY_T (#472)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-retire-any-sentinel.md
+++ b/docs/superpowers/plans/2026-07-12-retire-any-sentinel.md
@@ -172,18 +172,26 @@ In `synthesizer.ts`, change all 27 `return "any"` to `return ANY_T` (already imp
 
 `resolveResultFieldType` (`synthesizer.ts:75`) and the `:199` site return `VariableType | "any" | null`, where `"any"` is a signal ("caller returns any") and `null` means "no resolution." Narrow the return to `VariableType | null`. Replace `return "any"` with `return ANY_T`. Then read each caller: where it did `if (x === "any") return "any"`, it now receives `ANY_T` (a real type) and should set/return it as the type; where it checked `null`, that branch is unchanged. Confirm the control flow matches the original for both the any-case and the null-case.
 
-- [ ] **Step 3: Migrate the nine `flow.test.ts` assertions**
+These signal-site folds are the riskiest edits in the migration, and they rely on manual "the caller behaves the same" reasoning. Before trusting it, grep the suite for coverage: confirm a test exercises `resolveResultFieldType`'s any-branch (a field in `RESULT_FIELDS` on an un-narrowed Result) AND its null-branch (a non-Result field). If neither is covered, add a synth test in `synthesizer`-adjacent tests that reads a Result field both ways and asserts the resulting type. Do not rely on tsc alone for these.
 
-`uniteTypes` and `typeAt` now return `ANY_T`, so `expect(...).toBe("any")` fails. Change each of the nine sites (`flow.test.ts:41,106,149,303,309,400,519,529,568`) from:
+- [ ] **Step 3: Migrate ALL `flow.test.ts` edits (assertions AND value inputs)**
+
+Narrowing `ScopeType`/`uniteTypes`/`typeAt` breaks two kinds of site in this file. Both must be done here.
+
+**(a) Nine assertion right-hand sides** (`:41,106,149,303,309,400,519,529,568`). `uniteTypes`/`typeAt` now return `ANY_T`, so `.toBe("any")` fails. Use `toEqual(ANY_T)`, not `isAnyType(...)`:
 
 ```ts
-expect(typeAt(ref("y"), start, env(scope))).toBe("any");
+expect(typeAt(ref("y"), start, env(scope))).toEqual(ANY_T);
 ```
-to:
-```ts
-expect(isAnyType(typeAt(ref("y"), start, env(scope)))).toBe(true);
-```
-Import `isAnyType` from `./utils.js` in the test file. This is an assertion update, not a behavior change.
+
+`toEqual(ANY_T)` deep-equals the object and fails on the string form. `isAnyType(...)` is too weak here: during this task `isAnyType` still accepts both forms, so it could not tell a correctly-migrated `ANY_T` from a half-migrated string. Import `ANY_T` from `./primitives.js`.
+
+**(b) Three value-input sites** that pass the string into a now-narrowed `VariableType` slot. These are `"any"` → `ANY_T` substitutions, not assertion swaps:
+- `:41` `uniteTypes(["any", STR], {})` → `uniteTypes([ANY_T, STR], {})` (line 41 needs BOTH halves: the input here and its assertion RHS).
+- `:559` `scope.declare("x", "any")` → `scope.declare("x", ANY_T)`.
+- `:565` `type: "any"` on the assign `FlowNode` literal → `type: ANY_T`.
+
+Task 3 Step 4 (follow the compiler) will flag (b) as type errors if missed, but list them here so the executor does not mark Step 3 done after only the nine assertions.
 
 - [ ] **Step 4: Follow the compiler outward**
 
@@ -205,7 +213,8 @@ Narrow the any-sentinel spine to VariableType (#472)
 
 synthType, ScopeType, inferredReturnTypes, uniteTypes, typeAt now return/store
 VariableType and produce ANY_T. Handle the resolveResultFieldType | null signal
-sites. Migrate flow.test.ts assertions from `.toBe("any")` to isAnyType checks.
+sites. Migrate flow.test.ts: nine assertions to toEqual(ANY_T) plus three
+"any" -> ANY_T value-input substitutions.
 ```
 
 ---
@@ -214,7 +223,7 @@ sites. Migrate flow.test.ts assertions from `.toBe("any")` to isAnyType checks.
 
 Continue the narrow-and-fix pass until no `VariableType | "any"` signature remains. Each file or producer-cluster that compiles cleanly on its own may be its own commit; keep the invariant (returns + signature together).
 
-**Files (as the compiler surfaces them):** `checker.ts` (with its `| undefined` signal sites at `:50,:74,:979`), `scopes.ts`, `resolveCall.ts`, `builtins.ts`, `inference.ts`, `matchExprTypes.ts`, `typeCases.ts`, `interruptAnalysis.ts`, `functionTypeRaises.ts` (`| null | undefined` sites at `:38,:131`), `functionValueEffects.ts`, `effectSets.ts`, `effectPayloadCheck.ts`, `matchExhaustiveness.ts`, `narrowing.ts`, `flowBuilder.ts`, `index.ts`.
+**Files (as the compiler surfaces them):** `types.ts` (remaining sentinel signatures at `:67-70`, `:85`, `:106`, `:117`, `:139` — `:99` was done in Task 3; `:106` `matchExprTypes` and `:67-70` ripple widely), `checker.ts` (with its `| undefined` signal sites at `:50,:74,:979`), `scopes.ts`, `resolveCall.ts`, `builtins.ts`, `inference.ts`, `matchExprTypes.ts`, `typeCases.ts`, `interruptAnalysis.ts`, `functionTypeRaises.ts` (`| null | undefined` sites at `:38,:131`), `functionValueEffects.ts`, `effectSets.ts`, `effectPayloadCheck.ts`, `matchExhaustiveness.ts`, `narrowing.ts`, `flowBuilder.ts`, `assignability.ts`, `index.ts`.
 
 - [ ] **Step 1: Find remaining sentinel signatures**
 
@@ -228,22 +237,59 @@ Work through the list. For each producer: change its `return "any"` (if any) to 
 
 `checker.ts:50,:74,:979` (`VariableType | "any" | undefined`) and `functionTypeRaises.ts:38,:131` (`VariableType | "any" | null | undefined`): keep `null`/`undefined` with their meanings; fold only the `"any"` disjunct into `VariableType` as `ANY_T`, verifying each caller treated the any-case like any other unknown-type result.
 
-- [ ] **Step 3: Collapse the back-to-back assignability check**
+- [ ] **Step 3: Delete the redundant assignability FAST PATH (not the alias-aware check)**
 
-In `assignability.ts`, once `isAssignable`'s `source`/`target` are `VariableType`, the string-form check (now `isAnyType(source) || isAnyType(target)`) and the object-form check at `:487-488` (`resolvedSource.value === "any" || ...`) are redundant. Keep one. Delete the other and its apologetic comment (symptom #3 in the spec).
+`assignability.ts` has two `any` checks, and they are NOT interchangeable — deleting the wrong one regresses `type Foo = any`.
 
-- [ ] **Step 4: Confirm no sentinel signatures remain**
+- `:435` is in `isAssignableGuarded`, **before** `safeResolveType`. Task 2 rewrote it to `if (isAnyType(source) || isAnyType(target)) return true;`. It only catches a *bare* `ANY_T` source/target. For an alias node like `type Foo = any`, `source` is a `typeAliasVariable`, so `isAnyType(source)` is `false` here.
+- `:487-488` is in `isAssignableInner`, **after** `safeResolveType` resolves aliases. It catches both the bare case and `type Foo = any` (which resolves to `primitiveType("any")`). The apologetic comment at `:485` sits on THIS check.
+
+`safeResolveType` of a bare `ANY_T` returns itself, so `:487-488` already covers everything `:435` covers, plus aliases. **Delete `:435` (the redundant pre-resolution fast path). KEEP `:487-488`.** Deleting `:487-488` instead would make an `any`-aliased value non-assignable to anything — a real regression, and finding 5's test below would catch it.
+
+Then fold the surviving `:487-488` object-form check into the predicate: `if (isAnyType(resolvedSource) || isAnyType(resolvedTarget)) return true;`. Reword or drop the `:485` comment.
+
+- [ ] **Step 4: Add the alias-to-any assignability regression test**
+
+Nothing in `assignability.test.ts` covers an alias whose body is `any` — exactly the case Step 3's wrong deletion would break. Add it to `lib/typeChecker/assignability.test.ts` (match the file's existing helper style for `isAssignable` and alias maps):
+
+```ts
+it("a value typed as an any-alias is assignable both directions", () => {
+  const aliases = { Foo: { type: "primitiveType", value: "any" } };
+  const FooRef = { type: "typeAliasVariable", aliasName: "Foo" };
+  expect(isAssignable(FooRef, NUMBER_T, aliases)).toBe(true); // any-alias -> concrete
+  expect(isAssignable(NUMBER_T, FooRef, aliases)).toBe(true); // concrete -> any-alias
+});
+```
+
+Run it BEFORE and AFTER the Step 3 edit. It passes both times if Step 3 is correct. It fails after if `:487-488` was deleted by mistake.
+
+- [ ] **Step 5: Fold the orphaned object-form `.value === "any"` checks into `isAnyType`**
+
+The spec's goal is that every "is this any?" test is one call to `isAnyType`. Task 2 deliberately left the object-form checks alone; pick them up now (nothing is left that could still be the string, so the fold is safe and satisfies the goal). Fold each:
+
+| Site | Current | Fold to |
+|---|---|---|
+| `checker.ts:523` | `hint.type === "primitiveType" && hint.value === "any"` | `isAnyType(hint)` |
+| `synthesizer.ts:910` | `resolved.type === "primitiveType" && resolved.value === "any"` | `isAnyType(resolved)` |
+| `typeCases.ts:119` | `members.some((rm) => rm.type === "primitiveType" && rm.value === "any")` | `members.some(isAnyType)` |
+| `effectSets.ts:47` | `t.type === "primitiveType" && t.value === "any"` | `isAnyType(t)` |
+| `utils.ts:122` | `t.type === "primitiveType" && t.value === "any"` | `isAnyType(t)` |
+| `assignability.ts:406` | `resolved.value === "null" \|\| resolved.value === "any"` | `resolved.value === "null" \|\| isAnyType(resolved)` (fold the any-half only; leave the null-half) |
+
+(`utils.ts:49` is the `isAnyType` body itself — leave it. `inference.ts:130` is the duplicate deleted in Task 5.)
+
+- [ ] **Step 6: Confirm no sentinel signatures OR object-form checks remain**
 
 ```bash
-grep -rn '| "any"' lib/typeChecker/ | grep -v '\.test\.'
+grep -rn '| "any"' lib/typeChecker/ | grep -v '\.test\.'          # expected: empty
+grep -rn '\.value === "any"' lib/typeChecker/ | grep -v '\.test\.' # expected: only utils.ts:49 (the isAnyType body)
 ```
-Expected: empty.
 
-- [ ] **Step 5: Verify green**
+- [ ] **Step 7: Verify green**
 
-Both commands → `/tmp/t4.log`. tsc clean; suite passes.
+Both commands → `/tmp/t4.log`. tsc clean; suite passes, including the new alias-to-any test.
 
-- [ ] **Step 6: Commit** (or several commits across this task)
+- [ ] **Step 8: Commit** (or several commits across this task)
 
 ```bash
 git add lib/typeChecker/
@@ -254,8 +300,10 @@ git commit -F /tmp/commit4.txt
 Narrow remaining any-sentinel producers to VariableType (#472)
 
 All producer signatures now return VariableType. Fold the | undefined and
-| null | undefined signal sites. Collapse the back-to-back any check in
-isAssignable into one.
+| null | undefined signal sites. Delete the redundant pre-resolution any
+fast path in isAssignable (keep the alias-aware post-resolution check) and
+add an alias-to-any regression test. Fold the orphaned object-form
+.value === "any" checks into isAnyType.
 ```
 
 ---
@@ -311,7 +359,7 @@ isAnyType back to VariableType. The string sentinel is now unrepresentable.
 
 ### Task 6: Regression guard test
 
-A cheap test that fails if the sentinel creeps back. The type system already blocks producing it; this documents the intent and catches a stray reintroduction in review.
+A cheap tripwire, not a proof. The compiler is the real guarantee: once every signature is `VariableType`, the sentinel is unrepresentable. This test documents the intent and catches a stray hand-edit that slips past the formatter. It scans for three patterns: the `| "any"` signature (spaced or not, either union order), a bare `return "any"`, and a reintroduced object-form `.value === "any"` check outside the one place it belongs.
 
 **Files:**
 - Create: `lib/typeChecker/anySentinelRetired.test.ts`
@@ -326,25 +374,47 @@ import { fileURLToPath } from "url";
 
 const dir = path.dirname(fileURLToPath(import.meta.url));
 
-function sourceFiles(): string[] {
-  return fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"))
-    .map((f) => path.join(dir, f));
+// Recursive so a future subdir under lib/typeChecker is not silently dropped.
+function sourceFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
 }
 
+const files = sourceFiles(dir);
+
 describe("the 'any' string sentinel stays retired (#472)", () => {
-  it("no file declares a `VariableType | \"any\"` signature", () => {
-    for (const file of sourceFiles()) {
+  it("no signature unions VariableType with the \"any\" string", () => {
+    // Matches `| "any"` and `"any" |` with any spacing, so a formatter-evading
+    // hand-edit or reversed member order is still caught.
+    const re = /(\|\s*"any")|("any"\s*\|)/;
+    for (const file of files) {
       const src = fs.readFileSync(file, "utf8");
-      expect(src.includes('| "any"'), path.basename(file)).toBe(false);
+      expect(re.test(src), path.basename(file)).toBe(false);
     }
   });
 
-  it("no file returns the bare `\"any\"` string", () => {
-    for (const file of sourceFiles()) {
+  it("no file returns the bare \"any\" string", () => {
+    const re = /return\s+\(?\s*"any"/;
+    for (const file of files) {
       const src = fs.readFileSync(file, "utf8");
-      expect(/return\s+"any"/.test(src), path.basename(file)).toBe(false);
+      expect(re.test(src), path.basename(file)).toBe(false);
+    }
+  });
+
+  it("no inline object-form any-check outside isAnyType", () => {
+    // The one legitimate `.value === "any"` is isAnyType's body in utils.ts.
+    const re = /\.value\s*===\s*"any"/;
+    for (const file of files) {
+      if (path.basename(file) === "utils.ts") continue;
+      const src = fs.readFileSync(file, "utf8");
+      expect(re.test(src), path.basename(file)).toBe(false);
     }
   });
 });
@@ -352,12 +422,17 @@ describe("the 'any' string sentinel stays retired (#472)", () => {
 
 - [ ] **Step 2: Run it**
 
-Run: `pnpm exec vitest run lib/typeChecker/anySentinelRetired.test.ts 2>&1 | tee /tmp/t6.log | tail -10`
-Expected: PASS (both assertions green, proving the retirement is complete).
+Run: `pnpm exec vitest run lib/typeChecker/anySentinelRetired.test.ts 2>&1 | tee /tmp/t6.log | tail -12`
+Expected: PASS (all three green).
 
-- [ ] **Step 3: Sanity-check the guard bites**
+- [ ] **Step 3: Sanity-check that each assertion bites**
 
-Temporarily add `return "any"` to any source file, rerun the test, confirm it FAILS, then revert. (Do not commit the temporary edit.)
+Prove all three catch a violation. One at a time, temporarily introduce a violation, rerun, confirm that specific test FAILS, then revert:
+- add `x: VariableType | "any"` to a source file → assertion 1 fails.
+- add `return "any"` to a function → assertion 2 fails.
+- add `foo.value === "any"` outside `utils.ts` → assertion 3 fails.
+
+Do not commit any temporary edit.
 
 - [ ] **Step 4: Commit**
 
@@ -369,8 +444,9 @@ git commit -F /tmp/commit6.txt
 ```
 Guard against reintroducing the "any" sentinel (#472)
 
-Scans lib/typeChecker source for `| "any"` signatures and bare `return "any"`.
-Backstops the type-level guarantee against a stray reintroduction.
+Recursive scan of lib/typeChecker source for `| "any"` signatures (either
+union order), bare `return "any"`, and inline `.value === "any"` object-form
+checks outside isAnyType. A tripwire backing the type-level guarantee.
 ```
 
 ---
@@ -384,10 +460,13 @@ Backstops the type-level guarantee against a stray reintroduction.
 - Move 3 (spine + remaining producers, signal sites) → Tasks 3, 4. ✓
 - Move 4 (delete maybeAny, inference dups, isAnyType narrow-back, widenType casts, ScopeType) → Task 5. ✓
 - Control-signal sites (`| null` synth, `| undefined` checker, `| null | undefined` functionTypeRaises) → Task 3 Step 2, Task 4 Step 2. ✓
-- flow.test.ts nine-assertion migration → Task 3 Step 3. ✓
+- flow.test.ts migration: nine assertions (`toEqual(ANY_T)`) + three value-input substitutions → Task 3 Step 3. ✓
 - Behavior-preservation gate + stop-on-flip → Global Constraints, per-task verify. ✓
-- Regression guard → Task 6. ✓
-- Symptom #3 (assignability dedup) → Task 4 Step 3. ✓
+- Regression guard (three patterns, recursive, self-bite) → Task 6. ✓
+- Assignability any check: delete the redundant pre-resolution fast path `:435`, KEEP alias-aware `:487-488`, add alias-to-any test → Task 4 Steps 3-4 (review finding 1 + 5). ✓
+- Object-form `.value === "any"` checks folded into `isAnyType` → Task 4 Step 5 (review finding 4). ✓
+- `types.ts` remaining signatures named → Task 4 file list (review finding 3). ✓
+- Signal-site branch coverage confirmed/added → Task 3 Step 2 (review finding 5). ✓
 
 **Placeholder scan:** none. The compiler-discovered edits in Tasks 3-4 are method-plus-grep, not placeholders — the exact set is defined by tsc output, which is the point of a compiler-guided refactor.
 

--- a/docs/superpowers/plans/2026-07-12-retire-any-sentinel.md
+++ b/docs/superpowers/plans/2026-07-12-retire-any-sentinel.md
@@ -1,0 +1,394 @@
+# Retire the `"any"` string sentinel — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the `VariableType | "any"` string sentinel from `lib/typeChecker/`. Represent "unknown type" only as the object `ANY_T`. No behavior change.
+
+**Architecture:** The change is contained to `lib/typeChecker/`. It runs in four moves: widen `isAnyType` to accept both forms, route every literal comparison through it, then retire the string producer-by-producer under a strict invariant, then delete the dead machinery. The compiler drives the retirement: once a producer's signature narrows to `VariableType`, any leftover `=== "any"` becomes a TS2367 compile error.
+
+**Tech Stack:** TypeScript (ESM, `@/` path aliases via tsc-alias), vitest.
+
+## Global Constraints
+
+- **Work only in `lib/typeChecker/`.** The sentinel never escapes this directory. Do not touch backends or other consumers.
+- **Behavior-preserving.** Every existing test passes, with one deliberate exception: `flow.test.ts`'s nine `.toBe("any")` assertions migrate to `isAnyType(...)` checks (Task 3). If any other test flips, STOP — it means the string and object were not treated identically somewhere, which is a real asymmetry to investigate.
+- **The core invariant.** Change a function's returns and narrow its signature **in the same commit**. Never change `return "any"` to `return ANY_T` while the signature is still `VariableType | "any"` — that opens a silent-break window the compiler cannot see.
+- `ANY_T` is `{ type: "primitiveType", value: "any" }`, exported from `lib/typeChecker/primitives.js`. `isAnyType` is exported from `lib/typeChecker/utils.js`.
+- Never use dynamic imports. Use `type` not `interface`.
+- **Save test output to a file** (`| tee /tmp/<name>.log`) so failures do not require a rerun — the suite is slow.
+- We are on branch `worktree-retire-any-sentinel`. Never commit to `main`. Re-check `git branch --show-current` before every commit.
+- Do NOT run the full agency test suite. Only `lib/typeChecker/` unit tests are needed here.
+
+## Verification commands (used throughout)
+
+- Typecheck: `pnpm exec tsc --noEmit 2>&1 | tail -20`
+- Unit + fixture suite: `pnpm exec vitest run lib/typeChecker/ 2>&1 | tee /tmp/tc.log | tail -25`
+
+Run both from `/Users/adityabhargava/agency-lang/.claude/worktrees/retire-any-sentinel/packages/agency-lang`.
+
+---
+
+### Task 1: Widen `isAnyType`; collapse the four paired sites (Move 1)
+
+**Files:**
+- Modify: `lib/typeChecker/utils.ts:48`
+- Modify: `lib/typeChecker/matchExprTypes.ts:78,149`, `lib/typeChecker/scopes.ts:425,428`
+
+**Interfaces:**
+- Produces: `isAnyType(t: VariableType | "any"): boolean` (parameter widened; return unchanged)
+
+- [ ] **Step 1: Widen the `isAnyType` parameter**
+
+In `lib/typeChecker/utils.ts`, change:
+
+```ts
+export function isAnyType(t: VariableType): boolean {
+  return t.type === "primitiveType" && t.value === "any";
+}
+```
+
+to:
+
+```ts
+// Accepts the string sentinel too, only during the #472 migration. Once every
+// signature is narrowed to VariableType, the `| "any"` is removed again.
+export function isAnyType(t: VariableType | "any"): boolean {
+  return t === "any" || (t.type === "primitiveType" && t.value === "any");
+}
+```
+
+- [ ] **Step 2: Collapse the four paired comparison sites**
+
+At `matchExprTypes.ts:78` and `:149`, both read:
+
+```ts
+const isAny = (t: VariableType | "any") => t === "any" || isAnyType(t);
+```
+
+Since `isAnyType` now handles both, replace each with a direct call at the use sites, or simplify the local to `const isAny = isAnyType;`. Prefer deleting the local and calling `isAnyType` directly.
+
+At `scopes.ts:425` and `:428`, replace `iterableType === "any" || isAnyType(iterableType)` with `isAnyType(iterableType)`.
+
+- [ ] **Step 3: Verify green**
+
+Run both verification commands. Expected: tsc clean, full `lib/typeChecker/` suite passes. Save to `/tmp/t1.log`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/typeChecker/utils.ts lib/typeChecker/matchExprTypes.ts lib/typeChecker/scopes.ts
+git commit -F /tmp/commit1.txt
+```
+`/tmp/commit1.txt`:
+```
+Widen isAnyType to accept both any representations (#472)
+
+Transitional: isAnyType now accepts the "any" string sentinel as well as
+ANY_T, so comparison sites can route through one helper. Collapse the four
+paired `=== "any" || isAnyType(t)` sites.
+```
+
+---
+
+### Task 2: Route every comparison through `isAnyType` (Move 2)
+
+This is the bulk of the change, and it is behavior-preserving. No producer changes here. After it, no code reads the `"any"` literal by hand, which closes the silent-break window for Task 3.
+
+**Files:** every non-test file under `lib/typeChecker/` that compares against `"any"`. Find them:
+
+```bash
+grep -rn '=== "any"\|!== "any"' lib/typeChecker/ | grep -v '\.test\.'
+```
+
+Expected: 65 sites (56 `===`, 9 `!==`).
+
+**Interfaces:** none changed. Pure internal rewrite.
+
+- [ ] **Step 1: Rewrite each comparison**
+
+Apply this transformation at every site the grep lists:
+
+- `X === "any"` → `isAnyType(X)`
+- `X !== "any"` → `!isAnyType(X)`
+
+Where `X` is a compound expression, keep it parenthesized as needed: `foo.bar !== "any"` → `!isAnyType(foo.bar)`.
+
+Add `import { isAnyType } from "./utils.js";` to any file that now calls it and did not import it. (`inference.ts` has its own local `isAnyType` — leave that for Task 5; do not add a second import there yet.)
+
+Two sites need a note, not different handling:
+
+- `assignability.ts:438`: `if (source === "any" || target === "any") return true;` → `if (isAnyType(source) || isAnyType(target)) return true;`. Leave the second, object-form check at `:487-488` alone for now; Task 4 collapses the pair.
+- `widenType` (`assignability.ts:342`): `if (vt === "any") return "any";` → `if (isAnyType(vt)) return "any";`. The `return "any"` is a producer and stays until Task 5.
+
+Do NOT touch `return "any"` statements or `.value === "any"` object-form checks in this task. Only the two comparison operators above.
+
+- [ ] **Step 2: Confirm no bare comparisons remain**
+
+```bash
+grep -rn '=== "any"\|!== "any"' lib/typeChecker/ | grep -v '\.test\.'
+```
+Expected: empty.
+
+- [ ] **Step 3: Verify green**
+
+Run both verification commands → `/tmp/t2.log`. tsc clean; full suite passes unchanged (behavior-preserving). If a test fails here, a comparison was rewritten incorrectly — fix before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/typeChecker/
+git commit -F /tmp/commit2.txt
+```
+`/tmp/commit2.txt`:
+```
+Route every "any" comparison through isAnyType (#472)
+
+Behavior-preserving sweep of all 65 literal comparisons (=== / !== "any")
+onto isAnyType. No producer changes yet. Removes every by-hand string check,
+so the upcoming producer narrowing has nothing left to silently break.
+```
+
+---
+
+### Task 3: Narrow the spine (Move 3, part 1)
+
+`synthType`, `ScopeType`, and `inferredReturnTypes` are interlinked: narrowing one forces the others plus their consumers. This is one large atomic commit. It also handles the `synthesizer.ts` `| null` signal sites and the `flow.test.ts` assertion migration.
+
+**Files:**
+- Modify: `lib/typeChecker/synthesizer.ts` (`synthType:252`, `resolveResultFieldType:75`, the `:199` signal site, 27 `return "any"` → `return ANY_T`)
+- Modify: `lib/typeChecker/scope.ts:3` (`ScopeType`), `lib/typeChecker/flow.ts` (`uniteTypes:154`, `typeAt:188`)
+- Modify: `lib/typeChecker/types.ts:99` (`inferredReturnTypes`)
+- Modify: `lib/typeChecker/flow.test.ts` (9 assertions)
+- Plus whatever the compiler flags in consumers of the above.
+
+**Interfaces:**
+- Produces: `synthType(...): VariableType` (was `| "any"`); `ScopeType = VariableType` (alias kept for now, collapsed in Task 5); `typeAt(...): VariableType`; `inferredReturnTypes: Record<string, VariableType>`
+
+- [ ] **Step 1: Flip producers to `ANY_T` and narrow signatures together**
+
+In `synthesizer.ts`, change all 27 `return "any"` to `return ANY_T` (already imported). Narrow `synthType`'s return type from `VariableType | "any"` to `VariableType`. Do the same for `inferredReturnTypes` in `types.ts` and for `uniteTypes`/`typeAt` in `flow.ts`. Change `ScopeType` (`scope.ts:3`) from `VariableType | "any"` to `VariableType` (keep the alias name; Task 5 removes it).
+
+- [ ] **Step 2: Handle the two `| null` signal sites**
+
+`resolveResultFieldType` (`synthesizer.ts:75`) and the `:199` site return `VariableType | "any" | null`, where `"any"` is a signal ("caller returns any") and `null` means "no resolution." Narrow the return to `VariableType | null`. Replace `return "any"` with `return ANY_T`. Then read each caller: where it did `if (x === "any") return "any"`, it now receives `ANY_T` (a real type) and should set/return it as the type; where it checked `null`, that branch is unchanged. Confirm the control flow matches the original for both the any-case and the null-case.
+
+- [ ] **Step 3: Migrate the nine `flow.test.ts` assertions**
+
+`uniteTypes` and `typeAt` now return `ANY_T`, so `expect(...).toBe("any")` fails. Change each of the nine sites (`flow.test.ts:41,106,149,303,309,400,519,529,568`) from:
+
+```ts
+expect(typeAt(ref("y"), start, env(scope))).toBe("any");
+```
+to:
+```ts
+expect(isAnyType(typeAt(ref("y"), start, env(scope)))).toBe(true);
+```
+Import `isAnyType` from `./utils.js` in the test file. This is an assertion update, not a behavior change.
+
+- [ ] **Step 4: Follow the compiler outward**
+
+Narrowing the spine turns leftover mismatches into compile errors. Run `pnpm exec tsc --noEmit 2>&1 | tail -40` and fix each error. Most will be consumers that still typed a result as `VariableType | "any"` — narrow those too. Repeat until tsc is clean. This is the compiler enumerating the fallout; do not hunt by hand.
+
+- [ ] **Step 5: Verify green**
+
+Both verification commands → `/tmp/t3.log`. tsc clean; suite passes (with the migrated `flow.test.ts` assertions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/typeChecker/
+git commit -F /tmp/commit3.txt
+```
+`/tmp/commit3.txt`:
+```
+Narrow the any-sentinel spine to VariableType (#472)
+
+synthType, ScopeType, inferredReturnTypes, uniteTypes, typeAt now return/store
+VariableType and produce ANY_T. Handle the resolveResultFieldType | null signal
+sites. Migrate flow.test.ts assertions from `.toBe("any")` to isAnyType checks.
+```
+
+---
+
+### Task 4: Narrow the remaining producers to green (Move 3, part 2)
+
+Continue the narrow-and-fix pass until no `VariableType | "any"` signature remains. Each file or producer-cluster that compiles cleanly on its own may be its own commit; keep the invariant (returns + signature together).
+
+**Files (as the compiler surfaces them):** `checker.ts` (with its `| undefined` signal sites at `:50,:74,:979`), `scopes.ts`, `resolveCall.ts`, `builtins.ts`, `inference.ts`, `matchExprTypes.ts`, `typeCases.ts`, `interruptAnalysis.ts`, `functionTypeRaises.ts` (`| null | undefined` sites at `:38,:131`), `functionValueEffects.ts`, `effectSets.ts`, `effectPayloadCheck.ts`, `matchExhaustiveness.ts`, `narrowing.ts`, `flowBuilder.ts`, `index.ts`.
+
+- [ ] **Step 1: Find remaining sentinel signatures**
+
+```bash
+grep -rn '| "any"' lib/typeChecker/ | grep -v '\.test\.'
+```
+
+Work through the list. For each producer: change its `return "any"` (if any) to `return ANY_T`, narrow the signature, and fix the compiler's fallout.
+
+- [ ] **Step 2: Handle the `| undefined` and `| null | undefined` signal sites**
+
+`checker.ts:50,:74,:979` (`VariableType | "any" | undefined`) and `functionTypeRaises.ts:38,:131` (`VariableType | "any" | null | undefined`): keep `null`/`undefined` with their meanings; fold only the `"any"` disjunct into `VariableType` as `ANY_T`, verifying each caller treated the any-case like any other unknown-type result.
+
+- [ ] **Step 3: Collapse the back-to-back assignability check**
+
+In `assignability.ts`, once `isAssignable`'s `source`/`target` are `VariableType`, the string-form check (now `isAnyType(source) || isAnyType(target)`) and the object-form check at `:487-488` (`resolvedSource.value === "any" || ...`) are redundant. Keep one. Delete the other and its apologetic comment (symptom #3 in the spec).
+
+- [ ] **Step 4: Confirm no sentinel signatures remain**
+
+```bash
+grep -rn '| "any"' lib/typeChecker/ | grep -v '\.test\.'
+```
+Expected: empty.
+
+- [ ] **Step 5: Verify green**
+
+Both commands → `/tmp/t4.log`. tsc clean; suite passes.
+
+- [ ] **Step 6: Commit** (or several commits across this task)
+
+```bash
+git add lib/typeChecker/
+git commit -F /tmp/commit4.txt
+```
+`/tmp/commit4.txt`:
+```
+Narrow remaining any-sentinel producers to VariableType (#472)
+
+All producer signatures now return VariableType. Fold the | undefined and
+| null | undefined signal sites. Collapse the back-to-back any check in
+isAssignable into one.
+```
+
+---
+
+### Task 5: Delete the dead machinery (Move 4)
+
+Nothing produces the string now, so the transitional scaffolding comes out.
+
+**Files:** `synthesizer.ts` (`maybeAny:236`, `:600` caller), `inference.ts:126,129`, `utils.ts:48`, `assignability.ts` (`widenType`), `scope.ts:3`
+
+- [ ] **Step 1: Delete `maybeAny`**
+
+Remove `maybeAny` (`synthesizer.ts:236`). At its one caller (`:600`), `maybeAny(synthType(inner, scope, ctx))` becomes `synthType(inner, scope, ctx)` — `synthType` now returns `VariableType` directly.
+
+- [ ] **Step 2: Fold the `inference.ts` duplicates**
+
+Delete the local `const ANY_T` (`inference.ts:126`) and the local `isAnyType` (`:129`). Add `import { ANY_T } from "./primitives.js";` and `import { isAnyType } from "./utils.js";` (merge into existing import lines if present).
+
+- [ ] **Step 3: Narrow `isAnyType` back to `VariableType`**
+
+In `utils.ts`, restore the parameter and drop the transitional branch:
+
+```ts
+export function isAnyType(t: VariableType): boolean {
+  return t.type === "primitiveType" && t.value === "any";
+}
+```
+
+- [ ] **Step 4: De-cast `widenType` and collapse `ScopeType`**
+
+In `assignability.ts`, narrow `widenType` to `widenType(vt: VariableType): VariableType`, delete the `if (vt === "any") return "any";` line, and remove every `as VariableType` cast in its body (they are now unnecessary). In `scope.ts`, replace `type ScopeType = VariableType | "any"` usage: either set `type ScopeType = VariableType` or replace `ScopeType` with `VariableType` throughout and delete the alias. Prefer deleting the alias.
+
+- [ ] **Step 5: Verify green**
+
+Both commands → `/tmp/t5.log`. tsc clean; suite passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/typeChecker/
+git commit -F /tmp/commit5.txt
+```
+`/tmp/commit5.txt`:
+```
+Delete the any-sentinel scaffolding (#472)
+
+Remove maybeAny, the inference.ts local ANY_T + isAnyType duplicates,
+widenType's | "any" branch and casts, and the ScopeType alias. Narrow
+isAnyType back to VariableType. The string sentinel is now unrepresentable.
+```
+
+---
+
+### Task 6: Regression guard test
+
+A cheap test that fails if the sentinel creeps back. The type system already blocks producing it; this documents the intent and catches a stray reintroduction in review.
+
+**Files:**
+- Create: `lib/typeChecker/anySentinelRetired.test.ts`
+
+- [ ] **Step 1: Write the guard test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+
+function sourceFiles(): string[] {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"))
+    .map((f) => path.join(dir, f));
+}
+
+describe("the 'any' string sentinel stays retired (#472)", () => {
+  it("no file declares a `VariableType | \"any\"` signature", () => {
+    for (const file of sourceFiles()) {
+      const src = fs.readFileSync(file, "utf8");
+      expect(src.includes('| "any"'), path.basename(file)).toBe(false);
+    }
+  });
+
+  it("no file returns the bare `\"any\"` string", () => {
+    for (const file of sourceFiles()) {
+      const src = fs.readFileSync(file, "utf8");
+      expect(/return\s+"any"/.test(src), path.basename(file)).toBe(false);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pnpm exec vitest run lib/typeChecker/anySentinelRetired.test.ts 2>&1 | tee /tmp/t6.log | tail -10`
+Expected: PASS (both assertions green, proving the retirement is complete).
+
+- [ ] **Step 3: Sanity-check the guard bites**
+
+Temporarily add `return "any"` to any source file, rerun the test, confirm it FAILS, then revert. (Do not commit the temporary edit.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/typeChecker/anySentinelRetired.test.ts
+git commit -F /tmp/commit6.txt
+```
+`/tmp/commit6.txt`:
+```
+Guard against reintroducing the "any" sentinel (#472)
+
+Scans lib/typeChecker source for `| "any"` signatures and bare `return "any"`.
+Backstops the type-level guarantee against a stray reintroduction.
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Core invariant (returns + narrow together) → Global Constraints + Task 3/4 method. ✓
+- Move 1 (widen isAnyType, 4 paired sites) → Task 1. ✓
+- Move 2 (route 65 comparisons) → Task 2. ✓
+- Move 3 (spine + remaining producers, signal sites) → Tasks 3, 4. ✓
+- Move 4 (delete maybeAny, inference dups, isAnyType narrow-back, widenType casts, ScopeType) → Task 5. ✓
+- Control-signal sites (`| null` synth, `| undefined` checker, `| null | undefined` functionTypeRaises) → Task 3 Step 2, Task 4 Step 2. ✓
+- flow.test.ts nine-assertion migration → Task 3 Step 3. ✓
+- Behavior-preservation gate + stop-on-flip → Global Constraints, per-task verify. ✓
+- Regression guard → Task 6. ✓
+- Symptom #3 (assignability dedup) → Task 4 Step 3. ✓
+
+**Placeholder scan:** none. The compiler-discovered edits in Tasks 3-4 are method-plus-grep, not placeholders — the exact set is defined by tsc output, which is the point of a compiler-guided refactor.
+
+**Type consistency:** `isAnyType` widens in Task 1, narrows back in Task 5. `synthType`/`ScopeType`/`typeAt`/`inferredReturnTypes` narrow to `VariableType` in Task 3. `ANY_T` from `primitives.js`, `isAnyType` from `utils.js` throughout.

--- a/docs/superpowers/specs/2026-07-12-retire-any-sentinel-design.md
+++ b/docs/superpowers/specs/2026-07-12-retire-any-sentinel-design.md
@@ -19,9 +19,11 @@ return either a real object or that string. Its signature reads
 
 Two spellings of one idea tax every reader. Three symptoms recur:
 
-1. **Every check asks the question twice.** The pattern `t === "any" ||
-   isAnyType(t)` appears across the checker. It tests the string form, then
-   the object form.
+1. **Comparisons test the string by hand.** About 65 sites compare against the
+   literal, as `t === "any"` (56 sites) or `t !== "any"` (9 sites). Each one
+   knows only the string form. Four of them pair the check with the object
+   form as `t === "any" || isAnyType(t)`, spelling out the redundancy in a
+   single line.
 2. **A conversion helper exists only to bridge the two.** `maybeAny()` turns
    the string into `ANY_T` so it fits inside a structured type. It has no
    other reason to exist.
@@ -75,31 +77,54 @@ lists most of the remaining work for you.
 returns `VariableType | "any"` and carries `as VariableType` casts to paper
 over the union. Those casts disappear once its signature narrows.
 
+## The core invariant
+
+One rule makes this safe, and breaking it is the main hazard:
+
+> **Change a function's returns and narrow its signature in the same commit.
+> Never change returns ahead of the narrowing.**
+
+Here is why. Suppose a producer changes `return "any"` to `return ANY_T` but
+keeps its wide `VariableType | "any"` signature. A consumer that does
+`if (t === "any")` still type-checks, because the signature still allows the
+string. But `t` now holds the object, so the comparison is `false` at runtime
+and the any-handling branch silently dies. Behavior changes and nothing fails
+to compile.
+
+The narrowing is what protects us. Once the signature is `VariableType`, a
+leftover `t === "any"` becomes a "no overlap" compile error (TS2367). The
+return change alone protects nothing. So the two always travel together.
+
 ## Migration mechanics
 
-The order is what makes this safe. We lean on one temporary widening so that
-no intermediate state is ever half-broken.
+Four moves, in order. The first two are behavior-preserving and
+compiler-clean. The third does the retirement under the invariant above.
 
-**Step 1: Teach `isAnyType` to accept both forms.** Widen its parameter from
-`VariableType` to `VariableType | "any"` (`utils.ts:48`). Every
-`t === "any" || isAnyType(t)` then collapses to `isAnyType(t)`. Behavior is
-unchanged, because both forms already count as `any`. This is the safety mat
-for every later step.
+**Move 1: Teach `isAnyType` to accept both forms.** Widen its parameter from
+`VariableType` to `VariableType | "any"` (`utils.ts:48`). This is small, and
+it lets the next move rewrite every check to a single helper call.
 
-**Step 2: Produce the object, not the string.** Change each `return "any"` to
-`return ANY_T`. Both mean "I don't know," so the meaning is identical. Start
-with the innermost helpers and work outward.
+**Move 2: Route every comparison through `isAnyType`.** Replace all 65 literal
+comparisons. `t === "any"` becomes `isAnyType(t)`. `t !== "any"` becomes
+`!isAnyType(t)`. The four paired sites collapse to one call. This move is the
+bulk of the change, and it is behavior-preserving: `isAnyType` on the string
+returns exactly what `=== "any"` did. After it, no code reads the literal by
+hand. That is what closes the silent-break window. When producers switch to
+`ANY_T` in the next move, no string comparison is left to go quietly false.
 
-**Step 3: Narrow one signature; let the compiler find the fallout.** When a
-function starts returning a real object, narrow its signature from
-`VariableType | "any"` to `VariableType`. The compiler flags every caller that
-still expected the string. Follow the errors outward, one function at a time,
-until a file is clean. The compiler enumerates the work; we do not hunt by
-hand.
+**Move 3: Retire the string, producer by producer.** For each producer, in one
+commit: change its `return "any"` to `return ANY_T`, narrow its signature from
+`VariableType | "any"` to `VariableType`, and fix whatever the compiler then
+flags. Because Move 2 already converted the comparisons, the fallout is small
+and mechanical. Any comparison Move 2 missed surfaces here as a TS2367 error
+the moment its producing signature narrows. That is the invariant working as a
+backstop. Start with the spine (`synthType`, `ScopeType`,
+`inferredReturnTypes`) and let the compiler pull in each producer's consumers.
 
-**Step 4: Delete the dead machinery.** Once nothing produces the string:
+**Move 4: Delete the dead machinery.** Once nothing produces the string:
 - Delete `maybeAny` (`synthesizer.ts:236`). Nothing is left to convert.
-- Delete the duplicate `isAnyType` in `inference.ts:129`. Use the shared one.
+- In `inference.ts`, delete the local `const ANY_T` (`:126`) and the duplicate
+  `isAnyType` (`:129`). Import both from `primitives.js` and `utils.js`.
 - Narrow `isAnyType`'s parameter back to `VariableType`. The string no longer
   exists, so the helper should stop pretending it might.
 - Remove the `as VariableType` casts in `widenType`.
@@ -131,35 +156,55 @@ Where it branched on `"any"` specifically, rewrite the branch by hand.
 
 ## Suggested commit order
 
-Innermost first, so each commit compiles and the compiler guides the next.
+Commits follow the moves above, not the file layout. Moves 1 and 2 are global
+sweeps. Move 3's commits are scoped by *a producer signature plus the
+consumers the compiler flags when it narrows*, because those cannot be split:
+narrowing `synthType` alone turns every `=== "any"` on its result across
+`checker.ts`, `flow.ts`, and `scopes.ts` into a compile error at once. A
+file-scoped commit could not compile in isolation. Each commit here does
+compile and pass tests on its own.
 
-1. Widen `isAnyType` to accept both forms; collapse every
-   `t === "any" || isAnyType(t)`.
-2. `synthesizer.ts` internals: `return ANY_T`, narrow `synthType` and its
-   helpers. Handle the two `| null` signal sites here.
-3. `scope.ts` / `flow.ts`: collapse `ScopeType`, narrow the flow walker.
-4. `checker.ts` / `scopes.ts`: narrow, including the `| undefined` signal sites.
-5. `resolveCall.ts` / `builtins.ts` / `inference.ts`: narrow; delete the
-   duplicate `isAnyType`.
-6. Remaining consumers: `matchExprTypes.ts`, `typeCases.ts`,
-   `interruptAnalysis.ts`, `functionTypeRaises.ts`, `functionValueEffects.ts`,
-   `effectSets.ts`, `effectPayloadCheck.ts`, `matchExhaustiveness.ts`,
-   `narrowing.ts`, `flowBuilder.ts`, `index.ts`, `types.ts`.
-7. Cleanup: delete `maybeAny`; narrow `isAnyType` back to `VariableType`;
-   remove `widenType`'s casts; update `types.ts` `inferredReturnTypes`.
+1. **Widen `isAnyType`** to accept `VariableType | "any"` (Move 1). Collapse
+   the four paired sites while here.
+2. **Route all comparisons through `isAnyType`** (Move 2). All 65 sites. No
+   producer changes yet, so this is behavior-preserving and compiles green.
+3. **Narrow the spine and its fallout** (Move 3). `synthType`,
+   `ScopeType`, and `inferredReturnTypes` are interlinked; narrowing one drags
+   in the others plus their consumers. Expect one large, atomic commit here,
+   including the `| null` signal sites in `synthesizer.ts` and the `ScopeType`
+   collapse in `scope.ts` / `flow.ts`.
+4. **Narrow the remaining producers**, each with its consumers, as the
+   compiler surfaces them: `checker.ts` (with its `| undefined` signal sites),
+   `scopes.ts`, `resolveCall.ts`, `builtins.ts`, `inference.ts`,
+   `matchExprTypes.ts`, `typeCases.ts`, `interruptAnalysis.ts`,
+   `functionTypeRaises.ts`, `functionValueEffects.ts`, and the rest. Split into
+   as many commits as compile cleanly on their own.
+5. **Cleanup** (Move 4): delete `maybeAny`; fold `inference.ts`'s local
+   `ANY_T` and duplicate `isAnyType` into imports; narrow `isAnyType` back to
+   `VariableType`; remove `widenType`'s casts; collapse the `ScopeType` alias.
 
-The counts are a guide, not a contract. The compiler decides when a step is
-done: a file is finished when it type-checks with the narrowed signatures.
+The counts are a guide, not a contract. The compiler decides when a commit is
+done: it is finished when it type-checks with the narrowed signatures and the
+suite passes.
 
 ## Testing and the safety net
 
 This change must alter no behavior, so the existing suite is the gate.
 
-- Run the full `lib/typeChecker/` unit suite. Every test passes unchanged.
+- Run the full `lib/typeChecker/` unit suite. Every test passes, with one
+  expected exception below.
 - Run the fixture integration tests. Diagnostics stay byte-identical.
-- If any test flips, stop. A flip means the string and the object were **not**
-  treated identically somewhere. That is a real asymmetry, and it needs a look
-  before the migration continues.
+- If a test flips for any other reason, stop. A flip means the string and the
+  object were **not** treated identically somewhere. That is a real asymmetry,
+  and it needs a look before the migration continues.
+
+**One test file changes on purpose: `flow.test.ts`.** It asserts on the
+sentinel *value* at nine sites, as `expect(...).toBe("any")`. Those functions
+return `ANY_T` after Move 3, so `.toBe("any")` would fail. Migrate each to an
+object check, `expect(isAnyType(...)).toBe(true)`, in the commit that narrows
+the producing signature. This is an assertion update, not a behavior change.
+No other test asserts on a `| "any"` signature, so the rest of the suite needs
+nothing beyond passing.
 
 Add one cheap regression guard so the sentinel cannot creep back: a test that
 scans `lib/typeChecker/` source and asserts no `VariableType | "any"`
@@ -176,6 +221,8 @@ stray reintroduction in review.
 - **Signal sites.** The `| null` and `| undefined` sites are the one place a
   mechanical swap could change control flow. They are enumerated above and get
   per-site review.
-- **Size.** The change touches roughly 283 spots across 30 files. It is wide.
-  It is also mechanical and compiler-guarded, so width is low-risk. One PR
-  keeps it atomic and avoids a lingering half-migrated state.
+- **Size.** The change spans 23 non-test files in `lib/typeChecker/`: 65
+  comparison sites, 35 `return "any"` producers, and roughly 240 sentinel-
+  related occurrences in all. It is wide. It is also mechanical and
+  compiler-guarded, so width is low-risk. One PR keeps it atomic and avoids a
+  lingering half-migrated state.

--- a/docs/superpowers/specs/2026-07-12-retire-any-sentinel-design.md
+++ b/docs/superpowers/specs/2026-07-12-retire-any-sentinel-design.md
@@ -1,0 +1,181 @@
+# Retire the `"any"` string sentinel in favor of `ANY_T`
+
+**Issue:** #472. **Delivery:** one PR, built as an ordered stack of commits.
+
+## The problem
+
+The typechecker needs a way to say "I don't know this type." That stand-in is
+called `any`. Today the checker writes `any` two ways.
+
+One way is a proper type object:
+
+```ts
+const ANY_T = { type: "primitiveType", value: "any" };
+```
+
+The other way is the bare string `"any"`. A function that computes a type may
+return either a real object or that string. Its signature reads
+`VariableType | "any"`.
+
+Two spellings of one idea tax every reader. Three symptoms recur:
+
+1. **Every check asks the question twice.** The pattern `t === "any" ||
+   isAnyType(t)` appears across the checker. It tests the string form, then
+   the object form.
+2. **A conversion helper exists only to bridge the two.** `maybeAny()` turns
+   the string into `ANY_T` so it fits inside a structured type. It has no
+   other reason to exist.
+3. **The assignability check special-cases `any` twice, back to back.** One
+   branch handles the string, another handles the object, with a comment
+   admitting they do the same thing.
+
+Only `any` has this problem. Every other keyword (`null`, `never`, `void`,
+`boolean`, `string`, `number`, `regex`) lives purely as an object and never
+appears as a string sentinel. `any` alone got infected because it is the
+value the checker returns when inference gives up, and `return "any"` was
+easier to type than `return ANY_T`.
+
+## Goal and non-goals
+
+**Goal.** Delete the string sentinel. Keep `ANY_T`. Every function returns a
+plain `VariableType`. Every "is this any?" test becomes one call to
+`isAnyType`. `maybeAny` and the duplicate local `isAnyType` in `inference.ts`
+are deleted.
+
+**This changes no behavior.** The checker already treats the string and the
+object identically. The assignability code proves it: both forms return the
+same answer. Swapping one for the other is invisible to every program the
+checker runs. The test suite is the proof.
+
+**Non-goals.**
+- No other keyword changes. `null`, `never`, and the rest stay as they are.
+- No new checker behavior. This is a pure representation change.
+- Nothing outside `lib/typeChecker/` changes. The sentinel is fully contained
+  there. It never reaches the backends, and `synthType` has no external
+  callers. (Verified: zero `| "any"` signatures live outside `lib/typeChecker/`.)
+
+## The spine: three central definitions
+
+The sentinel radiates from three declarations. Narrow these, and the compiler
+lists most of the remaining work for you.
+
+1. **`ScopeType`** (`scope.ts:3`): `type ScopeType = VariableType | "any"`.
+   The `Scope` stores every variable as a `ScopeType`, so `flow.ts` and
+   `scopes.ts` carry the sentinel everywhere they read a variable. Once the
+   sentinel is gone, `ScopeType` equals `VariableType` and the alias has no
+   remaining purpose. Collapse it to `VariableType` and remove the alias.
+2. **`synthType`** (`synthesizer.ts:252`): returns `VariableType | "any"`.
+   This is the main producer. It holds 27 of the 35 `return "any"` sites in
+   the checker.
+3. **`inferredReturnTypes`** (`types.ts:99`):
+   `Record<string, VariableType | "any">` on the checker context. This is why
+   `synthPipeRhs` performs its awkward `!== "any"` narrowing dance.
+
+`widenType` (`assignability.ts:341`) is a fourth, smaller anchor. It takes and
+returns `VariableType | "any"` and carries `as VariableType` casts to paper
+over the union. Those casts disappear once its signature narrows.
+
+## Migration mechanics
+
+The order is what makes this safe. We lean on one temporary widening so that
+no intermediate state is ever half-broken.
+
+**Step 1: Teach `isAnyType` to accept both forms.** Widen its parameter from
+`VariableType` to `VariableType | "any"` (`utils.ts:48`). Every
+`t === "any" || isAnyType(t)` then collapses to `isAnyType(t)`. Behavior is
+unchanged, because both forms already count as `any`. This is the safety mat
+for every later step.
+
+**Step 2: Produce the object, not the string.** Change each `return "any"` to
+`return ANY_T`. Both mean "I don't know," so the meaning is identical. Start
+with the innermost helpers and work outward.
+
+**Step 3: Narrow one signature; let the compiler find the fallout.** When a
+function starts returning a real object, narrow its signature from
+`VariableType | "any"` to `VariableType`. The compiler flags every caller that
+still expected the string. Follow the errors outward, one function at a time,
+until a file is clean. The compiler enumerates the work; we do not hunt by
+hand.
+
+**Step 4: Delete the dead machinery.** Once nothing produces the string:
+- Delete `maybeAny` (`synthesizer.ts:236`). Nothing is left to convert.
+- Delete the duplicate `isAnyType` in `inference.ts:129`. Use the shared one.
+- Narrow `isAnyType`'s parameter back to `VariableType`. The string no longer
+  exists, so the helper should stop pretending it might.
+- Remove the `as VariableType` casts in `widenType`.
+- Collapse `ScopeType` to `VariableType` and remove the alias.
+
+After the final narrowing, the string `"any"` is not a valid type anywhere in
+the checker. Any attempt to reintroduce it fails to compile.
+
+## The control-signal sites need hands
+
+A few functions use `"any"` as a **signal**, not a type. There the string
+travels next to `null` or `undefined`, which carry their own meanings. These
+cannot be blind-swapped. Each one gets read and rewritten deliberately:
+
+- `synthesizer.ts:75` and `synthesizer.ts:199` return
+  `VariableType | "any" | null`. Here `"any"` means "caller should return
+  any," and `null` means "no resolution, keep looking." `resolveResultFieldType`
+  is the clearest case.
+- `checker.ts:50`, `:74`, `:979` return `VariableType | "any" | undefined`,
+  where `undefined` means "absent."
+- `functionTypeRaises.ts:38` and `:131` carry
+  `VariableType | "any" | null | undefined`.
+
+For each site the rule is the same. Keep `null` and `undefined` with their
+current meanings. Fold only the `"any"` disjunct into `VariableType` as
+`ANY_T`. Before folding, confirm the caller treated the `"any"` case the same
+way it treats any other unknown-type result. Where it did, the fold is safe.
+Where it branched on `"any"` specifically, rewrite the branch by hand.
+
+## Suggested commit order
+
+Innermost first, so each commit compiles and the compiler guides the next.
+
+1. Widen `isAnyType` to accept both forms; collapse every
+   `t === "any" || isAnyType(t)`.
+2. `synthesizer.ts` internals: `return ANY_T`, narrow `synthType` and its
+   helpers. Handle the two `| null` signal sites here.
+3. `scope.ts` / `flow.ts`: collapse `ScopeType`, narrow the flow walker.
+4. `checker.ts` / `scopes.ts`: narrow, including the `| undefined` signal sites.
+5. `resolveCall.ts` / `builtins.ts` / `inference.ts`: narrow; delete the
+   duplicate `isAnyType`.
+6. Remaining consumers: `matchExprTypes.ts`, `typeCases.ts`,
+   `interruptAnalysis.ts`, `functionTypeRaises.ts`, `functionValueEffects.ts`,
+   `effectSets.ts`, `effectPayloadCheck.ts`, `matchExhaustiveness.ts`,
+   `narrowing.ts`, `flowBuilder.ts`, `index.ts`, `types.ts`.
+7. Cleanup: delete `maybeAny`; narrow `isAnyType` back to `VariableType`;
+   remove `widenType`'s casts; update `types.ts` `inferredReturnTypes`.
+
+The counts are a guide, not a contract. The compiler decides when a step is
+done: a file is finished when it type-checks with the narrowed signatures.
+
+## Testing and the safety net
+
+This change must alter no behavior, so the existing suite is the gate.
+
+- Run the full `lib/typeChecker/` unit suite. Every test passes unchanged.
+- Run the fixture integration tests. Diagnostics stay byte-identical.
+- If any test flips, stop. A flip means the string and the object were **not**
+  treated identically somewhere. That is a real asymmetry, and it needs a look
+  before the migration continues.
+
+Add one cheap regression guard so the sentinel cannot creep back: a test that
+scans `lib/typeChecker/` source and asserts no `VariableType | "any"`
+signature and no bare `return "any"` remain. The type system already blocks
+production of the sentinel; this guard documents the intent and catches a
+stray reintroduction in review.
+
+## Risks
+
+- **Hidden asymmetry.** The whole plan rests on the string and the object
+  being interchangeable. The assignability code and the test suite support
+  that, but a rarely-hit path could differ. The test suite is the detector,
+  and the "stop on a flip" rule is the response.
+- **Signal sites.** The `| null` and `| undefined` sites are the one place a
+  mechanical swap could change control flow. They are enumerated above and get
+  per-site review.
+- **Size.** The change touches roughly 283 spots across 30 files. It is wide.
+  It is also mechanical and compiler-guarded, so width is low-risk. One PR
+  keeps it atomic and avoids a lingering half-migrated state.

--- a/packages/agency-lang/lib/lsp/builtinHover.ts
+++ b/packages/agency-lang/lib/lsp/builtinHover.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "../typeChecker/utils.js";
 import type { BuiltinSignature } from "../typeChecker/types.js";
 import { BUILTIN_FUNCTION_TYPES } from "../typeChecker/builtins.js";
 import { JS_GLOBALS, lookupJsMember } from "../typeChecker/resolveCall.js";
@@ -10,14 +11,14 @@ import { formatTypeHint } from "../utils/formatType.js";
  */
 function formatSig(sig: BuiltinSignature): string {
   const parts = sig.params.map((p) =>
-    p === "any" ? "any" : formatTypeHint(p),
+    isAnyType(p) ? "any" : formatTypeHint(p),
   );
   if (sig.restParam !== undefined) {
     const rest =
-      sig.restParam === "any" ? "any" : formatTypeHint(sig.restParam);
+      isAnyType(sig.restParam) ? "any" : formatTypeHint(sig.restParam);
     parts.push(`...${rest}[]`);
   }
-  const ret = sig.returnType === "any" ? "any" : formatTypeHint(sig.returnType);
+  const ret = isAnyType(sig.returnType) ? "any" : formatTypeHint(sig.returnType);
   return `(${parts.join(", ")}) => ${ret}`;
 }
 

--- a/packages/agency-lang/lib/lsp/inlayHint.ts
+++ b/packages/agency-lang/lib/lsp/inlayHint.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "../typeChecker/utils.js";
 import { InlayHint, InlayHintKind } from "vscode-languageserver-protocol";
 import type { AgencyProgram } from "../types.js";
 import type { ScopeInfo } from "../typeChecker/types.js";
@@ -21,7 +22,7 @@ export function getInlayHints(
     if (!containingScope) continue;
 
     const resolved = containingScope.scope.lookup(node.variableName);
-    if (!resolved || resolved === "any") continue;
+    if (!resolved || isAnyType(resolved)) continue;
 
     // Position hint after variable name: loc.col is start of let/const,
     // so variable name starts at loc.col + declKind.length + 1

--- a/packages/agency-lang/lib/lsp/typeResolution.ts
+++ b/packages/agency-lang/lib/lsp/typeResolution.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "../typeChecker/utils.js";
 import { getWordAtPosition } from "../cli/definition.js";
 import type { AgencyProgram, VariableType } from "../types.js";
 import type { ScopeInfo } from "../typeChecker/types.js";
@@ -20,6 +21,6 @@ export function resolveTypeAtPosition(
   if (!scope) return null;
 
   const resolved = scope.scope.lookup(word);
-  if (!resolved || resolved === "any") return null;
+  if (!resolved || isAnyType(resolved)) return null;
   return resolved;
 }

--- a/packages/agency-lang/lib/typeChecker/anySentinelRetired.test.ts
+++ b/packages/agency-lang/lib/typeChecker/anySentinelRetired.test.ts
@@ -45,11 +45,14 @@ describe("the 'any' string sentinel stays retired (#472)", () => {
 
   it("no inline object-form any-check outside isAnyType", () => {
     // The one legitimate `.value === "any"` is isAnyType's body in utils.ts.
-    const re = /\.value\s*===\s*"any"/;
+    // Assert a COUNT (1 there, 0 elsewhere) rather than skipping utils.ts, so
+    // a second inline check added to a different function there is still caught.
+    const re = /\.value\s*===\s*"any"/g;
     for (const file of files) {
-      if (path.basename(file) === "utils.ts") continue;
       const src = fs.readFileSync(file, "utf8");
-      expect(re.test(src), path.basename(file)).toBe(false);
+      const matches = src.match(re) ?? [];
+      const expected = path.basename(file) === "utils.ts" ? 1 : 0;
+      expect(matches.length, path.basename(file)).toBe(expected);
     }
   });
 });

--- a/packages/agency-lang/lib/typeChecker/anySentinelRetired.test.ts
+++ b/packages/agency-lang/lib/typeChecker/anySentinelRetired.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+
+// Recursive so a future subdir under lib/typeChecker is not silently dropped.
+function sourceFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const files = sourceFiles(dir);
+
+// A cheap tripwire backing the type-level guarantee (#472), not a proof: once
+// every signature is VariableType, the "any" string sentinel is
+// unrepresentable. This catches a stray hand-edit that slips past the compiler
+// or formatter.
+describe("the 'any' string sentinel stays retired (#472)", () => {
+  it('no signature unions VariableType with the "any" string', () => {
+    // Match `| "any"` and `"any" |` with any spacing, so a formatter-evading
+    // hand-edit or reversed member order is still caught.
+    const re = /(\|\s*"any")|("any"\s*\|)/;
+    for (const file of files) {
+      const src = fs.readFileSync(file, "utf8");
+      expect(re.test(src), path.basename(file)).toBe(false);
+    }
+  });
+
+  it('no file returns the bare "any" string', () => {
+    const re = /return\s+\(?\s*"any"/;
+    for (const file of files) {
+      const src = fs.readFileSync(file, "utf8");
+      expect(re.test(src), path.basename(file)).toBe(false);
+    }
+  });
+
+  it("no inline object-form any-check outside isAnyType", () => {
+    // The one legitimate `.value === "any"` is isAnyType's body in utils.ts.
+    const re = /\.value\s*===\s*"any"/;
+    for (const file of files) {
+      if (path.basename(file) === "utils.ts") continue;
+      const src = fs.readFileSync(file, "utf8");
+      expect(re.test(src), path.basename(file)).toBe(false);
+    }
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/assignability.test.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.test.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import { describe, it, expect } from "vitest";
 import { isAssignable, isNever, widenType } from "./assignability.js";
 import { formatTypeHint } from "../cli/util.js";
@@ -32,7 +33,7 @@ describe("never (bottom type)", () => {
   it("isNever recognizes only the never primitive", () => {
     expect(isNever(NEVER_T)).toBe(true);
     expect(isNever(STRING_T)).toBe(false);
-    expect(isNever("any")).toBe(false);
+    expect(isNever(ANY_T)).toBe(false);
   });
 
   it("widenType passes never through unchanged", () => {

--- a/packages/agency-lang/lib/typeChecker/assignability.test.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.test.ts
@@ -236,3 +236,17 @@ describe("narrowed Result member assignable to Result type", () => {
     expect(isAssignable(other, resultT, {})).toBe(false);
   });
 });
+
+describe("an alias whose body is `any` (#472)", () => {
+  // Regression: the post-resolution any check is the only one that catches an
+  // alias resolving to `any` (the pre-resolution fast path was removed). A
+  // typeAliasVariable is not itself `any`, so deleting the post-resolution
+  // check would make an any-alias non-assignable to anything.
+  const aliases = { Foo: { body: ANY_T } };
+  const FooRef: VariableType = { type: "typeAliasVariable", aliasName: "Foo" };
+
+  it("is assignable both directions", () => {
+    expect(isAssignable(FooRef, NUMBER_T, aliases)).toBe(true); // any-alias -> concrete
+    expect(isAssignable(NUMBER_T, FooRef, aliases)).toBe(true); // concrete -> any-alias
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -403,7 +403,7 @@ export function isOptionalType(
 ): boolean {
   const resolved = safeResolveType(vt, typeAliases);
   if (resolved.type === "primitiveType")
-    return resolved.value === "null" || resolved.value === "any";
+    return resolved.value === "null" || isAnyType(resolved);
   if (resolved.type === "unionType")
     return resolved.types.some((t) => isOptionalType(t, typeAliases));
   return false;
@@ -435,8 +435,10 @@ function isAssignableGuarded(
   typeAliases: Record<string, TypeAliasEntry>,
   inProgress: Set<string>,
 ): boolean {
-  if (isAnyType(source) || isAnyType(target)) return true;
-
+  // No pre-resolution any fast path: `any` is caught post-resolution in
+  // isAssignableInner, which also covers an alias whose body is `any`
+  // (e.g. `type Foo = any`). A pre-resolution isAnyType(source) would miss
+  // that alias and regress its assignability.
   const named =
     source.type === "typeAliasVariable" ||
     source.type === "genericType" ||
@@ -482,11 +484,9 @@ function isAssignableInner(
     return true;
   }
 
-  // primitiveType("any") behaves the same as the "any" sentinel
-  if (
-    (resolvedSource.type === "primitiveType" && resolvedSource.value === "any") ||
-    (resolvedTarget.type === "primitiveType" && resolvedTarget.value === "any")
-  ) {
+  // `any` on either side (including an alias resolving to `any`) is
+  // assignable both ways.
+  if (isAnyType(resolvedSource) || isAnyType(resolvedTarget)) {
     return true;
   }
 

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import { Tag, TypeAliasEntry, TypeParam, VariableType } from "../types.js";
 import { ANY_T, BOOLEAN_T, NUMBER_T, STRING_T } from "./primitives.js";
 import { substituteTypeParams } from "./substitute.js";
@@ -339,6 +340,10 @@ function collectLiteralKeys(keyType: VariableType): string[] | null {
 }
 
 export function widenType(vt: VariableType | "any"): VariableType | "any" {
+  // NOTE: string-only check on purpose. widenType is a structure-preserving
+  // map; the ANY_T *object* must fall through to `return vt` (default) so it
+  // stays an object. Collapsing it to the string here corrupts nested fields
+  // (e.g. resultType.successType). Task 5 deletes this line with the sentinel.
   if (vt === "any") return "any";
   switch (vt.type) {
     case "stringLiteralType":
@@ -389,7 +394,7 @@ export function widenType(vt: VariableType | "any"): VariableType | "any" {
 
 /** True iff `vt` is the bottom type `never`. */
 export function isNever(vt: VariableType | "any"): boolean {
-  return vt !== "any" && vt.type === "primitiveType" && vt.value === "never";
+  return !isAnyType(vt) && vt.type === "primitiveType" && vt.value === "never";
 }
 
 /**
@@ -435,7 +440,7 @@ function isAssignableGuarded(
   typeAliases: Record<string, TypeAliasEntry>,
   inProgress: Set<string>,
 ): boolean {
-  if (source === "any" || target === "any") return true;
+  if (isAnyType(source) || isAnyType(target)) return true;
 
   const named =
     source.type === "typeAliasVariable" ||

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -339,12 +339,7 @@ function collectLiteralKeys(keyType: VariableType): string[] | null {
   return null;
 }
 
-export function widenType(vt: VariableType | "any"): VariableType | "any" {
-  // NOTE: string-only check on purpose. widenType is a structure-preserving
-  // map; the ANY_T *object* must fall through to `return vt` (default) so it
-  // stays an object. Collapsing it to the string here corrupts nested fields
-  // (e.g. resultType.successType). Task 5 deletes this line with the sentinel.
-  if (vt === "any") return "any";
+export function widenType(vt: VariableType): VariableType {
   switch (vt.type) {
     case "stringLiteralType":
       return STRING_T;
@@ -357,35 +352,35 @@ export function widenType(vt: VariableType | "any"): VariableType | "any" {
         type: "objectType",
         properties: vt.properties.map((p) => ({
           key: p.key,
-          value: widenType(p.value) as VariableType,
+          value: widenType(p.value),
         })),
       };
     case "arrayType":
       return {
         type: "arrayType",
-        elementType: widenType(vt.elementType) as VariableType,
+        elementType: widenType(vt.elementType),
       };
     case "unionType":
       return {
         type: "unionType",
-        types: vt.types.map((t) => widenType(t) as VariableType),
+        types: vt.types.map((t) => widenType(t)),
       };
     case "resultType":
       return {
         type: "resultType",
-        successType: widenType(vt.successType) as VariableType,
-        failureType: widenType(vt.failureType) as VariableType,
+        successType: widenType(vt.successType),
+        failureType: widenType(vt.failureType),
       };
     case "schemaType":
       return {
         type: "schemaType",
-        inner: widenType(vt.inner) as VariableType,
+        inner: widenType(vt.inner),
       };
     case "genericType":
       return {
         type: "genericType",
         name: vt.name,
-        typeArgs: vt.typeArgs.map((a) => widenType(a) as VariableType),
+        typeArgs: vt.typeArgs.map((a) => widenType(a)),
       };
     default:
       return vt;
@@ -393,7 +388,7 @@ export function widenType(vt: VariableType | "any"): VariableType | "any" {
 }
 
 /** True iff `vt` is the bottom type `never`. */
-export function isNever(vt: VariableType | "any"): boolean {
+export function isNever(vt: VariableType): boolean {
   return !isAnyType(vt) && vt.type === "primitiveType" && vt.value === "never";
 }
 
@@ -415,8 +410,8 @@ export function isOptionalType(
 }
 
 export function isAssignable(
-  source: VariableType | "any",
-  target: VariableType | "any",
+  source: VariableType,
+  target: VariableType,
   typeAliases: Record<string, TypeAliasEntry>,
 ): boolean {
   return isAssignableGuarded(source, target, typeAliases, new Set());
@@ -435,8 +430,8 @@ export function isAssignable(
  * repeats recompute real results.
  */
 function isAssignableGuarded(
-  source: VariableType | "any",
-  target: VariableType | "any",
+  source: VariableType,
+  target: VariableType,
   typeAliases: Record<string, TypeAliasEntry>,
   inProgress: Set<string>,
 ): boolean {

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -191,19 +191,19 @@ const llmContent: VariableType = {
 export const AGENCY_FUNCTION_METHOD_TYPES: Record<string, BuiltinSignature> = {
   describe: {
     params: [string],
-    returnType: "any",
+    returnType: ANY_T,
     description:
       "Override the tool description an LLM sees for this function. Returns a new tool.",
   },
   preapprove: {
     params: [],
-    returnType: "any",
+    returnType: ANY_T,
     description:
       "Auto-approve every interrupt this function raises. Returns a new tool.",
   },
   rename: {
     params: [string],
-    returnType: "any",
+    returnType: ANY_T,
     description:
       "Give this tool a distinct name (the name the LLM sees and that tool-call dispatch matches). Use when deriving several tools from one function — `.partial()`/`.describe()`/import aliases keep the base name, which collides in a single `llm({tools})` call. Returns a new tool.",
   },
@@ -222,23 +222,23 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
 
   // --- Result type (lib/runtime/result.ts) ---
   success: {
-    params: ["any"],
-    returnType: "any",
+    params: [ANY_T],
+    returnType: ANY_T,
     description: "Wrap a value in a successful `Result`.",
   },
   failure: {
-    params: ["any", "any"],
+    params: [ANY_T, ANY_T],
     minParams: 1,
-    returnType: "any",
+    returnType: ANY_T,
     description: "Wrap an error (and optionally a value) in a failed `Result`.",
   },
   isSuccess: {
-    params: ["any"],
+    params: [ANY_T],
     returnType: boolean,
     description: "Check whether a `Result` is a success.",
   },
   isFailure: {
-    params: ["any"],
+    params: [ANY_T],
     returnType: boolean,
     description: "Check whether a `Result` is a failure.",
   },
@@ -247,7 +247,7 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
   // processFunctionCall in typescriptBuilder.ts). Registered here so the
   // undefined-function diagnostic doesn't warn on legitimate usage.
   throw: {
-    params: ["any"],
+    params: [ANY_T],
     returnType: voidT,
     description:
       "Raise an exception. Unwinds the current function/node. Argument is coerced to a string for the Error message.",
@@ -259,14 +259,14 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
   // `emit` stdlib wrapper calls it. Registered here so `std::statelog`
   // (which now owns `emit`) type-checks clean.
   _emit: {
-    params: ["any"],
+    params: [ANY_T],
     returnType: voidT,
     description: "Emit a custom event to the host via the onEmit callback.",
   },
 
   // --- Checkpoint / rewind ---
   restore: {
-    params: ["any", "any"],
+    params: [ANY_T, ANY_T],
     returnType: voidT,
     description:
       "Restore execution to a previously captured checkpoint. Accepts a checkpoint object or ID and an options object (e.g. `{ maxRestores: 3 }` or variable overrides).",
@@ -274,21 +274,21 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
 
   // --- Handler outcomes (reserved names) ---
   approve: {
-    params: ["any"],
+    params: [ANY_T],
     minParams: 0,
-    returnType: "any",
+    returnType: ANY_T,
     description:
       "Inside a `handle ... with` block, approve the wrapped action (optionally substituting a return value).",
   },
   reject: {
-    params: ["any"],
+    params: [ANY_T],
     minParams: 0,
-    returnType: "any",
+    returnType: ANY_T,
     description: "Inside a `handle ... with` block, block the wrapped action.",
   },
   propagate: {
     params: [],
-    returnType: "any",
+    returnType: ANY_T,
     description:
       "Inside a `handle ... with` block, pass the interrupt up to the next handler in the chain.",
   },
@@ -302,7 +302,7 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
   },
   getCheckpoint: {
     params: [number],
-    returnType: "any",
+    returnType: ANY_T,
     description: "Return the full checkpoint object for a given checkpoint ID.",
   },
 
@@ -324,7 +324,7 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
   },
   race: {
     params: [anyArray],
-    returnType: "any",
+    returnType: ANY_T,
     acceptsBlock: true,
     acceptsNamedArgs: { shared: boolean },
     description:
@@ -333,7 +333,7 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
 
   callback: {
     params: [string],
-    returnType: "any",
+    returnType: ANY_T,
     acceptsBlock: true,
     description:
       "Register a callback. Use as `callback('<eventName>') as data { ... }`. The block receives event data as an argument.",

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -521,7 +521,7 @@ function checkBlockArgShape(
     if (
       hint === undefined ||
       hint.type === "blockType" ||
-      (hint.type === "primitiveType" && hint.value === "any")
+      isAnyType(hint)
     ) {
       return true;
     }

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -381,7 +381,7 @@ function checkCallAgainstBuiltinSig(
     }
     seenNamed.add(a.name);
     // Validate the named-arg value's type against the declared one
-    // (Copilot #4). Skip when the allowlist entry is `"any"`.
+    // (Copilot #4). Skip when the allowlist entry is the `any` type.
     const expected = allowedNamed[a.name];
     if (!isAnyType(expected)) {
       const actual = synthType(a.value, scope, ctx);

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -382,9 +382,9 @@ function checkCallAgainstBuiltinSig(
     // Validate the named-arg value's type against the declared one
     // (Copilot #4). Skip when the allowlist entry is `"any"`.
     const expected = allowedNamed[a.name];
-    if (expected !== "any") {
+    if (!isAnyType(expected)) {
       const actual = synthType(a.value, scope, ctx);
-      if (actual !== "any" && !isAssignable(actual, expected, typeAliases)) {
+      if (!isAnyType(actual) && !isAssignable(actual, expected, typeAliases)) {
         ctx.errors.push(
           diagnostic(
             "namedArgTypeMismatch",
@@ -745,7 +745,7 @@ function checkArgsAgainstParams(
     }
     const argType = synthType(innerArg, scope, ctx);
     const paramType = slot?.type;
-    if (paramType === undefined || paramType === "any" || argType === "any") {
+    if (paramType === undefined || isAnyType(paramType) || isAnyType(argType)) {
       continue;
     }
     // Validated params accept either the un-bang'd type T or any Result —
@@ -791,7 +791,7 @@ function checkSplatAgainstRemainingParams(
   ctx: TypeCheckerContext,
 ): void {
   const splatType = synthType(splatSource, scope, ctx);
-  if (splatType === "any") return;
+  if (isAnyType(splatType)) return;
   if (splatType.type !== "arrayType") {
     const splatStr = formatTypeHint(splatType);
     ctx.errors.push(
@@ -813,7 +813,7 @@ function checkSplatAgainstRemainingParams(
     const slot = sig.resolveSlot({ kind: "positional", index: i });
     if (!slot) continue;
     const paramType = slot.type;
-    if (paramType === undefined || paramType === "any") continue;
+    if (paramType === undefined || isAnyType(paramType)) continue;
     if (isAssignable(elementType, paramType, typeAliases)) continue;
     const paramStr = formatTypeHint(paramType);
     ctx.errors.push(
@@ -951,10 +951,10 @@ function validatePipeArg(
   ctx: TypeCheckerContext,
 ): void {
   const slotType = pipeRhsSlotType(expr.right, ctx);
-  if (slotType === undefined || slotType === "any") return;
+  if (slotType === undefined || isAnyType(slotType)) return;
 
   const leftType = synthType(expr.left, scope, ctx);
-  if (leftType === "any") return;
+  if (isAnyType(leftType)) return;
   const flowingType =
     leftType.type === "resultType" ? leftType.successType : leftType;
   if (isAnyType(flowingType)) return;
@@ -1005,7 +1005,7 @@ function checkCatchDefaultType(
   ctx: TypeCheckerContext,
 ): void {
   const left = synthType(node.left, scope, ctx);
-  if (left === "any") return;
+  if (isAnyType(left)) return;
   const expected = left.type === "resultType" ? left.successType : left;
   checkType(node.right, expected, scope, "catch default", ctx);
 }

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import { diagnostic } from "./diagnostics.js";
 import {
   AgencyNode,
@@ -47,9 +48,9 @@ import { isSchemaTypeHint } from "../utils/schemaParam.js";
  */
 function variadicElementType(
   param: FunctionParameter,
-): VariableType | "any" | undefined {
+): VariableType | undefined {
   if (param.typeHint?.type === "arrayType") return param.typeHint.elementType;
-  return param.typeHint ?? "any";
+  return param.typeHint ?? ANY_T;
 }
 
 /**
@@ -71,7 +72,7 @@ function variadicNamedSlotType(
 }
 
 export type ParamSlot = {
-  type: VariableType | "any" | undefined;
+  type: VariableType | undefined;
   validated: boolean;
   /** Original parameter name. Absent for builtins (which can't take named args). */
   name?: string;
@@ -976,7 +977,7 @@ function validatePipeArg(
 function pipeRhsSlotType(
   rhs: AgencyNode,
   ctx: TypeCheckerContext,
-): VariableType | "any" | undefined {
+): VariableType | undefined {
   if (rhs.type === "variableName") {
     const params = getParamsForNodeOrFunc(rhs.value, ctx);
     return params?.[0]?.typeHint;

--- a/packages/agency-lang/lib/typeChecker/effectPayloadCheck.ts
+++ b/packages/agency-lang/lib/typeChecker/effectPayloadCheck.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import { diagnostic } from "./diagnostics.js";
 import type { TypeCheckerContext, ScopeInfo } from "./types.js";
 import type { EffectDeclaration } from "../types/effectDeclaration.js";
@@ -174,7 +175,7 @@ function checkRaiseSite(
   // After the named/splat filters above, `dataArg` is a positional Expression
   // which is a subset of AgencyNode (the union just isn't narrow enough for TS).
   const argType = synthType(dataArg as Parameters<typeof synthType>[0], info.scope, ctx);
-  if (argType === "any") return; // can't say anything useful
+  if (isAnyType(argType)) return; // can't say anything useful
 
   // Per-field checks against the resolved data object for precise messages.
   if (argType.type === "objectType") {

--- a/packages/agency-lang/lib/typeChecker/effectSets.ts
+++ b/packages/agency-lang/lib/typeChecker/effectSets.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import type { VariableType } from "../types.js";
 import type { TypeAliasEntry } from "../types/typeHints.js";
 
@@ -44,7 +45,7 @@ export function resolveEffectSet(
 
   const walk = (t: VariableType | undefined): void => {
     if (!t) return;
-    if (t.type === "primitiveType" && t.value === "any") {
+    if (isAnyType(t)) {
       any = true;
       return;
     }

--- a/packages/agency-lang/lib/typeChecker/flow.test.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.test.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import { describe, it, expect } from "vitest";
 import {
   referenceKey,
@@ -38,7 +39,7 @@ describe("referenceKey", () => {
 
 describe("uniteTypes", () => {
   it("any dominates", () => {
-    expect(uniteTypes(["any", STR], {})).toBe("any");
+    expect(uniteTypes([ANY_T, STR], {})).toEqual(ANY_T);
   });
   it("drops never members (identity element)", () => {
     expect(uniteTypes([NEVER_T, STR], {})).toEqual(STR);
@@ -103,7 +104,7 @@ describe("typeAt", () => {
     scope.declare("x", STR);
     const start: FlowNode = { kind: "start", scope };
     expect(typeAt(ref("x"), start, env(scope))).toEqual(STR);
-    expect(typeAt(ref("y"), start, env(scope))).toBe("any");
+    expect(typeAt(ref("y"), start, env(scope))).toEqual(ANY_T);
   });
 
   it("assign: overrides the matching reference only", () => {
@@ -146,7 +147,7 @@ describe("typeAt", () => {
         keep: true,
       },
     };
-    expect(typeAt(ref("u"), narrow, env(scope))).toBe("any");
+    expect(typeAt(ref("u"), narrow, env(scope))).toEqual(ANY_T);
   });
 
   it("join: unites the predecessors", () => {
@@ -300,13 +301,13 @@ describe("typeAt — property paths (M1)", () => {
 
   it("start: missing property → any", () => {
     const s = boxScope();
-    expect(typeAt(pathRef("box", "bogus"), { kind: "start", scope: s }, env(s))).toBe("any");
+    expect(typeAt(pathRef("box", "bogus"), { kind: "start", scope: s }, env(s))).toEqual(ANY_T);
   });
 
   it("start: non-object base → any (no primitive-member lookup)", () => {
     const s = new Scope("p");
     s.declare("str", STR);
-    expect(typeAt(pathRef("str", "length"), { kind: "start", scope: s }, env(s))).toBe("any");
+    expect(typeAt(pathRef("str", "length"), { kind: "start", scope: s }, env(s))).toEqual(ANY_T);
   });
 
   it("start: Record<K,V> base → V", () => {
@@ -397,7 +398,7 @@ describe("typeAt — path prefix invalidation (M1)", () => {
     // box.r.value re-resolves from the reassigned (un-narrowed) Result → success
     // member's `.value` is gone; structural resolve of `.value` on a resultType
     // is "any" (diagnostic-free resolvePath).
-    expect(typeAt(pathRef("box", "r", "value"), reassigned, env(s))).toBe("any");
+    expect(typeAt(pathRef("box", "r", "value"), reassigned, env(s))).toEqual(ANY_T);
   });
 
   it("loop back-edge: a body reassign of the base re-resolves box.r from widened", () => {
@@ -516,7 +517,7 @@ describe("PathSegment helpers + index resolution (M2)", () => {
   });
 
   it("returns any for an index on a non-array, non-Record receiver", () => {
-    expect(at("n", [idx(0)], NUM)).toBe("any");
+    expect(at("n", [idx(0)], NUM)).toEqual(ANY_T);
   });
 
   it("resolves an index segment into a Record<K,V> value type", () => {
@@ -526,7 +527,7 @@ describe("PathSegment helpers + index resolution (M2)", () => {
 
   it("returns any for an index hop into an objectType", () => {
     const OBJ: VariableType = { type: "objectType", properties: [{ key: "a", value: NUM }] };
-    expect(at("o", [idx(0)], OBJ)).toBe("any");
+    expect(at("o", [idx(0)], OBJ)).toEqual(ANY_T);
   });
 
   it("assigning arr[0] invalidates arr[0] (index exact-key + element re-resolve)", () => {
@@ -556,16 +557,16 @@ describe("memo auto-invalidation (generation counter)", () => {
     // AND re-declare the consumer; the declare bump invalidates entries
     // derived from the old snapshot.
     const scope = new Scope("fn");
-    scope.declare("x", "any");
+    scope.declare("x", ANY_T);
     const start: FlowNode = { kind: "start", scope };
     const assign: Extract<FlowNode, { kind: "assign" }> = {
       kind: "assign",
       prev: start,
       ref: ref("x"),
-      type: "any",
+      type: ANY_T,
     };
     const e = env(scope);
-    expect(typeAt(ref("x"), assign, e)).toBe("any"); // memoized under old gen
+    expect(typeAt(ref("x"), assign, e)).toEqual(ANY_T); // memoized under old gen
     assign.type = STR;
     scope.declare("x", STR);
     expect(typeAt(ref("x"), assign, e)).toEqual(STR);

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import { isAnyType } from "./utils.js";
 import type { AgencyNode, TypeAliasEntry, VariableType } from "../types.js";
 import type { Refine, NarrowCandidate } from "./narrowing.js";
@@ -38,16 +39,16 @@ function resolvePath(
 ): ScopeType {
   let current: ScopeType = baseType;
   for (const seg of chain) {
-    if (isAnyType(current)) return "any";
+    if (isAnyType(current)) return ANY_T;
     const resolved = safeResolveType(current, aliases);
     if (seg.kind === "prop") {
       if (resolved.type === "objectType") {
         const p = resolved.properties.find((pr) => pr.key === seg.name);
-        current = p ? p.value : "any";
+        current = p ? p.value : ANY_T;
       } else if (resolved.type === "genericType" && resolved.name === "Record") {
         current = resolved.typeArgs[1];
       } else {
-        return "any";
+        return ANY_T;
       }
     } else {
       // index segment: array element, or Record value (Record<K,V>[i] → V)
@@ -56,7 +57,7 @@ function resolvePath(
       } else if (resolved.type === "genericType" && resolved.name === "Record") {
         current = resolved.typeArgs[1];
       } else {
-        return "any";
+        return ANY_T;
       }
     }
   }
@@ -69,7 +70,7 @@ export function declaredPathType(
   ref: Reference,
   aliases: Record<string, TypeAliasEntry>,
 ): ScopeType {
-  return resolvePath(scope.lookup(ref.variable) ?? "any", ref.chain, aliases);
+  return resolvePath(scope.lookup(ref.variable) ?? ANY_T, ref.chain, aliases);
 }
 
 /**
@@ -156,7 +157,7 @@ export function uniteTypes(
   types: ScopeType[],
   aliases: Record<string, TypeAliasEntry>,
 ): ScopeType {
-  if (types.some((t) => isAnyType(t))) return "any";
+  if (types.some((t) => isAnyType(t))) return ANY_T;
   const concrete = (types as VariableType[]).filter((t) => !isNever(t));
   if (concrete.length === 0) return NEVER_T;
   const seen: Record<string, VariableType> = {};
@@ -223,7 +224,7 @@ function computeTypeAt(
 ): ScopeType {
   switch (at.kind) {
     case "start": {
-      const base = at.scope.lookup(ref.variable) ?? "any";
+      const base = at.scope.lookup(ref.variable) ?? ANY_T;
       return ref.chain.length === 0 ? base : resolvePath(base, ref.chain, env.typeAliases);
     }
     case "assign": {
@@ -241,7 +242,7 @@ function computeTypeAt(
     case "narrow": {
       if (referenceKey(at.ref) !== key) return typeAt(ref, at.prev, env);
       const base = typeAt(ref, at.prev, env);
-      if (isAnyType(base)) return "any";
+      if (isAnyType(base)) return ANY_T;
       return applyRefine(base, at.refine, env.typeAliases) ?? base;
     }
     case "join":

--- a/packages/agency-lang/lib/typeChecker/flow.ts
+++ b/packages/agency-lang/lib/typeChecker/flow.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import type { AgencyNode, TypeAliasEntry, VariableType } from "../types.js";
 import type { Refine, NarrowCandidate } from "./narrowing.js";
 import { narrowByRefine } from "./narrowing.js";
@@ -37,7 +38,7 @@ function resolvePath(
 ): ScopeType {
   let current: ScopeType = baseType;
   for (const seg of chain) {
-    if (current === "any") return "any";
+    if (isAnyType(current)) return "any";
     const resolved = safeResolveType(current, aliases);
     if (seg.kind === "prop") {
       if (resolved.type === "objectType") {
@@ -155,7 +156,7 @@ export function uniteTypes(
   types: ScopeType[],
   aliases: Record<string, TypeAliasEntry>,
 ): ScopeType {
-  if (types.some((t) => t === "any")) return "any";
+  if (types.some((t) => isAnyType(t))) return "any";
   const concrete = (types as VariableType[]).filter((t) => !isNever(t));
   if (concrete.length === 0) return NEVER_T;
   const seen: Record<string, VariableType> = {};
@@ -240,7 +241,7 @@ function computeTypeAt(
     case "narrow": {
       if (referenceKey(at.ref) !== key) return typeAt(ref, at.prev, env);
       const base = typeAt(ref, at.prev, env);
-      if (base === "any") return "any";
+      if (isAnyType(base)) return "any";
       return applyRefine(base, at.refine, env.typeAliases) ?? base;
     }
     case "join":
@@ -358,7 +359,7 @@ export function widenAtLoopBackEdge(
     const before = typeAt(r, loopEntry, env);
     const after = bodyEnd.kind === "exit" ? before : typeAt(r, bodyEnd, env);
     const unchanged =
-      before === "any" || after === "any"
+      isAnyType(before) || isAnyType(after)
         ? before === after
         : typeKey(before, env.typeAliases) === typeKey(after, env.typeAliases);
     if (unchanged) {

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import type { AgencyNode, Expression } from "../types.js";
 import type { AccessChainElement } from "../types/access.js";
 import { Scope, type ScopeType } from "./scope.js";
@@ -200,7 +201,7 @@ const statementRules: StatementRuleTable = {
       kind: "assign",
       prev: flow,
       ref: { variable: node.variableName, chain: [] },
-      type: env.scope.lookup(node.variableName) ?? "any",
+      type: env.scope.lookup(node.variableName) ?? ANY_T,
     };
     // Expression-match consumer (`const x = match(...)`): the type snapshotted
     // above is stale — the union isn't computed until computeMatchExprTypes

--- a/packages/agency-lang/lib/typeChecker/functionTypeRaises.ts
+++ b/packages/agency-lang/lib/typeChecker/functionTypeRaises.ts
@@ -36,7 +36,7 @@ type EffectMap = Record<string, InterruptEffect[]>;
 
 /** A function value flowing into a typed slot. `target` is the slot's declared
  *  type, or a nullish value when there is none (then there's nothing to check). */
-type Flow = { source: Expression; target: VariableType | "any" | null | undefined };
+type Flow = { source: Expression; target: VariableType | null | undefined };
 
 // -- WHERE: the sites a node introduces --------------------------------------
 
@@ -129,7 +129,7 @@ function valueFlows(
 /** The effects a function-type target allows, or null for no constraint: not a
  *  function type, no `raises` clause, or `<*>` (which allows anything). */
 function targetAllowed(
-  target: VariableType | "any" | null | undefined,
+  target: VariableType | null | undefined,
   ctx: TypeCheckerContext,
 ): { labels: string[]; name: string } | null {
   if (!target || isAnyType(target)) return null;

--- a/packages/agency-lang/lib/typeChecker/functionTypeRaises.ts
+++ b/packages/agency-lang/lib/typeChecker/functionTypeRaises.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import { diagnostic, type DiagnosticParams } from "./diagnostics.js";
 import type { SourceLocation } from "../types/base.js";
 import type { TypeCheckError } from "./types.js";
@@ -131,7 +132,7 @@ function targetAllowed(
   target: VariableType | "any" | null | undefined,
   ctx: TypeCheckerContext,
 ): { labels: string[]; name: string } | null {
-  if (!target || target === "any") return null;
+  if (!target || isAnyType(target)) return null;
   const resolved = safeResolveType(target, ctx.getTypeAliases());
   if (resolved.type !== "blockType" || !resolved.raises) return null;
   const allowed = resolveEffectSet(resolved.raises, ctx.getTypeAliases());

--- a/packages/agency-lang/lib/typeChecker/functionValueEffects.ts
+++ b/packages/agency-lang/lib/typeChecker/functionValueEffects.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import type { AgencyNode, Expression } from "../types.js";
 import type { BlockType } from "../types/typeHints.js";
 import type { InterruptEffect } from "../symbolTable.js";
@@ -78,7 +79,7 @@ export function functionValueEffects(
   }
 
   const synthed = synthType(expr, info.scope, ctx);
-  if (synthed === "any") {
+  if (isAnyType(synthed)) {
     return NO_EFFECTS; // unknown type — claim nothing (the checker's fail-open convention)
   }
 

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -84,7 +84,7 @@ export class TypeChecker {
   private symbolTable?: SymbolTable;
   private currentFile?: string;
   private errors: TypeCheckError[] = [];
-  private inferredReturnTypes: Record<string, VariableType | "any"> = {};
+  private inferredReturnTypes: Record<string, VariableType> = {};
   private inferringReturnType = new Set<string>();
   private sourceText: string | undefined;
 
@@ -475,8 +475,8 @@ export class TypeChecker {
 
   /** Delegating method preserved for test compatibility. */
   isAssignable(
-    source: VariableType | "any",
-    target: VariableType | "any",
+    source: VariableType,
+    target: VariableType,
   ): boolean {
     return _isAssignable(source, target, this.typeAliases);
   }

--- a/packages/agency-lang/lib/typeChecker/inference.ts
+++ b/packages/agency-lang/lib/typeChecker/inference.ts
@@ -42,7 +42,7 @@ export function inferReturnTypeFor(
   }
 
   // in a cycle trying to infer the return type,
-  // just bail out and return "any" to avoid infinite recursion.
+  // just bail out with ANY_T to avoid infinite recursion.
   if (ctx.inferringReturnType.has(name)) {
     return ANY_T;
   }

--- a/packages/agency-lang/lib/typeChecker/inference.ts
+++ b/packages/agency-lang/lib/typeChecker/inference.ts
@@ -1,4 +1,5 @@
 import { isAnyType } from "./utils.js";
+import { ANY_T } from "./primitives.js";
 import {
   AgencyNode,
   FunctionDefinition,
@@ -124,7 +125,6 @@ export function inferReturnTypeFor(
 
 type ResultTypes = readonly ResultType[];
 
-const ANY_T: VariableType = { type: "primitiveType", value: "any" };
 
 /**
  * Merge multiple Result types from different return paths. The success type

--- a/packages/agency-lang/lib/typeChecker/inference.ts
+++ b/packages/agency-lang/lib/typeChecker/inference.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import {
   AgencyNode,
   FunctionDefinition,
@@ -80,7 +81,7 @@ export function inferReturnTypeFor(
     } else {
       const typeAliases = ctx.getTypeAliases();
       const types = returnValues.map((v) => synthType(v, scope, ctx));
-      if (types.some((t) => t === "any")) {
+      if (types.some((t) => isAnyType(t))) {
         inferred = "any";
       } else {
         const concrete = types as VariableType[];
@@ -111,7 +112,7 @@ export function inferReturnTypeFor(
     // explicitly annotated a non-Result return type are caught earlier in
     // index.ts (section 1d) — this branch only handles unannotated returns.
     const hasValidatedParam = def.parameters.some((p) => p.validated);
-    if (hasValidatedParam && inferred !== "any") {
+    if (hasValidatedParam && !isAnyType(inferred)) {
       inferred = resultTypeForValidation(inferred, true);
     }
 
@@ -124,11 +125,6 @@ export function inferReturnTypeFor(
 type ResultTypes = readonly ResultType[];
 
 const ANY_T: VariableType = { type: "primitiveType", value: "any" };
-
-/** True when t is the "any" sentinel synth result expressed as a primitive. */
-function isAnyType(t: VariableType): boolean {
-  return t.type === "primitiveType" && t.value === "any";
-}
 
 /**
  * Merge multiple Result types from different return paths. The success type

--- a/packages/agency-lang/lib/typeChecker/inference.ts
+++ b/packages/agency-lang/lib/typeChecker/inference.ts
@@ -35,7 +35,7 @@ export function inferReturnTypeFor(
   name: string,
   def: FunctionDefinition | GraphNodeDefinition,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   if (name in ctx.inferredReturnTypes) {
     return ctx.inferredReturnTypes[name];
   }
@@ -43,7 +43,7 @@ export function inferReturnTypeFor(
   // in a cycle trying to infer the return type,
   // just bail out and return "any" to avoid infinite recursion.
   if (ctx.inferringReturnType.has(name)) {
-    return "any";
+    return ANY_T;
   }
 
   ctx.inferringReturnType.add(name);
@@ -56,7 +56,7 @@ export function inferReturnTypeFor(
   return ctx.withScope(defScopeKey, () => {
     const scope = new Scope(defScopeKey);
     for (const param of def.parameters) {
-      scope.declare(param.name, param.typeHint ?? "any");
+      scope.declare(param.name, param.typeHint ?? ANY_T);
     }
     walkScopeBody(def.body, scope, ctx);
 
@@ -75,14 +75,14 @@ export function inferReturnTypeFor(
       }
     }
 
-    let inferred: VariableType | "any";
+    let inferred: VariableType;
     if (returnValues.length === 0) {
       inferred = { type: "primitiveType", value: "void" };
     } else {
       const typeAliases = ctx.getTypeAliases();
       const types = returnValues.map((v) => synthType(v, scope, ctx));
       if (types.some((t) => isAnyType(t))) {
-        inferred = "any";
+        inferred = ANY_T;
       } else {
         const concrete = types as VariableType[];
         // Returns that are all Result-typed merge into a single Result<T, E>
@@ -102,7 +102,7 @@ export function inferReturnTypeFor(
               isAssignable(t, first, typeAliases) &&
               isAssignable(first, t, typeAliases),
           );
-          inferred = allSame ? first : "any";
+          inferred = allSame ? first : ANY_T;
         }
       }
     }

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import { diagnostic, type DiagnosticParams } from "./diagnostics.js";
 import type { InterruptEffect } from "../symbolTable.js";
 import type { TypeCheckerContext, ScopeInfo } from "./types.js";
@@ -123,7 +124,7 @@ function calleeDeclaredEffects(
   ctx: TypeCheckerContext,
 ): string[] {
   const t = scope.lookup(functionName);
-  if (t === undefined || t === "any") return [];
+  if (t === undefined || isAnyType(t)) return [];
   const resolved = safeResolveType(t, ctx.getTypeAliases());
   if (resolved.type !== "blockType" || !resolved.raises) return [];
   const set = resolveEffectSet(resolved.raises, ctx.getTypeAliases());
@@ -228,7 +229,7 @@ function functionRefsInArgs(
 
 /** Recursively extract function names from a synthesized type. */
 function functionNamesFromType(t: VariableType | "any", out: string[]): void {
-  if (t === "any") return;
+  if (isAnyType(t)) return;
   switch (t.type) {
     case "functionRefType":
       addUnique(out, t.name);

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -228,7 +228,7 @@ function functionRefsInArgs(
 }
 
 /** Recursively extract function names from a synthesized type. */
-function functionNamesFromType(t: VariableType | "any", out: string[]): void {
+function functionNamesFromType(t: VariableType, out: string[]): void {
   if (isAnyType(t)) return;
   switch (t.type) {
     case "functionRefType":

--- a/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExhaustiveness.ts
@@ -13,7 +13,7 @@ type Severity = "silent" | "warn" | "error";
 type CaseValue = MatchArmMeta["caseValue"]; // MatchPattern | "_"
 type NormalizedArm = { caseValue: CaseValue; guarded: boolean };
 type MatchSite = {
-  scrutineeType: VariableType | "any";
+  scrutineeType: VariableType;
   arms: NormalizedArm[];
   loc: SourceLocation | undefined;
   /** True when the match is used in expression position (`const x = match(...)`).

--- a/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
@@ -78,9 +78,7 @@ export function computeMatchExprTypes(
         // union can't be narrowed.
         ctx.matchExprTypes[id] = types.some(isAnyType)
           ? ANY_T
-          : unionTypes(
-              (types as VariableType[]).map((t) => widenType(t) as VariableType),
-            );
+          : unionTypes(types.map((t) => widenType(t)));
       }
 
     });

--- a/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import type { VariableType } from "../types.js";
 import type { MatchYield } from "../types/matchYield.js";
 import type { SourceLocation } from "../types/base.js";
@@ -65,7 +66,7 @@ export function computeMatchExprTypes(
         const typeExpr = (y: MatchYield) => y.typeSource ?? y.value;
         const types = yields.map((y) => {
           const e = typeExpr(y);
-          return e ? synthType(e, info.scope, ctx) : "any";
+          return e ? synthType(e, info.scope, ctx) : ANY_T;
         });
         // Record each yield's UNWIDENED type + loc for CHECKED-position
         // per-arm assignability checking (see `checkMatchExprYields`).
@@ -76,7 +77,7 @@ export function computeMatchExprTypes(
         // A yield of `any` makes the whole match's value type `any` — the
         // union can't be narrowed.
         ctx.matchExprTypes[id] = types.some(isAnyType)
-          ? "any"
+          ? ANY_T
           : unionTypes(
               (types as VariableType[]).map((t) => widenType(t) as VariableType),
             );

--- a/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
+++ b/packages/agency-lang/lib/typeChecker/matchExprTypes.ts
@@ -73,10 +73,9 @@ export function computeMatchExprTypes(
           type: types[i],
           loc: typeExpr(y)?.loc ?? y.loc,
         }));
-        // A yield of `any` (the sentinel string OR the `any` primitive) makes
-        // the whole match's value type `any` — the union can't be narrowed.
-        const isAny = (t: VariableType | "any") => t === "any" || isAnyType(t);
-        ctx.matchExprTypes[id] = types.some(isAny)
+        // A yield of `any` makes the whole match's value type `any` — the
+        // union can't be narrowed.
+        ctx.matchExprTypes[id] = types.some(isAnyType)
           ? "any"
           : unionTypes(
               (types as VariableType[]).map((t) => widenType(t) as VariableType),
@@ -146,8 +145,7 @@ export function checkMatchExprYields(
   if (!yields) return;
   // If ANY arm yields `any` the match's value type collapses to `any` (same
   // rule as `matchExprTypes`), which is assignable to anything — no error.
-  const isAny = (t: VariableType | "any") => t === "any" || isAnyType(t);
-  if (yields.some((y) => isAny(y.type))) return;
+  if (yields.some((y) => isAnyType(y.type))) return;
   // Report the FIRST arm whose UNWIDENED yield type is not assignable to the
   // expected type. Anchoring on that arm's value gives a precise location and
   // names the offending value; stopping after one keeps the diagnostic count

--- a/packages/agency-lang/lib/typeChecker/narrowing.ts
+++ b/packages/agency-lang/lib/typeChecker/narrowing.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import type { AgencyNode, Expression, TypeAliasEntry, IfElse, VariableType } from "../types.js";
 import type {
   StringLiteralType,
@@ -416,7 +417,7 @@ export function applyNarrowing(
     if (cand.ref.chain.length !== 0) continue;
     const name = cand.ref.variable;
     const current = childScope.lookup(name);
-    if (!current || current === "any") continue;
+    if (!current || isAnyType(current)) continue;
     // "what to narrow to" is delegated to narrowByRefine (the same dispatcher
     // the flow path uses). It resolves through type-alias variables itself
     // (mirrors synthValueAccess) so alias-typed scrutinees still narrow; null

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -125,8 +125,8 @@ export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
     params: [{ type: "unionType", types: [STRING_T, NUMBER_T] }],
     returnType: NUMBER_T,
   }),
-  isNaN: callable({ params: ["any"], returnType: BOOLEAN_T }),
-  isFinite: callable({ params: ["any"], returnType: BOOLEAN_T }),
+  isNaN: callable({ params: [ANY_T], returnType: BOOLEAN_T }),
+  isFinite: callable({ params: [ANY_T], returnType: BOOLEAN_T }),
   encodeURIComponent: callable({ params: [STRING_T], returnType: STRING_T }),
   decodeURIComponent: callable({ params: [STRING_T], returnType: STRING_T }),
   encodeURI: callable({ params: [STRING_T], returnType: STRING_T }),
@@ -136,17 +136,17 @@ export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
   clearTimeout: callable(),
   clearInterval: callable(),
   queueMicrotask: callable(),
-  structuredClone: callable({ params: ["any"], returnType: "any" }),
+  structuredClone: callable({ params: [ANY_T], returnType: ANY_T }),
   BigInt: callable(),
   Symbol: callable(),
 
   // --- Namespaces ---
   JSON: namespace({
-    parse: callable({ params: [STRING_T], returnType: "any" }),
+    parse: callable({ params: [STRING_T], returnType: ANY_T }),
     // JSON.stringify(value, replacer?, space?). Replacer can be many things —
     // type as `any` to avoid false positives.
     stringify: callable({
-      params: ["any", "any", { type: "unionType", types: [STRING_T, NUMBER_T] }],
+      params: [ANY_T, ANY_T, { type: "unionType", types: [STRING_T, NUMBER_T] }],
       minParams: 1,
       returnType: STRING_T,
     }),
@@ -179,22 +179,22 @@ export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
     random: callable({ params: [], returnType: NUMBER_T }),
   }),
   Object: namespace({
-    keys: callable({ params: ["any"], returnType: stringArray }),
-    values: callable({ params: ["any"], returnType: anyArray }),
-    entries: callable({ params: ["any"], returnType: anyArray }),
-    fromEntries: callable({ params: [anyArray], returnType: "any" }),
+    keys: callable({ params: [ANY_T], returnType: stringArray }),
+    values: callable({ params: [ANY_T], returnType: anyArray }),
+    entries: callable({ params: [ANY_T], returnType: anyArray }),
+    fromEntries: callable({ params: [anyArray], returnType: ANY_T }),
     // `Object.create(proto, props?)` — used e.g. with `null` to make a
     // null-prototype map that's safe against user-controlled keys like
     // "__proto__" (see std::index `groupBy`).
-    create: callable({ params: ["any", "any"], minParams: 1, returnType: "any" }),
+    create: callable({ params: [ANY_T, ANY_T], minParams: 1, returnType: ANY_T }),
     assign: callable(),
-    freeze: callable({ params: ["any"], returnType: "any" }),
-    getOwnPropertyNames: callable({ params: ["any"], returnType: stringArray }),
-    getPrototypeOf: callable({ params: ["any"], returnType: "any" }),
+    freeze: callable({ params: [ANY_T], returnType: ANY_T }),
+    getOwnPropertyNames: callable({ params: [ANY_T], returnType: stringArray }),
+    getPrototypeOf: callable({ params: [ANY_T], returnType: ANY_T }),
     setPrototypeOf: callable(),
   }),
   Array: namespace({
-    isArray: callable({ params: ["any"], returnType: BOOLEAN_T }),
+    isArray: callable({ params: [ANY_T], returnType: BOOLEAN_T }),
     from: callable(),
     of: callable(),
   }),
@@ -205,15 +205,15 @@ export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
       fromCharCode: callable({ params: [], restParam: NUMBER_T, returnType: STRING_T }),
       raw: callable(),
     },
-    { params: ["any"], minParams: 0, returnType: STRING_T },
+    { params: [ANY_T], minParams: 0, returnType: STRING_T },
   ),
   // `Number(x)` coerces to a number; the rest are member helpers.
   Number: namespace(
     {
-      isInteger: callable({ params: ["any"], returnType: BOOLEAN_T }),
-      isFinite: callable({ params: ["any"], returnType: BOOLEAN_T }),
-      isNaN: callable({ params: ["any"], returnType: BOOLEAN_T }),
-      isSafeInteger: callable({ params: ["any"], returnType: BOOLEAN_T }),
+      isInteger: callable({ params: [ANY_T], returnType: BOOLEAN_T }),
+      isFinite: callable({ params: [ANY_T], returnType: BOOLEAN_T }),
+      isNaN: callable({ params: [ANY_T], returnType: BOOLEAN_T }),
+      isSafeInteger: callable({ params: [ANY_T], returnType: BOOLEAN_T }),
       parseFloat: callable({
         params: [{ type: "unionType", types: [STRING_T, NUMBER_T] }],
         returnType: NUMBER_T,
@@ -224,10 +224,10 @@ export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
         returnType: NUMBER_T,
       }),
     },
-    { params: ["any"], minParams: 0, returnType: NUMBER_T },
+    { params: [ANY_T], minParams: 0, returnType: NUMBER_T },
   ),
   // `Boolean(x)` coerces any value to a boolean.
-  Boolean: callable({ params: ["any"], minParams: 0, returnType: BOOLEAN_T }),
+  Boolean: callable({ params: [ANY_T], minParams: 0, returnType: BOOLEAN_T }),
   Date: namespace({
     now: callable({ params: [], returnType: NUMBER_T }),
     parse: callable({ params: [STRING_T], returnType: NUMBER_T }),

--- a/packages/agency-lang/lib/typeChecker/scope.test.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.test.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import { describe, it, expect } from "vitest";
 import { Scope } from "./scope.js";
 import type { VariableType } from "../types.js";
@@ -87,7 +88,7 @@ describe("generation counter", () => {
     const root = new Scope("global");
     const fn = new Scope("fn", root, true);
     const g0 = fn.currentGeneration();
-    fn.declare("x", "any");
+    fn.declare("x", ANY_T);
     expect(fn.currentGeneration()).toBe(g0 + 1);
     expect(root.currentGeneration()).toBe(g0 + 1);
   });
@@ -97,9 +98,9 @@ describe("generation counter", () => {
     // equal the existing entry; the paired assign-node patch relies on the
     // bump regardless. Pins against a skip-if-unchanged "optimization".
     const fn = new Scope("fn");
-    fn.declare("x", "any");
+    fn.declare("x", ANY_T);
     const g0 = fn.currentGeneration();
-    fn.declare("x", "any");
+    fn.declare("x", ANY_T);
     expect(fn.currentGeneration()).toBe(g0 + 1);
   });
 
@@ -108,7 +109,7 @@ describe("generation counter", () => {
     const child = fn.child();
     expect(child.detached).toBe(true);
     const g0 = fn.currentGeneration();
-    child.declareLocal("cbParam", "any");
+    child.declareLocal("cbParam", ANY_T);
     expect(fn.currentGeneration()).toBe(g0);
   });
 
@@ -117,7 +118,7 @@ describe("generation counter", () => {
     const fn = new Scope("fn");
     const grandchild = fn.child().child();
     const g0 = fn.currentGeneration();
-    grandchild.declareLocal("cbParam", "any");
+    grandchild.declareLocal("cbParam", ANY_T);
     expect(fn.currentGeneration()).toBe(g0);
   });
 
@@ -125,7 +126,7 @@ describe("generation counter", () => {
     const fn = new Scope("fn");
     const child = fn.child();
     const g0 = fn.currentGeneration();
-    child.declare("real", "any");
+    child.declare("real", ANY_T);
     expect(fn.currentGeneration()).toBe(g0 + 1);
   });
 
@@ -133,14 +134,14 @@ describe("generation counter", () => {
     const fn = new Scope("fn");
     const grandchild = fn.child().child();
     const g0 = fn.currentGeneration();
-    grandchild.declare("real", "any");
+    grandchild.declare("real", ANY_T);
     expect(fn.currentGeneration()).toBe(g0 + 1);
   });
 
   it("declareLocal on an attached scope bumps", () => {
     const fn = new Scope("fn");
     const g0 = fn.currentGeneration();
-    fn.declareLocal("x", "any");
+    fn.declareLocal("x", ANY_T);
     expect(fn.currentGeneration()).toBe(g0 + 1);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/scope.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.ts
@@ -1,6 +1,6 @@
 import type { VariableType } from "../types.js";
 
-export type ScopeType = VariableType | "any";
+export type ScopeType = VariableType;
 
 export class Scope {
   readonly key: string;

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import {
   AgencyNode,
   FunctionDefinition,
@@ -67,7 +68,7 @@ function buildDefScope(
   // top-level scope is fully walked before any def scope is built).
   const scope = new Scope(sk, topLevelScope, true);
   for (const param of def.parameters) {
-    scope.declare(param.name, param.typeHint ?? "any");
+    scope.declare(param.name, param.typeHint ?? ANY_T);
   }
   ctx.withScope(sk, () => {
     walkScopeBody(def.body, scope, ctx);
@@ -294,7 +295,7 @@ function synthAccessChainTargetType(
   scope: Scope,
   ctx: TypeCheckerContext,
   flowNode: FlowNode | undefined,
-): VariableType | "any" {
+): VariableType {
   const base: VariableNameLiteral = {
     type: "variableName",
     value: variableName,
@@ -315,8 +316,8 @@ function synthAccessChainTargetType(
 function reportNotAssignable(
   ctx: TypeCheckerContext,
   variableName: string,
-  actual: VariableType | "any",
-  expected: VariableType | "any",
+  actual: VariableType,
+  expected: VariableType,
   loc: SourceLocation | undefined,
 ): void {
   if (isAnyType(actual) || isAnyType(expected)) return;
@@ -400,7 +401,7 @@ export function walkScopeBody(
       case "importStatement":
         for (const importName of node.importedNames) {
           for (const name of getImportedNames(importName)) {
-            scope.declare(name, "any");
+            scope.declare(name, ANY_T);
           }
         }
         break;
@@ -410,8 +411,8 @@ export function walkScopeBody(
         // first (element for arrays, key for records/objects); `secondType`
         // is the second (numeric index for arrays, VALUE for records/objects),
         // mirroring how the runtime `Runner.loop` passes callback arguments.
-        let itemType: VariableType | "any";
-        let secondType: VariableType | "any";
+        let itemType: VariableType;
+        let secondType: VariableType;
         // Record-like: `for (k, v in obj)` binds key + value. A shared helper
         // (`recordLikeKeyValue`) handles both `Record<K, V>` and structural
         // object literals (`objectType`), so this typer and index-access
@@ -426,10 +427,10 @@ export function walkScopeBody(
             ? undefined
             : recordLikeKeyValue(iterableType);
         if (isAnyType(iterableType)) {
-          itemType = "any";
+          itemType = ANY_T;
           // Iterable kind is unknown, so the second var could be either an
           // index or a value — leave it as `any` rather than assume a number.
-          secondType = "any";
+          secondType = ANY_T;
         } else if (iterableType.type === "arrayType") {
           itemType = iterableType.elementType;
           secondType = NUMBER_T;
@@ -437,8 +438,8 @@ export function walkScopeBody(
           itemType = recordLike.key;
           secondType = recordLike.value;
         } else {
-          itemType = "any";
-          secondType = "any";
+          itemType = ANY_T;
+          secondType = ANY_T;
           ctx.errors.push(
             diagnostic(
               "forLoopIterableType",
@@ -510,7 +511,7 @@ export function walkScopeBody(
           }
           scope.declare(
             node.handler.param.name,
-            node.handler.param.typeHint ?? "any",
+            node.handler.param.typeHint ?? ANY_T,
           );
           walkScopeBody(node.handler.body, scope, ctx);
         }
@@ -527,7 +528,7 @@ export function walkScopeBody(
             const slotType = slot?.params[i]?.typeAnnotation;
             scope.declare(
               param.name,
-              param.typeHint ?? slotType ?? "any",
+              param.typeHint ?? slotType ?? ANY_T,
             );
           });
           walkScopeBody(node.block.body, scope, ctx);

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -319,7 +319,7 @@ function reportNotAssignable(
   expected: VariableType | "any",
   loc: SourceLocation | undefined,
 ): void {
-  if (actual === "any" || expected === "any") return;
+  if (isAnyType(actual) || isAnyType(expected)) return;
   if (isAssignable(actual, expected, ctx.getTypeAliases())) return;
   ctx.errors.push(
     diagnostic(

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -422,10 +422,10 @@ export function walkScopeBody(
         // binder over a bare `Result`) is as unknowable as the "any" string —
         // treat both as "could be any iterable" rather than rejecting.
         const recordLike =
-          iterableType === "any" || isAnyType(iterableType)
+          isAnyType(iterableType)
             ? undefined
             : recordLikeKeyValue(iterableType);
-        if (iterableType === "any" || isAnyType(iterableType)) {
+        if (isAnyType(iterableType)) {
           itemType = "any";
           // Iterable kind is unknown, so the second var could be either an
           // index or a value — leave it as `any` rather than assume a number.

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -908,8 +908,7 @@ export function synthValueAccess(
 
     if (isAnyType(currentType)) return ANY_T;
     const resolved = safeResolveType(currentType, typeAliases);
-    if (resolved.type === "primitiveType" && resolved.value === "any")
-      return ANY_T;
+    if (isAnyType(resolved)) return ANY_T;
     // never is the bottom type: any access on it is itself never, and emits no
     // diagnostic (a provably-unreachable receiver must not flag spurious
     // missing-member errors).

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -228,17 +228,6 @@ function accessResultField(
 }
 
 /**
- * `synthType` returns `VariableType | "any"` where `"any"` is the literal
- * string sentinel meaning "we don't know". When we want to embed that
- * result inside a structured VariableType (e.g. as ResultType.successType,
- * which is just `VariableType`), convert the sentinel into the equivalent
- * primitiveType("any") so the inner field is a real VariableType.
- */
-function maybeAny(t: VariableType): VariableType {
-  return isAnyType(t) ? ANY_T : t;
-}
-
-/**
  * Return the inner expression for a plain positional argument, or undefined
  * for splat / named args. Synth-time special cases (success/failure) decline
  * to fire on those forms because the per-arg type isn't directly available.
@@ -598,7 +587,7 @@ function synthFunctionCall(
   ) {
     const inner = asPositionalArg(expr.arguments[0]);
     if (inner) {
-      const innerType = maybeAny(synthType(inner, scope, ctx));
+      const innerType = synthType(inner, scope, ctx);
       return expr.functionName === "success"
         ? { type: "resultType", successType: innerType, failureType: ANY_T }
         : { type: "resultType", successType: ANY_T, failureType: innerType };

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -61,7 +61,7 @@ const RESULT_BRANCH_FIELDS = new Set(
  * Resolve a field access on a `ResultType` against the narrowing layer.
  * Returns:
  *  - a `VariableType`  → caller should set `currentType = ...; break;`
- *  - the string `"any"` → caller should `return "any"` (Result field on an
+ *  - the string `"any"` → caller should `return ANY_T` (Result field on an
  *    un-narrowed Result; un-typed escape hatch until Increment 3 tightens
  *    `.value` on Failure into a hard error)
  *  - `null` → no resolution; fall through to the next case in `synthValueAccess`
@@ -73,12 +73,12 @@ const RESULT_BRANCH_FIELDS = new Set(
 function resolveResultFieldType(
   _resolved: ResultType,
   fieldName: string,
-): VariableType | "any" | null {
+): VariableType | null {
   // Narrowed Results are now real member object types (narrowed via the
   // discriminant engine), so this only sees UN-narrowed Results: keep the
   // lenient `any` for known Result fields. Task 2 deletes this entirely and
   // routes un-narrowed Results through strict union access.
-  if (RESULT_FIELDS.has(fieldName)) return "any";
+  if (RESULT_FIELDS.has(fieldName)) return ANY_T;
   return null;
 }
 
@@ -197,7 +197,7 @@ function accessResultField(
   aliases: Record<string, TypeAliasEntry>,
   ctx: TypeCheckerContext,
   loc: SourceLocation | undefined,
-): VariableType | "any" | null {
+): VariableType | null {
   const severity = strictMemberAccessSeverity(ctx);
   if (severity === "silent") {
     return resolveResultFieldType(result, fieldName);
@@ -234,7 +234,7 @@ function accessResultField(
  * which is just `VariableType`), convert the sentinel into the equivalent
  * primitiveType("any") so the inner field is a real VariableType.
  */
-function maybeAny(t: VariableType | "any"): VariableType {
+function maybeAny(t: VariableType): VariableType {
   return isAnyType(t) ? ANY_T : t;
 }
 
@@ -254,7 +254,7 @@ export function synthType(
   expr: AgencyNode,
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   switch (expr.type) {
     case "variableName": {
       // Expression-match temp: `__matchval_<id>` is the synthetic ref the
@@ -263,7 +263,7 @@ export function synthType(
       // outer yield that reads an inner match's temp gets the inner union.
       const matchvalId = parseMatchValId(expr.value);
       if (matchvalId !== undefined) {
-        return ctx.matchExprTypes[matchvalId] ?? "any";
+        return ctx.matchExprTypes[matchvalId] ?? ANY_T;
       }
       const scopeType = scope.lookup(expr.value);
       if (scopeType) {
@@ -321,7 +321,7 @@ export function synthType(
           returnType: imported.returnType ?? null,
         };
       }
-      return "any";
+      return ANY_T;
     }
     case "number":
     case "unitLiteral":
@@ -365,7 +365,7 @@ export function synthType(
       // their own `def schema()` (which would create parse ambiguity).
       return { type: "schemaType", inner: expr.typeArg };
     default:
-      return "any";
+      return ANY_T;
   }
 }
 
@@ -378,7 +378,7 @@ function synthTryExpression(
   expr: AgencyNode & { type: "tryExpression" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const inner = synthType(expr.call, scope, ctx);
   if (isAnyType(inner)) return inner;
   if (inner.type === "resultType") return inner;
@@ -410,7 +410,7 @@ function synthBinOp(
   expr: AgencyNode & { type: "binOpExpression" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const op = expr.operator;
   if (op === "catch") return synthCatch(expr, scope, ctx);
   if (op === "|>") return synthPipe(expr, scope, ctx);
@@ -440,7 +440,7 @@ function synthBinOp(
   if (op === "+") {
     const leftType = synthType(expr.left, scope, ctx);
     const rightType = synthType(expr.right, scope, ctx);
-    const isString = (t: VariableType | "any") =>
+    const isString = (t: VariableType) =>
       !isAnyType(t) &&
       ((t.type === "primitiveType" && t.value === "string") ||
         t.type === "stringLiteralType");
@@ -464,10 +464,10 @@ function synthLogical(
   expr: AgencyNode & { type: "binOpExpression" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const left = synthType(expr.left, scope, ctx);
   const right = synthType(expr.right, scope, ctx);
-  if (isAnyType(left) || isAnyType(right)) return "any";
+  if (isAnyType(left) || isAnyType(right)) return ANY_T;
   const seen = new Map<string, VariableType>();
   const aliases = ctx.getTypeAliases();
   const collect = (t: VariableType) => {
@@ -495,7 +495,7 @@ function synthNullishCoalesce(
   expr: AgencyNode & { type: "binOpExpression" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const left = synthType(expr.left, scope, ctx);
   if (isAnyType(left)) return synthType(expr.right, scope, ctx);
   const stripped = stripNullable(left);
@@ -530,7 +530,7 @@ function synthCatch(
   expr: AgencyNode & { type: "binOpExpression" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const left = synthType(expr.left, scope, ctx);
   if (isAnyType(left)) return left;
   if (left.type === "resultType") {
@@ -554,7 +554,7 @@ function synthPipe(
   expr: AgencyNode & { type: "binOpExpression" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const right = synthPipeRhs(expr.right, scope, ctx);
   if (isAnyType(right)) return right;
   if (right.type === "resultType") return right;
@@ -570,7 +570,7 @@ function synthPipeRhs(
   rhs: AgencyNode,
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const rhsType = synthType(rhs, scope, ctx);
   if (!isAnyType(rhsType) && rhsType.type === "functionRefType") {
     const returnType =
@@ -587,7 +587,7 @@ function synthFunctionCall(
   expr: AgencyNode & { type: "functionCall" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   // Result constructors: parameterize ResultType from the argument so callers
   // get `Result<T, any>` (success) or `Result<any, T>` (failure). The names
   // are reserved at the typechecker level (see RESERVED_FUNCTION_NAMES in
@@ -622,29 +622,29 @@ function synthFunctionCall(
       return BUILTIN_FUNCTION_TYPES[expr.functionName].returnType;
     }
   }
-  return "any";
+  return ANY_T;
 }
 
 function synthArray(
   expr: AgencyNode & { type: "agencyArray" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   if (expr.items.length === 0)
     return { type: "arrayType", elementType: ANY_T };
-  const itemTypes: (VariableType | "any")[] = [];
+  const itemTypes: (VariableType)[] = [];
   for (const item of expr.items) {
     if (item.type === "splat") {
       const splatType = synthType(item.value, scope, ctx);
-      if (isAnyType(splatType)) return "any";
-      if (splatType.type !== "arrayType") return "any";
+      if (isAnyType(splatType)) return ANY_T;
+      if (splatType.type !== "arrayType") return ANY_T;
       itemTypes.push(splatType.elementType);
       continue;
     }
     itemTypes.push(synthType(item, scope, ctx));
   }
   const concreteTypes = itemTypes.filter((t): t is VariableType => !isAnyType(t));
-  if (concreteTypes.length === 0) return "any";
+  if (concreteTypes.length === 0) return ANY_T;
   if (concreteTypes.length === 1) {
     return { type: "arrayType", elementType: concreteTypes[0] };
   }
@@ -675,7 +675,7 @@ function synthObject(
   expr: AgencyNode & { type: "agencyObject" },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   // Use a Map so later entries overwrite earlier ones (later-wins for splats
   // followed by explicit keys, e.g. { ...a, x: "new" } produces x's literal type).
   const properties = new Map<string, VariableType>();
@@ -687,8 +687,8 @@ function synthObject(
   for (const entry of expr.entries) {
     if ("type" in entry && entry.type === "splat") {
       const splatType = synthType(entry.value, scope, ctx);
-      if (isAnyType(splatType)) return "any";
-      if (splatType.type !== "objectType") return "any";
+      if (isAnyType(splatType)) return ANY_T;
+      if (splatType.type !== "objectType") return ANY_T;
       for (const prop of splatType.properties)
         properties.set(prop.key, prop.value);
       continue;
@@ -709,7 +709,7 @@ function synthObject(
       ? NULL_T
       : synthType(kv.value, scope, ctx);
     if (isAnyType(valueType)) {
-      return "any";
+      return ANY_T;
     }
     if (kv.computedKey) {
       hasComputedKey = true;
@@ -723,7 +723,7 @@ function synthObject(
       ...Array.from(properties.values()),
       ...computedValueTypes,
     ];
-    if (allValueTypes.length === 0) return "any";
+    if (allValueTypes.length === 0) return ANY_T;
     const unique = uniqBy(allValueTypes, (t) => typeKey(t, ctx.getTypeAliases()));
     const valueType: VariableType =
       unique.length === 1
@@ -847,7 +847,7 @@ function validateAgencyFunctionMethod(
 function narrowedPathPrefix(
   expr: ValueAccess,
   ctx: TypeCheckerContext,
-): { type: VariableType | "any"; consumed: number } | null {
+): { type: VariableType; consumed: number } | null {
   if (!ctx.flowEnv || expr.base.type !== "variableName") return null;
   const flow = ctx.flowEnv.flowOf.get(expr);
   if (!flow) return null;
@@ -883,7 +883,7 @@ export function synthValueAccess(
   expr: ValueAccess,
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const typeAliases = ctx.getTypeAliases();
 
   // When a narrowed stable prefix applies, start the structural walk from its
@@ -901,15 +901,15 @@ export function synthValueAccess(
       const methodName = element.functionCall.functionName;
       if (methodName === "partial" || methodName in AGENCY_FUNCTION_METHOD_TYPES) {
         validateAgencyFunctionMethod(expr, element, methodName, scope, ctx);
-        currentType = "any";
+        currentType = ANY_T;
         continue;
       }
     }
 
-    if (isAnyType(currentType)) return "any";
+    if (isAnyType(currentType)) return ANY_T;
     const resolved = safeResolveType(currentType, typeAliases);
     if (resolved.type === "primitiveType" && resolved.value === "any")
-      return "any";
+      return ANY_T;
     // never is the bottom type: any access on it is itself never, and emits no
     // diagnostic (a provably-unreachable receiver must not flag spurious
     // missing-member errors).
@@ -931,7 +931,7 @@ export function synthValueAccess(
             ctx,
             expr.loc,
           );
-          if (fieldType !== null && isAnyType(fieldType)) return "any";
+          if (fieldType !== null && isAnyType(fieldType)) return ANY_T;
           if (fieldType !== null) {
             currentType = fieldType;
             break;
@@ -949,7 +949,7 @@ export function synthValueAccess(
           );
           if (memberType === null) {
             pushPropertyDoesNotExist(ctx, element.name, resolved, expr.loc);
-            return "any";
+            return ANY_T;
           }
           currentType = memberType;
         } else if (resolved.type === "objectType") {
@@ -958,7 +958,7 @@ export function synthValueAccess(
             currentType = prop.value;
           } else {
             pushPropertyDoesNotExist(ctx, element.name, resolved, expr.loc);
-            return "any";
+            return ANY_T;
           }
         } else if (resolved.type === "genericType" && resolved.name === "Record") {
           // Record<K, V>: property access yields V (key existence is dynamic).
@@ -971,7 +971,7 @@ export function synthValueAccess(
             break;
           }
           pushPropertyDoesNotExist(ctx, element.name, resolved, expr.loc);
-          return "any";
+          return ANY_T;
         }
         break;
       }
@@ -986,7 +986,7 @@ export function synthValueAccess(
           if (recordLike) {
             currentType = recordLike.value;
           } else {
-            return "any";
+            return ANY_T;
           }
         }
         break;
@@ -1043,7 +1043,7 @@ export function synthValueAccess(
           currentType = isAnyType(sig.returnType) ? ANY_T : sig.returnType;
           break;
         }
-        return "any";
+        return ANY_T;
       }
     }
   }
@@ -1113,7 +1113,7 @@ function validatePrimitiveMethodCall(
     const arg = args[i];
     if ("type" in arg && arg.type === "splat") continue; // skip splat element check for primitives
     const slotType =
-      i < sig.params.length ? sig.params[i] : (sig.restParam as VariableType | "any" | undefined);
+      i < sig.params.length ? sig.params[i] : (sig.restParam as VariableType | undefined);
     if (slotType === undefined || isAnyType(slotType)) continue;
     const argType = synthType(arg as AgencyNode, scope, ctx);
     if (isAnyType(argType)) continue;
@@ -1154,7 +1154,7 @@ function synthArrayCallbackMethod(
   call: { functionName: string; arguments: AgencyNode[] | unknown[]; block?: BlockArgument },
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const elementT = receiver.elementType;
   if (cbKind === "sameArray") return receiver;
   if (cbKind === "void") return VOID_T;
@@ -1192,7 +1192,7 @@ function synthArrayCallbackMethod(
     }
     return cbReturn;
   }
-  return "any";
+  return ANY_T;
 }
 
 /**
@@ -1211,17 +1211,17 @@ function synthCallbackReturnType(
   elementT: VariableType,
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   if (call.block) {
     return synthBlockReturnType(call.block, elementT, scope, ctx);
   }
   const args = (call.arguments as AgencyNode[]) ?? [];
-  if (args.length === 0) return "any";
+  if (args.length === 0) return ANY_T;
   const cbType = synthType(args[0], scope, ctx);
-  if (isAnyType(cbType)) return "any";
-  if (cbType.type === "functionRefType") return cbType.returnType ?? "any";
+  if (isAnyType(cbType)) return ANY_T;
+  if (cbType.type === "functionRefType") return cbType.returnType ?? ANY_T;
   if (cbType.type === "blockType") return cbType.returnType;
-  return "any";
+  return ANY_T;
 }
 
 /**
@@ -1239,7 +1239,7 @@ function synthBlockReturnType(
   elementT: VariableType,
   scope: Scope,
   ctx: TypeCheckerContext,
-): VariableType | "any" {
+): VariableType {
   const child = scope.child();
   // First param is the element; second (if present) is the index for
   // most array iteration methods. We don't try to special-case `reduce`
@@ -1248,18 +1248,18 @@ function synthBlockReturnType(
   block.params.forEach((p, i) => {
     if (i === 0) child.declareLocal(p.name, elementT);
     else if (i === 1) child.declareLocal(p.name, NUMBER_T);
-    else child.declareLocal(p.name, "any");
+    else child.declareLocal(p.name, ANY_T);
   });
 
-  const returnTypes: (VariableType | "any")[] = [];
+  const returnTypes: (VariableType)[] = [];
   for (const { node } of walkNodes(block.body)) {
     if (node.type === "returnStatement" && node.value) {
       returnTypes.push(synthType(node.value, child, ctx));
     }
   }
-  if (returnTypes.length === 0) return "any";
+  if (returnTypes.length === 0) return ANY_T;
   const concrete = returnTypes.filter((t): t is VariableType => !isAnyType(t));
-  if (concrete.length === 0) return "any";
+  if (concrete.length === 0) return ANY_T;
   if (concrete.length === 1) return concrete[0];
   // Dedupe structurally identical types.
   const seen = new Map<string, VariableType>();

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import { diagnostic } from "./diagnostics.js";
 import { AgencyNode, Expression, VariableType, ValueAccess, formatUnitLiteral } from "../types.js";
 import { parseMatchValId } from "../matchVal.js";
@@ -234,7 +235,7 @@ function accessResultField(
  * primitiveType("any") so the inner field is a real VariableType.
  */
 function maybeAny(t: VariableType | "any"): VariableType {
-  return t === "any" ? ANY_T : t;
+  return isAnyType(t) ? ANY_T : t;
 }
 
 /**
@@ -379,7 +380,7 @@ function synthTryExpression(
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
   const inner = synthType(expr.call, scope, ctx);
-  if (inner === "any") return inner;
+  if (isAnyType(inner)) return inner;
   if (inner.type === "resultType") return inner;
   return { type: "resultType", successType: inner, failureType: ANY_T };
 }
@@ -440,7 +441,7 @@ function synthBinOp(
     const leftType = synthType(expr.left, scope, ctx);
     const rightType = synthType(expr.right, scope, ctx);
     const isString = (t: VariableType | "any") =>
-      t !== "any" &&
+      !isAnyType(t) &&
       ((t.type === "primitiveType" && t.value === "string") ||
         t.type === "stringLiteralType");
     if (isString(leftType) || isString(rightType)) {
@@ -466,7 +467,7 @@ function synthLogical(
 ): VariableType | "any" {
   const left = synthType(expr.left, scope, ctx);
   const right = synthType(expr.right, scope, ctx);
-  if (left === "any" || right === "any") return "any";
+  if (isAnyType(left) || isAnyType(right)) return "any";
   const seen = new Map<string, VariableType>();
   const aliases = ctx.getTypeAliases();
   const collect = (t: VariableType) => {
@@ -496,7 +497,7 @@ function synthNullishCoalesce(
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
   const left = synthType(expr.left, scope, ctx);
-  if (left === "any") return synthType(expr.right, scope, ctx);
+  if (isAnyType(left)) return synthType(expr.right, scope, ctx);
   const stripped = stripNullable(left);
   if (stripped === undefined) return synthType(expr.right, scope, ctx);
   return stripped;
@@ -531,7 +532,7 @@ function synthCatch(
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
   const left = synthType(expr.left, scope, ctx);
-  if (left === "any") return left;
+  if (isAnyType(left)) return left;
   if (left.type === "resultType") {
     // `catch` on a non-Result is a no-op at runtime — type is just left.
     return left.successType;
@@ -555,7 +556,7 @@ function synthPipe(
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
   const right = synthPipeRhs(expr.right, scope, ctx);
-  if (right === "any") return right;
+  if (isAnyType(right)) return right;
   if (right.type === "resultType") return right;
   return { type: "resultType", successType: right, failureType: ANY_T };
 }
@@ -571,10 +572,10 @@ function synthPipeRhs(
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
   const rhsType = synthType(rhs, scope, ctx);
-  if (rhsType !== "any" && rhsType.type === "functionRefType") {
+  if (!isAnyType(rhsType) && rhsType.type === "functionRefType") {
     const returnType =
       rhsType.returnType ??
-      (ctx.inferredReturnTypes[rhsType.name] !== "any"
+      (!isAnyType(ctx.inferredReturnTypes[rhsType.name])
         ? (ctx.inferredReturnTypes[rhsType.name] as VariableType | undefined)
         : undefined);
     if (returnType) return resultTypeForValidation(returnType, rhsType.returnTypeValidated);
@@ -635,14 +636,14 @@ function synthArray(
   for (const item of expr.items) {
     if (item.type === "splat") {
       const splatType = synthType(item.value, scope, ctx);
-      if (splatType === "any") return "any";
+      if (isAnyType(splatType)) return "any";
       if (splatType.type !== "arrayType") return "any";
       itemTypes.push(splatType.elementType);
       continue;
     }
     itemTypes.push(synthType(item, scope, ctx));
   }
-  const concreteTypes = itemTypes.filter((t) => t !== "any");
+  const concreteTypes = itemTypes.filter((t): t is VariableType => !isAnyType(t));
   if (concreteTypes.length === 0) return "any";
   if (concreteTypes.length === 1) {
     return { type: "arrayType", elementType: concreteTypes[0] };
@@ -686,7 +687,7 @@ function synthObject(
   for (const entry of expr.entries) {
     if ("type" in entry && entry.type === "splat") {
       const splatType = synthType(entry.value, scope, ctx);
-      if (splatType === "any") return "any";
+      if (isAnyType(splatType)) return "any";
       if (splatType.type !== "objectType") return "any";
       for (const prop of splatType.properties)
         properties.set(prop.key, prop.value);
@@ -707,7 +708,7 @@ function synthObject(
     const valueType = isNullLiteralExpr(kv.value)
       ? NULL_T
       : synthType(kv.value, scope, ctx);
-    if (valueType === "any") {
+    if (isAnyType(valueType)) {
       return "any";
     }
     if (kv.computedKey) {
@@ -797,7 +798,7 @@ function validateAgencyFunctionMethod(
           ? param.typeHint
           : { type: "arrayType", elementType: param.typeHint };
         const actual = synthType(arg.value, scope, ctx);
-        if (actual === "any") continue;
+        if (isAnyType(actual)) continue;
         if (!isAssignable(actual, expected, typeAliases)) {
           ctx.errors.push(
             diagnostic(
@@ -905,7 +906,7 @@ export function synthValueAccess(
       }
     }
 
-    if (currentType === "any") return "any";
+    if (isAnyType(currentType)) return "any";
     const resolved = safeResolveType(currentType, typeAliases);
     if (resolved.type === "primitiveType" && resolved.value === "any")
       return "any";
@@ -930,7 +931,7 @@ export function synthValueAccess(
             ctx,
             expr.loc,
           );
-          if (fieldType === "any") return "any";
+          if (fieldType !== null && isAnyType(fieldType)) return "any";
           if (fieldType !== null) {
             currentType = fieldType;
             break;
@@ -1039,7 +1040,7 @@ export function synthValueAccess(
         if (member && member.kind === "method") {
           const sig = resolveSig(member.sig, resolved);
           validatePrimitiveMethodCall(expr, element.functionCall, sig, scope, ctx);
-          currentType = sig.returnType === "any" ? ANY_T : sig.returnType;
+          currentType = isAnyType(sig.returnType) ? ANY_T : sig.returnType;
           break;
         }
         return "any";
@@ -1113,9 +1114,9 @@ function validatePrimitiveMethodCall(
     if ("type" in arg && arg.type === "splat") continue; // skip splat element check for primitives
     const slotType =
       i < sig.params.length ? sig.params[i] : (sig.restParam as VariableType | "any" | undefined);
-    if (slotType === undefined || slotType === "any") continue;
+    if (slotType === undefined || isAnyType(slotType)) continue;
     const argType = synthType(arg as AgencyNode, scope, ctx);
-    if (argType === "any") continue;
+    if (isAnyType(argType)) continue;
     if (!isAssignable(argType, slotType, typeAliases)) {
       ctx.errors.push(
         diagnostic(
@@ -1167,11 +1168,11 @@ function synthArrayCallbackMethod(
   const cbReturn = synthCallbackReturnType(call, elementT, scope, ctx);
 
   if (cbKind === "arrayU") {
-    if (cbReturn === "any") return ANY_T;
+    if (isAnyType(cbReturn)) return ANY_T;
     return { type: "arrayType", elementType: cbReturn };
   }
   if (cbKind === "flatten") {
-    if (cbReturn === "any") return ANY_T;
+    if (isAnyType(cbReturn)) return ANY_T;
     // `flatMap`'s callback returns `Array<U>`; we unwrap one level.
     if (cbReturn.type === "arrayType") return cbReturn;
     // Callback returned a non-array — flatMap silently treats it as a
@@ -1217,7 +1218,7 @@ function synthCallbackReturnType(
   const args = (call.arguments as AgencyNode[]) ?? [];
   if (args.length === 0) return "any";
   const cbType = synthType(args[0], scope, ctx);
-  if (cbType === "any") return "any";
+  if (isAnyType(cbType)) return "any";
   if (cbType.type === "functionRefType") return cbType.returnType ?? "any";
   if (cbType.type === "blockType") return cbType.returnType;
   return "any";
@@ -1257,7 +1258,7 @@ function synthBlockReturnType(
     }
   }
   if (returnTypes.length === 0) return "any";
-  const concrete = returnTypes.filter((t): t is VariableType => t !== "any");
+  const concrete = returnTypes.filter((t): t is VariableType => !isAnyType(t));
   if (concrete.length === 0) return "any";
   if (concrete.length === 1) return concrete[0];
   // Dedupe structurally identical types.

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -60,10 +60,9 @@ const RESULT_BRANCH_FIELDS = new Set(
 /**
  * Resolve a field access on a `ResultType` against the narrowing layer.
  * Returns:
- *  - a `VariableType`  → caller should set `currentType = ...; break;`
- *  - the string `"any"` → caller should `return ANY_T` (Result field on an
- *    un-narrowed Result; un-typed escape hatch until Increment 3 tightens
- *    `.value` on Failure into a hard error)
+ *  - a concrete `VariableType` → caller should set `currentType = ...; break;`
+ *  - `ANY_T` → the un-typed escape hatch for a Result field on an un-narrowed
+ *    Result (until Increment 3 tightens `.value` on Failure into a hard error)
  *  - `null` → no resolution; fall through to the next case in `synthValueAccess`
  *
  * Pulled out of `synthValueAccess` to keep that function under the

--- a/packages/agency-lang/lib/typeChecker/typeCases.test.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.test.ts
@@ -1,3 +1,4 @@
+import { ANY_T } from "./primitives.js";
 import { describe, it, expect } from "vitest";
 import { decomposeCases } from "./typeCases.js";
 import { STRING_T, NUMBER_T } from "./primitives.js";
@@ -39,7 +40,7 @@ describe("decomposeCases", () => {
   });
 
   it("any → open", () => {
-    expect(decomposeCases("any", {})).toEqual({ cases: [], closed: false });
+    expect(decomposeCases(ANY_T, {})).toEqual({ cases: [], closed: false });
   });
 
   it("union containing any → open", () => {

--- a/packages/agency-lang/lib/typeChecker/typeCases.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.ts
@@ -117,7 +117,7 @@ export function decomposeCases(
   if (resolved.type === "unionType") {
     if (resolved.isEffectSet) return OPEN; // owned by resolveEffectSet, never re-walked
     const members = resolved.types.map((m) => safeResolveType(m, aliases));
-    if (members.some((rm) => rm.type === "primitiveType" && rm.value === "any")) {
+    if (members.some(isAnyType)) {
       return OPEN; // a union with an open member can't be required to be exhaustive
     }
     // B2: a union whose members are all literal-tagged, distinct-valued objects

--- a/packages/agency-lang/lib/typeChecker/typeCases.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.ts
@@ -1,3 +1,4 @@
+import { isAnyType } from "./utils.js";
 import type { VariableType, TypeAliasEntry } from "../types.js";
 import { safeResolveType } from "./assignability.js";
 import { unescapeStringLiteralValue } from "../parsers/parsers.js";
@@ -101,7 +102,7 @@ export function decomposeCases(
   type: VariableType | "any",
   aliases: Record<string, TypeAliasEntry>,
 ): CaseSet {
-  if (type === "any") return OPEN;
+  if (isAnyType(type)) return OPEN;
   // safeResolveType yields ANY_T (a primitiveType "any"), never the string
   // "any"; an unresolved/any type falls through to the default OPEN below.
   const resolved = safeResolveType(type, aliases);

--- a/packages/agency-lang/lib/typeChecker/typeCases.ts
+++ b/packages/agency-lang/lib/typeChecker/typeCases.ts
@@ -99,7 +99,7 @@ function allDistinct(values: (string | number | boolean)[]): boolean {
  * their enumeration belongs to `resolveEffectSet` (handler-narrowing spec).
  */
 export function decomposeCases(
-  type: VariableType | "any",
+  type: VariableType,
   aliases: Record<string, TypeAliasEntry>,
 ): CaseSet {
   if (isAnyType(type)) return OPEN;

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -64,10 +64,10 @@ export type ScopeInfo = {
 };
 
 export type BuiltinSignature = {
-  params: (VariableType | "any")[];
-  returnType: VariableType | "any";
+  params: (VariableType)[];
+  returnType: VariableType;
   minParams?: number; // if set, arity is [minParams, params.length]; otherwise exact
-  restParam?: VariableType | "any"; // if set, accepts unlimited extra args of this type after the fixed params
+  restParam?: VariableType; // if set, accepts unlimited extra args of this type after the fixed params
   /** One-line markdown description shown in LSP hover. */
   description?: string;
   /** If true, the typechecker allows a block argument on calls to this
@@ -82,7 +82,7 @@ export type BuiltinSignature = {
    *  silently going through. Values are typechecked against the
    *  declared type; duplicates are rejected. Use `"any"` to skip
    *  value validation. */
-  acceptsNamedArgs?: Record<string, VariableType | "any">;
+  acceptsNamedArgs?: Record<string, VariableType>;
 };
 
 export type TypeCheckerContext = {
@@ -96,14 +96,14 @@ export type TypeCheckerContext = {
   jsImportedNames: Record<string, true>;
   interruptEffectsByFunction: Record<string, InterruptEffect[]>;
   errors: TypeCheckError[];
-  inferredReturnTypes: Record<string, VariableType | "any">;
+  inferredReturnTypes: Record<string, VariableType>;
   inferringReturnType: Set<string>;
   /** The value type of each expression-position `match`, keyed by its match id.
    *  Populated by `computeMatchExprTypes` (runs after buildFlowGraphs, before
    *  checkScopes): the widened union of the match's `matchYield` value types, or
    *  "any" if any yield is "any". Consumed by the `__matchval_<id>` synth hook
    *  and the `matchExprSource` assignment check. */
-  matchExprTypes: Record<number, VariableType | "any">;
+  matchExprTypes: Record<number, VariableType>;
   /** The UNWIDENED value type + source loc of every `matchYield` of each
    *  expression-position `match`, keyed by match id. Populated alongside
    *  `matchExprTypes` by `computeMatchExprTypes`. In a CHECKED position (the
@@ -114,7 +114,7 @@ export type TypeCheckerContext = {
    *  `matchExprTypes` is used only for synthesis (unannotated) positions. */
   matchExprYieldTypes: Record<
     number,
-    { type: VariableType | "any"; loc: SourceLocation | undefined }[]
+    { type: VariableType; loc: SourceLocation | undefined }[]
   >;
   config: AgencyConfig;
   /** Optional symbol table threaded through from `buildCompilationUnit`.
@@ -136,5 +136,5 @@ export type TypeCheckerContext = {
   inferReturnTypeFor(
     name: string,
     def: FunctionDefinition | GraphNodeDefinition,
-  ): VariableType | "any";
+  ): VariableType;
 };

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -80,8 +80,8 @@ export type BuiltinSignature = {
    *  builtins use this to permit `fork(items, shared: true)` /
    *  `race(items, shared: true)` without opening the door to typos
    *  silently going through. Values are typechecked against the
-   *  declared type; duplicates are rejected. Use `"any"` to skip
-   *  value validation. */
+   *  declared type; duplicates are rejected. Use the `any` type
+   *  (`ANY_T`) to skip value validation. */
   acceptsNamedArgs?: Record<string, VariableType>;
 };
 

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -125,7 +125,7 @@ function typeAcceptsResult(t: VariableType): boolean {
   if (t.type === "resultType") {
     return true;
   }
-  if (t.type === "primitiveType" && t.value === "any") {
+  if (isAnyType(t)) {
     return true;
   }
   if (t.type === "unionType") {

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -196,7 +196,7 @@ export function checkType(
  * neither hand-rolls the message.
  */
 export function emitAssignabilityError(
-  actual: VariableType | "any",
+  actual: VariableType,
   expected: VariableType,
   loc: SourceLocation | undefined,
   context: string,

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -45,14 +45,12 @@ export function getBlockSlot(
   return last.typeHint;
 }
 
-// Accepts the string sentinel too, only during the #472 migration. Once every
-// signature is narrowed to VariableType, the `| "any"` is removed again.
-// A type predicate so callers narrow the string away in the false branch,
-// exactly as the `x === "any"` comparisons it replaces did.
+/** True when `t` is the `any` type. A type predicate so the false branch
+ *  narrows to the non-`any` variants at call sites. */
 export function isAnyType(
-  t: VariableType | "any",
-): t is "any" | (VariableType & { type: "primitiveType"; value: "any" }) {
-  return t === "any" || (t.type === "primitiveType" && t.value === "any");
+  t: VariableType,
+): t is VariableType & { type: "primitiveType"; value: "any" } {
+  return t.type === "primitiveType" && t.value === "any";
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -45,8 +45,14 @@ export function getBlockSlot(
   return last.typeHint;
 }
 
-export function isAnyType(t: VariableType): boolean {
-  return t.type === "primitiveType" && t.value === "any";
+// Accepts the string sentinel too, only during the #472 migration. Once every
+// signature is narrowed to VariableType, the `| "any"` is removed again.
+// A type predicate so callers narrow the string away in the false branch,
+// exactly as the `x === "any"` comparisons it replaces did.
+export function isAnyType(
+  t: VariableType | "any",
+): t is "any" | (VariableType & { type: "primitiveType"; value: "any" }) {
+  return t === "any" || (t.type === "primitiveType" && t.value === "any");
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -178,7 +178,7 @@ export function checkType(
   }
 
   const actualType = synthType(expr, scope, ctx);
-  if (actualType === "any") return;
+  if (isAnyType(actualType)) return;
 
   // Literal value nodes may carry no loc of their own; anchor on the
   // enclosing statement when the caller supplied one.
@@ -202,7 +202,7 @@ export function emitAssignabilityError(
   context: string,
   ctx: TypeCheckerContext,
 ): void {
-  if (actual === "any") return;
+  if (isAnyType(actual)) return;
   if (isAssignable(actual, expected, ctx.getTypeAliases())) return;
   ctx.errors.push(
     diagnostic(
@@ -232,7 +232,7 @@ export function checkConditionType(
   ctx: TypeCheckerContext,
 ): void {
   const actualType = synthType(condition, scope, ctx);
-  if (actualType === "any") {
+  if (isAnyType(actualType)) {
     return;
   }
   const typeAliases = ctx.getTypeAliases();


### PR DESCRIPTION
Closes #472. Retires the `"any"` string sentinel from the type checker: "unknown type" is now represented only by the `ANY_T` object, never the bare string `"any"`.

## Why

The checker represented "I don't know this type" two ways — the string `"any"` (in `VariableType | "any"` signatures) and the `ANY_T` object (`primitiveType("any")`). Every dual representation is a standing bug generator: comparisons asked the question twice (`t === "any" || isAnyType(t)`), `maybeAny()` existed only to bridge the two, and `isAssignable` special-cased `any` twice back to back. This deletes the string form so one shape flows through everything, and — once signatures are narrowed to `VariableType` — the compiler makes the sentinel unrepresentable.

## What changed

Behavior-preserving throughout. Delivered as an ordered stack under one invariant: **a producer's returns and its signature narrowing land together**, so a leftover `=== "any"` becomes a TS2367 compile error rather than silently going false.

1. **`isAnyType` widened** to a type predicate accepting both forms during the migration (so every comparison could route through one helper and still narrow).
2. **Every comparison** (65 sites) routed through `isAnyType` — behavior-preserving, closing the silent-break window before any producer changed.
3. **Spine + all producers narrowed** to `VariableType`: `synthType`, `ScopeType`, `inferredReturnTypes`, `uniteTypes`, `typeAt`, and 35 `return "any"` → `return ANY_T`. The `| null` / `| undefined` signal sites kept their extra members. `widenType` fully cleaned up. LSP consumers (`builtinHover`, `inlayHint`, `typeResolution`) route their now-dead string comparisons through `isAnyType`.
4. **Object-form folds + assignability cleanup**: the six inline `.value === "any"` checks fold into `isAnyType`; the redundant pre-resolution `any` fast path in `isAssignableGuarded` is deleted (the post-resolution check is the only one that catches `type Foo = any`).
5. **Scaffolding deleted**: `maybeAny`, `inference.ts`'s local `ANY_T`/`isAnyType` duplicates; `isAnyType` narrowed back to `VariableType`.
6. **Regression guard**: a test scanning the source for `| "any"` signatures, bare `return "any"`, and stray inline `.value === "any"`.

`ScopeType` is left as `type ScopeType = VariableType` — it is an exported semantic name used across the backends, not a pure sentinel artifact, so removing it would churn unrelated code without retiring anything.

## Two subtleties worth review

- **`widenType` is a structure-preserving map**, so its `vt === "any"` check could NOT be mechanically swapped to `isAnyType` mid-migration: `isAnyType(ANY_T_object)` is true, and returning the string there corrupted nested `resultType` fields (a bare `Result` parses to `{successType:"any", failureType:"any"}`). Caught by the behavior gate; `widenType` was cleaned up in full instead.
- **The assignability fast-path deletion** (`isAssignableGuarded`) is a real correctness point: deleting the *other* check would have regressed `type Foo = any` assignability. A both-directions regression test locks it.

## Testing

`tsc --noEmit` clean. The full `lib/` unit suite passes: **8132 tests, 0 failures** — no behavior change, with one deliberate exception (`flow.test.ts` assertions moved from `.toBe("any")` to `.toEqual(ANY_T)`, plus three value-input migrations). Every task ended green before the next began.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
