### PR TITLE
Exempt the stdlib prelude from the reserved-name check (fix AG4002 cascade breaking main)

### DIFF
--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -48,6 +48,8 @@ import { checkConflictingMarkers } from "./conflictingMarkers.js";
 import { refineInlineHandlerParams } from "./handlerParamTyping.js";
 import { checkEffectPayloads, buildEffectRegistry } from "./effectPayloadCheck.js";
 import type { SymbolTable } from "../symbolTable.js";
+import { isNonTemplatedStdlib } from "../importPaths.js";
+import * as path from "node:path";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { checkMissingImports } from "./missingImportDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
@@ -212,13 +214,25 @@ export class TypeChecker {
     // on `success(x)` and `failure(msg)` parameterizing ResultType, and on
     // `Result` being the built-in type. Allowing user definitions of these
     // names would silently change semantics.
+    //
+    // Exempt the non-templated stdlib prelude (`std::index`): it is the
+    // canonical *definition* site of these built-ins (e.g. `export def
+    // callback(...)`), so its own declarations must be allowed. Without this,
+    // typechecking the prelude reports AG4002 against its own `callback`, and
+    // because the prelude is auto-imported everywhere that failure cascades
+    // into every file's typecheck step.
+    const isPreludeSource = this.currentFile
+      ? isNonTemplatedStdlib(path.resolve(this.currentFile))
+      : false;
     const reservedFn = (name: string, loc: SourceLocation | undefined) =>
       this.errors.push(diagnostic("reservedBuiltinRedefined", { name }, loc ?? null));
-    for (const [name, def] of Object.entries(this.functionDefs)) {
-      if (RESERVED_FUNCTION_NAMES.has(name)) reservedFn(name, def.loc);
-    }
-    for (const [name, def] of Object.entries(this.nodeDefs)) {
-      if (RESERVED_FUNCTION_NAMES.has(name)) reservedFn(name, def.loc);
+    if (!isPreludeSource) {
+      for (const [name, def] of Object.entries(this.functionDefs)) {
+        if (RESERVED_FUNCTION_NAMES.has(name)) reservedFn(name, def.loc);
+      }
+      for (const [name, def] of Object.entries(this.nodeDefs)) {
+        if (RESERVED_FUNCTION_NAMES.has(name)) reservedFn(name, def.loc);
+      }
     }
     for (const [, aliases] of this.scopedTypeAliases.scopes()) {
       for (const name of Object.keys(aliases)) {
@@ -242,6 +256,7 @@ export class TypeChecker {
     // graphNode bodies — and check the variable name. Only fires on actual
     // declarations (where `declKind` is set), not reassignments.
     for (const { node } of walkNodes(this.program.nodes)) {
+      if (isPreludeSource) break;
       if (node.type !== "assignment") continue;
       if (!node.declKind) continue;
       if (RESERVED_FUNCTION_NAMES.has(node.variableName)) {

--- a/packages/agency-lang/lib/typeChecker/reservedNameDeclaration.test.ts
+++ b/packages/agency-lang/lib/typeChecker/reservedNameDeclaration.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { writeFileSync, unlinkSync } from "fs";
+import { writeFileSync, unlinkSync, readFileSync } from "fs";
 import path from "path";
 import os from "os";
 import { parseAgency } from "../parser.js";
 import { SymbolTable } from "../symbolTable.js";
+import { getStdlibDir } from "../importPaths.js";
 import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck } from "./index.js";
 import type { TypeCheckError } from "./types.js";
@@ -105,5 +106,29 @@ describe("reserved-name declaration check", () => {
       (e) => e.message.includes("callback") && e.message.includes("reserved"),
     );
     expect(reserved).toHaveLength(1);
+  });
+
+  // Regression: the non-templated stdlib prelude (`std::index`) is the
+  // canonical *definition* site of these built-ins (e.g. `export def
+  // callback(...)`), so it must be exempt from the reserved-name check.
+  // Before the exemption, typechecking the prelude reported AG4002 against its
+  // own `callback`, and because the prelude is auto-imported everywhere that
+  // one error cascaded into every file's typecheck step (whole suite -> ~34%).
+  it("exempts the stdlib prelude from the reserved-name check (its own builtins)", () => {
+    const preludePath = path.join(getStdlibDir(), "index.agency");
+    const source = readFileSync(preludePath, "utf-8");
+    const parseResult = parseAgency(source, {});
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) return;
+    const symbolTable = SymbolTable.build(preludePath, {});
+    const info = buildCompilationUnit(
+      parseResult.result,
+      symbolTable,
+      preludePath,
+      source,
+    );
+    const errors = typeCheck(parseResult.result, {}, info).errors;
+    const reserved = errors.filter((e) => e.message.includes("reserved built-in"));
+    expect(reserved).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

`main` is red: `agency-tests` fails at **34%** (788/2288 steps) after #534 merged. The trigger is a single diagnostic on the auto-imported prelude:

```
stdlib/index.agency:493:1 - error AG4002: 'callback' is a reserved built-in; cannot be redefined.
```

`stdlib/index.agency` defines `export def callback(...)` — the canonical definition of the `callback` builtin. The reserved-name check (`lib/typeChecker/index.ts`) flags any top-level `def`/`node`/variable whose name is in `RESERVED_FUNCTION_NAMES`, but had **no exemption for the prelude itself**. Because the prelude is auto-imported into every `.agency` file, that one error lands in nearly every file's typecheck step and collapses the whole suite.

This is a **latent type-checker gap**, not a bug in the std::agents code: the reserved-name enforcement landed on `main` after the #534 branch was cut, and #534's stdlib-import-graph changes (`std::agency` now importing `std::shell`, plus the new `std::agents/*` modules) were enough to route the prelude through this pass and expose it. Neither `stdlib/index.agency` nor the reserved-names list was touched by #534.

## Fix

Skip the `RESERVED_FUNCTION_NAMES` check when the file being checked is a non-templated stdlib prelude (`isNonTemplatedStdlib`) — the prelude is the *definition* site of these built-ins, so its own declarations must be allowed. User code that redefines a reserved built-in is still rejected.

Adds a regression test that typechecks the real prelude and asserts no reserved-built-in error.

## Verification

- Standalone `typecheck stdlib/index.agency`: AG4002 **gone** (present before the fix).
- Full-tree `agency test tests/agency -p 12` (the CI command): **770/772 files, 1074/1076 tests pass, 0 AG4002** — up from 34%.
- User `def callback` still rejected (exemption is prelude-only).
- `reservedNameDeclaration.test.ts`: 10/10 (9 existing + new regression test).
- Full typechecker + symbolTable unit suite: 82 files / 1568 tests pass.

The only 2 non-passing files in the local full run are unrelated to this change (both pre-existing, neither memory-related):
- `threads/messages` — a **flaky real-LLM test**: it asks the model to sum primes; the recorded fixture expects `68`, the model returned `77`. Non-deterministic, independent of this change.
- `verify-agent` — a pre-existing **llmMocks scope quirk** from #534 lifting `verify` into `stdlib/agency.agency` (mock scoped `"verify"` no longer matches module `stdlib/agency.agency`). It **passed 100% in the merged-main CI** (verify fails open). Tracked as a separate follow-up.

Note: the local run also prints a `FATAL ERROR: Reached heap limit` stack trace — that is the **expected** death of the intentionally `32mb`-capped subprocess in `tests/agency/subprocess/limit-memory.agency` (that test passes); it is not an OOM in the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
