### PR TITLE
Revive block refs across subprocess resume via lazy stub (#513)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-issue-513-block-ref-revive-fix.md
+++ b/docs/superpowers/plans/2026-07-14-issue-513-block-ref-revive-fix.md
@@ -1,0 +1,895 @@
+# Fix #513: Block References Must Survive Cross-Process Resume — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task in the main session (owner preference: no subagent-driven development). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a paused subprocess resume correctly when a `guard(...) as { }` block (or any block-taking function) sits on its serialized stack, per the approved spec `docs/superpowers/specs/2026-07-14-issue-513-block-ref-revive-fix-design.md`.
+
+**Architecture:** One runtime change (FunctionRefReviver returns a lazy-throwing stub for unregistered `__block_<n>` refs instead of dying at restore), locked in by two subprocess regression fixtures, followed by the `run()` single-call-site cleanup this bug was blocking, and a bounded probe of the scoped-callbacks sibling case.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/`), Agency stdlib (`stdlib/agency.agency`), vitest unit tests, Agency execution fixtures (`tests/agency/subprocess/`).
+
+## Global Constraints
+
+- Work in a fresh worktree + branch (`fix/513-block-ref-revive`) created via superpowers:using-git-worktrees BEFORE the first commit. Never commit to main. Re-check `git branch --show-current` before every commit.
+- Run `make` after changing any `stdlib/*.agency` file, and after any `lib/` change that fixtures exercise (fixtures run against `dist/`).
+- Save all test output to files (`tee /tmp/...`). Never rerun a test just to re-read its failure.
+- Do NOT run the full agency test suite locally. Run only the fixtures named in this plan. CI runs the rest on the PR.
+- Write commit messages and the PR body to files and pass them with `-F` (apostrophes break inline `-m`).
+- The disable value for a guard dimension is a NEGATIVE number. `guard(cost: null, time: null)` throws. Never write `guard(cost: null)` meaning "no cap".
+- Agency has NO ternary (`? :`). Use `if ... then ... else` expressions or `if` statements (`docs/site/guide/basic-syntax.md:68`).
+- End commit messages with a Co-Authored-By line naming the EXECUTING session's model. For this session: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` (adjust if a different model executes).
+
+---
+
+### Task 1: Regression fixtures that fail today
+
+Two fixtures from the verified repros. They fail on the current code and define done for Task 2. Working repro copies (with debug prints to strip) exist in `packages/agency-lang/tmp/guard-nested-repro*.agency`; the fixtures below are the clean versions.
+
+**Files:**
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.agency`
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.test.json`
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.agency`
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.test.json`
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.agency`
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.test.json`
+- Commit also: `docs/superpowers/specs/2026-07-14-issue-513-block-ref-revive-fix-design.md` (currently untracked; this branch's paper trail)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the three fixture paths above. Task 2 runs them and expects PASS; Task 3 re-runs them.
+
+- [ ] **Step 1: Write the maxCost fixture**
+
+Create `packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.agency`:
+
+```
+import { compile, run } from "std::agency"
+
+// #513 regression: the middle hop's run() uses maxCost, which wraps _run in
+// a guard block INSIDE run(). The grandchild's bash is unhandled anywhere, so
+// the middle process pauses and serializes WHILE the guard block's frame
+// (holding a FunctionRef to the block) is on its stack. Resume must revive
+// that state in a fresh process: before the fix, FunctionRefReviver threw on
+// the unregistered "__block_<n>" ref and the resume died.
+node main() {
+  const grandSource = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo deep-ok")
+  return r.stdout
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const result = run(compiled: c.value, node: "main", maxCost: 1.0)
+    if (isSuccess(result)) {
+      return result.value.data
+    }
+    return "inner run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isSuccess(result)) {
+      return "OK: ${result.value.data}"
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+Create `packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "#513: run(maxCost:) on the middle hop; grandchild interrupt pauses the tree; one approval resumes through the internal guard block",
+      "input": "",
+      "expectedOutput": "\"OK: deep-ok\\n\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the user-guard fixture**
+
+Create `packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.agency`. Same shape; the middle hop wraps a plain `run()` in a user-level guard block, proving the fix covers the whole pattern, not just `run()`'s internal guard:
+
+```
+import { compile, run } from "std::agency"
+
+// #513 regression, user-level variant: a hand-written guard(...) as { } wraps
+// the middle hop's run(). The serialized middle stack holds the user block's
+// FunctionRef. This is the case that proves ANY block-taking function is
+// pause-safe across process boundaries, not just run(maxCost:).
+node main() {
+  const grandSource = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo deep-ok")
+  return r.stdout
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const guarded = guard(cost: 1.0) as {
+      const result = run(compiled: c.value, node: "main")
+      if (isSuccess(result)) {
+        return result.value.data
+      }
+      return "inner run failed"
+    }
+    if (isSuccess(guarded)) {
+      return guarded.value
+    }
+    return "guard tripped"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isSuccess(result)) {
+      return "OK: ${result.value.data}"
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+Create `packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.test.json` — identical to Step 1's json except `nodeName`/`description`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "#513: user-level guard(cost:) as { } around the middle hop's run(); one approval resumes through the user block",
+      "input": "",
+      "expectedOutput": "\"OK: deep-ok\\n\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Write the user-wrapper fixture**
+
+The spec's stated goal is that USERLAND block-taking functions are pause-safe, not just stdlib `guard`. This fixture is the direct evidence: a user-defined `def` with a block parameter wraps the pausing `run()`.
+
+Create `packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.agency`:
+
+```
+import { compile, run } from "std::agency"
+
+// #513 regression, userland variant: a USER-DEFINED function with a block
+// parameter wraps the middle hop's run(). Its frame serializes a FunctionRef
+// to the anonymous block, exactly like guard()'s does. This pins the spec's
+// goal that guard-like constructs are buildable in userland with no runtime
+// changes and stay pause-safe across process boundaries.
+node main() {
+  const grandSource = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo deep-ok")
+  return r.stdout
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+
+def withWrapper(block: () -> any = null): any {
+  const result = block()
+  return result
+}
+
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const wrapped = withWrapper() as {
+      const result = run(compiled: c.value, node: "main")
+      if (isSuccess(result)) {
+        return result.value.data
+      }
+      return "inner run failed"
+    }
+    return wrapped
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isSuccess(result)) {
+      return "OK: ${result.value.data}"
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+Create `packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.test.json` — same shape as Step 1's json with:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "#513: a user-defined block-taking function wraps the middle hop's run(); one approval resumes through the user block",
+      "input": "",
+      "expectedOutput": "\"OK: deep-ok\\n\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Run all three fixtures to verify they FAIL today**
+
+From `packages/agency-lang/`:
+
+```bash
+pnpm run agency test tests/agency/subprocess/nested-pause-maxcost.agency 2>&1 | tee /tmp/513-t1-maxcost.log
+pnpm run agency test tests/agency/subprocess/nested-pause-user-guard.agency 2>&1 | tee /tmp/513-t1-userguard.log
+pnpm run agency test tests/agency/subprocess/nested-pause-user-wrapper.agency 2>&1 | tee /tmp/513-t1-userwrapper.log
+```
+
+Expected: ALL THREE FAIL with the harness error `Expected 1 interrupts but only 0 occurred` (verified 2026-07-14 for the first two: the reviver throw kills the middle process before the bash interrupt ever surfaces to the harness). If a failure looks different, read the log; do not proceed until the failure is understood.
+
+- [ ] **Step 5: Commit (spec + failing fixtures)**
+
+Write `/tmp/513-commit-1.txt`:
+
+```
+Add failing #513 regression fixtures + design spec
+
+All three fixtures pause a nested subprocess while a block-holding frame
+is on its serialized stack (run(maxCost:), user guard, user-defined
+wrapper). They fail today because FunctionRefReviver throws on the
+unregistered block ref at restore. The spec documents the verified root
+cause and the fix design.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+```
+
+```bash
+git branch --show-current   # must be fix/513-block-ref-revive
+git add docs/superpowers/specs/2026-07-14-issue-513-block-ref-revive-fix-design.md packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.* packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.* packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.*
+git commit -F /tmp/513-commit-1.txt
+```
+
+---
+
+### Task 2: Reviver lazy stub
+
+**Files:**
+- Create: `packages/agency-lang/lib/runtime/blockNames.ts`
+- Modify: `packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts:94-114` (`findInRegistry`)
+- Modify: `packages/agency-lang/lib/backends/typescriptBuilder/stepPathTracker.ts:89-91` (`nextBlockName`)
+- Test: `packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts`
+
+**Interfaces:**
+- Consumes: `AgencyFunction` constructor `new AgencyFunction({ name, module, fn, params, toolDefinition })` (`lib/runtime/agencyFunction.ts`).
+- Produces: `makeBlockName(counter: number): string` and `isBlockName(name: string): boolean` in `lib/runtime/blockNames.ts` — the single source of truth for the `__block_<n>` naming scheme, used by BOTH the backend (minting) and the reviver (recognizing). `findInRegistry` returns a stub `AgencyFunction` for unregistered block names and throws the existing error for all other misses. Task 1's fixtures and Task 3 depend on this behavior.
+
+**Context — the naming scheme is a de-facto reserved prefix, not a compiler-enforced one.** Verified 2026-07-14: `def __block_0(): string { ... }` typechecks CLEAN. The reserved-name diagnostics cover only specific identifiers (`success`, `failure`, `Result` — `lib/symbolTable.ts:431`), not the `__` prefix. This is accepted: a collision needs a user to name a function `__block_<n>` AND have it hit a registry miss (renamed/removed between pause and resume), and the failure mode is a soft stub rather than a hard throw. Do NOT add a serialize-time `isBlock` field — it would reuse the same regex in a different place and add zero robustness. If real hardening is ever wanted, that is a separate issue: a creation-time block flag on `AgencyFunction` plus a reserved-prefix diagnostic.
+
+- [ ] **Step 1: Create the shared block-name module**
+
+The `__block_<n>` convention is minted in exactly one place today (`stepPathTracker.nextBlockName`). The reviver must not re-encode that convention privately — one source of truth for both sides. Direction matters: runtime must not import from `lib/backends/`, but backends already imports from runtime (`typescriptBuilder.ts:82` imports `moduleIdToOrigin` from `runtime/origin.js`). So the module lives in runtime.
+
+Create `packages/agency-lang/lib/runtime/blockNames.ts`:
+
+```ts
+/** Single source of truth for the compiler's anonymous-block naming scheme.
+ *  The backend MINTS names via makeBlockName (stepPathTracker.nextBlockName);
+ *  the runtime RECOGNIZES them via isBlockName (FunctionRefReviver's stub
+ *  decision for unregistered refs). Keeping both here means the two
+ *  subsystems cannot silently desync.
+ *
+ *  "__block_" is a de-facto reserved prefix: no diagnostic rejects a user
+ *  function with such a name today, but misclassification requires a
+ *  registry miss too, and the failure mode is a soft lazy-throwing stub. */
+export function makeBlockName(counter: number): string {
+  return `__block_${counter}`;
+}
+
+export function isBlockName(name: string): boolean {
+  return /^__block_\d+$/.test(name);
+}
+```
+
+In `lib/backends/typescriptBuilder/stepPathTracker.ts`, change `nextBlockName` (lines 89-91) to mint through the shared function:
+
+```ts
+  nextBlockName(): string {
+    return makeBlockName(this.blockCounter++);
+  }
+```
+
+and add the import at the top of the file:
+
+```ts
+import { makeBlockName } from "@/runtime/blockNames.js";
+```
+
+- [ ] **Step 2: Write the failing unit tests**
+
+In `lib/runtime/revivers/functionRefReviver.test.ts`, inside `describe("revive")`, after the `"throws when function is not found"` test (which stays — non-block names keep the eager throw), add:
+
+```ts
+    it("revives an unregistered block ref to a stub instead of throwing", () => {
+      reviver.registry = {};
+      const stub = reviver.revive({
+        name: "__block_0",
+        module: "stdlib/agency.agency",
+      });
+      expect(AgencyFunction.isAgencyFunction(stub)).toBe(true);
+      expect(stub.name).toBe("__block_0");
+      expect(stub.module).toBe("stdlib/agency.agency");
+    });
+
+    it("the block stub is a tripwire: invoking it surfaces a rebind error", async () => {
+      reviver.registry = {};
+      const stub = reviver.revive({
+        name: "__block_7",
+        module: "test.agency",
+      });
+      // invoke() may reject or convert the throw to a failure Result
+      // depending on failure-propagation settings; accept either, but the
+      // tripwire message must surface.
+      const outcome = await stub
+        .invoke({ type: "positional", args: [] })
+        .then((v: unknown) => v, (e: unknown) => e);
+      const msg =
+        outcome instanceof Error ? outcome.message : JSON.stringify(outcome);
+      expect(msg).toContain("before replay rebound it");
+    });
+
+    it("non-block names still throw eagerly on a registry miss", () => {
+      reviver.registry = {};
+      expect(() =>
+        reviver.revive({ name: "__blockish", module: "test.agency" }),
+      ).toThrow("not found in registry");
+      expect(() =>
+        reviver.revive({ name: "__block_", module: "test.agency" }),
+      ).toThrow("not found in registry");
+    });
+
+    it("a REGISTERED block name resolves to the real function, not a stub", async () => {
+      // Pins the lookup-before-regex ordering: moving the block check ahead
+      // of the registry lookup would silently stub every registered block.
+      const real = makeAgencyFunction("__block_0", "test.agency");
+      reviver.registry = { "test.agency:__block_0": real };
+      const result = reviver.revive({
+        name: "__block_0",
+        module: "test.agency",
+      });
+      expect(result).toBe(real);
+    });
+```
+
+- [ ] **Step 3: Run the unit tests to verify they fail**
+
+```bash
+pnpm test:run lib/runtime/revivers/functionRefReviver.test.ts 2>&1 | tee /tmp/513-t2-unit.log
+```
+
+Expected: the two new block-stub tests FAIL (`revive` throws "not found in registry"); everything else PASSES.
+
+- [ ] **Step 4: Implement the stub**
+
+In `lib/runtime/revivers/functionRefReviver.ts`, add the import at the top:
+
+```ts
+import { isBlockName } from "../blockNames.js";
+```
+
+Replace the throw at the bottom of `findInRegistry` (lines 110-113) with:
+
+```ts
+    // Compiler-generated blocks register themselves only when their creating
+    // line executes. A fresh process restoring a checkpoint has executed
+    // nothing yet, so a miss here is EXPECTED for blocks — replay rebinds
+    // block args at function entry before anything can call them (#513).
+    if (isBlockName(name)) {
+      return makeBlockStub(name, module);
+    }
+    throw new Error(
+      `FunctionRefReviver: function "${name}" from module "${module}" not found in registry. ` +
+      `The function may have been renamed or removed since this state was serialized.`
+    );
+```
+
+and add the stub factory as a module-level function at the bottom of the file (below the class):
+
+```ts
+/** A lazy tripwire for an unregistered block reference: a real
+ *  AgencyFunction (so restore succeeds and the frame slot is filled) whose
+ *  body throws a precise error IF anything invokes it. In every correct
+ *  replay the generated def body overwrites the slot with a fresh block
+ *  before any call, so this never fires. Plain `new` on purpose — the stub
+ *  must NOT self-register the way AgencyFunction.create does. */
+function makeBlockStub(name: string, module: string): AgencyFunction {
+  return new AgencyFunction({
+    name,
+    module,
+    fn: () => {
+      throw new Error(
+        `Block "${name}" from module "${module}" crossed a serialization ` +
+          `boundary and was invoked before replay rebound it. This is a ` +
+          `runtime bug — please report it.`,
+      );
+    },
+    params: [],
+    toolDefinition: null,
+  });
+}
+```
+
+(`AgencyFunction` is already imported at the top of the file.)
+
+- [ ] **Step 5: Run the unit tests to verify they pass**
+
+```bash
+pnpm test:run lib/runtime/revivers/functionRefReviver.test.ts 2>&1 | tee /tmp/513-t2-unit.log
+```
+
+Expected: ALL PASS, including the pre-existing `"throws when function is not found"`.
+
+- [ ] **Step 6: Rebuild and run the Task 1 fixtures**
+
+```bash
+make 2>&1 | tail -3
+pnpm run agency test tests/agency/subprocess/nested-pause-maxcost.agency 2>&1 | tee /tmp/513-t2-maxcost.log
+pnpm run agency test tests/agency/subprocess/nested-pause-user-guard.agency 2>&1 | tee /tmp/513-t2-userguard.log
+pnpm run agency test tests/agency/subprocess/nested-pause-user-wrapper.agency 2>&1 | tee /tmp/513-t2-userwrapper.log
+```
+
+Expected: ALL THREE PASS with `✓ Exact match passed` (verified achievable 2026-07-14 for the first two with exactly this change; the wrapper variant exercises the identical mechanism).
+
+- [ ] **Step 7: Run the neighborhood regression sample**
+
+```bash
+for f in nested-pause-resume pause-multi-cycle callback-forwarding-nested-relay run-max-cost; do
+  echo "== $f"
+  pnpm run agency test "tests/agency/subprocess/$f.agency"
+done 2>&1 | tee /tmp/513-t2-regression.log
+```
+
+Expected: all PASS (`run-max-cost` contains several tests — every one must pass; the rest have 1 each).
+
+- [ ] **Step 8: Commit**
+
+Write `/tmp/513-commit-2.txt`:
+
+```
+Revive unregistered block refs to a lazy stub instead of dying (#513)
+
+Blocks self-register at creation time, so a fresh process restoring a
+checkpoint always misses them in the registry — the eager throw killed
+every cross-process resume that had a block-taking function (guard) on
+the serialized stack. Replay rebinds block args before use; the stub is
+a tripwire that errors precisely at the call if a rebind ever fails.
+Named functions keep the eager throw (a real rename/removal signal).
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+```
+
+```bash
+git branch --show-current   # must be fix/513-block-ref-revive
+git add lib/runtime/blockNames.ts lib/runtime/revivers/functionRefReviver.ts lib/runtime/revivers/functionRefReviver.test.ts lib/backends/typescriptBuilder/stepPathTracker.ts
+git commit -F /tmp/513-commit-2.txt
+```
+
+---
+
+### Task 3: Collapse `run()` to a single guarded call site
+
+**Files:**
+- Modify: `packages/agency-lang/stdlib/agency.agency:161-196` (the two-call-sites region inside `run()`)
+
+**Interfaces:**
+- Consumes: Task 2 (the guarded path must survive nested pause). `pushGuardImpl` disable rule: a NEGATIVE limit disables the dimension; `guard(cost: null, time: null)` throws (`lib/stdlib/thread.ts:258`).
+- Produces: `run()` behavior unchanged for callers; every `run()` call now exercises the guard-block path.
+
+- [ ] **Step 1: Replace the two call sites**
+
+In `stdlib/agency.agency`, delete this region (currently lines 161-196 — the comment, the `if (maxCost == null)` early return, and the `const guarded = guard(...)` opener):
+
+```
+  // Two call sites on purpose. Wrapping the no-cap path in an inert
+  // guard block breaks nested subprocess pause/resume: when THIS process
+  // is itself a subprocess that pauses on a bubbled interrupt, resuming
+  // its serialized stack through the guard block loses the block's
+  // return value and run() yields undefined (see the nested-pause-resume
+  // fixture, which caught this in CI). Keep the argument lists below
+  // IDENTICAL.
+  if (maxCost == null) {
+    return try _run(
+      compiled,
+      node,
+      args,
+      wallClock,
+      memory,
+      ipcPayload,
+      stdout,
+      configOverrides,
+      cwd,
+      maxDepth,
+    )
+  }
+  const guarded = guard(cost: maxCost) as {
+```
+
+and replace it with:
+
+```
+  // guard() disables a dimension on a NEGATIVE value (null for BOTH
+  // dimensions throws), so a null maxCost maps to the disable value and
+  // one guarded call site serves both cases. Safe since #513: block
+  // frames revive correctly across a nested subprocess pause.
+  const NO_COST_CAP = -1.0
+  const cap = if maxCost != null then maxCost else NO_COST_CAP
+  const guarded = guard(cost: cap) as {
+```
+
+(Agency has no ternary; `if ... then ... else` is the expression form, `docs/site/guide/basic-syntax.md:68`.)
+
+Leave the block body (`return try _run(...)` with the ten arguments), the `guardFailure → limit_exceeded` translation, and `return guarded` untouched.
+
+- [ ] **Step 2: Rebuild and verify the collapse compiles**
+
+```bash
+make 2>&1 | tee /tmp/513-t3-make.log | tail -5
+```
+
+Expected: clean build (stdlib recompiles; no diagnostics).
+
+- [ ] **Step 3: Run the affected fixtures**
+
+The collapse routes EVERY `run()` through the guard block — a structural change to the default path — so the sample must cover the structurally different flows now newly guarded: plain pause, multi-cycle pause, concurrent interrupts, and a reject path:
+
+```bash
+for f in nested-pause-resume pause-multi-cycle concurrent-handled handler-reject nested-pause-maxcost nested-pause-user-guard nested-pause-user-wrapper run-max-cost cost-no-double-charge-across-pause; do
+  echo "== $f"
+  pnpm run agency test "tests/agency/subprocess/$f.agency"
+done 2>&1 | tee /tmp/513-t3-fixtures.log
+```
+
+Expected: all PASS. Pay attention to `run-max-cost`'s `nested` test (outer guard must not trip on the inner cap) and `cost-no-double-charge-across-pause` (cost accounting across the now-always-guarded pause).
+
+- [ ] **Step 4: Commit**
+
+Write `/tmp/513-commit-3.txt`:
+
+```
+Collapse run() to a single always-guarded call site
+
+The duplicated ten-argument _run call existed only to keep the default
+path out of the guard block while #513 was unfixed. With block refs
+reviving correctly, one call site serves both cases: maxCost null maps
+to -1, which guard() treats as cost-dimension disabled. Every run()
+call now exercises the guarded path, so the whole subprocess suite is
+a regression alarm for #513.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+```
+
+```bash
+git branch --show-current   # must be fix/513-block-ref-revive
+git add stdlib/agency.agency
+git commit -F /tmp/513-commit-3.txt
+```
+
+---
+
+### Task 4: Probe the scoped-callbacks sibling case
+
+`State.toJSON` serializes `scopedCallbacks` function values as FunctionRefs too, and callback registrations are NOT rebound by replay the way block arguments are (their registration step is skipped by the step counter). This task determines empirically whether that case is broken, and applies the spec's decision tree. It is a probe with a decision gate — do not silently grow it into a rework of callback registration.
+
+**Files:**
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-scoped-callback.agency`
+- Create: `packages/agency-lang/tests/agency/subprocess/nested-pause-scoped-callback.test.json`
+
+**Interfaces:**
+- Consumes: Task 2's stub behavior; the `callback("onNodeStart") as data { ... }` idiom (see `tests/agency/subprocess/callback-forwarding-child-events.agency`).
+- Produces: either a passing coverage fixture, or a filed follow-up issue with the fixture attached.
+
+- [ ] **Step 1: Write the probe fixture**
+
+Create `packages/agency-lang/tests/agency/subprocess/nested-pause-scoped-callback.agency`. The middle process registers a block-bodied callback, pauses across serialization, and after resuming runs a second child — proving the callback still fires post-resume. Both child sources travel as node args from the top process (triple-quoted strings cannot nest — same pattern as `nested-pause-resume`). The counter is declared at MODULE scope, mirroring the proven `callback-forwarding-child-events.agency`, so a capture-semantics quirk cannot muddy the probe:
+
+```
+import { compile, run } from "std::agency"
+
+// #513 sibling probe: the middle process registers a block-bodied scoped
+// callback, then pauses across serialize/resume (grandchild bash is
+// unhandled). After the resume it runs a SECOND child; if the callback
+// survived the round trip, that child's onNodeStart increments the counter
+// again. Healthy expectation: cb=2 (grandchild start + second child start).
+node main() {
+  const grandSource = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo deep-ok")
+  return r.stdout
+}
+"""
+  const secondSource = """
+node main() {
+  return "second done"
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+
+let starts: number = 0
+
+node main(grandSource: string, secondSource: string) {
+  callback("onNodeStart") as data {
+    starts = starts + 1
+  }
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  const c2 = compile(secondSource)
+  if (isFailure(c2)) {
+    return "second compile failed"
+  }
+  handle {
+    const result = run(compiled: c.value, node: "main")
+    if (isFailure(result)) {
+      return "inner run failed"
+    }
+    const second = run(compiled: c2.value, node: "main")
+    if (isFailure(second)) {
+      return "second run failed"
+    }
+    return "${result.value.data}:cb=${starts}"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource, secondSource: secondSource },
+    )
+    if (isSuccess(result)) {
+      return "OK: ${result.value.data}"
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+```
+
+The middle node's own `main` start does not count: the callback registers after that node has already started. Verify the fixture parses before running it: `pnpm run ast tests/agency/subprocess/nested-pause-scoped-callback.agency > /dev/null && echo PARSES`.
+
+- [ ] **Step 2: Run the probe and record the outcome**
+
+Create `nested-pause-scoped-callback.test.json` with a provisional expectation (`"OK: deep-ok\n:cb=2"` is NOT yet trustworthy — the exact count depends on which starts are forwarded):
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "#513 sibling: a block-bodied scoped callback survives the middle hop's pause/serialize/resume and still fires afterward",
+      "input": "",
+      "expectedOutput": "PIN AFTER FIRST RUN",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}
+```
+
+```bash
+pnpm run agency test tests/agency/subprocess/nested-pause-scoped-callback.agency 2>&1 | tee /tmp/513-t4-probe.log
+```
+
+Read the actual output from the log. Interpret per the spec's decision tree. **Pin only proof, never just "whatever appeared":** the healthy value is `"OK: deep-ok\n:cb=2"` — the count MUST include the post-resume second child's start. A cb=1 output means the callback died at the pause; do not pin it.
+
+- **Callback fired after resume** (output shows the second child's start counted, i.e. cb=2): pin `expectedOutput` to the observed full string, re-run to green, keep the fixture as coverage. Proceed to Step 3.
+- **Anything else** (cb=1, run failure, or the Task 2 tripwire message in the log): the case is broken independently of this fix. Do NOT fix callback re-registration in this PR. File a follow-up issue with `gh issue create` (title: `Scoped callbacks with block bodies do not survive cross-process resume`; body written to a file, referencing this fixture, the observed output, and #513), paste the fixture into the issue body as the repro, and DELETE the fixture files from the branch so CI stays green. Proceed to Step 3.
+
+Either way, summarize the observed outcome for the owner in the task report.
+
+- [ ] **Step 3: Commit (fixture, or issue link in the commit body)**
+
+Write `/tmp/513-commit-4.txt` — adjust the first line to match the outcome:
+
+```
+Probe scoped-callback survival across subprocess pause (#513 sibling)
+
+[EITHER] The block-bodied scoped callback survives cross-process resume;
+fixture pins the behavior.
+[OR] The case is broken independently of the #513 fix; filed #<N> with
+the repro attached instead of shipping a red fixture.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+```
+
+```bash
+git branch --show-current   # must be fix/513-block-ref-revive
+git add -A packages/agency-lang/tests/agency/subprocess/
+git commit -F /tmp/513-commit-4.txt
+```
+
+---
+
+### Task 5: Correct the record and open the PR
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-13-issue-513-guard-block-subprocess-resume-investigation.md` (banner at top)
+
+**Interfaces:**
+- Consumes: everything above, merged into the branch.
+- Produces: the PR.
+
+- [ ] **Step 1: Add the correction banner**
+
+At the very top of `docs/superpowers/specs/2026-07-13-issue-513-guard-block-subprocess-resume-investigation.md`, immediately under the title line, insert:
+
+```markdown
+> **CORRECTION (2026-07-14):** The root-cause theory below is WRONG. The
+> subprocess payload does NOT get lost on a popped block frame — checkpoints
+> are stamped while block frames are live, and positional replay realigns
+> them. The verified cause is `FunctionRefReviver` throwing eagerly on
+> unregistered `__block_<n>` references when a FRESH process restores a
+> checkpoint (blocks self-register only when their creating line executes).
+> See `2026-07-14-issue-513-block-ref-revive-fix-design.md` for the verified
+> mechanism and the fix. The code references below remain useful.
+```
+
+- [ ] **Step 2: Commit**
+
+Write `/tmp/513-commit-5.txt`:
+
+```
+Correct the #513 investigation spec's root-cause theory
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+```
+
+```bash
+git branch --show-current   # must be fix/513-block-ref-revive
+git add docs/superpowers/specs/2026-07-13-issue-513-guard-block-subprocess-resume-investigation.md
+git commit -F /tmp/513-commit-5.txt
+```
+
+- [ ] **Step 3: Push and open the PR**
+
+Write the PR body to `/tmp/513-pr-body.md`:
+
+```markdown
+Fixes #513.
+
+## What was actually wrong
+
+Blocks (`as { }`) self-register in the function-ref registry when their
+creating line executes. A frame that holds a block argument serializes it as
+a `FunctionRef` name reference. When a paused subprocess is re-forked, the
+fresh process restores the checkpoint BEFORE running any code, so the block
+is not registered yet — and `FunctionRefReviver` threw eagerly, killing the
+whole resume. The revived value was garbage anyway: replay rebinds block
+arguments at function entry before anything can call them.
+
+The earlier investigation doc blamed a popped block frame; that theory is
+wrong and is corrected in-repo.
+
+## The fix
+
+- `FunctionRefReviver`: an unregistered block ref now revives to a lazy stub
+  that throws a precise error IF invoked (a tripwire that never fires in
+  correct replays). Named functions keep the eager throw — for them a miss
+  means the program really changed. The `__block_<n>` naming scheme now has
+  a single source of truth (`lib/runtime/blockNames.ts`) shared by the
+  backend that mints names and the reviver that recognizes them.
+- Three regression fixtures: nested pause through `run(maxCost:)`, through a
+  user-level `guard(...) as { }`, and through a user-DEFINED block-taking
+  wrapper (the userland-extensibility goal, pinned).
+- `run()` collapsed to a single always-guarded call site (the #512 review
+  note this bug was blocking). Every `run()` now exercises the guarded path.
+- Scoped-callback sibling case probed; outcome recorded in the task history.
+
+## Testing
+
+- New unit tests for the reviver contract split.
+- New fixtures pass; `nested-pause-resume`, `pause-multi-cycle`,
+  `callback-forwarding-nested-relay`, `run-max-cost`, and
+  `cost-no-double-charge-across-pause` pass locally.
+- CI runs the full agency suite.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+```bash
+git push -u origin fix/513-block-ref-revive
+gh pr create --title "Revive block refs across subprocess resume via lazy stub (#513)" --body-file /tmp/513-pr-body.md
+```
+
+Expected: PR URL printed. Report it to the owner.

--- a/docs/superpowers/specs/2026-07-13-issue-513-guard-block-subprocess-resume-investigation.md
+++ b/docs/superpowers/specs/2026-07-13-issue-513-guard-block-subprocess-resume-investigation.md
@@ -1,0 +1,193 @@
+# Issue #513 — guard block around a paused subprocess `run()` loses its value after serialize/resume
+
+> **CORRECTION (2026-07-14):** The root-cause theory below is WRONG. The
+> subprocess payload does NOT get lost on a popped block frame — checkpoints
+> are stamped while block frames are live, and positional replay realigns
+> them. The verified cause is `FunctionRefReviver` throwing eagerly on
+> unregistered `__block_<n>` references when a FRESH process restores a
+> checkpoint (blocks self-register only when their creating line executes).
+> See `2026-07-14-issue-513-block-ref-revive-fix-design.md` for the verified
+> mechanism and the fix. The code references below remain useful.
+
+**Investigation date:** 2026-07-13
+**Issue:** https://github.com/egonSchiele/agency-lang/issues/513
+**Status:** Root cause confirmed (code-grounded, high confidence). Not yet fixed.
+
+---
+
+## Symptom (from the issue)
+
+When a subprocess pauses on a bubbled interrupt and its serialized stack contains a
+`guard(...) as { ... }` block wrapping the paused `run()` call, resuming loses the block's
+return value: after the approval resumes the tree, the outer `run(...)` expression evaluates
+to `undefined` instead of the child's Result. The node then crashes with
+`Cannot read properties of undefined (reading X)` when it touches `result`.
+
+- Single-level (in-memory) pause/resume through a guard block **works**.
+- The value is lost **only** when the process holding the guard block is itself a subprocess,
+  i.e. its state stack goes through checkpoint serialize/deserialize before the resume.
+- Reproduces without any PR #512 feature by writing the inner hop as a user-level
+  `guard(cost: 1.0) as { return run(...) }`, so the bug is in guard-block resume across
+  serialization, not in `maxCost` itself.
+
+**Impact on #512:** `run(maxCost: ...)` wraps `_run` in a guard block, so `maxCost` on a nested
+run that pauses returns `undefined`. PR #512 keeps the no-cap path guard-free (two call sites)
+so default behavior is unaffected; collapsing to a single always-guarded call site (a review
+suggestion) is blocked on this bug.
+
+---
+
+## Root cause
+
+The paused subprocess's **resume payload is stored on a frame that gets discarded during
+serialization** when `run()` sits inside a `guard(...) as { }` block.
+
+### The mechanism, step by step
+
+1. When a nested `run()` (`_run`) pauses on a bubbled interrupt, `_run` stashes everything
+   needed to resume the child — the child's checkpoint, the surfaced interrupts, the node —
+   into a **frame local**:
+   - `lib/runtime/ipc.ts:1255` → `saveSubprocessPayload(args.parentFrame, { childCheckpoint, interrupts, node, subprocessSessionId })`
+   - `args.parentFrame` is `stateStack.lastFrame()` — set at `lib/runtime/ipc.ts:1331`
+     (`const parentFrame = stateStack.lastFrame();`)
+   - The payload lands in `frame.locals["__subprocess_state_0"]`
+     (`SUBPROCESS_PAYLOAD_KEY`, `lib/runtime/ipc.ts:496–499`)
+
+2. The design **assumes that frame is serialized** with the parent. The comment at
+   `lib/runtime/ipc.ts:1252–1254` says exactly this:
+   > *"Opaque payload: serialized with the parent frame; NEVER walked by State.toJSON — the
+   > child checkpoint belongs to another process and must not be spliced into the parent replay."*
+
+3. But when `_run` runs inside a `guard(...) as { return try _run(...) }` block, `lastFrame()`
+   is the **block's own frame** (`__bframe_<blockName>`), not `run()`'s def frame. The frame
+   chain at the moment `_run` executes is:
+
+   ```
+   run() def frame            (persistent — serialized)
+     └─ guard() def frame     (persistent — serialized)         [pushed by the guard def]
+          └─ _runGuarded(...)  (TS seam — pushes NO agency frame)
+               └─ __call(block)
+                    └─ block frame __bframe_<block>  ← lastFrame() here  (EPHEMERAL)
+                         └─ try _run(...)   → saveSubprocessPayload(__bframe, ...)
+   ```
+
+4. The block frame is created fresh by `setupFunction()` and **popped in a `finally`**:
+   - `lib/templates/backends/typescriptGenerator/blockSetup.mustache`:
+     the block body runs inside `try { ... } finally { __bsetup.stateStack.pop(); }`
+   - So by the time the process serializes its state stack, the block frame is **already gone**,
+     taking `__subprocess_state_0` with it.
+
+5. On deserialize-resume, `loadSubprocessPayload(parentFrame)` returns `undefined`
+   (`lib/runtime/ipc.ts:1202`), `_run` cannot pair the resume responses with a saved child
+   checkpoint, and the outer `run()` expression evaluates to `undefined`. That is the crash.
+
+### Why in-memory / single-level works (the issue's key clue)
+
+In memory, resume is driven by the **live `runBatch` branch objects** and the live interrupt's
+`.checkpoint` reference. The frame-local `__subprocess_state_0` is only the
+**serialization-survival copy**. Only the serialize → deserialize path actually reads the
+payload back off a frame — which is precisely the case where the popped-block-frame loss bites.
+This exactly matches the issue's observation that the failure is specific to
+serialize/deserialize.
+
+### Why the existing workaround works
+
+`run()` already keeps a **guard-free no-cap path** — the two-call-sites structure at
+`stdlib/agency.agency:161–216` (see the explanatory comment at lines 161–167). When
+`maxCost == null`, `try _run(...)` runs **directly in `run()`'s own def frame** (persistent,
+serialized), so `lastFrame()` is `run()`'s frame and the payload survives. The guard block is
+only introduced on the `maxCost != null` path (`stdlib/agency.agency:182`), which is exactly the
+broken path.
+
+---
+
+## What was ruled out during investigation
+
+- **The block value itself is NOT the lost state.** `State.toJSON()` does
+  `deepClone(this.args)` (`lib/runtime/state/stateStack.ts:204`), which drops function values —
+  and the block is an `AgencyFunction`. This looked like the culprit at first. But it is not:
+  the generated def body rebinds the block **unconditionally on every (re-)invocation**. Verified
+  empirically by compiling a probe def with a block param — the generated body emits
+  `__stack.args["block"] = block === __UNSET ? null : block;` at the top, before any runner step
+  (`lib/backends/typescriptBuilder.ts:2045` is the analogous `__stack.args[...] = ...` binding).
+  On resume, `main` re-executes, creates a **fresh** block `AgencyFunction`, and passes it into
+  the reused (deserialized) frame, overwriting the dropped one. So the block is present and
+  callable on resume — the only lost thing is the frame-local subprocess payload.
+
+- **Not the `try`-expression / `__tryCall` value-passthrough.** `__tryCall` correctly passes
+  interrupts through untouched (`lib/runtime/result.ts:177`, `hasInterrupts(value)` guard) and
+  passes a returned Result through without double-wrapping. This is in the same *family* as #483
+  (`try llm()` losing its success value), and the issue author flagged the resemblance, but the
+  mechanism here is distinct: #483 is a codegen value-drop with no pause involved; #513 is a
+  frame-lifecycle loss specific to pause + serialize.
+
+---
+
+## Key code references
+
+| Location | Role |
+|---|---|
+| `lib/runtime/ipc.ts:496–508` | `SUBPROCESS_PAYLOAD_KEY = "__subprocess_state_0"`, `saveSubprocessPayload` / `loadSubprocessPayload` / `clearSubprocessPayload` — payload lives in `frame.locals` |
+| `lib/runtime/ipc.ts:1331` | `const parentFrame = stateStack.lastFrame();` — the frame the payload is written to |
+| `lib/runtime/ipc.ts:1252–1263` | Interrupted branch: saves payload, comment asserts it is "serialized with the parent frame" |
+| `lib/runtime/ipc.ts:1202`, `1266` | `loadSubprocessPayload` on resume; `clearSubprocessPayload` on success |
+| `lib/runtime/ipc.ts:480–490` | `SubprocessResumePayload` type (childCheckpoint, interrupts, node, sessionId) |
+| `lib/templates/backends/typescriptGenerator/blockSetup.mustache` | Block frame created by `setupFunction()`, popped in `finally` (`__bsetup.stateStack.pop()`) |
+| `lib/backends/typescriptBuilder.ts:1743–1797` | `processBlockArgument` — how `as { }` blocks compile (own frame `__bframe_<name>`, own `blockName` scope) |
+| `lib/runtime/state/stateStack.ts:619–640` | `getNewState()` — in deserialize mode returns the existing (deserialized) frame; in serialize mode pushes a new one |
+| `lib/runtime/state/stateStack.ts:202–208` | `State.toJSON()` — `deepClone(this.args)` drops functions (why `scopedCallbacks` are special-cased at 209–217) |
+| `stdlib/agency.agency:161–216` | `run()` two-call-sites: guard-free no-cap path (works) vs `guard(cost:) as { }` path (broken). Comment at 161–167 already documents the footgun without pinning the mechanism. |
+| `stdlib/thread.agency:212–252` | `guard` def: `_pushGuard` → `_runGuarded(ids, block)` → `_popGuard` |
+| `lib/stdlib/thread.ts:357–378` | `_runGuarded` TS seam: `__tryCall(() => __call(block, ...), { ownedGuardIds, ... })`. Comment notes `stack.lastFrame()` is guard()'s own frame (the TS call pushes no agency frame). |
+| `lib/runtime/result.ts:168–231` | `__tryCall` — interrupt passthrough (177), guardTrip→Failure conversion gated on `ownedGuardIds` (205) |
+
+---
+
+## Fix options
+
+Two altitudes.
+
+### A. Narrow fix — unblocks #512, fixes `maxCost` (recommended if the goal is just #512)
+
+Move the cost-guard wrapping out of an Agency `as { }` block and into a TS seam so `_run`
+always executes with `run()`'s **persistent def frame** as `lastFrame()`.
+
+Because `_runGuarded` deliberately pushes **no** Agency frame, a helper along the lines of
+`_runGuarded(ids, () => _run(...))` with a **plain TS closure** (not an Agency block) would run
+`_run` against `run()`'s def frame — so `saveSubprocessPayload` lands on a serialized frame —
+while still passing `ownedGuardIds` so `__tryCall` converts a cost trip to a Failure. This also
+collapses `run()` to a single call site (the review suggestion #512 was blocked on).
+
+- **Fixes:** `run(maxCost:)` under nested pause; #512 single-call-site cleanup.
+- **Does NOT fix:** a user-written `guard(...) as { return run(...) }` (still loses the payload).
+- **Effort:** ~half a day + a nested-pause fixture.
+- **Risk:** low-moderate — confined to the `run()` cost-cap path and the `_runGuarded` seam.
+
+### B. General fix — removes the footgun (the real altitude)
+
+Make the subprocess payload survive an enclosing block frame's pop, so *any* subprocess `run()`
+wrapped in *any* user `guard`/block resumes correctly across serialization.
+
+Candidate approaches:
+- Save `__subprocess_state_0` on the nearest **serialized** frame by walking past ephemeral
+  block frames (keyed to avoid collisions when multiple runs share an ancestor frame), or
+- Flush a block frame's `__subprocess_state_0` down to its owner frame **before** the `finally`
+  pop in the block template.
+
+- **Fixes:** all subprocess runs inside any block/guard across serialize.
+- **Effort:** ~1–2 days + fixtures for user-`guard`-around-`run` across serialize.
+- **Risk:** higher — touches the block-frame lifecycle and the fork/race pop invariant the
+  block template's `finally` comment warns about (popping the ALS-current stack, not
+  `__ctx.stateStack`, matters for parallel/fork/race branches).
+
+### Recommendation
+
+Do **B** if we want the footgun gone — the current mitigation is "never wrap a subprocess run in
+a block," which is easy to violate and only enforced by a comment. Do **A** if the immediate goal
+is just unblocking #512 and making `maxCost` correct under nested pause.
+
+Either way, write the **failing test first**: a `tests/agency/subprocess/` fixture matching the
+issue's repro (child holds the `guard(...) as { }` block, grandchild `bash` pauses, one approval
+resumes the whole tree, assert the node returns `OK: deep-ok`). The existing
+`tests/agency/subprocess/nested-pause-resume.agency` is the guard-free version to fork from; the
+`run-max-cost.agency` fixture is the closest existing coverage of `maxCost` forwarding.

--- a/docs/superpowers/specs/2026-07-14-issue-513-block-ref-revive-fix-design.md
+++ b/docs/superpowers/specs/2026-07-14-issue-513-block-ref-revive-fix-design.md
@@ -1,0 +1,188 @@
+# Fix #513: block references must survive cross-process resume
+
+**Date:** 2026-07-14
+**Issue:** https://github.com/egonSchiele/agency-lang/issues/513
+**Status:** Design approved in discussion; ready for implementation planning.
+**Supersedes:** `docs/superpowers/specs/2026-07-13-issue-513-guard-block-subprocess-resume-investigation.md`. That document's root-cause theory (subprocess payload saved on an ephemeral block frame that gets popped before serialization) is **wrong**. This spec records the verified mechanism and the fix. The old document should be updated to point here as part of this work.
+
+---
+
+## 1. Symptom
+
+A subprocess pauses on a bubbled interrupt while a `guard(...) as { ... }` block wraps the paused `run()` call. After the approval resumes the tree, `run()` returns a failure instead of the child's result. The caller then crashes with `Cannot read properties of undefined` when it touches `result.value`.
+
+This breaks `run(maxCost: ...)` on any nested run that pauses, because `run()` wraps `_run` in a guard block internally. It equally breaks a user-written `guard(...) as { return run(...) }`.
+
+## 2. Verified root cause
+
+Empirically verified on 2026-07-14 by running both repro variants (see section 5).
+
+**Blocks register themselves at creation time.** Every compiled block is an `AgencyFunction` created like this:
+
+```ts
+__AgencyFunction.create(
+  { name: "__block_0", module: "stdlib/agency.agency", fn: ..., ... },
+  __toolRegistry,   // create() adds the block to the function-ref registry
+)
+```
+
+**Frames serialize function values as name references.** The guard's frame holds the block as an argument. `State.toJSON` clones args through `nativeTypeReplacer`, which writes an `AgencyFunction` as:
+
+```json
+{ "__nativeType": "FunctionRef", "module": "stdlib/agency.agency", "name": "__block_0" }
+```
+
+**Revival is eager, and it happens before any code runs.** When the paused process is re-forked, it parses the checkpoint JSON with `nativeTypeReviver` during restore. `FunctionRefReviver.findInRegistry` (`lib/runtime/revivers/functionRefReviver.ts:110`) looks each reference up in the registry and **throws** on a miss:
+
+```
+FunctionRefReviver: function "__block_0" from module "stdlib/agency.agency"
+not found in registry. The function may have been renamed or removed since
+this state was serialized.
+```
+
+In a fresh process, no code has executed yet, so no block has registered itself. The lookup misses, the restore throws, the resumed process dies, and the outer `run()` returns a failure.
+
+**The revived value was garbage anyway.** On replay, every function body rebinds its block arguments unconditionally at entry:
+
+```ts
+__stack.args["block"] = block;   // fresh block, overwrites whatever restore put there
+```
+
+So the restore dies fetching a value the replay was about to throw away. This was proven directly: with a stub in place of the throw, the stub was never invoked across the full repro and regression runs.
+
+**Why in-process pause/resume never hit this:** in one process, the block-creating line has always executed before any checkpoint of it exists, so the block is already in the registry and revival succeeds.
+
+**Why the test suite never hit this.** The bug needs three conditions at once:
+
+1. A block-taking function (like `guard`) mid-execution on the stack at pause time, so a block reference sits in a serialized frame.
+2. The pause crosses a process boundary (subprocess pause), so the state round-trips through JSON in a fresh process.
+3. No handler resolves the interrupt in-process, so the middle process actually dies and gets re-forked.
+
+Each existing test family misses exactly one: `tests/agency/guards/*` are single-process (no 2); `nested-pause-resume` and friends hold no block in any frame (no 1); `run-max-cost` approves everything in-process so nothing pauses mid-guard (no 3). The two-call-site workaround in `run()` (section 4.3) kept the default subprocess path guard-free, which kept most tests out of the danger zone.
+
+## 3. Design decisions already made (with the owner)
+
+- **Fix the pattern, not just `guard`.** Any user-written function that takes an `as { }` block must be pause-safe across process boundaries. This keeps guard-like constructs buildable in userland with no runtime changes, which is an explicit goal.
+- **No `runner.guard()` language construct.** Considered and rejected: it would fix only `guard`, and it would make guard-like constructs require runtime changes forever.
+- **Blocks keep their own frames.** The frame layer is not broken: checkpoints are stamped while block frames are live, and positional replay realigns them. Verified empirically.
+
+## 4. The fix
+
+### 4.1 Reviver: lazy stub for unregistered block references
+
+In `FunctionRefReviver.findInRegistry`, when the lookup misses **and the name is a compiler-generated block name**, return a placeholder instead of throwing:
+
+```ts
+// Compiler-generated blocks (steps.nextBlockName() → "__block_<n>") register
+// themselves only when their creating line executes. A fresh process restoring
+// a checkpoint has not executed anything yet, so a miss here is EXPECTED.
+// Replay rebinds block args at function entry before anything can call them.
+// The stub is a tripwire: if some path invokes a block that replay failed to
+// rebind, we get a precise error at the call instead of a dead restore.
+if (/^__block_\d+$/.test(name)) {
+  return new AgencyFunction({
+    name,
+    module,
+    fn: () => {
+      throw new Error(
+        `Block "${name}" from module "${module}" crossed a serialization ` +
+        `boundary and was invoked before replay rebound it. This is a ` +
+        `runtime bug — please report it.`,
+      );
+    },
+    params: [],
+    toolDefinition: null,
+  });
+}
+throw new Error(/* existing message, unchanged */);
+```
+
+Named functions keep the eager throw. For them, a registry miss means the program really changed between pause and resume (a renamed or removed function), and no replay will fix it. The user needs that error immediately.
+
+The existing unit test that asserts the throw (`functionRefReviver.test.ts:85`) splits in two: block-named refs get a stub whose invocation throws; other refs keep the eager throw.
+
+### 4.2 Regression fixtures
+
+Promote the two verified repros (currently in `packages/agency-lang/tmp/`) to fixtures in `tests/agency/subprocess/`:
+
+- `nested-pause-maxcost.agency` — `nested-pause-resume` with the middle hop's run as `run(compiled: ..., node: "main", maxCost: 1.0)`. This is condition 1 via `run()`'s internal guard block.
+- `nested-pause-user-guard.agency` — same, but the middle hop wraps a plain `run(...)` in a user-level `guard(cost: 1.0) as { ... }`. This is condition 1 via a user block, proving the fix covers the pattern and not just `run()`.
+
+Both: the grandchild's `bash` interrupt is unhandled everywhere, surfaces to the harness, one approval resumes the whole tree, expected output `"OK: deep-ok\n"` exact. Both currently fail; both passed with the experimental fix.
+
+### 4.3 Collapse `run()` to a single call site
+
+`run()` in `stdlib/agency.agency:161` currently contains the identical ten-argument `_run` call twice — a deliberate workaround for this bug, with a comment warning to keep the copies in sync. `pushGuardImpl` already supports negative-as-disabled, added specifically for this collapse (see its comment). Replace both call sites with one:
+
+```ts
+// maxCost null = no cap. guard() disables a dimension on a negative
+// value, so map null to -1 and keep a single guarded call site.
+let cap = -1.0
+if (maxCost != null) {
+  cap = maxCost
+}
+const guarded = guard(cost: cap) as {
+  return try _run(compiled, node, args, wallClock, memory,
+                  ipcPayload, stdout, configOverrides, cwd, maxDepth)
+}
+```
+
+The existing `guardFailure → limit_exceeded` translation below it stays unchanged. Delete the two-call-sites comment; its explanation is the superseded wrong theory.
+
+Note: `guard(cost: null, time: null)` **throws** ("guard() requires at least one of: cost, time"). The disable value is negative, never null. Get this right in every snippet.
+
+This collapse is also the regression alarm: after it, every `run()` call in the entire subprocess suite exercises the guarded path.
+
+### 4.4 Check the sibling case: scoped callbacks holding blocks
+
+`State.toJSON` also serializes `scopedCallbacks` function values as FunctionRefs. A callback registered with a block (`callback("onEmit") as { ... }`) that sits on a serialized frame likely hits the same eager throw at restore today. Unlike block *arguments*, scoped callbacks are **not** obviously rebound by replay (their registration step is skipped by the step counter on resume, by design).
+
+Task for the implementation plan: write a fixture (subprocess pauses while a block-based scoped callback is registered on a serialized frame; after resume, trigger the callback). Three possible outcomes:
+
+- It already works through some path I haven't traced → keep the fixture as coverage.
+- It breaks at restore today and the stub makes it break later, at fire time → decide: fix rebinding in this PR if small, or file a follow-up issue with the fixture attached.
+- The situation can't occur (e.g. callbacks are re-registered another way) → document why next to the fixture.
+
+Do not let this expand the PR silently. If it needs real work, it becomes its own issue.
+
+### 4.5 Correct the record
+
+- Update `docs/superpowers/specs/2026-07-13-issue-513-guard-block-subprocess-resume-investigation.md` with a banner pointing to this spec and a one-paragraph correction. Keep the old text below the banner for the paper trail (its code references are still useful).
+- The `run-max-cost` fixture comment and the guards guide need no changes; the guards guide's behavior claims stay true.
+
+## 5. Evidence collected (2026-07-14)
+
+- Both repro variants fail on the current branch with the `FunctionRefReviver ... __block_0 not found` failure surfaced via `printJSON(result)` on the outer `run()`.
+- With the reviver patched to fail soft (stub), **both variants pass end to end** (`"OK: deep-ok"`), and the stub is never invoked.
+- Regression sample with the patch, all passing: `nested-pause-resume`, `pause-multi-cycle`, `callback-forwarding-nested-relay`, all four `run-max-cost` tests.
+- The patch was reverted after the experiment; the working tree is clean of it.
+
+## 6. Out of scope
+
+- `runner.guard()` or any promotion of `guard` to a language construct (rejected, section 3).
+- Changing how blocks get frames, or redirecting block-frame writes to the parent frame (not needed; frame layer verified correct).
+- The subprocess-payload accessors in `lib/runtime/ipc.ts` (`saveSubprocessPayload` etc.) — they were never the problem.
+- True serialization of closures (a block's captured variables). Replay-rebinding remains the mechanism; the stub is the tripwire for violations.
+- The CLI cost/time guards plan (`docs/superpowers/plans/2026-07-13-cli-cost-time-guards.md`) proceeds unchanged, after this lands.
+
+## 7. Testing
+
+- Unit: `functionRefReviver.test.ts` — block-named miss returns a stub; stub invocation throws the "was invoked before replay rebound it" message; non-block miss still throws eagerly with the original message.
+- Execution fixtures: the two new `tests/agency/subprocess/` fixtures (section 4.2), plus the scoped-callback fixture (section 4.4).
+- Existing suites: `tests/agency/subprocess/` and `tests/agency/guards/` must pass untouched. CI runs the full agency suite; locally run only the fixtures named here.
+- `make` after every `stdlib/*.agency` change; save test output to files.
+
+## 8. Risks and edge cases
+
+- **A user function named `__block_0`.** Double-underscore names should be compiler-reserved (there is a reserved-name check, AG4002). Verify during implementation that a user cannot `def __block_0`, so the regex in 4.1 can't misclassify a real user function. If users can create such names, tighten the discriminator (e.g. mark block refs explicitly at serialize time with a `isBlock: true` field — slightly bigger change, strictly more precise; acceptable fallback).
+- **Stale registry entries in-process.** In one process, revival of a block ref returns whatever closure last registered under that name, which may carry stale captures. Pre-existing behavior, unchanged by this fix, papered over by replay rebinding. Noted here so nobody mistakes it for new.
+- **Stub reachable through data.** A block stored in a local or a data structure (`let f = <block>` before the pause) is *not* rebound by argument rebinding; if code after the resume calls `f`, it hits the stub. Today that same program dies at restore, so the stub strictly improves it (later, precise error vs. dead process). The fixture in 4.4 probes the nearest real-world instance of this class.
+
+## 9. Deliverables checklist
+
+1. Reviver change + unit tests (4.1).
+2. Two regression fixtures (4.2).
+3. `run()` single call site + comment cleanup + `make` (4.3).
+4. Scoped-callback probe fixture + decision (4.4).
+5. Banner correction on the old investigation spec (4.5).
+6. PR references issue #513 and unblocks the #512 review note.

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -83,7 +83,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L374))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L359))
 
 ### Feedback
 
@@ -102,7 +102,7 @@ export type Feedback = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L392))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L377))
 
 ### WriteFailure
 
@@ -118,7 +118,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L601))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L586))
 
 ### AST
 
@@ -141,7 +141,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L752))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L737))
 
 ## Effects
 
@@ -321,7 +321,7 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L208))
 
 ### runCode
 
@@ -387,7 +387,7 @@ re-raises std::run and the child's own effects re-prompt.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L303))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L288))
 
 ### typecheck
 
@@ -411,7 +411,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L364))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L349))
 
 ### getEffects
 
@@ -435,7 +435,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L376))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L361))
 
 ### mergeFeedback
 
@@ -458,7 +458,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L398))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L383))
 
 ### review
 
@@ -482,7 +482,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L469))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
 
 ### renderFeedback
 
@@ -502,7 +502,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L500))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L485))
 
 ### feedbackHasErrors
 
@@ -523,7 +523,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L512))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L497))
 
 ### failOpenFeedback
 
@@ -543,7 +543,7 @@ Pass a successful feedback list through unchanged; map any failure to
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L529))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L514))
 
 ### syntaxHintFor
 
@@ -564,7 +564,7 @@ A specific syntax reminder to inject next to a diagnostic, or "" when no
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L540))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L525))
 
 ### verify
 
@@ -587,7 +587,7 @@ Reconstruct a task's success criteria, run the produced artifact against
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L583))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L568))
 
 ### writeAgency
 
@@ -618,7 +618,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L664))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L649))
 
 ### typecheckFile
 
@@ -643,7 +643,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L732))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L717))
 
 ### parseAST
 
@@ -663,7 +663,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L758))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L743))
 
 ### writeAST
 
@@ -700,7 +700,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L770))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L755))
 
 ### format
 
@@ -720,7 +720,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L792))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L777))
 
 ### formatFile
 
@@ -747,7 +747,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L803))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L788))
 
 ### walkAST
 
@@ -776,7 +776,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L822))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L807))
 
 ### getNodesOfType
 
@@ -798,7 +798,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L842))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L827))
 
 ### getImports
 
@@ -818,7 +818,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L852))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L837))
 
 ### getFunctions
 
@@ -838,7 +838,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L861))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L846))
 
 ### getGraphNodes
 
@@ -858,7 +858,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L870))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L855))
 
 ### filterImports
 
@@ -910,7 +910,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L897))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L882))
 
 ### getVersion
 
@@ -922,4 +922,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L923))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L908))

--- a/packages/agency-lang/lib/backends/typescriptBuilder/stepPathTracker.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/stepPathTracker.ts
@@ -1,3 +1,5 @@
+import { makeBlockName } from "@/runtime/blockNames.js";
+
 /**
  * Tracks the per-statement bookkeeping that the TypeScriptBuilder needs to
  * generate stepped function bodies, loop break/continue cleanup, and
@@ -87,6 +89,6 @@ export class StepPathTracker {
 
   /** Returns the next unique `__block_<n>` name. */
   nextBlockName(): string {
-    return `__block_${this.blockCounter++}`;
+    return makeBlockName(this.blockCounter++);
   }
 }

--- a/packages/agency-lang/lib/runtime/blockNames.test.ts
+++ b/packages/agency-lang/lib/runtime/blockNames.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { makeBlockName, isBlockName } from "./blockNames.js";
+
+describe("blockNames", () => {
+  it("minted names are always recognized by the sibling predicate", () => {
+    expect(isBlockName(makeBlockName(0))).toBe(true);
+    expect(isBlockName(makeBlockName(42))).toBe(true);
+  });
+
+  it("rejects non-block shapes", () => {
+    expect(isBlockName("__blockish")).toBe(false);
+    expect(isBlockName("__block_")).toBe(false);
+    expect(isBlockName("__block_1.5")).toBe(false);
+    expect(isBlockName("__cb_main_0")).toBe(false);
+  });
+
+  it("minting refuses input the predicate could not recognize", () => {
+    expect(() => makeBlockName(1.5)).toThrow("non-negative integer");
+    expect(() => makeBlockName(-1)).toThrow("non-negative integer");
+  });
+});

--- a/packages/agency-lang/lib/runtime/blockNames.ts
+++ b/packages/agency-lang/lib/runtime/blockNames.ts
@@ -8,6 +8,14 @@
  *  function with such a name today, but misclassification requires a
  *  registry miss too, and the failure mode is a soft lazy-throwing stub. */
 export function makeBlockName(counter: number): string {
+  // isBlockName only recognizes \d+, so minting is restricted to the same
+  // shape — otherwise this file's whole reason to exist (the two sides
+  // cannot desync) would be false for non-integer input.
+  if (!Number.isInteger(counter) || counter < 0) {
+    throw new Error(
+      `makeBlockName: counter must be a non-negative integer (got ${counter})`,
+    );
+  }
   return `__block_${counter}`;
 }
 

--- a/packages/agency-lang/lib/runtime/blockNames.ts
+++ b/packages/agency-lang/lib/runtime/blockNames.ts
@@ -1,0 +1,16 @@
+/** Single source of truth for the compiler's anonymous-block naming scheme.
+ *  The backend MINTS names via makeBlockName (stepPathTracker.nextBlockName);
+ *  the runtime RECOGNIZES them via isBlockName (FunctionRefReviver's stub
+ *  decision for unregistered refs). Keeping both here means the two
+ *  subsystems cannot silently desync.
+ *
+ *  "__block_" is a de-facto reserved prefix: no diagnostic rejects a user
+ *  function with such a name today, but misclassification requires a
+ *  registry miss too, and the failure mode is a soft lazy-throwing stub. */
+export function makeBlockName(counter: number): string {
+  return `__block_${counter}`;
+}
+
+export function isBlockName(name: string): boolean {
+  return /^__block_\d+$/.test(name);
+}

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
@@ -84,6 +84,56 @@ describe("FunctionRefReviver", () => {
       expect(() => reviver.revive({ name: "missing", module: "test.agency" }))
         .toThrow("not found in registry");
     });
+
+    it("revives an unregistered block ref to a stub instead of throwing", () => {
+      reviver.registry = {};
+      const stub = reviver.revive({
+        name: "__block_0",
+        module: "stdlib/agency.agency",
+      });
+      expect(AgencyFunction.isAgencyFunction(stub)).toBe(true);
+      expect(stub.name).toBe("__block_0");
+      expect(stub.module).toBe("stdlib/agency.agency");
+    });
+
+    it("the block stub is a tripwire: invoking it surfaces a rebind error", async () => {
+      reviver.registry = {};
+      const stub = reviver.revive({
+        name: "__block_7",
+        module: "test.agency",
+      });
+      // invoke() may reject or convert the throw to a failure Result
+      // depending on failure-propagation settings; accept either, but the
+      // tripwire message must surface.
+      const outcome = await stub
+        .invoke({ type: "positional", args: [] })
+        .then((v: unknown) => v, (e: unknown) => e);
+      const msg =
+        outcome instanceof Error ? outcome.message : JSON.stringify(outcome);
+      expect(msg).toContain("before replay rebound it");
+    });
+
+    it("non-block names still throw eagerly on a registry miss", () => {
+      reviver.registry = {};
+      expect(() =>
+        reviver.revive({ name: "__blockish", module: "test.agency" }),
+      ).toThrow("not found in registry");
+      expect(() =>
+        reviver.revive({ name: "__block_", module: "test.agency" }),
+      ).toThrow("not found in registry");
+    });
+
+    it("a REGISTERED block name resolves to the real function, not a stub", () => {
+      // Pins the lookup-before-regex ordering: moving the block check ahead
+      // of the registry lookup would silently stub every registered block.
+      const real = makeAgencyFunction("__block_0", "test.agency");
+      reviver.registry = { "test.agency:__block_0": real };
+      const result = reviver.revive({
+        name: "__block_0",
+        module: "test.agency",
+      });
+      expect(result).toBe(real);
+    });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
@@ -1,6 +1,7 @@
 import { BaseReviver } from "./baseReviver.js";
 import { AgencyFunction } from "../agencyFunction.js";
 import type { FuncParam, ToolDefinition } from "../agencyFunction.js";
+import { isBlockName } from "../blockNames.js";
 
 type FunctionRefRegistry = Record<string, AgencyFunction>;
 
@@ -107,9 +108,38 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
       }
     }
 
+    // Compiler-generated blocks register themselves only when their creating
+    // line executes. A fresh process restoring a checkpoint has executed
+    // nothing yet, so a miss here is EXPECTED for blocks — replay rebinds
+    // block args at function entry before anything can call them (#513).
+    if (isBlockName(name)) {
+      return makeBlockStub(name, module);
+    }
     throw new Error(
       `FunctionRefReviver: function "${name}" from module "${module}" not found in registry. ` +
       `The function may have been renamed or removed since this state was serialized.`
     );
   }
+}
+
+/** A lazy tripwire for an unregistered block reference: a real
+ *  AgencyFunction (so restore succeeds and the frame slot is filled) whose
+ *  body throws a precise error IF anything invokes it. In every correct
+ *  replay the generated def body overwrites the slot with a fresh block
+ *  before any call, so this never fires. Plain `new` on purpose — the stub
+ *  must NOT self-register the way AgencyFunction.create does. */
+function makeBlockStub(name: string, module: string): AgencyFunction {
+  return new AgencyFunction({
+    name,
+    module,
+    fn: () => {
+      throw new Error(
+        `Block "${name}" from module "${module}" crossed a serialization ` +
+          `boundary and was invoked before replay rebound it. This is a ` +
+          `runtime bug — please report it.`,
+      );
+    },
+    params: [],
+    toolDefinition: null,
+  });
 }

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -158,28 +158,13 @@ export def run(
     depth: _subprocessDepth() + 1
   })
 
-  // Two call sites on purpose. Wrapping the no-cap path in an inert
-  // guard block breaks nested subprocess pause/resume: when THIS process
-  // is itself a subprocess that pauses on a bubbled interrupt, resuming
-  // its serialized stack through the guard block loses the block's
-  // return value and run() yields undefined (see the nested-pause-resume
-  // fixture, which caught this in CI). Keep the argument lists below
-  // IDENTICAL.
-  if (maxCost == null) {
-    return try _run(
-      compiled,
-      node,
-      args,
-      wallClock,
-      memory,
-      ipcPayload,
-      stdout,
-      configOverrides,
-      cwd,
-      maxDepth,
-    )
-  }
-  const guarded = guard(cost: maxCost) as {
+  // guard() disables a dimension on a NEGATIVE value (null for BOTH
+  // dimensions throws), so a null maxCost maps to the disable value and
+  // one guarded call site serves both cases. Safe since #513: block
+  // frames revive correctly across a nested subprocess pause.
+  const NO_COST_CAP = -1.0
+  const cap = if maxCost != null then maxCost else NO_COST_CAP
+  const guarded = guard(cost: cap) as {
     return try _run(
       compiled,
       node,

--- a/packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.agency
+++ b/packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.agency
@@ -1,0 +1,56 @@
+import { compile, run } from "std::agency"
+
+// #513 regression: the middle hop's run() uses maxCost, which wraps _run in
+// a guard block INSIDE run(). The grandchild's bash is unhandled anywhere, so
+// the middle process pauses and serializes WHILE the guard block's frame
+// (holding a FunctionRef to the block) is on its stack. Resume must revive
+// that state in a fresh process: before the fix, FunctionRefReviver threw on
+// the unregistered "__block_<n>" ref and the resume died.
+node main() {
+  const grandSource = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo deep-ok")
+  return r.stdout
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const result = run(compiled: c.value, node: "main", maxCost: 1.0)
+    if (isSuccess(result)) {
+      return result.value.data
+    }
+    return "inner run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isSuccess(result)) {
+      return "OK: ${result.value.data}"
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/nested-pause-maxcost.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "#513: run(maxCost:) on the middle hop; grandchild interrupt pauses the tree; one approval resumes through the internal guard block",
+      "input": "",
+      "expectedOutput": "\"OK: deep-ok\\n\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.agency
+++ b/packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.agency
@@ -1,0 +1,61 @@
+import { compile, run } from "std::agency"
+
+// #513 regression, user-level variant: a hand-written guard(...) as { } wraps
+// the middle hop's run(). The serialized middle stack holds the user block's
+// FunctionRef. This is the case that proves ANY block-taking function is
+// pause-safe across process boundaries, not just run(maxCost:).
+node main() {
+  const grandSource = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo deep-ok")
+  return r.stdout
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+import { guard } from "std::thread"
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const guarded = guard(cost: 1.0) as {
+      const result = run(compiled: c.value, node: "main")
+      if (isSuccess(result)) {
+        return result.value.data
+      }
+      return "inner run failed"
+    }
+    if (isSuccess(guarded)) {
+      return guarded.value
+    }
+    return "guard tripped"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isSuccess(result)) {
+      return "OK: ${result.value.data}"
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/nested-pause-user-guard.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "#513: user-level guard(cost:) as { } around the middle hop's run(); one approval resumes through the user block",
+      "input": "",
+      "expectedOutput": "\"OK: deep-ok\\n\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.agency
+++ b/packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.agency
@@ -1,0 +1,64 @@
+import { compile, run } from "std::agency"
+
+// #513 regression, userland variant: a USER-DEFINED function with a block
+// parameter wraps the middle hop's run(). Its frame serializes a FunctionRef
+// to the anonymous block, exactly like guard()'s does. This pins the spec's
+// goal that guard-like constructs are buildable in userland with no runtime
+// changes and stay pause-safe across process boundaries.
+node main() {
+  const grandSource = """
+import { bash } from "std::shell"
+node main() {
+  let r = bash("echo deep-ok")
+  return r.stdout
+}
+"""
+  const childSource = """
+import { compile, run } from "std::agency"
+
+def withWrapper(block: () -> any = null): any {
+  const result = block()
+  return result
+}
+
+node main(grandSource: string) {
+  const c = compile(grandSource)
+  if (isFailure(c)) {
+    return "inner compile failed"
+  }
+  handle {
+    const wrapped = withWrapper() as {
+      const result = run(compiled: c.value, node: "main")
+      if (isSuccess(result)) {
+        return result.value.data
+      }
+      return "inner run failed"
+    }
+    return wrapped
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}
+"""
+  const compileResult = compile(childSource)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(
+      compiled: compileResult.value,
+      node: "main",
+      args: { grandSource: grandSource },
+    )
+    if (isSuccess(result)) {
+      return "OK: ${result.value.data}"
+    }
+    return "run failed"
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/nested-pause-user-wrapper.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "#513: a user-defined block-taking function wraps the middle hop's run(); one approval resumes through the user block",
+      "input": "",
+      "expectedOutput": "\"OK: deep-ok\\n\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #513.

## What was actually wrong

Blocks (`as { }`) self-register in the function-ref registry when their
creating line executes. A frame that holds a block argument serializes it as
a `FunctionRef` name reference. When a paused subprocess is re-forked, the
fresh process restores the checkpoint BEFORE running any code, so the block
is not registered yet — and `FunctionRefReviver` threw eagerly, killing the
whole resume. The revived value was garbage anyway: replay rebinds block
arguments at function entry before anything can call them.

The earlier investigation doc blamed a popped block frame; that theory is
wrong. The doc lands here with a correction banner.

## The fix

- `FunctionRefReviver`: an unregistered block ref now revives to a lazy stub
  that throws a precise error IF invoked (a tripwire that never fires in
  correct replays). Named functions keep the eager throw — for them a miss
  means the program really changed. The `__block_<n>` naming scheme now has
  a single source of truth (`lib/runtime/blockNames.ts`) shared by the
  backend that mints names (stepPathTracker) and the reviver that recognizes
  them.
- Three regression fixtures: nested pause through `run(maxCost:)`, through a
  user-level `guard(...) as { }`, and through a user-DEFINED block-taking
  wrapper (pins the goal that userland guard-like constructs are pause-safe
  with no runtime changes).
- `run()` collapsed to a single always-guarded call site (the #512 review
  note this bug was blocking). Every `run()` now exercises the guarded path,
  so the whole subprocess suite becomes a regression alarm for #513.
- Probed the sibling case (scoped callbacks with block bodies across a
  cross-process resume): it is broken independently, for `__cb_<scope>_<n>`
  names, and a stub alone would NOT be safe there (callback registrations
  are not rebound by replay). Filed #544 with the repro instead of shipping
  a red fixture.

## Testing

- Reviver unit tests: stub for unregistered block names, tripwire message on
  stub invocation, eager throw preserved for non-block names (`__blockish`,
  `__block_`), and registered-block-returns-real (pins lookup-before-regex
  ordering). 29/29 pass.
- All three new fixtures fail before the reviver change with the exact
  pre-fix signature (`Expected 1 interrupts but only 0 occurred`) and pass
  after it.
- Local regression sample, all passing: `nested-pause-resume`,
  `pause-multi-cycle`, `concurrent-handled`, `handler-reject`,
  `callback-forwarding-nested-relay`, `run-max-cost` (5 tests),
  `cost-no-double-charge-across-pause`.
- `pnpm run lint:structure` clean; CI runs the full agency suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
