### PR TITLE
Fix agent one-shot: install policy handler and route the default target

### DIFF
--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -588,16 +588,21 @@ def checkForAttachments(expanded: string): Attachment[] {
 export def agentReplyVia(target: AgentTarget, userMsg: string): string {
   const expanded = expandSlash(userMsg, projectCommands)
   return match(target) {
-    null => {
-      const attachments = checkForAttachments(expanded)
-      return mainAgent([expanded, ...attachments])
-    }
     "main" => mainAgent(expanded)
     "code" => codeAgent(expanded, false)
     "research" => researchAgent(expanded, false)
     "oracle" => oracleAgent(expanded, false)
     "explorer" => explorerAgent(expanded, false)
     "review" => reviewAgent(expanded, false)
+    _ => {
+      // Coordinator default. `null` (from `agentReply`) and `""` (the one-shot /
+      // seed-turn value when `--agent` is unset) both land here and run the full
+      // coordinator, which routes as usual. Anything unrecognized degrades to the
+      // coordinator too, rather than returning a null reply. Attachments are
+      // detected here so image/PDF paths in the prompt reach the model.
+      const attachments = checkForAttachments(expanded)
+      return mainAgent([expanded, ...attachments])
+    }
   }
 }
 

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -585,23 +585,33 @@ def checkForAttachments(expanded: string): Attachment[] {
   return attachments
 }
 
+// Run the coordinator on a prompt, auto-attaching any image/PDF paths found in
+// it. A text-only turn stays a bare string (checkForAttachments returns []) so
+// the stored thread-message shape is unchanged for the common case; only a turn
+// with real attachments becomes a parts array.
+def coordinatorReply(expanded: string): string {
+  const attachments = checkForAttachments(expanded)
+  if (attachments.length == 0) {
+    return mainAgent(expanded)
+  }
+  return mainAgent([expanded, ...attachments])
+}
+
 export def agentReplyVia(target: AgentTarget, userMsg: string): string {
   const expanded = expandSlash(userMsg, projectCommands)
   return match(target) {
-    "main" => mainAgent(expanded)
     "code" => codeAgent(expanded, false)
     "research" => researchAgent(expanded, false)
     "oracle" => oracleAgent(expanded, false)
     "explorer" => explorerAgent(expanded, false)
     "review" => reviewAgent(expanded, false)
     _ => {
-      // Coordinator default. `null` (from `agentReply`) and `""` (the one-shot /
-      // seed-turn value when `--agent` is unset) both land here and run the full
+      // Coordinator default. `null` (from `agentReply`), `"main"`, and `""` (the
+      // one-shot / seed-turn value when `--agent` is unset) all run the full
       // coordinator, which routes as usual. Anything unrecognized degrades to the
-      // coordinator too, rather than returning a null reply. Attachments are
-      // detected here so image/PDF paths in the prompt reach the model.
-      const attachments = checkForAttachments(expanded)
-      return mainAgent([expanded, ...attachments])
+      // coordinator too, rather than returning a null reply. All three paths
+      // attach identically, so `--agent main` matches the default coordinator.
+      return coordinatorReply(expanded)
     }
   }
 }

--- a/packages/agency-lang/lib/agents/agency-agent/lib/policy.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/lib/policy.agency
@@ -13,7 +13,7 @@ import {
 import { cwd } from "std::system"
 import { ChoiceItem, chooseOption } from "std::ui"
 
-import { POLICY_PATH } from "./config.agency"
+import { POLICY_PATH, SESSION_POLICY_PATH } from "./config.agency"
 
 
 // Print `--policy` usage and list the built-in policies (name + one-line


### PR DESCRIPTION
## Summary

Fixes two bugs that made the agent unusable in one-shot mode (`agency agent -p "..."`), which is how the terminal-bench adapter runs it (`--policy approve-all`, one-shot). Surfaced by a benchmark run where every git tool "hung" in a repo.

### 1. Policy handler never installed (the reported "git tools hang")

`lib/policy.agency`'s `getPolicyForAgent` references `SESSION_POLICY_PATH` but the module only imported `POLICY_PATH`. When a built-in policy is passed (`--policy approve-all`), it hit `return SESSION_POLICY_PATH` and threw a `ReferenceError`, so `setupSession` never installed the `cliPolicyHandler`.

With no handler, every read-tool interrupt (`gitStatus`, `gitLog`, `gitBranchList`, ...) surfaced as an **interactive approval prompt**, which then hung on the `std::tty` lock in the non-interactive benchmark (`Still waiting for lock 'std::tty' after 30000ms` → exit 13). It looked like "the git tools error in a non-repo," but the dir was a repo — the real cause was the missing policy handler.

**Fix:** import `SESSION_POLICY_PATH` from `./config.agency`.

> Note: this typechecked only because the directory-seeded symbol table sees the constant via `agent.agency`; each `.agency` compiles to its own module, so it was `undefined` at runtime. Same failure class as the earlier `policy.agency` missing-imports fix.

### 2. One-shot / seed turn returned a `null` reply

`agentReplyVia`'s `match(target)` handled `null` and the named subagents, but `oneShotAgent` and `runSeedTurn` pass `startAgent = args.flags.agent ?? ""` — the **empty string** when `--agent` is unset. `""` matched no arm, so the coordinator never ran and the reply came back `null` (agent printed `null`, no LLM call at all).

The pre-refactor code had a trailing `return mainAgent(parts)` catch-all for exactly this default case; it was removed during the refactor because `parts` was undefined. This restores it correctly as a `_` arm, so `null`, `""`, and any unrecognized target all run the coordinator (with attachment detection), matching the original intent.

## Verification

- `agency agent --policy approve-all --provider anthropic --model claude-sonnet-4-5 -p "What is 2+2?..."` → replies `4` (previously: hung, then after the policy fix: printed `null`).
- Statelog confirms the policy handler now installs and auto-approves interrupts, and the coordinator turn runs.
- `agentTurn` (29/29) and `routing` (2/2) execution tests pass. `make` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
