### PR TITLE
Make the destructive marker authoritative; add destructive { } regions

### DIFF
--- a/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-plan-review.md
+++ b/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-plan-review.md
@@ -1,0 +1,177 @@
+# Plan review: destructive marker authoritative — implementation plan
+
+Reviewer: Claude
+Date: 2026-07-12
+Target: `docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-plan.md`
+Prior rounds: spec reviews `-review.md`, `-review-2.md`
+Branch/worktree: `feat/destructive-marker-authoritative`
+
+## Verdict
+
+**Do not execute as written.** The plan is well-structured, TDD-ordered, and its
+runtime/codegen core (Tasks 5–6) is correct and carries the fail-open guard from
+the spec review through faithfully. But verification against the code finds three
+must-fix defects and one altitude question, all rooted in the same place: the plan
+under-estimates what wiring a **new transparent AST node** costs in this codebase.
+The Global Constraints, Tasks 5, 6, 8, 9, 10, 12–15 are sound. Tasks 2, 3, 4, 7
+need correction before a worker starts, or they will hit silent, hard-to-debug
+failures (bare identifiers, skipped lowering, a formatter crash, and a broken
+`destructive def`).
+
+## Blocking 1 — Task 2 parser will hard-fail `destructive def`
+
+The prescribed parser commits at the wrong point. `parseError(...)` is a
+**committing (cut)** combinator — once reached, a failure inside it throws instead
+of backtracking. This is exactly documented on the sibling at
+`parsers.ts:4205–4210` (handleBlock):
+
+> Require a word boundary so an identifier like `handler(...)` isn't matched as the
+> `handle` keyword. Without this, the committing `parseError` below throws
+> "expected `{`" instead of letting the statement parser backtrack.
+
+`handle`/`handler` disambiguate because the next char after `handle` is `r` (a
+`varNameChar`), so `not(varNameChar)` fails *before* the commit. **`destructive`
+does not have this property**: both `destructive {` and `destructive def` have a
+**space** after the keyword, so `not(varNameChar)` succeeds for *both*, the parser
+commits, then `char("{")` (the first parser inside `parseError`) fails on the `d`
+of `def` → **throws "expected `{`", no backtrack → `destructive def` fails to
+parse.** The plan's stated rationale ("the `not(varNameChar)` word boundary is
+what lets `destructive def` backtrack cleanly") is therefore wrong.
+
+Fix: move the commit point to *after* the `{` is seen — make `char("{")` a soft
+gate outside `parseError`:
+
+```typescript
+seqC(
+  set("type", "destructiveBlock"),
+  str("destructive"),
+  not(varNameChar),
+  optionalSpaces,
+  char("{"),                       // SOFT gate: fails on `destructive def` → backtracks
+  captureCaptures(parseError(
+    "unterminated destructive block",
+    optionalSpacesOrNewline,
+    capture(bodyParser, "body"),
+    optionalSpacesOrNewline,
+    char("}"),
+  )),
+)
+```
+
+Now `destructive def` fails softly at `char("{")` and the statement `or(...)`
+moves on. Keep Step 6 (regression on `destructive def`) — it is the right guard,
+and with the current plan text it would fail.
+
+## Blocking 2 — a new transparent block touches ~8 dispatch sites; the plan wires ~2
+
+`walkNodes` does **not** descend into arbitrary `.body` generically. Statement-body
+descent is driven by one table — `lib/utils/bodySlots.ts` — which the plan never
+mentions. Its own header warns: a missing case "silently skipped lowering." The
+plan's Task 4 Step 1 ("Confirm the generic walker descends into `.body`
+generically") will mislead the worker into thinking descent is free; it is not —
+you must add `case "destructiveBlock": return [bodyField(node)]` to `bodySlots.ts`.
+That one registration feeds both `walkNodes` (→ `SymbolTable.build`, which walks
+via `walkNodes` at `symbolTable.ts:170/203/401/466`) and `mapBodies`.
+
+But `bodySlots` is not the only enumerator. Grepping every site that handles the
+transparent siblings `seqBlock`/`parallelBlock` shows a new transparent block must
+be added to **all** of these — the plan covers only scopes (vaguely):
+
+| Site | Purpose | In plan? |
+|---|---|---|
+| `lib/utils/bodySlots.ts:137` | walkNodes + mapBodies master table | **No** — critical |
+| `lib/typeChecker/flowBuilder.ts:272` | flow-sensitive narrowing (Result safety) | **No** |
+| `lib/typeChecker/scopes.ts:493` | scope walk (transparent) | Vague (Task 4) |
+| `lib/preprocessors/typescriptPreprocessor.ts:72` | main preprocessor `walkBody` (hand-enumerated, no fallthrough) | **No** |
+| `lib/preprocessors/injectSchemaArgs.ts:148` | schema-arg injection (hand-enumerated) | **No** |
+| `lib/preprocessors/liftCallbacks.ts:202` | callback lifting (hand-enumerated) | **No** |
+| `lib/backends/agencyGenerator.ts:532` | **the formatter** (`default: throw`) | **Wrong file** (see Blocking 3) |
+| `lib/lowering/patternLowering.ts:633/671`, `parallelDesugar.ts` | pattern/parallel desugar | confirm N/A |
+
+Each of `typescriptPreprocessor`, `injectSchemaArgs`, `liftCallbacks` is a
+hand-rolled `else if (node.type === "parallelBlock" || node.type === "seqBlock")`
+with **no generic fallthrough** — so `destructive { }` bodies are silently skipped
+by preprocessing, schema injection, and callback lifting unless a case is added.
+The `flowBuilder` miss is the most dangerous of the silent ones: this codebase's
+Result-safety rests on flow narrowing, and a block whose body the flow graph never
+enters could mis-narrow or miss a safety diagnostic.
+
+Fix: replace Task 4 with an explicit "wire the new node into every body-dispatch
+site" task that names each file above, adds `destructiveBlock` alongside
+`seqBlock`, and leads with `bodySlots.ts`. Add a test that a variable *referenced*
+inside the block resolves to `__stack.locals.x` (not a bare identifier) — that is
+the concrete symptom of a missed `bodySlots`/walk registration.
+
+## Blocking 3 — Task 3 names the wrong formatter file
+
+`lib/formatter.ts` (verified: 15 lines) only delegates to `generateAgency`. The
+actual pretty-printer dispatch is `AgencyGenerator.processNode` in
+`lib/backends/agencyGenerator.ts`, whose `switch` ends in
+`default: throw new Error("Unhandled Agency node type: ...")` (`:534`). Adding the
+case to `lib/formatter.ts` does nothing; without a case in `agencyGenerator.ts`,
+`pnpm run fmt` and every AgencyGenerator roundtrip **throws** on a `destructive { }`.
+Point Task 3 at `agencyGenerator.ts` (mirror `processSeqBlock`/`processParallelBlock`
+at `:530–533`), and keep the roundtrip test.
+
+## Altitude — reuse `seqBlock` instead of cloning it into a fraction of its sites
+
+`seqBlock` already *is* a transparent, stepped, no-new-scope block that is
+registered in every dispatch table above and treated transparently by typecheck
+(`scopes.ts:493`), flow (`flowBuilder.ts:272`), preprocessing, and lowering. The
+plan reconstructs that machinery from scratch as `destructiveBlock` (notably the
+Task 6 inline-splice) but only wires a fraction of the sites — which is the root
+of Blocking 2.
+
+Strongly consider desugaring `destructive { body }` to a **marked `seqBlock`** (a
+`seqBlock` carrying a `destructive: true` flag) in an early preprocessor, so every
+downstream pass sees a `seqBlock` it already handles and only the parser,
+`bodySlots`, the formatter, and one codegen branch (emit the entry flip when the
+flag is set) need to know the construct exists. Open question to resolve first:
+does `seqBlock`'s **runtime** codegen keep locals on the function activation
+(`__self`), or give the block its own frame? If it is frame-transparent at runtime,
+it is the ideal base and Task 6's from-scratch splice is redundant. If it takes a
+frame, the plan's bespoke inline-splice is justified — but Blocking 2's site-wiring
+is still required either way. Either resolve this or state explicitly why a
+distinct node beats a marked `seqBlock`.
+
+## Moderate — Task 6 entry-flip alignment
+
+Task 6 pushes `blockEntryFlip()` into the *active* `currentPart` without a
+preceding `flushPart()`. If a plain (non-flushing) statement immediately precedes
+the block, the flip merges into that statement's step and runs one step "early."
+In the migrated stdlib pattern this is benign (the gate is an interrupt, which is
+compound and flushes, so `currentPart` is null at the block). But for the general
+construct, consider `flushPart()` before pushing the flip so it aligns to the
+block's own first step — matches the "entry" semantics and avoids a flip sharing a
+checkpoint step with a pre-region statement. Low risk (the flip is idempotent and
+serialization-preserved), but worth a line and a test with a plain statement
+before the block.
+
+## Minor
+
+- **Task 7 misses the `:225` `registerMarkers` call site.** `compilationUnit.ts`
+  calls `registerMarkers` at `:211`, `:225`, and `:307` (plan names `:211`/`:307`).
+  `:225` passes an explicit `{ destructive: true }` so it is harmless, but the task
+  says "call sites at :211/:307" — note `:225` exists so the worker doesn't assume
+  two.
+- **Task 5 `init()` signature change** — confirm the only callers are
+  `typescriptBuilder.ts:2132` and the unit test (grep before changing; the plan
+  updates both, which is correct if that is the full set).
+- **Task 10 Step 3 (decl-visibility) is a good transparency guard** — keep it, and
+  note it also exercises Blocking 2 (a missed `bodySlots`/scope registration makes
+  `y` unresolved). Consider asserting a *referenced* variable inside the block
+  resolves too, per Blocking 2.
+- **Task 11 nested-`destructive {}`-in-`destructive def`** — good, but assert the
+  compiled output emits the redundant `__destructiveRan = true` harmlessly (the
+  spec's "harmless no-op" claim), not just "parses."
+
+## Coverage assessment
+
+Spec → task mapping is otherwise complete: function-entry commit (Task 5),
+inline-splice/fail-open guard (Task 6, correct), derived metadata without mutating
+`node.markers` (Task 7, verified against `:2266`/`:2340`), dead-heuristic removal
+(Task 8), region-model tests + the four review mandates (Tasks 9–11), stdlib
+migration enumerated per function (Tasks 12–15), docs (Task 16). The gaps are not
+in *what* the plan set out to cover but in the *mechanism* for the new node —
+Blockings 1–3 and the altitude question. Fix those four and the plan is
+executable.

--- a/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-plan.md
+++ b/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-plan.md
@@ -1,0 +1,795 @@
+# Destructive Marker Authoritative — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `destructive` declaration authoritative for tool removal-on-failure by committing at region entry (function entry for `destructive def`, or a new inline `destructive { }` block), deleting the import-name heuristic, and migrating stdlib so interrupt gates stay retryable-on-rejection.
+
+**Architecture:** Runtime removal already keys on the `destructiveRan` flag via `failureTier`. We change only *where the flag is set*: `destructive def` sets it in `init()` at function entry; a new transparent, inline-spliced `destructive { }` block sets it at block entry on the enclosing function's `__self`. "Is-destructive" metadata (descriptor marker, MCP/HTTP hint, registry) is derived as marked-OR-contains-block, without mutating `node.markers`.
+
+**Tech Stack:** TypeScript; tarsec parser combinators (`lib/parsers/`); the TsIR/`ts.*` builders and `TypeScriptBuilder` (`lib/backends/`); Agency execution tests (`tests/agency/*.test.json` + `.agency`) and typescriptGenerator fixtures.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md`. Every task's requirements implicitly include it.
+- **Fail-open is the cardinal danger.** The `destructive { }` entry flip MUST land on the enclosing **function's** `__self` (activation `.locals`), never a block frame. A conventional (frame-bearing) block writes `__bstack.locals.__destructiveRan` which evaporates at block exit → escaping failure carries `destructiveRan = false` → tool NOT removed. Inline-splice is mandatory.
+- Do NOT mutate `node.markers.destructive`. It feeds `inDestructiveFunction`/the entry flip (raw marker only). "Contains a block" is a *derived* value used only for metadata (descriptor/hint/registry).
+- `destructive { }` introduces **no new lexical scope** — declarations inside are visible after it.
+- After editing any `stdlib/*.agency`, rebuild with `make` (not `pnpm run build`) so `dist/` and the `.js` siblings update.
+- Save test output to a file when running suites (repo convention; tests are slow/expensive). Do NOT run the full agency suite locally — run the specific tests named in each task.
+- Run `pnpm run lint:structure` before finishing; keep to existing patterns (objects not maps, arrays not sets, types not interfaces, no dynamic imports).
+
+---
+
+### Task 1: `DestructiveBlock` AST node type
+
+**Files:**
+- Create: `lib/types/destructiveBlock.ts`
+- Modify: `lib/types.ts` (export + `AgencyNode` union)
+
+**Interfaces:**
+- Produces: `type DestructiveBlock = BaseNode & { type: "destructiveBlock"; body: AgencyNode[] }`.
+
+- [ ] **Step 1: Create the type file**
+
+`lib/types/destructiveBlock.ts`:
+```typescript
+import { AgencyNode } from "../types.js";
+import { BaseNode } from "./base.js";
+
+/** A `destructive { ... }` region. Marks its body as destructive: entering it
+ *  flips the enclosing function's `__destructiveRan`. It is transparent — no new
+ *  lexical scope, and its body is compiled INLINE into the enclosing function's
+ *  stepped statement stream (see DestructiveTracking / processBodyAsParts), so
+ *  interrupts inside resume correctly and the flip lands on the function's
+ *  `__self`, not a block frame. */
+export type DestructiveBlock = BaseNode & {
+  type: "destructiveBlock";
+  body: AgencyNode[];
+};
+```
+
+- [ ] **Step 2: Export it and add to the `AgencyNode` union in `lib/types.ts`**
+
+Mirror how `parallelBlock` is wired. Add near the other block re-exports:
+```typescript
+export * from "./types/destructiveBlock.js";
+```
+Add `"destructiveBlock"` to the `AgencyNode` union / node-type list (the same list that includes `"handleBlock"`, `"parallelBlock"`, `"matchBlock"` — search for `"handleBlock"` in `lib/types.ts` and add `"destructiveBlock"` alongside, importing the type at the top like the others).
+
+- [ ] **Step 3: Typecheck compiles**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | head -20`
+Expected: no new errors referencing `destructiveBlock`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/types/destructiveBlock.ts lib/types.ts
+git commit -m "types: add DestructiveBlock AST node"
+```
+
+---
+
+### Task 2: Parser for `destructive { }`
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts` (add `destructiveBlockParser`; wire into the statement `or(...)` list near line 3992 where `handleBlockParser` is registered)
+- Test: `lib/parsers/destructiveBlock.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `DestructiveBlock` (Task 1), existing combinators `withLoc`, `memo`, `seqC`, `set`, `str`, `not`, `varNameChar`, `optionalSpaces`, `optionalSpacesOrNewline`, `char`, `capture`, `parseError`, `bodyParser`.
+- Produces: `export const destructiveBlockParser: Parser<DestructiveBlock>`.
+
+Model exactly on `handleBlockParser` (`lib/parsers/parsers.ts:4201`), minus the `with` handler tail. The `not(varNameChar)` word boundary is what lets `destructive` used as an identifier, and `destructive def`, backtrack cleanly instead of committing to the block path.
+
+- [ ] **Step 1: Write failing parser tests**
+
+`lib/parsers/destructiveBlock.test.ts`:
+```typescript
+import { describe, it, expect } from "vitest";
+import { destructiveBlockParser } from "./parsers.js";
+
+describe("destructiveBlockParser", () => {
+  it("parses an empty block", () => {
+    const r = destructiveBlockParser("destructive { }");
+    expect(r.success).toBe(true);
+    expect(r.result).toMatchObject({ type: "destructiveBlock", body: [] });
+  });
+
+  it("parses a block with statements", () => {
+    const r = destructiveBlockParser('destructive {\n  return _write(x)\n}');
+    expect(r.success).toBe(true);
+    expect(r.result.type).toBe("destructiveBlock");
+    expect(r.result.body.length).toBe(1);
+  });
+
+  it("does NOT match `destructive def` (backtracks: no `{`)", () => {
+    const r = destructiveBlockParser("destructive def f() { }");
+    expect(r.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/parsers/destructiveBlock.test.ts 2>&1 | tail -20`
+Expected: FAIL — `destructiveBlockParser` is not exported.
+
+- [ ] **Step 3: Implement the parser**
+
+Add near `handleBlockParser` in `lib/parsers/parsers.ts`:
+```typescript
+export const destructiveBlockParser: Parser<DestructiveBlock> = withLoc(memo(
+  "destructiveBlockParser",
+  seqC(
+    set("type", "destructiveBlock"),
+    str("destructive"),
+    // Word boundary: `destructive def`, `destructiveThing`, and a bare
+    // `destructive` identifier must NOT commit to this parser — they backtrack.
+    not(varNameChar),
+    optionalSpaces,
+    captureCaptures(
+      parseError(
+        "expected `{` to open destructive block body",
+        char("{"),
+        optionalSpacesOrNewline,
+        capture(bodyParser, "body"),
+        optionalSpacesOrNewline,
+        char("}"),
+      ),
+    ),
+  ),
+));
+```
+Import `DestructiveBlock` at the top of `parsers.ts` alongside `HandleBlock`.
+
+- [ ] **Step 4: Wire into the statement parser**
+
+At `lib/parsers/parsers.ts:3992`, the statement `or(...)` includes `lazy(() => handleBlockParser)`. Add `lazy(() => destructiveBlockParser)` in the same list. Place it BEFORE any function-call/expression statement parser so `destructive {` is tried as a block first, but the `not(varNameChar)` + `char("{")` ensure `destructive def`/identifiers fall through.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `pnpm vitest run lib/parsers/destructiveBlock.test.ts 2>&1 | tail -20`
+Expected: PASS (3/3).
+
+- [ ] **Step 6: Verify `destructive def` still parses (regression)**
+
+Run: `pnpm vitest run lib/parsers/function.test.ts 2>&1 | tail -10`
+Expected: PASS (unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/destructiveBlock.test.ts
+git commit -m "parser: parse destructive { } block statements"
+```
+
+---
+
+### Task 3: Formatter for `destructive { }`
+
+**Files:**
+- Modify: `lib/formatter.ts` (add a `destructiveBlock` case in the node dispatch)
+- Test: `lib/formatter.test.ts` (add a case)
+
+**Interfaces:**
+- Consumes: `DestructiveBlock`; the formatter's body-indenting helper (find how `handleBlock` / `matchBlock` / `parallelBlock` format their `body` and mirror it).
+
+- [ ] **Step 1: Write a failing roundtrip test**
+
+Add to `lib/formatter.test.ts` (follow the file's existing roundtrip helper):
+```typescript
+it("formats a destructive block", () => {
+  const src = 'def f() {\n  destructive {\n    return _write(x)\n  }\n}\n';
+  expect(format(src)).toBe(src);
+});
+```
+(Use whatever `format`/roundtrip helper the file already defines.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/formatter.test.ts -t "destructive block" 2>&1 | tail -20`
+Expected: FAIL (unknown node type / wrong output).
+
+- [ ] **Step 3: Implement the formatter case**
+
+In `lib/formatter.ts`, find the node-type dispatch (search for `"handleBlock"` or `"parallelBlock"`). Add a `destructiveBlock` case that emits `destructive {`, the indented formatted body, then `}` — mirroring the sibling block formatter exactly (same indent utility and body-join the file already uses).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run lib/formatter.test.ts -t "destructive block" 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/formatter.ts lib/formatter.test.ts
+git commit -m "formatter: format destructive { } blocks"
+```
+
+---
+
+### Task 4: Typecheck / symbol-table pass-through for the block body
+
+**Files:**
+- Modify: whichever passes dispatch on node type and would otherwise skip a `destructiveBlock` (typechecker statement handler; symbol-table body walk). Confirm `lib/utils/node.ts` `walkNodes` descends into `.body` generically.
+- Test: `tests/typescriptGenerator/destructive-block.agency` + `.mts` (Task 6 adds these; here add a typecheck test)
+
+**Interfaces:**
+- Consumes: `DestructiveBlock.body`.
+
+- [ ] **Step 1: Confirm the generic walker descends into `.body`**
+
+Run: `grep -n "body\|children\|Object.values\|for (const" lib/utils/node.ts | head`
+If `walkNodes` iterates node fields generically (descending into arrays of nodes like `.body`), symbol resolution, `raises`/effect checking, and narrowing see the block body for free. If it enumerates specific node types, add `destructiveBlock` to the list that recurses into `.body`.
+
+- [ ] **Step 2: Write a failing typecheck test**
+
+Add an Agency source that would produce a type error INSIDE a block and assert the checker reports it (proving the body is checked). Use the project's typecheck test harness (search `tests/` / `lib/typeChecker` for an existing "expect diagnostic" pattern). Example source:
+```
+def f(): number {
+  destructive {
+    let x: string = 5   // type error must be reported
+    return 1
+  }
+}
+```
+Assert a diagnostic is produced at the `let x` line.
+
+- [ ] **Step 3: Run to verify failure**
+
+Expected: no diagnostic (body skipped) OR a crash on unknown node type — either proves the pass needs a case.
+
+- [ ] **Step 4: Add the pass-through**
+
+Wherever a pass switches on node type and hits `destructiveBlock`, treat it as "recurse into `.body` in the current scope" (no new scope, no new bindings). Match the lightest sibling (e.g. how a plain grouping / `seqBlock` body is walked).
+
+- [ ] **Step 5: Run to verify pass; then full typechecker suite**
+
+Run: `pnpm vitest run lib/typeChecker 2>&1 | tail -15`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "typecheck: walk destructive { } block bodies in the enclosing scope"
+```
+
+---
+
+### Task 5: Function-level commit-at-entry (`destructive def`)
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder/destructiveTracking.ts` (`init()`, `statementFlips()`, add `blockEntryFlip()`)
+- Modify: `lib/backends/typescriptBuilder.ts:2132` (pass `inDestructiveFunction` to `init()`)
+- Test: `lib/backends/typescriptBuilder/destructiveTracking.test.ts`
+
+**Interfaces:**
+- Produces: `init(inDestructiveFunction: boolean): TsNode`; `blockEntryFlip(): TsNode` (used by Task 6); `statementFlips` no longer references `containsImpureCall`.
+
+- [ ] **Step 1: Update the unit tests (TDD)**
+
+In `destructiveTracking.test.ts`:
+- Keep/adjust the `init()` test: `init(false)` prints `__self.__destructiveRan = __self.__destructiveRan ?? false;`; ADD `init(true)` prints `__self.__destructiveRan = true;`.
+- Replace the "impure call flips inside a destructive function" cases with: inside a destructive function, `statementFlips(anyStmt, true)` returns `{}` (no per-statement flip — commit is at entry).
+- Add: `blockEntryFlip()` prints `__self.__destructiveRan = true;`.
+- Keep the Rule-2 (non-destructive caller) outcome-flip / pre-flip tests unchanged.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/backends/typescriptBuilder/destructiveTracking.test.ts 2>&1 | tail -20`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `destructiveTracking.ts`:
+```typescript
+/** Function-entry init. A `destructive def` commits its whole body: set the
+ *  flag true at entry (init runs AFTER arg binding, so a bad-args failure that
+ *  halts before init stays retryable). A non-destructive function keeps the
+ *  `?? false` default so an externally set value (decision-8, block entry) is
+ *  preserved. */
+init(inDestructiveFunction: boolean): TsNode {
+  return ts.assign(
+    ts.self("__destructiveRan"),
+    inDestructiveFunction
+      ? ts.bool(true)
+      : ts.binOp(ts.self("__destructiveRan"), "??", ts.bool(false)),
+  );
+}
+
+/** The `destructive { }` entry flip. Emitted INLINE in the enclosing function's
+ *  stepped body (never in a block frame), so `ts.self` resolves to the
+ *  function's `__self`. */
+blockEntryFlip(): TsNode {
+  return this.markTrue(); // __self.__destructiveRan = true
+}
+```
+Make `markTrue()` non-private (or call `ts.assign(ts.self("__destructiveRan"), ts.bool(true))` directly in `blockEntryFlip`).
+
+Change `statementFlips` so the destructive-function branch no longer scans:
+```typescript
+statementFlips(stmt, inDestructiveFunction) {
+  // A destructive def commits at entry (init); no per-statement flips.
+  if (inDestructiveFunction) return {};
+  // Rule 2 (non-destructive caller of a destructive fn) — unchanged.
+  const outcomeVar = this.destructiveOutcomeVar(stmt);
+  if (outcomeVar) return { post: this.outcomeFlip(outcomeVar) };
+  return this.names.containsDestructiveCall(stmt) ? { pre: this.markTrue() } : {};
+}
+```
+
+In `lib/backends/typescriptBuilder.ts:2132`, change the call:
+```typescript
+setupStmts.push(this.tracking.init(this.scopes.inDestructiveFunction));
+```
+(`this.scopes.inDestructiveFunction` is set at `:2266` from `node.markers?.destructive`, before this line runs.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm vitest run lib/backends/typescriptBuilder/destructiveTracking.test.ts 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder/destructiveTracking.ts lib/backends/typescriptBuilder.ts lib/backends/typescriptBuilder/destructiveTracking.test.ts
+git commit -m "codegen: destructive def commits at function entry; drop per-statement Rule 1"
+```
+
+---
+
+### Task 6: Inline-splice codegen for `destructive { }` (the fail-open guard)
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts` — `processBodyAsParts` loop (~3954–4010)
+- Test: `tests/typescriptGenerator/destructive-block.agency` + `.mts` (fixtures); assertion below
+
+**Interfaces:**
+- Consumes: `DestructiveTracking.blockEntryFlip()` (Task 5).
+
+**THE headline constraint (Global Constraints): the block must be spliced inline into the enclosing stepped stream, NOT compiled as a frame-bearing block, or the flip evaporates and the tool fails open.** Mirror the existing pipe-chain inline expansion.
+
+- [ ] **Step 1: Refactor the loop body into a recursive `emitStmt` closure**
+
+In `processBodyAsParts`, extract the per-statement work (currently the body of `for (const stmt of body)`) into a local `const emitStmt = (stmt: AgencyNode): void => { ... }`, then make the loop `for (const stmt of body) emitStmt(stmt);`. Keep `flushPart()` after the loop. `emitStmt` must contain the existing pipe-chain check, the `flushPart` gate, `statementFlips`, `processStatement`, the `post` flip, async-branch-key, and source-map logic — verbatim, replacing `continue;` with `return;`.
+
+- [ ] **Step 2: Add the `destructiveBlock` case at the top of `emitStmt`**
+
+Immediately after the pipe-chain check inside `emitStmt`:
+```typescript
+if (stmt.type === "destructiveBlock") {
+  // Entry flip on the ENCLOSING function's __self (inline — no block frame),
+  // pushed as a non-step preamble into the active part, exactly like a pre-flip.
+  if (!currentPart) currentPart = [];
+  currentPart.push(this.tracking.blockEntryFlip());
+  // Splice the body inline: each inner statement gets continuing substep ids,
+  // its declarations stay visible after the block, and interrupts inside resume
+  // relative to statements that follow the block.
+  for (const inner of (stmt as DestructiveBlock).body) emitStmt(inner);
+  return;
+}
+```
+Import `DestructiveBlock` in `typescriptBuilder.ts`.
+
+- [ ] **Step 3: Create the fixture**
+
+`tests/typescriptGenerator/destructive-block.agency`:
+```
+def writeThing(x: number): Result {
+  const p = prep(x)
+  return interrupt std::doit("ok?", { x: x })
+  destructive {
+    return try _doWrite(p)
+  }
+}
+```
+Generate the `.mts` per the repo's fixture workflow: `make fixtures` (or the documented single-fixture command). Inspect the generated code and CONFIRM: `__self.__destructiveRan = true` appears inside `writeThing`'s body (referencing the function `__self`), NOT inside a `__bstack`/block frame, and the `return try _doWrite(p)` sits in the same stepped stream.
+
+- [ ] **Step 4: Run the generator fixture check**
+
+Run: `pnpm vitest run tests/typescriptGenerator 2>&1 | tail -20`
+Expected: PASS (fixture matches committed `.mts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder.ts tests/typescriptGenerator/destructive-block.*
+git commit -m "codegen: inline-splice destructive { } so the entry flip lands on the function __self"
+```
+
+---
+
+### Task 7: Derived is-destructive metadata (marked OR contains-block)
+
+**Files:**
+- Create: `lib/backends/functionContainsDestructiveBlock.ts` (small shared helper)
+- Modify: `lib/backends/typescriptBuilder.ts:2340` (descriptor marker) using the derived value
+- Modify: `lib/compilationUnit.ts` (`registerMarkers` call sites at :211/:307 pass a derived `isDestructive`)
+- Test: `lib/backends/functionContainsDestructiveBlock.test.ts`; a serving/registry test
+
+**Interfaces:**
+- Produces: `functionContainsDestructiveBlock(body: AgencyNode[]): boolean` (walks for any `destructiveBlock`, recursing into nested bodies via `walkNodes`).
+- **MUST NOT** mutate `node.markers`. The entry flip / `inDestructiveFunction` (`:2266`) continue to read the raw `node.markers?.destructive` ONLY.
+
+- [ ] **Step 1: Write failing helper test**
+
+`lib/backends/functionContainsDestructiveBlock.test.ts`:
+```typescript
+import { describe, it, expect } from "vitest";
+import { functionContainsDestructiveBlock } from "./functionContainsDestructiveBlock.js";
+
+describe("functionContainsDestructiveBlock", () => {
+  it("true when a destructive block is present (even nested in an if)", () => {
+    const body = [{ type: "ifElse", condition: {}, thenBody: [
+      { type: "destructiveBlock", body: [] },
+    ], elseBody: [] }] as any;
+    expect(functionContainsDestructiveBlock(body)).toBe(true);
+  });
+  it("false with no block", () => {
+    expect(functionContainsDestructiveBlock([{ type: "returnStatement", value: {} }] as any)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm vitest run lib/backends/functionContainsDestructiveBlock.test.ts 2>&1 | tail -15`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement the helper**
+
+`lib/backends/functionContainsDestructiveBlock.ts`:
+```typescript
+import { AgencyNode } from "../types.js";
+import { walkNodesArray } from "../utils/node.js";
+
+/** True if any `destructive { }` block appears anywhere in `body` (including
+ *  nested blocks/ifs/loops). Used for is-destructive METADATA only (descriptor
+ *  marker, MCP/HTTP hint, destructiveFunctions registry) — never for the entry
+ *  flip, which keys on the raw `destructive def` marker alone. */
+export function functionContainsDestructiveBlock(body: AgencyNode[]): boolean {
+  for (const { node } of walkNodesArray(body)) {
+    if (node.type === "destructiveBlock") return true;
+  }
+  return false;
+}
+```
+(Confirm `walkNodesArray`'s exact name/signature in `lib/utils/node.ts`; match it.)
+
+- [ ] **Step 4: Use it for the descriptor marker**
+
+In `lib/backends/typescriptBuilder.ts` ~2340:
+```typescript
+const isDestructive =
+  !!node.markers?.destructive ||
+  functionContainsDestructiveBlock(node.body);
+if (isDestructive || node.markers?.idempotent) {
+  const markerProps: Record<string, TsNode> = {};
+  if (isDestructive) markerProps.destructive = ts.bool(true);
+  if (node.markers.idempotent) markerProps.idempotent = ts.bool(true);
+  createProps.markers = ts.obj(markerProps);
+}
+```
+Do NOT touch `:2266` (`inDestructiveFunction = !!node.markers?.destructive`).
+
+- [ ] **Step 5: Use it for the registry**
+
+In `lib/compilationUnit.ts`, at the `registerMarkers(unit, node.functionName, node.markers)` call (~:211) and the re-export call (~:307), pass a marker object whose `destructive` is the derived value. Simplest: extend `registerMarkers` to also take `containsBlock: boolean` and OR it in:
+```typescript
+function registerMarkers(unit, localName, markers, containsBlock = false) {
+  if (markers?.destructive || containsBlock) unit.destructiveFunctions[localName] = true;
+  if (markers?.idempotent) unit.idempotentFunctions[localName] = true;
+}
+```
+At `:211`: `registerMarkers(unit, node.functionName, node.markers, functionContainsDestructiveBlock(node.body));`. At `:307` (re-export), the block info comes from the resolved symbol's body if available; if the re-export path has no body, pass `false` (a re-exported name's own def already registered it locally).
+
+- [ ] **Step 6: Run helper test + serving/registry tests**
+
+Run: `pnpm vitest run lib/backends/functionContainsDestructiveBlock.test.ts lib/serve/mcp/adapter.test.ts lib/serve/http/adapter.test.ts 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/backends/functionContainsDestructiveBlock.ts lib/backends/functionContainsDestructiveBlock.test.ts lib/backends/typescriptBuilder.ts lib/compilationUnit.ts
+git commit -m "codegen: derive is-destructive as marked-OR-contains-block for descriptor/hint/registry"
+```
+
+---
+
+### Task 8: Remove the dead `containsImpureCall` heuristic
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder/nameClassifier.ts` (remove `containsImpureCall` + `isImpureImportedFunction` if now unused)
+- Modify: `nameClassifier.test.ts` (remove its tests)
+
+- [ ] **Step 1: Confirm no remaining consumer**
+
+Run: `grep -rn "containsImpureCall" lib/ | grep -v ".test.ts"`
+Expected: only the definition (its sole caller was the old `statementFlips` Rule 1, removed in Task 5). If `isImpureImportedFunction` has no other consumer, remove it too (check with the same grep).
+
+- [ ] **Step 2: Delete the methods and their tests**
+
+Remove `containsImpureCall` (and `isImpureImportedFunction` if dead) from `nameClassifier.ts`; delete the corresponding `nameClassifier.test.ts` cases.
+
+- [ ] **Step 3: Typecheck + nameClassifier tests**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | head; pnpm vitest run lib/backends/typescriptBuilder/nameClassifier.test.ts 2>&1 | tail -10`
+Expected: no errors; tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder/nameClassifier.ts lib/backends/typescriptBuilder/nameClassifier.test.ts
+git commit -m "cleanup: remove dead containsImpureCall import heuristic"
+```
+
+---
+
+### Task 9: Rewrite the `destructive-tracking` execution tests to the region model
+
+**Files:**
+- Modify: `tests/agency/destructive-tracking.agency`
+- Modify: `tests/agency/destructive-tracking.test.json`
+
+**Interfaces:** these are Agency execution tests (no LLM). `destructiveRan`/`neverStarted` are read off the failure Result and returned as arrays for exact match.
+
+- [ ] **Step 1: Rewrite the source to use a block**
+
+`burn` becomes a plain `def` whose destructive work sits in a `destructive { }` block after a validation guard, so "refuse before the region" stays clean:
+```
+def burn(x: number): Result {
+  if (x < 0) {
+    return failure("refused before doing anything")   // before the region → clean
+  }
+  destructive {
+    return failure("failed after starting")            // inside the region → committed
+  }
+}
+```
+Keep `caller`, `cleanRefusal`, `startedThenFailed`, `plainFailure` node shapes. Add a `destructive def` case to prove function-entry commit, e.g.:
+```
+destructive def burnWhole(): Result {
+  return failure("committed at entry")
+}
+node wholeEntry() {
+  const r = burnWhole()
+  if (isFailure(r)) { return [r.neverStarted, r.destructiveRan] }
+  return "unexpected"
+}
+```
+
+- [ ] **Step 2: Update expectations in `.test.json`**
+
+- `cleanRefusal` (burn(-1), refuses before block) → `[false,false]` (unchanged intent).
+- `startedThenFailed` (burn(1), fails in block) → `[false,true]`.
+- New `wholeEntry` (`destructive def` fails at entry) → `[false,true]`.
+- `plainFailure` (unmarked, no block) → `[false,false]`.
+- Re-derive the `succeededThenFailed` / `trySwallowed` / `blockHalt` / `blockJoin` / `ifBlock` / `forBlock` cases against the new source (rewrite whichever assumed the old import-heuristic flips). Any case whose destructive work now lives in a `destructive { }` block should still yield `destructiveRan = true` when a failure escapes after entering it.
+
+- [ ] **Step 3: Run the single test**
+
+Run: `pnpm run a test tests/agency/destructive-tracking.test.json 2>&1 | tee /tmp/dtrack.log | tail -30`
+Expected: all cases pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/agency/destructive-tracking.agency tests/agency/destructive-tracking.test.json
+git commit -m "test: rewrite destructive-tracking to the region model"
+```
+
+---
+
+### Task 10: Behavior tests — the review's mandated coverage
+
+**Files:**
+- Create: `tests/agency/destructive-block.agency` + `tests/agency/destructive-block.test.json`
+
+Cover the four review mandates deterministically (no real LLM):
+
+- [ ] **Step 1: Frame-escape (Finding A — anti-fail-open).** A `def` with a `destructive { }` block whose work fails; the failure escapes the WHOLE function; assert `destructiveRan === true` on the escaping failure (read at the caller, i.e. after the function returns), NOT merely at block entry.
+```
+def wf(): Result {
+  destructive { return failure("boom") }
+}
+node frameEscape() {
+  const r = wf()
+  if (isFailure(r)) { return [r.destructiveRan] }   // must be [true]
+  return "unexpected"
+}
+```
+Expected output `[true]`. (In a frame-local mis-implementation this is `[false]`.)
+
+- [ ] **Step 2: Return-in-block (Finding D).** Confirm a `return` inside `destructive { }` exits the function and the escaping failure carries the flag — covered by Step 1's `return failure(...)` inside the block; add a success variant:
+```
+def wr(): number {
+  destructive { return 42 }
+}
+node returnInBlock() { return wr() }   // exact 42
+```
+
+- [ ] **Step 3: Declaration visibility (Finding B).** A `let` declared inside the block is used AFTER the block:
+```
+def dv(): number {
+  destructive { let y = 10 }
+  return y + 1
+}
+node declVisible() { return dv() }   // exact 11
+```
+(If the block were a real frame, `y` would be out of scope → compile error. This test guards the transparency.)
+
+- [ ] **Step 4: Interrupt in a destructive block (mandated).** A `destructive { }` block containing an interrupt; approve → resumes and completes; reject → the tool/function surfaces the rejection. Model on `tests/agency/interrupts/interrupt.agency` structure with `interruptHandlers` in the `.test.json`. Add an interrupt AFTER a statement following the block to prove continuous substep ids on resume:
+```
+def ib(): string {
+  destructive {
+    const a = interrupt("go?")
+    return "did ${a}"
+  }
+}
+node interruptInBlock() { return ib() }
+```
+`.test.json` entry with an `approve` handler and exact/expected output; a second entry with `reject` asserting the failure surfaces. Use `useTestLLMProvider: true` if any llm() is involved; here `ib()` has no llm(), so a direct interrupt handler suffices.
+
+- [ ] **Step 5: Run**
+
+Run: `pnpm run a test tests/agency/destructive-block.test.json 2>&1 | tee /tmp/dblock.log | tail -40`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/agency/destructive-block.agency tests/agency/destructive-block.test.json
+git commit -m "test: destructive block frame-escape, return, decl-visibility, interrupt-resume"
+```
+
+---
+
+### Task 11: Parser disambiguation tests (Finding E)
+
+**Files:**
+- Modify: `lib/parsers/destructiveBlock.test.ts` (extend); add a fixture for nested-in-`destructive def`
+
+- [ ] **Step 1: Add cases**
+
+```typescript
+it("parses `destructive { }` as a statement inside a function body", () => {
+  // via the statement/body parser, not the block parser directly
+});
+it("nested destructive { } inside a destructive def compiles (no-op, flag already true)", () => {
+  // parse `destructive def f() { destructive { return 1 } }` and assert it parses
+});
+```
+Also add an agency fixture `tests/typescriptGenerator/destructive-nested.agency` with a `destructive def` containing a `destructive { }` and confirm it compiles (the inner block's flip is a redundant `= true`).
+
+- [ ] **Step 2: Run parser + generator tests; commit**
+
+Run: `pnpm vitest run lib/parsers/destructiveBlock.test.ts tests/typescriptGenerator 2>&1 | tail -20`
+```bash
+git add -A && git commit -m "test: destructive block parser disambiguation + nested-in-destructive-def"
+```
+
+---
+
+### Task 12: Migrate `stdlib/git.agency`
+
+**Files:** Modify `stdlib/git.agency` (9 functions). Uniform rule: `export destructive def` → `export def`, wrap every statement AFTER the `return interrupt <effect>(...)` gate in `destructive { }`. Prep/validation/message-building BEFORE the gate stays outside.
+
+Per-function work regions (everything after the gate line):
+- `gitAdd`: `destructive { _gitRun(dir, addArgs({...})); return "Staged changes" }`
+- `gitCommit`: `destructive { return _gitRun(dir, commitArgs({message})) }`
+- `gitCheckout`: `destructive { return _gitRun(dir, checkoutArgs({target, force})) }`
+- `gitSwitch`: `destructive { return _gitRun(dir, switchArgs({branch, create})) }`
+- `gitBranchCreate`: `destructive { _gitRun(dir, branchCreateArgs({branch})); return "Created branch ${branch}" }`
+- `gitBranchDelete`: `destructive { _gitRun(dir, branchDeleteArgs({...})); return "Deleted branch ${branch}" }`
+- `gitStashPush`: `destructive { return _gitRun(dir, stashPushArgs({message})) }`
+- `gitStashPop`: `destructive { return _gitRun(dir, stashPopArgs()) }`
+- `gitRestore`: `destructive { _gitRun(dir, restoreArgs({paths, staged})); return "Restored ${paths.length} file(s)" }`
+
+Keep the `raises <std::git::*>` clauses and docstrings unchanged.
+
+- [ ] **Step 1: Apply the migration to all 9 functions** (change `destructive def`→`def`; wrap post-gate work).
+- [ ] **Step 2: Rebuild**
+
+Run: `make 2>&1 | tail -15`
+Expected: build succeeds.
+
+- [ ] **Step 3: Confirm client hint preserved**
+
+Add/extend a serving test (or reuse `lib/serve/*/adapter.test.ts`) asserting `gitAdd` still reports `destructive: true` / `destructiveHint`. If git isn't in an existing serving fixture, add a focused unit check compiling a tiny module that imports `gitAdd` and asserting the descriptor marker.
+Run: `pnpm vitest run lib/serve 2>&1 | tail -15`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add stdlib/git.agency && git commit -m "stdlib: migrate git destructive defs to destructive { } regions"
+```
+
+---
+
+### Task 13: Migrate `stdlib/fs.agency`
+
+**Files:** Modify `stdlib/fs.agency` (6 functions). Same rule.
+
+Work regions (after the `return interrupt std::<effect>(...)` gate; prep like `useAgentCwd` resolution and `edit`'s `_previewEdit` stays outside):
+- `edit`: `destructive { return try _multiedit(dir, filename, edits) }`
+- `applyPatch`: `destructive { return try _applyPatch(patch, allowedPaths) }`
+- `mkdir`: `destructive { return try _mkdir(dir, allowedPaths) }`
+- `copy`: `destructive { return try _copy(src, dest, allowedPaths) }`
+- `move`: `destructive { return try _move(src, dest, allowedPaths) }`
+- `remove`: `destructive { return try _remove(target, allowedPaths) }`
+
+- [ ] **Step 1: Apply** (`destructive def`→`def`; wrap post-gate).
+- [ ] **Step 2: Rebuild** — `make 2>&1 | tail -15`.
+- [ ] **Step 3: Smoke** — compile a file importing `edit` and confirm it builds; if there is an fs stdlib test, run it. Run: `pnpm run compile foo.agency` on a scratch that imports one fs fn, or run any existing `tests/agency/*fs*`/`write-binary` test.
+- [ ] **Step 4: Commit** — `git add stdlib/fs.agency && git commit -m "stdlib: migrate fs destructive defs to destructive { } regions"`
+
+---
+
+### Task 14: Migrate `stdlib/index.agency` (`write`, `writeBinary`) and `stdlib/clipboard.agency` (`copy`)
+
+**Files:** Modify `stdlib/index.agency`, `stdlib/clipboard.agency`.
+
+Work regions:
+- `write`: `destructive { return try _write(dir, filename, content, mode) }`
+- `writeBinary`: `destructive { return try _writeBinary(dir, filename, base64, mode) }`
+- `clipboard.copy`: `destructive { _copy(text) }`
+
+(Leave `paste`, `readBinary`, and other non-`destructive` functions untouched.)
+
+- [ ] **Step 1: Apply** (`destructive def`→`def`; wrap post-gate).
+- [ ] **Step 2: Rebuild** — `make 2>&1 | tail -15`.
+- [ ] **Step 3: Run the write tests** — Run: `pnpm run a test tests/agency/write-binary.test.json 2>&1 | tail -20` and any `write` agency test. Expected: pass (behavior unchanged on approval; the block is transparent).
+- [ ] **Step 4: Migrated-tool behavior test.** Add/extend an agency test (deterministic) for `write`: rejecting the "Are you sure?" gate returns a retryable failure (the block was never entered → `destructiveRan` false); a forced in-block failure removes the tool. Model on `tests/agency/write-binary.test.json` (which already has a `writeBinaryRejectedDoesNotWrite` case — extend it to assert retryability/`destructiveRan`).
+- [ ] **Step 5: Commit** — `git add stdlib/index.agency stdlib/clipboard.agency tests/agency/write-binary.* && git commit -m "stdlib: migrate write/writeBinary/clipboard.copy to destructive { } regions"`
+
+- [ ] **Step 6: Sweep for any missed `destructive def`**
+
+Run: `grep -rn "destructive def" stdlib/`
+Expected: empty (all migrated). If any remain (e.g. `shell.agency` exec/bash), migrate them with the same rule in this step and re-run `make`.
+
+---
+
+### Task 15: Migrate `stdlib/shell.agency` (`exec`, `bash`)
+
+**Files:** Modify `stdlib/shell.agency`. Read each function first (`sed -n '41,140p' stdlib/shell.agency`) — these may not follow the exact `return interrupt` shape, so **enumerate each one's gate/work boundary explicitly** before wrapping (Finding D: a mis-drawn boundary leaves committed work outside the region = fail-open).
+
+- [ ] **Step 1: Read and record each function's split** (prep / gate / work) as a comment in the task notes; wrap only the post-gate effectful work in `destructive { }`; `destructive def`→`def`.
+- [ ] **Step 2: Rebuild** — `make 2>&1 | tail -15`.
+- [ ] **Step 3: Run any shell/exec agency test; smoke a compile importing `bash`.**
+- [ ] **Step 4: Commit** — `git add stdlib/shell.agency && git commit -m "stdlib: migrate shell exec/bash to destructive { } regions"`
+
+---
+
+### Task 16: Docs
+
+**Files:**
+- Modify: `docs/site/guide/llm-part-2.md` (the "when a tool call fails" section): document that a `destructive def` commits at entry and introduce the `destructive { }` block for granular regions with the gate-outside pattern.
+- Modify: `lib/runtime/result.ts` — JSDoc on `destructiveRan`: "execution entered a destructive region (a `destructive def` body or a `destructive { }` block)."
+- Modify: doc comments in `lib/backends/typescriptBuilder/destructiveTracking.ts` referencing the old import-heuristic rationale.
+
+- [ ] **Step 1: Update the three doc locations** with the region model (show the migrated `write` before/after as the example).
+- [ ] **Step 2: Regenerate stdlib docs if needed** — Run: `make` (regenerates `agency doc` output). Confirm `docs/site/stdlib/*.md` still builds.
+- [ ] **Step 3: Commit** — `git add -A && git commit -m "docs: document destructive { } regions and the region-commit model"`
+
+---
+
+### Task 17: Full-suite verification
+
+- [ ] **Step 1: Structural lint** — Run: `pnpm run lint:structure 2>&1 | tail -20`. Fix any violations.
+- [ ] **Step 2: Full lib test suite** — Run: `pnpm test:run 2>&1 | tee /tmp/libtests.log | tail -30`. Expected: green (8000+). Investigate any failure via the saved log.
+- [ ] **Step 3: Build** — Run: `make 2>&1 | tail -15`. Expected: success.
+- [ ] **Step 4: Do NOT run the full agency suite locally** (slow/expensive; CI runs it). Confirm the targeted agency tests from Tasks 9, 10, 14 pass from their saved logs.
+- [ ] **Step 5: Open the PR** — push the branch and open a PR summarizing: region-commit model, new `destructive { }` construct, derived is-destructive metadata, stdlib migration, and the fail-open guard. Note the deferred non-goal (unifying the success path onto the runtime flag).
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** function-entry commit → Task 5; `destructive { }` construct → Tasks 1–4, 6; inline-splice/fail-open guard → Task 6 + Global Constraints; derived is-destructive metadata (no `node.markers` mutation) → Task 7; remove `containsImpureCall` → Task 8; stdlib migration (enumerated) → Tasks 12–15; the four review test mandates → Tasks 10–11; docs → Task 16. All spec sections map to a task.
+
+**Placeholder scan:** every code step shows real code; stdlib splits are enumerated per function; the one genuinely unknown-shape functions (`shell.agency`) get an explicit read-and-enumerate step (Finding D) rather than an assumed pattern.
+
+**Type consistency:** `functionContainsDestructiveBlock(body)`, `init(inDestructiveFunction)`, `blockEntryFlip()`, node `type: "destructiveBlock"` with `.body` are used consistently across Tasks 1, 5, 6, 7.

--- a/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-plan.md
+++ b/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-plan.md
@@ -1,88 +1,99 @@
-# Destructive Marker Authoritative — Implementation Plan
+# Destructive Marker Authoritative — Implementation Plan (v2: marked-seqBlock)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the `destructive` declaration authoritative for tool removal-on-failure by committing at region entry (function entry for `destructive def`, or a new inline `destructive { }` block), deleting the import-name heuristic, and migrating stdlib so interrupt gates stay retryable-on-rejection.
+**Goal:** Make the `destructive` declaration authoritative for tool removal-on-failure by committing at region entry (function entry for `destructive def`, or a `destructive { }` region), deleting the import-name heuristic, and migrating stdlib so interrupt gates stay retryable-on-rejection.
 
-**Architecture:** Runtime removal already keys on the `destructiveRan` flag via `failureTier`. We change only *where the flag is set*: `destructive def` sets it in `init()` at function entry; a new transparent, inline-spliced `destructive { }` block sets it at block entry on the enclosing function's `__self`. "Is-destructive" metadata (descriptor marker, MCP/HTTP hint, registry) is derived as marked-OR-contains-block, without mutating `node.markers`.
+**Architecture:** Runtime removal already keys on the `destructiveRan` flag via `failureTier`. `destructive def` sets it in `init()` at function entry. The `destructive { }` region is a **`seqBlock` carrying a `destructive: true` flag** — NOT a new node. `seqBlock` is already runtime-frame-transparent (`parallelDesugar.ts:424` inlines a standalone `seqBlock` to its body, on the function's `__self`) and already threaded through every dispatch site (bodySlots, flow, scopes, preprocessors, formatter, lowering). We only teach four places about the flag: the parser, the formatter, the desugar step (prepend the entry-flip when inlining a destructive seqBlock), and the derived is-destructive metadata. The entry-flip is a tiny synthetic leaf node `markDestructiveRan` introduced during desugar and emitted by codegen as `__self.__destructiveRan = true`.
 
-**Tech Stack:** TypeScript; tarsec parser combinators (`lib/parsers/`); the TsIR/`ts.*` builders and `TypeScriptBuilder` (`lib/backends/`); Agency execution tests (`tests/agency/*.test.json` + `.agency`) and typescriptGenerator fixtures.
+**Tech Stack:** TypeScript; tarsec parser combinators (`lib/parsers/`); TsIR/`ts.*` builders and `TypeScriptBuilder`/`AgencyGenerator` (`lib/backends/`); preprocessors (`lib/preprocessors/`); Agency execution tests (`tests/agency/*.test.json` + `.agency`) and typescriptGenerator fixtures.
 
 ## Global Constraints
 
-- Spec: `docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md`. Every task's requirements implicitly include it.
-- **Fail-open is the cardinal danger.** The `destructive { }` entry flip MUST land on the enclosing **function's** `__self` (activation `.locals`), never a block frame. A conventional (frame-bearing) block writes `__bstack.locals.__destructiveRan` which evaporates at block exit → escaping failure carries `destructiveRan = false` → tool NOT removed. Inline-splice is mandatory.
-- Do NOT mutate `node.markers.destructive`. It feeds `inDestructiveFunction`/the entry flip (raw marker only). "Contains a block" is a *derived* value used only for metadata (descriptor/hint/registry).
-- `destructive { }` introduces **no new lexical scope** — declarations inside are visible after it.
-- After editing any `stdlib/*.agency`, rebuild with `make` (not `pnpm run build`) so `dist/` and the `.js` siblings update.
-- Save test output to a file when running suites (repo convention; tests are slow/expensive). Do NOT run the full agency suite locally — run the specific tests named in each task.
-- Run `pnpm run lint:structure` before finishing; keep to existing patterns (objects not maps, arrays not sets, types not interfaces, no dynamic imports).
+- Spec: `docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md`. Every task implicitly includes it.
+- **Fail-open is the cardinal danger.** The entry-flip MUST land on the enclosing **function's** `__self` (activation `.locals`), never a block frame. This is guaranteed here because a destructive `seqBlock` is INLINED into the function body by `desugarParallelInBody` before codegen, so the emitted `__self.__destructiveRan = true` resolves to the function activation. Do NOT compile a destructive region as a frame-bearing block; do NOT exempt destructive seqBlocks from `parallelDesugar` inlining. Task 4's frame-escape test guards this.
+- Do NOT mutate `node.markers.destructive`. It feeds `inDestructiveFunction`/the function-entry flip (raw `destructive def` marker only). "Contains a destructive region" is a *derived* value used only for metadata (descriptor/hint/registry).
+- `destructive { }` is a `seqBlock` → **no new lexical scope** (declarations inside are visible after it, exactly as `seq { }`).
+- After editing any `stdlib/*.agency`, rebuild with `make` (not `pnpm run build`).
+- Save suite output to a file when running (repo convention). Do NOT run the full agency suite locally — run the specific tests named per task.
+- Run `pnpm run lint:structure` before finishing. Objects not maps, arrays not sets, types not interfaces, no dynamic imports.
+
+## Why this is small (context for the worker)
+
+A brand-new transparent AST node would have to be added to ~8 hand-enumerated dispatch sites (`lib/utils/bodySlots.ts`, `lib/typeChecker/flowBuilder.ts`, `lib/typeChecker/scopes.ts`, `lib/preprocessors/typescriptPreprocessor.ts`, `injectSchemaArgs.ts`, `liftCallbacks.ts`, the formatter, lowering) or silently break narrowing/preprocessing. By reusing `seqBlock` (which is already in all of them), we avoid that entirely. The only genuinely new node is `markDestructiveRan`, a **leaf** (no body) introduced *after* typecheck by the desugar step, so only codegen (and a defensive `bodySlots` case) must know it exists.
 
 ---
 
-### Task 1: `DestructiveBlock` AST node type
+### Task 1: `SeqBlock.destructive` flag + `markDestructiveRan` leaf node
 
 **Files:**
-- Create: `lib/types/destructiveBlock.ts`
+- Modify: `lib/types/parallelBlock.ts` (add `destructive?: boolean` to `SeqBlock`)
+- Create: `lib/types/markDestructiveRan.ts`
 - Modify: `lib/types.ts` (export + `AgencyNode` union)
 
 **Interfaces:**
-- Produces: `type DestructiveBlock = BaseNode & { type: "destructiveBlock"; body: AgencyNode[] }`.
+- Produces: `SeqBlock & { destructive?: boolean }`; `type MarkDestructiveRan = BaseNode & { type: "markDestructiveRan" }`.
 
-- [ ] **Step 1: Create the type file**
+- [ ] **Step 1: Add the flag to `SeqBlock`**
 
-`lib/types/destructiveBlock.ts`:
+In `lib/types/parallelBlock.ts`:
 ```typescript
-import { AgencyNode } from "../types.js";
-import { BaseNode } from "./base.js";
-
-/** A `destructive { ... }` region. Marks its body as destructive: entering it
- *  flips the enclosing function's `__destructiveRan`. It is transparent — no new
- *  lexical scope, and its body is compiled INLINE into the enclosing function's
- *  stepped statement stream (see DestructiveTracking / processBodyAsParts), so
- *  interrupts inside resume correctly and the flip lands on the function's
- *  `__self`, not a block frame. */
-export type DestructiveBlock = BaseNode & {
-  type: "destructiveBlock";
+export type SeqBlock = BaseNode & {
+  type: "seqBlock";
   body: AgencyNode[];
+  /** True when written as `destructive { ... }` rather than `seq { ... }`.
+   *  Marks the region destructive: the desugar step prepends a
+   *  `markDestructiveRan` when inlining it. Formatter prints `destructive {`. */
+  destructive?: boolean;
 };
 ```
 
-- [ ] **Step 2: Export it and add to the `AgencyNode` union in `lib/types.ts`**
+- [ ] **Step 2: Create the leaf node**
 
-Mirror how `parallelBlock` is wired. Add near the other block re-exports:
+`lib/types/markDestructiveRan.ts`:
 ```typescript
-export * from "./types/destructiveBlock.js";
-```
-Add `"destructiveBlock"` to the `AgencyNode` union / node-type list (the same list that includes `"handleBlock"`, `"parallelBlock"`, `"matchBlock"` — search for `"handleBlock"` in `lib/types.ts` and add `"destructiveBlock"` alongside, importing the type at the top like the others).
+import { BaseNode } from "./base.js";
 
-- [ ] **Step 3: Typecheck compiles**
+/** Synthetic, bodyless statement emitted by parallelDesugar when it inlines a
+ *  `destructive` seqBlock. Codegen turns it into `__self.__destructiveRan = true`
+ *  on the ENCLOSING function activation (the seqBlock is inlined, so `__self` is
+ *  the function). Never parsed, never formatted (introduced after typecheck). */
+export type MarkDestructiveRan = BaseNode & {
+  type: "markDestructiveRan";
+};
+```
+
+- [ ] **Step 3: Wire into `lib/types.ts`**
+
+Add `export * from "./types/markDestructiveRan.js";` and add `MarkDestructiveRan` to the `AgencyNode` union (import it at top, add `| MarkDestructiveRan` alongside `| SeqBlock`).
+
+- [ ] **Step 4: Typecheck**
 
 Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | head -20`
-Expected: no new errors referencing `destructiveBlock`.
+Expected: no new errors.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add lib/types/destructiveBlock.ts lib/types.ts
-git commit -m "types: add DestructiveBlock AST node"
+git add lib/types/parallelBlock.ts lib/types/markDestructiveRan.ts lib/types.ts
+git commit -m "types: SeqBlock.destructive flag + markDestructiveRan leaf node"
 ```
 
 ---
 
-### Task 2: Parser for `destructive { }`
+### Task 2: Parse `destructive { }` into a flagged `seqBlock`
 
 **Files:**
-- Modify: `lib/parsers/parsers.ts` (add `destructiveBlockParser`; wire into the statement `or(...)` list near line 3992 where `handleBlockParser` is registered)
+- Modify: `lib/parsers/parsers.ts` (add `destructiveBlockParser`; wire into the statement `or(...)` near `:3988` where `seqBlockParser` is listed)
 - Test: `lib/parsers/destructiveBlock.test.ts` (create)
 
 **Interfaces:**
-- Consumes: `DestructiveBlock` (Task 1), existing combinators `withLoc`, `memo`, `seqC`, `set`, `str`, `not`, `varNameChar`, `optionalSpaces`, `optionalSpacesOrNewline`, `char`, `capture`, `parseError`, `bodyParser`.
-- Produces: `export const destructiveBlockParser: Parser<DestructiveBlock>`.
+- Consumes: `SeqBlock`, combinators `withLoc`, `memo`, `label`, `seqC`, `set`, `str`, `not`, `varNameChar`, `optionalSpaces`, `optionalSpacesOrNewline`, `char`, `capture`, `captureCaptures`, `parseError`, `bodyParser`.
+- Produces: `export const destructiveBlockParser: Parser<SeqBlock>` yielding `{ type: "seqBlock", destructive: true, body }`.
 
-Model exactly on `handleBlockParser` (`lib/parsers/parsers.ts:4201`), minus the `with` handler tail. The `not(varNameChar)` word boundary is what lets `destructive` used as an identifier, and `destructive def`, backtrack cleanly instead of committing to the block path.
+**Blocking-1 correctness:** `parseError(...)` is a **committing (cut)** combinator. `not(varNameChar)` succeeds for BOTH `destructive {` and `destructive def` (both have a space after the keyword), so it cannot disambiguate. The `char("{")` gate MUST sit OUTSIDE `parseError`, so `destructive def` fails softly at `{` and the statement `or(...)` backtracks. (The sibling `seqBlockParser` gets away with `{` inside `parseError` only because `seq` is never a function modifier.)
 
-- [ ] **Step 1: Write failing parser tests**
+- [ ] **Step 1: Write failing tests**
 
 `lib/parsers/destructiveBlock.test.ts`:
 ```typescript
@@ -90,22 +101,22 @@ import { describe, it, expect } from "vitest";
 import { destructiveBlockParser } from "./parsers.js";
 
 describe("destructiveBlockParser", () => {
-  it("parses an empty block", () => {
-    const r = destructiveBlockParser("destructive { }");
+  it("parses to a seqBlock flagged destructive", () => {
+    const r = destructiveBlockParser("destructive { return f(x) }");
     expect(r.success).toBe(true);
-    expect(r.result).toMatchObject({ type: "destructiveBlock", body: [] });
-  });
-
-  it("parses a block with statements", () => {
-    const r = destructiveBlockParser('destructive {\n  return _write(x)\n}');
-    expect(r.success).toBe(true);
-    expect(r.result.type).toBe("destructiveBlock");
+    expect(r.result).toMatchObject({ type: "seqBlock", destructive: true });
     expect(r.result.body.length).toBe(1);
   });
 
-  it("does NOT match `destructive def` (backtracks: no `{`)", () => {
+  it("empty block", () => {
+    const r = destructiveBlockParser("destructive { }");
+    expect(r.success).toBe(true);
+    expect(r.result).toMatchObject({ type: "seqBlock", destructive: true, body: [] });
+  });
+
+  it("does NOT match `destructive def` (soft-fails at `{` → backtracks)", () => {
     const r = destructiveBlockParser("destructive def f() { }");
-    expect(r.success).toBe(false);
+    expect(r.success).toBe(false); // must be a soft failure, not a thrown cut
   });
 });
 ```
@@ -113,25 +124,24 @@ describe("destructiveBlockParser", () => {
 - [ ] **Step 2: Run to verify failure**
 
 Run: `pnpm vitest run lib/parsers/destructiveBlock.test.ts 2>&1 | tail -20`
-Expected: FAIL — `destructiveBlockParser` is not exported.
+Expected: FAIL — not exported.
 
-- [ ] **Step 3: Implement the parser**
+- [ ] **Step 3: Implement (soft `{` gate)**
 
-Add near `handleBlockParser` in `lib/parsers/parsers.ts`:
+Add near `seqBlockParser` in `lib/parsers/parsers.ts`:
 ```typescript
-export const destructiveBlockParser: Parser<DestructiveBlock> = withLoc(memo(
+export const destructiveBlockParser: Parser<SeqBlock> = label("a destructive block", withLoc(memo(
   "destructiveBlockParser",
   seqC(
-    set("type", "destructiveBlock"),
+    set("type", "seqBlock"),
+    set("destructive", true),
     str("destructive"),
-    // Word boundary: `destructive def`, `destructiveThing`, and a bare
-    // `destructive` identifier must NOT commit to this parser — they backtrack.
-    not(varNameChar),
+    not(varNameChar),   // reject `destructiveThing`; NOT sufficient alone for `def`
     optionalSpaces,
+    char("{"),          // SOFT gate OUTSIDE parseError: `destructive def` fails here → backtracks
     captureCaptures(
       parseError(
-        "expected `{` to open destructive block body",
-        char("{"),
+        "unterminated destructive block",
         optionalSpacesOrNewline,
         capture(bodyParser, "body"),
         optionalSpacesOrNewline,
@@ -139,241 +149,133 @@ export const destructiveBlockParser: Parser<DestructiveBlock> = withLoc(memo(
       ),
     ),
   ),
-));
+)));
 ```
-Import `DestructiveBlock` at the top of `parsers.ts` alongside `HandleBlock`.
+(Confirm `set(...)` two-value usage matches the codebase; if `set` takes one pair, use two `set(...)` entries as shown.)
 
 - [ ] **Step 4: Wire into the statement parser**
 
-At `lib/parsers/parsers.ts:3992`, the statement `or(...)` includes `lazy(() => handleBlockParser)`. Add `lazy(() => destructiveBlockParser)` in the same list. Place it BEFORE any function-call/expression statement parser so `destructive {` is tried as a block first, but the `not(varNameChar)` + `char("{")` ensure `destructive def`/identifiers fall through.
+At `lib/parsers/parsers.ts:3988`, next to `lazy(() => seqBlockParser)`, add `lazy(() => destructiveBlockParser)`. Order: place it so `destructive {` is tried; the soft `{` gate makes `destructive def`/identifiers fall through.
 
-- [ ] **Step 5: Run tests to verify pass**
+- [ ] **Step 5: Run tests + `destructive def` regression**
 
-Run: `pnpm vitest run lib/parsers/destructiveBlock.test.ts 2>&1 | tail -20`
-Expected: PASS (3/3).
-
-- [ ] **Step 6: Verify `destructive def` still parses (regression)**
-
-Run: `pnpm vitest run lib/parsers/function.test.ts 2>&1 | tail -10`
-Expected: PASS (unchanged).
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add lib/parsers/parsers.ts lib/parsers/destructiveBlock.test.ts
-git commit -m "parser: parse destructive { } block statements"
-```
-
----
-
-### Task 3: Formatter for `destructive { }`
-
-**Files:**
-- Modify: `lib/formatter.ts` (add a `destructiveBlock` case in the node dispatch)
-- Test: `lib/formatter.test.ts` (add a case)
-
-**Interfaces:**
-- Consumes: `DestructiveBlock`; the formatter's body-indenting helper (find how `handleBlock` / `matchBlock` / `parallelBlock` format their `body` and mirror it).
-
-- [ ] **Step 1: Write a failing roundtrip test**
-
-Add to `lib/formatter.test.ts` (follow the file's existing roundtrip helper):
-```typescript
-it("formats a destructive block", () => {
-  const src = 'def f() {\n  destructive {\n    return _write(x)\n  }\n}\n';
-  expect(format(src)).toBe(src);
-});
-```
-(Use whatever `format`/roundtrip helper the file already defines.)
-
-- [ ] **Step 2: Run to verify failure**
-
-Run: `pnpm vitest run lib/formatter.test.ts -t "destructive block" 2>&1 | tail -20`
-Expected: FAIL (unknown node type / wrong output).
-
-- [ ] **Step 3: Implement the formatter case**
-
-In `lib/formatter.ts`, find the node-type dispatch (search for `"handleBlock"` or `"parallelBlock"`). Add a `destructiveBlock` case that emits `destructive {`, the indented formatted body, then `}` — mirroring the sibling block formatter exactly (same indent utility and body-join the file already uses).
-
-- [ ] **Step 4: Run to verify pass**
-
-Run: `pnpm vitest run lib/formatter.test.ts -t "destructive block" 2>&1 | tail -20`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add lib/formatter.ts lib/formatter.test.ts
-git commit -m "formatter: format destructive { } blocks"
-```
-
----
-
-### Task 4: Typecheck / symbol-table pass-through for the block body
-
-**Files:**
-- Modify: whichever passes dispatch on node type and would otherwise skip a `destructiveBlock` (typechecker statement handler; symbol-table body walk). Confirm `lib/utils/node.ts` `walkNodes` descends into `.body` generically.
-- Test: `tests/typescriptGenerator/destructive-block.agency` + `.mts` (Task 6 adds these; here add a typecheck test)
-
-**Interfaces:**
-- Consumes: `DestructiveBlock.body`.
-
-- [ ] **Step 1: Confirm the generic walker descends into `.body`**
-
-Run: `grep -n "body\|children\|Object.values\|for (const" lib/utils/node.ts | head`
-If `walkNodes` iterates node fields generically (descending into arrays of nodes like `.body`), symbol resolution, `raises`/effect checking, and narrowing see the block body for free. If it enumerates specific node types, add `destructiveBlock` to the list that recurses into `.body`.
-
-- [ ] **Step 2: Write a failing typecheck test**
-
-Add an Agency source that would produce a type error INSIDE a block and assert the checker reports it (proving the body is checked). Use the project's typecheck test harness (search `tests/` / `lib/typeChecker` for an existing "expect diagnostic" pattern). Example source:
-```
-def f(): number {
-  destructive {
-    let x: string = 5   // type error must be reported
-    return 1
-  }
-}
-```
-Assert a diagnostic is produced at the `let x` line.
-
-- [ ] **Step 3: Run to verify failure**
-
-Expected: no diagnostic (body skipped) OR a crash on unknown node type — either proves the pass needs a case.
-
-- [ ] **Step 4: Add the pass-through**
-
-Wherever a pass switches on node type and hits `destructiveBlock`, treat it as "recurse into `.body` in the current scope" (no new scope, no new bindings). Match the lightest sibling (e.g. how a plain grouping / `seqBlock` body is walked).
-
-- [ ] **Step 5: Run to verify pass; then full typechecker suite**
-
-Run: `pnpm vitest run lib/typeChecker 2>&1 | tail -15`
-Expected: PASS, no regressions.
+Run: `pnpm vitest run lib/parsers/destructiveBlock.test.ts lib/parsers/function.test.ts 2>&1 | tail -20`
+Expected: PASS (block tests + `destructive def` still parses).
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add -A
-git commit -m "typecheck: walk destructive { } block bodies in the enclosing scope"
+git add lib/parsers/parsers.ts lib/parsers/destructiveBlock.test.ts
+git commit -m "parser: destructive { } parses to a destructive-flagged seqBlock"
 ```
 
 ---
 
-### Task 5: Function-level commit-at-entry (`destructive def`)
+### Task 3: Format a destructive seqBlock as `destructive { }`
 
 **Files:**
-- Modify: `lib/backends/typescriptBuilder/destructiveTracking.ts` (`init()`, `statementFlips()`, add `blockEntryFlip()`)
-- Modify: `lib/backends/typescriptBuilder.ts:2132` (pass `inDestructiveFunction` to `init()`)
-- Test: `lib/backends/typescriptBuilder/destructiveTracking.test.ts`
+- Modify: `lib/backends/agencyGenerator.ts` (`processSeqBlock`, `:1635`)
+- Test: `lib/backends/agencyGenerator.test.ts` (or the formatter roundtrip test file)
 
-**Interfaces:**
-- Produces: `init(inDestructiveFunction: boolean): TsNode`; `blockEntryFlip(): TsNode` (used by Task 6); `statementFlips` no longer references `containsImpureCall`.
+**Blocking-3 correctness:** the real pretty-printer is `AgencyGenerator.processNode` (`agencyGenerator.ts`), whose `switch` ends in `default: throw`. `lib/formatter.ts` (15 lines) only delegates here. `seqBlock` is already dispatched at `:532` → `processSeqBlock`. We only change the keyword.
 
-- [ ] **Step 1: Update the unit tests (TDD)**
+- [ ] **Step 1: Write failing roundtrip test**
 
-In `destructiveTracking.test.ts`:
-- Keep/adjust the `init()` test: `init(false)` prints `__self.__destructiveRan = __self.__destructiveRan ?? false;`; ADD `init(true)` prints `__self.__destructiveRan = true;`.
-- Replace the "impure call flips inside a destructive function" cases with: inside a destructive function, `statementFlips(anyStmt, true)` returns `{}` (no per-statement flip — commit is at entry).
-- Add: `blockEntryFlip()` prints `__self.__destructiveRan = true;`.
-- Keep the Rule-2 (non-destructive caller) outcome-flip / pre-flip tests unchanged.
+Add:
+```typescript
+it("formats a destructive block", () => {
+  const src = 'def f() {\n  destructive {\n    return _w(x)\n  }\n}\n';
+  expect(format(src)).toBe(src); // use the file's existing roundtrip helper
+});
+it("still formats a seq block as seq", () => {
+  const src = 'def f() {\n  seq {\n    return 1\n  }\n}\n';
+  expect(format(src)).toBe(src);
+});
+```
 
 - [ ] **Step 2: Run to verify failure**
 
-Run: `pnpm vitest run lib/backends/typescriptBuilder/destructiveTracking.test.ts 2>&1 | tail -20`
-Expected: FAIL.
+Run: `pnpm vitest run lib/backends/agencyGenerator.test.ts -t "destructive block" 2>&1 | tail -20`
+Expected: FAIL (prints `seq {`).
 
 - [ ] **Step 3: Implement**
 
-In `destructiveTracking.ts`:
+In `processSeqBlock` (`:1635`):
 ```typescript
-/** Function-entry init. A `destructive def` commits its whole body: set the
- *  flag true at entry (init runs AFTER arg binding, so a bad-args failure that
- *  halts before init stays retryable). A non-destructive function keeps the
- *  `?? false` default so an externally set value (decision-8, block entry) is
- *  preserved. */
-init(inDestructiveFunction: boolean): TsNode {
-  return ts.assign(
-    ts.self("__destructiveRan"),
-    inDestructiveFunction
-      ? ts.bool(true)
-      : ts.binOp(ts.self("__destructiveRan"), "??", ts.bool(false)),
-  );
-}
-
-/** The `destructive { }` entry flip. Emitted INLINE in the enclosing function's
- *  stepped body (never in a block frame), so `ts.self` resolves to the
- *  function's `__self`. */
-blockEntryFlip(): TsNode {
-  return this.markTrue(); // __self.__destructiveRan = true
+protected processSeqBlock(node: SeqBlock): string {
+  this.increaseIndent();
+  const bodyCodeStr = this.renderBody(node.body);
+  this.decreaseIndent();
+  const kw = node.destructive ? "destructive" : "seq";
+  return this.indentStr(`${kw} {\n${bodyCodeStr}${this.indentStr("}")}`);
 }
 ```
-Make `markTrue()` non-private (or call `ts.assign(ts.self("__destructiveRan"), ts.bool(true))` directly in `blockEntryFlip`).
-
-Change `statementFlips` so the destructive-function branch no longer scans:
-```typescript
-statementFlips(stmt, inDestructiveFunction) {
-  // A destructive def commits at entry (init); no per-statement flips.
-  if (inDestructiveFunction) return {};
-  // Rule 2 (non-destructive caller of a destructive fn) — unchanged.
-  const outcomeVar = this.destructiveOutcomeVar(stmt);
-  if (outcomeVar) return { post: this.outcomeFlip(outcomeVar) };
-  return this.names.containsDestructiveCall(stmt) ? { pre: this.markTrue() } : {};
-}
-```
-
-In `lib/backends/typescriptBuilder.ts:2132`, change the call:
-```typescript
-setupStmts.push(this.tracking.init(this.scopes.inDestructiveFunction));
-```
-(`this.scopes.inDestructiveFunction` is set at `:2266` from `node.markers?.destructive`, before this line runs.)
 
 - [ ] **Step 4: Run to verify pass**
 
-Run: `pnpm vitest run lib/backends/typescriptBuilder/destructiveTracking.test.ts 2>&1 | tail -20`
-Expected: PASS.
+Run: `pnpm vitest run lib/backends/agencyGenerator.test.ts -t "block" 2>&1 | tail -20`
+Expected: PASS (both).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add lib/backends/typescriptBuilder/destructiveTracking.ts lib/backends/typescriptBuilder.ts lib/backends/typescriptBuilder/destructiveTracking.test.ts
-git commit -m "codegen: destructive def commits at function entry; drop per-statement Rule 1"
+git add lib/backends/agencyGenerator.ts lib/backends/agencyGenerator.test.ts
+git commit -m "formatter: print destructive { } for a destructive seqBlock"
 ```
 
 ---
 
-### Task 6: Inline-splice codegen for `destructive { }` (the fail-open guard)
+### Task 4: Desugar prepends the entry-flip; codegen emits it (the fail-open guard)
 
 **Files:**
-- Modify: `lib/backends/typescriptBuilder.ts` — `processBodyAsParts` loop (~3954–4010)
-- Test: `tests/typescriptGenerator/destructive-block.agency` + `.mts` (fixtures); assertion below
+- Modify: `lib/preprocessors/parallelDesugar.ts` (`desugarParallelInBody`, `:424` seqBlock branch)
+- Modify: `lib/backends/typescriptBuilder.ts` (`processNode` case for `markDestructiveRan`)
+- Modify: `lib/backends/typescriptBuilder/destructiveTracking.ts` (add public `blockEntryFlip()`)
+- Modify: `lib/utils/bodySlots.ts` (defensive `markDestructiveRan` → `[]`)
+- Test: `tests/typescriptGenerator/destructive-block.agency` + `.mts`
 
 **Interfaces:**
-- Consumes: `DestructiveTracking.blockEntryFlip()` (Task 5).
+- Produces: `DestructiveTracking.blockEntryFlip(): TsNode` → `__self.__destructiveRan = true`.
 
-**THE headline constraint (Global Constraints): the block must be spliced inline into the enclosing stepped stream, NOT compiled as a frame-bearing block, or the flip evaporates and the tool fails open.** Mirror the existing pipe-chain inline expansion.
+- [ ] **Step 1: Prepend the flip when inlining a destructive seqBlock**
 
-- [ ] **Step 1: Refactor the loop body into a recursive `emitStmt` closure**
-
-In `processBodyAsParts`, extract the per-statement work (currently the body of `for (const stmt of body)`) into a local `const emitStmt = (stmt: AgencyNode): void => { ... }`, then make the loop `for (const stmt of body) emitStmt(stmt);`. Keep `flushPart()` after the loop. `emitStmt` must contain the existing pipe-chain check, the `flushPart` gate, `statementFlips`, `processStatement`, the `post` flip, async-branch-key, and source-map logic — verbatim, replacing `continue;` with `return;`.
-
-- [ ] **Step 2: Add the `destructiveBlock` case at the top of `emitStmt`**
-
-Immediately after the pipe-chain check inside `emitStmt`:
+In `parallelDesugar.ts`, the `else if (node.type === "seqBlock")` branch (`:424`) currently does `result.push(...desugarParallelInBody(node.body));`. Change to:
 ```typescript
-if (stmt.type === "destructiveBlock") {
-  // Entry flip on the ENCLOSING function's __self (inline — no block frame),
-  // pushed as a non-step preamble into the active part, exactly like a pre-flip.
-  if (!currentPart) currentPart = [];
-  currentPart.push(this.tracking.blockEntryFlip());
-  // Splice the body inline: each inner statement gets continuing substep ids,
-  // its declarations stay visible after the block, and interrupts inside resume
-  // relative to statements that follow the block.
-  for (const inner of (stmt as DestructiveBlock).body) emitStmt(inner);
-  return;
+} else if (node.type === "seqBlock") {
+  // Outside a parallel context a seq block inlines to its body. A destructive
+  // seqBlock additionally commits: prepend the flip so it runs on the enclosing
+  // function's __self (this inlining is exactly why __self is the function).
+  if (node.destructive) {
+    result.push({ type: "markDestructiveRan" } as AgencyNode);
+  }
+  result.push(...desugarParallelInBody(node.body));
 }
 ```
-Import `DestructiveBlock` in `typescriptBuilder.ts`.
+(Import `AgencyNode` if not already; the loc field is optional on the synthetic node.)
 
-- [ ] **Step 3: Create the fixture**
+- [ ] **Step 2: Add `blockEntryFlip()` to DestructiveTracking**
+
+```typescript
+/** `__self.__destructiveRan = true`, for the markDestructiveRan codegen. */
+blockEntryFlip(): TsNode {
+  return ts.assign(ts.self("__destructiveRan"), ts.bool(true));
+}
+```
+
+- [ ] **Step 3: Codegen case for `markDestructiveRan`**
+
+In `TypeScriptBuilder.processNode` (find the `switch (node.type)` / dispatch), add:
+```typescript
+case "markDestructiveRan":
+  return this.tracking.blockEntryFlip();
+```
+This is emitted inline in the function body (the seqBlock was inlined), so `ts.self` resolves to the function `__self`.
+
+- [ ] **Step 4: Defensive bodySlots case**
+
+In `lib/utils/bodySlots.ts`, add `case "markDestructiveRan": return [];` (leaf, no body) so any `walkNodes`/`mapBodies` pass running after desugar treats it as inert. Confirm the file's default behavior; if it already returns `[]` for unknown, this is belt-and-suspenders but harmless.
+
+- [ ] **Step 5: Create the fixture and CONFIRM frame placement**
 
 `tests/typescriptGenerator/destructive-block.agency`:
 ```
@@ -385,86 +287,134 @@ def writeThing(x: number): Result {
   }
 }
 ```
-Generate the `.mts` per the repo's fixture workflow: `make fixtures` (or the documented single-fixture command). Inspect the generated code and CONFIRM: `__self.__destructiveRan = true` appears inside `writeThing`'s body (referencing the function `__self`), NOT inside a `__bstack`/block frame, and the `return try _doWrite(p)` sits in the same stepped stream.
+Generate the `.mts` (`make fixtures` or the single-fixture command). CONFIRM in the generated code: `__self.__destructiveRan = true;` appears inside `writeThing`'s body referencing the function `__self` (NOT a `__bstack` frame), immediately before the inlined `_doWrite` step; and NO `seqBlock`/block frame remains.
 
-- [ ] **Step 4: Run the generator fixture check**
+- [ ] **Step 6: Run generator fixtures**
 
 Run: `pnpm vitest run tests/typescriptGenerator 2>&1 | tail -20`
-Expected: PASS (fixture matches committed `.mts`).
+Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add lib/backends/typescriptBuilder.ts tests/typescriptGenerator/destructive-block.*
-git commit -m "codegen: inline-splice destructive { } so the entry flip lands on the function __self"
+git add lib/preprocessors/parallelDesugar.ts lib/backends/typescriptBuilder.ts lib/backends/typescriptBuilder/destructiveTracking.ts lib/utils/bodySlots.ts tests/typescriptGenerator/destructive-block.*
+git commit -m "codegen: destructive seqBlock inlines a markDestructiveRan flip on the function __self"
 ```
 
 ---
 
-### Task 7: Derived is-destructive metadata (marked OR contains-block)
+### Task 5: `destructive def` commits at function entry; drop per-statement Rule 1
 
 **Files:**
-- Create: `lib/backends/functionContainsDestructiveBlock.ts` (small shared helper)
-- Modify: `lib/backends/typescriptBuilder.ts:2340` (descriptor marker) using the derived value
-- Modify: `lib/compilationUnit.ts` (`registerMarkers` call sites at :211/:307 pass a derived `isDestructive`)
-- Test: `lib/backends/functionContainsDestructiveBlock.test.ts`; a serving/registry test
+- Modify: `lib/backends/typescriptBuilder/destructiveTracking.ts` (`init()`, `statementFlips()`)
+- Modify: `lib/backends/typescriptBuilder.ts:2132` (pass `inDestructiveFunction`)
+- Test: `lib/backends/typescriptBuilder/destructiveTracking.test.ts`
+
+- [ ] **Step 1: Confirm `init()` caller set**
+
+Run: `grep -rn "tracking.init(\|\.init()" lib/backends/typescriptBuilder.ts lib/backends/typescriptBuilder/destructiveTracking.test.ts`
+Expected: the codegen call at `:2132` and the unit test — the full set the signature change touches.
+
+- [ ] **Step 2: Update unit tests (TDD)**
+
+- `init(false)` → `__self.__destructiveRan = __self.__destructiveRan ?? false;`
+- `init(true)` → `__self.__destructiveRan = true;`
+- inside a destructive function, `statementFlips(anyStmt, true)` → `{}` (commit is at entry).
+- `blockEntryFlip()` → `__self.__destructiveRan = true;`
+- keep Rule-2 (non-destructive caller) outcome-flip/pre-flip tests.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `pnpm vitest run lib/backends/typescriptBuilder/destructiveTracking.test.ts 2>&1 | tail -20`
+Expected: FAIL.
+
+- [ ] **Step 4: Implement**
+
+```typescript
+init(inDestructiveFunction: boolean): TsNode {
+  return ts.assign(
+    ts.self("__destructiveRan"),
+    inDestructiveFunction
+      ? ts.bool(true)
+      : ts.binOp(ts.self("__destructiveRan"), "??", ts.bool(false)),
+  );
+}
+
+statementFlips(stmt, inDestructiveFunction) {
+  if (inDestructiveFunction) return {}; // destructive def commits at entry
+  const outcomeVar = this.destructiveOutcomeVar(stmt);
+  if (outcomeVar) return { post: this.outcomeFlip(outcomeVar) };
+  return this.names.containsDestructiveCall(stmt) ? { pre: this.markTrue() } : {};
+}
+```
+At `typescriptBuilder.ts:2132`: `setupStmts.push(this.tracking.init(this.scopes.inDestructiveFunction));`
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pnpm vitest run lib/backends/typescriptBuilder/destructiveTracking.test.ts 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder/destructiveTracking.ts lib/backends/typescriptBuilder.ts lib/backends/typescriptBuilder/destructiveTracking.test.ts
+git commit -m "codegen: destructive def commits at function entry; drop per-statement Rule 1"
+```
+
+---
+
+### Task 6: Derived is-destructive metadata (marked OR contains a destructive region)
+
+**Files:**
+- Create: `lib/backends/functionContainsDestructiveBlock.ts`
+- Modify: `lib/backends/typescriptBuilder.ts:2340` (descriptor marker)
+- Modify: `lib/compilationUnit.ts` (`registerMarkers` at `:211`, `:225`, `:307`)
+- Test: `lib/backends/functionContainsDestructiveBlock.test.ts`; serving tests
 
 **Interfaces:**
-- Produces: `functionContainsDestructiveBlock(body: AgencyNode[]): boolean` (walks for any `destructiveBlock`, recursing into nested bodies via `walkNodes`).
-- **MUST NOT** mutate `node.markers`. The entry flip / `inDestructiveFunction` (`:2266`) continue to read the raw `node.markers?.destructive` ONLY.
+- Produces: `functionContainsDestructiveBlock(body: AgencyNode[]): boolean` (walks for a `seqBlock` with `destructive === true`).
+- MUST NOT mutate `node.markers`. The entry flip / `inDestructiveFunction` (`:2266`) still read the raw marker only.
 
-- [ ] **Step 1: Write failing helper test**
+- [ ] **Step 1: Failing helper test**
 
-`lib/backends/functionContainsDestructiveBlock.test.ts`:
 ```typescript
-import { describe, it, expect } from "vitest";
 import { functionContainsDestructiveBlock } from "./functionContainsDestructiveBlock.js";
-
-describe("functionContainsDestructiveBlock", () => {
-  it("true when a destructive block is present (even nested in an if)", () => {
-    const body = [{ type: "ifElse", condition: {}, thenBody: [
-      { type: "destructiveBlock", body: [] },
-    ], elseBody: [] }] as any;
-    expect(functionContainsDestructiveBlock(body)).toBe(true);
-  });
-  it("false with no block", () => {
-    expect(functionContainsDestructiveBlock([{ type: "returnStatement", value: {} }] as any)).toBe(false);
-  });
+it("true for a destructive seqBlock (even nested)", () => {
+  const body = [{ type: "ifElse", condition: {}, thenBody: [
+    { type: "seqBlock", destructive: true, body: [] },
+  ], elseBody: [] }] as any;
+  expect(functionContainsDestructiveBlock(body)).toBe(true);
+});
+it("false for a plain seqBlock / no block", () => {
+  expect(functionContainsDestructiveBlock([{ type: "seqBlock", body: [] }] as any)).toBe(false);
 });
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [ ] **Step 2: Run to verify failure** — `pnpm vitest run lib/backends/functionContainsDestructiveBlock.test.ts 2>&1 | tail -15` → FAIL.
 
-Run: `pnpm vitest run lib/backends/functionContainsDestructiveBlock.test.ts 2>&1 | tail -15`
-Expected: FAIL (module not found).
+- [ ] **Step 3: Implement helper**
 
-- [ ] **Step 3: Implement the helper**
-
-`lib/backends/functionContainsDestructiveBlock.ts`:
 ```typescript
-import { AgencyNode } from "../types.js";
+import { AgencyNode, SeqBlock } from "../types.js";
 import { walkNodesArray } from "../utils/node.js";
 
-/** True if any `destructive { }` block appears anywhere in `body` (including
- *  nested blocks/ifs/loops). Used for is-destructive METADATA only (descriptor
- *  marker, MCP/HTTP hint, destructiveFunctions registry) — never for the entry
- *  flip, which keys on the raw `destructive def` marker alone. */
+/** True if any `destructive { }` region (a seqBlock flagged destructive) appears
+ *  in `body`. Metadata ONLY (descriptor marker, MCP/HTTP hint, registry) — never
+ *  the entry flip, which keys on the raw `destructive def` marker. */
 export function functionContainsDestructiveBlock(body: AgencyNode[]): boolean {
   for (const { node } of walkNodesArray(body)) {
-    if (node.type === "destructiveBlock") return true;
+    if (node.type === "seqBlock" && (node as SeqBlock).destructive) return true;
   }
   return false;
 }
 ```
-(Confirm `walkNodesArray`'s exact name/signature in `lib/utils/node.ts`; match it.)
+(Match `walkNodesArray`'s exact name in `lib/utils/node.ts`.)
 
-- [ ] **Step 4: Use it for the descriptor marker**
+- [ ] **Step 4: Descriptor marker (`:2340`)**
 
-In `lib/backends/typescriptBuilder.ts` ~2340:
 ```typescript
 const isDestructive =
-  !!node.markers?.destructive ||
-  functionContainsDestructiveBlock(node.body);
+  !!node.markers?.destructive || functionContainsDestructiveBlock(node.body);
 if (isDestructive || node.markers?.idempotent) {
   const markerProps: Record<string, TsNode> = {};
   if (isDestructive) markerProps.destructive = ts.bool(true);
@@ -472,73 +422,42 @@ if (isDestructive || node.markers?.idempotent) {
   createProps.markers = ts.obj(markerProps);
 }
 ```
-Do NOT touch `:2266` (`inDestructiveFunction = !!node.markers?.destructive`).
+Leave `:2266` untouched.
 
-- [ ] **Step 5: Use it for the registry**
+- [ ] **Step 5: Registry (`compilationUnit.ts`)**
 
-In `lib/compilationUnit.ts`, at the `registerMarkers(unit, node.functionName, node.markers)` call (~:211) and the re-export call (~:307), pass a marker object whose `destructive` is the derived value. Simplest: extend `registerMarkers` to also take `containsBlock: boolean` and OR it in:
-```typescript
-function registerMarkers(unit, localName, markers, containsBlock = false) {
-  if (markers?.destructive || containsBlock) unit.destructiveFunctions[localName] = true;
-  if (markers?.idempotent) unit.idempotentFunctions[localName] = true;
-}
-```
-At `:211`: `registerMarkers(unit, node.functionName, node.markers, functionContainsDestructiveBlock(node.body));`. At `:307` (re-export), the block info comes from the resolved symbol's body if available; if the re-export path has no body, pass `false` (a re-exported name's own def already registered it locally).
+`registerMarkers` gains a `containsBlock = false` param and ORs it into `destructiveFunctions`. Call sites:
+- `:211` `registerMarkers(unit, node.functionName, node.markers, functionContainsDestructiveBlock(node.body))`.
+- `:225` passes an explicit `{ destructive: true }` (already destructive) — leave as-is (no block info needed).
+- `:307` (re-export) — pass `false`; the name's own def already registered it locally.
 
-- [ ] **Step 6: Run helper test + serving/registry tests**
+- [ ] **Step 6: Run helper + serving tests; commit**
 
 Run: `pnpm vitest run lib/backends/functionContainsDestructiveBlock.test.ts lib/serve/mcp/adapter.test.ts lib/serve/http/adapter.test.ts 2>&1 | tail -20`
-Expected: PASS.
-
-- [ ] **Step 7: Commit**
-
 ```bash
 git add lib/backends/functionContainsDestructiveBlock.ts lib/backends/functionContainsDestructiveBlock.test.ts lib/backends/typescriptBuilder.ts lib/compilationUnit.ts
-git commit -m "codegen: derive is-destructive as marked-OR-contains-block for descriptor/hint/registry"
+git commit -m "codegen: derive is-destructive as marked-OR-contains-destructive-region"
 ```
 
 ---
 
-### Task 8: Remove the dead `containsImpureCall` heuristic
+### Task 7: Remove the dead `containsImpureCall` heuristic
 
-**Files:**
-- Modify: `lib/backends/typescriptBuilder/nameClassifier.ts` (remove `containsImpureCall` + `isImpureImportedFunction` if now unused)
-- Modify: `nameClassifier.test.ts` (remove its tests)
+**Files:** `lib/backends/typescriptBuilder/nameClassifier.ts` (+ its test)
 
-- [ ] **Step 1: Confirm no remaining consumer**
-
-Run: `grep -rn "containsImpureCall" lib/ | grep -v ".test.ts"`
-Expected: only the definition (its sole caller was the old `statementFlips` Rule 1, removed in Task 5). If `isImpureImportedFunction` has no other consumer, remove it too (check with the same grep).
-
-- [ ] **Step 2: Delete the methods and their tests**
-
-Remove `containsImpureCall` (and `isImpureImportedFunction` if dead) from `nameClassifier.ts`; delete the corresponding `nameClassifier.test.ts` cases.
-
-- [ ] **Step 3: Typecheck + nameClassifier tests**
-
-Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | head; pnpm vitest run lib/backends/typescriptBuilder/nameClassifier.test.ts 2>&1 | tail -10`
-Expected: no errors; tests pass.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add lib/backends/typescriptBuilder/nameClassifier.ts lib/backends/typescriptBuilder/nameClassifier.test.ts
-git commit -m "cleanup: remove dead containsImpureCall import heuristic"
-```
+- [ ] **Step 1: Confirm no consumer** — `grep -rn "containsImpureCall" lib/ | grep -v ".test.ts"` → only the definition.
+- [ ] **Step 2: Delete** `containsImpureCall` (and `isImpureImportedFunction` if now unused — re-grep) + their tests.
+- [ ] **Step 3: Typecheck + nameClassifier tests** — `npx tsc --noEmit -p tsconfig.json 2>&1 | head; pnpm vitest run lib/backends/typescriptBuilder/nameClassifier.test.ts 2>&1 | tail -10` → clean.
+- [ ] **Step 4: Commit** — `git add -A && git commit -m "cleanup: remove dead containsImpureCall import heuristic"`
 
 ---
 
-### Task 9: Rewrite the `destructive-tracking` execution tests to the region model
+### Task 8: Rewrite the `destructive-tracking` execution tests to the region model
 
-**Files:**
-- Modify: `tests/agency/destructive-tracking.agency`
-- Modify: `tests/agency/destructive-tracking.test.json`
+**Files:** `tests/agency/destructive-tracking.agency`, `tests/agency/destructive-tracking.test.json`
 
-**Interfaces:** these are Agency execution tests (no LLM). `destructiveRan`/`neverStarted` are read off the failure Result and returned as arrays for exact match.
+- [ ] **Step 1: Rewrite `burn` to use a destructive region**
 
-- [ ] **Step 1: Rewrite the source to use a block**
-
-`burn` becomes a plain `def` whose destructive work sits in a `destructive { }` block after a validation guard, so "refuse before the region" stays clean:
 ```
 def burn(x: number): Result {
   if (x < 0) {
@@ -548,11 +467,9 @@ def burn(x: number): Result {
     return failure("failed after starting")            // inside the region → committed
   }
 }
-```
-Keep `caller`, `cleanRefusal`, `startedThenFailed`, `plainFailure` node shapes. Add a `destructive def` case to prove function-entry commit, e.g.:
-```
+
 destructive def burnWhole(): Result {
-  return failure("committed at entry")
+  return failure("committed at entry")                 // destructive def → entry commit
 }
 node wholeEntry() {
   const r = burnWhole()
@@ -560,68 +477,53 @@ node wholeEntry() {
   return "unexpected"
 }
 ```
+(`r.neverStarted` / `r.destructiveRan` are existing failure-Result fields, read exactly as the current tests already do.)
 
-- [ ] **Step 2: Update expectations in `.test.json`**
+- [ ] **Step 2: Update `.test.json` expectations**
 
-- `cleanRefusal` (burn(-1), refuses before block) → `[false,false]` (unchanged intent).
-- `startedThenFailed` (burn(1), fails in block) → `[false,true]`.
-- New `wholeEntry` (`destructive def` fails at entry) → `[false,true]`.
-- `plainFailure` (unmarked, no block) → `[false,false]`.
-- Re-derive the `succeededThenFailed` / `trySwallowed` / `blockHalt` / `blockJoin` / `ifBlock` / `forBlock` cases against the new source (rewrite whichever assumed the old import-heuristic flips). Any case whose destructive work now lives in a `destructive { }` block should still yield `destructiveRan = true` when a failure escapes after entering it.
+- `cleanRefusal` (burn(-1), before region) → `[false,false]`.
+- `startedThenFailed` (burn(1), in region) → `[false,true]`.
+- `wholeEntry` (`destructive def` fails at entry) → `[false,true]`.
+- `plainFailure` (unmarked, no region) → `[false,false]`.
+- Re-derive `succeededThenFailed`/`trySwallowed`/`blockHalt`/`blockJoin`/`ifBlock`/`forBlock` against the new source: any that depended on the old import-heuristic per-statement flip must now put their destructive work inside a `destructive { }` region to yield `destructiveRan = true`.
 
-- [ ] **Step 3: Run the single test**
-
-Run: `pnpm run a test tests/agency/destructive-tracking.test.json 2>&1 | tee /tmp/dtrack.log | tail -30`
-Expected: all cases pass.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add tests/agency/destructive-tracking.agency tests/agency/destructive-tracking.test.json
-git commit -m "test: rewrite destructive-tracking to the region model"
-```
+- [ ] **Step 3: Run** — `pnpm run a test tests/agency/destructive-tracking.test.json 2>&1 | tee /tmp/dtrack.log | tail -30` → all pass.
+- [ ] **Step 4: Commit** — `git add tests/agency/destructive-tracking.* && git commit -m "test: rewrite destructive-tracking to the region model"`
 
 ---
 
-### Task 10: Behavior tests — the review's mandated coverage
+### Task 9: Behavior tests — the review's mandated coverage
 
-**Files:**
-- Create: `tests/agency/destructive-block.agency` + `tests/agency/destructive-block.test.json`
+**Files:** `tests/agency/destructive-block.agency` + `.test.json`
 
-Cover the four review mandates deterministically (no real LLM):
-
-- [ ] **Step 1: Frame-escape (Finding A — anti-fail-open).** A `def` with a `destructive { }` block whose work fails; the failure escapes the WHOLE function; assert `destructiveRan === true` on the escaping failure (read at the caller, i.e. after the function returns), NOT merely at block entry.
+- [ ] **Step 1: Frame-escape (Finding A — anti-fail-open).**
 ```
-def wf(): Result {
-  destructive { return failure("boom") }
-}
+def wf(): Result { destructive { return failure("boom") } }
 node frameEscape() {
   const r = wf()
-  if (isFailure(r)) { return [r.destructiveRan] }   // must be [true]
+  if (isFailure(r)) { return [r.destructiveRan] }   // MUST be [true]
   return "unexpected"
 }
 ```
-Expected output `[true]`. (In a frame-local mis-implementation this is `[false]`.)
+Expected `[true]`. (Frame-local mis-impl gives `[false]`.)
 
-- [ ] **Step 2: Return-in-block (Finding D).** Confirm a `return` inside `destructive { }` exits the function and the escaping failure carries the flag — covered by Step 1's `return failure(...)` inside the block; add a success variant:
-```
-def wr(): number {
-  destructive { return 42 }
-}
-node returnInBlock() { return wr() }   // exact 42
-```
-
-- [ ] **Step 3: Declaration visibility (Finding B).** A `let` declared inside the block is used AFTER the block:
+- [ ] **Step 2: Declaration visibility + referenced-var (Finding B / Blocking 2 symptom).**
 ```
 def dv(): number {
   destructive { let y = 10 }
-  return y + 1
+  return y + 1                 // y visible after the region (transparent)
 }
 node declVisible() { return dv() }   // exact 11
 ```
-(If the block were a real frame, `y` would be out of scope → compile error. This test guards the transparency.)
+(If the region weren't inlined-transparent, `y` would be unresolved → compile error or a bare-identifier codegen. This guards the seqBlock wiring.)
 
-- [ ] **Step 4: Interrupt in a destructive block (mandated).** A `destructive { }` block containing an interrupt; approve → resumes and completes; reject → the tool/function surfaces the rejection. Model on `tests/agency/interrupts/interrupt.agency` structure with `interruptHandlers` in the `.test.json`. Add an interrupt AFTER a statement following the block to prove continuous substep ids on resume:
+- [ ] **Step 3: Return-in-block (Finding D).**
+```
+def wr(): number { destructive { return 42 } }
+node returnInBlock() { return wr() }   // exact 42
+```
+
+- [ ] **Step 4: Interrupt in a destructive block, with a following statement (continuous steps).**
 ```
 def ib(): string {
   destructive {
@@ -631,53 +533,28 @@ def ib(): string {
 }
 node interruptInBlock() { return ib() }
 ```
-`.test.json` entry with an `approve` handler and exact/expected output; a second entry with `reject` asserting the failure surfaces. Use `useTestLLMProvider: true` if any llm() is involved; here `ib()` has no llm(), so a direct interrupt handler suffices.
+`.test.json`: one entry with an `approve` interruptHandler (assert the resumed result); one with `reject` (assert the failure surfaces). No `llm()` here, so a direct interrupt handler suffices (no `useTestLLMProvider` needed).
 
-- [ ] **Step 5: Run**
-
-Run: `pnpm run a test tests/agency/destructive-block.test.json 2>&1 | tee /tmp/dblock.log | tail -40`
-Expected: all pass.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add tests/agency/destructive-block.agency tests/agency/destructive-block.test.json
-git commit -m "test: destructive block frame-escape, return, decl-visibility, interrupt-resume"
-```
+- [ ] **Step 5: Run** — `pnpm run a test tests/agency/destructive-block.test.json 2>&1 | tee /tmp/dblock.log | tail -40` → all pass.
+- [ ] **Step 6: Commit** — `git add tests/agency/destructive-block.* && git commit -m "test: destructive region frame-escape, decl-visibility, return, interrupt-resume"`
 
 ---
 
-### Task 11: Parser disambiguation tests (Finding E)
+### Task 10: Parser disambiguation + nested-region tests (Finding E)
 
-**Files:**
-- Modify: `lib/parsers/destructiveBlock.test.ts` (extend); add a fixture for nested-in-`destructive def`
+**Files:** extend `lib/parsers/destructiveBlock.test.ts`; add `tests/typescriptGenerator/destructive-nested.agency` + `.mts`
 
-- [ ] **Step 1: Add cases**
-
-```typescript
-it("parses `destructive { }` as a statement inside a function body", () => {
-  // via the statement/body parser, not the block parser directly
-});
-it("nested destructive { } inside a destructive def compiles (no-op, flag already true)", () => {
-  // parse `destructive def f() { destructive { return 1 } }` and assert it parses
-});
-```
-Also add an agency fixture `tests/typescriptGenerator/destructive-nested.agency` with a `destructive def` containing a `destructive { }` and confirm it compiles (the inner block's flip is a redundant `= true`).
-
-- [ ] **Step 2: Run parser + generator tests; commit**
-
-Run: `pnpm vitest run lib/parsers/destructiveBlock.test.ts tests/typescriptGenerator 2>&1 | tail -20`
-```bash
-git add -A && git commit -m "test: destructive block parser disambiguation + nested-in-destructive-def"
-```
+- [ ] **Step 1: Parser cases** — `destructive` as an ordinary identifier still parses (e.g. `let destructive = 1` if permitted, else a call `destructive(x)` must not be captured as a block); `destructive def` unchanged; `destructive { }` as a statement inside a body.
+- [ ] **Step 2: Nested fixture** — `destructive def f() { destructive { return 1 } }`. Generate the `.mts`; ASSERT the compiled output contains the redundant `__self.__destructiveRan = true` harmlessly (the spec's "harmless no-op"): the function-entry `= true` from `init(true)`, plus the region's `markDestructiveRan` `= true`. Confirms nesting compiles and both flips land on the function `__self`.
+- [ ] **Step 3: Run + commit** — `pnpm vitest run lib/parsers/destructiveBlock.test.ts tests/typescriptGenerator 2>&1 | tail -20`; `git add -A && git commit -m "test: destructive region parser disambiguation + nested-in-destructive-def"`
 
 ---
 
-### Task 12: Migrate `stdlib/git.agency`
+### Task 11: Migrate `stdlib/git.agency` (9 functions)
 
-**Files:** Modify `stdlib/git.agency` (9 functions). Uniform rule: `export destructive def` → `export def`, wrap every statement AFTER the `return interrupt <effect>(...)` gate in `destructive { }`. Prep/validation/message-building BEFORE the gate stays outside.
+`export destructive def` → `export def`; wrap every statement AFTER the `return interrupt <effect>(...)` gate in `destructive { }`. Prep/validation/message-building BEFORE the gate stays outside. `raises <...>` and docstrings unchanged.
 
-Per-function work regions (everything after the gate line):
+Work regions (after the gate line):
 - `gitAdd`: `destructive { _gitRun(dir, addArgs({...})); return "Staged changes" }`
 - `gitCommit`: `destructive { return _gitRun(dir, commitArgs({message})) }`
 - `gitCheckout`: `destructive { return _gitRun(dir, checkoutArgs({target, force})) }`
@@ -688,32 +565,16 @@ Per-function work regions (everything after the gate line):
 - `gitStashPop`: `destructive { return _gitRun(dir, stashPopArgs()) }`
 - `gitRestore`: `destructive { _gitRun(dir, restoreArgs({paths, staged})); return "Restored ${paths.length} file(s)" }`
 
-Keep the `raises <std::git::*>` clauses and docstrings unchanged.
-
-- [ ] **Step 1: Apply the migration to all 9 functions** (change `destructive def`→`def`; wrap post-gate work).
-- [ ] **Step 2: Rebuild**
-
-Run: `make 2>&1 | tail -15`
-Expected: build succeeds.
-
-- [ ] **Step 3: Confirm client hint preserved**
-
-Add/extend a serving test (or reuse `lib/serve/*/adapter.test.ts`) asserting `gitAdd` still reports `destructive: true` / `destructiveHint`. If git isn't in an existing serving fixture, add a focused unit check compiling a tiny module that imports `gitAdd` and asserting the descriptor marker.
-Run: `pnpm vitest run lib/serve 2>&1 | tail -15`
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add stdlib/git.agency && git commit -m "stdlib: migrate git destructive defs to destructive { } regions"
-```
+- [ ] **Step 1: Apply** to all 9.
+- [ ] **Step 2: Rebuild** — `make 2>&1 | tail -15` → success.
+- [ ] **Step 3: Client-hint preserved** — assert `gitAdd` still reports `destructive`/`destructiveHint` (extend `lib/serve/*/adapter.test.ts` or compile a tiny importing module and check the descriptor marker). Run: `pnpm vitest run lib/serve 2>&1 | tail -15`.
+- [ ] **Step 4: Commit** — `git add stdlib/git.agency && git commit -m "stdlib: migrate git to destructive { } regions"`
 
 ---
 
-### Task 13: Migrate `stdlib/fs.agency`
+### Task 12: Migrate `stdlib/fs.agency` (6 functions)
 
-**Files:** Modify `stdlib/fs.agency` (6 functions). Same rule.
-
-Work regions (after the `return interrupt std::<effect>(...)` gate; prep like `useAgentCwd` resolution and `edit`'s `_previewEdit` stays outside):
+Work regions (prep like `useAgentCwd` and `edit`'s `_previewEdit` stays outside):
 - `edit`: `destructive { return try _multiedit(dir, filename, edits) }`
 - `applyPatch`: `destructive { return try _applyPatch(patch, allowedPaths) }`
 - `mkdir`: `destructive { return try _mkdir(dir, allowedPaths) }`
@@ -721,75 +582,58 @@ Work regions (after the `return interrupt std::<effect>(...)` gate; prep like `u
 - `move`: `destructive { return try _move(src, dest, allowedPaths) }`
 - `remove`: `destructive { return try _remove(target, allowedPaths) }`
 
-- [ ] **Step 1: Apply** (`destructive def`→`def`; wrap post-gate).
-- [ ] **Step 2: Rebuild** — `make 2>&1 | tail -15`.
-- [ ] **Step 3: Smoke** — compile a file importing `edit` and confirm it builds; if there is an fs stdlib test, run it. Run: `pnpm run compile foo.agency` on a scratch that imports one fs fn, or run any existing `tests/agency/*fs*`/`write-binary` test.
-- [ ] **Step 4: Commit** — `git add stdlib/fs.agency && git commit -m "stdlib: migrate fs destructive defs to destructive { } regions"`
+- [ ] **Step 1: Apply.** **Step 2:** `make 2>&1 | tail -15`. **Step 3:** compile a scratch importing `edit`; run any `fs`/`write-binary` agency test. **Step 4:** `git add stdlib/fs.agency && git commit -m "stdlib: migrate fs to destructive { } regions"`
 
 ---
 
-### Task 14: Migrate `stdlib/index.agency` (`write`, `writeBinary`) and `stdlib/clipboard.agency` (`copy`)
-
-**Files:** Modify `stdlib/index.agency`, `stdlib/clipboard.agency`.
+### Task 13: Migrate `stdlib/index.agency` (`write`, `writeBinary`) + `stdlib/clipboard.agency` (`copy`)
 
 Work regions:
 - `write`: `destructive { return try _write(dir, filename, content, mode) }`
 - `writeBinary`: `destructive { return try _writeBinary(dir, filename, base64, mode) }`
 - `clipboard.copy`: `destructive { _copy(text) }`
 
-(Leave `paste`, `readBinary`, and other non-`destructive` functions untouched.)
+(Leave `paste`, `readBinary`, and non-destructive functions untouched.)
 
-- [ ] **Step 1: Apply** (`destructive def`→`def`; wrap post-gate).
-- [ ] **Step 2: Rebuild** — `make 2>&1 | tail -15`.
-- [ ] **Step 3: Run the write tests** — Run: `pnpm run a test tests/agency/write-binary.test.json 2>&1 | tail -20` and any `write` agency test. Expected: pass (behavior unchanged on approval; the block is transparent).
-- [ ] **Step 4: Migrated-tool behavior test.** Add/extend an agency test (deterministic) for `write`: rejecting the "Are you sure?" gate returns a retryable failure (the block was never entered → `destructiveRan` false); a forced in-block failure removes the tool. Model on `tests/agency/write-binary.test.json` (which already has a `writeBinaryRejectedDoesNotWrite` case — extend it to assert retryability/`destructiveRan`).
-- [ ] **Step 5: Commit** — `git add stdlib/index.agency stdlib/clipboard.agency tests/agency/write-binary.* && git commit -m "stdlib: migrate write/writeBinary/clipboard.copy to destructive { } regions"`
+- [ ] **Step 1: Apply.** **Step 2:** `make 2>&1 | tail -15`. **Step 3:** `pnpm run a test tests/agency/write-binary.test.json 2>&1 | tail -20` → pass. **Step 4: Migrated-tool behavior test** — extend `write-binary.test.json`'s `writeBinaryRejectedDoesNotWrite` to assert the rejected-gate failure is retryable (`destructiveRan` false, region never entered). **Step 5:** `git add stdlib/index.agency stdlib/clipboard.agency tests/agency/write-binary.* && git commit -m "stdlib: migrate write/writeBinary/clipboard.copy to destructive { } regions"`
 
-- [ ] **Step 6: Sweep for any missed `destructive def`**
-
-Run: `grep -rn "destructive def" stdlib/`
-Expected: empty (all migrated). If any remain (e.g. `shell.agency` exec/bash), migrate them with the same rule in this step and re-run `make`.
+- [ ] **Step 6: Sweep** — `grep -rn "destructive def" stdlib/` → migrate any stragglers (see Task 14) then `make`.
 
 ---
 
-### Task 15: Migrate `stdlib/shell.agency` (`exec`, `bash`)
+### Task 14: Migrate `stdlib/shell.agency` (`exec`, `bash`)
 
-**Files:** Modify `stdlib/shell.agency`. Read each function first (`sed -n '41,140p' stdlib/shell.agency`) — these may not follow the exact `return interrupt` shape, so **enumerate each one's gate/work boundary explicitly** before wrapping (Finding D: a mis-drawn boundary leaves committed work outside the region = fail-open).
+These may not follow the exact `return interrupt` shape — **read and enumerate each split explicitly** (Finding D: a mis-drawn boundary leaves committed work outside the region = fail-open, or pulls the gate inside = removes on rejection).
 
-- [ ] **Step 1: Read and record each function's split** (prep / gate / work) as a comment in the task notes; wrap only the post-gate effectful work in `destructive { }`; `destructive def`→`def`.
-- [ ] **Step 2: Rebuild** — `make 2>&1 | tail -15`.
-- [ ] **Step 3: Run any shell/exec agency test; smoke a compile importing `bash`.**
-- [ ] **Step 4: Commit** — `git add stdlib/shell.agency && git commit -m "stdlib: migrate shell exec/bash to destructive { } regions"`
+- [ ] **Step 1:** `sed -n '41,140p' stdlib/shell.agency`; record each function's prep/gate/work; wrap only post-gate effectful work in `destructive { }`; `destructive def`→`def`.
+- [ ] **Step 2:** `make 2>&1 | tail -15`. **Step 3:** run any shell/exec agency test; compile a scratch importing `bash`. **Step 4:** `git add stdlib/shell.agency && git commit -m "stdlib: migrate shell exec/bash to destructive { } regions"`
 
 ---
 
-### Task 16: Docs
+### Task 15: Docs
 
-**Files:**
-- Modify: `docs/site/guide/llm-part-2.md` (the "when a tool call fails" section): document that a `destructive def` commits at entry and introduce the `destructive { }` block for granular regions with the gate-outside pattern.
-- Modify: `lib/runtime/result.ts` — JSDoc on `destructiveRan`: "execution entered a destructive region (a `destructive def` body or a `destructive { }` block)."
-- Modify: doc comments in `lib/backends/typescriptBuilder/destructiveTracking.ts` referencing the old import-heuristic rationale.
+**Files:** `docs/site/guide/llm-part-2.md` ("when a tool call fails": `destructive def` commits at entry; introduce `destructive { }` regions with the gate-outside pattern, using migrated `write` before/after); `lib/runtime/result.ts` JSDoc on `destructiveRan` ("execution entered a destructive region — a `destructive def` body or a `destructive { }` region"); doc comments in `destructiveTracking.ts` referencing the old import-heuristic.
 
-- [ ] **Step 1: Update the three doc locations** with the region model (show the migrated `write` before/after as the example).
-- [ ] **Step 2: Regenerate stdlib docs if needed** — Run: `make` (regenerates `agency doc` output). Confirm `docs/site/stdlib/*.md` still builds.
-- [ ] **Step 3: Commit** — `git add -A && git commit -m "docs: document destructive { } regions and the region-commit model"`
+- [ ] **Step 1: Update.** **Step 2:** `make` (regenerates `agency doc`); confirm `docs/site/stdlib/*.md` builds. **Step 3:** `git add -A && git commit -m "docs: document destructive { } regions and the region-commit model"`
 
 ---
 
-### Task 17: Full-suite verification
+### Task 16: Full-suite verification + PR
 
-- [ ] **Step 1: Structural lint** — Run: `pnpm run lint:structure 2>&1 | tail -20`. Fix any violations.
-- [ ] **Step 2: Full lib test suite** — Run: `pnpm test:run 2>&1 | tee /tmp/libtests.log | tail -30`. Expected: green (8000+). Investigate any failure via the saved log.
-- [ ] **Step 3: Build** — Run: `make 2>&1 | tail -15`. Expected: success.
-- [ ] **Step 4: Do NOT run the full agency suite locally** (slow/expensive; CI runs it). Confirm the targeted agency tests from Tasks 9, 10, 14 pass from their saved logs.
-- [ ] **Step 5: Open the PR** — push the branch and open a PR summarizing: region-commit model, new `destructive { }` construct, derived is-destructive metadata, stdlib migration, and the fail-open guard. Note the deferred non-goal (unifying the success path onto the runtime flag).
+- [ ] **Step 1:** `pnpm run lint:structure 2>&1 | tail -20` — fix violations.
+- [ ] **Step 2:** `pnpm test:run 2>&1 | tee /tmp/libtests.log | tail -30` — green (8000+).
+- [ ] **Step 3:** `make 2>&1 | tail -15` — success.
+- [ ] **Step 4:** Do NOT run the full agency suite locally; confirm the targeted tests (Tasks 8, 9, 13) pass from saved logs.
+- [ ] **Step 5:** Push; open the PR summarizing region-commit model, `destructive { }` as a marked seqBlock, derived metadata, stdlib migration, and the fail-open guard. Note the deferred non-goal (unify the success path onto the runtime flag).
 
 ---
 
 ## Self-Review (completed by plan author)
 
-**Spec coverage:** function-entry commit → Task 5; `destructive { }` construct → Tasks 1–4, 6; inline-splice/fail-open guard → Task 6 + Global Constraints; derived is-destructive metadata (no `node.markers` mutation) → Task 7; remove `containsImpureCall` → Task 8; stdlib migration (enumerated) → Tasks 12–15; the four review test mandates → Tasks 10–11; docs → Task 16. All spec sections map to a task.
+**Spec coverage:** function-entry commit → Task 5; `destructive { }` region (marked seqBlock) → Tasks 1–4; inline-transparency / fail-open guard → Task 4 + Global Constraints + Task 9 frame-escape; derived is-destructive without mutating `node.markers` → Task 6; remove `containsImpureCall` → Task 7; region-model tests + the four review mandates → Tasks 8–10; stdlib migration enumerated → Tasks 11–14; docs → Task 15. All spec sections map.
 
-**Placeholder scan:** every code step shows real code; stdlib splits are enumerated per function; the one genuinely unknown-shape functions (`shell.agency`) get an explicit read-and-enumerate step (Finding D) rather than an assumed pattern.
+**Review findings addressed:** Blocking 1 (parser cut) → Task 2 soft-`{` gate. Blocking 2 (8 dispatch sites) → dissolved by reusing `seqBlock`; only `bodySlots` gets a defensive leaf case (Task 4). Blocking 3 (formatter file) → Task 3 targets `agencyGenerator.ts:processSeqBlock`. Moderate (flip alignment) → the flip is its own inlined statement, not merged into a pre-region step. Minors: `:225` registry site noted (Task 6); `init()` caller grep (Task 5 Step 1); referenced-var/decl-visibility (Task 9 Step 2); nested compiled-output assertion (Task 10 Step 2).
 
-**Type consistency:** `functionContainsDestructiveBlock(body)`, `init(inDestructiveFunction)`, `blockEntryFlip()`, node `type: "destructiveBlock"` with `.body` are used consistently across Tasks 1, 5, 6, 7.
+**Placeholder scan:** every code step shows real code; stdlib splits enumerated per function; `shell.agency` gets an explicit read-and-enumerate step.
+
+**Type consistency:** `SeqBlock.destructive`, `MarkDestructiveRan`, `blockEntryFlip()`, `init(inDestructiveFunction)`, `functionContainsDestructiveBlock(body)` are used consistently across Tasks 1, 4, 5, 6.

--- a/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-review-2.md
+++ b/docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-review-2.md
@@ -1,0 +1,156 @@
+# Review round 2: destructive marker authoritative — the `destructive { }` region design
+
+Reviewer: Claude
+Date: 2026-07-12
+Target: `docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md`
+Prior round: `docs/superpowers/plans/2026-07-12-destructive-marker-authoritative-review.md`
+Branch/worktree: `feat/destructive-marker-authoritative`
+
+## Verdict
+
+**Close to executable; no blockers, but one caution must become the headline of
+the codegen task.** The spec was rewritten around a new `destructive { }` block
+construct — a genuine improvement that resolves both round-1 findings at the
+root:
+
+- Round-1 Finding 1 (comment/blank-line flips): gone. The per-statement
+  `containsImpureCall` scan is removed entirely; commit is now a single
+  region-entry flip. No incidental-body-content sensitivity remains.
+- Round-1 Finding 2 (guard-before-interrupt): gone, and now the *motivating*
+  case. The Problem section correctly shows every real stdlib `destructive def`
+  preps before its gate, so no whole-function rule can work — the gate must sit
+  *outside* the destructive region, which the block expresses and a marker
+  cannot.
+
+The two-notions separation (metadata `isDestructive` vs runtime `destructiveRan`)
+is well thought through and the blast-radius section already anticipates the
+descriptor-vs-entry-flip split. Findings below are one must-emphasize caution and
+several precision/test items.
+
+## Verified against code
+
+- **`neverStarted` survives `init() = true`.** `init()` is pushed at
+  `typescriptBuilder.ts:2132`, *after* the param-binding assignments
+  (`:2112–2129`). So a `destructive def` whose arg binding fails halts before
+  `init()` runs → `destructiveRan` stays false → `neverStarted`/retryable. §Design
+  "Runtime commit points" is correct.
+- **Entry flip keys on the raw marker alone.** `inDestructiveFunction` is set from
+  `node.markers?.destructive` at `:2266`. The spec's instruction to keep the
+  entry flip on the raw marker (not the derived `isDestructive`) matches how the
+  code already reads it.
+- **Rule 2 trusts the callee's runtime flag.** The outcome-flip
+  (`isFailure(r) ? r.destructiveRan : true`) means a callee whose `destructive {}`
+  block was never reached returns `destructiveRan = false` and does not taint its
+  caller. §Design point 4 holds.
+- **`containsImpureCall` is dead after removing Rule 1** — sole consumer was the
+  Rule-1 scan (confirmed round 1).
+- **`destructive` is a modifier-table keyword** (`parsers.ts:4704`,
+  `str("destructive")` + spaces), so the new block parser must coexist with it
+  (Finding E).
+
+## Finding A (must be the headline of the codegen task) — a conventional block would evaporate the flip, failing OPEN
+
+The single load-bearing constraint is buried in prose. Inside a normal Agency
+block, `__self = __bstack.locals` (the block's own frame) — verified at
+`typescriptBuilder.ts:3118–3119`:
+
+> Scope must be "block" so processLlmCall assigns into `__bstack.locals.__prompt`,
+> which is what `ts.self(...)` resolves to inside a block (where
+> `__self = __bstack.locals`).
+
+So if `destructive { }` were compiled as a conventional block, the entry flip
+`__self.__destructiveRan = true` would write the **block's** locals and evaporate
+at block exit. The failure leaving the function would then carry
+`destructiveRan = false` → the tool is **not** removed. That is the dangerous
+direction (fail-open), and it is the exact pre-existing hole where writeAgency's
+guard-block flips already evaporate.
+
+The spec's "no new lexical scope / use `processBodyAsParts` / NOT
+`processBlockPlain`" is the correct fix, but states the *what* without the *why*.
+Make the failure mode explicit so no one reuses block infrastructure as a
+shortcut, and pin it with a test that asserts `destructiveRan` is **true on a
+failure that escapes the whole function after the block** (i.e. reaches the
+function's exit stamp / activation `__self`), not merely observable at block
+entry. Testing at block entry alone would pass even in the broken frame-local
+implementation.
+
+## Finding B (moderate) — specify the inline-splice mechanism, not just "use processBodyAsParts"
+
+For (1) substep ids continuous with the enclosing body (so an interrupt inside
+the block resumes at the correct step relative to statements *after* the block)
+and (2) declarations inside the block visible after it, the block body must be
+**spliced into the enclosing statement stream**, not returned as one compound
+node from `processStatement`.
+
+The existing precedent is the pipe-chain expansion inside `processBodyAsParts`
+(`:3956–3972`): detect the special node, `flushPart()`, emit the pre-formed runner
+nodes inline with continuing ids, `continue`. Direct the implementer to mirror
+that shape for `destructiveBlock`: in `processBodyAsParts`, special-case it —
+flush, push the entry flip into the active part, then process its body inline with
+continuing ids. Without this pin, a naive `processStatement` case returns one
+compound node and silently breaks both interrupt-resume and declaration
+visibility. Add a test: a `let` declared inside `destructive { }` is used after
+the block, and an interrupt inside the block resumes correctly with a statement
+following the block.
+
+## Finding C (moderate) — success-path coarseness is now reachable in normal control flow; state it, don't imply parity
+
+On the SUCCESS path, `toolDidDestructiveWork` reads the coarse descriptor marker,
+not the runtime flag — confirmed at `prompt.ts:1156–1158`:
+
+```
+const toolDidDestructiveWork = isFailure(toolResult)
+  ? toolResult.destructiveRan
+  : !!handler.markers?.destructive;
+```
+
+For a contains-block function this is true whenever the tool succeeds, even if
+execution never entered the block — e.g. an early `return success()` before the
+block, or a block behind a condition. That over-taints the caller via decision-8.
+Under the old whole-function model, success ⇒ did-work was defensible (the whole
+body was destructive). Under the block model it is now reachable in ordinary
+control flow. The spec's "consistent with today's `destructive def` success
+handling" undersells this.
+
+It is the **safe** direction (over-taint, never under-taint), so acceptable — but
+say so precisely so the owner signs off knowing the new reachability. If precision
+is wanted, name as a possible non-goal: the success path could also consult the
+runtime `destructiveRan` (which the transparent-block flip already maintains on
+`__self`), collapsing the failure and success paths onto one signal.
+
+## Finding D (minor) — migration: `return` inside the block, and per-function boundary is real work
+
+- The `write` example wraps `return try _write(...)` in `destructive { }`. A
+  `return` inside the transparent block must halt the **function** and trigger the
+  function exit stamp that folds `destructiveRan` — which works only because the
+  block is inline (Finding A), not a frame with its own halt. Add to the
+  transparency test: a `return` inside `destructive { }` exits the function and
+  the escaping failure carries `destructiveRan = true`.
+- The uniform three-line pattern (prep / gate / `destructive { work }`) will not
+  hold for every function — some split effectful work across statements or
+  interleave post-processing. The spec acknowledges "the exact gate/work boundary
+  must be identified"; the plan should **enumerate each function's split**
+  explicitly rather than assume the pattern, since a mis-drawn boundary either
+  leaves committed work outside the region (fail-open) or pulls the gate inside
+  it (removes on legitimate rejection).
+
+## Finding E (minor / confirm) — parser disambiguation cases to pin
+
+`destructive` is parsed by the function-modifier table (`parsers.ts:4704`). The
+new block statement parser must be positioned so that `destructive {` cleanly
+fails the function-def path (no `def` follows) and backtracks to the block parser,
+and so `destructive` as an ordinary identifier/expression still parses. Feasible
+with tarsec `or` backtracking; pin with tests for: `destructive { }` as a
+statement, `destructive def` unchanged, and a nested `destructive { }` inside a
+`destructive def` (spec says harmless no-op — assert it compiles and the flag is
+already true).
+
+## Altitude
+
+Right call. Introducing a language construct is heavier than the round-1 predicate
+tweak, but the Problem section earns it: no whole-function marker can express
+"gate outside, committed work inside," and my round-1 review already showed the
+lighter interrupt-heuristic breaks on real stdlib code. A block is the clean,
+composable primitive. One optional addition: a one-line rejected-alternatives note
+(e.g. why a block beats marking the interrupt itself, or a `gate { }` inverse)
+would round out the design the way round 1 had one.

--- a/docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md
+++ b/docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md
@@ -1,0 +1,203 @@
+# Make the `destructive` marker authoritative for tool removal-on-failure
+
+Date: 2026-07-12
+Status: Design (approved, pre-plan)
+
+## Problem
+
+When an LLM-callable tool marked `destructive` fails, it should be removed from
+the tool set so the model cannot call it again — a failure may have left the
+world in an unclean state. Today that does not reliably happen. Removal is gated
+on a runtime flag, `destructiveRan`, and the flag is set by a compiler heuristic
+that has nothing to do with the `destructive` declaration.
+
+Inside a `destructive`-marked function, `DestructiveTracking.statementFlips`
+(in `lib/backends/typescriptBuilder/destructiveTracking.ts`) emits
+`__self.__destructiveRan = true` before any statement for which
+`NameClassifier.containsImpureCall(stmt)` is true. `containsImpureCall` returns
+true only when the statement calls an **imported** name or a member of
+`BUILTIN_FUNCTIONS`. `BUILTIN_FUNCTIONS` is `{}` (empty, `lib/config.ts`), so in
+practice the flag flips only before a statement that calls an imported symbol.
+
+Consequences, all verified by compiling probes and running the real LLM:
+
+- A `destructive` function whose interrupt is its first statement, rejected,
+  keeps `destructiveRan = false` → the tool-loop classifies the failure as the
+  `neutral` tier ("you may call this tool again") → the model retries it up to
+  `MAX_TOOL_FAILURES` (5). Removal never happens after a single failure.
+- Adding `print("hello")` before the interrupt *does* cause removal — only
+  because `print` is a prelude **import**, so `containsImpureCall` fires. The
+  effect turns on an unrelated accident (import vs. local `def`), not on the
+  `destructive` declaration.
+- A call to a same-file `def` (which could do arbitrary destructive I/O) does
+  **not** flip the flag, because a local `def` is not an import.
+
+So whether a failed destructive tool is removed depends on whether its body
+happened to call an imported symbol before failing. That is incoherent: the
+`destructive` marker is a user declaration and should be authoritative.
+
+## Goal
+
+A tool declared `destructive` that **fails** is removed and cannot be called
+again by the LLM, regardless of the body — with one narrow, principled
+exception: failures where **no non-interrupt statement of the body executed**.
+Success stays re-callable (unchanged).
+
+### Retryable vs. removed (agreed)
+
+A destructive tool's failure is **retryable** iff *no non-interrupt statement of
+its body executed before the failure*; otherwise the tool is **removed**.
+
+| Failure point | non-interrupt stmt ran? | Outcome |
+|---|---|---|
+| Bad arguments — argument binding fails, body never starts | no | retryable (`neverStarted` tier) |
+| Rejected at an interrupt that is the first/only statement executed | no | retryable (`neutral` tier) |
+| Any statement other than a leading interrupt runs, then fails | **yes** | **removed** (`destructive` tier) |
+| Success | — | stays callable (unchanged) |
+
+Accepted trade-off: pure validation-refusals in destructive tools become
+non-retryable. A guard like `if (x < 0) { return failure(...) }` is a
+non-interrupt statement, so reaching it commits the tool. The model can no
+longer "fix the arguments and retry" *once the body has started*; it can still
+retry a call that failed **argument binding** (see the bad-args row), because
+there the body never ran.
+
+## Approach (chosen: redefine the flip predicate)
+
+Change the single predicate that decides when `destructiveRan` flips inside a
+destructive function, from "the statement calls an import" to "the statement is
+anything other than raising an interrupt." This makes one concept mean one thing
+across all three consumers of `destructiveRan` (the observable `r.destructiveRan`
+Result field, decision-8 caller propagation, and statelog), and deletes the
+import heuristic from this path.
+
+Rejected alternative — *tool-loop only*: leave `destructiveRan`'s import
+heuristic in place for the field/decision-8, and make `failureTier` key on
+`handler.markers.destructive` plus a new parallel signal for "a non-interrupt
+statement ran." Rejected because it adds a second flag and leaves the incoherent
+import-heuristic meaning of `destructiveRan` in place — the exact thing this
+change is meant to remove.
+
+## Design
+
+### 1. Codegen: the flip predicate
+
+In `DestructiveTracking.statementFlips`, the `inDestructiveFunction` branch
+currently returns a pre-flip when `containsImpureCall(stmt)`. Replace that
+condition with `!isInterruptOnlyStatement(stmt)`:
+
+```
+if (inDestructiveFunction) {
+  return isInterruptOnlyStatement(stmt) ? {} : { pre: markTrue() };
+}
+```
+
+Emitting `markTrue()` before every non-interrupt statement is redundant after
+the first (the flag is sticky `= true`) but harmless and needs no "first
+statement" bookkeeping. The `init()` (`__destructiveRan = __destructiveRan ?? false`)
+and `exitStamp()` (`stampFailureBoundary(runner.haltResult, __self.__destructiveRan)`)
+are unchanged. The non-destructive branch (Rule 2, `containsDestructiveCall`
+before calls to `destructive` functions) is unchanged.
+
+`containsImpureCall` in `NameClassifier` is no longer used by this rule. Confirm
+during implementation that it has no remaining consumer; if dead, remove it.
+
+### 2. `isInterruptOnlyStatement(stmt)`
+
+True only for a statement whose *sole* action is raising an interrupt:
+
+- a bare `interruptStatement` (`interrupt(...)` or `raise ...`); or
+- a `returnStatement` whose `value` is directly an `interruptStatement`
+  (`return interrupt(...)`); or
+- an assignment whose value is directly an `interruptStatement`
+  (`let x = interrupt(...)`).
+
+Everything else is non-interrupt and flips the flag: pure computation, property
+access, calls (local or imported), `if`/`while`/`for` (even one that merely
+wraps an interrupt in its body), and any expression that only *contains* an
+interrupt as a sub-part. Deliberately conservative — only a leading, direct
+interrupt gate is treated as clean. (`return interrupt(...)` parses as a
+`returnStatement` whose `value.type === "interruptStatement"`; verified.)
+
+Correctness edge: the predicate must fire only on **executable** statements.
+Non-executable nodes (comments, blank lines, type-only nodes) must not flip the
+flag. Today `containsImpureCall` returns false for them so they never flip;
+`!isInterruptOnlyStatement` would return true for them, so the implementation
+must confirm `statementFlips` is reached only for executable statements (it is
+guarded by an earlier `continue`/skip in the statement loop) or exclude those
+node types explicitly.
+
+### 3. New meaning of `destructiveRan`
+
+"At least one non-interrupt statement of a destructive function's body began
+executing." This replaces "a statement was about to call an imported symbol." It
+is the same value observed by:
+
+- the `r.destructiveRan` field on `ResultFailure` (`lib/runtime/result.ts`),
+  typed in the checker (`resultUnion.ts`, `synthesizer.ts`);
+- decision-8 propagation, where a destructive tool inside `llm()` folds its flag
+  into the caller's activation (`lib/runtime/prompt.ts`, `markDestructiveWork`);
+- statelog (`lib/statelogClient.ts`).
+
+Consequence to note: decision-8 propagation now fires on *any* non-interrupt
+work in a destructive callee, not just imported calls — so an enclosing
+agent-as-tool is tainted more readily. This is consistent with the model (a
+destructive sub-operation that did work and then failed taints the caller).
+
+### 4. Removal wiring — unchanged
+
+`failureTier` (`lib/runtime/prompt.ts`) already returns the `destructive` tier
+(→ `removedTools.push`) when `failure.destructiveRan` is true, and the
+`neverStarted` tier (retryable) when the body never started. With the corrected
+flip, no tool-loop change is needed:
+
+- bad args → body never runs → `destructiveRan` false, `neverStarted` true →
+  `neverStarted` tier (retryable);
+- rejected at a leading interrupt → `destructiveRan` false, `neverStarted` false
+  → `neutral` tier (retryable);
+- any other statement then fail → `destructiveRan` true → `destructive` tier
+  (removed);
+- success → not a failure → no removal.
+
+The `destructive` tier already removes the tool after a **single** such failure
+and messages the model that the tool can no longer be called.
+
+## Blast radius / files
+
+- `lib/backends/typescriptBuilder/destructiveTracking.ts` — predicate change +
+  `isInterruptOnlyStatement` (here or on `NameClassifier`); its unit tests
+  (`destructiveTracking.test.ts`) — the "impure call flips" cases become
+  "non-interrupt statement flips"; the `init()` unconditional test is unchanged.
+- `NameClassifier` (`lib/backends/typescriptBuilder/nameClassifier.ts`) — remove
+  `containsImpureCall` if it becomes dead.
+- `tests/agency/destructive-tracking.agency` (+ `.test.json`) — rewrite the
+  expectations. Under the new rule `burn(-1)` fails at `if (x < 0) return
+  failure(...)`, a non-interrupt statement, so `destructiveRan` is now **true**;
+  it is no longer a "clean refusal." Replace/extend with genuine clean cases
+  (interrupt-first reject → false; bad-args → false) and keep a work-then-fail
+  case (→ true).
+- `lib/runtime/result.ts` — JSDoc on the `destructiveRan` field.
+- `docs/site/guide/llm-part-2.md` — the "when a tool call fails" section:
+  reword "clean refusal" to "pre-body / interrupt-gate only."
+- Doc comments in `destructiveTracking.ts` referencing the old rationale.
+
+## Testing
+
+- Rewrite the `destructive-tracking` agency tests to encode the agreed table:
+  interrupt-first reject → retryable/`destructiveRan` false; any other statement
+  then fail → removed/`destructiveRan` true; bad-args → retryable.
+- Add a tool-removal behavior test (agency or agency-js, deterministic LLM — no
+  real model needed, since removal is driven by `destructiveRan`, which is
+  deterministic): a `destructive` tool that runs a non-interrupt statement then
+  fails is removed after one failure; one rejected only at its leading interrupt
+  is not.
+- Unit tests for `isInterruptOnlyStatement` and the flip predicate.
+- Full lib suite (8000+) must stay green.
+
+## Non-goals
+
+- Whether a **non-destructive** tool's rejected interrupt should be retryable at
+  all — that is a separate question (surfaced by the `interrupt.test.json`
+  flake, PR #533) and is not addressed here.
+- Success-path semantics — a successful destructive tool remains callable
+  (unchanged).

--- a/docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md
+++ b/docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md
@@ -114,22 +114,49 @@ before failing. Otherwise it is retryable.
 
 The block introduces **no new lexical scope** — it is purely a
 destructive-region marker; declarations inside it are visible after it, like a
-plain statement group. Its body statements must be compiled through the **same
-step-aware statement machinery as the enclosing function body**
-(`processBodyAsParts`, which assigns substep ids and drives interrupt
-pause/resume), NOT through `processBlockPlain` (which is the interrupt-free
-"plain" path used for expression-position match arms). Concretely,
-`destructive { s1; s2 }` compiles as the stream `[flip, s1, s2]` inside the
-enclosing function's stepped statements, so `s1`/`s2` get normal substep ids.
+plain statement group. Its body statements are compiled through the **same
+step-aware statement machinery as the enclosing function body**, spliced INLINE
+into that stream. Concretely, `destructive { s1; s2 }` compiles as
+`[flip, s1, s2]` inside the enclosing function's stepped statements, so
+`s1`/`s2` get substep ids continuous with the rest of the body.
+
+**HEADLINE CONSTRAINT for the codegen task — a conventional block flips the flag
+into the wrong frame and fails OPEN.** Inside a normal Agency block,
+`__self = __bstack.locals` (the block's own frame, `typescriptBuilder.ts`
+~3118). If `destructive { }` were compiled as a conventional block, the entry
+flip `__self.__destructiveRan = true` would write the **block's** locals and
+**evaporate at block exit**. The failure leaving the function would then carry
+`destructiveRan = false` → the tool is **NOT removed**. That is the dangerous
+(fail-open) direction, and it is the same pre-existing hole where writeAgency's
+guard-block flips already evaporate. The flip must land on the **enclosing
+function's** activation `__self` — which is exactly why the block must be
+inlined (transparent), not compiled as a frame-bearing block.
+
+**Implementation mechanism (pin this, don't paraphrase as "use
+`processBodyAsParts`").** Mirror the existing pipe-chain expansion inside
+`processBodyAsParts` (`typescriptBuilder.ts` ~3956–3972): special-case a
+`destructiveBlock` node in that loop — `flushPart()`, push the entry flip into
+the active part, then process the block's body statements **inline with
+continuing substep ids**, then `continue`. Do NOT return one compound node from
+`processStatement`: that silently breaks both interrupt-resume (ids no longer
+continuous with statements after the block) and declaration visibility
+(bindings trapped in a nested node). Use `processBlockPlain` nowhere here (it is
+the interrupt-free "plain" path for expression-position match arms).
 
 **Interrupts inside a destructive block must work correctly** (explicit
 requirement). Because the region commits at entry, an interrupt inside the block
 is after the commit: rejecting it removes the tool (you placed the gate inside
-the destructive region). The mechanics must hold regardless: an `interrupt(...)`
-or async call inside the block pauses and resumes at the right substep, and the
-entry `__destructiveRan = true` survives checkpoint/resume — it re-applies
-idempotently on replay and is already preserved across serialization (per the
-#522 boundary-folding design). This is mandated by tests (below).
+the destructive region). Because the block is inlined, an `interrupt(...)` or
+async call inside it pauses and resumes at the correct substep relative to
+statements *after* the block, and the entry `__destructiveRan = true` survives
+checkpoint/resume — it re-applies idempotently on replay and is preserved across
+serialization (per the #522 boundary-folding design). A `return` inside the
+block halts the **function** (again, only because the block is inline) and hits
+the function exit stamp that folds `destructiveRan`. All of this is mandated by
+tests (below), including one that asserts `destructiveRan` is true on a failure
+that **escapes the whole function after the block** (reaches the function's exit
+stamp / activation `__self`) — testing only at block entry would pass even in
+the broken frame-local implementation.
 
 ### `destructiveRan` meaning
 
@@ -192,12 +219,17 @@ move, remove), `stdlib/shell.agency` (exec, bash), `stdlib/index.agency`
 (write, writeBinary), `stdlib/clipboard.agency` (copy), and any others surfaced
 by `grep -rn "destructive def" stdlib/`.
 
-Per-function the exact gate/work boundary must be identified — several use the
-`return interrupt <effect>(...)` continuation form, where the statement after
-the gate is the work performed on approval; the `destructive { }` wraps that
-work. Because these functions contain a `destructive { }` block, they remain
-`markers.destructive`-true for client hints and the Rule 2 registry (see "Two
-notions"). Rebuild with `make` after editing any stdlib `.agency`.
+The uniform three-line pattern will NOT hold for every function — some split
+effectful work across statements, interleave post-processing, or use the
+`return interrupt <effect>(...)` continuation form (where the statement after
+the gate is the work performed on approval). The **plan must enumerate each
+function's gate/work split explicitly** rather than assume the pattern: a
+mis-drawn boundary either leaves committed work *outside* the region (fail-open:
+the tool is not removed after doing damage) or pulls the gate *inside* it
+(removes the tool on a legitimate rejection). Because these functions contain a
+`destructive { }` block, they remain `isDestructive`-true for client hints and
+the Rule 2 registry (see "Two notions"). Rebuild with `make` after editing any
+stdlib `.agency`.
 
 ## Blast radius / files
 
@@ -214,10 +246,16 @@ notions"). Rebuild with `make` after editing any stdlib `.agency`.
   would wrongly turn on `inDestructiveFunction`/the entry flip for a
   contains-block-only function. Note the emitted descriptor marker is also read
   at runtime on the SUCCESS path (`handler.markers?.destructive` →
-  `toolDidDestructiveWork`, `prompt.ts` ~1157); for a contains-block function
-  this coarsely assumes the block ran on success, consistent with today's
-  `destructive def` success handling. The failure path stays precise (it uses
-  the runtime `destructiveRan`).
+  `toolDidDestructiveWork`, `prompt.ts` ~1156–1158). For a contains-block
+  function this is true whenever the tool succeeds, **even if execution never
+  entered the block** — e.g. an early `return success()` before the block, or a
+  block behind a condition. Under the old whole-function model success ⇒
+  did-work was exact; under the block model this over-taint becomes reachable in
+  ordinary control flow, propagating `destructiveRan` to the caller via
+  decision-8 when the block may not have run. It is the **safe** direction
+  (over-taint, never under-taint), so it is acceptable — see the non-goal option
+  to unify the success path onto the runtime flag. The failure path stays
+  precise (it uses the runtime `destructiveRan`).
 - `lib/compilationUnit.ts` — populate `destructiveFunctions` from marked-OR-
   contains-block (~180).
 - `lib/backends/typescriptBuilder/nameClassifier.ts` — remove `containsImpureCall`
@@ -237,19 +275,34 @@ notions"). Rebuild with `make` after editing any stdlib `.agency`.
 - Rewrite `destructive-tracking` agency tests to the region model:
   `destructive def` body entry → `destructiveRan` true; `destructive { }` entry
   → true; failure before a block (prep/gate) → false; bad-args → false.
+- **Frame-escape test (Finding A — the anti-fail-open guard):** a failure that
+  escapes the **whole function** after passing through a `destructive { }` block
+  must carry `destructiveRan = true` at the function exit stamp / activation
+  `__self` — NOT merely observable at block entry. A test that only checks the
+  flag at block entry would pass even in the broken frame-local implementation,
+  so this test must assert at function-escape.
 - **Interrupts in a destructive block** (mandated): an execution test where a
   `destructive { }` block contains an interrupt — approve path resumes and
   completes; reject path removes the tool; a pause/resume across the block
-  preserves `destructiveRan`. These are deterministic (no real LLM needed;
-  removal is `destructiveRan`-driven).
+  preserves `destructiveRan`. Deterministic (no real LLM; removal is
+  `destructiveRan`-driven).
+- **Inline-splice test (Finding B):** a `let` declared inside `destructive { }`
+  is used *after* the block (declaration visibility), and an interrupt inside the
+  block resumes correctly with a statement following the block (continuous
+  substep ids).
+- **Return-in-block test (Finding D):** a `return` inside `destructive { }` exits
+  the function; an escaping failure after such a block carries
+  `destructiveRan = true`.
 - Tool-removal behavior test: a tool that fails inside its destructive region is
   removed after one failure; one that fails/rejects before the region is
   retryable.
 - Stdlib: a representative migrated tool (e.g. `write`) — rejecting the gate is
   retryable; failing inside the block removes it; MCP/HTTP still report it
   destructive.
-- Parser/formatter unit tests for `destructive { }`; typescriptGenerator
-  fixtures.
+- **Parser disambiguation (Finding E):** `destructive { }` as a statement;
+  `destructive def` unchanged; `destructive` as an ordinary identifier still
+  parses; a nested `destructive { }` inside a `destructive def` compiles (no-op,
+  flag already true). Plus formatter unit tests and typescriptGenerator fixtures.
 - Full lib suite (8000+) green.
 
 ## Non-goals
@@ -258,3 +311,31 @@ notions"). Rebuild with `make` after editing any stdlib `.agency`.
   separate question (the `interrupt.test.json` flake, PR #533).
 - Success-path semantics — a successful destructive tool stays callable.
 - Block-level lexical scoping — `destructive { }` introduces no new scope.
+- **Unifying the success path onto the runtime flag (Finding C option, not
+  taken):** the SUCCESS-path `toolDidDestructiveWork` could consult the runtime
+  `destructiveRan` (which the transparent-block flip already maintains on
+  `__self`) instead of the coarse descriptor marker, collapsing the success and
+  failure paths onto one signal and removing the over-taint. Left out to keep
+  this change scoped; the current over-taint is the safe direction. Revisit if
+  the extra caller-taint proves noisy.
+
+## Rejected alternatives
+
+- **A per-statement heuristic (round-1 predicate approach).** Flip
+  `destructiveRan` before the first "non-interrupt" (or "impure-call") statement.
+  Rejected: every real stdlib `destructive def` preps before its gate, so the
+  first statement commits and rejecting the gate removes the tool. No
+  whole-function rule can express "gate outside, committed work inside."
+- **Marking the interrupt itself** (e.g. a "committing interrupt"). Rejected: the
+  commit boundary is the *work*, not the gate; a function may have work with no
+  gate, or a gate far from the work. A region names the work directly.
+- **An `idempotent { }` block, for syntactic symmetry with `destructive { }`.**
+  Rejected: the two markers are not mirror concepts. `destructive` is a *commit
+  point* — a function has a natural before/after boundary (clean prep/gate, then
+  touching the world), which a region expresses. `idempotent` is a *global
+  promise* that re-running the whole tool from the start is safe; a retry always
+  restarts the tool, never resumes at a sub-region, so there is nothing for a
+  region boundary to attach to and nothing consumes a per-region idempotency
+  signal. An `idempotent { }` block would compile to nothing operational and
+  would falsely imply a tool can be "partly idempotent." `idempotent` stays a
+  function marker only.

--- a/docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md
+++ b/docs/superpowers/specs/2026-07-12-destructive-marker-authoritative-design.md
@@ -1,4 +1,4 @@
-# Make the `destructive` marker authoritative for tool removal-on-failure
+# Make the `destructive` marker authoritative for removal-on-failure, via destructive regions
 
 Date: 2026-07-12
 Status: Design (approved, pre-plan)
@@ -7,197 +7,254 @@ Status: Design (approved, pre-plan)
 
 When an LLM-callable tool marked `destructive` fails, it should be removed from
 the tool set so the model cannot call it again — a failure may have left the
-world in an unclean state. Today that does not reliably happen. Removal is gated
-on a runtime flag, `destructiveRan`, and the flag is set by a compiler heuristic
-that has nothing to do with the `destructive` declaration.
+world in an unclean state. Today that does not reliably happen, and *whether* it
+happens depends on an accident of the function body.
 
-Inside a `destructive`-marked function, `DestructiveTracking.statementFlips`
-(in `lib/backends/typescriptBuilder/destructiveTracking.ts`) emits
-`__self.__destructiveRan = true` before any statement for which
-`NameClassifier.containsImpureCall(stmt)` is true. `containsImpureCall` returns
-true only when the statement calls an **imported** name or a member of
-`BUILTIN_FUNCTIONS`. `BUILTIN_FUNCTIONS` is `{}` (empty, `lib/config.ts`), so in
-practice the flag flips only before a statement that calls an imported symbol.
+Removal is gated on a runtime flag, `destructiveRan`. `failureTier`
+(`lib/runtime/prompt.ts`) returns the `destructive` tier (→ remove the tool)
+only when a failure carries `destructiveRan === true`. Inside a
+`destructive`-marked function, `DestructiveTracking.statementFlips`
+(`lib/backends/typescriptBuilder/destructiveTracking.ts`) sets the flag before
+any statement for which `NameClassifier.containsImpureCall(stmt)` is true —
+i.e. the statement calls an **imported** symbol (`BUILTIN_FUNCTIONS` is empty,
+`lib/config.ts`). So the flag flips based on whether the body happened to call
+an import (e.g. `print`) versus a same-file `def`, not on the `destructive`
+declaration. Verified by compiling probes: a call to a local `def` emits no
+flip; the flip appears only before an imported call. `print("hello")` before an
+interrupt flips it; a local helper does not.
 
-Consequences, all verified by compiling probes and running the real LLM:
-
-- A `destructive` function whose interrupt is its first statement, rejected,
-  keeps `destructiveRan = false` → the tool-loop classifies the failure as the
-  `neutral` tier ("you may call this tool again") → the model retries it up to
-  `MAX_TOOL_FAILURES` (5). Removal never happens after a single failure.
-- Adding `print("hello")` before the interrupt *does* cause removal — only
-  because `print` is a prelude **import**, so `containsImpureCall` fires. The
-  effect turns on an unrelated accident (import vs. local `def`), not on the
-  `destructive` declaration.
-- A call to a same-file `def` (which could do arbitrary destructive I/O) does
-  **not** flip the flag, because a local `def` is not an import.
-
-So whether a failed destructive tool is removed depends on whether its body
-happened to call an imported symbol before failing. That is incoherent: the
-`destructive` marker is a user declaration and should be authoritative.
-
-## Goal
-
-A tool declared `destructive` that **fails** is removed and cannot be called
-again by the LLM, regardless of the body — with one narrow, principled
-exception: failures where **no non-interrupt statement of the body executed**.
-Success stays re-callable (unchanged).
-
-### Retryable vs. removed (agreed)
-
-A destructive tool's failure is **retryable** iff *no non-interrupt statement of
-its body executed before the failure*; otherwise the tool is **removed**.
-
-| Failure point | non-interrupt stmt ran? | Outcome |
-|---|---|---|
-| Bad arguments — argument binding fails, body never starts | no | retryable (`neverStarted` tier) |
-| Rejected at an interrupt that is the first/only statement executed | no | retryable (`neutral` tier) |
-| Any statement other than a leading interrupt runs, then fails | **yes** | **removed** (`destructive` tier) |
-| Success | — | stays callable (unchanged) |
-
-Accepted trade-off: pure validation-refusals in destructive tools become
-non-retryable. A guard like `if (x < 0) { return failure(...) }` is a
-non-interrupt statement, so reaching it commits the tool. The model can no
-longer "fix the arguments and retry" *once the body has started*; it can still
-retry a call that failed **argument binding** (see the bad-args row), because
-there the body never ran.
-
-## Approach (chosen: redefine the flip predicate)
-
-Change the single predicate that decides when `destructiveRan` flips inside a
-destructive function, from "the statement calls an import" to "the statement is
-anything other than raising an interrupt." This makes one concept mean one thing
-across all three consumers of `destructiveRan` (the observable `r.destructiveRan`
-Result field, decision-8 caller propagation, and statelog), and deletes the
-import heuristic from this path.
-
-Rejected alternative — *tool-loop only*: leave `destructiveRan`'s import
-heuristic in place for the field/decision-8, and make `failureTier` key on
-`handler.markers.destructive` plus a new parallel signal for "a non-interrupt
-statement ran." Rejected because it adds a second flag and leaves the incoherent
-import-heuristic meaning of `destructiveRan` in place — the exact thing this
-change is meant to remove.
-
-## Design
-
-### 1. Codegen: the flip predicate
-
-In `DestructiveTracking.statementFlips`, the `inDestructiveFunction` branch
-currently returns a pre-flip when `containsImpureCall(stmt)`. Replace that
-condition with `!isInterruptOnlyStatement(stmt)`:
+The interrupt-guard idea does not rescue this in practice. Every real
+`destructive` function in stdlib validates/preps **before** its interrupt gate:
 
 ```
-if (inDestructiveFunction) {
-  return isInterruptOnlyStatement(stmt) ? {} : { pre: markTrue() };
+export destructive def write(...) {
+  if (useAgentCwd) { dir = applyAgentCwd(dir) }          // prep
+  return interrupt std::write("Are you sure?", {...})     // gate
+  return try _write(...)                                  // the destructive work
 }
 ```
 
-Emitting `markTrue()` before every non-interrupt statement is redundant after
-the first (the flag is sticky `= true`) but harmless and needs no "first
-statement" bookkeeping. The `init()` (`__destructiveRan = __destructiveRan ?? false`)
-and `exitStamp()` (`stampFailureBoundary(runner.haltResult, __self.__destructiveRan)`)
-are unchanged. The non-destructive branch (Rule 2, `containsDestructiveCall`
-before calls to `destructive` functions) is unchanged.
+Any rule that keys "committed" on "a non-interrupt statement ran" would treat
+the `if (useAgentCwd)` prep as committing, so rejecting the confirmation would
+remove `write` for the rest of the session. Rejecting one write should not
+disable writes forever. The gate needs to sit *outside* the destructive region,
+which a whole-function marker cannot express.
 
-`containsImpureCall` in `NameClassifier` is no longer used by this rule. Confirm
-during implementation that it has no remaining consumer; if dead, remove it.
+## Goal
 
-### 2. `isInterruptOnlyStatement(stmt)`
+Make the `destructive` declaration authoritative and let the user say exactly
+which code is destructive:
 
-True only for a statement whose *sole* action is raising an interrupt:
+- A function marked `destructive def` — its **entire body** is destructive.
+  Entering the body commits; any failure removes the tool. (No interrupt
+  special-case: the whole body is destructive by declaration.)
+- A new `destructive { ... }` **block** — only the code inside is destructive.
+  Entering the block commits; failing inside removes the tool. Code before the
+  block (prep, an interrupt gate) is not destructive, so failing there — or
+  rejecting the gate — is retryable.
+- Success stays re-callable (unchanged). Argument-binding failures (body never
+  runs) stay retryable (`neverStarted`).
 
-- a bare `interruptStatement` (`interrupt(...)` or `raise ...`); or
-- a `returnStatement` whose `value` is directly an `interruptStatement`
-  (`return interrupt(...)`); or
-- an assignment whose value is directly an `interruptStatement`
-  (`let x = interrupt(...)`).
+No compiler heuristic. The user declares the boundary; the compiler marks it.
 
-Everything else is non-interrupt and flips the flag: pure computation, property
-access, calls (local or imported), `if`/`while`/`for` (even one that merely
-wraps an interrupt in its body), and any expression that only *contains* an
-interrupt as a sub-part. Deliberately conservative — only a leading, direct
-interrupt gate is treated as clean. (`return interrupt(...)` parses as a
-`returnStatement` whose `value.type === "interruptStatement"`; verified.)
+### Retryable vs. removed
 
-Correctness edge: the predicate must fire only on **executable** statements.
-Non-executable nodes (comments, blank lines, type-only nodes) must not flip the
-flag. Today `containsImpureCall` returns false for them so they never flip;
-`!isInterruptOnlyStatement` would return true for them, so the implementation
-must confirm `statementFlips` is reached only for executable statements (it is
-guarded by an earlier `continue`/skip in the statement loop) or exclude those
-node types explicitly.
+A destructive tool's failure removes the tool iff execution **entered a
+destructive region** (a `destructive def` body, or a `destructive { }` block)
+before failing. Otherwise it is retryable.
 
-### 3. New meaning of `destructiveRan`
+| Failure point | Entered a destructive region? | Outcome |
+|---|---|---|
+| Bad arguments — binding fails, body never runs | no | retryable (`neverStarted`) |
+| Rejected at an interrupt gate placed before the region | no | retryable (`neutral`) |
+| Inside a `destructive def` body (any statement) | yes | removed |
+| Inside a `destructive { }` block | yes | removed |
+| Success | — | stays callable |
 
-"At least one non-interrupt statement of a destructive function's body began
-executing." This replaces "a statement was about to call an imported symbol." It
-is the same value observed by:
+## Design
 
-- the `r.destructiveRan` field on `ResultFailure` (`lib/runtime/result.ts`),
-  typed in the checker (`resultUnion.ts`, `synthesizer.ts`);
-- decision-8 propagation, where a destructive tool inside `llm()` folds its flag
-  into the caller's activation (`lib/runtime/prompt.ts`, `markDestructiveWork`);
-- statelog (`lib/statelogClient.ts`).
+### Two notions, deliberately separated
 
-Consequence to note: decision-8 propagation now fires on *any* non-interrupt
-work in a destructive callee, not just imported calls — so an enclosing
-agent-as-tool is tainted more readily. This is consistent with the model (a
-destructive sub-operation that did work and then failed taints the caller).
+1. **Is a function destructive?** (metadata) — true if it is marked
+   `destructive def` **OR** its body contains a `destructive { }` block. This
+   drives the tool descriptor `markers.destructive` (`typescriptBuilder.ts`
+   ~2340), the MCP `destructiveHint` and HTTP `/list` boolean
+   (`lib/serve/*/adapter.ts`, both read `markers?.destructive`), and the
+   `compilationUnit.destructiveFunctions` registry used by Rule 2. A migrated
+   `def gitAdd(...) { … destructive { … } }` therefore still reports as
+   destructive to clients and to callers.
+2. **When does `destructiveRan` flip?** (runtime removal) — at **function
+   entry** for `destructive def`, or at **block entry** for `destructive { }`.
+   Only entering a region commits.
 
-### 4. Removal wiring — unchanged
+### Runtime commit points (codegen)
 
-`failureTier` (`lib/runtime/prompt.ts`) already returns the `destructive` tier
-(→ `removedTools.push`) when `failure.destructiveRan` is true, and the
-`neverStarted` tier (retryable) when the body never started. With the corrected
-flip, no tool-loop change is needed:
+- `destructive def`: `DestructiveTracking.init()` currently emits
+  `__self.__destructiveRan = __self.__destructiveRan ?? false`. For a
+  destructive-marked function, emit `__self.__destructiveRan = true` instead.
+  `init()` runs after argument binding and before the body, so an
+  argument-binding failure (`neverStarted`) still carries `destructiveRan =
+  false` and stays retryable; once the body begins, the tool is committed.
+- `destructive { }` block: emit `__self.__destructiveRan = true` at block entry,
+  as a non-step-consuming preamble (the same way the current pre-flip is pushed
+  into the active "part" without its own substep id), then compile the block
+  body.
+- A function that only **contains** a block (not itself marked `destructive
+  def`) does **not** flip at entry — it keeps the `?? false` init and commits
+  only when the block is entered. The entry flip is tied to the `destructive
+  def` marker alone; "contains a block" affects only the metadata notion below.
+- The per-statement Rule 1 scan (`containsImpureCall`) is **removed**.
+- Rule 2 (a non-destructive function calling a destructive function: the
+  outcome-flip that ORs the callee's `destructiveRan` into the caller, plus the
+  conservative pre-flip) is **unchanged**. It already trusts the callee's
+  runtime flag, so a function whose `destructive { }` block was not reached
+  returns `destructiveRan = false` and does not taint its caller.
 
-- bad args → body never runs → `destructiveRan` false, `neverStarted` true →
-  `neverStarted` tier (retryable);
-- rejected at a leading interrupt → `destructiveRan` false, `neverStarted` false
-  → `neutral` tier (retryable);
-- any other statement then fail → `destructiveRan` true → `destructive` tier
-  (removed);
-- success → not a failure → no removal.
+### The `destructive { }` block is a transparent, stepped region
 
-The `destructive` tier already removes the tool after a **single** such failure
-and messages the model that the tool can no longer be called.
+The block introduces **no new lexical scope** — it is purely a
+destructive-region marker; declarations inside it are visible after it, like a
+plain statement group. Its body statements must be compiled through the **same
+step-aware statement machinery as the enclosing function body**
+(`processBodyAsParts`, which assigns substep ids and drives interrupt
+pause/resume), NOT through `processBlockPlain` (which is the interrupt-free
+"plain" path used for expression-position match arms). Concretely,
+`destructive { s1; s2 }` compiles as the stream `[flip, s1, s2]` inside the
+enclosing function's stepped statements, so `s1`/`s2` get normal substep ids.
+
+**Interrupts inside a destructive block must work correctly** (explicit
+requirement). Because the region commits at entry, an interrupt inside the block
+is after the commit: rejecting it removes the tool (you placed the gate inside
+the destructive region). The mechanics must hold regardless: an `interrupt(...)`
+or async call inside the block pauses and resumes at the right substep, and the
+entry `__destructiveRan = true` survives checkpoint/resume — it re-applies
+idempotently on replay and is already preserved across serialization (per the
+#522 boundary-folding design). This is mandated by tests (below).
+
+### `destructiveRan` meaning
+
+"Execution entered a destructive region" — a `destructive def` body or a
+`destructive { }` block. One meaning across all consumers: the `r.destructiveRan`
+field on `ResultFailure` (`lib/runtime/result.ts`, typed in `resultUnion.ts` /
+`synthesizer.ts`), decision-8 caller propagation
+(`lib/runtime/prompt.ts` / `markDestructiveWork`), and statelog
+(`lib/statelogClient.ts`).
+
+### Removal wiring — unchanged
+
+`failureTier` already returns the `destructive` tier (→ single-failure removal)
+when `destructiveRan` is true, and `neverStarted` (retryable) when the body
+never started. With commit driven by region-entry, the table above holds with
+no tool-loop change.
+
+## New construct: `destructive { }`
+
+Following `docs/dev/adding-features.md` (adding an AST node):
+
+- **Type** — `DestructiveBlock = BaseNode & { type: "destructiveBlock"; body:
+  AgencyNode[] }` in `lib/types/`; export from `lib/types.ts`; add to the
+  `AgencyNode` union.
+- **Parser** — parse `destructive { … }` in `lib/parsers/parsers.ts`, wired into
+  the statement parser; co-located tests. Must disambiguate `destructive {`
+  (block) from the `destructive def` function marker and from `destructive` used
+  as an identifier.
+- **Formatter** — format `destructive { … }` (block body indented).
+- **Codegen** — a case that emits the entry flip and compiles the body through
+  the stepped statement path (see above).
+- **Typecheck / symbol table** — the block body typechecks and resolves in the
+  enclosing scope (no new bindings semantics). Confirm the generic node walkers
+  (`walkNodes`) descend into `.body` so symbol resolution, effect/`raises`
+  checking, and narrowing see the body; add a passthrough case where a pass
+  dispatches on node type.
+- **Fixtures** — `.agency`/`.mts` pairs in `tests/typescriptGenerator/`.
+
+Nesting notes: a `destructive { }` inside a `destructive def`, or nested
+`destructive { }` blocks, are harmless no-ops (the flag is already/again set).
+
+## Stdlib migration (in scope, this change)
+
+Migrate every stdlib `destructive def` whose interrupt gate should stay
+retryable-on-rejection to `def` + `destructive { }` around only the effectful
+work. Pattern:
+
+```
+export destructive def f(...) {          export def f(...) {
+  prep                              →       prep
+  interrupt gate                            interrupt gate
+  work                                       destructive { work }
+}                                         }
+```
+
+Functions to migrate (~20+): `stdlib/git.agency` (gitAdd, gitCommit,
+gitCheckout, gitSwitch, gitBranchCreate, gitBranchDelete, gitStashPush,
+gitStashPop, gitRestore), `stdlib/fs.agency` (edit, applyPatch, mkdir, copy,
+move, remove), `stdlib/shell.agency` (exec, bash), `stdlib/index.agency`
+(write, writeBinary), `stdlib/clipboard.agency` (copy), and any others surfaced
+by `grep -rn "destructive def" stdlib/`.
+
+Per-function the exact gate/work boundary must be identified — several use the
+`return interrupt <effect>(...)` continuation form, where the statement after
+the gate is the work performed on approval; the `destructive { }` wraps that
+work. Because these functions contain a `destructive { }` block, they remain
+`markers.destructive`-true for client hints and the Rule 2 registry (see "Two
+notions"). Rebuild with `make` after editing any stdlib `.agency`.
 
 ## Blast radius / files
 
-- `lib/backends/typescriptBuilder/destructiveTracking.ts` — predicate change +
-  `isInterruptOnlyStatement` (here or on `NameClassifier`); its unit tests
-  (`destructiveTracking.test.ts`) — the "impure call flips" cases become
-  "non-interrupt statement flips"; the `init()` unconditional test is unchanged.
-- `NameClassifier` (`lib/backends/typescriptBuilder/nameClassifier.ts`) — remove
-  `containsImpureCall` if it becomes dead.
-- `tests/agency/destructive-tracking.agency` (+ `.test.json`) — rewrite the
-  expectations. Under the new rule `burn(-1)` fails at `if (x < 0) return
-  failure(...)`, a non-interrupt statement, so `destructiveRan` is now **true**;
-  it is no longer a "clean refusal." Replace/extend with genuine clean cases
-  (interrupt-first reject → false; bad-args → false) and keep a work-then-fail
-  case (→ true).
-- `lib/runtime/result.ts` — JSDoc on the `destructiveRan` field.
-- `docs/site/guide/llm-part-2.md` — the "when a tool call fails" section:
-  reword "clean refusal" to "pre-body / interrupt-gate only."
-- Doc comments in `destructiveTracking.ts` referencing the old rationale.
+- `lib/backends/typescriptBuilder/destructiveTracking.ts` — `init()` sets `true`
+  for destructive functions; remove the `statementFlips` Rule-1 scan; its unit
+  tests.
+- `lib/backends/typescriptBuilder.ts` — `destructiveBlock` codegen case. Two
+  distinct predicates: (a) the **entry flip** (`init()` → `= true`) and
+  `inDestructiveFunction` (~2266) key on the raw `destructive def` marker ALONE
+  (`node.markers?.destructive`); (b) the **emitted descriptor** marker (~2340),
+  the MCP/HTTP hint, and the `destructiveFunctions` registry use a *derived*
+  `isDestructive = node.markers?.destructive || containsDestructiveBlock(node)`.
+  Do NOT mutate `node.markers.destructive` to fold in "contains a block" — that
+  would wrongly turn on `inDestructiveFunction`/the entry flip for a
+  contains-block-only function. Note the emitted descriptor marker is also read
+  at runtime on the SUCCESS path (`handler.markers?.destructive` →
+  `toolDidDestructiveWork`, `prompt.ts` ~1157); for a contains-block function
+  this coarsely assumes the block ran on success, consistent with today's
+  `destructive def` success handling. The failure path stays precise (it uses
+  the runtime `destructiveRan`).
+- `lib/compilationUnit.ts` — populate `destructiveFunctions` from marked-OR-
+  contains-block (~180).
+- `lib/backends/typescriptBuilder/nameClassifier.ts` — remove `containsImpureCall`
+  (sole consumer was Rule 1); confirm no other consumer.
+- New AST node plumbing: `lib/types/`, `lib/types.ts`, `lib/parsers/parsers.ts`
+  (+ tests), formatter, typecheck/symbol-table passthrough.
+- `tests/agency/destructive-tracking.agency` (+ `.test.json`) — rewrite to the
+  region model (see Testing).
+- Stdlib `.agency` files listed above (+ their tests where behavior asserts
+  removal/retryability).
+- `lib/runtime/result.ts` JSDoc on `destructiveRan`; `docs/site/guide/llm-part-2.md`
+  ("when a tool call fails" + document the `destructive { }` block);
+  doc comments in `destructiveTracking.ts`.
 
 ## Testing
 
-- Rewrite the `destructive-tracking` agency tests to encode the agreed table:
-  interrupt-first reject → retryable/`destructiveRan` false; any other statement
-  then fail → removed/`destructiveRan` true; bad-args → retryable.
-- Add a tool-removal behavior test (agency or agency-js, deterministic LLM — no
-  real model needed, since removal is driven by `destructiveRan`, which is
-  deterministic): a `destructive` tool that runs a non-interrupt statement then
-  fails is removed after one failure; one rejected only at its leading interrupt
-  is not.
-- Unit tests for `isInterruptOnlyStatement` and the flip predicate.
-- Full lib suite (8000+) must stay green.
+- Rewrite `destructive-tracking` agency tests to the region model:
+  `destructive def` body entry → `destructiveRan` true; `destructive { }` entry
+  → true; failure before a block (prep/gate) → false; bad-args → false.
+- **Interrupts in a destructive block** (mandated): an execution test where a
+  `destructive { }` block contains an interrupt — approve path resumes and
+  completes; reject path removes the tool; a pause/resume across the block
+  preserves `destructiveRan`. These are deterministic (no real LLM needed;
+  removal is `destructiveRan`-driven).
+- Tool-removal behavior test: a tool that fails inside its destructive region is
+  removed after one failure; one that fails/rejects before the region is
+  retryable.
+- Stdlib: a representative migrated tool (e.g. `write`) — rejecting the gate is
+  retryable; failing inside the block removes it; MCP/HTTP still report it
+  destructive.
+- Parser/formatter unit tests for `destructive { }`; typescriptGenerator
+  fixtures.
+- Full lib suite (8000+) green.
 
 ## Non-goals
 
-- Whether a **non-destructive** tool's rejected interrupt should be retryable at
-  all — that is a separate question (surfaced by the `interrupt.test.json`
-  flake, PR #533) and is not addressed here.
-- Success-path semantics — a successful destructive tool remains callable
-  (unchanged).
+- Whether a **non-destructive** tool's rejected interrupt should be retryable —
+  separate question (the `interrupt.test.json` flake, PR #533).
+- Success-path semantics — a successful destructive tool stays callable.
+- Block-level lexical scoping — `destructive { }` introduces no new scope.

--- a/packages/agency-lang/docs/site/guide/llm-part-2.md
+++ b/packages/agency-lang/docs/site/guide/llm-part-2.md
@@ -33,9 +33,28 @@ destructive def chargeCard(amount: number): string {
 }
 ```
 
-If a `destructive` tool starts running and then fails, Agency removes it from the conversation. The model cannot call it again, and the tool result tells it so: the operation may have partially completed, so the state must be verified by hand rather than by retrying.
+A `destructive def` marks the **whole body** as destructive: entering it commits. If the tool then fails anywhere in its body, Agency removes it from the conversation. The model cannot call it again, and the tool result tells it so: the operation may have partially completed, so the state must be verified by hand rather than by retrying.
 
-There is one exception. If the call fails *before the tool body starts* — the model passed the wrong arguments, or too few — then nothing happened yet, so the tool stays callable. Only a failure *after* the destructive work began locks the tool out.
+There is one exception. If the call fails *before the body starts* — the model passed the wrong arguments, or too few — then nothing ran yet, so the tool stays callable.
+
+#### `destructive { }` regions
+
+Marking a whole function `destructive` is often too coarse. Real tools validate their arguments and ask the user to confirm *before* doing anything dangerous — and rejecting that confirmation should leave the tool callable, not lock it out. Use a `destructive { }` region to mark only the effectful part, and leave the prep and the confirmation gate outside it:
+
+```agency
+def write(filename: string, content: string): Result {
+  const path = resolvePath(filename)
+  // Ask first — rejecting this is retryable, nothing has happened yet.
+  return interrupt std::write("Write to this file?", { path: path })
+  // Only this commits. A failure here removes the tool; a rejected
+  // confirmation above does not.
+  destructive {
+    return try _write(path, content)
+  }
+}
+```
+
+Entering the region flips the tool into "committed": a failure inside it (or after it) removes the tool, exactly like a `destructive def`. A failure *before* the region — a validation refusal, or a rejected interrupt gate — is retryable. The region introduces no new scope; variables declared inside it are visible afterward. A function that contains a `destructive { }` region is reported as destructive to clients (MCP/HTTP) just like a `destructive def`.
 
 ### `idempotent`
 
@@ -55,7 +74,7 @@ An `idempotent` tool stays callable after a failure (like the default), but the 
 |---|---|---|
 | *(unmarked)* | Yes | Re-callable, but not promised safe to repeat blindly. |
 | `idempotent` | Yes | Always safe to re-run. |
-| `destructive` | Only if it never started | Dangerous to repeat; locked out once it begins. |
+| `destructive` | Only if the body/region never started | Dangerous to repeat; locked out once a destructive region is entered. |
 
 These markers are about *retry safety* only. They are independent of [interrupts](/guide/interrupts), which gate whether a tool runs at all.
 

--- a/packages/agency-lang/docs/site/guide/llm-part-2.md
+++ b/packages/agency-lang/docs/site/guide/llm-part-2.md
@@ -33,28 +33,26 @@ destructive def chargeCard(amount: number): string {
 }
 ```
 
-A `destructive def` marks the **whole body** as destructive: entering it commits. If the tool then fails anywhere in its body, Agency removes it from the conversation. The model cannot call it again, and the tool result tells it so: the operation may have partially completed, so the state must be verified by hand rather than by retrying.
+A `destructive def` marks the whole body as destructive. Once the body starts, a failure anywhere removes the tool. The model cannot call it again: the operation may have half-finished, so its state needs a manual check.
 
-There is one exception. If the call fails *before the body starts* — the model passed the wrong arguments, or too few — then nothing ran yet, so the tool stays callable.
+One exception: a call that fails before the body starts (wrong or missing arguments) ran nothing, so the tool stays callable.
 
 #### `destructive { }` regions
 
-Marking a whole function `destructive` is often too coarse. Real tools validate their arguments and ask the user to confirm *before* doing anything dangerous — and rejecting that confirmation should leave the tool callable, not lock it out. Use a `destructive { }` region to mark only the effectful part, and leave the prep and the confirmation gate outside it:
+Marking a whole function is often too coarse. Most tools validate their arguments and ask for confirmation first. Rejecting that confirmation should leave the tool callable. Wrap only the effectful part in a `destructive { }` region, and keep the prep and the gate outside it:
 
 ```agency
 def write(filename: string, content: string): Result {
   const path = resolvePath(filename)
-  // Ask first — rejecting this is retryable, nothing has happened yet.
+  // Rejecting this gate is retryable: nothing has happened yet.
   return interrupt std::write("Write to this file?", { path: path })
-  // Only this commits. A failure here removes the tool; a rejected
-  // confirmation above does not.
   destructive {
     return try _write(path, content)
   }
 }
 ```
 
-Entering the region flips the tool into "committed": a failure inside it (or after it) removes the tool, exactly like a `destructive def`. A failure *before* the region — a validation refusal, or a rejected interrupt gate — is retryable. The region introduces no new scope; variables declared inside it are visible afterward. A function that contains a `destructive { }` region is reported as destructive to clients (MCP/HTTP) just like a `destructive def`.
+Entering the region commits the tool. A failure inside it, or after it, removes the tool. A failure before it stays retryable, whether a validation refusal or a rejected gate. The region adds no new scope, so a variable declared inside it is visible afterward. A function with a `destructive { }` region is reported as destructive to clients, the same as a `destructive def`.
 
 ### `idempotent`
 

--- a/packages/agency-lang/docs/site/stdlib/auth/keyring.md
+++ b/packages/agency-lang/docs/site/stdlib/auth/keyring.md
@@ -109,7 +109,7 @@ Retrieve a secret from the system keyring. Returns the secret value, or null if 
 
 **Throws:** `std::getSecret`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L47))
 
 ### deleteSecret
 
@@ -133,7 +133,7 @@ Delete a secret from the system keyring. Returns true if deleted, false if the k
 
 **Throws:** `std::deleteSecret`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L62))
 
 ### isKeyringAvailable
 
@@ -145,4 +145,4 @@ Check if the system keyring is available on this platform. Returns true on macOS
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/keyring.agency#L79))

--- a/packages/agency-lang/docs/site/stdlib/calendar.md
+++ b/packages/agency-lang/docs/site/stdlib/calendar.md
@@ -251,7 +251,7 @@ Update an existing event on Google Calendar. Pass the eventId and any fields to 
 
 **Throws:** `std::updateEvent`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L135))
 
 ### deleteEvent
 
@@ -275,4 +275,4 @@ Delete an event from Google Calendar by its event ID. Returns { deleted: true } 
 
 **Throws:** `std::deleteEvent`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/calendar.agency#L167))

--- a/packages/agency-lang/docs/site/stdlib/clipboard.md
+++ b/packages/agency-lang/docs/site/stdlib/clipboard.md
@@ -67,4 +67,4 @@ Read text from the system clipboard and return it.
 
 **Throws:** `std::clipboardPaste`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/clipboard.agency#L31))

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -153,7 +153,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L80))
 
 ### mkdir
 
@@ -183,7 +183,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L92))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L96))
 
 ### copy
 
@@ -216,7 +216,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L116))
 
 ### move
 
@@ -249,7 +249,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L139))
 
 ### remove
 
@@ -279,4 +279,4 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L152))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L162))

--- a/packages/agency-lang/docs/site/stdlib/git.md
+++ b/packages/agency-lang/docs/site/stdlib/git.md
@@ -536,7 +536,7 @@ Create a commit from the staged changes.
 
 **Throws:** `std::git::commit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L214))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L216))
 
 ### gitCheckout
 
@@ -567,7 +567,7 @@ Bind `force: false` via `.partial()` to forbid discarding local changes.
 
 **Throws:** `std::git::checkout`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L226))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L230))
 
 ### gitSwitch
 
@@ -596,7 +596,7 @@ Switch to a branch.
 
 **Throws:** `std::git::switch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L248))
 
 ### gitBranchCreate
 
@@ -622,7 +622,7 @@ Create a new branch at HEAD (does not switch to it).
 
 **Throws:** `std::git::branchCreate`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L254))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L262))
 
 ### gitBranchDelete
 
@@ -657,7 +657,7 @@ Guardrails: bind `force: false` and/or a `protectedBranches` list via
 
 **Throws:** `std::git::branchDelete`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L268))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L278))
 
 ### gitStashPush
 
@@ -683,7 +683,7 @@ Stash the working-tree changes.
 
 **Throws:** `std::git::stashPush`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L287))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L299))
 
 ### gitStashPop
 
@@ -704,7 +704,7 @@ Apply and drop the most recent stash.
 
 **Throws:** `std::git::stashPop`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L298))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L312))
 
 ### gitRestore
 
@@ -739,4 +739,4 @@ Restore files to a previous state.
 
 **Throws:** `std::git::restore`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L310))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L326))

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -307,7 +307,7 @@ Write base64-encoded binary data to a file: images, audio, video, PDFs, or any
 
 **Throws:** `std::writeBinary`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L195))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L197))
 
 ### readBinary
 
@@ -338,7 +338,7 @@ Read a file and return its contents as a Base64-encoded string. Works for any
 
 **Throws:** `std::readBinary`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L227))
 
 ### range
 
@@ -361,7 +361,7 @@ Generate an array of numbers. With one argument, counts from 0 to start-1;
 
 **Returns:** `number[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L246))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L250))
 
 ### map
 
@@ -383,7 +383,7 @@ Map a function over an array, returning a new array of results.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L267))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L271))
 
 ### filter
 
@@ -405,7 +405,7 @@ Return a new array containing only the elements for which the function returns t
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L281))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L285))
 
 ### exclude
 
@@ -427,7 +427,7 @@ Return a new array excluding elements for which the function returns true.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L297))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L301))
 
 ### find
 
@@ -449,7 +449,7 @@ Return the first element for which the function returns true, or null if none ma
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L313))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L317))
 
 ### findIndex
 
@@ -471,7 +471,7 @@ Return the index of the first element for which the function returns true, or -1
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L328))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L332))
 
 ### reduce
 
@@ -495,7 +495,7 @@ Reduce an array to a single value by applying a function to an accumulator and e
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L343))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L347))
 
 ### flatMap
 
@@ -517,7 +517,7 @@ Map a function over an array and flatten the results by one level.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L358))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L362))
 
 ### every
 
@@ -539,7 +539,7 @@ Return true if the function returns true for every element in the array.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L375))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L379))
 
 ### some
 
@@ -561,7 +561,7 @@ Return true if the function returns true for at least one element in the array.
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L390))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L394))
 
 ### count
 
@@ -583,7 +583,7 @@ Count the number of elements in the array for which the function returns true.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L405))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L409))
 
 ### sortBy
 
@@ -605,7 +605,7 @@ Return a new array sorted by the values returned by the function, in ascending o
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L421))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L425))
 
 ### unique
 
@@ -627,7 +627,7 @@ Return a new array with duplicate elements removed, using the function to determ
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L448))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L452))
 
 ### groupBy
 
@@ -649,7 +649,7 @@ Group elements of an array by the value returned by the function. Returns an obj
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L473))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L477))
 
 ### callback
 
@@ -671,4 +671,4 @@ Register a callback for a lifecycle event. A callback registered inside a
 | name | `string` |  |
 | fn | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L493))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/index.agency#L497))

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -284,7 +284,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Throws:** `std::memory::recall`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L211))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L213))
 
 ### forget
 
@@ -306,4 +306,4 @@ Soft-delete facts matching the query from the knowledge graph. Data is
 
 **Throws:** `std::memory::forget`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L231))

--- a/packages/agency-lang/docs/site/stdlib/messaging/email.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/email.md
@@ -160,7 +160,7 @@ Send an email using the SendGrid API. Requires `SENDGRID_API_KEY` env var or pas
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L82))
 
 ### sendWithMailgun
 
@@ -222,4 +222,4 @@ Send an email using the Mailgun API. Requires `MAILGUN_API_KEY` and `MAILGUN_DOM
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L123))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -180,7 +180,7 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L107))
 
 ### ls
 
@@ -218,7 +218,7 @@ List entries in a directory. Each entry has name, path, type ("file", "dir", "sy
 
 **Throws:** `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L158))
 
 ### grep
 
@@ -259,7 +259,7 @@ Search for a regex pattern in files under a directory. Returns matches with file
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L190))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L194))
 
 ### glob
 
@@ -295,7 +295,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Fails if the p
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L227))
 
 ### stat
 
@@ -329,7 +329,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L258))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L262))
 
 ### exists
 
@@ -360,7 +360,7 @@ Return true if a file or directory exists at the given path. Probing a path outs
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L280))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L284))
 
 ### which
 
@@ -380,4 +380,4 @@ Locate an executable in PATH and return its absolute path, or an empty string if
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L300))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L304))

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -1075,3 +1075,25 @@ describe("AgencyGenerator - destructive/idempotent markers", () => {
     expect(roundTrip(once)).toBe(once);
   });
 });
+
+describe("AgencyGenerator - destructive/seq blocks", () => {
+  function formatAgency(input: string): string {
+    const parseResult = parseAgency(input, {}, false);
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) return "";
+    const generator = new AgencyGenerator();
+    return generator.generate(parseResult.result).output.trim();
+  }
+
+  it("formats a destructive block with the destructive keyword", () => {
+    const output = formatAgency('def f() {\n  destructive {\n    return _w(x)\n  }\n}');
+    expect(output).toContain("destructive {");
+    expect(output).not.toContain("seq {");
+  });
+
+  it("still formats a seq block as seq", () => {
+    const output = formatAgency('def f() {\n  seq {\n    return 1\n  }\n}');
+    expect(output).toContain("seq {");
+    expect(output).not.toContain("destructive {");
+  });
+});

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1636,7 +1636,8 @@ export class AgencyGenerator {
     this.increaseIndent();
     const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
-    return this.indentStr(`seq {\n${bodyCodeStr}${this.indentStr("}")}`);
+    const kw = node.destructive ? "destructive" : "seq";
+    return this.indentStr(`${kw} {\n${bodyCodeStr}${this.indentStr("}")}`);
   }
 
   protected processHandleBlock(node: HandleBlock): string {

--- a/packages/agency-lang/lib/backends/functionContainsDestructiveBlock.test.ts
+++ b/packages/agency-lang/lib/backends/functionContainsDestructiveBlock.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { functionContainsDestructiveBlock } from "./functionContainsDestructiveBlock.js";
+import type { AgencyNode } from "../types.js";
+
+describe("functionContainsDestructiveBlock", () => {
+  it("true for a top-level destructive seqBlock", () => {
+    const body = [{ type: "seqBlock", destructive: true, body: [] }] as AgencyNode[];
+    expect(functionContainsDestructiveBlock(body)).toBe(true);
+  });
+
+  it("true for a destructive seqBlock nested inside an if", () => {
+    const body = [
+      {
+        type: "ifElse",
+        condition: { type: "boolean", value: true },
+        thenBody: [{ type: "seqBlock", destructive: true, body: [] }],
+        elseBody: [],
+      },
+    ] as unknown as AgencyNode[];
+    expect(functionContainsDestructiveBlock(body)).toBe(true);
+  });
+
+  it("false for a plain (non-destructive) seqBlock", () => {
+    const body = [{ type: "seqBlock", body: [] }] as AgencyNode[];
+    expect(functionContainsDestructiveBlock(body)).toBe(false);
+  });
+
+  it("true for the post-desugar markDestructiveRan leaf", () => {
+    const body = [{ type: "markDestructiveRan" }] as AgencyNode[];
+    expect(functionContainsDestructiveBlock(body)).toBe(true);
+  });
+
+  it("false when there is no seqBlock", () => {
+    const body = [{ type: "returnStatement", value: { type: "number", value: 1 } }] as unknown as AgencyNode[];
+    expect(functionContainsDestructiveBlock(body)).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/backends/functionContainsDestructiveBlock.ts
+++ b/packages/agency-lang/lib/backends/functionContainsDestructiveBlock.ts
@@ -7,6 +7,15 @@ import { walkNodesArray } from "../utils/node.js";
  *  registry. NEVER for the entry flip, which keys on the raw `destructive def`
  *  marker alone.
  *
+ *  This answers only "does the function DECLARE its own destructive work" — via
+ *  a region here, or via the raw `destructive def` marker checked by the caller.
+ *  It deliberately does NOT treat a function that merely CALLS a `destructive`
+ *  function as destructive: that runtime taint is handled separately by Rule 2
+ *  (`NameClassifier.containsDestructiveCall` + the `destructiveFunctions`
+ *  registry), which folds a callee's `destructiveRan` into the caller's failure.
+ *  (Agency has no nested function definitions, so there is no destructive-marked
+ *  function to find inside a body.)
+ *
  *  Matches BOTH forms of the region so it works on either side of the
  *  parallelDesugar pass: pre-desugar it is a `seqBlock` flagged `destructive`
  *  (what `compilationUnit` sees); post-desugar the seqBlock is inlined and the

--- a/packages/agency-lang/lib/backends/functionContainsDestructiveBlock.ts
+++ b/packages/agency-lang/lib/backends/functionContainsDestructiveBlock.ts
@@ -1,0 +1,21 @@
+import type { AgencyNode, SeqBlock } from "../types.js";
+import { walkNodesArray } from "../utils/node.js";
+
+/** True if any `destructive { }` region appears anywhere in `body`, including
+ *  nested blocks/ifs/loops. Used for the is-destructive METADATA only — the
+ *  emitted descriptor marker, the MCP/HTTP hint, and the `destructiveFunctions`
+ *  registry. NEVER for the entry flip, which keys on the raw `destructive def`
+ *  marker alone.
+ *
+ *  Matches BOTH forms of the region so it works on either side of the
+ *  parallelDesugar pass: pre-desugar it is a `seqBlock` flagged `destructive`
+ *  (what `compilationUnit` sees); post-desugar the seqBlock is inlined and the
+ *  region survives as a `markDestructiveRan` leaf (what `TypeScriptBuilder`
+ *  sees). */
+export function functionContainsDestructiveBlock(body: AgencyNode[]): boolean {
+  for (const { node } of walkNodesArray(body)) {
+    if (node.type === "markDestructiveRan") return true;
+    if (node.type === "seqBlock" && (node as SeqBlock).destructive) return true;
+  }
+  return false;
+}

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -112,6 +112,7 @@ import { SourceMapBuilder } from "./sourceMap.js";
 import { ScopeManager } from "./typescriptBuilder/scopeManager.js";
 import { StepPathTracker } from "./typescriptBuilder/stepPathTracker.js";
 import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
+import { functionContainsDestructiveBlock } from "./functionContainsDestructiveBlock.js";
 import { DestructiveTracking } from "./typescriptBuilder/destructiveTracking.js";
 import { PipeChainEmitter } from "./typescriptBuilder/pipeChainEmitter.js";
 import { AssignmentEmitter } from "./typescriptBuilder/assignmentEmitter.js";
@@ -2341,10 +2342,18 @@ export class TypeScriptBuilder {
     };
     // Carry the retry-safety markers so the tool loop and MCP adapter can
     // read them off the registered AgencyFunction. Emitted only when set.
-    if (node.markers?.destructive || node.markers?.idempotent) {
+    // "Destructive" for metadata purposes is DERIVED: the raw `destructive def`
+    // marker OR the presence of a `destructive { }` region in the body. (The
+    // entry flip / `inDestructiveFunction` still key on the raw marker alone —
+    // see `:2266` — so a contains-region-only function does not commit at
+    // entry.)
+    const isDestructive =
+      !!node.markers?.destructive ||
+      functionContainsDestructiveBlock(node.body);
+    if (isDestructive || node.markers?.idempotent) {
       const markerProps: Record<string, TsNode> = {};
-      if (node.markers.destructive) markerProps.destructive = ts.bool(true);
-      if (node.markers.idempotent) markerProps.idempotent = ts.bool(true);
+      if (isDestructive) markerProps.destructive = ts.bool(true);
+      if (node.markers?.idempotent) markerProps.idempotent = ts.bool(true);
       createProps.markers = ts.obj(markerProps);
     }
     const createCall = $.id("__AgencyFunction")

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -554,7 +554,7 @@ export class TypeScriptBuilder {
       case "markDestructiveRan":
         // Synthetic flip from an inlined `destructive { }` region. Inlined into
         // the function body, so `__self` is the function activation.
-        return this.tracking.blockEntryFlip();
+        return this.tracking.markDestructiveRan();
       case "typeAlias":
         if (this.hoistedTypeAliasNodes.has(node)) return ts.empty();
         return this.processTypeAlias(node);

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2068,6 +2068,7 @@ export class TypeScriptBuilder {
     bodyCode: TsNode[];
     skipHooks?: boolean;
     hoistedAliases?: TsNode[];
+    inDestructiveFunction?: boolean;
   }): TsNode[] {
     const { functionName, parameters, bodyCode, skipHooks } = opts;
     const hoistedAliases = opts.hoistedAliases ?? [];
@@ -2133,8 +2134,11 @@ export class TypeScriptBuilder {
       }
     }
 
-    // __self.__destructiveRan init — see DestructiveTracking.init().
-    setupStmts.push(this.tracking.init(this.scopes.inDestructiveFunction));
+    // __self.__destructiveRan init — see DestructiveTracking.init(). Read the
+    // flag from opts (threaded from processFunctionDefinition): by the time this
+    // runs the scope-manager flag has already been restored, so reading it here
+    // would always see false.
+    setupStmts.push(this.tracking.init(!!opts.inDestructiveFunction));
 
     // Create runner for step execution. `threads` is read directly from
     // the setup-function result, which now resolves it from the active
@@ -2301,6 +2305,7 @@ export class TypeScriptBuilder {
       bodyCode,
       skipHooks: false,
       hoistedAliases,
+      inDestructiveFunction: !!node.markers?.destructive,
     });
 
     const funcDecl = ts.functionDecl(

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -550,6 +550,10 @@ export class TypeScriptBuilder {
 
   private processNode(node: AgencyNode): TsNode {
     switch (node.type) {
+      case "markDestructiveRan":
+        // Synthetic flip from an inlined `destructive { }` region. Inlined into
+        // the function body, so `__self` is the function activation.
+        return this.tracking.blockEntryFlip();
       case "typeAlias":
         if (this.hoistedTypeAliasNodes.has(node)) return ts.empty();
         return this.processTypeAlias(node);
@@ -2129,7 +2133,7 @@ export class TypeScriptBuilder {
     }
 
     // __self.__destructiveRan init — see DestructiveTracking.init().
-    setupStmts.push(this.tracking.init());
+    setupStmts.push(this.tracking.init(this.scopes.inDestructiveFunction));
 
     // Create runner for step execution. `threads` is read directly from
     // the setup-function result, which now resolves it from the active

--- a/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.test.ts
@@ -58,8 +58,8 @@ describe("DestructiveTracking", () => {
     );
   });
 
-  it("blockEntryFlip() sets the flag true (destructive { } region entry)", () => {
-    expect(printTs(bareTracker().blockEntryFlip()).trim()).toBe(
+  it("markDestructiveRan() sets the flag true (destructive { } region entry)", () => {
+    expect(printTs(bareTracker().markDestructiveRan()).trim()).toBe(
       "__self.__destructiveRan = true;",
     );
   });

--- a/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.test.ts
@@ -46,9 +46,21 @@ const flips = (
 };
 
 describe("DestructiveTracking", () => {
-  it("init() is the unconditional boolean init", () => {
-    expect(printTs(bareTracker().init()).trim()).toBe(
+  it("init(false) is the `?? false` default for a non-destructive function", () => {
+    expect(printTs(bareTracker().init(false)).trim()).toBe(
       "__self.__destructiveRan = __self.__destructiveRan ?? false;",
+    );
+  });
+
+  it("init(true) commits at entry for a `destructive def`", () => {
+    expect(printTs(bareTracker().init(true)).trim()).toBe(
+      "__self.__destructiveRan = true;",
+    );
+  });
+
+  it("blockEntryFlip() sets the flag true (destructive { } region entry)", () => {
+    expect(printTs(bareTracker().blockEntryFlip()).trim()).toBe(
+      "__self.__destructiveRan = true;",
     );
   });
 
@@ -138,16 +150,17 @@ describe("DestructiveTracking", () => {
     });
   });
 
-  it("inside a destructive function, an impure statement gets the PRE flip", () => {
-    // `read` is an imported stdlib function → impure. Inside a destructive
-    // function, any impure statement marks the activation.
+  it("inside a destructive function, no per-statement flips (commit is at entry)", () => {
+    // A `destructive def` commits at entry via init(true); statementFlips emits
+    // nothing per-statement, regardless of what the statement calls.
     const { tracking, body } = setup(
       `import { read } from "std::index"\n` +
         `destructive def burn() { const s = read("f") }`,
       "burn",
     );
-    const f = flips(tracking, body[0], true);
-    expect(f.pre).toBe("__self.__destructiveRan = true;");
-    expect(f.post).toBeUndefined();
+    expect(flips(tracking, body[0], true)).toEqual({
+      pre: undefined,
+      post: undefined,
+    });
   });
 });

--- a/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.ts
@@ -6,9 +6,10 @@ import type { NameClassifier } from "./nameClassifier.js";
 
 /**
  * Emits the destructive-execution tracking codegen: the per-function
- * `__destructiveRan` init, the function-exit boundary stamp, and the
- * per-statement flips. Extracted from TypeScriptBuilder so the tracking rules
- * live in one declarative place instead of scattered through a 4k-line file.
+ * `__destructiveRan` init, the function-exit boundary stamp, the region-entry
+ * flip (`blockEntryFlip`, emitted by a `markDestructiveRan` node from an inlined
+ * `destructive { }` region), and the Rule-2 caller-side flips. Extracted from
+ * TypeScriptBuilder so the tracking rules live in one declarative place.
  *
  * Stateless by design: every method is a pure function of its arguments (the
  * `inDestructiveFunction` flag is passed in, not held), so it can be
@@ -16,8 +17,13 @@ import type { NameClassifier } from "./nameClassifier.js";
  *
  * How the flag works: every function activation carries a boolean
  * `__self.__destructiveRan`. It starts false and is only ever flipped to true
- * (sticky). The function exit folds it into any departing failure via
- * `stampFailureBoundary`, so a failure reports whether destructive work ran.
+ * (sticky). It is set at ENTRY for a `destructive def` (init(true)), or at
+ * region entry for a `destructive { }` region. The function exit folds it into
+ * any departing failure via `stampFailureBoundary`, so a failure reports whether
+ * execution entered a destructive region. NOTE: because a `destructive { }`
+ * region is inlined into the function body before codegen, its flip lands on the
+ * function's `__self` — never a block frame — which is what keeps a failure
+ * escaping the function from carrying a false (fail-open) flag.
  */
 export class DestructiveTracking {
   constructor(

--- a/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.ts
@@ -7,9 +7,9 @@ import type { NameClassifier } from "./nameClassifier.js";
 /**
  * Emits the destructive-execution tracking codegen: the per-function
  * `__destructiveRan` init, the function-exit boundary stamp, the region-entry
- * flip (`blockEntryFlip`, emitted by a `markDestructiveRan` node from an inlined
- * `destructive { }` region), and the Rule-2 caller-side flips. Extracted from
- * TypeScriptBuilder so the tracking rules live in one declarative place.
+ * flip (`markDestructiveRan`, emitted by a `markDestructiveRan` node from an
+ * inlined `destructive { }` region), and the Rule-2 caller-side flips. Extracted
+ * from TypeScriptBuilder so the tracking rules live in one declarative place.
  *
  * Stateless by design: every method is a pure function of its arguments (the
  * `inDestructiveFunction` flag is passed in, not held), so it can be
@@ -53,13 +53,6 @@ export class DestructiveTracking {
     );
   }
 
-  /** `__self.__destructiveRan = true` — the entry flip a `destructive { }`
-   *  region emits (via the `markDestructiveRan` node). Because the region is
-   *  inlined into the function body, `ts.self` resolves to the function's
-   *  `__self`, not a block frame. */
-  blockEntryFlip(): TsNode {
-    return this.markTrue();
-  }
 
   /** `stampFailureBoundary(runner.haltResult, __self.__destructiveRan)` — the
    *  expression the function-exit halt check embeds to fold this activation's
@@ -92,12 +85,14 @@ export class DestructiveTracking {
       return { post: this.outcomeFlip(outcomeVar) };
     }
     return this.names.containsDestructiveCall(stmt)
-      ? { pre: this.markTrue() }
+      ? { pre: this.markDestructiveRan() }
       : {};
   }
 
-  /** `__self.__destructiveRan = true` — the conservative pre-flip. */
-  private markTrue(): TsNode {
+  /** `__self.__destructiveRan = true` — sets the activation's destructive-ran
+   *  flag. Emitted at a `destructive { }` region entry (via the
+   *  `markDestructiveRan` node) and as the Rule-2 conservative pre-flip. */
+  markDestructiveRan(): TsNode {
     return ts.assign(ts.self("__destructiveRan"), ts.bool(true));
   }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/destructiveTracking.ts
@@ -33,11 +33,26 @@ export class DestructiveTracking {
    *  destructive tool inside an llm() call), which the builder cannot see
    *  statically; the unconditional boolean init keeps the exit stamp from
    *  ever computing `x || undefined`. */
-  init(): TsNode {
+  init(inDestructiveFunction: boolean): TsNode {
+    // A `destructive def` commits its whole body: set the flag true at entry.
+    // `init()` runs AFTER argument binding, so an arg-binding failure that halts
+    // before it stays retryable (`neverStarted`). A non-destructive function
+    // keeps the `?? false` default so an externally set value (decision-8, or a
+    // `destructive { }` region's flip) is preserved.
     return ts.assign(
       ts.self("__destructiveRan"),
-      ts.binOp(ts.self("__destructiveRan"), "??", ts.bool(false)),
+      inDestructiveFunction
+        ? ts.bool(true)
+        : ts.binOp(ts.self("__destructiveRan"), "??", ts.bool(false)),
     );
+  }
+
+  /** `__self.__destructiveRan = true` — the entry flip a `destructive { }`
+   *  region emits (via the `markDestructiveRan` node). Because the region is
+   *  inlined into the function body, `ts.self` resolves to the function's
+   *  `__self`, not a block frame. */
+  blockEntryFlip(): TsNode {
+    return this.markTrue();
   }
 
   /** `stampFailureBoundary(runner.haltResult, __self.__destructiveRan)` — the
@@ -50,10 +65,9 @@ export class DestructiveTracking {
     ]);
   }
 
-  /** Pre- and post-statement destructive flips for one statement.
-   *
-   *  Rule 1 (inside a destructive-marked function): any possibly-effectful
-   *  statement marks the activation before it runs.
+  /** Post-statement destructive flip for one statement, for a function that is
+   *  NOT itself `destructive`. A `destructive def` commits at entry (see
+   *  `init`), so it needs no per-statement flips.
    *
    *  Rule 2 (any function calling a destructive fn): when the call's result
    *  binds to a simple local (`const r = burn()` / `const r = try burn()`), an
@@ -65,9 +79,8 @@ export class DestructiveTracking {
     stmt: AgencyNode,
     inDestructiveFunction: boolean,
   ): { pre?: TsNode; post?: TsNode } {
-    if (inDestructiveFunction) {
-      return this.names.containsImpureCall(stmt) ? { pre: this.markTrue() } : {};
-    }
+    // A `destructive def` commits at entry; no per-statement flips.
+    if (inDestructiveFunction) return {};
     const outcomeVar = this.destructiveOutcomeVar(stmt);
     if (outcomeVar) {
       return { post: this.outcomeFlip(outcomeVar) };

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nameClassifier.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nameClassifier.ts
@@ -2,7 +2,6 @@ import type { AgencyNode } from "../../types.js";
 import type { CompilationUnit } from "../../compilationUnit.js";
 import { getImportedNames } from "../../types/importStatement.js";
 import { walkNodesArray } from "../../utils/node.js";
-import { BUILTIN_FUNCTIONS } from "../../config.js";
 
 /**
  * Plain JS functions that bypass the `__call` dispatcher and are invoked
@@ -108,19 +107,6 @@ export class NameClassifier {
     return false;
   }
 
-  /**
-   * True if `functionName` was imported from another module. Any imported
-   * call is treated as possibly-effectful: the compiler cannot see inside
-   * it. (Before the `safe` retirement this also consulted `safeFunctions`;
-   * that registry is gone, so every import is impure.)
-   */
-  isImpureImportedFunction(functionName: string): boolean {
-    return (
-      this.plainTsImportNames.has(functionName) ||
-      this.agencyImportNames.has(functionName)
-    );
-  }
-
   /** The function name a call-bearing node targets, if any. Handles a plain
    *  `functionCall` and the `try f()` case (`walkNodes` yields the
    *  tryExpression node but does not descend into its `.call`, so the common
@@ -139,27 +125,15 @@ export class NameClassifier {
     return undefined;
   }
 
-  /** Recursively walks `node` and returns true if any function call within it is impure. */
-  containsImpureCall(node: AgencyNode): boolean {
-    for (const { node: subNode } of walkNodesArray([node])) {
-      const name = this.callTarget(subNode);
-      if (name === undefined) continue;
-      if (this.isImpureImportedFunction(name)) return true;
-      // Object.hasOwn, not a truthy index: a call to a function named
-      // `toString`/`constructor` would otherwise match an inherited
-      // prototype member on the plain BUILTIN_FUNCTIONS object.
-      if (Object.hasOwn(BUILTIN_FUNCTIONS, name)) return true;
-    }
-    return false;
-  }
-
   /** Recursively walks `node` and returns true if any function call within
-   *  it targets a function marked `destructive`. Same walker shape as
-   *  containsImpureCall; reads the destructiveFunctions registry. */
+   *  it targets a function marked `destructive`; reads the destructiveFunctions
+   *  registry. */
   containsDestructiveCall(node: AgencyNode): boolean {
     for (const { node: subNode } of walkNodesArray([node])) {
       const name = this.callTarget(subNode);
-      // Object.hasOwn, not a truthy index — see containsImpureCall.
+      // Object.hasOwn, not a truthy index: a call to a function named
+      // `toString`/`constructor` would otherwise match an inherited prototype
+      // member on the plain destructiveFunctions object.
       if (
         name !== undefined &&
         Object.hasOwn(this.compilationUnit.destructiveFunctions, name)

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -19,6 +19,7 @@ import { getImportedNames } from "./types/importStatement.js";
 import type { SymbolTable, InterruptEffect } from "./symbolTable.js";
 import { collectTypeAliasTags } from "./symbolTable.js";
 import { walkNodes } from "./utils/node.js";
+import { functionContainsDestructiveBlock } from "./backends/functionContainsDestructiveBlock.js";
 import { resultTypeForValidation } from "./typeChecker/validation.js";
 import { visitTypes } from "./typeChecker/typeWalker.js";
 
@@ -175,8 +176,11 @@ function registerMarkers(
   unit: CompilationUnit,
   localName: string,
   markers: FunctionMarkers | undefined,
+  containsDestructiveBlock = false,
 ): void {
-  if (markers?.destructive) {
+  // A function is destructive for the registry (Rule 2 caller propagation) if it
+  // is marked `destructive def` OR contains a `destructive { }` region.
+  if (markers?.destructive || containsDestructiveBlock) {
     unit.destructiveFunctions[localName] = true;
   }
   if (markers?.idempotent) {
@@ -208,7 +212,12 @@ export function buildCompilationUnit(
     switch (node.type) {
       case "function":
         unit.functionDefinitions[node.functionName] = node;
-        registerMarkers(unit, node.functionName, node.markers);
+        registerMarkers(
+          unit,
+          node.functionName,
+          node.markers,
+          functionContainsDestructiveBlock(node.body),
+        );
         break;
       case "graphNode":
         unit.graphNodes.push(node);

--- a/packages/agency-lang/lib/parsers/destructiveBlock.test.ts
+++ b/packages/agency-lang/lib/parsers/destructiveBlock.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { destructiveBlockParser } from "./parsers.js";
+
+describe("destructiveBlockParser", () => {
+  it("parses to a seqBlock flagged destructive", () => {
+    const r = destructiveBlockParser("destructive { return f(x) }");
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.result).toMatchObject({ type: "seqBlock", destructive: true });
+    expect(r.result.body.length).toBe(1);
+  });
+
+  it("parses an empty block", () => {
+    const r = destructiveBlockParser("destructive { }");
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.result).toMatchObject({ type: "seqBlock", destructive: true, body: [] });
+  });
+
+  it("does NOT match `destructive def` (soft-fails at `{`, backtracks)", () => {
+    const r = destructiveBlockParser("destructive def f() { }");
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/parsers/destructiveBlock.test.ts
+++ b/packages/agency-lang/lib/parsers/destructiveBlock.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { destructiveBlockParser } from "./parsers.js";
+import { parseAgency } from "../parser.js";
 
 describe("destructiveBlockParser", () => {
   it("parses to a seqBlock flagged destructive", () => {
@@ -20,5 +21,28 @@ describe("destructiveBlockParser", () => {
   it("does NOT match `destructive def` (soft-fails at `{`, backtracks)", () => {
     const r = destructiveBlockParser("destructive def f() { }");
     expect(r.success).toBe(false);
+  });
+
+  it("a full program: `destructive def` with a nested `destructive { }` parses", () => {
+    const r = parseAgency(
+      "destructive def f(): number {\n  destructive {\n    return 1\n  }\n}",
+      {},
+      false,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("a top-level `destructive { }` inside a function body parses via the statement parser", () => {
+    const r = parseAgency(
+      "def f(): number {\n  destructive {\n    return 1\n  }\n}",
+      {},
+      false,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("`destructive def` at program level still parses (regression)", () => {
+    const r = parseAgency("destructive def f(): number {\n  return 1\n}", {}, false);
+    expect(r.success).toBe(true);
   });
 });

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3986,6 +3986,7 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
   lazy(() => whileLoopParser),
   lazy(() => parallelBlockParser),
   lazy(() => seqBlockParser),
+  lazy(() => destructiveBlockParser),
   matchBlockParser,
   lazy(() => ifParser),
   lazy(() => messageThreadParser),
@@ -4473,6 +4474,32 @@ export const seqBlockParser: Parser<SeqBlock> = label("a seq block", withLoc(mem
       parseError(
         "expected `{` to open seq block body",
         char("{"),
+        optionalSpacesOrNewline,
+        capture(bodyParser, "body"),
+        optionalSpacesOrNewline,
+        char("}"),
+      ),
+    ),
+  ),
+)));
+
+// A `destructive { ... }` region parses to a `seqBlock` flagged `destructive`.
+// The `char("{")` is a SOFT gate OUTSIDE `parseError` (a committing cut): a
+// leading `destructive def` fails here and the statement parser backtracks.
+// `not(varNameChar)` alone cannot disambiguate — both `destructive {` and
+// `destructive def` have a space after the keyword.
+export const destructiveBlockParser: Parser<SeqBlock> = label("a destructive block", withLoc(memo(
+  "destructiveBlockParser",
+  seqC(
+    set("type", "seqBlock"),
+    set("destructive", true as boolean),
+    str("destructive"),
+    not(varNameChar),
+    optionalSpaces,
+    char("{"),
+    captureCaptures(
+      parseError(
+        "unterminated destructive block",
         optionalSpacesOrNewline,
         capture(bodyParser, "body"),
         optionalSpacesOrNewline,

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
@@ -100,6 +100,36 @@ describe("validateParallelBlock", () => {
     expect(() => validateParallelBlock(findParallelBlock(body))).not.toThrow();
   });
 
+  it("rejects a `destructive { }` region as a direct parallel arm (fail-open guard)", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          destructive { rm() }
+          let b = bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /`destructive \{ \}` region is not allowed inside a `parallel` block/,
+    );
+  });
+
+  it("rejects a `destructive { }` region nested inside a `seq` arm", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          seq {
+            destructive { rm() }
+          }
+          let b = bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /`destructive \{ \}` region is not allowed inside a `parallel` block/,
+    );
+  });
+
   it("rejects cross-arm references", () => {
     const body = getMainBody(`
       node main() {

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
@@ -423,7 +423,13 @@ export function desugarParallelInBody(body: AgencyNode[]): AgencyNode[] {
       result.push(...desugarOneParallel(node));
     } else if (node.type === "seqBlock") {
       // Outside a parallel context, a seq block has no runtime effect; inline
-      // its body after recursively desugaring.
+      // its body after recursively desugaring. A `destructive` seqBlock also
+      // commits: prepend the flip so it runs on the ENCLOSING function's
+      // `__self` (this inlining is exactly why `__self` is the function, not a
+      // block frame — the fail-open guard).
+      if (node.destructive) {
+        result.push({ type: "markDestructiveRan" } as AgencyNode);
+      }
       result.push(...desugarParallelInBody(node.body));
     } else {
       // Recurse into nested control-flow bodies, then keep the node.

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
@@ -15,6 +15,7 @@ import {
 } from "@/types.js";
 import { BinOpExpression } from "@/types/binop.js";
 import { BlockArgument } from "@/types/blockArgument.js";
+import { functionContainsDestructiveBlock } from "@/backends/functionContainsDestructiveBlock.js";
 
 /**
  * Statement allowlist enforcement and cross-arm reference checks for `parallel`
@@ -77,6 +78,18 @@ function isAssignmentDecl(node: AgencyNode): node is Assignment {
  * then check cross-arm references. Throws on violation.
  */
 export function validateParallelBlock(pb: ParallelBlock): void {
+  // 0. A `destructive { }` region cannot live inside a `parallel` block. Each
+  //    arm runs in its own fork branch, whose `__self` is the branch frame — so
+  //    a region's `__destructiveRan` flip would land there, never on the calling
+  //    tool's activation, and could never remove the tool on failure (a silent
+  //    fail-open). Reject it rather than accept broken commit semantics. This
+  //    walks the whole subtree, so a region nested in a `seq` arm is caught too.
+  if (functionContainsDestructiveBlock(pb.body)) {
+    throw new Error(
+      "A `destructive { }` region is not allowed inside a `parallel` block: it would run in a fork branch and could not commit its destructive work to the calling tool. Move the destructive region out of the `parallel` block.",
+    );
+  }
+
   // 1. Allowlist check.
   for (const child of pb.body) {
     if (!ALLOWED_ARM_TYPES.has(child.type)) {

--- a/packages/agency-lang/lib/runtime/result.ts
+++ b/packages/agency-lang/lib/runtime/result.ts
@@ -56,7 +56,8 @@ export type FailureOpts = {
    *  layer's pre-execution tag — trust-the-producer, because nothing can
    *  correct a wrongly-true claim. */
   neverStarted?: boolean;
-  /** A statement containing a destructive-marked call had started. */
+  /** Execution entered a destructive region — a `destructive def` body (which
+   *  commits at entry) or a `destructive { }` region. */
   destructiveRan?: boolean;
   functionName?: string;
   args?: Record<string, any>;
@@ -82,9 +83,10 @@ export type ResultFailure = {
    *  Trust-the-producer: there is no correcting machinery, so nothing else
    *  may set it. */
   neverStarted: boolean;
-  /** A destructive-marked call had started when this failure was produced.
-   *  Birth default false; boundaries OR the activation's flag in via
-   *  stampFailureBoundary. */
+  /** Execution had entered a destructive region — a `destructive def` body
+   *  (commits at function entry) or a `destructive { }` region (commits at
+   *  region entry) — when this failure was produced. Birth default false;
+   *  boundaries OR the activation's flag in via stampFailureBoundary. */
   destructiveRan: boolean;
   functionName: string | null;
   args: Record<string, any> | null;

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -27,6 +27,7 @@ import { TypeAlias, VariableType } from "./types/typeHints.js";
 import { EffectDeclaration } from "./types/effectDeclaration.js";
 import { WhileLoop } from "./types/whileLoop.js";
 import { ParallelBlock, SeqBlock } from "./types/parallelBlock.js";
+import { MarkDestructiveRan } from "./types/markDestructiveRan.js";
 import { AwaitPending } from "./types/awaitPending.js";
 import { HandleBlock } from "./types/handleBlock.js";
 import { DebuggerStatement } from "./types/debuggerStatement.js";
@@ -64,6 +65,7 @@ export * from "./types/gotoStatement.js";
 export * from "./types/typeHints.js";
 export * from "./types/whileLoop.js";
 export * from "./types/parallelBlock.js";
+export * from "./types/markDestructiveRan.js";
 export * from "./types/forLoop.js";
 export * from "./types/handleBlock.js";
 export * from "./types/keyword.js";
@@ -315,6 +317,7 @@ export type AgencyNode =
   | WhileLoop
   | ParallelBlock
   | SeqBlock
+  | MarkDestructiveRan
   | IfElse
   | NewLine
   | RawCode

--- a/packages/agency-lang/lib/types/markDestructiveRan.ts
+++ b/packages/agency-lang/lib/types/markDestructiveRan.ts
@@ -1,0 +1,9 @@
+import { BaseNode } from "./base.js";
+
+/** Synthetic, bodyless statement emitted by parallelDesugar when it inlines a
+ *  `destructive` seqBlock. Codegen turns it into `__self.__destructiveRan = true`
+ *  on the ENCLOSING function activation (the seqBlock is inlined, so `__self` is
+ *  the function). Never parsed, never formatted (introduced after typecheck). */
+export type MarkDestructiveRan = BaseNode & {
+  type: "markDestructiveRan";
+};

--- a/packages/agency-lang/lib/types/parallelBlock.ts
+++ b/packages/agency-lang/lib/types/parallelBlock.ts
@@ -13,4 +13,9 @@ export type ParallelBlock = BaseNode & {
 export type SeqBlock = BaseNode & {
   type: "seqBlock";
   body: AgencyNode[];
+  /** True when written as `destructive { ... }` rather than `seq { ... }`.
+   *  Marks the region destructive: parallelDesugar prepends a
+   *  `markDestructiveRan` when inlining it, and the formatter prints
+   *  `destructive {`. */
+  destructive?: boolean;
 };

--- a/packages/agency-lang/lib/utils/bodySlots.ts
+++ b/packages/agency-lang/lib/utils/bodySlots.ts
@@ -136,6 +136,9 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
       return [bodyField(node as ParallelBlock)];
     case "seqBlock":
       return [bodyField(node as SeqBlock)];
+    case "markDestructiveRan":
+      // Synthetic leaf (no body) introduced post-typecheck by parallelDesugar.
+      return [];
     case "messageThread":
       return [bodyField(node as MessageThread)];
     case "blockArgument":

--- a/packages/agency-lang/stdlib/auth/keyring.agency
+++ b/packages/agency-lang/stdlib/auth/keyring.agency
@@ -26,7 +26,7 @@ effect std::setSecret { key: string, service: string }
 effect std::getSecret { key: string, service: string }
 effect std::deleteSecret { key: string, service: string }
 
-export destructive def setSecret(key: string, value: string, service: string = "agency-lang"): Result {
+export def setSecret(key: string, value: string, service: string = "agency-lang"): Result {
   """
   Store a secret in the system keyring, overwriting any existing value for the same key.
 
@@ -39,7 +39,9 @@ export destructive def setSecret(key: string, value: string, service: string = "
     service: service
   })
 
-  return try _setSecret(key, value, service)
+  destructive {
+    return try _setSecret(key, value, service)
+  }
 }
 
 export def getSecret(key: string, service: string = "agency-lang"): Result {
@@ -57,7 +59,7 @@ export def getSecret(key: string, service: string = "agency-lang"): Result {
   return try _getSecret(key, service)
 }
 
-export destructive def deleteSecret(key: string, service: string = "agency-lang"): Result {
+export def deleteSecret(key: string, service: string = "agency-lang"): Result {
   """
   Delete a secret from the system keyring. Returns true if deleted, false if the key did not exist.
 
@@ -69,7 +71,9 @@ export destructive def deleteSecret(key: string, service: string = "agency-lang"
     service: service
   })
 
-  return try _deleteSecret(key, service)
+  destructive {
+    return try _deleteSecret(key, service)
+  }
 }
 
 export def isKeyringAvailable(): boolean {

--- a/packages/agency-lang/stdlib/auth/oauth.agency
+++ b/packages/agency-lang/stdlib/auth/oauth.agency
@@ -91,7 +91,7 @@ export def isAuthorized(name: string): boolean {
   return _isAuthorized(name)
 }
 
-export destructive def revokeAuth(name: string): Result {
+export def revokeAuth(name: string): Result {
   """
   Delete stored OAuth tokens for a provider. Re-authorization is required before the provider can be used again.
 
@@ -101,5 +101,7 @@ export destructive def revokeAuth(name: string): Result {
     name: name
   })
 
-  return try _revokeAuth(name)
+  destructive {
+    return try _revokeAuth(name)
+  }
 }

--- a/packages/agency-lang/stdlib/calendar.agency
+++ b/packages/agency-lang/stdlib/calendar.agency
@@ -101,7 +101,7 @@ export def listEvents(maxResults: number = 10, timeMin: string = "", timeMax: st
   })
 }
 
-export destructive def createEvent(summary: string, start: string, end: string, description: string = "", location: string = "", calendarId: string = "primary"): Result {
+export def createEvent(summary: string, start: string, end: string, description: string = "", location: string = "", calendarId: string = "primary"): Result {
   """
   Create a new event on Google Calendar. Returns the created event.
 
@@ -120,17 +120,19 @@ export destructive def createEvent(summary: string, start: string, end: string, 
     location: location
   })
 
-  return try _createEvent({
-    summary: summary,
-    start: start,
-    end: end,
-    description: description,
-    location: location,
-    calendarId: calendarId
-  })
+  destructive {
+    return try _createEvent({
+      summary: summary,
+      start: start,
+      end: end,
+      description: description,
+      location: location,
+      calendarId: calendarId
+    })
+  }
 }
 
-export destructive def updateEvent(eventId: string, summary: string = "", start: string = "", end: string = "", description: string = "", location: string = "", calendarId: string = "primary"): Result {
+export def updateEvent(eventId: string, summary: string = "", start: string = "", end: string = "", description: string = "", location: string = "", calendarId: string = "primary"): Result {
   """
   Update an existing event on Google Calendar. Pass the eventId and any fields to change. An empty string means "don't change". Returns the updated event.
 
@@ -149,18 +151,20 @@ export destructive def updateEvent(eventId: string, summary: string = "", start:
     end: end
   })
 
-  return try _updateEvent({
-    eventId: eventId,
-    summary: summary,
-    start: start,
-    end: end,
-    description: description,
-    location: location,
-    calendarId: calendarId
-  })
+  destructive {
+    return try _updateEvent({
+      eventId: eventId,
+      summary: summary,
+      start: start,
+      end: end,
+      description: description,
+      location: location,
+      calendarId: calendarId
+    })
+  }
 }
 
-export destructive def deleteEvent(eventId: string, calendarId: string = "primary"): Result {
+export def deleteEvent(eventId: string, calendarId: string = "primary"): Result {
   """
   Delete an event from Google Calendar by its event ID. Returns { deleted: true } on success.
 
@@ -172,5 +176,7 @@ export destructive def deleteEvent(eventId: string, calendarId: string = "primar
     calendarId: calendarId
   })
 
-  return try _deleteEvent(eventId, calendarId)
+  destructive {
+    return try _deleteEvent(eventId, calendarId)
+  }
 }

--- a/packages/agency-lang/stdlib/clipboard.agency
+++ b/packages/agency-lang/stdlib/clipboard.agency
@@ -15,7 +15,7 @@ import { _copy, _paste } from "agency-lang/stdlib-lib/clipboard.js"
 effect std::clipboardCopy {}
 effect std::clipboardPaste {}
 
-export destructive def copy(text: string) {
+export def copy(text: string) {
   """
   Copy text to the system clipboard.
 
@@ -23,7 +23,9 @@ export destructive def copy(text: string) {
   """
   return interrupt std::clipboardCopy("Are you sure you want to copy text to the clipboard?")
 
-  _copy(text)
+  destructive {
+    _copy(text)
+  }
 }
 
 export def paste(): string {

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -44,7 +44,7 @@ effect std::remove { target: string }
  * whole interrupt object, so the contents are at `data.data.before` /
  * `data.data.after` (e.g. `print(diff(data.data.before, data.data.after, color: true))`).
  */
-export destructive def edit(filename: string, edits: Edit[], dir: string = ".", useAgentCwd: boolean = false): Result {
+export def edit(filename: string, edits: Edit[], dir: string = ".", useAgentCwd: boolean = false): Result {
   """
   Edit a single file by applying one or more text replacements atomically. Each edit's oldText must match a unique, non-overlapping region of the file as it stands when that edit runs (after earlier edits in the same call). If any edit fails, nothing is written.
 
@@ -67,7 +67,9 @@ export destructive def edit(filename: string, edits: Edit[], dir: string = ".", 
     after: preview.after
   })
 
-  return try _multiedit(dir, filename, edits)
+  destructive {
+    return try _multiedit(dir, filename, edits)
+  }
 }
 
 type PatchResult = {
@@ -75,7 +77,7 @@ type PatchResult = {
   files: string[]
 }
 
-export destructive def applyPatch(patch: string, allowedPaths: string[] = []): Result {
+export def applyPatch(patch: string, allowedPaths: string[] = []): Result {
   """
   Apply a unified diff to the working tree. Supports file creation (--- /dev/null), line additions, deletions, and context. Fails on a malformed diff or on a context-line mismatch against the current file contents.
 
@@ -86,10 +88,12 @@ export destructive def applyPatch(patch: string, allowedPaths: string[] = []): R
     patch: patch
   })
 
-  return try _applyPatch(patch, allowedPaths)
+  destructive {
+    return try _applyPatch(patch, allowedPaths)
+  }
 }
 
-export destructive def mkdir(dir: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
+export def mkdir(dir: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
   """
   Create a directory, including any missing parent directories. Idempotent: succeeds if the directory already exists. Fails if a non-directory entry already occupies the path, or on permission errors.
 
@@ -104,10 +108,12 @@ export destructive def mkdir(dir: string, allowedPaths: string[] = [], useAgentC
     dir: dir
   })
 
-  return try _mkdir(dir, allowedPaths)
+  destructive {
+    return try _mkdir(dir, allowedPaths)
+  }
 }
 
-export destructive def copy(src: string, dest: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
+export def copy(src: string, dest: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
   """
   Copy a file or directory. Directories are copied recursively. Fails if src does not exist or dest cannot be written.
 
@@ -125,10 +131,12 @@ export destructive def copy(src: string, dest: string, allowedPaths: string[] = 
     dest: dest
   })
 
-  return try _copy(src, dest, allowedPaths)
+  destructive {
+    return try _copy(src, dest, allowedPaths)
+  }
 }
 
-export destructive def move(src: string, dest: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
+export def move(src: string, dest: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
   """
   Move or rename a file or directory. Falls back to copy+remove if src and dest are on different filesystems. Fails if src does not exist.
 
@@ -146,10 +154,12 @@ export destructive def move(src: string, dest: string, allowedPaths: string[] = 
     dest: dest
   })
 
-  return try _move(src, dest, allowedPaths)
+  destructive {
+    return try _move(src, dest, allowedPaths)
+  }
 }
 
-export destructive def remove(target: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
+export def remove(target: string, allowedPaths: string[] = [], useAgentCwd: boolean = false): Result {
   """
   Delete a file or directory. Directories are removed recursively. Does not fail if the target does not exist.
 
@@ -164,6 +174,8 @@ export destructive def remove(target: string, allowedPaths: string[] = [], useAg
     target: target
   })
 
-  return try _remove(target, allowedPaths)
+  destructive {
+    return try _remove(target, allowedPaths)
+  }
 }
 

--- a/packages/agency-lang/stdlib/git.agency
+++ b/packages/agency-lang/stdlib/git.agency
@@ -195,7 +195,7 @@ export idempotent def gitStashList(cwd: string = ""): GitStash[] raises <std::gi
 /** `all` and `allowedPaths` are developer guardrails: bind `all: false` and/or
     a prefix list for `allowedPaths` via `.partial()` before handing this to an
     agent. */
-export destructive def gitAdd(paths: string[] = [], all: boolean = false, allowedPaths: string[] = [], cwd: string = ""): string raises <std::git::add> {
+export def gitAdd(paths: string[] = [], all: boolean = false, allowedPaths: string[] = [], cwd: string = ""): string raises <std::git::add> {
   """
   Stage changes for commit.
   @param paths - Files to stage (may not start with "-").
@@ -207,11 +207,13 @@ export destructive def gitAdd(paths: string[] = [], all: boolean = false, allowe
   assertAllNotRestricted(all, allowedPaths)
   assertPathsContained(paths, allowedPaths, dir)
   return interrupt std::git::add("Stage changes", { cwd: dir, paths: paths, all: all })
-  _gitRun(dir, addArgs({ paths: paths, all: all }))
-  return "Staged changes"
+  destructive {
+    _gitRun(dir, addArgs({ paths: paths, all: all }))
+    return "Staged changes"
+  }
 }
 
-export destructive def gitCommit(message: string, cwd: string = ""): string raises <std::git::commit> {
+export def gitCommit(message: string, cwd: string = ""): string raises <std::git::commit> {
   """
   Create a commit from the staged changes.
   @param message - The commit message.
@@ -219,11 +221,13 @@ export destructive def gitCommit(message: string, cwd: string = ""): string rais
   """
   const dir = repoDir(cwd)
   return interrupt std::git::commit("Create commit: ${message}", { cwd: dir, message: message })
-  return _gitRun(dir, commitArgs({ message: message }))
+  destructive {
+    return _gitRun(dir, commitArgs({ message: message }))
+  }
 }
 
 /** Bind `force: false` via `.partial()` to forbid discarding local changes. */
-export destructive def gitCheckout(target: string, force: boolean = false, cwd: string = ""): string raises <std::git::checkout> {
+export def gitCheckout(target: string, force: boolean = false, cwd: string = ""): string raises <std::git::checkout> {
   """
   Check out a branch, commit, or path.
   @param target - The branch/commit/path (may not start with "-").
@@ -236,10 +240,12 @@ export destructive def gitCheckout(target: string, force: boolean = false, cwd: 
     message = "Force checkout ${target} (DISCARDS local changes, cannot be undone)"
   }
   return interrupt std::git::checkout(message, { cwd: dir, target: target, force: force })
-  return _gitRun(dir, checkoutArgs({ target: target, force: force }))
+  destructive {
+    return _gitRun(dir, checkoutArgs({ target: target, force: force }))
+  }
 }
 
-export destructive def gitSwitch(branch: string, create: boolean = false, cwd: string = ""): string raises <std::git::switch> {
+export def gitSwitch(branch: string, create: boolean = false, cwd: string = ""): string raises <std::git::switch> {
   """
   Switch to a branch.
   @param branch - The branch to switch to (may not start with "-").
@@ -248,10 +254,12 @@ export destructive def gitSwitch(branch: string, create: boolean = false, cwd: s
   """
   const dir = repoDir(cwd)
   return interrupt std::git::switch("Switch to branch ${branch}", { cwd: dir, branch: branch, create: create })
-  return _gitRun(dir, switchArgs({ branch: branch, create: create }))
+  destructive {
+    return _gitRun(dir, switchArgs({ branch: branch, create: create }))
+  }
 }
 
-export destructive def gitBranchCreate(branch: string, cwd: string = ""): string raises <std::git::branchCreate> {
+export def gitBranchCreate(branch: string, cwd: string = ""): string raises <std::git::branchCreate> {
   """
   Create a new branch at HEAD (does not switch to it).
   @param branch - The new branch name (may not start with "-").
@@ -259,13 +267,15 @@ export destructive def gitBranchCreate(branch: string, cwd: string = ""): string
   """
   const dir = repoDir(cwd)
   return interrupt std::git::branchCreate("Create branch ${branch}", { cwd: dir, branch: branch })
-  _gitRun(dir, branchCreateArgs({ branch: branch }))
-  return "Created branch ${branch}"
+  destructive {
+    _gitRun(dir, branchCreateArgs({ branch: branch }))
+    return "Created branch ${branch}"
+  }
 }
 
 /** Guardrails: bind `force: false` and/or a `protectedBranches` list via
     `.partial()` before handing this to an agent. */
-export destructive def gitBranchDelete(branch: string, force: boolean = false, protectedBranches: string[] = [], cwd: string = ""): string raises <std::git::branchDelete> {
+export def gitBranchDelete(branch: string, force: boolean = false, protectedBranches: string[] = [], cwd: string = ""): string raises <std::git::branchDelete> {
   """
   Delete a local branch.
   @param branch - The branch to delete (may not start with "-").
@@ -280,11 +290,13 @@ export destructive def gitBranchDelete(branch: string, force: boolean = false, p
     message = "Force-delete branch ${branch} (may discard unmerged commits, cannot be undone)"
   }
   return interrupt std::git::branchDelete(message, { cwd: dir, branch: branch, force: force })
-  _gitRun(dir, branchDeleteArgs({ branch: branch, force: force, protectedBranches: protectedBranches }))
-  return "Deleted branch ${branch}"
+  destructive {
+    _gitRun(dir, branchDeleteArgs({ branch: branch, force: force, protectedBranches: protectedBranches }))
+    return "Deleted branch ${branch}"
+  }
 }
 
-export destructive def gitStashPush(message: string = "", cwd: string = ""): string raises <std::git::stashPush> {
+export def gitStashPush(message: string = "", cwd: string = ""): string raises <std::git::stashPush> {
   """
   Stash the working-tree changes.
   @param message - Optional stash message.
@@ -292,22 +304,26 @@ export destructive def gitStashPush(message: string = "", cwd: string = ""): str
   """
   const dir = repoDir(cwd)
   return interrupt std::git::stashPush("Stash changes", { cwd: dir, message: message })
-  return _gitRun(dir, stashPushArgs({ message: message }))
+  destructive {
+    return _gitRun(dir, stashPushArgs({ message: message }))
+  }
 }
 
-export destructive def gitStashPop(cwd: string = ""): string raises <std::git::stashPop> {
+export def gitStashPop(cwd: string = ""): string raises <std::git::stashPop> {
   """
   Apply and drop the most recent stash.
   @param cwd - The git repo directory. Defaults to the agent working directory. Pass an absolute path to target a different repo.
   """
   const dir = repoDir(cwd)
   return interrupt std::git::stashPop("Pop the latest stash", { cwd: dir })
-  return _gitRun(dir, stashPopArgs())
+  destructive {
+    return _gitRun(dir, stashPopArgs())
+  }
 }
 
 /** `allowedPaths` is a developer guardrail: bind a prefix list via `.partial()`
     to constrain which paths the model may restore. */
-export destructive def gitRestore(paths: string[], staged: boolean = false, allowedPaths: string[] = [], cwd: string = ""): string raises <std::git::restore> {
+export def gitRestore(paths: string[], staged: boolean = false, allowedPaths: string[] = [], cwd: string = ""): string raises <std::git::restore> {
   """
   Restore files to a previous state.
   @param paths - Files to restore (may not start with "-").
@@ -322,6 +338,8 @@ export destructive def gitRestore(paths: string[], staged: boolean = false, allo
     message = "Unstage ${paths.length} file(s)"
   }
   return interrupt std::git::restore(message, { cwd: dir, paths: paths, staged: staged })
-  _gitRun(dir, restoreArgs({ paths: paths, staged: staged }))
-  return "Restored ${paths.length} file(s)"
+  destructive {
+    _gitRun(dir, restoreArgs({ paths: paths, staged: staged }))
+    return "Restored ${paths.length} file(s)"
+  }
 }

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -164,7 +164,7 @@ export idempotent def read(
   return try _read(dir, filename, offset, limit)
 }
 
-export destructive def write(
+export def write(
   filename: string,
   content: string,
   dir: string = ".",
@@ -189,10 +189,12 @@ export destructive def write(
     content: content,
     mode: mode
   })
-  return try _write(dir, filename, content, mode)
+  destructive {
+    return try _write(dir, filename, content, mode)
+  }
 }
 
-export destructive def writeBinary(
+export def writeBinary(
   filename: string,
   base64: string,
   dir: string = ".",
@@ -217,7 +219,9 @@ export destructive def writeBinary(
     filename: filename,
     mode: mode
   })
-  return try _writeBinary(dir, filename, base64, mode)
+  destructive {
+    return try _writeBinary(dir, filename, base64, mode)
+  }
 }
 
 export idempotent def readBinary(

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -180,7 +180,7 @@ export def memory(config: MemoryConfig, block: () -> any = null): Result {
   return result
 }
 
-export destructive def remember(content: string) {
+export def remember(content: string) {
   """
   Extract structured facts (entities, observations, and relations) from
   the given text and store them in the knowledge graph.
@@ -192,17 +192,19 @@ export destructive def remember(content: string) {
       contentLength: content.length
     })
 
-    thread {
-      const prompt = _buildExtractionPrompt(content)
-      // Bang validation: a malformed extraction is a failure Result, not
-      // a mistyped value. Before this, a provider returning prose or an
-      // empty string crashed the tool and memory silently stopped
-      // persisting (issue #494).
-      const result: ExtractionResult! = llm(prompt)
-      if (result is success(extraction)) {
-        _applyExtractionResult(extraction)
-      } else {
-        return result
+    destructive {
+      thread {
+        const prompt = _buildExtractionPrompt(content)
+        // Bang validation: a malformed extraction is a failure Result, not
+        // a mistyped value. Before this, a provider returning prose or an
+        // empty string crashed the tool and memory silently stopped
+        // persisting (issue #494).
+        const result: ExtractionResult! = llm(prompt)
+        if (result is success(extraction)) {
+          _applyExtractionResult(extraction)
+        } else {
+          return result
+        }
       }
     }
   }

--- a/packages/agency-lang/stdlib/messaging/email.agency
+++ b/packages/agency-lang/stdlib/messaging/email.agency
@@ -38,7 +38,7 @@ type EmailResult = {
 effect std::sendEmail { from: string, to: string, subject: string }
 
 /** Send an email using the Resend API. Requires `RESEND_API_KEY` env var or pass apiKey directly. */
-export destructive def sendWithResend(from: string, to: string, subject: string, html: string = "", text: string = "", cc: string = "", bcc: string = "", replyTo: string = "", apiKey: string = "", allowList: string[] = [], blockList: string[] = []): Result {
+export def sendWithResend(from: string, to: string, subject: string, html: string = "", text: string = "", cc: string = "", bcc: string = "", replyTo: string = "", apiKey: string = "", allowList: string[] = [], blockList: string[] = []): Result {
   """
   Send an email using the Resend API.
 
@@ -60,24 +60,26 @@ export destructive def sendWithResend(from: string, to: string, subject: string,
     subject: subject
   })
 
-  return try _sendWithResend({
-    from: from,
-    to: to,
-    subject: subject,
-    html: html,
-    text: text,
-    cc: cc,
-    bcc: bcc,
-    replyTo: replyTo
-  }, {
-    apiKey: apiKey,
-    allowList: allowList,
-    blockList: blockList
-  })
+  destructive {
+    return try _sendWithResend({
+      from: from,
+      to: to,
+      subject: subject,
+      html: html,
+      text: text,
+      cc: cc,
+      bcc: bcc,
+      replyTo: replyTo
+    }, {
+      apiKey: apiKey,
+      allowList: allowList,
+      blockList: blockList
+    })
+  }
 }
 
 /** Send an email using the SendGrid API. Requires `SENDGRID_API_KEY` env var or pass apiKey directly. */
-export destructive def sendWithSendGrid(from: string, to: string, subject: string, html: string = "", text: string = "", cc: string = "", bcc: string = "", replyTo: string = "", apiKey: string = "", allowList: string[] = [], blockList: string[] = []): Result {
+export def sendWithSendGrid(from: string, to: string, subject: string, html: string = "", text: string = "", cc: string = "", bcc: string = "", replyTo: string = "", apiKey: string = "", allowList: string[] = [], blockList: string[] = []): Result {
   """
   Send an email using the SendGrid API.
 
@@ -99,24 +101,26 @@ export destructive def sendWithSendGrid(from: string, to: string, subject: strin
     subject: subject
   })
 
-  return try _sendWithSendGrid({
-    from: from,
-    to: to,
-    subject: subject,
-    html: html,
-    text: text,
-    cc: cc,
-    bcc: bcc,
-    replyTo: replyTo
-  }, {
-    apiKey: apiKey,
-    allowList: allowList,
-    blockList: blockList
-  })
+  destructive {
+    return try _sendWithSendGrid({
+      from: from,
+      to: to,
+      subject: subject,
+      html: html,
+      text: text,
+      cc: cc,
+      bcc: bcc,
+      replyTo: replyTo
+    }, {
+      apiKey: apiKey,
+      allowList: allowList,
+      blockList: blockList
+    })
+  }
 }
 
 /** Send an email using the Mailgun API. Requires `MAILGUN_API_KEY` and `MAILGUN_DOMAIN` env vars, or pass them directly. Set region to "eu" for the EU endpoint. */
-export destructive def sendWithMailgun(from: string, to: string, subject: string, html: string = "", text: string = "", cc: string = "", bcc: string = "", replyTo: string = "", apiKey: string = "", domain: string = "", region: string = "", allowList: string[] = [], blockList: string[] = []): Result {
+export def sendWithMailgun(from: string, to: string, subject: string, html: string = "", text: string = "", cc: string = "", bcc: string = "", replyTo: string = "", apiKey: string = "", domain: string = "", region: string = "", allowList: string[] = [], blockList: string[] = []): Result {
   """
   Send an email using the Mailgun API.
 
@@ -140,20 +144,22 @@ export destructive def sendWithMailgun(from: string, to: string, subject: string
     subject: subject
   })
 
-  return try _sendWithMailgun({
-    from: from,
-    to: to,
-    subject: subject,
-    html: html,
-    text: text,
-    cc: cc,
-    bcc: bcc,
-    replyTo: replyTo
-  }, {
-    apiKey: apiKey,
-    domain: domain,
-    region: region,
-    allowList: allowList,
-    blockList: blockList
-  })
+  destructive {
+    return try _sendWithMailgun({
+      from: from,
+      to: to,
+      subject: subject,
+      html: html,
+      text: text,
+      cc: cc,
+      bcc: bcc,
+      replyTo: replyTo
+    }, {
+      apiKey: apiKey,
+      domain: domain,
+      region: region,
+      allowList: allowList,
+      blockList: blockList
+    })
+  }
 }

--- a/packages/agency-lang/stdlib/messaging/imessage.agency
+++ b/packages/agency-lang/stdlib/messaging/imessage.agency
@@ -21,7 +21,7 @@ type IMessageResult = {
 effect std::sendIMessage { to: string }
 
 /** Only works on macOS with Messages.app signed in to iMessage. No API key required. */
-export destructive def sendIMessage(to: string, message: string, allowList: string[] = [], blockList: string[] = []): Result {
+export def sendIMessage(to: string, message: string, allowList: string[] = [], blockList: string[] = []): Result {
   """
   Send an iMessage via the macOS Messages app.
 
@@ -34,8 +34,10 @@ export destructive def sendIMessage(to: string, message: string, allowList: stri
     to: to
   })
 
-  return try _sendIMessage(to, message, {
-    allowList: allowList,
-    blockList: blockList
-  })
+  destructive {
+    return try _sendIMessage(to, message, {
+      allowList: allowList,
+      blockList: blockList
+    })
+  }
 }

--- a/packages/agency-lang/stdlib/messaging/sms.agency
+++ b/packages/agency-lang/stdlib/messaging/sms.agency
@@ -23,7 +23,7 @@ type SmsResult = {
 effect std::sendSms { to: string }
 
 /** Requires `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` env vars, or pass them directly. */
-export destructive def sendSms(to: string, body: string, from: string = "", accountSid: string = "", authToken: string = "", allowList: string[] = [], blockList: string[] = []): Result {
+export def sendSms(to: string, body: string, from: string = "", accountSid: string = "", authToken: string = "", allowList: string[] = [], blockList: string[] = []): Result {
   """
   Send an SMS text message via the Twilio API.
 
@@ -39,11 +39,13 @@ export destructive def sendSms(to: string, body: string, from: string = "", acco
     to: to
   })
 
-  return try _sendSms(to, body, {
-    from: from,
-    accountSid: accountSid,
-    authToken: authToken,
-    allowList: allowList,
-    blockList: blockList
-  })
+  destructive {
+    return try _sendSms(to, body, {
+      from: from,
+      accountSid: accountSid,
+      authToken: authToken,
+      allowList: allowList,
+      blockList: blockList
+    })
+  }
 }

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -38,7 +38,7 @@ effect std::ls { dir: string, recursive: boolean, maxResults: number }
 effect std::grep { pattern: string, dir: string, flags: string, maxResults: number }
 effect std::glob { pattern: string, dir: string, maxResults: number }
 
-export destructive def exec(
+export def exec(
   command: string,
   args: string[] = [],
   cwd: string = "",
@@ -83,18 +83,20 @@ export destructive def exec(
     stdin: stdin
   })
 
-  return _exec(
-    command,
-    args,
-    cwd,
-    timeout,
-    stdin,
-    {
-    allowedExecutables: allowedExecutables,
-    blockedCommands: blockedCommands,
-    allowedPaths: allowedPaths
-  },
-  )
+  destructive {
+    return _exec(
+      command,
+      args,
+      cwd,
+      timeout,
+      stdin,
+      {
+      allowedExecutables: allowedExecutables,
+      blockedCommands: blockedCommands,
+      allowedPaths: allowedPaths
+    },
+    )
+  }
 }
 
 /**
@@ -102,7 +104,7 @@ export destructive def exec(
  * shell command string itself, so prefer running an executable directly with
  * structured arguments when capability narrowing matters.
  */
-export destructive def bash(
+export def bash(
   command: string,
   cwd: string = "",
   timeout: number = 0,
@@ -132,16 +134,18 @@ export destructive def bash(
     stdin: stdin
   })
 
-  return _bash(
-    command,
-    cwd,
-    timeout,
-    stdin,
-    {
-    blockedCommands: blockedCommands,
-    allowedPaths: allowedPaths
-  },
-  )
+  destructive {
+    return _bash(
+      command,
+      cwd,
+      timeout,
+      stdin,
+      {
+      blockedCommands: blockedCommands,
+      allowedPaths: allowedPaths
+    },
+    )
+  }
 }
 
 type LsEntry = {

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -91,10 +91,10 @@ export def exec(
       timeout,
       stdin,
       {
-      allowedExecutables: allowedExecutables,
-      blockedCommands: blockedCommands,
-      allowedPaths: allowedPaths
-    },
+        allowedExecutables: allowedExecutables,
+        blockedCommands: blockedCommands,
+        allowedPaths: allowedPaths
+      },
     )
   }
 }
@@ -141,9 +141,9 @@ export def bash(
       timeout,
       stdin,
       {
-      blockedCommands: blockedCommands,
-      allowedPaths: allowedPaths
-    },
+        blockedCommands: blockedCommands,
+        allowedPaths: allowedPaths
+      },
     )
   }
 }

--- a/packages/agency-lang/tests/agency/destructive-block.agency
+++ b/packages/agency-lang/tests/agency/destructive-block.agency
@@ -1,0 +1,62 @@
+// Finding A (anti-fail-open): a failure escaping the WHOLE function after a
+// destructive region must carry destructiveRan. In a frame-local mis-impl the
+// flip would evaporate at block exit and this would be [false].
+def wf(): Result {
+  destructive {
+    return failure("boom")
+  }
+}
+node frameEscape() {
+  const r = wf()
+  if (isFailure(r)) {
+    return [r.destructiveRan]
+  }
+  return "unexpected"
+}
+
+// Finding D: a `return` inside a destructive region exits the function.
+def wr(): number {
+  destructive {
+    return 42
+  }
+}
+node returnInBlock() {
+  return wr()
+}
+
+// Finding B: a `let` declared inside the region is visible after it (the region
+// is transparent — no new scope). A frame-bearing block would leave `y`
+// unresolved.
+def dv(): number {
+  destructive {
+    let y = 10
+  }
+  return y + 1
+}
+node declVisible() {
+  return dv()
+}
+
+// Interrupts work inside a destructive region: pause on the interrupt, resume,
+// and complete.
+def ib(): string {
+  destructive {
+    interrupt("go?")
+    return "done"
+  }
+}
+node interruptInBlock() {
+  return ib()
+}
+
+// Interrupt inside the region, with a statement AFTER the region — resume must
+// land on the correct (continuous) substep.
+def ib2(): string {
+  destructive {
+    interrupt("go?")
+  }
+  return "after"
+}
+node interruptAfter() {
+  return ib2()
+}

--- a/packages/agency-lang/tests/agency/destructive-block.agency
+++ b/packages/agency-lang/tests/agency/destructive-block.agency
@@ -60,3 +60,20 @@ def ib2(): string {
 node interruptAfter() {
   return ib2()
 }
+
+// The migrated-stdlib contract: an interrupt gate placed BEFORE the region.
+// Rejecting the gate fails before the region is entered, so the failure is
+// retryable (destructiveRan = false) — the tool is NOT removed.
+def gated(): Result {
+  const ok = interrupt("Proceed?")
+  destructive {
+    return failure("did the destructive work")
+  }
+}
+node rejectGateBeforeRegion() {
+  const r = gated()
+  if (isFailure(r)) {
+    return [r.destructiveRan]
+  }
+  return "unexpected"
+}

--- a/packages/agency-lang/tests/agency/destructive-block.test.json
+++ b/packages/agency-lang/tests/agency/destructive-block.test.json
@@ -1,9 +1,88 @@
 {
   "tests": [
-    { "nodeName": "frameEscape", "description": "failure escaping the function after a destructive region carries destructiveRan", "input": "", "expectedOutput": "[true]", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "returnInBlock", "description": "return inside a destructive region exits the function", "input": "", "expectedOutput": "42", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "declVisible", "description": "a let declared inside the region is visible after it (transparent)", "input": "", "expectedOutput": "11", "evaluationCriteria": [{ "type": "exact" }] },
-    { "nodeName": "interruptInBlock", "description": "interrupt inside a destructive region pauses and resumes", "input": "", "expectedOutput": "\"done\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "go?" }] },
-    { "nodeName": "interruptAfter", "description": "interrupt in region resumes onto the statement after the region", "input": "", "expectedOutput": "\"after\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "go?" }] }
+    {
+      "nodeName": "frameEscape",
+      "description": "failure escaping the function after a destructive region carries destructiveRan",
+      "input": "",
+      "expectedOutput": "[true]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "returnInBlock",
+      "description": "return inside a destructive region exits the function",
+      "input": "",
+      "expectedOutput": "42",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "declVisible",
+      "description": "a let declared inside the region is visible after it (transparent)",
+      "input": "",
+      "expectedOutput": "11",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "interruptInBlock",
+      "description": "interrupt inside a destructive region pauses and resumes",
+      "input": "",
+      "expectedOutput": "\"done\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "go?"
+        }
+      ]
+    },
+    {
+      "nodeName": "interruptAfter",
+      "description": "interrupt in region resumes onto the statement after the region",
+      "input": "",
+      "expectedOutput": "\"after\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "go?"
+        }
+      ]
+    },
+    {
+      "nodeName": "rejectGateBeforeRegion",
+      "description": "rejecting an interrupt gate placed before a destructive region is retryable (destructiveRan false)",
+      "input": "",
+      "expectedOutput": "[false]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "reject",
+          "expectedMessage": "Proceed?"
+        }
+      ]
+    }
   ]
 }

--- a/packages/agency-lang/tests/agency/destructive-block.test.json
+++ b/packages/agency-lang/tests/agency/destructive-block.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [
+    { "nodeName": "frameEscape", "description": "failure escaping the function after a destructive region carries destructiveRan", "input": "", "expectedOutput": "[true]", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "returnInBlock", "description": "return inside a destructive region exits the function", "input": "", "expectedOutput": "42", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "declVisible", "description": "a let declared inside the region is visible after it (transparent)", "input": "", "expectedOutput": "11", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "interruptInBlock", "description": "interrupt inside a destructive region pauses and resumes", "input": "", "expectedOutput": "\"done\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "go?" }] },
+    { "nodeName": "interruptAfter", "description": "interrupt in region resumes onto the statement after the region", "input": "", "expectedOutput": "\"after\"", "evaluationCriteria": [{ "type": "exact" }], "interruptHandlers": [{ "action": "approve", "expectedMessage": "go?" }] }
+  ]
+}

--- a/packages/agency-lang/tests/agency/destructive-tracking.agency
+++ b/packages/agency-lang/tests/agency/destructive-tracking.agency
@@ -1,14 +1,32 @@
-destructive def burn(x: number): Result {
+// A `def` whose destructive work sits in a `destructive { }` region, guarded by
+// a validation refusal BEFORE the region. Refuse before the region → clean
+// (retryable); fail inside → committed.
+def burn(x: number): Result {
   if (x < 0) {
     return failure("refused before doing anything")
   }
-  print("burning")
-  return failure("failed after starting")
+  destructive {
+    print("burning")
+    return failure("failed after starting")
+  }
 }
 
 destructive def burnOk(): number {
   print("burning fine")
   return 42
+}
+
+// A `destructive def` commits its WHOLE body at entry: failing anywhere (even
+// the first statement) carries destructiveRan.
+destructive def burnWhole(): Result {
+  return failure("committed at entry")
+}
+node wholeEntry() {
+  const r = burnWhole()
+  if (isFailure(r)) {
+    return [r.neverStarted, r.destructiveRan]
+  }
+  return "unexpected"
 }
 
 def caller(x: number): Result {

--- a/packages/agency-lang/tests/agency/destructive-tracking.test.json
+++ b/packages/agency-lang/tests/agency/destructive-tracking.test.json
@@ -2,6 +2,7 @@
   "tests": [
     { "nodeName": "cleanRefusal", "description": "refused destructive call does not poison the caller", "input": "", "expectedOutput": "[false,false]", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "startedThenFailed", "description": "failure after destructive work carries destructiveRan", "input": "", "expectedOutput": "[false,true]", "evaluationCriteria": [{ "type": "exact" }] },
+    { "nodeName": "wholeEntry", "description": "destructive def commits at entry: failing at the first statement carries destructiveRan", "input": "", "expectedOutput": "[false,true]", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "succeededThenFailed", "description": "destructive success then later failure carries destructiveRan", "input": "", "expectedOutput": "[true]", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "trySwallowed", "description": "try over a returned destructive failure ORs it into the activation", "input": "", "expectedOutput": "[true]", "evaluationCriteria": [{ "type": "exact" }] },
     { "nodeName": "blockHalt", "description": "destructive work and failure inside a block: escaping failure stamped at block halt", "input": "", "expectedOutput": "[true]", "evaluationCriteria": [{ "type": "exact" }] },

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.agency
@@ -1,0 +1,18 @@
+def prep(x: number): number {
+  return x
+}
+
+def _doWrite(p: number): number {
+  return p
+}
+
+def writeThing(x: number): number {
+  const p = prep(x)
+  destructive {
+    return _doWrite(p)
+  }
+}
+
+node main() {
+  return writeThing(1)
+}

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -1,0 +1,730 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "agency-lang/zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import os from "os";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
+  RestoreSignal,
+  AgencyAbort,
+  deepClone as __deepClone,
+  deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  functionRefReviver as __functionRefReviver,
+  DeterministicClient as __DeterministicClient,
+  installFetchMock as __installFetchMock,
+  createLogger as __createLogger,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false,
+    observability: false
+  },
+  smoltalkDefaults: {
+    apiKey: {
+      openAi: __process.env["OPENAI_API_KEY"] || "",
+      google: __process.env["GEMINI_API_KEY"] || "",
+      anthropic: __process.env["ANTHROPIC_API_KEY"] || "",
+      openRouter: __process.env["OPENROUTER_API_KEY"] || "",
+      deepInfra: __process.env["DEEPINFRA_API_KEY"] || "",
+      liteLlm: __process.env["LITELLM_API_KEY"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_API_KEY"] || ""
+    },
+    baseUrl: {
+      liteLlm: __process.env["LITELLM_BASE_URL"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
+    },
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  logLevel: "info",
+  traceConfig: {
+    program: "destructiveBlock.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Handler result builtins and interrupt response constructors (unified types)
+export function approve(value?: any) { return { type: "approve" as const, value }; }
+export function reject(value?: any) { return { type: "reject" as const, value }; }
+function propagate() { return { type: "propagate" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, hasInterrupts, isDebugger };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
+export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+// Auto-activate the deterministic LLM client when AGENCY_LLM_MOCKS is set.
+// The test runner (lib/cli/util.ts) populates this env var as a JSON string
+// when AGENCY_USE_TEST_LLM_PROVIDER=1. Both the agency evaluate template
+// and the agency-js test.js paths import this module, so this single block
+// covers both code paths.
+if (__process.env.AGENCY_LLM_MOCKS) {
+  __globalCtx.setLLMClient(
+    new __DeterministicClient(JSON.parse(__process.env.AGENCY_LLM_MOCKS))
+  );
+}
+
+// Auto-activate fetch mocking when AGENCY_FETCH_MOCKS_FILE points at a mocks
+// file. The runner writes resolved mocks (returnFile bodies already inlined) to
+// a temp file and passes its path — a file, not an inline env value, so a large
+// response body can't blow the exec arg/env size limit (ARG_MAX). Independent of
+// AGENCY_LLM_MOCKS — a test may mock the network while using a real LLM, or vice
+// versa. Installed before any node runs, ahead of any http.ts / stdlib / interop
+// fetch.
+if (__process.env.AGENCY_FETCH_MOCKS_FILE) {
+  __installFetchMock(JSON.parse(readFileSync(__process.env.AGENCY_FETCH_MOCKS_FILE, "utf-8")));
+}
+
+// Share a single registry object across every compiled module. With
+// composite "module:name" keys, all modules' helpers — plus
+// runtime-created blocks registered by `AgencyFunction.create` while
+// a function is executing — stay reachable from `FunctionRefReviver`
+// no matter which module touched the registry last.
+export const __toolRegistry: Record<string, any> = (__functionRefReviver.registry ??= {} as any);
+
+function __registerTool(value: unknown, _aliasName?: string) {
+  // Composite "module:name" key keyed off the function's *own*
+  // identity, not the importing module's local alias — so different
+  // modules that import the same function don't shadow each other in
+  // the shared global registry that `FunctionRefReviver` reads from.
+  // `_aliasName` is kept in the signature for backwards compatibility
+  // with already-compiled callers that pass it.
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[`${value.module}:${value.name}`] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const _run = __AgencyFunction.create({ name: "_run", module: "__runtime", fn: __runtime_run_impl, params: [{ name: "compiled", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "node", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "args", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "wallClock", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "memory", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "ipcPayload", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "stdout", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "configOverrides", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "cwd", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "maxDepth", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+
+function registerTools(tools: any[]) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[`${tool.module}:${tool.name}`] = tool;
+    }
+  }
+}
+
+async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("destructiveBlock.agency")) {
+    return;
+  }
+  __ctx.globals.markInitialized("destructiveBlock.agency")
+}
+__registerGlobalsInit("destructiveBlock.agency", __initializeGlobals);
+async function __registerTopLevelCallbacks(__ctx) {
+  __ctx.topLevelCallbacks = [];
+}
+__functionRefReviver.registry = __toolRegistry;
+async function __prep_impl(x: number) {
+  const __setupData = setupFunction();
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  if (!__globals()!.isInitialized("destructiveBlock.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  __stack.args["x"] = x;
+  __self.__destructiveRan = __self.__destructiveRan ?? false;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "destructiveBlock.agency", scopeName: "prep", threads: __setupData.threads });
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("x" in __overrides) {
+    x = __overrides["x"];
+    __stack.args["x"] = x;
+  }
+
+}
+
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __setupData.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onFunctionStart",
+          data: {
+            functionName: "prep",
+            args: {
+              x: x
+            },
+            moduleId: "destructiveBlock.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__functionCompleted = true;
+runner.halt(__stack.args.x)
+return;
+      });
+    })
+    if (runner.halted) {
+      if (isFailure(runner.haltResult)) {
+        stampFailureBoundary(runner.haltResult, __self.__destructiveRan)
+      }
+      return runner.haltResult;
+    }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// All aborts — cancellations (Esc / abort) AND guard trips — are now a single
+// AgencyAbort carrying an AbortCause, and must propagate untouched. The owning
+// guard's `try` converts its own guardTrip; every other abort unwinds. One
+// rung replaces the old GuardExceededError + isAbortError ladder. Converting
+// any abort to a Failure here would (a) hide a guard trip so the block appears
+// to succeed over budget, and (b) let a cancel limp onward / surface as a
+// logged ERROR the REPL can't recognize. See lib/runtime/errors.ts (§5).
+if (__error instanceof AgencyAbort) {
+  throw __error;
+}
+// Surface the underlying exception via logger + statelog before
+// converting to a Failure. Without this, a caller that doesn't
+// inspect the result (the common case for void side-effect calls)
+// silently loses the error — a debugging nightmare. See the
+// recordAlwaysScoped bug debugged in
+// https://ampcode.com/threads/T-019e7a3a-edfa-74d6-917a-255c31bf8491.
+{
+  const __errMsg = __error instanceof Error ? __error.message : String(__error);
+  const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+  const __log = __createLogger(__ctx.logLevel);
+  __log.error("Function " + "prep" + " threw an exception (converted to Failure): " + __errMsg);
+  if (__errStack) __log.error(__errStack);
+  __ctx.statelogClient?.error?.({
+    errorType: "runtimeError",
+    message: __errMsg,
+    functionName: "prep",
+  });
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: getRuntimeContext().ctx.getResultCheckpoint(),
+    destructiveRan: __self.__destructiveRan,
+    functionName: "prep",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    __stateStack()?.pop()
+    if (__functionCompleted) {
+      await callHook({
+        name: "onFunctionEnd",
+        data: {
+          functionName: "prep",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+export const prep = __AgencyFunction.create({
+  name: "prep",
+  module: "destructiveBlock.agency",
+  fn: __prep_impl,
+  params: [{
+    name: "x",
+    hasDefault: false,
+    defaultValue: undefined,
+    variadic: false,
+    isFunctionTyped: false,
+    acceptsResult: false
+  }],
+  toolDefinition: {
+    name: "prep",
+    description: "No description provided.",
+    schema: z.object({"x": z.number(), })
+  },
+  exported: false
+}, __toolRegistry);
+async function ___doWrite_impl(p: number) {
+  const __setupData = setupFunction();
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  if (!__globals()!.isInitialized("destructiveBlock.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  __stack.args["p"] = p;
+  __self.__destructiveRan = __self.__destructiveRan ?? false;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "destructiveBlock.agency", scopeName: "_doWrite", threads: __setupData.threads });
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("p" in __overrides) {
+    p = __overrides["p"];
+    __stack.args["p"] = p;
+  }
+
+}
+
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __setupData.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onFunctionStart",
+          data: {
+            functionName: "_doWrite",
+            args: {
+              p: p
+            },
+            moduleId: "destructiveBlock.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__functionCompleted = true;
+runner.halt(__stack.args.p)
+return;
+      });
+    })
+    if (runner.halted) {
+      if (isFailure(runner.haltResult)) {
+        stampFailureBoundary(runner.haltResult, __self.__destructiveRan)
+      }
+      return runner.haltResult;
+    }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// All aborts — cancellations (Esc / abort) AND guard trips — are now a single
+// AgencyAbort carrying an AbortCause, and must propagate untouched. The owning
+// guard's `try` converts its own guardTrip; every other abort unwinds. One
+// rung replaces the old GuardExceededError + isAbortError ladder. Converting
+// any abort to a Failure here would (a) hide a guard trip so the block appears
+// to succeed over budget, and (b) let a cancel limp onward / surface as a
+// logged ERROR the REPL can't recognize. See lib/runtime/errors.ts (§5).
+if (__error instanceof AgencyAbort) {
+  throw __error;
+}
+// Surface the underlying exception via logger + statelog before
+// converting to a Failure. Without this, a caller that doesn't
+// inspect the result (the common case for void side-effect calls)
+// silently loses the error — a debugging nightmare. See the
+// recordAlwaysScoped bug debugged in
+// https://ampcode.com/threads/T-019e7a3a-edfa-74d6-917a-255c31bf8491.
+{
+  const __errMsg = __error instanceof Error ? __error.message : String(__error);
+  const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+  const __log = __createLogger(__ctx.logLevel);
+  __log.error("Function " + "_doWrite" + " threw an exception (converted to Failure): " + __errMsg);
+  if (__errStack) __log.error(__errStack);
+  __ctx.statelogClient?.error?.({
+    errorType: "runtimeError",
+    message: __errMsg,
+    functionName: "_doWrite",
+  });
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: getRuntimeContext().ctx.getResultCheckpoint(),
+    destructiveRan: __self.__destructiveRan,
+    functionName: "_doWrite",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    __stateStack()?.pop()
+    if (__functionCompleted) {
+      await callHook({
+        name: "onFunctionEnd",
+        data: {
+          functionName: "_doWrite",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+export const _doWrite = __AgencyFunction.create({
+  name: "_doWrite",
+  module: "destructiveBlock.agency",
+  fn: ___doWrite_impl,
+  params: [{
+    name: "p",
+    hasDefault: false,
+    defaultValue: undefined,
+    variadic: false,
+    isFunctionTyped: false,
+    acceptsResult: false
+  }],
+  toolDefinition: {
+    name: "_doWrite",
+    description: "No description provided.",
+    schema: z.object({"p": z.number(), })
+  },
+  exported: false
+}, __toolRegistry);
+async function __writeThing_impl(x: number) {
+  const __setupData = setupFunction();
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  if (!__globals()!.isInitialized("destructiveBlock.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  __stack.args["x"] = x;
+  __self.__destructiveRan = __self.__destructiveRan ?? false;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "destructiveBlock.agency", scopeName: "writeThing", threads: __setupData.threads });
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("x" in __overrides) {
+    x = __overrides["x"];
+    __stack.args["x"] = x;
+  }
+
+}
+
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __setupData.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onFunctionStart",
+          data: {
+            functionName: "writeThing",
+            args: {
+              x: x
+            },
+            moduleId: "destructiveBlock.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.p = await __call(prep, {
+          type: "positional",
+          args: [__stack.args.x]
+        });
+if (hasInterrupts(__stack.locals.p)) {
+          await getRuntimeContext().ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.p)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+__self.__destructiveRan = true;
+      });
+      await runner.step(3, async (runner) => {
+__functionCompleted = true;
+runner.halt(await __call(_doWrite, {
+          type: "positional",
+          args: [__stack.locals.p]
+        }))
+return;
+      });
+    })
+    if (runner.halted) {
+      if (isFailure(runner.haltResult)) {
+        stampFailureBoundary(runner.haltResult, __self.__destructiveRan)
+      }
+      return runner.haltResult;
+    }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// All aborts — cancellations (Esc / abort) AND guard trips — are now a single
+// AgencyAbort carrying an AbortCause, and must propagate untouched. The owning
+// guard's `try` converts its own guardTrip; every other abort unwinds. One
+// rung replaces the old GuardExceededError + isAbortError ladder. Converting
+// any abort to a Failure here would (a) hide a guard trip so the block appears
+// to succeed over budget, and (b) let a cancel limp onward / surface as a
+// logged ERROR the REPL can't recognize. See lib/runtime/errors.ts (§5).
+if (__error instanceof AgencyAbort) {
+  throw __error;
+}
+// Surface the underlying exception via logger + statelog before
+// converting to a Failure. Without this, a caller that doesn't
+// inspect the result (the common case for void side-effect calls)
+// silently loses the error — a debugging nightmare. See the
+// recordAlwaysScoped bug debugged in
+// https://ampcode.com/threads/T-019e7a3a-edfa-74d6-917a-255c31bf8491.
+{
+  const __errMsg = __error instanceof Error ? __error.message : String(__error);
+  const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+  const __log = __createLogger(__ctx.logLevel);
+  __log.error("Function " + "writeThing" + " threw an exception (converted to Failure): " + __errMsg);
+  if (__errStack) __log.error(__errStack);
+  __ctx.statelogClient?.error?.({
+    errorType: "runtimeError",
+    message: __errMsg,
+    functionName: "writeThing",
+  });
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: getRuntimeContext().ctx.getResultCheckpoint(),
+    destructiveRan: __self.__destructiveRan,
+    functionName: "writeThing",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    __stateStack()?.pop()
+    if (__functionCompleted) {
+      await callHook({
+        name: "onFunctionEnd",
+        data: {
+          functionName: "writeThing",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+export const writeThing = __AgencyFunction.create({
+  name: "writeThing",
+  module: "destructiveBlock.agency",
+  fn: __writeThing_impl,
+  params: [{
+    name: "x",
+    hasDefault: false,
+    defaultValue: undefined,
+    variadic: false,
+    isFunctionTyped: false,
+    acceptsResult: false
+  }],
+  toolDefinition: {
+    name: "writeThing",
+    description: "No description provided.",
+    schema: z.object({"x": z.number(), })
+  },
+  exported: false
+}, __toolRegistry);
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "destructiveBlock.agency", scopeName: "main", threads: __setupData.threads });
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __ctx.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+runner.halt({
+          messages: __threads(),
+          data: await __call(writeThing, {
+            type: "positional",
+            args: [1]
+          })
+        })
+return;
+      });
+    })
+    if (runner.halted) return runner.haltResult;
+    await runner.hook(2, async () => {
+await callHook({
+        name: "onNodeEnd",
+        data: {
+          nodeName: "main",
+          data: undefined
+        }
+      })
+    });
+    return {
+      messages: __threads(),
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof AgencyAbort) {
+      throw __error
+    }
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
+    return {
+      messages: __threads(),
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals,
+    registerTopLevelCallbacks: __registerTopLevelCallbacks,
+    moduleDir: __dirname
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    const __result = await main(initialState);
+    await resolveCliInterrupts(__result, respondToInterrupts)
+  } catch (__error: any) {
+    console.error(`
+Agent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"destructiveBlock.agency:prep":{"1":{"line":1,"col":2}},"destructiveBlock.agency:_doWrite":{"1":{"line":5,"col":2}},"destructiveBlock.agency:writeThing":{"1":{"line":9,"col":2},"3":{"line":11,"col":4}},"destructiveBlock.agency:main":{"1":{"line":16,"col":2}}};

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -621,7 +621,10 @@ export const writeThing = __AgencyFunction.create({
     description: "No description provided.",
     schema: z.object({"x": z.number(), })
   },
-  exported: false
+  exported: false,
+  markers: {
+    destructive: true
+  }
 }, __toolRegistry);
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
@@ -650,6 +653,7 @@ await callHook({
         })
       });
       await runner.step(1, async (runner) => {
+__self.__destructiveRan = true;
 runner.halt({
           messages: __threads(),
           data: await __call(writeThing, {

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.agency
@@ -1,0 +1,9 @@
+destructive def f(): number {
+  destructive {
+    return 1
+  }
+}
+
+node main() {
+  return f()
+}

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -1,0 +1,420 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "agency-lang/zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import os from "os";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  runExportedFunction as _runExportedFunction,
+  RestoreSignal,
+  AgencyAbort,
+  deepClone as __deepClone,
+  deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, stampFailureBoundary, markDestructiveWork, __pipeBind, __tryCall, __catchResult, __eq, __nn,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  functionRefReviver as __functionRefReviver,
+  DeterministicClient as __DeterministicClient,
+  installFetchMock as __installFetchMock,
+  createLogger as __createLogger,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false,
+    observability: false
+  },
+  smoltalkDefaults: {
+    apiKey: {
+      openAi: __process.env["OPENAI_API_KEY"] || "",
+      google: __process.env["GEMINI_API_KEY"] || "",
+      anthropic: __process.env["ANTHROPIC_API_KEY"] || "",
+      openRouter: __process.env["OPENROUTER_API_KEY"] || "",
+      deepInfra: __process.env["DEEPINFRA_API_KEY"] || "",
+      liteLlm: __process.env["LITELLM_API_KEY"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_API_KEY"] || ""
+    },
+    baseUrl: {
+      liteLlm: __process.env["LITELLM_BASE_URL"] || "",
+      openAiCompat: __process.env["OPENAI_COMPAT_BASE_URL"] || ""
+    },
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  logLevel: "info",
+  traceConfig: {
+    program: "destructiveNested.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Handler result builtins and interrupt response constructors (unified types)
+export function approve(value?: any) { return { type: "approve" as const, value }; }
+export function reject(value?: any) { return { type: "reject" as const, value }; }
+function propagate() { return { type: "propagate" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, hasInterrupts, isDebugger };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+// Invoke an exported function in a node-grade execution frame. Used by
+// `agency serve` to call a function from an HTTP/MCP request — outside any
+// Agency execution frame, which generated function bodies otherwise require.
+export const __invokeFunction = (fn: any, namedArgs: Record<string, unknown>) => _runExportedFunction({ ctx: __globalCtx, fn, namedArgs, initializeGlobals: __initializeGlobals, registerTopLevelCallbacks: __registerTopLevelCallbacks, moduleDir: __dirname });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
+export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+// Auto-activate the deterministic LLM client when AGENCY_LLM_MOCKS is set.
+// The test runner (lib/cli/util.ts) populates this env var as a JSON string
+// when AGENCY_USE_TEST_LLM_PROVIDER=1. Both the agency evaluate template
+// and the agency-js test.js paths import this module, so this single block
+// covers both code paths.
+if (__process.env.AGENCY_LLM_MOCKS) {
+  __globalCtx.setLLMClient(
+    new __DeterministicClient(JSON.parse(__process.env.AGENCY_LLM_MOCKS))
+  );
+}
+
+// Auto-activate fetch mocking when AGENCY_FETCH_MOCKS_FILE points at a mocks
+// file. The runner writes resolved mocks (returnFile bodies already inlined) to
+// a temp file and passes its path — a file, not an inline env value, so a large
+// response body can't blow the exec arg/env size limit (ARG_MAX). Independent of
+// AGENCY_LLM_MOCKS — a test may mock the network while using a real LLM, or vice
+// versa. Installed before any node runs, ahead of any http.ts / stdlib / interop
+// fetch.
+if (__process.env.AGENCY_FETCH_MOCKS_FILE) {
+  __installFetchMock(JSON.parse(readFileSync(__process.env.AGENCY_FETCH_MOCKS_FILE, "utf-8")));
+}
+
+// Share a single registry object across every compiled module. With
+// composite "module:name" keys, all modules' helpers — plus
+// runtime-created blocks registered by `AgencyFunction.create` while
+// a function is executing — stay reachable from `FunctionRefReviver`
+// no matter which module touched the registry last.
+export const __toolRegistry: Record<string, any> = (__functionRefReviver.registry ??= {} as any);
+
+function __registerTool(value: unknown, _aliasName?: string) {
+  // Composite "module:name" key keyed off the function's *own*
+  // identity, not the importing module's local alias — so different
+  // modules that import the same function don't shadow each other in
+  // the shared global registry that `FunctionRefReviver` reads from.
+  // `_aliasName` is kept in the signature for backwards compatibility
+  // with already-compiled callers that pass it.
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[`${value.module}:${value.name}`] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const _run = __AgencyFunction.create({ name: "_run", module: "__runtime", fn: __runtime_run_impl, params: [{ name: "compiled", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "node", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "args", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "wallClock", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "memory", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "ipcPayload", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "stdout", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "configOverrides", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "cwd", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "maxDepth", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+
+function registerTools(tools: any[]) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[`${tool.module}:${tool.name}`] = tool;
+    }
+  }
+}
+
+async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("destructiveNested.agency")) {
+    return;
+  }
+  __ctx.globals.markInitialized("destructiveNested.agency")
+}
+__registerGlobalsInit("destructiveNested.agency", __initializeGlobals);
+async function __registerTopLevelCallbacks(__ctx) {
+  __ctx.topLevelCallbacks = [];
+}
+__functionRefReviver.registry = __toolRegistry;
+async function __f_impl() {
+  const __setupData = setupFunction();
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  if (!__globals()!.isInitialized("destructiveNested.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  __self.__destructiveRan = true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "destructiveNested.agency", scopeName: "f", threads: __setupData.threads });
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+
+}
+
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __setupData.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onFunctionStart",
+          data: {
+            functionName: "f",
+            args: {},
+            moduleId: "destructiveNested.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__self.__destructiveRan = true;
+      });
+      await runner.step(2, async (runner) => {
+__functionCompleted = true;
+runner.halt(1)
+return;
+      });
+    })
+    if (runner.halted) {
+      if (isFailure(runner.haltResult)) {
+        stampFailureBoundary(runner.haltResult, __self.__destructiveRan)
+      }
+      return runner.haltResult;
+    }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// All aborts — cancellations (Esc / abort) AND guard trips — are now a single
+// AgencyAbort carrying an AbortCause, and must propagate untouched. The owning
+// guard's `try` converts its own guardTrip; every other abort unwinds. One
+// rung replaces the old GuardExceededError + isAbortError ladder. Converting
+// any abort to a Failure here would (a) hide a guard trip so the block appears
+// to succeed over budget, and (b) let a cancel limp onward / surface as a
+// logged ERROR the REPL can't recognize. See lib/runtime/errors.ts (§5).
+if (__error instanceof AgencyAbort) {
+  throw __error;
+}
+// Surface the underlying exception via logger + statelog before
+// converting to a Failure. Without this, a caller that doesn't
+// inspect the result (the common case for void side-effect calls)
+// silently loses the error — a debugging nightmare. See the
+// recordAlwaysScoped bug debugged in
+// https://ampcode.com/threads/T-019e7a3a-edfa-74d6-917a-255c31bf8491.
+{
+  const __errMsg = __error instanceof Error ? __error.message : String(__error);
+  const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+  const __log = __createLogger(__ctx.logLevel);
+  __log.error("Function " + "f" + " threw an exception (converted to Failure): " + __errMsg);
+  if (__errStack) __log.error(__errStack);
+  __ctx.statelogClient?.error?.({
+    errorType: "runtimeError",
+    message: __errMsg,
+    functionName: "f",
+  });
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: getRuntimeContext().ctx.getResultCheckpoint(),
+    destructiveRan: __self.__destructiveRan,
+    functionName: "f",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    __stateStack()?.pop()
+    if (__functionCompleted) {
+      await callHook({
+        name: "onFunctionEnd",
+        data: {
+          functionName: "f",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+export const f = __AgencyFunction.create({
+  name: "f",
+  module: "destructiveNested.agency",
+  fn: __f_impl,
+  params: [],
+  toolDefinition: {
+    name: "f",
+    description: "No description provided.",
+    schema: z.object({})
+  },
+  exported: false,
+  markers: {
+    destructive: true
+  }
+}, __toolRegistry);
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __ctx = getRuntimeContext().ctx;
+let __forked;
+let __functionCompleted = false;
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "destructiveNested.agency", scopeName: "main", threads: __setupData.threads });
+  try {
+    await agencyStore.run({
+      ...getRuntimeContext(),
+      ctx: __ctx,
+      stack: __ctx.stateStack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
+await callHook({
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__self.__destructiveRan = true;
+runner.halt({
+          messages: __threads(),
+          data: await __call(f, {
+            type: "positional",
+            args: []
+          })
+        })
+return;
+      });
+    })
+    if (runner.halted) return runner.haltResult;
+    await runner.hook(2, async () => {
+await callHook({
+        name: "onNodeEnd",
+        data: {
+          nodeName: "main",
+          data: undefined
+        }
+      })
+    });
+    return {
+      messages: __threads(),
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof AgencyAbort) {
+      throw __error
+    }
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
+    return {
+      messages: __threads(),
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals,
+    registerTopLevelCallbacks: __registerTopLevelCallbacks,
+    moduleDir: __dirname
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    const __result = await main(initialState);
+    await resolveCliInterrupts(__result, respondToInterrupts)
+  } catch (__error: any) {
+    console.error(`
+Agent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"destructiveNested.agency:f":{"2":{"line":2,"col":4}},"destructiveNested.agency:main":{"1":{"line":7,"col":2}}};


### PR DESCRIPTION
## Summary

Makes the `destructive` declaration **authoritative** for tool removal-on-failure, and adds a `destructive { }` region so a tool's interrupt gate can stay retryable-on-rejection.

Previously, whether a failed `destructive` tool got removed was gated on a compiler heuristic (`containsImpureCall` — did the body call an *imported* symbol before failing), so `print` mattered but a same-file `def` didn't, and every real stdlib tool (which validates before its gate) became non-retryable on a rejected confirmation. Now:

- **`destructive def`** commits its whole body at **function entry**. Any failure in the body removes the tool; only an argument-binding failure (body never ran) stays retryable.
- **`destructive { }` region** (new) commits at **region entry**. Prep and the interrupt gate sit *outside* it, so rejecting the gate is retryable; a failure inside removes the tool.

## Design & reviews

Spec + two spec-review rounds + one plan-review round are included under `docs/superpowers/`. The plan review drove the key implementation decision below.

## Implementation

`destructive { }` is **not** a new AST node — it's a `seqBlock` carrying a `destructive: true` flag. `seqBlock` is already runtime-frame-transparent (`parallelDesugar` inlines a standalone seqBlock to its body on the function's `__self`) and already threaded through every body-dispatch site (bodySlots, flow-narrowing, scopes, preprocessors, formatter, lowering). Reusing it avoids wiring a new transparent node into ~8 hand-enumerated sites (and the silent breakage that would cause). Four places learn the flag:

1. **Parser** — `destructive { }` → `seqBlock{ destructive: true }`. The `{` is a soft gate (outside the committing `parseError`) so `destructive def` backtracks cleanly.
2. **Formatter** — `AgencyGenerator.processSeqBlock` prints `destructive {` when flagged.
3. **Desugar** — `parallelDesugar` prepends a synthetic `markDestructiveRan` leaf when inlining a destructive seqBlock; codegen emits it as `__self.__destructiveRan = true`. Because the seqBlock is inlined, the flip lands on the **function** activation, never a block frame — this is the fail-open guard.
4. **Metadata** — `isDestructive = marked OR contains-destructive-region` drives the descriptor marker, the MCP/HTTP client hint, and the `destructiveFunctions` registry, *without* mutating `node.markers` (which still keys the entry flip on the raw marker alone).

Also: `destructive def` sets the flag at entry via `init(true)`; the old per-statement Rule-1 scan and the dead `containsImpureCall`/`isImpureImportedFunction` heuristic are removed. Removal wiring (`failureTier`) is unchanged.

Two bugs found and fixed during implementation:
- `init` read the scope's `inDestructiveFunction` flag *after* it was restored, so `destructive def` never committed at entry — now threaded explicitly through `buildFunctionBody`.
- The metadata helper matches the region on **both** sides of desugar (the `seqBlock` pre-desugar in `compilationUnit`, the `markDestructiveRan` leaf post-desugar in `TypeScriptBuilder`).

## Stdlib migration

All ~29 stdlib `destructive def` functions migrated to `def` + `destructive { work }`, wrapping only the post-gate effectful work: git (9), fs (6), shell (2), index write/writeBinary (2), clipboard (1), calendar (3), memory (1, non-uniform — wraps its `thread` block), auth keyring/oauth (3), messaging email/imessage/sms (5). Each still reports `destructive` to clients via the contains-region derivation. Rejecting any of their confirmation gates is now retryable.

## Tests

- `destructive-tracking` rewritten to the region model (+ a `destructive def` entry-commit case).
- New `destructive-block` execution tests: **frame-escape** (a failure escaping the function after a region carries `destructiveRan` — the anti-fail-open guard), declaration-visibility (transparency), return-in-region, and interrupt-inside-region resume (with a statement after the region).
- Parser disambiguation + nested-`destructive{}`-in-`destructive def` fixture (asserts the harmless redundant flip).
- typescriptGenerator fixtures for the region and the nested case.

## Verification

- Full lib suite: **8163 passed**, 41 skipped. The one failure — `lib/cli/runShim/resolver.test.ts` — is a pre-existing worktree-naming artifact: the test asserts the checkout path `.includes("agency-lang")`, which is false in a worktree named `agency-destructive-marker-impl` but true in the `agency-lang` repo checkout (and in CI). Untouched by this branch; passes on the main checkout.
- `pnpm run lint:structure`, `tsc --noEmit`, and `make` all clean.
- Targeted agency tests (destructive-tracking, destructive-block, write-binary) pass.

## Non-goals

- Whether a *non-destructive* tool's rejected interrupt should be retryable (separate; PR #533).
- Unifying the success-path `toolDidDestructiveWork` onto the runtime flag (documented non-goal; the current over-taint is the safe direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
