### PR TITLE
Guard time semantics: time <= 0 disables; input-wait is free

### DIFF
--- a/docs/superpowers/plans/2026-07-13-cli-cost-time-guards.md
+++ b/docs/superpowers/plans/2026-07-13-cli-cost-time-guards.md
@@ -1,0 +1,1212 @@
+# CLI cost/time guards + working-time semantics — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--max-cost` / `--max-time` flags to `agency run` and `agency agent`, make time budgets stop counting while waiting on a human, and give each `fork` branch its own time budget.
+
+**Architecture:** Reuse the existing guard primitives (`CostGuard`, `TimeGuard`, `pushGuard`) and the `--policy` CLI→env→runtime plumbing. Three PRs, semantics first: (1) tighten the disable rule for time and make input-wait free; (2) per-branch time budgets; (3) CLI flags installing a root guard, with a distinct exit code.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/`), stdlib TS seams (`lib/stdlib/`), commander CLI (`scripts/agency.ts`), tarsec-based codegen (`lib/backends/`), Agency execution-test fixtures (`tests/agency/`).
+
+## Global Constraints
+
+- Guard disable ranges (verbatim from the design): **cost** disabled when value `< 0`, real limit when `>= 0` (`0` = "no paid spend" / local-models-only); **time** disabled when value `<= 0`, real limit when `> 0`.
+- Budget-exceeded exit code is **3**, defined once as a named constant in `lib/constants.ts`, distinct from `1` (generic failure) and `2` (usage error).
+- Cost stays shared/cumulative across `fork` branches (`CostGuard.cloneForBranch` returns `this`, unchanged). Only **time** becomes per-branch.
+- `sleep` still counts against time budgets. Only waiting on a human (`input`) is exempt.
+- `--max-cost` is bare dollars (no `$`). `--max-time` accepts duration strings only (`30s`, `5m`, `1h`, `500ms`), plus a leading `-` for a disable value; a bare unitless number is a usage error.
+- Never use dynamic imports. Objects over maps, arrays over sets, types over interfaces (per `docs/dev/coding-standards.md`).
+- Run `make` after changing stdlib `.agency` files. Save test output to a file.
+
+---
+
+# PR 1 — Time-zero disables + input-wait is free
+
+**Context for the implementer:** "Negative disables a dimension" already works — `pushGuardImpl` in `lib/stdlib/thread.ts:258` only pushes a guard when the limit is `>= 0`, and the `guard` docstring in `stdlib/thread.agency:212` already documents it. This PR does two things: (a) tighten **time** so `0` also disables (matches the design's "time `<= 0` disables"), and (b) stop counting time while `input` waits on a human.
+
+## Task 1.1: `time: 0` disables the time guard
+
+**Files:**
+- Modify: `lib/stdlib/thread.ts:281` (the `timeLimit != null && timeLimit >= 0` condition)
+- Modify: `stdlib/thread.agency:230` (docstring for `@param time`)
+- Test: `tests/agency/guards/guard-time-zero-disables.agency` + `.test.json` (create)
+
+**Interfaces:**
+- Consumes: `pushGuardImpl(stack, costLimit, timeLimit)` (existing, `lib/stdlib/thread.ts:258`).
+- Produces: no signature change. Behavior change only: `guard(time: 0)` installs no time guard.
+
+- [ ] **Step 1: Check nothing relies on `guard(time: 0)` tripping**
+
+Run: `grep -rn "time: 0\b\|TimeGuard(0)\|time: 0ms" tests/ lib/ stdlib/`
+Expected: no test asserts that a zero time budget trips. If any exists, note it and adjust that test to the new "disabled" meaning as part of this task.
+
+- [ ] **Step 2: Write the failing execution test**
+
+Create `tests/agency/guards/guard-time-zero-disables.agency`:
+
+```
+import { guard } from "std::thread"
+
+// A zero time budget disables the time guard: the block runs to
+// completion and returns its value instead of tripping. (A negative
+// budget already disables; this locks in that 0 does too, matching
+// the design's "time <= 0 disables" rule.)
+node main() {
+  const result = guard(time: 0) as {
+    sleep(20ms)
+    return "ran to completion"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}
+```
+
+Create `tests/agency/guards/guard-time-zero-disables.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ran to completion\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A zero time budget disables the time guard; the block runs to completion rather than tripping."
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm run a test tests/agency/guards/guard-time-zero-disables.agency 2>&1 | tee /tmp/pr1-t1.log`
+Expected: FAIL — with today's `>= 0`, a `TimeGuard(0)` is pushed and trips almost immediately, so output is `"tripped:timeoutFailure"`, not `"ran to completion"`.
+
+- [ ] **Step 4: Tighten the time condition**
+
+In `lib/stdlib/thread.ts`, change the time branch in `pushGuardImpl`:
+
+```ts
+  if (costLimit != null && costLimit >= 0) {
+    const g = new CostGuard(costLimit);
+    stack.pushGuard(g);
+    ids.push(g.guardId);
+  }
+  // Time: a NON-POSITIVE limit disables (0 would otherwise trip instantly and
+  // has no useful meaning). Cost differs on purpose: cost 0 is a real limit
+  // meaning "no paid spend" (local-models-only), since check() trips on
+  // spent > limit (strict).
+  if (timeLimit != null && timeLimit > 0) {
+    const g = new TimeGuard(timeLimit);
+    stack.pushGuard(g);
+    ids.push(g.guardId);
+  }
+```
+
+- [ ] **Step 5: Update the docstring**
+
+In `stdlib/thread.agency`, change the `@param time` line (around line 230):
+
+```
+  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null, zero, or negative = no time limit.
+```
+
+- [ ] **Step 6: Rebuild stdlib and run the test**
+
+Run: `make 2>&1 | tail -5 && pnpm run a test tests/agency/guards/guard-time-zero-disables.agency 2>&1 | tee /tmp/pr1-t1.log`
+Expected: PASS.
+
+- [ ] **Step 7: Confirm existing guard tests still pass**
+
+Run: `pnpm run a test tests/agency/guards/guard-time-trip.agency 2>&1 | tee -a /tmp/pr1-t1.log && pnpm run a test tests/agency/guards/guard-cost-no-trip.agency 2>&1 | tee -a /tmp/pr1-t1.log`
+Expected: both PASS (positive time budgets still trip; cost unaffected).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/stdlib/thread.ts stdlib/thread.agency tests/agency/guards/guard-time-zero-disables.*
+git commit -F /tmp/commit-1-1.txt
+```
+
+Where `/tmp/commit-1-1.txt` contains:
+
+```
+Make time: 0 disable the time guard (design: time <= 0 = no limit)
+
+Cost 0 stays a real limit (no paid spend / local-only); only time
+treats 0 as disabled, since a zero time budget trips instantly and
+has no useful meaning.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+## Task 1.2: Pause time guards while `input` waits on a human
+
+**Files:**
+- Modify: `lib/stdlib/builtins.ts:59-90` (`inputImpl`)
+- Test: `tests/agency/guards/guard-time-input-wait-free.agency` + `.test.json` (create)
+- Test: `tests/agency/guards/guard-time-sleep-still-counts.agency` + `.test.json` (create)
+
+**Interfaces:**
+- Consumes: `stack.guards` (array of `Guard`, `lib/runtime/state/stateStack.ts:309`); `Guard.pause()` / `Guard.resume(stack)` (`lib/runtime/guard.ts:59`).
+- Produces: no signature change to `inputImpl`. Behavior: time guards on the active branch stack do not accrue elapsed time across the input wait.
+
+- [ ] **Step 1: Add a test input override helper the fixtures can use**
+
+The real `input` blocks on stdin, which an execution test cannot drive. `inputImpl` already honors a global override at `builtins.ts:64` (`__agencyInputOverride`). The override must be exercised through the SAME pause/resume path as the real wait (see Step 4). To let a fixture install an override that also takes real time, add a tiny stdlib test seam.
+
+In `lib/stdlib/builtins.ts`, above `inputImpl`, add:
+
+```ts
+/** Test-only: install an input override that resolves after `delayMs`,
+ *  used by guard fixtures to simulate a slow human without touching stdin.
+ *  Exposed as the `_installSlowInput` builtin (test imports only). */
+export function _installSlowInput(delayMs: number, answer: string): void {
+  (globalThis as any).__agencyInputOverride = (_prompt: string) =>
+    new Promise<string>((resolve) => setTimeout(() => resolve(answer), delayMs));
+}
+```
+
+Register it as a test-only builtin (follow the existing `_input` registration in `lib/codegenBuiltins/` — mirror how another `_`-prefixed builtin with no context injection is registered; grep `"_round"` for the simplest analog and copy its registration entry).
+
+- [ ] **Step 2: Write the failing "input-wait is free" test**
+
+Create `tests/agency/guards/guard-time-input-wait-free.agency`:
+
+```
+import test { _installSlowInput } from "std::builtins"
+import { guard } from "std::thread"
+
+// A 40ms time budget wrapping an input() whose (simulated) human takes
+// 120ms to answer. Because input-wait does not count against a time
+// budget, the guard must NOT trip: the block returns the answer.
+node main() {
+  _installSlowInput(120, "hello")
+  const result = guard(time: 40ms) as {
+    const answer = input("your name? ")
+    return "got:${answer}"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}
+```
+
+Create `tests/agency/guards/guard-time-input-wait-free.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"got:hello\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A time budget does not count time spent waiting for a human via input(); a slow answer that exceeds the raw budget does not trip the guard."
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `make 2>&1 | tail -3 && pnpm run a test tests/agency/guards/guard-time-input-wait-free.agency 2>&1 | tee /tmp/pr1-t2.log`
+Expected: FAIL — today the timer keeps running during the wait, so the 120ms answer overruns the 40ms budget and output is `"tripped:timeoutFailure"`.
+
+- [ ] **Step 4: Wrap the input wait in pause/resume**
+
+Rewrite `inputImpl` in `lib/stdlib/builtins.ts` so BOTH the override path and the readline path pause the active stack's guards for the duration of the wait:
+
+```ts
+function inputImpl(
+  ctx: RuntimeContext<any>,
+  stack: StateStack,
+  prompt: string,
+): Promise<string> {
+  // Waiting on a human must not count against a time budget. Pause every
+  // guard on the active branch stack before blocking, resume after. These
+  // are the same idempotent calls the runner makes on halt()/step entry;
+  // CostGuard.pause() is a no-op, so only time budgets are affected.
+  stack.guards.forEach((g) => g.pause());
+  const resumeGuards = () => stack.guards.forEach((g) => g.resume(stack));
+
+  const override = (globalThis as any).__agencyInputOverride as
+    | ((prompt: string) => Promise<string>)
+    | undefined;
+  if (override) {
+    return override(prompt).finally(resumeGuards);
+  }
+  const signal = ctx.getAbortSignal(stack);
+  if (signal.aborted) {
+    resumeGuards();
+    return Promise.reject(new AgencyCancelledError("input cancelled"));
+  }
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise<string>((resolve, reject) => {
+    const onAbort = () => {
+      try { rl.close(); } catch {}
+      reject(new AgencyCancelledError("input cancelled"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    rl.question(prompt, (answer: string) => {
+      signal.removeEventListener("abort", onAbort);
+      rl.close();
+      resolve(answer);
+    });
+  }).finally(resumeGuards);
+}
+```
+
+Note: `getRuntimeContext().stack` (via `_input`) resolves the ALS active-branch stack, so pausing `stack.guards` targets the right scope. This is a no-op when there are no guards.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `make 2>&1 | tail -3 && pnpm run a test tests/agency/guards/guard-time-input-wait-free.agency 2>&1 | tee /tmp/pr1-t2.log`
+Expected: PASS — output `"got:hello"`.
+
+- [ ] **Step 6: Write the "sleep still counts" companion test**
+
+Create `tests/agency/guards/guard-time-sleep-still-counts.agency`:
+
+```
+import { guard } from "std::thread"
+
+// sleep is NOT exempt: it is the program deliberately spending time,
+// not waiting on a human. A sleep that overruns the budget still trips.
+node main() {
+  const result = guard(time: 20ms) as {
+    sleep(150ms)
+    sleep(1ms)
+    return "did not trip"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}
+```
+
+Create `tests/agency/guards/guard-time-sleep-still-counts.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped:timeoutFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "sleep still counts against a time budget; a sleep that overruns the limit trips, confirming only input-wait is exempt."
+    }
+  ]
+}
+```
+
+- [ ] **Step 7: Run the sleep test to verify it passes**
+
+Run: `pnpm run a test tests/agency/guards/guard-time-sleep-still-counts.agency 2>&1 | tee -a /tmp/pr1-t2.log`
+Expected: PASS.
+
+- [ ] **Step 8: Add an Esc-during-input regression test**
+
+Confirm `pause()` does not break external cancellation of an in-progress input wait. Create `tests/agency/guards/guard-input-abort-still-cancels.agency`:
+
+```
+import test { _installSlowInput } from "std::builtins"
+import { guard } from "std::thread"
+
+// pause() cancels only the guard's own timer; it leaves the abort
+// signal composed, so a time-guard TRIP still aborts an in-flight
+// input. Here the wait (500ms) far exceeds the budget (30ms), and the
+// input is NOT exempt from an abort that the guard itself fires... but
+// input-wait is exempt from COUNTING. So the guard never trips and the
+// answer returns. This asserts the wait is not spuriously aborted.
+node main() {
+  _installSlowInput(60, "ok")
+  const result = guard(time: 30ms) as {
+    const answer = input("q? ")
+    return "got:${answer}"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}
+```
+
+Create the matching `.test.json` expecting `"got:ok"`.
+
+> Implementer note: the interaction between a time-guard trip and an in-flight input is subtle. The property this PR guarantees is that input-wait does not *count*. Whether an outer NON-guard abort (Esc/`cancel()`) interrupts input is unchanged by this PR — it still works via the composed signal, which `pause()` leaves intact. If you want to assert Esc behavior directly, drive it through the existing cancellation test harness rather than a guard fixture.
+
+- [ ] **Step 9: Run the abort test**
+
+Run: `pnpm run a test tests/agency/guards/guard-input-abort-still-cancels.agency 2>&1 | tee -a /tmp/pr1-t2.log`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/stdlib/builtins.ts lib/codegenBuiltins/ tests/agency/guards/guard-time-input-wait-free.* tests/agency/guards/guard-time-sleep-still-counts.* tests/agency/guards/guard-input-abort-still-cancels.*
+git commit -F /tmp/commit-1-2.txt
+```
+
+`/tmp/commit-1-2.txt`:
+
+```
+Make input-wait free against time budgets
+
+Pause the active stack's guards around input()'s wait and resume
+after, so waiting on a human does not count against a --max-time or
+guard(time:) budget. sleep still counts. Reuses the runner's existing
+idempotent pause()/resume(); CostGuard.pause() is a no-op.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+- [ ] **Step 11: Update the guards guide**
+
+In `docs/site/guide/guards.md`, change the "When the clock ticks" list under `## Timeout` so `input` is now exempt:
+
+```
+When the clock ticks:
+- regular code execution = yes.
+- interrupts = no.
+- waiting for user input through `input` = no (waiting on a human is free).
+- `sleep` = yes.
+```
+
+Commit this doc change with the same message body (or fold into the Step 10 commit if not yet pushed).
+
+---
+
+# PR 2 — Per-branch time budgets
+
+**Context:** Today `TimeGuard.cloneForBranch` returns `undefined` (`lib/runtime/guard.ts:360`), so a `fork` branch has no timer of its own — the parent's single timer trips all branches via a composed abort signal. This PR gives each branch its own timer, inheriting the parent's REMAINING budget at fork time, so a branch's input-wait pauses only its own clock. This is what makes PR 1 correct inside a `fork`.
+
+**Read before starting:** `docs/dev/runBatch.md` (fork/race join), `lib/runtime/state/stateStack.ts:591` (`rehydrateInheritedGuardsFrom`), and the `TimeGuard` class (`lib/runtime/guard.ts:256`).
+
+## Task 2.1: Investigate the fork join + guard rehydration path
+
+**Files:** none (investigation task producing notes).
+
+- [ ] **Step 1: Trace how a branch stack gets its guards**
+
+Run: `grep -rn "cloneForBranch\|rehydrateInheritedGuardsFrom\|composeBranchAbortSignal" lib/runtime/ | grep -v test`
+Read each call site. Write a short note in the PR description answering:
+- Where is `cloneForBranch` called during fork/race setup, and with what `(parentStack, childStack)`?
+- After branches finish, does any code fold branch elapsed time back into the parent guard? (This determines whether "parent clock advances by the longest branch's working time" needs new join code or happens for free.)
+
+- [ ] **Step 2: Decide the join-accounting approach**
+
+Based on Step 1, choose one and record it:
+- **(a)** If the parent timer keeps running independently through the fork region (real wall clock), no join accounting is needed — the parent already reflects real elapsed time, and per-branch clones only serve the pause-on-input purpose. Prefer this if it holds: it is the smallest change.
+- **(b)** If the parent timer is paused/handed off during the fork, add join code that advances the parent's `elapsedMs` by `max(branch working-time deltas)` at branch completion.
+
+> Expectation from the design: option (a) is likely, because the parent Runner keeps stepping through the fork region. Confirm empirically before writing code.
+
+## Task 2.2: `TimeGuard.cloneForBranch` returns a per-branch timer
+
+**Files:**
+- Modify: `lib/runtime/guard.ts:360-365` (`TimeGuard.cloneForBranch`)
+- Test: `lib/runtime/guard.test.ts` (unit)
+- Test: `tests/agency/guards/guard-time-fork-per-branch.agency` + `.test.json` (create)
+
+**Interfaces:**
+- Consumes: `TimeGuard` fields `timeLimit`, `elapsedMs`, and the `Guard.cloneForBranch(parentStack, childStack)` contract (`lib/runtime/guard.ts:59`).
+- Produces: `TimeGuard.cloneForBranch` returns a NEW `TimeGuard` whose limit is the parent's remaining budget (`timeLimit - elapsedMs`, floored at a tiny positive epsilon), armed independently on the child stack.
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `lib/runtime/guard.test.ts`, add:
+
+```ts
+test("TimeGuard.cloneForBranch inherits the parent's remaining budget", () => {
+  const parent = new TimeGuard(10_000); // 10s
+  // Simulate 3s already spent on the parent before the fork.
+  (parent as unknown as { elapsedMs: number }).elapsedMs = 3_000;
+  const parentStack = new StateStack();
+  const childStack = new StateStack();
+  const child = parent.cloneForBranch(parentStack, childStack);
+  expect(child).toBeInstanceOf(TimeGuard);
+  // Child gets the remaining 7s, not a fresh 10s.
+  expect((child as TimeGuard).timeLimit).toBe(7_000);
+});
+```
+
+- [ ] **Step 2: Run the unit test to verify it fails**
+
+Run: `pnpm test:run lib/runtime/guard.test.ts 2>&1 | tee /tmp/pr2-t2.log`
+Expected: FAIL — `cloneForBranch` returns `undefined`, so `toBeInstanceOf(TimeGuard)` fails.
+
+- [ ] **Step 3: Implement per-branch cloning**
+
+Replace `TimeGuard.cloneForBranch` (`lib/runtime/guard.ts:360`):
+
+```ts
+  cloneForBranch(
+    _parentStack: StateStack,
+    _childStack: StateStack,
+  ): Guard {
+    // Wall-clock time is not cumulative across parallel branches, so each
+    // branch gets its OWN timer. It inherits the parent's REMAINING budget
+    // at fork time (timeLimit - elapsedMs), floored at 1ms, so the path
+    // "parent work, then branch" cannot exceed the original budget. Each
+    // branch pauses/resumes independently, so a branch's input-wait frees
+    // only that branch's clock. install()/resume() on the child stack arm
+    // the fresh timer.
+    const remaining = Math.max(1, this.timeLimit - this.currentElapsed());
+    return new TimeGuard(remaining);
+  }
+```
+
+Add a private helper on `TimeGuard` (near `check()`), since `elapsedMs` excludes the in-flight window:
+
+```ts
+  /** elapsedMs plus any in-flight running window. */
+  private currentElapsed(): number {
+    return (
+      this.elapsedMs +
+      (this.state === "running" && this.windowStart !== undefined
+        ? performance.now() - this.windowStart
+        : 0)
+    );
+  }
+```
+
+(Reuse `currentElapsed()` inside `check()` and `toJSON()` too, replacing their inline in-flight computations, to keep one source of truth. Optional but DRY.)
+
+- [ ] **Step 4: Run the unit test to verify it passes**
+
+Run: `pnpm test:run lib/runtime/guard.test.ts 2>&1 | tee /tmp/pr2-t2.log`
+Expected: PASS.
+
+- [ ] **Step 5: Write the per-branch execution test**
+
+Create `tests/agency/guards/guard-time-fork-per-branch.agency`:
+
+```
+import test { _installSlowInput } from "std::builtins"
+import { guard } from "std::thread"
+
+// Two branches under one time budget. Branch A waits on a (simulated)
+// slow human; branch B does a short sleep. With per-branch timers and
+// input-wait exempt, A's wait does not consume the budget, so neither
+// branch trips and both return.
+node main() {
+  _installSlowInput(120, "A")
+  const result = guard(time: 60ms) as {
+    let outA = ""
+    let outB = ""
+    fork([1, 2]) as which {
+      if (which == 1) {
+        outA = input("A? ")
+      } else {
+        sleep(20ms)
+        outB = "B-done"
+      }
+    }
+    return "${outA}:${outB}"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}
+```
+
+> Implementer note: verify the exact `fork` syntax and how branch-local writes surface against `tests/agency/guards/guard-cost-fork.agency`. Adjust the fixture to match the real fork idiom (the shape above is illustrative). The assertion that matters: the run does NOT trip.
+
+Create the matching `.test.json`. Set `expectedOutput` to whatever the corrected fixture actually returns on success (run it once after Step 6 to capture, then pin it) — but it MUST NOT be a `tripped:` value.
+
+- [ ] **Step 6: Run the execution test**
+
+Run: `make 2>&1 | tail -3 && pnpm run a test tests/agency/guards/guard-time-fork-per-branch.agency 2>&1 | tee -a /tmp/pr2-t2.log`
+Expected: PASS (no trip).
+
+- [ ] **Step 7: Run all existing guard fixtures**
+
+Run: `for f in tests/agency/guards/*.agency; do echo "== $f =="; pnpm run a test "$f"; done 2>&1 | tee /tmp/pr2-allguards.log`
+Expected: all PASS. Pay special attention to `guard-time-nested-outer-tighter`, `guard-concurrent-branches`, and any `guard-time-*` fork fixture — per-branch cloning must not regress nested/shared time semantics.
+
+- [ ] **Step 8: Verify interrupt+resume inside a fork branch**
+
+Run: `pnpm run a test tests/agency/guards/guard-cost-shared-survives-interrupt.agency 2>&1 | tee -a /tmp/pr2-allguards.log`
+If a time-guard analog does not exist, create `guard-time-branch-survives-interrupt.agency`: a `guard(time: <large>)` around a `fork` where a branch takes an interrupt, then resumes and completes. Assert no spurious trip and correct return. This checks that per-branch clones serialize/rehydrate correctly (`TimeGuard.toJSON`/`fromJSON` + `rehydrateInheritedGuardsFrom`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/runtime/guard.ts lib/runtime/guard.test.ts tests/agency/guards/guard-time-fork-per-branch.* tests/agency/guards/guard-time-branch-survives-interrupt.*
+git commit -F /tmp/commit-2-2.txt
+```
+
+`/tmp/commit-2-2.txt`:
+
+```
+Give each fork branch its own time budget
+
+TimeGuard.cloneForBranch now returns a per-branch timer inheriting the
+parent's remaining budget, so wall-clock time is measured per branch
+(not cumulatively) and a branch's input-wait pauses only its own clock.
+Cost stays shared/cumulative. Fixes input-wait exemption inside fork.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+# PR 3 — `--max-cost` / `--max-time` CLI flags
+
+**Context:** Mirror the `--policy` plumbing (commit `9fec82ef1`): resolve flags → set env vars on the spawned child → runtime installs a root guard. Both `agency run` (`lib/cli/commands.ts:328`) and `agency agent` (`lib/cli/runBundledAgent.ts:102`) spawn a child and pass env; both children run through `runNode` in `lib/runtime/node.ts`.
+
+## Task 3.1: Constants + budget resolver
+
+**Files:**
+- Modify: `lib/constants.ts` (add env names + exit code)
+- Create: `lib/cli/budget.ts` (flag parsing → env values)
+- Test: `lib/cli/budget.test.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `AGENCY_MAX_COST = "AGENCY_MAX_COST"`, `AGENCY_MAX_TIME = "AGENCY_MAX_TIME"`, `EXIT_CODE_BUDGET_EXCEEDED = 3` in `lib/constants.ts`.
+  - `resolveBudget(opts: { maxCost?: string; maxTime?: string }): { maxCost?: string; maxTime?: string }` in `lib/cli/budget.ts` — returns the env-var string values (dollars for cost, milliseconds for time), or throws `Error` on a malformed value. Negative/disable values pass through verbatim (cost `< 0`, time `<= 0`); the runtime install applies the disable rule.
+  - `parseDurationMs(s: string): number` in `lib/cli/budget.ts` — parses `30s`/`5m`/`1h`/`500ms`/`-1s` to milliseconds; throws on a bare unitless number.
+
+- [ ] **Step 1: Add constants**
+
+In `lib/constants.ts`, after the `AGENCY_RUN_POLICY*` block:
+
+```ts
+/** Env vars carrying `agency run`/`agency agent` --max-cost / --max-time to
+ *  the spawned child, which installs a root guard from them. Cleared then set
+ *  by the CLI, exactly like AGENCY_RUN_POLICY. */
+export const AGENCY_MAX_COST = "AGENCY_MAX_COST";
+export const AGENCY_MAX_TIME = "AGENCY_MAX_TIME";
+
+/** Process exit code when a top-level cost/time budget is exceeded. Distinct
+ *  from 1 (generic failure) and 2 (usage error). */
+export const EXIT_CODE_BUDGET_EXCEEDED = 3;
+```
+
+- [ ] **Step 2: Write failing resolver tests**
+
+Create `lib/cli/budget.test.ts`:
+
+```ts
+import { describe, test, expect } from "vitest";
+import { resolveBudget, parseDurationMs } from "@/cli/budget.js";
+
+describe("parseDurationMs", () => {
+  test("parses unit-suffixed durations", () => {
+    expect(parseDurationMs("500ms")).toBe(500);
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("5m")).toBe(300_000);
+    expect(parseDurationMs("1h")).toBe(3_600_000);
+  });
+  test("accepts a leading minus (disable value)", () => {
+    expect(parseDurationMs("-1s")).toBe(-1_000);
+  });
+  test("rejects a bare unitless number", () => {
+    expect(() => parseDurationMs("300")).toThrow(/duration/i);
+  });
+});
+
+describe("resolveBudget", () => {
+  test("cost: passes through numeric dollars, incl. 0 and negative", () => {
+    expect(resolveBudget({ maxCost: "0.50" }).maxCost).toBe("0.5");
+    expect(resolveBudget({ maxCost: "0" }).maxCost).toBe("0");
+    expect(resolveBudget({ maxCost: "-1" }).maxCost).toBe("-1");
+  });
+  test("cost: rejects non-numeric", () => {
+    expect(() => resolveBudget({ maxCost: "abc" })).toThrow(/max-cost/i);
+  });
+  test("time: converts to ms string", () => {
+    expect(resolveBudget({ maxTime: "5m" }).maxTime).toBe("300000");
+    expect(resolveBudget({ maxTime: "-1s" }).maxTime).toBe("-1000");
+  });
+  test("time: rejects a bare number", () => {
+    expect(() => resolveBudget({ maxTime: "300" })).toThrow(/max-time/i);
+  });
+  test("omitted flags produce no env values", () => {
+    expect(resolveBudget({})).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm test:run lib/cli/budget.test.ts 2>&1 | tee /tmp/pr3-t1.log`
+Expected: FAIL — module `@/cli/budget.js` does not exist.
+
+- [ ] **Step 4: Implement the resolver**
+
+Create `lib/cli/budget.ts`:
+
+```ts
+const UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+/** Parse a duration string (`30s`, `5m`, `1h`, `500ms`, or a leading-minus
+ *  disable value like `-1s`) to milliseconds. A bare unitless number throws:
+ *  the CLI requires an explicit unit so a value's meaning is never guessed. */
+export function parseDurationMs(s: string): number {
+  const m = /^(-?\d+(?:\.\d+)?)(ms|s|m|h|d|w)$/.exec(s.trim());
+  if (!m) {
+    throw new Error(
+      `--max-time: expected a duration like 30s, 5m, 1h, or 500ms (got "${s}")`,
+    );
+  }
+  return parseFloat(m[1]) * UNIT_MS[m[2]];
+}
+
+/** Resolve --max-cost / --max-time flag strings into the env-var string
+ *  values the child reads. Cost stays as dollars; time becomes milliseconds.
+ *  Negative/zero pass through — the runtime install applies the disable rule
+ *  (cost < 0 disables; time <= 0 disables). */
+export function resolveBudget(opts: {
+  maxCost?: string;
+  maxTime?: string;
+}): { maxCost?: string; maxTime?: string } {
+  const out: { maxCost?: string; maxTime?: string } = {};
+  if (opts.maxCost !== undefined) {
+    const n = Number(opts.maxCost);
+    if (!Number.isFinite(n)) {
+      throw new Error(
+        `--max-cost: expected a number of dollars (got "${opts.maxCost}")`,
+      );
+    }
+    out.maxCost = String(n);
+  }
+  if (opts.maxTime !== undefined) {
+    out.maxTime = String(parseDurationMs(opts.maxTime));
+  }
+  return out;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm test:run lib/cli/budget.test.ts 2>&1 | tee /tmp/pr3-t1.log`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/constants.ts lib/cli/budget.ts lib/cli/budget.test.ts
+git commit -F /tmp/commit-3-1.txt
+```
+
+`/tmp/commit-3-1.txt`:
+
+```
+Add budget flag resolver + constants for --max-cost/--max-time
+
+resolveBudget parses the flags into env-var values (dollars, ms) with
+strict validation; a bare unitless --max-time is a usage error. Adds
+AGENCY_MAX_COST/AGENCY_MAX_TIME env names and EXIT_CODE_BUDGET_EXCEEDED=3.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+## Task 3.2: Install the root guard from env in the runtime
+
+**Files:**
+- Create: `lib/runtime/rootBudget.ts` (read env → push guards)
+- Modify: `lib/runtime/node.ts:355` (call the installer next to `installRunPolicyHandler`)
+- Test: `lib/runtime/rootBudget.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `AGENCY_MAX_COST`, `AGENCY_MAX_TIME` (`lib/constants.ts`); `StateStack.pushGuard`; `CostGuard`, `TimeGuard`; the root-process gate used by `installRunPolicyHandler` (read `lib/runtime/runPolicyHandler.ts` + `lib/runtime/node.ts:352` to reuse the exact "root process, not IPC subprocess" condition).
+- Produces: `installRootBudget(stack: StateStack): void` in `lib/runtime/rootBudget.ts` — pushes a `CostGuard` when `AGENCY_MAX_COST` parses to `>= 0`, and a `TimeGuard` when `AGENCY_MAX_TIME` parses to `> 0`. No-op when the env vars are absent or in the disable range, or when not the root process.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `lib/runtime/rootBudget.test.ts`:
+
+```ts
+import { describe, test, expect, afterEach } from "vitest";
+import { installRootBudget } from "@/runtime/rootBudget.js";
+import { StateStack } from "@/runtime/state/stateStack.js";
+import { CostGuard, TimeGuard } from "@/runtime/guard.js";
+import { AGENCY_MAX_COST, AGENCY_MAX_TIME } from "@/constants.js";
+
+afterEach(() => {
+  delete process.env[AGENCY_MAX_COST];
+  delete process.env[AGENCY_MAX_TIME];
+});
+
+describe("installRootBudget", () => {
+  test("pushes a CostGuard for a non-negative cost", () => {
+    process.env[AGENCY_MAX_COST] = "0.5";
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.some((g) => g instanceof CostGuard)).toBe(true);
+  });
+  test("cost 0 still installs (local-only limit)", () => {
+    process.env[AGENCY_MAX_COST] = "0";
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.some((g) => g instanceof CostGuard)).toBe(true);
+  });
+  test("negative cost installs nothing", () => {
+    process.env[AGENCY_MAX_COST] = "-1";
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.length).toBe(0);
+  });
+  test("time <= 0 installs nothing; time > 0 installs a TimeGuard", () => {
+    process.env[AGENCY_MAX_TIME] = "0";
+    const s1 = new StateStack();
+    installRootBudget(s1);
+    expect(s1.guards.length).toBe(0);
+
+    process.env[AGENCY_MAX_TIME] = "5000";
+    const s2 = new StateStack();
+    installRootBudget(s2);
+    expect(s2.guards.some((g) => g instanceof TimeGuard)).toBe(true);
+  });
+  test("no env vars: no guards", () => {
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test:run lib/runtime/rootBudget.test.ts 2>&1 | tee /tmp/pr3-t2.log`
+Expected: FAIL — `@/runtime/rootBudget.js` does not exist.
+
+- [ ] **Step 3: Implement the installer**
+
+Create `lib/runtime/rootBudget.ts`:
+
+```ts
+import { AGENCY_MAX_COST, AGENCY_MAX_TIME } from "../constants.js";
+import { CostGuard, TimeGuard } from "./guard.js";
+import type { StateStack } from "./state/stateStack.js";
+
+/** Install a root cost/time guard from AGENCY_MAX_COST / AGENCY_MAX_TIME.
+ *  Applies the disable rule: cost < 0 installs nothing; time <= 0 installs
+ *  nothing (cost 0 IS a real limit — no paid spend). Called once at the
+ *  root, wrapping the node body — the same place installRunPolicyHandler
+ *  runs. The caller gates on the root-process condition. */
+export function installRootBudget(stack: StateStack): void {
+  const rawCost = process.env[AGENCY_MAX_COST];
+  if (rawCost !== undefined) {
+    const cost = Number(rawCost);
+    if (Number.isFinite(cost) && cost >= 0) {
+      stack.pushGuard(new CostGuard(cost));
+    }
+  }
+  const rawTime = process.env[AGENCY_MAX_TIME];
+  if (rawTime !== undefined) {
+    const ms = Number(rawTime);
+    if (Number.isFinite(ms) && ms > 0) {
+      stack.pushGuard(new TimeGuard(ms));
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test:run lib/runtime/rootBudget.test.ts 2>&1 | tee /tmp/pr3-t2.log`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the installer into `runNode`**
+
+In `lib/runtime/node.ts`, read how `installRunPolicyHandler(execCtx)` at line 355 gates on the root process (it no-ops for IPC subprocesses). Install the root budget on the top-level stack under the SAME gate, right after that call. Use `execCtx`'s top-level stack (the same stack the root policy handler is installed against — confirm the field name by reading the surrounding code; it is the `ctx.stateStack` / exec-context root stack, NOT an ALS branch stack):
+
+```ts
+  installRunPolicyHandler(execCtx);
+  // Install a root cost/time budget from --max-cost / --max-time (via env).
+  // Same root-only gate as the policy handler: no-op in IPC subprocesses,
+  // whose budgets are owned by the parent's guard. Outermost, before the
+  // node body runs, so it cannot be bypassed.
+  installRootBudget(<the exec-context root StateStack>);
+```
+
+> Implementer note: verify the correct stack handle by reading `node.ts` around the `execCtx` creation and how `installRunPolicyHandler` reaches the root. If the root-process gate lives inside `installRunPolicyHandler`, replicate that same guard-condition here (extract it to a shared `isRootProcess()` helper if it is inline, to keep one source of truth).
+
+- [ ] **Step 6: Build and smoke-test the install**
+
+Create a scratch program `/tmp/budget-smoke.agency`:
+
+```
+node main() {
+  llm("say hi")
+  return "done"
+}
+```
+
+Run (should trip on the zero-cost / local-only rule with a hosted model):
+`AGENCY_MAX_COST=0 pnpm run agency /tmp/budget-smoke.agency 2>&1 | tee /tmp/pr3-smoke.log`
+Expected: a cost trip (the paid `llm` call exceeds the `$0` budget). Full user-facing message + exit code come in Task 3.3.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/runtime/rootBudget.ts lib/runtime/rootBudget.test.ts lib/runtime/node.ts
+git commit -F /tmp/commit-3-2.txt
+```
+
+`/tmp/commit-3-2.txt`:
+
+```
+Install a root cost/time guard from env at run start
+
+installRootBudget reads AGENCY_MAX_COST/AGENCY_MAX_TIME and pushes a
+root CostGuard/TimeGuard (applying the disable rule), wrapping the node
+body next to the run-policy handler under the same root-process gate.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+## Task 3.3: Report a budget trip with exit code 3
+
+**Files:**
+- Create: `lib/runtime/budgetExit.ts` (format message + exit)
+- Modify: `lib/backends/typescriptBuilder.ts:4440-4453` (the compiled entry's catch)
+- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache` (import the new symbols into generated code)
+- Test: `lib/runtime/budgetExit.test.ts` (create)
+- Test: `lib/cli/budgetRun.spawn.test.ts` (create; end-to-end)
+
+**Interfaces:**
+- Consumes: `isGuardExceededError` (`lib/runtime/guard.ts:493`), `GuardExceededError` fields `type`/`limit`/`spent`, `EXIT_CODE_BUDGET_EXCEEDED`.
+- Produces: `reportBudgetExceededAndExit(error: unknown): void` in `lib/runtime/budgetExit.ts` — if `error` is a `GuardExceededError`, print the user-facing overrun message and `process.exit(3)`; otherwise return (caller falls through to its existing crash handling).
+
+- [ ] **Step 1: Write failing tests for the reporter**
+
+Create `lib/runtime/budgetExit.test.ts`:
+
+```ts
+import { describe, test, expect, vi } from "vitest";
+import { formatBudgetExceeded } from "@/runtime/budgetExit.js";
+import { GuardExceededError } from "@/runtime/guard.js";
+
+describe("formatBudgetExceeded", () => {
+  test("cost message", () => {
+    const e = new GuardExceededError("cost", 0.5, 0.63, "g1");
+    expect(formatBudgetExceeded(e)).toBe(
+      "Exceeded cost limit of $0.5 (used $0.63)",
+    );
+  });
+  test("time message renders ms", () => {
+    const e = new GuardExceededError("time", 5000, 5002, "g1");
+    expect(formatBudgetExceeded(e)).toBe(
+      "Exceeded time limit of 5000ms (ran 5002ms)",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/runtime/budgetExit.test.ts 2>&1 | tee /tmp/pr3-t3.log`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement the reporter**
+
+Create `lib/runtime/budgetExit.ts`:
+
+```ts
+import { EXIT_CODE_BUDGET_EXCEEDED } from "../constants.js";
+import { isGuardExceededError, GuardExceededError } from "./guard.js";
+
+/** User-facing one-line message for a tripped top-level budget. */
+export function formatBudgetExceeded(e: GuardExceededError): string {
+  if (e.type === "cost") {
+    return `Exceeded cost limit of $${e.limit} (used $${e.spent})`;
+  }
+  return `Exceeded time limit of ${e.limit}ms (ran ${e.spent}ms)`;
+}
+
+/** If `error` is a top-level budget trip, report it and exit with code 3.
+ *  Otherwise return so the caller can handle it as an ordinary crash. Only a
+ *  ROOT guard (no owning try) reaches here — a user guard() trip is always
+ *  converted to a Result by _runGuarded, so this never misfires on those. */
+export function reportBudgetExceededAndExit(error: unknown): void {
+  if (isGuardExceededError(error)) {
+    console.error(formatBudgetExceeded(error));
+    process.exit(EXIT_CODE_BUDGET_EXCEEDED);
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm test:run lib/runtime/budgetExit.test.ts 2>&1 | tee /tmp/pr3-t3.log`
+Expected: PASS.
+
+- [ ] **Step 5: Import the symbols into generated code**
+
+In `lib/templates/backends/typescriptGenerator/imports.mustache`, add `reportBudgetExceededAndExit` to the runtime import list (the block that already imports `runNode`, `success`, `__tryCall`, etc. — see line 12/25). Rebuild templates after: `pnpm run templates`.
+
+- [ ] **Step 6: Prepend the budget check to the compiled entry's catch**
+
+In `lib/backends/typescriptBuilder.ts`, in the `ts.tryCatch(...)` catch body (currently line 4440: `consoleError("Agent crashed: ...")` then `throw`), emit a call to `reportBudgetExceededAndExit(__error)` BEFORE the existing `console.error` + `throw`. Since it `process.exit(3)`s on a budget trip, it never returns in that case; any other error falls through to the existing crash path. Concretely, prepend to the catch `ts.statements([...])`:
+
+```ts
+ts.exprStatement(
+  ts.call(ts.id("reportBudgetExceededAndExit"), [ts.id("__error")]),
+),
+```
+
+(Match the existing `ts.*` builder style in this file; grep nearby for `ts.call(ts.id(` usage.)
+
+- [ ] **Step 7: Regenerate fixtures**
+
+Run: `make 2>&1 | tail -5 && make fixtures 2>&1 | tail -20 | tee /tmp/pr3-fixtures.log`
+Expected: fixtures rebuild. Inspect the diff (`git diff --stat tests/`) — every compiled fixture that has a `main` should gain the `reportBudgetExceededAndExit(__error)` line in its entry catch, and nothing else should change.
+
+- [ ] **Step 8: Write the end-to-end spawn test**
+
+Create `lib/cli/budgetRun.spawn.test.ts`, modeled on `lib/cli/runPolicy.spawn.test.ts` (read it first for the spawn/tmp-file harness). It should:
+- Write a tiny `.agency` program that makes one paid `llm` call (or, to avoid an LLM call, a program that `sleep`s past a small `--max-time`).
+- Run `agency run --max-time 20ms <file>` via the CLI entry.
+- Assert exit code is `3` and stderr contains `Exceeded time limit`.
+- A second case: set `AGENCY_MAX_TIME` in the parent env, run WITHOUT the flag, and assert it is cleared (does not leak) so the run completes normally.
+
+```ts
+// Sketch — fill in using runPolicy.spawn.test.ts's harness:
+test("--max-time trip exits 3 with a budget message", async () => {
+  const file = writeTmpAgency(`
+node main() {
+  sleep(200ms)
+  return "done"
+}`);
+  const { code, stderr } = await runCli(["run", "--max-time", "20ms", file]);
+  expect(code).toBe(3);
+  expect(stderr).toMatch(/Exceeded time limit/);
+});
+```
+
+- [ ] **Step 9: Run the spawn test**
+
+Run: `pnpm test:run lib/cli/budgetRun.spawn.test.ts 2>&1 | tee /tmp/pr3-spawn.log`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/runtime/budgetExit.ts lib/runtime/budgetExit.test.ts lib/backends/typescriptBuilder.ts lib/templates/backends/typescriptGenerator/imports.mustache lib/templates/backends/typescriptGenerator/imports.ts lib/cli/budgetRun.spawn.test.ts tests/
+git commit -F /tmp/commit-3-3.txt
+```
+
+`/tmp/commit-3-3.txt`:
+
+```
+Report a top-level budget trip with exit code 3
+
+A root-guard trip escaping to the compiled entry's catch now prints a
+user-facing overrun message and exits 3 (distinct from 1/2). Only root
+guards reach here; user guard() trips are already converted to Results.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+## Task 3.4: Wire the flags into `agency run` and `agency agent`
+
+**Files:**
+- Modify: `scripts/agency.ts` (add `--max-cost`/`--max-time` options to `run` and `agent`; pass resolved values down)
+- Modify: `lib/cli/commands.ts:328` (`run` sets the env vars, cleared-then-set)
+- Modify: `lib/cli/runBundledAgent.ts:102` (`runBundledAgent` sets the env vars)
+- Docs: `docs/site/cli/` (run/agent flag docs) + `docs/site/guide/guards.md`
+
+**Interfaces:**
+- Consumes: `resolveBudget` (Task 3.1); `AGENCY_MAX_COST`, `AGENCY_MAX_TIME`.
+- Produces: `run(config, inputFile, outputFile?, resumeFile?, runPolicy?, budget?)` gains a `budget?: { maxCost?: string; maxTime?: string }` param; `runBundledAgent(..., budget?)` likewise.
+
+- [ ] **Step 1: Add options to the `run` command**
+
+In `scripts/agency.ts`, extend `RunOptions` and add the two options where `--policy` is declared (around line 280):
+
+```ts
+type RunOptions = CliFlags & {
+  resume?: string;
+  policy?: string;
+  approve?: string;
+  reject?: string;
+  interactive?: boolean;
+  maxCost?: string;
+  maxTime?: string;
+};
+```
+
+```ts
+      .option(
+        "--max-cost <dollars>",
+        "Abort if the run's LLM spend exceeds this many dollars (e.g. 0.50). 0 = no paid spend (local models only); negative = no limit",
+      )
+      .option(
+        "--max-time <duration>",
+        "Abort if the run's working time exceeds this duration (e.g. 30s, 5m, 1h, 500ms). Time spent waiting for input is not counted; negative/0 = no limit",
+      )
+```
+
+- [ ] **Step 2: Resolve + pass the budget in `runWithOptions`**
+
+In `runWithOptions` (around line 165), after resolving `runPolicy`:
+
+```ts
+    let budget;
+    try {
+      budget = resolveBudget({ maxCost: options.maxCost, maxTime: options.maxTime });
+    } catch (e) {
+      console.error(`Error: ${(e as Error).message}`);
+      process.exit(2);
+    }
+    run(config, input, undefined, options.resume, runPolicy, budget);
+```
+
+Add `import { resolveBudget } from "@/cli/budget.js";` at the top.
+
+- [ ] **Step 3: Set the env vars in `commands.ts` `run`**
+
+In `lib/cli/commands.ts`, extend the `run` signature and env setup (mirror the `AGENCY_RUN_POLICY` clear-then-set at lines 351-358):
+
+```ts
+export function run(
+  config: AgencyConfig,
+  inputFile: string,
+  outputFile?: string,
+  resumeFile?: string,
+  runPolicy?: { policyJson: string; interactive: boolean },
+  budget?: { maxCost?: string; maxTime?: string },
+): void {
+```
+
+```ts
+  delete env[AGENCY_MAX_COST];
+  delete env[AGENCY_MAX_TIME];
+  if (budget?.maxCost !== undefined) env[AGENCY_MAX_COST] = budget.maxCost;
+  if (budget?.maxTime !== undefined) env[AGENCY_MAX_TIME] = budget.maxTime;
+```
+
+Add `AGENCY_MAX_COST, AGENCY_MAX_TIME` to the `@/constants.js` import at the top of the file.
+
+- [ ] **Step 4: Add options to the `agent` command**
+
+In `scripts/agency.ts`, the `agent` command currently forwards raw `args`. Add `--max-cost`/`--max-time` as declared options and resolve them into env values passed to `runBundledAgent`. Because the agent forwards unknown args to the bundled agent, add these two as FIRST-CLASS commander options on the `agent` command (so commander parses them out), then resolve with `resolveBudget` and hand the result to `agent(config, args, budget)`.
+
+```ts
+    .command("agent")
+    .description("Launch the Agency language assistant agent (run `agency agent --help` for agent flags)")
+    .argument("[args...]", "Arguments forwarded to the agent")
+    .option("--max-cost <dollars>", "Abort if the agent's LLM spend exceeds this many dollars (0 = local only; negative = no limit)")
+    .option("--max-time <duration>", "Abort if the agent's working time exceeds this duration (e.g. 30m); input-wait is not counted; negative/0 = no limit")
+    .helpOption(false)
+    .action((args: string[], opts: { maxCost?: string; maxTime?: string }) => {
+      const config = getConfig();
+      let budget;
+      try {
+        budget = resolveBudget({ maxCost: opts.maxCost, maxTime: opts.maxTime });
+      } catch (e) {
+        console.error(`Error: ${(e as Error).message}`);
+        process.exit(2);
+      }
+      agent(config, args, budget);
+    });
+```
+
+> Implementer note: confirm `--max-time`'s leading-minus value isn't swallowed by commander as an unknown flag. If `--max-time -1s` mis-parses, document that disabling on the CLI uses `--max-time=-1s` (attached form), and add a test for the attached form.
+
+- [ ] **Step 5: Thread the budget through `agent` → `runBundledAgent`**
+
+In `lib/cli/agent.ts`:
+
+```ts
+export function agent(
+  config: AgencyConfig,
+  args: string[] = [],
+  budget?: { maxCost?: string; maxTime?: string },
+): void {
+  runBundledAgent(config, "agency-agent", args, {}, budget);
+}
+```
+
+In `lib/cli/runBundledAgent.ts`, add a `budget` param and set the env vars (cleared-then-set) alongside the existing `env` setup (around line 129):
+
+```ts
+export function runBundledAgent(
+  config: AgencyConfig,
+  agentName: string,
+  args: string[] = [],
+  deps: { spawn?: typeof realSpawn } = {},
+  budget?: { maxCost?: string; maxTime?: string },
+): void {
+  // ...
+  delete env[AGENCY_MAX_COST];
+  delete env[AGENCY_MAX_TIME];
+  if (budget?.maxCost !== undefined) env[AGENCY_MAX_COST] = budget.maxCost;
+  if (budget?.maxTime !== undefined) env[AGENCY_MAX_TIME] = budget.maxTime;
+```
+
+Add the `@/constants.js` import.
+
+- [ ] **Step 6: Build and end-to-end test both commands**
+
+Run: `make 2>&1 | tail -5`
+Then verify `run`:
+`pnpm run agency run --max-time 20ms /tmp/budget-smoke-sleep.agency; echo "exit=$?"`
+(where the program sleeps 200ms) — expect the overrun message and `exit=3`.
+
+Then verify usage errors:
+`pnpm run agency run --max-time 300 /tmp/budget-smoke.agency; echo "exit=$?"` — expect a `--max-time` error and `exit=2`.
+
+Save output: append `2>&1 | tee -a /tmp/pr3-e2e.log` to each.
+
+- [ ] **Step 7: Add a CLI parse test for the agent command**
+
+Create/extend a commander test (grep for an existing `createProgram` test in `scripts/` or `lib/cli/`) asserting `agency agent --max-cost 0.5 foo` resolves `budget.maxCost === "0.5"` and forwards `["foo"]` to the agent. If the agent command has no existing unit test harness, cover this via a `runBundledAgent` spawn test with an injected `spawn` dep (see `runBundledAgent`'s `deps.spawn`) asserting the env vars are set on the spawned child.
+
+- [ ] **Step 8: Run the CLI test**
+
+Run: `pnpm test:run <the test file> 2>&1 | tee /tmp/pr3-cli.log`
+Expected: PASS.
+
+- [ ] **Step 9: Update docs**
+
+- `docs/site/guide/guards.md`: add a short "From the command line" section noting `--max-cost`/`--max-time` on `agency run` and `agency agent`, the `cost: 0` local-only trick, and exit code 3.
+- CLI reference pages under `docs/site/cli/` for `run` and `agent`: document both flags, units, and the disable (negative) values.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add scripts/agency.ts lib/cli/commands.ts lib/cli/agent.ts lib/cli/runBundledAgent.ts docs/site/
+git commit -F /tmp/commit-3-4.txt
+```
+
+`/tmp/commit-3-4.txt`:
+
+```
+Add --max-cost / --max-time to agency run and agency agent
+
+Flags resolve to AGENCY_MAX_COST/AGENCY_MAX_TIME on the spawned child
+(cleared-then-set like --policy), which installs a root guard. A tripped
+budget aborts with exit code 3. Negative disables; cost 0 = local-only.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec §1 flags** → PR 3 Tasks 3.1/3.4. **§2 runtime install** → 3.2. **§3 trip + exit 3** → 3.3. **§4 input-wait** → PR 1 Task 1.2. **§5 disable rule** → PR 1 Task 1.1 (time-zero delta; negative already done). **§5 cost:0 local-only** → covered by existing strict `>` check, tested in 3.2 + documented in 3.4. **§5 per-branch time** → PR 2. **Testing** section → fixtures across all three PRs.
+- **Known risk carried into execution:** PR 2's fork-join accounting (Task 2.1) and the exact root stack handle in `node.ts` (Task 3.2 Step 5) require in-task verification — both are flagged with explicit investigation steps rather than guessed code.
+- **Fixture regeneration:** Task 3.3 changes codegen and requires `make fixtures`; the diff must be inspected to confirm only the entry-catch line changed.

--- a/docs/superpowers/specs/2026-07-13-cli-cost-time-guards-design.md
+++ b/docs/superpowers/specs/2026-07-13-cli-cost-time-guards-design.md
@@ -1,0 +1,272 @@
+# Design: `--max-cost` / `--max-time` CLI flags + working-time semantics for guards
+
+Date: 2026-07-13
+Status: Design (pending review)
+
+## Goal
+
+Two things, one coherent theme — *bound how much an agent run can spend and how
+long it can work, and make "how long" mean the agent's actual working time.*
+
+1. Add `--max-cost` and `--max-time` flags to `agency run` and `agency agent`.
+   They install a top-level cost/time [guard](../../site/guide/guards.md) around
+   the whole program.
+2. Make time budgets stop counting while the agent waits for a human, so a
+   `--max-time` (or an in-program `guard(time:)`) measures compute time, not
+   wall-clock that includes a person's think/type time.
+3. Give each `fork` branch its own time budget, so the change in (2) is correct
+   even when the agent asks for input from inside parallel work.
+4. Let a negative value disable a guard dimension, in both the language and the
+   CLI, without affecting outer guards.
+
+The guard runtime primitives (`CostGuard`, `TimeGuard`, `pushGuard`) already
+exist. This work reuses them; it does not build a new limiting mechanism.
+
+## Background: how the pieces already work
+
+- **Guards** cap the cost and/or time of a block and return a `Result`. See
+  `lib/runtime/guard.ts` and the [guards guide](../../site/guide/guards.md).
+- **`CostGuard`** holds a cumulative `spent` counter. `check()` trips only when
+  `spent > costLimit` (strict; `guard.ts:177`). Shared across `fork` branches
+  (`cloneForBranch` returns `this`), so parallel spend accumulates against one
+  counter — correct, because money adds up under parallelism.
+- **`TimeGuard`** measures *compute time*: the sum of `(pause, resume)` windows
+  (`guard.ts:257`). `pause()` banks the current window and cancels the timer;
+  `resume()` re-arms it for the remaining budget. The runner calls `pause()` on
+  `halt()` (`runner.ts:253`) and `resume()` at every step entry
+  (`runner.ts:266`). This is why interrupts don't count: an interrupt halts the
+  runner, which pauses the timer. Today `TimeGuard.cloneForBranch` returns
+  `undefined`, so a `fork` branch has no timer of its own; the parent's single
+  timer trips all branches via a composed abort signal.
+- **The `--policy` flag** (commit `9fec82ef1`) is the template for CLI→runtime
+  plumbing: the CLI resolves the flag, clears any inherited `AGENCY_RUN_POLICY*`
+  from the child env, sets the env var, and the runtime installs the handler at
+  the root in `node.ts` (`installRunPolicyHandler`, `node.ts:355`) — outermost,
+  after the exec context exists, before the node body runs.
+- **Both `agency run` and `agency agent` spawn a Node subprocess** (`commands.ts`
+  `run`, `runBundledAgent.ts`) and pass env to it. Both flow through the same
+  runtime entry in `node.ts`. So one env-var-driven install covers both.
+- **`input`** is implemented by `inputImpl` (`builtins.ts:59`), which awaits
+  `rl.question` inline inside a running step. No halt happens, so nothing pauses
+  the time guard — which is exactly why input-wait counts today.
+
+## Approaches considered (mechanism)
+
+- **A. Env var → root guard install in the runtime (chosen).** The CLI parses
+  the flags, sets `AGENCY_MAX_COST` / `AGENCY_MAX_TIME` on the child, and the
+  runtime installs a root `CostGuard` / `TimeGuard` at the same spot that
+  installs the root policy handler. A near-exact clone of the `--policy`
+  plumbing; reuses the guard primitives unchanged; one implementation covers
+  both commands.
+- **B. Codegen wrapping.** Emit a `guard(...) { <node body> }` at compile time.
+  Rejected: invasive, touches generated TS, forces the compiler to know about
+  runtime flags.
+- **C. Reuse `std::agency.run`'s subprocess `maxCost`.** Rejected: that path
+  wraps a *child* subprocess from inside Agency code and does not fit a
+  top-level CLI flag.
+
+## Design
+
+### 1. CLI flags
+
+`agency run` and `agency agent` each gain:
+
+- `--max-cost <dollars>` — a bare number of dollars, e.g. `--max-cost 0.50`.
+  No `$` prefix (the shell would expand `$0`). Kebab-case, matching every
+  existing flag.
+- `--max-time <duration>` — duration strings only: `30s`, `5m`, `1h`, `500ms`,
+  reusing the language's unit-literal grammar. A bare unitless number is a usage
+  error (exit 2).
+
+Both flags are optional and independent. Supplying both installs both guards.
+Parsed values become env vars on the spawned child: `AGENCY_MAX_COST` (dollars,
+as a string) and `AGENCY_MAX_TIME` (milliseconds, as a string). The CLI deletes
+any inherited `AGENCY_MAX_*` from the child env before setting them, so this
+invocation's flags fully determine behavior — same hygiene as `--policy`.
+
+Value validation, per dimension (see §5 for the "disable" rule):
+
+| Dimension | Usage error | Disabled | Real limit |
+|-----------|-------------|----------|------------|
+| cost | non-numeric | value `< 0` | value `>= 0` (`0` = local-only) |
+| time | bare unitless number | value `<= 0` | value `> 0` |
+
+The `--max-time` duration parser accepts a leading `-` so a disable value
+(`-1s`) can be expressed.
+
+### 2. Runtime install
+
+In `node.ts`, right where `installRunPolicyHandler(execCtx)` runs (root process
+only — not IPC subprocesses; outermost position), the runtime reads
+`AGENCY_MAX_COST` / `AGENCY_MAX_TIME` and pushes a `CostGuard` / `TimeGuard`
+onto the root state stack, wrapping the node body. A value in the "disabled"
+range installs nothing for that dimension.
+
+### 3. Trip behavior + exit code
+
+The root guard has no Agency-level `try`/`match` around it, so a trip surfaces as
+an uncaught `GuardExceededError` out of the node run. The runtime catches it at
+the entry layer and:
+
+- Prints a clear message to stderr from the guard's failure data:
+  - cost: `Exceeded cost limit of $0.50 (used $0.63)`
+  - time: `Exceeded time limit of 5m (ran 5m2s)`
+- Exits with **code 3 = budget exceeded**, a named constant in `constants.ts`
+  (where the `AGENCY_RUN_POLICY*` names already live), referenced from both the
+  runtime and any CLI-side handling. Distinct from `1` (generic failure) and `2`
+  (usage error).
+
+If both guards are configured, the one that fires first wins (cost checks at
+LLM-call boundaries, time at step boundaries).
+
+Inherited asymmetry, stated for the reader: a **time** trip fires the abort
+signal, tearing down in-flight HTTP and signalling other code; a **cost** trip
+does not — it enforces at the next LLM-call boundary. This comes from the guard
+primitives, not from this feature. Child subprocesses started via
+`std::agency.run` are already covered by an enclosing guard, so a top-level
+budget bounds a whole agent tree.
+
+### 4. Input-wait is free, everywhere
+
+Any time budget stops counting while the agent waits for a human. This is a
+language-wide change to `TimeGuard` behavior: it applies to both the CLI
+`--max-time` root guard and a developer's in-program `guard(time:)`. The
+consistent rule is "waiting on a person never costs time."
+
+Mechanism: wrap the input wait in `inputImpl` so the active branch stack's
+guards are paused before blocking on stdin and resumed afterward:
+
+```
+pause active time guards on the branch stack
+await the human's answer          // rl.question, or the test input override
+finally: resume those guards
+```
+
+These are the same `pause()` / `resume()` calls the runner already makes on
+`halt()` / step entry, and they are idempotent. `CostGuard.pause()` is a
+documented no-op, so this only affects time budgets; cost still accrues. `sleep`
+is left counting, because it is the program deliberately spending time, not
+waiting on a person.
+
+Details to get right:
+
+- Use the ALS-resolved active branch stack (`getRuntimeContext().stack`), the
+  same stack `withTimeGuard` uses — not the top-level stack. No-op safely when
+  `input` runs with no stack (bootstrap).
+- The pause/resume must wrap the **test input override path** too (the
+  `__agencyInputOverride` branch at `builtins.ts:64`), not only the real
+  readline path, so the behavior is observable in tests and identical in both
+  paths.
+- `pause()` cancels only the timer; it leaves `stack.abortSignal` composed, so
+  Esc / `cancel()` / a losing `race` still aborts an in-progress input wait.
+  This needs a confirming test.
+
+### 5. Negative disables a dimension; per-branch time, cumulative cost
+
+**Disable rule.** When a dimension's value is in its "disabled" range (cost
+`< 0`, time `<= 0`), no guard is installed for that dimension. The `guard(...)`
+block still runs its body and still returns a `Result`; it simply installs no
+limit of its own.
+
+This makes nesting safe with no special case. A skipped guard is not on the
+stack, so any outer guard keeps enforcing, and the inner block's usage still
+counts against the outer guard:
+
+```
+guard(cost: $5.0) {          // outer $5 limit installed
+  guard(cost: -1) {          // negative: no inner cost guard installed
+    return doExpensiveWork()  // spend still counts against the outer $5
+  }
+}
+```
+
+A disabled inner guard means "no *extra* inner limit here," not "unlimited."
+Per-dimension disable works too: `guard(cost: -1, time: 5m)` installs only the
+time guard.
+
+**`cost: 0` is a real, useful limit.** Because `check()` trips on
+`spent > costLimit` (strict), a limit of `0` never trips while spend stays at
+`$0` and trips on the first paid call. That is exactly "no paid spend allowed,"
+i.e. a local-models-only guarantee. The pre-call cost gate blocks a paid call
+*before* it runs, so the user is not charged even once. This is documented as a
+feature. `time: 0` has no sensible meaning (it would trip instantly), so it
+falls in time's disabled range.
+
+**Per-branch time budgets.** `TimeGuard.cloneForBranch` changes from returning
+`undefined` to returning a fresh per-branch timer. Each branch gets its own
+countdown, its own pause state, and its own abort controller. Consequences:
+
+- A branch's human-wait pauses only that branch's timer; working siblings keep
+  counting on theirs.
+- Each branch inherits the parent's **remaining** budget at fork moment
+  (`timeLimit - parent.elapsedMs`), not a fresh full budget. This keeps the
+  invariant "no single causal path exceeds the budget": if the parent spends
+  3 minutes then forks a 10-minute budget, each branch gets 7, so the path
+  through a branch is 3 + 7 = 10, not 3 + 10 = 13.
+- After the branches rejoin, the parent's clock advances by the longest branch's
+  working time — the real wall time the parallel region took. **To verify
+  against the actual `fork`/`runBatch` join before committing to code** (see
+  Open questions).
+
+Cost stays shared and cumulative (`cloneForBranch` returns `this`, unchanged),
+because money adds up under parallelism and wall-clock time does not. The two
+dimensions differ on purpose.
+
+## Testing
+
+All time-guard and disable tests are agency execution tests (`tests/agency/`)
+and need no LLM. Cost tests reuse the existing cost-injection pattern under
+`tests/agency/guards/`.
+
+- **Flag parsing (unit).** `--max-cost` accepts `0` and positive numbers, treats
+  negative as disable, rejects non-numeric. `--max-time` accepts
+  `30s`/`5m`/`1h`/`500ms`, treats `<= 0` as disable, rejects a bare unitless
+  number. Both map to the right env values.
+- **Flag → run (spawn),** in the style of `runPolicy.spawn.test.ts`: a program
+  under a tiny budget aborts with exit code 3 and prints the overrun message. An
+  inherited `AGENCY_MAX_*` from the parent shell is cleared and does not leak.
+- **Input-wait exclusion (exec).** A simulated slow human answer: a time budget
+  that would trip during the wait does not. Uses the test input override, which
+  the pause/resume wrapping must cover.
+- **`sleep` still counts (exec).** A companion test proving `sleep` inside the
+  same budget does trip.
+- **Esc during input (exec).** Aborting mid-input-wait still cancels the input.
+- **Per-branch timers (exec).** A `fork` where one branch waits on input while
+  siblings work: the waiter is spared, the workers are charged, and a branch
+  born after the parent spent time gets only the remaining budget.
+- **Disable rule (exec).** `guard(cost: -1)` inside `guard(cost: $X)` does not
+  disable the outer guard; the inner block's spend still trips the outer.
+- **`cost: 0` local-only (exec).** Zero spend does not trip; a positive charge
+  does.
+- **Cost unchanged.** Existing cost-guard and cost-fork tests still pass,
+  confirming only time semantics changed.
+
+## Sequencing (three PRs)
+
+Semantics first, flags last — the guard behavior is built and tested before it
+is exposed on the CLI.
+
+1. **PR 1 — Negative disables + input-wait free** (§5 disable rule, §4).
+   Teach the guards to accept negative values (disable a dimension) and to stop
+   counting time while waiting on a human. Input-wait exclusion is correct at the
+   top level after this PR; the fork case is completed by PR 2.
+2. **PR 2 — Per-branch time budgets** (§5 per-branch). Give each `fork` branch
+   its own timer. The largest and riskiest change; also what makes PR 1's
+   input-wait exclusion correct inside a `fork`.
+3. **PR 3 — CLI flags** (§1–3). Add `--max-cost` / `--max-time` to `agency run`
+   and `agency agent`, the root install, and exit code 3. Built on the now-final
+   guard semantics.
+
+## Open questions / to verify during planning
+
+- **Fork join accounting.** Confirm how `fork`/`runBatch` joins branch stacks
+  and where to fold "parent clock advances by the longest branch's working time"
+  into the join path. Verify against `docs/dev/runBatch.md` and the runner.
+- **Per-branch timer + interrupt/resume.** `TimeGuard` serializes `elapsedMs`
+  and re-arms on resume. Confirm per-branch clones serialize and rehydrate
+  correctly across an interrupt taken inside a `fork` branch
+  (`rehydrateInheritedGuardsFrom`).
+- **`--max-time` on the interactive agent.** With input-wait excluded, a
+  session cap now measures the agent's working time across the whole session,
+  which is the intuitive meaning. Document that `sleep` still counts.
+```

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -67,7 +67,7 @@ if (isFailure(result)) {
 When the clock ticks:
 - regular code execution = yes.
 - interrupts = no.
-- waiting for user input through `input` = yes.
+- waiting for user input through `input` = no (waiting on a human is free).
 - `sleep` = yes.
 
 When the time guard fires, any in-flight HTTP requests are cancelled and an abort signal is sent to other code as well.

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -70,6 +70,12 @@ When the clock ticks:
 - waiting for user input through `input` = no (waiting on a human is free).
 - `sleep` = yes.
 
+One current limitation: the `input` exemption applies to time guards on the
+same execution branch. If `input()` runs inside a `fork` or `race` branch,
+an *outer* time guard's clock keeps running during the wait, because fork
+branches do not yet carry their own copy of the parent's timer. Per-branch
+time budgets (the next change in this series) remove this limitation.
+
 When the time guard fires, any in-flight HTTP requests are cancelled and an abort signal is sent to other code as well.
 
 ## Nested guards

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -316,7 +316,7 @@ Run a block under a cost limit, a time limit, or both, aborting the
   `error.actualTime`, in milliseconds).
 
   @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null or negative = no cost limit.
-  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null or negative = no time limit.
+  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null, zero, or negative = no time limit.
   @param block - The work to run under the guard.
 
   Example:

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -34,7 +34,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L55))
 
 ### Attachment
 
@@ -45,7 +45,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L60))
 
 ### ModelCost
 
@@ -58,7 +58,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L162))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L163))
 
 ### GuardFailureData
 
@@ -72,7 +72,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L181))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L182))
 
 ### ThreadMessage
 
@@ -83,7 +83,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L254))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L269))
 
 ### ThreadInfo
 
@@ -99,7 +99,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L259))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L274))
 
 ## Functions
 
@@ -121,7 +121,7 @@ Add a system message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L64))
 
 ### userMessage
 
@@ -141,7 +141,7 @@ Add a user message to the current thread's message history. Use this
 |---|---|---|
 | msg | `string \| (string \| Attachment)[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
 
 ### image
 
@@ -170,7 +170,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L86))
 
 ### file
 
@@ -201,7 +201,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L102))
 
 ### attachToReply
 
@@ -223,7 +223,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L119))
 
 ### assistantMessage
 
@@ -243,7 +243,7 @@ Add an assistant message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L132))
 
 ### getCost
 
@@ -262,7 +262,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L148))
 
 ### getTokens
 
@@ -274,7 +274,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
 
 ### getModelCosts
 
@@ -292,7 +292,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L173))
 
 ### guard
 
@@ -362,7 +362,7 @@ Run a block under a cost limit, a time limit, or both, aborting the
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L212))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L213))
 
 ### listThreads
 
@@ -395,7 +395,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L331))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L346))
 
 ### currentThreadId
 
@@ -410,7 +410,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L384))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L399))
 
 ### getThread
 
@@ -442,4 +442,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L394))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L409))

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -105,6 +105,17 @@ export class RuntimeContext<T> {
   emit a checkpoint.*/
   _toolCallDepth: number;
   debuggerState: DebuggerState | null;
+  /** When set, `input()` calls this instead of opening its own readline on
+   *  stdin. Installed by hosts that own the terminal for this execution:
+   *  the REPL routes questions through its readline, and the
+   *  `_installSlowInput` test seam simulates a slow human. Per-execution on
+   *  purpose (never a process global): two runs in one process must not see
+   *  each other's override. Never serialized — checkpoints capture the
+   *  StateStack and GlobalStore, not the context. The TUI debugger still
+   *  uses the legacy `globalThis.__agencyInputOverride` channel because it
+   *  only sees the compiled module's exports; `inputImpl` falls back to
+   *  that global until the debugger migrates. */
+  inputOverride?: (prompt: string) => Promise<string>;
   private traceWriter: TraceWriter | null;
 
   // we need a single statelog client instance that can be used across the entire execution of the graph,

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -56,26 +56,46 @@ export function _parseJSON(text: string): any {
  * `AgencyCancelledError`, which `__tryCall` re-throws so cancellation
  * actually propagates.
  */
+/** Test-only: install an input override that resolves after `delayMs`,
+ *  used by guard fixtures to simulate a slow human without touching stdin.
+ *  Exposed to fixtures as the non-exported `_installSlowInput` def in
+ *  `stdlib/thread.agency` (test imports only). */
+export function _installSlowInputImpl(delayMs: number, answer: string): void {
+  (globalThis as any).__agencyInputOverride = (_prompt: string) =>
+    new Promise<string>((resolve) => setTimeout(() => resolve(answer), delayMs));
+}
+
 function inputImpl(
   ctx: RuntimeContext<any>,
   stack: StateStack,
   prompt: string,
 ): Promise<string> {
+  // Waiting on a human must not count against a time budget. Pause every
+  // guard on the active branch stack before blocking, resume after. These
+  // are the same idempotent calls the runner makes on halt()/step entry;
+  // CostGuard.pause() is a no-op, so only time budgets are affected.
+  // pause() cancels only the guard's own timer — the composed abort signal
+  // stays intact, so external cancellation (Ctrl-C, race-loser) still
+  // releases the wait.
+  stack.guards.forEach((g) => g.pause());
+  const resumeGuards = () => stack.guards.forEach((g) => g.resume(stack));
+
   const override = (globalThis as any).__agencyInputOverride as
     | ((prompt: string) => Promise<string>)
     | undefined;
   if (override) {
-    return override(prompt);
+    return override(prompt).finally(resumeGuards);
   }
   const signal = ctx.getAbortSignal(stack);
   if (signal.aborted) {
+    resumeGuards();
     return Promise.reject(new AgencyCancelledError("input cancelled"));
   }
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
-  return new Promise((resolve, reject) => {
+  return new Promise<string>((resolve, reject) => {
     const onAbort = () => {
       try { rl.close(); } catch {}
       reject(new AgencyCancelledError("input cancelled"));
@@ -86,7 +106,7 @@ function inputImpl(
       rl.close();
       resolve(answer);
     });
-  });
+  }).finally(resumeGuards);
 }
 
 /** Deprecated context-injected wrapper kept in place during the ALS

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -56,15 +56,6 @@ export function _parseJSON(text: string): any {
  * `AgencyCancelledError`, which `__tryCall` re-throws so cancellation
  * actually propagates.
  */
-/** Test-only: install an input override that resolves after `delayMs`,
- *  used by guard fixtures to simulate a slow human without touching stdin.
- *  Exposed to fixtures as the non-exported `_installSlowInput` def in
- *  `stdlib/thread.agency` (test imports only). */
-export function _installSlowInputImpl(delayMs: number, answer: string): void {
-  (globalThis as any).__agencyInputOverride = (_prompt: string) =>
-    new Promise<string>((resolve) => setTimeout(() => resolve(answer), delayMs));
-}
-
 function inputImpl(
   ctx: RuntimeContext<any>,
   stack: StateStack,
@@ -84,7 +75,12 @@ function inputImpl(
     | ((prompt: string) => Promise<string>)
     | undefined;
   if (override) {
-    return override(prompt).finally(resumeGuards);
+    // Promise.resolve().then(...) so a synchronously-throwing override
+    // still reaches the finally — otherwise the guards stay paused for
+    // the rest of the run.
+    return Promise.resolve()
+      .then(() => override(prompt))
+      .finally(resumeGuards);
   }
   const signal = ctx.getAbortSignal(stack);
   if (signal.aborted) {
@@ -120,6 +116,15 @@ export function __internal_input(
   prompt: string,
 ): Promise<string> {
   return inputImpl(ctx, stack, prompt);
+}
+
+/** Test-only: install an input override that resolves after `delayMs`,
+ *  used by guard fixtures to simulate a slow human without touching stdin.
+ *  Exposed to fixtures as the non-exported `_installSlowInput` def in
+ *  `stdlib/thread.agency` (test imports only). */
+export function _installSlowInputImpl(delayMs: number, answer: string): void {
+  (globalThis as any).__agencyInputOverride = (_prompt: string) =>
+    new Promise<string>((resolve) => setTimeout(() => resolve(answer), delayMs));
 }
 
 /** ALS-reading replacement. Same body as `__internal_input`. */

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -71,9 +71,14 @@ function inputImpl(
   stack.guards.forEach((g) => g.pause());
   const resumeGuards = () => stack.guards.forEach((g) => g.resume(stack));
 
-  const override = (globalThis as any).__agencyInputOverride as
-    | ((prompt: string) => Promise<string>)
-    | undefined;
+  // Per-execution override first (REPL readline routing, test seams —
+  // see RuntimeContext.inputOverride). The globalThis fallback exists
+  // only for the TUI debugger, which cannot reach the ctx yet.
+  const override =
+    ctx.inputOverride ??
+    ((globalThis as any).__agencyInputOverride as
+      | ((prompt: string) => Promise<string>)
+      | undefined);
   if (override) {
     // Promise.resolve().then(...) so a synchronously-throwing override
     // still reaches the finally — otherwise the guards stay paused for
@@ -120,10 +125,13 @@ export function __internal_input(
 
 /** Test-only: install an input override that resolves after `delayMs`,
  *  used by guard fixtures to simulate a slow human without touching stdin.
- *  Exposed to fixtures as the non-exported `_installSlowInput` def in
- *  `stdlib/thread.agency` (test imports only). */
+ *  Installs on the EXECUTION's context, not globalThis, so it lives and
+ *  dies with the run that called it. Exposed to fixtures as the
+ *  non-exported `_installSlowInput` def in `stdlib/thread.agency`
+ *  (test imports only). */
 export function _installSlowInputImpl(delayMs: number, answer: string): void {
-  (globalThis as any).__agencyInputOverride = (_prompt: string) =>
+  const { ctx } = getRuntimeContext();
+  ctx.inputOverride = (_prompt: string) =>
     new Promise<string>((resolve) => setTimeout(() => resolve(answer), delayMs));
 }
 

--- a/packages/agency-lang/lib/stdlib/cli.ts
+++ b/packages/agency-lang/lib/stdlib/cli.ts
@@ -817,14 +817,16 @@ export async function _runLineRepl(
   };
 
   // Route nested `input()` calls through the same readline. The
-  // `_input` impl in `builtins.ts` checks `globalThis.__agencyInputOverride`
-  // before creating its own interface; routing through `rl` here
-  // means `chooseOption`'s fallback prompts share line-edit + history
-  // with the main REPL instead of contending for stdin with a second
+  // `_input` impl in `builtins.ts` checks `ctx.inputOverride` before
+  // creating its own interface; routing through `rl` here means
+  // `chooseOption`'s fallback prompts share line-edit + history with
+  // the main REPL instead of contending for stdin with a second
   // readline. Stops any running spinner first (see comment above).
-  const overrideKey = "__agencyInputOverride";
-  const prevOverride = (globalThis as any)[overrideKey];
-  (globalThis as any)[overrideKey] = (p: string): Promise<string> => {
+  // Installed on THIS execution's context (not globalThis) so the
+  // override lives and dies with the run that owns the readline.
+  const { ctx: replCtx } = getRuntimeContext();
+  const prevOverride = replCtx.inputOverride;
+  replCtx.inputOverride = (p: string): Promise<string> => {
     stopActiveSpinner();
     return new Promise<string>((resolve) => {
       rl.question(p, (answer) => resolve(answer));
@@ -1022,7 +1024,7 @@ export async function _runLineRepl(
     }
   } finally {
     teardownSlashTrigger();
-    (globalThis as any)[overrideKey] = prevOverride;
+    replCtx.inputOverride = prevOverride;
     (globalThis as any)[stopSpinnerKey] = prevStopSpinner;
     (globalThis as any)[clearHistoryKey] = prevClearHistory;
     // Persist whatever entries readline accumulated. `rl.history` is

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -278,7 +278,11 @@ function pushGuardImpl(
     stack.pushGuard(g);
     ids.push(g.guardId);
   }
-  if (timeLimit != null && timeLimit >= 0) {
+  // Time: a NON-POSITIVE limit disables (0 would otherwise trip instantly and
+  // has no useful meaning). Cost differs on purpose: cost 0 is a real limit
+  // meaning "no paid spend" (local-models-only), since check() trips on
+  // spent > limit (strict).
+  if (timeLimit != null && timeLimit > 0) {
     const g = new TimeGuard(timeLimit);
     stack.pushGuard(g);
     ids.push(g.guardId);

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -38,6 +38,7 @@ import {
   _runGuarded,
  } from "agency-lang/stdlib-lib/thread.js"
 
+import { _installSlowInputImpl } from "agency-lang/stdlib-lib/builtins.js"
 import {
   _listThreadsRaw,
   _getThread,
@@ -249,6 +250,20 @@ export def guard(
   const result = _runGuarded(ids, block)
   _popGuard(ids)
   return result
+}
+
+/** Test-only seam (import test { _installSlowInput }): install an input()
+override that answers after a delay, simulating a slow human without
+touching stdin. Guard fixtures use it to prove input-wait does not count
+against time budgets. */
+def _installSlowInput(delayMs: number, answer: string) {
+  """
+  Test-only: make input() resolve with `answer` after `delayMs` milliseconds.
+
+  @param delayMs - How long the simulated human takes to answer.
+  @param answer - The answer input() resolves with.
+  """
+  _installSlowInputImpl(delayMs, answer)
 }
 
 export type ThreadMessage = {

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -227,7 +227,7 @@ export def guard(
   `error.actualTime`, in milliseconds).
 
   @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null or negative = no cost limit.
-  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null or negative = no time limit.
+  @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null, zero, or negative = no time limit.
   @param block - The work to run under the guard.
 
   Example:

--- a/packages/agency-lang/tests/agency/guards/guard-input-abort-still-cancels.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-input-abort-still-cancels.agency
@@ -2,13 +2,14 @@ import { guard } from "std::thread"
 import test { _installSlowInput } from "std::thread"
 
 // pause() cancels only the guard's own timer; it leaves the composed
-// abort signal intact. Here the simulated human (60ms) exceeds the raw
-// budget (30ms), but input-wait is exempt from COUNTING, so the guard
+// abort signal intact. Here the simulated human (2s) exceeds the raw
+// budget (500ms), but input-wait is exempt from COUNTING, so the guard
 // never trips and the answer returns. This asserts the wait is not
-// spuriously aborted while guards are paused.
+// spuriously aborted while guards are paused. Budget sized well above
+// startup jitter (see guard-time-input-wait-free).
 node main() {
-  _installSlowInput(60, "ok")
-  const result = guard(time: 30ms) as {
+  _installSlowInput(2000, "ok")
+  const result = guard(time: 500ms) as {
     const answer = input("q? ")
     return "got:${answer}"
   }

--- a/packages/agency-lang/tests/agency/guards/guard-input-abort-still-cancels.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-input-abort-still-cancels.agency
@@ -1,0 +1,19 @@
+import { guard } from "std::thread"
+import test { _installSlowInput } from "std::thread"
+
+// pause() cancels only the guard's own timer; it leaves the composed
+// abort signal intact. Here the simulated human (60ms) exceeds the raw
+// budget (30ms), but input-wait is exempt from COUNTING, so the guard
+// never trips and the answer returns. This asserts the wait is not
+// spuriously aborted while guards are paused.
+node main() {
+  _installSlowInput(60, "ok")
+  const result = guard(time: 30ms) as {
+    const answer = input("q? ")
+    return "got:${answer}"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-input-abort-still-cancels.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-input-abort-still-cancels.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"got:ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Pausing time guards around an input wait does not spuriously abort the wait; the answer returns even when the wait exceeds the raw budget."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-input-wait-free.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-input-wait-free.agency
@@ -1,12 +1,16 @@
 import { guard } from "std::thread"
 import test { _installSlowInput } from "std::thread"
 
-// A 40ms time budget wrapping an input() whose (simulated) human takes
-// 120ms to answer. Because input-wait does not count against a time
+// A 500ms time budget wrapping an input() whose (simulated) human takes
+// 2s to answer. Because input-wait does not count against a time
 // budget, the guard must NOT trip: the block returns the answer.
+// The budget is deliberately large relative to the compute between
+// guard-install and the input pause, so cold-start jitter on a loaded
+// CI runner cannot trip the timer before input() pauses it. The only
+// relation the assertion needs is input_time > budget > compute_time.
 node main() {
-  _installSlowInput(120, "hello")
-  const result = guard(time: 40ms) as {
+  _installSlowInput(2000, "hello")
+  const result = guard(time: 500ms) as {
     const answer = input("your name? ")
     return "got:${answer}"
   }

--- a/packages/agency-lang/tests/agency/guards/guard-time-input-wait-free.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-input-wait-free.agency
@@ -1,0 +1,17 @@
+import { guard } from "std::thread"
+import test { _installSlowInput } from "std::thread"
+
+// A 40ms time budget wrapping an input() whose (simulated) human takes
+// 120ms to answer. Because input-wait does not count against a time
+// budget, the guard must NOT trip: the block returns the answer.
+node main() {
+  _installSlowInput(120, "hello")
+  const result = guard(time: 40ms) as {
+    const answer = input("your name? ")
+    return "got:${answer}"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-input-wait-free.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-time-input-wait-free.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"got:hello\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A time budget does not count time spent waiting for a human via input(); a slow answer that exceeds the raw budget does not trip the guard."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-sleep-still-counts.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-sleep-still-counts.agency
@@ -1,0 +1,15 @@
+import { guard } from "std::thread"
+
+// sleep is NOT exempt: it is the program deliberately spending time,
+// not waiting on a human. A sleep that overruns the budget still trips.
+node main() {
+  const result = guard(time: 20ms) as {
+    sleep(150ms)
+    sleep(1ms)
+    return "did not trip"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-sleep-still-counts.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-time-sleep-still-counts.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped:timeoutFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "sleep still counts against a time budget; a sleep that overruns the limit trips, confirming only input-wait is exempt."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-zero-disables.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-zero-disables.agency
@@ -1,0 +1,16 @@
+import { guard } from "std::thread"
+
+// A zero time budget disables the time guard: the block runs to
+// completion and returns its value instead of tripping. (A negative
+// budget already disables; this locks in that 0 does too, matching
+// the design's "time <= 0 disables" rule.)
+node main() {
+  const result = guard(time: 0) as {
+    sleep(20ms)
+    return "ran to completion"
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}"
+  }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-time-zero-disables.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-time-zero-disables.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ran to completion\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A zero time budget disables the time guard; the block runs to completion rather than tripping."
+    }
+  ]
+}


### PR DESCRIPTION
Part 1 of 3 of the CLI cost/time guards plan (`docs/superpowers/plans/2026-07-13-cli-cost-time-guards.md`, committed here). Semantics first; per-branch time budgets and the `--max-cost`/`--max-time` flags follow in separate PRs.

## Changes

**`guard(time: 0)` now disables the time guard** instead of tripping instantly. The design rule is: time `<= 0` disables (a zero time budget has no useful meaning), while cost keeps `0` as a real limit — "no paid spend", i.e. local-models-only — because the cost check trips on `spent > limit`. One-line condition change in `pushGuardImpl` plus the docstring.

**Waiting on a human via `input()` no longer counts against time budgets.** `inputImpl` pauses every guard on the active branch stack before blocking and resumes after, on both the override path and the readline path. These are the same idempotent `pause()`/`resume()` calls the runner makes at halt/step boundaries; `CostGuard.pause()` is a no-op, so only time budgets are affected. `pause()` cancels only the guard's own timer — the composed abort signal stays intact, so Ctrl-C / race-loser cancellation still releases a blocked input. `sleep` deliberately still counts: it is the program spending time, not a human.

Adds a test seam: `_installSlowInput(delayMs, answer)` (non-exported def in `std::thread`, reachable via `import test`) installs an `input()` override that answers after a delay, so fixtures can simulate a slow human without touching stdin.

## Tests

- `guard-time-zero-disables` — written first, failed with `tripped:timeoutFailure`, passes after the condition change.
- `guard-time-input-wait-free` — 40ms budget around a 120ms simulated human; written first, failed with `tripped:timeoutFailure`, passes after the pause/resume change.
- `guard-time-sleep-still-counts` — a sleep overrunning the budget still trips.
- `guard-input-abort-still-cancels` — the wait is not spuriously aborted while guards are paused.
- Existing time-guard fixtures all pass locally: `guard-time-trip`, `guard-time-no-trip`, `guard-time-and-cost`, `guard-time-nested`, `guard-time-nested-outer-tighter`, `guard-concurrent-branches`, `guard-cost-no-trip`.
- `lib/stdlib/thread.test.ts` + `lib/runtime/guard.test.ts`: 32/32; structural linter clean.

## Docs

`docs/site/guide/guards.md` "When the clock ticks" updated: `input` is now exempt. Generated `docs/site/stdlib/thread.md` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
