### PR TITLE
Enforce export-visibility on plain imports (AG4010) + valid JSON for parse dir/

### DIFF
--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -75,6 +75,7 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG4007](names.md#ag4007) | Variable '&#123;name&#125;' is not defined. |
 | [AG4008](names.md#ag4008) | '&#123;name&#125;' is not defined in '&#123;module&#125;'. |
 | [AG4009](names.md#ag4009) | Cannot find module '&#123;module&#125;'. |
+| [AG4010](names.md#ag4010) | '&#123;name&#125;' is defined in '&#123;module&#125;' but is not exported. Add the 'export' keyword to its definition. |
 
 ## Match and narrowing
 

--- a/packages/agency-lang/docs/site/diagnostics/names.md
+++ b/packages/agency-lang/docs/site/diagnostics/names.md
@@ -101,3 +101,13 @@ An import names a symbol that its target Agency module does not define. The chec
 An import points at a module that does not resolve to any file. The path — a relative `./…` path, a `std::` module, or a `pkg::` package — was resolved the same way the compiler resolves it, and nothing exists there.
 
 **How to fix:** correct the path, create the missing file, or install the package that provides it. Agency imports must resolve to a real module.
+
+<a id="ag4010"></a>
+
+## AG4010 — '&#123;name&#125;' is defined in '&#123;module&#125;' but is not exported. Add the 'export' keyword to its definition.
+
+*Default severity: error.*
+
+An import names a symbol that its target module defines but does not `export`. A plain `import { ... }` can only see `export`ed functions, types, and constants — a bare `def`/`type` without `export` is module-private. (Nodes are the exception: they are importable without `export`.) The compile path already rejects this; the type checker reports it too.
+
+**How to fix:** add the `export` keyword to the definition in the target file, or import a symbol that is exported.

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -471,7 +471,7 @@ function collectDirectInterruptEffects(body: AgencyNode[]): InterruptEffect[] {
   return effects.map((e) => ({ effect: e }));
 }
 
-function isExportedSymbol(sym: SymbolInfo): boolean {
+export function isExportedSymbol(sym: SymbolInfo): boolean {
   // Nodes are importable without an explicit `export` keyword (see importResolver
   // — node imports skip the assertExported check). Treat them as exported for
   // re-export purposes so `export { main } from "..."` and `export * from "..."`

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -239,6 +239,10 @@ node main() {
 
 **How to fix:** correct the path, create the missing file, or install the package that provides it. Agency imports must resolve to a real module.`,
 
+  importNameNotExported: `An import names a symbol that its target module defines but does not \`export\`. A plain \`import { ... }\` can only see \`export\`ed functions, types, and constants — a bare \`def\`/\`type\` without \`export\` is module-private. (Nodes are the exception: they are importable without \`export\`.) The compile path already rejects this; the type checker reports it too.
+
+**How to fix:** add the \`export\` keyword to the definition in the target file, or import a symbol that is exported.`,
+
   reassignToConst: `A \`const\` binding is fixed after its initial value: it cannot be reassigned. This assignment targets a name that was declared \`const\`.
 
 **How to fix:** declare it with \`let\` if it needs to change, or assign to a different variable.

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -444,6 +444,11 @@ export const DIAGNOSTICS = {
     severity: "error",
     message: "Cannot find module '{module}'.",
   },
+  importNameNotExported: {
+    code: "AG4010",
+    severity: "error",
+    message: "'{name}' is defined in '{module}' but is not exported. Add the 'export' keyword to its definition.",
+  },
   reservedBlockKeyword: {
     code: "AG4006",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.test.ts
@@ -221,4 +221,31 @@ describe("checkMissingImports", () => {
     );
     expect(errors.find((err) => err.name === "importNameNotExported")).toBeUndefined();
   });
+
+  it("errors on importing a non-exported type", () => {
+    const errors = check(
+      {
+        "lib.agency": "type Secret = number\n",
+        "use.agency": 'import { Secret } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importNameNotExported");
+    expect(e).toBeDefined();
+    expect(e?.message).toContain("Secret");
+  });
+
+  it("exempts a node imported via the plain `import { }` form", () => {
+    // The node exemption must hold on the importStatement path, not just via
+    // `import node { }` — importResolver rewrites this to a node import.
+    const errors = check(
+      {
+        "lib.agency": "node plainNode(): string {\n  return \"n\"\n}\n",
+        "use.agency": 'import { plainNode } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotExported")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.test.ts
@@ -184,4 +184,41 @@ describe("checkMissingImports", () => {
     expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
     expect(errors.find((err) => err.name === "importModuleNotFound")).toBeUndefined();
   });
+
+  it("errors when importing a defined-but-not-exported name", () => {
+    const errors = check(
+      {
+        "lib.agency": "def privateFn(): string {\n  return \"p\"\n}\n",
+        "use.agency": 'import { privateFn } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    const e = errors.find((err) => err.name === "importNameNotExported");
+    expect(e).toBeDefined();
+    expect(e?.message).toContain("privateFn");
+  });
+
+  it("does not require export for a node import (nodes are exempt)", () => {
+    const errors = check(
+      {
+        // plain `node`, no `export` keyword
+        "lib.agency": "node plainNode(): string {\n  return \"n\"\n}\n",
+        "use.agency": 'import node { plainNode } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotExported")).toBeUndefined();
+    expect(errors.find((err) => err.name === "importNameNotFound")).toBeUndefined();
+  });
+
+  it("lets `import test { }` see a non-exported name", () => {
+    const errors = check(
+      {
+        "lib.agency": "def privateFn(): string {\n  return \"p\"\n}\n",
+        "use.agency": 'import test { privateFn } from "./lib.agency"\n\nnode u(): string {\n  return "y"\n}\n',
+      },
+      "use.agency",
+    );
+    expect(errors.find((err) => err.name === "importNameNotExported")).toBeUndefined();
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.ts
@@ -9,6 +9,10 @@ type ImportSpec = {
   modulePath: string;
   names: readonly string[];
   loc: SourceLocation | null;
+  // `import test { ... }` may see non-exported symbols (first-party test wiring),
+  // so it bypasses the export-visibility check — matching the importResolver
+  // preprocessor's `assertImportable`.
+  testOnly: boolean;
 };
 
 /**
@@ -21,10 +25,11 @@ function toImportSpec(node: AgencyNode): ImportSpec | null {
     const names = node.importedNames
       .filter((nameType) => nameType.type === "namedImport")
       .flatMap((nameType) => nameType.importedNames);
-    return { modulePath: node.modulePath, names, loc: node.loc ?? null };
+    return { modulePath: node.modulePath, names, loc: node.loc ?? null, testOnly: !!node.testOnly };
   }
   if (node.type === "importNodeStatement") {
-    return { modulePath: node.agencyFile, names: node.importedNodes, loc: node.loc ?? null };
+    // Nodes are importable without `export`, so testOnly is irrelevant here.
+    return { modulePath: node.agencyFile, names: node.importedNodes, loc: node.loc ?? null, testOnly: false };
   }
   return null;
 }
@@ -64,6 +69,17 @@ export function checkMissingImports(ctx: TypeCheckerContext): void {
       if (!Object.prototype.hasOwnProperty.call(resolution.symbols, name)) {
         ctx.errors.push(
           diagnostic("importNameNotFound", { name, module: spec.modulePath }, spec.loc),
+        );
+        continue;
+      }
+      // Export-visibility: a name that exists but isn't `export`ed can't be
+      // imported. Nodes are exempt (importable without `export`); `import test`
+      // is exempt. Mirrors importResolver's `assertImportable`, which already
+      // throws for this on the compile path — this surfaces it in `tc` too.
+      const symbol = resolution.symbols[name];
+      if (!spec.testOnly && symbol.kind !== "node" && !symbol.exported) {
+        ctx.errors.push(
+          diagnostic("importNameNotExported", { name, module: spec.modulePath }, spec.loc),
         );
       }
     }

--- a/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/missingImportDiagnostic.ts
@@ -2,6 +2,7 @@ import { diagnostic } from "./diagnostics.js";
 import type { TypeCheckerContext } from "./types.js";
 import type { SourceLocation } from "../types/base.js";
 import type { AgencyNode } from "../types.js";
+import { isExportedSymbol } from "../symbolTable.js";
 
 /** A plain Agency import, normalized so the checker doesn't care which node
  *  kind it came from. */
@@ -73,11 +74,17 @@ export function checkMissingImports(ctx: TypeCheckerContext): void {
         continue;
       }
       // Export-visibility: a name that exists but isn't `export`ed can't be
-      // imported. Nodes are exempt (importable without `export`); `import test`
-      // is exempt. Mirrors importResolver's `assertImportable`, which already
-      // throws for this on the compile path — this surfaces it in `tc` too.
+      // imported. `isExportedSymbol` owns the rule (nodes are exempt —
+      // importable without `export`); `import test` is exempt too. Mirrors
+      // importResolver's `assertImportable`, which already throws for this on
+      // the compile path — this surfaces it in `tc` too.
+      //
+      // Note: a non-exported *constant* never reaches here — a `const` is only
+      // recorded as a symbol when `exported && static` (classifySymbols), so it
+      // trips importNameNotFound (AG4008) above instead. Consistent with
+      // importResolver, which throws "is not defined" for the same case.
       const symbol = resolution.symbols[name];
-      if (!spec.testOnly && symbol.kind !== "node" && !symbol.exported) {
+      if (!spec.testOnly && !isExportedSymbol(symbol)) {
         ctx.errors.push(
           diagnostic("importNameNotExported", { name, module: spec.modulePath }, spec.loc),
         );

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -140,6 +140,24 @@ async function defaultLoadMcpStartServer(): Promise<() => void> {
   return startMcpServer;
 }
 
+/**
+ * Print AST/preprocess results as ONE valid JSON document.
+ *
+ * A single input prints the bare AST (backward compatible with the
+ * one-file/stdin case). Multiple inputs — e.g. a directory — print a JSON
+ * array of `{ file, program }` so the output is a single parseable document
+ * instead of concatenated top-level objects. Zero inputs print nothing (the
+ * "no .agency files found" notice already went to stderr).
+ */
+function printAstResults(results: { file: string; program: unknown }[]): void {
+  if (results.length === 0) return;
+  if (results.length === 1) {
+    console.log(JSON.stringify(results[0].program, null, 2));
+    return;
+  }
+  console.log(JSON.stringify(results, null, 2));
+}
+
 export function createProgram(deps: CliDependencies = {}): Command {
   const loadLspStartServer =
     deps.loadLspStartServer ?? defaultLoadLspStartServer;
@@ -573,10 +591,14 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .argument("[inputs...]", "Paths to .agency input files")
     .action(async (inputs: string[]) => {
       const config = getConfig();
-      await forEachSource(inputs, (contents) => {
-        const result = parse(contents, config);
-        console.log(JSON.stringify(result, null, 2));
+      const results: { file: string; program: unknown }[] = [];
+      await forEachSource(inputs, (contents, src) => {
+        results.push({
+          file: src.kind === "file" ? src.path : "<stdin>",
+          program: parse(contents, config),
+        });
       });
+      printAstResults(results);
     });
 
   program
@@ -588,7 +610,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(async (inputs: string[]) => {
       const config = getConfig();
 
-      const processInput = (contents: string) => {
+      const preprocessInput = (contents: string): unknown => {
         const parsedProgram = parse(contents, config);
         const info = buildCompilationUnit(parsedProgram);
         const preprocessor = new TypescriptPreprocessor(
@@ -597,12 +619,17 @@ export function createProgram(deps: CliDependencies = {}): Command {
           info,
         );
         preprocessor.preprocess();
-        console.log(JSON.stringify(preprocessor.program, null, 2));
+        return preprocessor.program;
       };
 
-      await forEachSource(inputs, (contents) => {
-        processInput(contents);
+      const results: { file: string; program: unknown }[] = [];
+      await forEachSource(inputs, (contents, src) => {
+        results.push({
+          file: src.kind === "file" ? src.path : "<stdin>",
+          program: preprocessInput(contents),
+        });
       });
+      printAstResults(results);
     });
 
   function formatDuration(ms: number): string {

--- a/packages/agency-lang/tests/integration/cli-main/test.mjs
+++ b/packages/agency-lang/tests/integration/cli-main/test.mjs
@@ -489,6 +489,17 @@ try {
   const parseDirOut = runAgency("17a-parse-dir", ["parse", "parse-dir"]);
   assertIncludes(parseDirOut, "alphaMain");
   assertIncludes(parseDirOut, "betaMain");
+  // Multi-file parse output must be ONE valid JSON document (an array of
+  // { file, program }), not concatenated top-level objects.
+  const parseDirJson = JSON.parse(parseDirOut);
+  assert(
+    Array.isArray(parseDirJson) && parseDirJson.length === 2,
+    "parse on a directory should emit a JSON array with one entry per file",
+  );
+  assert(
+    parseDirJson.every((r) => typeof r.file === "string" && r.program),
+    "each parse-dir entry should carry its file path and program AST",
+  );
 
   // coverage
 


### PR DESCRIPTION
## Summary

Two follow-ups to the strict-imports work (#529), bundled because they're both small and touch adjacent surfaces. (The third follow-up — converting `SymbolTable.build`'s `export-from`/`pkg::` throws into clean diagnostics — is split into its own PR because it changes a 65-caller API contract.)

### 1. Enforce export-visibility on plain imports in the typechecker (AG4010)

Importing a defined-but-not-`export`ed function/type/constant is now a type error:

```
// lib.agency
def privateFn(): string { return "p" }   // no `export`
```
```
import { privateFn } from "./lib.agency"  // AG4010
```

This already fails on the **compile** path — the `importResolver` preprocessor throws `assertImportable` ("... is not exported"). It was just silent under `agency tc`. This surfaces it there too, as a clean diagnostic. Semantics mirror `importResolver` exactly:

- **Nodes are exempt** (importable without `export`).
- **`import test { }` bypasses it** (first-party test wiring may see private symbols).

**Blast radius measured before landing** (per the "measure first" call): swept `agency tc` over `stdlib` and the whole `tests/` tree → **0** violations, because anything that compiles already has exported imports. So a hard error is safe.

### 2. `parse`/`preprocess`: one valid JSON document for multiple inputs

`agency parse dir/` printed one JSON object per file, concatenated — not parseable. Now:

- single input → the bare AST (unchanged, backward compatible)
- multiple inputs → a JSON array of `{ file, program }`

Same fix applied to `preprocess`.

## Tests

- 3 new pass tests: non-exported import errors (AG4010), node import exempt, `import test` bypass. (`missingImportDiagnostic.test.ts` → 15 total.)
- Strengthened the `17a-parse-dir` cli-main case to `JSON.parse` the output and assert the array shape.

Verified locally: full typechecker vitest suite (1321 pass), the pass unit file (15 pass), cli-main integration harness (exit 0), structural linter clean, and direct CLI exercise of AG4010 (fires on private import, clean on exported + node) and the parse single-object/directory-array output.

AG4010 is documented via the generated `docs/site/diagnostics/` pages and `agency explain AG4010` (no manual CLI-page doc, per the #529 review preference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
