### PR TITLE
Add --max-cost / --max-time to agency run and agency agent (exit 3 on budget trip)

### DIFF
--- a/packages/agency-lang/docs/site/cli/agent.md
+++ b/packages/agency-lang/docs/site/cli/agent.md
@@ -18,7 +18,7 @@ This is a convenient way to get help with Agency without leaving your terminal.
 ## Budget flags
 
 - `agency agent --max-cost <dollars>` — abort if the agent's LLM spend exceeds this many dollars. `0` means no paid spend (local models only); negative means no limit.
-- `agency agent --max-time <duration>` — abort if the agent's working time exceeds this duration, e.g. `30m`. The value needs a unit (`30s`, `5m`, `1h`). Time spent waiting for your input does not count. Zero or negative means no limit.
+- `agency agent --max-time <duration>` — abort if the agent's working time exceeds this duration, e.g. `30m`. The value needs a unit (`30s`, `5m`, `1h`, `2d`, `1w`). Time spent waiting for your input does not count. Zero or negative means no limit.
 
 A tripped budget exits with code 3, distinct from `1` (crash) and `2` (usage error), so scripts can tell an overrun apart from a failure.
 

--- a/packages/agency-lang/docs/site/cli/agent.md
+++ b/packages/agency-lang/docs/site/cli/agent.md
@@ -15,6 +15,13 @@ Launches the Agency language assistant agent — an LLM agent that knows about A
 
 This is a convenient way to get help with Agency without leaving your terminal.
 
+## Budget flags
+
+- `agency agent --max-cost <dollars>` — abort if the agent's LLM spend exceeds this many dollars. `0` means no paid spend (local models only); negative means no limit.
+- `agency agent --max-time <duration>` — abort if the agent's working time exceeds this duration, e.g. `30m`. The value needs a unit (`30s`, `5m`, `1h`). Time spent waiting for your input does not count. Zero or negative means no limit.
+
+A tripped budget exits with code 3, distinct from `1` (crash) and `2` (usage error), so scripts can tell an overrun apart from a failure.
+
 ## The agent home directory
 
 The agent keeps its state — `settings.json`, `policy.json`, and conversation history — in `~/.agency-agent`. You can point it at a different directory:

--- a/packages/agency-lang/docs/site/cli/run.md
+++ b/packages/agency-lang/docs/site/cli/run.md
@@ -26,7 +26,7 @@ Note: This compiles the file to JavaScript and immediately executes it under the
 - `--resume <statefile>` — resume execution from a saved state file. This is what you'd use to continue a run that paused at an interrupt, after writing the user's responses into the state file. *work in progress*
 - `--trace [file]` — write an execution trace as the program runs. If you don't pass a filename, the trace is written to `<input>.trace`. See [traces and bundles](./trace-and-bundle.html) for what you can do with a trace file.
 - `--max-cost <dollars>` — abort the run if its LLM spend exceeds this many dollars, e.g. `--max-cost 0.50`. `0` means no paid spend at all (local models only). A negative value means no limit. A tripped budget exits with code 3 and prints the overrun.
-- `--max-time <duration>` — abort the run if its working time exceeds this duration, e.g. `--max-time 5m`. The value needs a unit: `500ms`, `30s`, `5m`, `1h`. Time spent waiting on a human does not count. Zero or negative means no limit. A tripped budget exits with code 3.
+- `--max-time <duration>` — abort the run if its working time exceeds this duration, e.g. `--max-time 5m`. The value needs a unit: `500ms`, `30s`, `5m`, `1h`, `2d`, `1w`. Time spent waiting on a human does not count. Zero or negative means no limit. A tripped budget exits with code 3.
 
 ## A note on global installs
 If you have installed agency globally, you should be aware of a classic node gotcha. A global install means that the agency CLI will be available everywhere. However, the agency-lang package can't be imported everywhere. This matters because when you compile your agency code into js, the js code imports the `agency-lang` package.

--- a/packages/agency-lang/docs/site/cli/run.md
+++ b/packages/agency-lang/docs/site/cli/run.md
@@ -25,6 +25,8 @@ Note: This compiles the file to JavaScript and immediately executes it under the
 
 - `--resume <statefile>` — resume execution from a saved state file. This is what you'd use to continue a run that paused at an interrupt, after writing the user's responses into the state file. *work in progress*
 - `--trace [file]` — write an execution trace as the program runs. If you don't pass a filename, the trace is written to `<input>.trace`. See [traces and bundles](./trace-and-bundle.html) for what you can do with a trace file.
+- `--max-cost <dollars>` — abort the run if its LLM spend exceeds this many dollars, e.g. `--max-cost 0.50`. `0` means no paid spend at all (local models only). A negative value means no limit. A tripped budget exits with code 3 and prints the overrun.
+- `--max-time <duration>` — abort the run if its working time exceeds this duration, e.g. `--max-time 5m`. The value needs a unit: `500ms`, `30s`, `5m`, `1h`. Time spent waiting on a human does not count. Zero or negative means no limit. A tripped budget exits with code 3.
 
 ## A note on global installs
 If you have installed agency globally, you should be aware of a classic node gotcha. A global install means that the agency CLI will be available everywhere. However, the agency-lang package can't be imported everywhere. This matters because when you compile your agency code into js, the js code imports the `agency-lang` package.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -4438,6 +4438,12 @@ export class TypeScriptBuilder {
               ),
             ]),
             ts.statements([
+              // A root budget trip (--max-cost/--max-time) exits 3 with a
+              // user-facing overrun message and never returns; every other
+              // error falls through to the crash path below. User guard()
+              // trips never reach here — _runGuarded converts them to
+              // Results at their boundary.
+              ts.call(ts.id("reportBudgetExceededAndExit"), [ts.id("__error")]),
               ts.consoleError(
                 ts.template([
                   {

--- a/packages/agency-lang/lib/cli/agent.ts
+++ b/packages/agency-lang/lib/cli/agent.ts
@@ -1,6 +1,10 @@
 import { AgencyConfig } from "@/config.js";
 import { runBundledAgent } from "./runBundledAgent.js";
 
-export function agent(config: AgencyConfig, args: string[] = []): void {
-  runBundledAgent(config, "agency-agent", args);
+export function agent(
+  config: AgencyConfig,
+  args: string[] = [],
+  budget?: { maxCost?: string; maxTime?: string },
+): void {
+  runBundledAgent(config, "agency-agent", args, {}, budget);
 }

--- a/packages/agency-lang/lib/cli/budget.test.ts
+++ b/packages/agency-lang/lib/cli/budget.test.ts
@@ -11,6 +11,13 @@ describe("parseDurationMs", () => {
   test("accepts a leading minus (disable value)", () => {
     expect(parseDurationMs("-1s")).toBe(-1_000);
   });
+  test("accepts days and weeks (documented units)", () => {
+    expect(parseDurationMs("2d")).toBe(172_800_000);
+    expect(parseDurationMs("1w")).toBe(604_800_000);
+  });
+  test("rejects a duration that overflows to Infinity", () => {
+    expect(() => parseDurationMs("9".repeat(320) + "s")).toThrow(/too large/);
+  });
   test("rejects a bare unitless number", () => {
     expect(() => parseDurationMs("300")).toThrow(/duration/i);
   });

--- a/packages/agency-lang/lib/cli/budget.test.ts
+++ b/packages/agency-lang/lib/cli/budget.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect } from "vitest";
+import { resolveBudget, parseDurationMs } from "@/cli/budget.js";
+
+describe("parseDurationMs", () => {
+  test("parses unit-suffixed durations", () => {
+    expect(parseDurationMs("500ms")).toBe(500);
+    expect(parseDurationMs("30s")).toBe(30_000);
+    expect(parseDurationMs("5m")).toBe(300_000);
+    expect(parseDurationMs("1h")).toBe(3_600_000);
+  });
+  test("accepts a leading minus (disable value)", () => {
+    expect(parseDurationMs("-1s")).toBe(-1_000);
+  });
+  test("rejects a bare unitless number", () => {
+    expect(() => parseDurationMs("300")).toThrow(/duration/i);
+  });
+  test("rejects garbage", () => {
+    expect(() => parseDurationMs("soon")).toThrow(/duration/i);
+  });
+});
+
+describe("resolveBudget", () => {
+  test("cost: passes through numeric dollars, incl. 0 and negative", () => {
+    expect(resolveBudget({ maxCost: "0.50" }).maxCost).toBe("0.5");
+    expect(resolveBudget({ maxCost: "0" }).maxCost).toBe("0");
+    expect(resolveBudget({ maxCost: "-1" }).maxCost).toBe("-1");
+  });
+  test("cost: rejects non-numeric", () => {
+    expect(() => resolveBudget({ maxCost: "abc" })).toThrow(/max-cost/i);
+  });
+  test("time: converts to ms string", () => {
+    expect(resolveBudget({ maxTime: "5m" }).maxTime).toBe("300000");
+    expect(resolveBudget({ maxTime: "-1s" }).maxTime).toBe("-1000");
+  });
+  test("time: rejects a bare number", () => {
+    expect(() => resolveBudget({ maxTime: "300" })).toThrow(/max-time/i);
+  });
+  test("omitted flags produce no env values", () => {
+    expect(resolveBudget({})).toEqual({});
+  });
+});

--- a/packages/agency-lang/lib/cli/budget.ts
+++ b/packages/agency-lang/lib/cli/budget.ts
@@ -7,17 +7,25 @@ const UNIT_MS: Record<string, number> = {
   w: 604_800_000,
 };
 
-/** Parse a duration string (`30s`, `5m`, `1h`, `500ms`, or a leading-minus
- *  disable value like `-1s`) to milliseconds. A bare unitless number throws:
- *  the CLI requires an explicit unit so a value's meaning is never guessed. */
+/** Parse a duration string (`500ms`, `30s`, `5m`, `1h`, `2d`, `1w`, or a
+ *  leading-minus disable value like `-1s`) to milliseconds. A bare unitless
+ *  number throws: the CLI requires an explicit unit so a value's meaning is
+ *  never guessed. The computed milliseconds must be finite — an absurdly
+ *  long digit string would otherwise overflow to Infinity, stringify into
+ *  the env, and silently install no guard (fail-open on a cost-control
+ *  feature). */
 export function parseDurationMs(s: string): number {
   const m = /^(-?\d+(?:\.\d+)?)(ms|s|m|h|d|w)$/.exec(s.trim());
   if (!m) {
     throw new Error(
-      `--max-time: expected a duration like 30s, 5m, 1h, or 500ms (got "${s}")`,
+      `--max-time: expected a duration like 500ms, 30s, 5m, 1h, 2d, or 1w (got "${s}")`,
     );
   }
-  return parseFloat(m[1]) * UNIT_MS[m[2]];
+  const ms = parseFloat(m[1]) * UNIT_MS[m[2]];
+  if (!Number.isFinite(ms)) {
+    throw new Error(`--max-time: duration is too large (got "${s}")`);
+  }
+  return ms;
 }
 
 /** Resolve --max-cost / --max-time flag strings into the env-var string

--- a/packages/agency-lang/lib/cli/budget.ts
+++ b/packages/agency-lang/lib/cli/budget.ts
@@ -1,0 +1,45 @@
+const UNIT_MS: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+/** Parse a duration string (`30s`, `5m`, `1h`, `500ms`, or a leading-minus
+ *  disable value like `-1s`) to milliseconds. A bare unitless number throws:
+ *  the CLI requires an explicit unit so a value's meaning is never guessed. */
+export function parseDurationMs(s: string): number {
+  const m = /^(-?\d+(?:\.\d+)?)(ms|s|m|h|d|w)$/.exec(s.trim());
+  if (!m) {
+    throw new Error(
+      `--max-time: expected a duration like 30s, 5m, 1h, or 500ms (got "${s}")`,
+    );
+  }
+  return parseFloat(m[1]) * UNIT_MS[m[2]];
+}
+
+/** Resolve --max-cost / --max-time flag strings into the env-var string
+ *  values the child reads. Cost stays as dollars; time becomes milliseconds.
+ *  Negative/zero pass through — the runtime install applies the disable rule
+ *  (cost < 0 disables; time <= 0 disables). */
+export function resolveBudget(opts: {
+  maxCost?: string;
+  maxTime?: string;
+}): { maxCost?: string; maxTime?: string } {
+  const out: { maxCost?: string; maxTime?: string } = {};
+  if (opts.maxCost !== undefined) {
+    const n = Number(opts.maxCost);
+    if (!Number.isFinite(n)) {
+      throw new Error(
+        `--max-cost: expected a number of dollars (got "${opts.maxCost}")`,
+      );
+    }
+    out.maxCost = String(n);
+  }
+  if (opts.maxTime !== undefined) {
+    out.maxTime = String(parseDurationMs(opts.maxTime));
+  }
+  return out;
+}

--- a/packages/agency-lang/lib/cli/budgetRun.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/budgetRun.spawn.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { mkdtempSync, writeFileSync, existsSync, realpathSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+
+const execFileAsync = promisify(execFile);
+
+// End-to-end: run the BUILT CLI and observe the budget-exceeded exit code
+// and message. Mirrors runPolicy.spawn.test.ts's harness.
+const CLI = path.resolve("dist/scripts/agency.js");
+
+function rmTemp(dir: string): void {
+  const root = realpathSync(tmpdir());
+  const resolved = realpathSync(dir);
+  if (resolved !== root && resolved.startsWith(root + path.sep)) {
+    rmSync(resolved, { recursive: true, force: true });
+  }
+}
+
+// Sleeps far past the tiny time budget the tests set. The direction is
+// jitter-safe: the EXPECTED outcome is the trip, and a slow runner only
+// makes the sleep overshoot harder.
+const SLEEPER = `node main() {
+  sleep(2s)
+  return "done"
+}
+`;
+
+function makeDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "budget-spawn-"));
+  writeFileSync(path.join(dir, "sleeper.agency"), SLEEPER);
+  return dir;
+}
+
+async function runCli(
+  dir: string,
+  args: string[],
+  env: Record<string, string> = {},
+) {
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      [CLI, "run", "sleeper.agency", ...args],
+      { cwd: dir, timeout: 60_000, env: { ...process.env, ...env } },
+    );
+    return { stdout, stderr, code: 0 };
+  } catch (e: any) {
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", code: e.code ?? 1 };
+  }
+}
+
+// Requires the built CLI; skip in a clean checkout (CI runs make first).
+describe.skipIf(!existsSync(CLI))("root budget (end-to-end)", () => {
+  it("--max-time flag trips the root guard: exit 3 + overrun message", async () => {
+    const dir = makeDir();
+    try {
+      const r = await runCli(dir, ["--max-time", "100ms"]);
+      expect(r.stderr).toMatch(/Exceeded time limit/);
+      expect(r.code).toBe(3);
+    } finally {
+      rmTemp(dir);
+    }
+  }, 90_000);
+
+  it("a bare unitless --max-time is a usage error (exit 2)", async () => {
+    const dir = makeDir();
+    try {
+      const r = await runCli(dir, ["--max-time", "300"]);
+      expect(r.stderr + r.stdout).toMatch(/max-time/);
+      expect(r.code).toBe(2);
+    } finally {
+      rmTemp(dir);
+    }
+  }, 90_000);
+
+  it("an inherited AGENCY_MAX_TIME does not leak when the flag is absent", async () => {
+    // The env var is an internal carrier from the CLI to its spawned
+    // child, not a user-facing knob: `agency run` clears-then-sets it,
+    // exactly like AGENCY_RUN_POLICY. A stale value from the parent
+    // shell must not constrain the run — the 2s sleeper completes.
+    const dir = makeDir();
+    try {
+      const r = await runCli(dir, [], { AGENCY_MAX_TIME: "100" });
+      expect(r.stderr).not.toMatch(/Exceeded time limit/);
+      expect(r.code).toBe(0);
+    } finally {
+      rmTemp(dir);
+    }
+  }, 90_000);
+});

--- a/packages/agency-lang/lib/cli/budgetRun.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/budgetRun.spawn.test.ts
@@ -28,9 +28,29 @@ const SLEEPER = `node main() {
 }
 `;
 
-function makeDir(): string {
+// The tripping work sits inside a USER guard block whose own (time) guard
+// has plenty of budget. The user boundary owns only its OWN guardId, so it
+// must NOT absorb the root budget's trip — the trip propagates to the
+// compiled entry and exits 3. If the boundary wrongly converted it, the
+// program would print GUARD_ABSORBED and exit 0.
+const GUARDED_SLEEPER = `import { guard } from "std::thread"
+
+node main() {
+  const inner = guard(time: 60s) as {
+    sleep(2s)
+    return "inner done"
+  }
+  if (isFailure(inner)) {
+    print("GUARD_ABSORBED:\${inner.error.type}")
+    return "absorbed"
+  }
+  return inner.value
+}
+`;
+
+function makeDir(fixture: string = SLEEPER): string {
   const dir = mkdtempSync(path.join(tmpdir(), "budget-spawn-"));
-  writeFileSync(path.join(dir, "sleeper.agency"), SLEEPER);
+  writeFileSync(path.join(dir, "sleeper.agency"), fixture);
   return dir;
 }
 
@@ -57,6 +77,18 @@ describe.skipIf(!existsSync(CLI))("root budget (end-to-end)", () => {
     const dir = makeDir();
     try {
       const r = await runCli(dir, ["--max-time", "100ms"]);
+      expect(r.stderr).toMatch(/Exceeded time limit/);
+      expect(r.code).toBe(3);
+    } finally {
+      rmTemp(dir);
+    }
+  }, 90_000);
+
+  it("a user guard() boundary does not absorb the root budget's trip", async () => {
+    const dir = makeDir(GUARDED_SLEEPER);
+    try {
+      const r = await runCli(dir, ["--max-time", "100ms"]);
+      expect(r.stdout).not.toMatch(/GUARD_ABSORBED/);
       expect(r.stderr).toMatch(/Exceeded time limit/);
       expect(r.code).toBe(3);
     } finally {

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -11,6 +11,8 @@ import {
   AGENCY_RUN_POLICY,
   AGENCY_RUN_POLICY_INTERACTIVE,
   AGENCY_RUN_POLICY_INTERACTIVE_ON,
+  AGENCY_MAX_COST,
+  AGENCY_MAX_TIME,
 } from "@/constants.js";
 import { parseAgency, replaceBlankLines } from "../parser.js";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -331,6 +333,7 @@ export function run(
   outputFile?: string,
   resumeFile?: string,
   runPolicy?: { policyJson: string; interactive: boolean },
+  budget?: { maxCost?: string; maxTime?: string },
 ): void {
   const output = compile(config, inputFile, outputFile, {
     importStrategy: new RunStrategy(),
@@ -356,6 +359,13 @@ export function run(
       env[AGENCY_RUN_POLICY_INTERACTIVE] = AGENCY_RUN_POLICY_INTERACTIVE_ON;
     }
   }
+  // Same clear-then-set discipline for the root budget: the env vars are an
+  // internal carrier from THIS run's flags to the child, never a knob a
+  // parent shell can set behind the user's back.
+  delete env[AGENCY_MAX_COST];
+  delete env[AGENCY_MAX_TIME];
+  if (budget?.maxCost !== undefined) env[AGENCY_MAX_COST] = budget.maxCost;
+  if (budget?.maxTime !== undefined) env[AGENCY_MAX_TIME] = budget.maxTime;
 
   // Use process.execPath so the child runs under the same Node as the CLI,
   // and pass our resolver shim so the compiled output's `import "agency-lang"`

--- a/packages/agency-lang/lib/cli/runBundledAgent.test.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.test.ts
@@ -132,6 +132,36 @@ describe("runBundledAgent passes config overrides to the child via env", () => {
     expect(opts.env.PATH).toBe(process.env.PATH);
   });
 
+  it("sets AGENCY_MAX_COST/AGENCY_MAX_TIME from the budget param and clears stale ones", () => {
+    const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
+    vi.stubEnv("AGENCY_MAX_COST", "999");
+    vi.stubEnv("AGENCY_MAX_TIME", "999999");
+
+    runBundledAgent({}, "agency-agent", ["--print", "hi"], {
+      spawn: spawnMock as never,
+    }, { maxCost: "0.5" });
+
+    const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
+    expect(opts.env.AGENCY_MAX_COST).toBe("0.5");
+    // No --max-time given: the stale inherited value must be CLEARED,
+    // not passed through — the env is an internal carrier, not a knob.
+    expect(opts.env.AGENCY_MAX_TIME).toBeUndefined();
+  });
+
+  it("clears both budget env vars when no budget is passed", () => {
+    const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
+    vi.stubEnv("AGENCY_MAX_COST", "999");
+    vi.stubEnv("AGENCY_MAX_TIME", "999999");
+
+    runBundledAgent({}, "agency-agent", ["--print", "hi"], {
+      spawn: spawnMock as never,
+    });
+
+    const opts = spawnMock.mock.calls[0][2] as { env: Record<string, string> };
+    expect(opts.env.AGENCY_MAX_COST).toBeUndefined();
+    expect(opts.env.AGENCY_MAX_TIME).toBeUndefined();
+  });
+
   it("does not set the env var when no debug flags are present", () => {
     const spawnMock = vi.fn((..._args: unknown[]) => ({ on: vi.fn() }) as never);
     runBundledAgent({}, "agency-agent", ["--print", "hi"], { spawn: spawnMock as never });

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -6,6 +6,7 @@ import {
   type CliFlags,
 } from "@/config.js";
 import { compile, compiledOutputNodeArgs } from "./commands.js";
+import { AGENCY_MAX_COST, AGENCY_MAX_TIME } from "@/constants.js";
 import { spawn as realSpawn } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
@@ -110,6 +111,7 @@ export function runBundledAgent(
   agentName: string,
   args: string[] = [],
   deps: { spawn?: typeof realSpawn } = {},
+  budget?: { maxCost?: string; maxTime?: string },
 ): void {
   const spawn = deps.spawn ?? realSpawn;
   const agentDir = path.resolve(currentDir, `../agents/${agentName}`);
@@ -143,6 +145,12 @@ export function runBundledAgent(
   if (agentHome !== null) {
     env.AGENCY_AGENT_HOME = agentHome;
   }
+  // Root budget carrier: cleared-then-set like AGENCY_RUN_POLICY, so a
+  // stale value from the parent shell never constrains the agent.
+  delete env[AGENCY_MAX_COST];
+  delete env[AGENCY_MAX_TIME];
+  if (budget?.maxCost !== undefined) env[AGENCY_MAX_COST] = budget.maxCost;
+  if (budget?.maxTime !== undefined) env[AGENCY_MAX_TIME] = budget.maxTime;
 
   const nodeProcess = spawn(
     process.execPath,

--- a/packages/agency-lang/lib/constants.ts
+++ b/packages/agency-lang/lib/constants.ts
@@ -55,3 +55,14 @@ export const AGENCY_RUN_POLICY_INTERACTIVE = "AGENCY_RUN_POLICY_INTERACTIVE";
 
 /** The truthy sentinel value for `AGENCY_RUN_POLICY_INTERACTIVE`. */
 export const AGENCY_RUN_POLICY_INTERACTIVE_ON = "1";
+
+/** Env vars carrying `agency run`/`agency agent` --max-cost / --max-time to
+ *  the spawned child, which installs a root guard from them. Cleared then set
+ *  by the CLI, exactly like AGENCY_RUN_POLICY. Cost is dollars; time is
+ *  milliseconds (the CLI parses duration strings before setting it). */
+export const AGENCY_MAX_COST = "AGENCY_MAX_COST";
+export const AGENCY_MAX_TIME = "AGENCY_MAX_TIME";
+
+/** Process exit code when a top-level cost/time budget is exceeded. Distinct
+ *  from 1 (generic failure) and 2 (usage error). */
+export const EXIT_CODE_BUDGET_EXCEEDED = 3;

--- a/packages/agency-lang/lib/runtime/budgetExit.test.ts
+++ b/packages/agency-lang/lib/runtime/budgetExit.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import {
+  formatBudgetExceeded,
+  reportBudgetExceededAndExit,
+} from "@/runtime/budgetExit.js";
+import { GuardExceededError } from "@/runtime/guard.js";
+import { EXIT_CODE_BUDGET_EXCEEDED } from "@/constants.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("formatBudgetExceeded", () => {
+  test("cost message", () => {
+    const e = new GuardExceededError("cost", 0.5, 0.63, "g1");
+    expect(formatBudgetExceeded(e)).toBe(
+      "Exceeded cost limit of $0.5 (used $0.63)",
+    );
+  });
+  test("time message renders ms", () => {
+    const e = new GuardExceededError("time", 5000, 5002, "g1");
+    expect(formatBudgetExceeded(e)).toBe(
+      "Exceeded time limit of 5000ms (ran 5002ms)",
+    );
+  });
+});
+
+describe("reportBudgetExceededAndExit", () => {
+  test("exits 3 with the message for a guard trip", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    reportBudgetExceededAndExit(new GuardExceededError("time", 100, 150, "g"));
+    expect(errSpy).toHaveBeenCalledWith("Exceeded time limit of 100ms (ran 150ms)");
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_CODE_BUDGET_EXCEEDED);
+  });
+  test("returns without exiting for a non-budget error", () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    reportBudgetExceededAndExit(new Error("plain crash"));
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agency-lang/lib/runtime/budgetExit.test.ts
+++ b/packages/agency-lang/lib/runtime/budgetExit.test.ts
@@ -4,6 +4,7 @@ import {
   reportBudgetExceededAndExit,
 } from "@/runtime/budgetExit.js";
 import { GuardExceededError } from "@/runtime/guard.js";
+import { AgencyCancelledError, makeAbortCause } from "@/runtime/errors.js";
 import { EXIT_CODE_BUDGET_EXCEEDED } from "@/constants.js";
 
 afterEach(() => {
@@ -12,27 +13,48 @@ afterEach(() => {
 
 describe("formatBudgetExceeded", () => {
   test("cost message", () => {
-    const e = new GuardExceededError("cost", 0.5, 0.63, "g1");
-    expect(formatBudgetExceeded(e)).toBe(
-      "Exceeded cost limit of $0.5 (used $0.63)",
-    );
+    expect(
+      formatBudgetExceeded({ dimension: "cost", limit: 0.5, spent: 0.63 }),
+    ).toBe("Exceeded cost limit of $0.5 (used $0.63)");
   });
-  test("time message renders ms", () => {
-    const e = new GuardExceededError("time", 5000, 5002, "g1");
-    expect(formatBudgetExceeded(e)).toBe(
-      "Exceeded time limit of 5000ms (ran 5002ms)",
-    );
+  test("time message renders whole ms", () => {
+    expect(
+      formatBudgetExceeded({ dimension: "time", limit: 5000, spent: 5002.4 }),
+    ).toBe("Exceeded time limit of 5000ms (ran 5002ms)");
   });
 });
 
 describe("reportBudgetExceededAndExit", () => {
-  test("exits 3 with the message for a guard trip", () => {
+  test("exits 3 for a GuardExceededError (shouldSkip delivery)", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi
       .spyOn(process, "exit")
       .mockImplementation((() => undefined) as never);
     reportBudgetExceededAndExit(new GuardExceededError("time", 100, 150, "g"));
-    expect(errSpy).toHaveBeenCalledWith("Exceeded time limit of 100ms (ran 150ms)");
+    expect(errSpy).toHaveBeenCalledWith(
+      "Exceeded time limit of 100ms (ran 150ms)",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(EXIT_CODE_BUDGET_EXCEEDED);
+  });
+  test("exits 3 for a cancelled leaf op carrying a guardTrip cause", () => {
+    // A root time trip usually lands THIS way: the timer aborts an
+    // in-flight sleep/fetch, whose leafCancel throws AgencyCancelledError
+    // with the guardTrip cause attached.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    const e = new AgencyCancelledError(
+      "sleep cancelled",
+      makeAbortCause({
+        kind: "guardTrip",
+        dimension: "time",
+        limit: 100,
+        spent: 140,
+        guardId: "g",
+      }),
+    );
+    reportBudgetExceededAndExit(e);
     expect(exitSpy).toHaveBeenCalledWith(EXIT_CODE_BUDGET_EXCEEDED);
   });
   test("returns without exiting for a non-budget error", () => {
@@ -40,6 +62,13 @@ describe("reportBudgetExceededAndExit", () => {
       .spyOn(process, "exit")
       .mockImplementation((() => undefined) as never);
     reportBudgetExceededAndExit(new Error("plain crash"));
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+  test("returns without exiting for a plain user cancel", () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as never);
+    reportBudgetExceededAndExit(new AgencyCancelledError("esc"));
     expect(exitSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/agency-lang/lib/runtime/budgetExit.ts
+++ b/packages/agency-lang/lib/runtime/budgetExit.ts
@@ -1,22 +1,32 @@
 import { EXIT_CODE_BUDGET_EXCEEDED } from "../constants.js";
-import { isGuardExceededError, GuardExceededError } from "./guard.js";
+import { readCause } from "./errors.js";
 
 /** User-facing one-line message for a tripped top-level budget. */
-export function formatBudgetExceeded(e: GuardExceededError): string {
-  if (e.type === "cost") {
-    return `Exceeded cost limit of $${e.limit} (used $${e.spent})`;
+export function formatBudgetExceeded(cause: {
+  dimension: "cost" | "time";
+  limit: number;
+  spent: number;
+}): string {
+  if (cause.dimension === "cost") {
+    return `Exceeded cost limit of $${cause.limit} (used $${cause.spent})`;
   }
-  return `Exceeded time limit of ${e.limit}ms (ran ${e.spent}ms)`;
+  return `Exceeded time limit of ${cause.limit}ms (ran ${Math.round(cause.spent)}ms)`;
 }
 
-/** If `error` is a top-level budget trip, report it and exit with code 3.
- *  Otherwise return so the caller can handle it as an ordinary crash. Only a
- *  ROOT guard (no owning try) reaches the compiled entry's catch — a user
- *  guard() trip is always converted to a Result by _runGuarded, so this
- *  never misfires on those. */
+/** If `error` carries a guard-trip cause, report it and exit with code 3.
+ *  Otherwise return so the caller handles it as an ordinary crash.
+ *
+ *  Detection is by CAUSE, not error class, because a root time trip can
+ *  surface two ways: the runner's shouldSkip throws GuardExceededError, or
+ *  an in-flight leaf op (sleep, fetch, LLM call) aborts first and throws
+ *  AgencyCancelledError carrying the same guardTrip cause. Both must exit 3.
+ *  Only a ROOT guard's trip reaches the compiled entry's catch — a user
+ *  guard() trip is converted to a Result at its boundary by _runGuarded,
+ *  so this never misfires on those. */
 export function reportBudgetExceededAndExit(error: unknown): void {
-  if (isGuardExceededError(error)) {
-    console.error(formatBudgetExceeded(error));
+  const cause = readCause(error);
+  if (cause?.kind === "guardTrip") {
+    console.error(formatBudgetExceeded(cause));
     process.exit(EXIT_CODE_BUDGET_EXCEEDED);
   }
 }

--- a/packages/agency-lang/lib/runtime/budgetExit.ts
+++ b/packages/agency-lang/lib/runtime/budgetExit.ts
@@ -1,0 +1,22 @@
+import { EXIT_CODE_BUDGET_EXCEEDED } from "../constants.js";
+import { isGuardExceededError, GuardExceededError } from "./guard.js";
+
+/** User-facing one-line message for a tripped top-level budget. */
+export function formatBudgetExceeded(e: GuardExceededError): string {
+  if (e.type === "cost") {
+    return `Exceeded cost limit of $${e.limit} (used $${e.spent})`;
+  }
+  return `Exceeded time limit of ${e.limit}ms (ran ${e.spent}ms)`;
+}
+
+/** If `error` is a top-level budget trip, report it and exit with code 3.
+ *  Otherwise return so the caller can handle it as an ordinary crash. Only a
+ *  ROOT guard (no owning try) reaches the compiled entry's catch — a user
+ *  guard() trip is always converted to a Result by _runGuarded, so this
+ *  never misfires on those. */
+export function reportBudgetExceededAndExit(error: unknown): void {
+  if (isGuardExceededError(error)) {
+    console.error(formatBudgetExceeded(error));
+    process.exit(EXIT_CODE_BUDGET_EXCEEDED);
+  }
+}

--- a/packages/agency-lang/lib/runtime/budgetExit.ts
+++ b/packages/agency-lang/lib/runtime/budgetExit.ts
@@ -1,14 +1,24 @@
 import { EXIT_CODE_BUDGET_EXCEEDED } from "../constants.js";
 import { readCause } from "./errors.js";
 
-/** User-facing one-line message for a tripped top-level budget. */
+/** Dollars for the overrun message: bounded precision with float noise
+ *  stripped, so accumulated token pricing can't surface artifacts like
+ *  0.30000000000000004 in user-facing output. */
+function fmtDollars(n: number): string {
+  return String(Number(n.toFixed(6)));
+}
+
+/** User-facing one-line message for a tripped top-level budget. Times
+ *  render in raw ms on purpose: only the millisecond value crosses the
+ *  env boundary, so the user's original unit string is not available
+ *  here, and ms is unambiguous. */
 export function formatBudgetExceeded(cause: {
   dimension: "cost" | "time";
   limit: number;
   spent: number;
 }): string {
   if (cause.dimension === "cost") {
-    return `Exceeded cost limit of $${cause.limit} (used $${cause.spent})`;
+    return `Exceeded cost limit of $${fmtDollars(cause.limit)} (used $${fmtDollars(cause.spent)})`;
   }
   return `Exceeded time limit of ${cause.limit}ms (ran ${Math.round(cause.spent)}ms)`;
 }

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -127,6 +127,7 @@ export {
 export type { Checkpoint } from "./state/checkpointStore.js";
 
 export { setupNode, setupFunction, runNode, runExportedFunction } from "./node.js";
+export { reportBudgetExceededAndExit, formatBudgetExceeded } from "./budgetExit.js";
 export { Runner } from "./runner.js";
 
 export { rewindFrom, applyOverrides } from "./rewind.js";

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -18,6 +18,7 @@ import { loadProviderModules } from "./providerModules.js";
 import { resolveTraceFilePath } from "./trace/traceWriter.js";
 import { getSubprocessRunInfo } from "./subprocessRunInfo.js";
 import { installRunPolicyHandler } from "./runPolicyHandler.js";
+import { installRootBudget } from "./rootBudget.js";
 import { GraphState, RunNodeResult } from "./types.js";
 import { createReturnObject } from "./utils.js";
 import { color } from "@/utils/termcolors.js";
@@ -353,6 +354,12 @@ export async function runNode({
   // subprocess). Installed here — after the exec context exists, before the
   // node body runs — so it is the outermost handler and cannot be bypassed.
   installRunPolicyHandler(execCtx);
+  // Install a root cost/time budget from --max-cost / --max-time (via env).
+  // Same root-only gate as the policy handler (isIpcMode, inside the
+  // installer): no-op in IPC subprocesses, whose budgets are owned by the
+  // parent's guard. Outermost, before the node body runs, so it cannot be
+  // bypassed.
+  installRootBudget(execCtx.stateStack);
   // Externally-passed callbacks are stored on ctx; hook execution merges them
   // with scoped/top-level callbacks at call time.
   if (callbacks) {

--- a/packages/agency-lang/lib/runtime/rootBudget.test.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, afterEach } from "vitest";
+import { installRootBudget } from "@/runtime/rootBudget.js";
+import { StateStack } from "@/runtime/state/stateStack.js";
+import { CostGuard, TimeGuard } from "@/runtime/guard.js";
+import { AGENCY_MAX_COST, AGENCY_MAX_TIME } from "@/constants.js";
+
+afterEach(() => {
+  delete process.env[AGENCY_MAX_COST];
+  delete process.env[AGENCY_MAX_TIME];
+});
+
+describe("installRootBudget", () => {
+  test("pushes a CostGuard for a non-negative cost", () => {
+    process.env[AGENCY_MAX_COST] = "0.5";
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.some((g) => g instanceof CostGuard)).toBe(true);
+  });
+  test("cost 0 still installs (local-only limit)", () => {
+    process.env[AGENCY_MAX_COST] = "0";
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.some((g) => g instanceof CostGuard)).toBe(true);
+  });
+  test("negative cost installs nothing", () => {
+    process.env[AGENCY_MAX_COST] = "-1";
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.length).toBe(0);
+  });
+  test("time <= 0 installs nothing; time > 0 installs a TimeGuard", () => {
+    process.env[AGENCY_MAX_TIME] = "0";
+    const s1 = new StateStack();
+    installRootBudget(s1);
+    expect(s1.guards.length).toBe(0);
+
+    process.env[AGENCY_MAX_TIME] = "5000";
+    const s2 = new StateStack();
+    installRootBudget(s2);
+    expect(s2.guards.some((g) => g instanceof TimeGuard)).toBe(true);
+  });
+  test("no env vars: no guards", () => {
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.length).toBe(0);
+  });
+  test("both set: cost then time, both installed", () => {
+    process.env[AGENCY_MAX_COST] = "1.5";
+    process.env[AGENCY_MAX_TIME] = "60000";
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards).toHaveLength(2);
+    expect(stack.guards[0]).toBeInstanceOf(CostGuard);
+    expect(stack.guards[1]).toBeInstanceOf(TimeGuard);
+  });
+});

--- a/packages/agency-lang/lib/runtime/rootBudget.test.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.test.ts
@@ -7,6 +7,9 @@ import { AGENCY_MAX_COST, AGENCY_MAX_TIME } from "@/constants.js";
 afterEach(() => {
   delete process.env[AGENCY_MAX_COST];
   delete process.env[AGENCY_MAX_TIME];
+  // installRootBudget no-ops under AGENCY_IPC=1; clear it so a leak from
+  // an IPC-mode test elsewhere can't turn these assertions flaky.
+  delete process.env.AGENCY_IPC;
 });
 
 describe("installRootBudget", () => {
@@ -40,6 +43,20 @@ describe("installRootBudget", () => {
     expect(s2.guards.some((g) => g instanceof TimeGuard)).toBe(true);
   });
   test("no env vars: no guards", () => {
+    const stack = new StateStack();
+    installRootBudget(stack);
+    expect(stack.guards.length).toBe(0);
+  });
+  test("malformed values FAIL CLOSED: refuse the run, never run unbounded", () => {
+    process.env[AGENCY_MAX_COST] = "abc";
+    expect(() => installRootBudget(new StateStack())).toThrow(/finite number/);
+    delete process.env[AGENCY_MAX_COST];
+    process.env[AGENCY_MAX_TIME] = "Infinity";
+    expect(() => installRootBudget(new StateStack())).toThrow(/finite number/);
+  });
+  test("no-op in IPC mode (child budgets are the parent guard's job)", () => {
+    process.env[AGENCY_MAX_COST] = "0.5";
+    process.env.AGENCY_IPC = "1";
     const stack = new StateStack();
     installRootBudget(stack);
     expect(stack.guards.length).toBe(0);

--- a/packages/agency-lang/lib/runtime/rootBudget.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.ts
@@ -1,0 +1,33 @@
+import { AGENCY_MAX_COST, AGENCY_MAX_TIME } from "../constants.js";
+import { CostGuard, TimeGuard } from "./guard.js";
+import { isIpcMode } from "./subprocessRunInfo.js";
+import type { StateStack } from "./state/stateStack.js";
+
+/** Install a root cost/time guard from AGENCY_MAX_COST / AGENCY_MAX_TIME.
+ *  Applies the disable rule: cost < 0 installs nothing; time <= 0 installs
+ *  nothing (cost 0 IS a real limit — no paid spend, local-models-only).
+ *  Called once at the root, next to installRunPolicyHandler, before the
+ *  node body runs, so the budget is outermost and cannot be bypassed.
+ *  No-op in IPC subprocesses — a child's budget is owned by the parent's
+ *  guard, which meters the subprocess through the branch clone.
+ *
+ *  pushGuard() installs immediately, so a time budget's clock starts at
+ *  run start — the intended whole-run semantics. Interrupt halts and
+ *  input() waits still pause it like any other time guard. */
+export function installRootBudget(stack: StateStack): void {
+  if (isIpcMode()) return;
+  const rawCost = process.env[AGENCY_MAX_COST];
+  if (rawCost !== undefined) {
+    const cost = Number(rawCost);
+    if (Number.isFinite(cost) && cost >= 0) {
+      stack.pushGuard(new CostGuard(cost));
+    }
+  }
+  const rawTime = process.env[AGENCY_MAX_TIME];
+  if (rawTime !== undefined) {
+    const ms = Number(rawTime);
+    if (Number.isFinite(ms) && ms > 0) {
+      stack.pushGuard(new TimeGuard(ms));
+    }
+  }
+}

--- a/packages/agency-lang/lib/runtime/rootBudget.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.ts
@@ -18,16 +18,33 @@ export function installRootBudget(stack: StateStack): void {
   if (isIpcMode()) return;
   const rawCost = process.env[AGENCY_MAX_COST];
   if (rawCost !== undefined) {
-    const cost = Number(rawCost);
-    if (Number.isFinite(cost) && cost >= 0) {
+    const cost = parseBudgetValue(rawCost, AGENCY_MAX_COST);
+    if (cost >= 0) {
       stack.pushGuard(new CostGuard(cost));
     }
   }
   const rawTime = process.env[AGENCY_MAX_TIME];
   if (rawTime !== undefined) {
-    const ms = Number(rawTime);
-    if (Number.isFinite(ms) && ms > 0) {
+    const ms = parseBudgetValue(rawTime, AGENCY_MAX_TIME);
+    if (ms > 0) {
       stack.pushGuard(new TimeGuard(ms));
     }
   }
+}
+
+/** FAIL CLOSED on a malformed budget value. The env is an internal
+ *  carrier and the CLI validates before setting it, so a non-finite
+ *  value here means a hand-set env or a bug — and for a cost-control
+ *  feature, silently running UNBOUNDED is the wrong failure direction.
+ *  Refuse the run instead. (Negative values are not malformed: they are
+ *  the documented disable range and fall through the install checks.) */
+function parseBudgetValue(raw: string, name: string): number {
+  const n = Number(raw);
+  if (raw.trim() === "" || !Number.isFinite(n)) {
+    throw new Error(
+      `${name} is set but not a finite number (got "${raw}"). Refusing to ` +
+        `run without the requested budget — unset it or pass a valid value.`,
+    );
+  }
+  return n;
 }

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -16,7 +16,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -338,7 +338,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
       )
       .option(
         "--max-time <duration>",
-        "Abort if the run's working time exceeds this duration (e.g. 30s, 5m, 1h). Waiting on a human is not counted; zero/negative = no limit",
+        "Abort if the run's working time exceeds this duration (e.g. 30s, 5m, 1h, 2d). Waiting on a human is not counted; zero/negative = no limit",
       );
   }
 
@@ -1082,7 +1082,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     )
     .option(
       "--max-time <duration>",
-      "Abort if the agent's working time exceeds this duration (e.g. 30m); waiting on a human is not counted; zero/negative = no limit",
+      "Abort if the agent's working time exceeds this duration (e.g. 30m or 2d); waiting on a human is not counted; zero/negative = no limit",
     )
     .helpOption(false)
     .action((args: string[], opts: { maxCost?: string; maxTime?: string }) => {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -17,6 +17,7 @@ import {
   installDirFromUrl,
 } from "@/cli/installLocation.js";
 import { pack } from "@/cli/pack.js";
+import { resolveBudget } from "@/cli/budget.js";
 import { fixtures, test, testTs, SlowTest } from "@/cli/test.js";
 import { generateReport, cleanCoverage } from "@/cli/coverage.js";
 import { createBundle, extractBundle } from "@/cli/bundle.js";
@@ -97,6 +98,8 @@ type RunOptions = CliFlags & {
   approve?: string;
   reject?: string;
   interactive?: boolean;
+  maxCost?: string;
+  maxTime?: string;
 };
 
 // commander option parsers. Match the WHOLE string against digits so
@@ -198,7 +201,17 @@ export function createProgram(deps: CliDependencies = {}): Command {
       console.error(`Error: ${(e as Error).message}`);
       process.exit(2);
     }
-    run(config, input, undefined, options.resume, runPolicy);
+    let budget;
+    try {
+      budget = resolveBudget({
+        maxCost: options.maxCost,
+        maxTime: options.maxTime,
+      });
+    } catch (e) {
+      console.error(`Error: ${(e as Error).message}`);
+      process.exit(2);
+    }
+    run(config, input, undefined, options.resume, runPolicy, budget);
   }
 
   program
@@ -318,6 +331,14 @@ export function createProgram(deps: CliDependencies = {}): Command {
       .option(
         "-i, --interactive",
         "Prompt on interrupts that surface unhandled (default: reject them)",
+      )
+      .option(
+        "--max-cost <dollars>",
+        "Abort if the run's LLM spend exceeds this many dollars (e.g. 0.50). 0 = no paid spend (local models only); negative = no limit",
+      )
+      .option(
+        "--max-time <duration>",
+        "Abort if the run's working time exceeds this duration (e.g. 30s, 5m, 1h). Waiting on a human is not counted; zero/negative = no limit",
       );
   }
 
@@ -1055,10 +1076,25 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .command("agent")
     .description("Launch the Agency language assistant agent (run `agency agent --help` for agent flags)")
     .argument("[args...]", "Arguments forwarded to the agent")
+    .option(
+      "--max-cost <dollars>",
+      "Abort if the agent's LLM spend exceeds this many dollars (0 = local models only; negative = no limit)",
+    )
+    .option(
+      "--max-time <duration>",
+      "Abort if the agent's working time exceeds this duration (e.g. 30m); waiting on a human is not counted; zero/negative = no limit",
+    )
     .helpOption(false)
-    .action((args: string[]) => {
+    .action((args: string[], opts: { maxCost?: string; maxTime?: string }) => {
       const config = getConfig();
-      agent(config, args);
+      let budget;
+      try {
+        budget = resolveBudget({ maxCost: opts.maxCost, maxTime: opts.maxTime });
+      } catch (e) {
+        console.error(`Error: ${(e as Error).message}`);
+        process.exit(2);
+      }
+      agent(config, args, budget);
     });
 
   program

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -289,6 +289,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -300,6 +300,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -341,6 +341,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -289,6 +289,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -469,6 +469,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -301,6 +301,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -472,6 +472,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -452,6 +452,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -436,6 +436,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -285,6 +285,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -485,6 +485,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -508,6 +508,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -303,6 +303,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -474,6 +474,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -725,6 +725,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -411,6 +411,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -291,6 +291,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -306,6 +306,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -290,6 +290,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -485,6 +485,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -625,6 +625,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -292,6 +292,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -507,6 +507,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -587,6 +587,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -309,6 +309,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -507,6 +507,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -342,6 +342,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -1272,6 +1272,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -563,6 +563,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -752,6 +752,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -464,6 +464,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -369,6 +369,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -376,6 +376,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -446,6 +446,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -26,7 +26,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -485,6 +485,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -496,6 +496,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -317,6 +317,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -303,6 +303,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -339,6 +339,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -284,6 +284,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -332,6 +332,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -661,6 +661,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -333,6 +333,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -338,6 +338,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -508,6 +508,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -499,6 +499,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -300,6 +300,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -303,6 +303,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -791,6 +791,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -308,6 +308,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -402,6 +402,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -275,6 +275,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -301,6 +301,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -290,6 +290,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -285,6 +285,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -718,6 +718,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -12,7 +12,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -307,6 +307,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -300,6 +300,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -292,6 +292,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -277,6 +277,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -450,6 +450,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -292,6 +292,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -268,6 +268,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -759,6 +759,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -338,6 +338,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -284,6 +284,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -305,6 +305,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -337,6 +337,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -307,6 +307,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -305,6 +305,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -293,6 +293,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -545,6 +545,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -309,6 +309,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -309,6 +309,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -453,6 +453,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -11,7 +11,7 @@ import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
   checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
-  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  interrupt, isInterrupt, hasInterrupts, reportUnhandledInterrupts, resolveCliInterrupts, reportBudgetExceededAndExit, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   runExportedFunction as _runExportedFunction,
@@ -305,6 +305,7 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
     const __result = await main(initialState);
     await resolveCliInterrupts(__result, respondToInterrupts)
   } catch (__error: any) {
+    reportBudgetExceededAndExit(__error)
     console.error(`
 Agent crashed: ${__error.message}`)
     throw __error


### PR DESCRIPTION
Part 3 of 3 of the CLI cost/time guards plan (`docs/superpowers/plans/2026-07-13-cli-cost-time-guards.md`). Follows #547 (time semantics) and #549 (per-branch time budgets), and closes out the stream.

## What this adds

`agency run` and `agency agent` accept `--max-cost <dollars>` and `--max-time <duration>`:

- Flags resolve to `AGENCY_MAX_COST` / `AGENCY_MAX_TIME` on the spawned child — cleared-then-set exactly like `--policy`, so the env vars are an internal carrier and a stale value from the parent shell can never constrain a run behind the user's back.
- The child installs a root `CostGuard`/`TimeGuard` in `runNode`, next to the run-policy handler, under the same `isIpcMode` root-process gate (IPC subprocesses are metered by the parent's guard through the branch clone from #549). The disable rules match the guard design: cost `< 0` off, cost `0` = no paid spend (local-models-only), time `<= 0` off.
- A tripped budget exits with code **3** (`EXIT_CODE_BUDGET_EXCEEDED`, distinct from 1 = crash and 2 = usage error) and prints a one-line overrun message. Detection in the compiled entry's catch is by guard-trip CAUSE, not error class: a root time trip usually surfaces as an aborted in-flight leaf op (`AgencyCancelledError` carrying the `guardTrip` cause) rather than a `GuardExceededError` — the end-to-end test caught exactly this.
- `--max-time` requires an explicit unit (`500ms`, `30s`, `5m`, `1h`); a bare number is a usage error so a value's meaning is never guessed. `--max-cost` is bare dollars.

## Testing

- Unit: duration parsing (units, leading-minus disable, unitless rejection), budget resolution, root-guard install rules (6 cases), trip formatting and both trip-delivery shapes (GuardExceededError and cancelled-leaf-with-cause), agent env carrier set/cleared via injected spawn.
- End-to-end spawn tests against the built CLI: `--max-time 100ms` on a 2s sleeper exits 3 with `Exceeded time limit`; a bare `--max-time 300` exits 2; an inherited `AGENCY_MAX_TIME` with no flag does not leak (the sleeper completes).
- Fixture regen: every compiled fixture's entry catch gains the `reportBudgetExceededAndExit(__error)` line plus its import — 93 files, nothing else changed.
- 435 unit tests across `lib/cli` + the new runtime files; structural linter clean; guard fixtures smoke-tested.

## Docs

`docs/site/cli/run.md` and `docs/site/cli/agent.md` document both flags, the units rule, the `cost: 0` local-only trick, and exit code 3. The guards guide (`docs/site/guide/guards.md`) is deliberately untouched per the #549 review; note it still carries the pre-#549 fork-limitation paragraph — happy to do a docs-only pass with whatever framing you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
