### PR TITLE
Add saveDraft: salvage partial work when a guard trips

### DIFF
--- a/docs/superpowers/plans/2026-07-14-save-draft-guards.md
+++ b/docs/superpowers/plans/2026-07-14-save-draft-guards.md
@@ -17,6 +17,9 @@
 - **After any change under `stdlib/` or `lib/`, run `make`** (regenerates stdlib `.js` + runtime). **After editing any `.mustache`, run `pnpm run templates` first.** (per CLAUDE.md)
 - **Agency execution tests run with `pnpm run agency test <file>`**; lib unit tests with `pnpm test:run <file>`. **Save test output to a file** (tests are slow/expensive — redirect and read the file).
 - Banned patterns (per `docs/dev/coding-standards.md`): no dynamic imports; objects not maps; arrays not sets; `type` not `interface`.
+- **Commit convention** (per repo history this week): write the message to a temp file and `git commit -F <file>` (apostrophes break `-m`); **plain imperative subject, no `feat(...)`/`fix(...)`/`test(...)` prefixes**; end the message with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. The commit steps below show a subject line — write it (plus the Co-Authored-By line) to a file and commit with `-F`.
+- **Branch:** work happens on `worktree-save-draft-guards`; **rename it to `save-draft-guards` before pushing** (the auto worktree- prefix is dropped by convention). Never commit to `main`; re-check `git branch --show-current` before each commit.
+- **Regenerate before running:** after editing a `.mustache`, `pnpm run templates`; after any `stdlib/` or `lib/` change, `make`. Commit regenerated `.ts`/`.js` artifacts alongside their sources.
 
 ---
 
@@ -211,7 +214,8 @@ Expected: PASS (7 tests).
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
 git add packages/agency-lang/lib/runtime/drafts.ts packages/agency-lang/lib/runtime/drafts.test.ts packages/agency-lang/lib/runtime/index.ts
-git commit -m "feat(saveDraft): branch-local draft store (StateStack.other)"
+printf '%s\n' "Add branch-local draft store for saveDraft (StateStack.other)" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
+git commit -F /tmp/sd-commit.txt
 ```
 
 ---
@@ -284,7 +288,8 @@ In `packages/agency-lang/lib/stdlib/thread.ts`, add near the guard helpers (afte
 ```ts
 import { writeDraft, readOutermostDraft, sweepDrafts } from "../runtime/drafts.js";
 import { success, isFailure } from "../runtime/result.js";
-import type { ResultValue, ResultFailure } from "../runtime/result.js";
+import { hasInterrupts } from "../runtime/interrupts.js";
+import type { ResultValue } from "../runtime/result.js";
 ```
 
 Then add:
@@ -305,9 +310,34 @@ export function _saveDraft(value: unknown): void {
 }
 ```
 
-- [ ] **Step 4: Modify `_runGuarded` to salvage on trip and sweep on exit**
+- [ ] **Step 4a: Thread the tripping guard's id into the failure**
 
-In `packages/agency-lang/lib/stdlib/thread.ts`, replace the body of `_runGuarded` (currently just `return __tryCall(...)`) with:
+Shape (`error.type`) is NOT ownership: a block can *return* an inner guard's
+failure value, which `__tryCall` passes through untouched (`result.ts:178`), so a
+guardFailure-shaped value can reach an outer `_runGuarded` without the outer
+guard tripping. We must salvage only when the failure came from **this** guard's
+own trip — so carry the `guardId`.
+
+In `packages/agency-lang/lib/runtime/result.ts`, change `guardFailureData` to
+accept and emit a `guardId` (additive internal field; existing `type`/`maxCost`/…
+consumers are unaffected). Update the signature/return type to add
+`guardId: string` and include `guardId` in BOTH returned objects (the `time` and
+the cost branch). Then at its single call site (the owned-guard branch, ~L212),
+pass the id:
+
+```ts
+return failure(
+  guardFailureData(guardCause.dimension, guardCause.limit, guardCause.spent, guardCause.guardId),
+  opts,
+);
+```
+
+- [ ] **Step 4b: Minimal edit to `_runGuarded` — salvage on OWN trip, never on interrupt**
+
+In `packages/agency-lang/lib/stdlib/thread.ts`, edit `_runGuarded` with the
+smallest change: **keep the existing `__tryCall(...)` call and its opts verbatim**
+(do not re-assert `checkpoint`/`functionName`/`args` — copy whatever the current
+source passes), capture `entryDepth` before it, and post-process its result:
 
 ```ts
 export async function _runGuarded(
@@ -317,6 +347,8 @@ export async function _runGuarded(
   const { ctx, stack } = getRuntimeContext();
   // Frames of the block + everything it calls live at indices >= entryDepth.
   const entryDepth = stack.stack.length;
+
+  // --- KEEP THE EXISTING __tryCall CALL EXACTLY AS IT IS TODAY ---
   const result = await __tryCall(
     () => __call(block, { type: "positional", args: [] }),
     {
@@ -326,27 +358,25 @@ export async function _runGuarded(
       args: stack.lastFrame()?.args,
     },
   );
+  // --- END unchanged call ---
 
-  // Salvage: a guardFailureData-shaped failure is produced ONLY by __tryCall's
-  // owned-guard branch, so its presence here means THIS guard tripped. If a
-  // draft was saved under it, return the outermost draft instead of the failure.
+  // The block PAUSED on an interrupt (not done). Pass the interrupts through
+  // untouched and DO NOT sweep — its drafts must survive to resume.
+  if (hasInterrupts(result)) return result;
+
+  // Salvage only when THIS guard tripped: the converted failure carries our
+  // guardId (Step 4a). A propagated inner failure carries a different id and is
+  // returned as-is. A non-guard failure has no guardId → not salvaged.
   let out: ResultValue = result;
-  if (isFailure(result) && isGuardTripFailure(result)) {
+  if (isFailure(result) && ids.includes((result.error as { guardId?: string })?.guardId as string)) {
     const draft = readOutermostDraft(stack, entryDepth);
     if (draft !== undefined) out = success(draft.value);
   }
 
-  // Clean this guard's region on BOTH outcomes so drafts never leak into a
+  // Clean this guard's region on non-interrupt exits so drafts never leak into a
   // later sibling guard or an outer guard.
   sweepDrafts(stack, entryDepth);
   return out;
-}
-
-/** A failure whose error carries GuardFailureData — produced only by the
- *  owned-guard conversion in __tryCall, i.e. this guard's own trip. */
-function isGuardTripFailure(f: ResultFailure): boolean {
-  const t = (f.error as { type?: string } | null | undefined)?.type;
-  return t === "guardFailure" || t === "timeoutFailure";
 }
 ```
 
@@ -512,13 +542,70 @@ node main() {
 
 `save-draft-nested-guards.test.json`: `"expectedOutput": "\"true\""`, `"llmMocks": [{ "return": "pong" }, { "return": "pong" }]`. (Inner trips on the first call and salvages `inner-draft`, sweeping its region; the second call pushes the outer over 0.000003 and it trips with no draft of its own — the swept inner draft must not be read, so `outer` is a failure.)
 
-- [ ] **Step 9: Run all six new tests**
+`save-draft-propagated-failure.agency` (a returned inner failure must NOT be salvaged by the outer guard — pins Step 4a's guardId ownership):
 
-Run each and save output, e.g.:
+```
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const outer = guard(cost: 10.0) as {           // generous — outer never trips
+    saveDraft("outer-draft")
+    const inner = guard(cost: 0.000001) as {      // inner trips, saves nothing
+      const reply = llm("Reply with: pong")
+      return reply
+    }
+    return inner                                  // deliberately propagate the failure
+  }
+  return "${isFailure(outer)}"
+}
+```
+
+`save-draft-propagated-failure.test.json`: `"expectedOutput": "\"true\""`, `"useTestLLMProvider": true`, `"llmMocks": [{ "return": "pong" }]`. (Without ownership-by-guardId, the outer would wrongly salvage `"outer-draft"` → `"false"`.)
+
+`save-draft-time-trip.agency` (salvage on a TIME trip — a different delivery path than cost, aborted-leaf with a guardTrip cause; use a ≥500ms budget for CI stability):
+
+```
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const result = guard(time: 500ms) as {
+    saveDraft("timed-draft")
+    sleep(2000)                 // exceeds 500ms → time trip
+    return "done"
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}
+```
+
+`save-draft-time-trip.test.json`: `"expectedOutput": "\"timed-draft\""`, `"evaluationCriteria": [{ "type": "exact" }]` (no LLM provider / mocks needed — the trip is time-based).
+
+`save-draft-interrupt-resume.agency` (the pre-interrupt draft survives an interrupt/resume cycle and is salvaged on a later trip — pins the no-sweep-on-interrupt rule / spec test #6):
+
+```
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const result = guard(time: 500ms) as {
+    saveDraft("pre-interrupt")
+    interrupt("continue?")      // pause; harness approves → resume
+    sleep(2000)                 // after resume, exceed 500ms → trip
+    return "done"
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}
+```
+
+`save-draft-interrupt-resume.test.json`: `"expectedOutput": "\"pre-interrupt\""`, `"evaluationCriteria": [{ "type": "exact" }]`, `"interruptHandlers": [{ "action": "approve" }]`.
+
+- [ ] **Step 9: Run all new behavior tests**
+
+Run each and save output:
 
 ```
 cd packages/agency-lang
-for t in no-draft last-wins outermost sequential-guards nested-guards; do
+for t in no-draft last-wins outermost sequential-guards nested-guards propagated-failure time-trip interrupt-resume; do
   pnpm run agency test tests/agency/guards/save-draft-$t.agency > /tmp/sd-$t.txt 2>&1
   echo "== $t =="; tail -5 /tmp/sd-$t.txt
 done
@@ -529,8 +616,9 @@ Expected: all PASS.
 
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
-git add packages/agency-lang/lib/stdlib/thread.ts packages/agency-lang/stdlib/thread.agency packages/agency-lang/tests/agency/guards/save-draft-*.agency packages/agency-lang/tests/agency/guards/save-draft-*.test.json packages/agency-lang/stdlib/
-git commit -m "feat(saveDraft): salvage outermost draft on guard trip; sweep region"
+git add packages/agency-lang/lib/runtime/result.ts packages/agency-lang/lib/stdlib/thread.ts packages/agency-lang/stdlib/thread.agency packages/agency-lang/tests/agency/guards/save-draft-*.agency packages/agency-lang/tests/agency/guards/save-draft-*.test.json packages/agency-lang/stdlib/
+printf '%s\n' "Salvage outermost draft on guard trip (guardId ownership; sweep region)" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
+git commit -F /tmp/sd-commit.txt
 ```
 
 ---
@@ -540,7 +628,9 @@ git commit -m "feat(saveDraft): salvage outermost draft on guard trip; sweep reg
 **Files:**
 - Modify: `packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache` (add `__clearTopFrameDraft` to the runtime import)
 - Modify: `packages/agency-lang/lib/backends/typescriptBuilder.ts` (def `finally`: clear before pop)
+- Modify: `packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache` (block: clear on normal completion)
 - Create: `packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.agency` (+ `.test.json`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-stale-block.agency` (+ `.test.json`)
 
 **Interfaces:**
 - Consumes: `__clearTopFrameDraft` (Task 1), exported from `agency-lang/runtime`; the generated `__functionCompleted` local and `__stateStack()` accessor (already in the def `finally`).
@@ -579,10 +669,48 @@ node main() {
 
 Create `save-draft-stale-sibling.test.json`: `"expectedOutput": "\"failed\""`, `"useTestLLMProvider": true`, `"llmMocks": [{ "return": "pong" }]`.
 
+Also create `packages/agency-lang/tests/agency/guards/save-draft-stale-block.agency` (the block-frame analogue — pins Step 5b). `withLabel` mirrors `guard`'s own trailing-block signature (`block: () -> any = null`), so the `as { }` call form parses; verify against `stdlib/thread.agency`'s `guard` def if unsure:
+
+```
+import { guard, saveDraft } from "std::thread"
+
+// A user combinator that runs a block on the CURRENT stack. Its block saves a
+// draft and completes NORMALLY (never cleared without Step 5b); then a sibling
+// trips and must NOT salvage the stale block draft.
+def withLabel(block: () -> any = null): any {
+  return block()
+}
+
+def tripper(): string {
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const x = withLabel() as {
+      saveDraft("stale-block")
+      return 1
+    }
+    const b = tripper()
+    return b
+  }
+  if (isSuccess(result)) { return "leaked:${result.value}" }
+  return "failed"
+}
+```
+
+Create `save-draft-stale-block.test.json`: `"expectedOutput": "\"failed\""`, `"useTestLLMProvider": true`, `"llmMocks": [{ "return": "pong" }]`.
+
 - [ ] **Step 2: Run it to verify it fails**
 
-Run: `cd packages/agency-lang && pnpm run agency test tests/agency/guards/save-draft-stale-sibling.agency > /tmp/sd-stale-1.txt 2>&1; tail -20 /tmp/sd-stale-1.txt`
-Expected: FAIL — output is `"leaked:stale"` (saver's draft is stale-read because it is never cleared).
+Run:
+```
+cd packages/agency-lang
+pnpm run agency test tests/agency/guards/save-draft-stale-sibling.agency > /tmp/sd-stale-1.txt 2>&1; tail -8 /tmp/sd-stale-1.txt
+pnpm run agency test tests/agency/guards/save-draft-stale-block.agency > /tmp/sd-block-1.txt 2>&1; tail -8 /tmp/sd-block-1.txt
+```
+Expected: BOTH FAIL — `stale-sibling` outputs `"leaked:stale"` (def draft never cleared) and `stale-block` outputs `"leaked:stale-block"` (block draft never cleared).
 
 - [ ] **Step 3: Add `__clearTopFrameDraft` to the generated runtime import**
 
@@ -625,6 +753,26 @@ ts.statements([
 
 (Only the first `ts.raw(...)` line is new; leave the rest of the block exactly as it is.)
 
+- [ ] **Step 5b: Clear block frames on normal completion too**
+
+Def frames aren't the only frames — a block-taking combinator's `as { }` block
+runs on the same stack and, if it saves a draft and completes normally, would
+leave a stale draft for a later sibling to salvage. Clear it in
+`packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache`.
+The template's `try` body ends with `return runner.halted ? runner.haltResult : undefined;`. Insert the clear as the last statement of the `try` body, **before** that return and gated on `!runner.halted`:
+
+```
+{{{body}}}
+if (!runner.halted) __clearTopFrameDraft(__bsetup.stateStack);
+return runner.halted ? runner.haltResult : undefined;
+```
+
+Why `!runner.halted`: a normal completion clears; a **halt** (interrupt) keeps the
+draft (so it survives resume — matches the no-sweep-on-interrupt rule); a **trip**
+throws before reaching this line, so the `finally` pops without clearing and the
+draft is kept for the boundary. `__clearTopFrameDraft` is already imported by the
+generated preamble (Step 3). Then re-run `pnpm run templates`.
+
 - [ ] **Step 6: Rebuild**
 
 Run: `cd packages/agency-lang && make > /tmp/sd-make-2.txt 2>&1; tail -15 /tmp/sd-make-2.txt`
@@ -634,20 +782,20 @@ Expected: build completes.
 
 ```
 cd packages/agency-lang
-pnpm run agency test tests/agency/guards/save-draft-stale-sibling.agency > /tmp/sd-stale-2.txt 2>&1; tail -8 /tmp/sd-stale-2.txt
-for t in basic no-draft last-wins outermost sequential-guards nested-guards; do
+for t in stale-sibling stale-block basic no-draft last-wins outermost sequential-guards nested-guards propagated-failure time-trip interrupt-resume; do
   pnpm run agency test tests/agency/guards/save-draft-$t.agency > /tmp/sd-re-$t.txt 2>&1
   echo "== $t =="; tail -3 /tmp/sd-re-$t.txt
 done
 ```
-Expected: stale-sibling PASSes (`"failed"`); all six earlier tests still PASS.
+Expected: `stale-sibling` and `stale-block` PASS (`"failed"`); all earlier tests still PASS.
 
 - [ ] **Step 8: Commit**
 
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
-git add packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts packages/agency-lang/lib/backends/typescriptBuilder.ts packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.*
-git commit -m "feat(saveDraft): clear a frame's draft on normal completion (no stale salvage)"
+git add packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts packages/agency-lang/lib/backends/typescriptBuilder.ts packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.* packages/agency-lang/tests/agency/guards/save-draft-stale-block.*
+printf '%s\n' "Clear frame drafts on normal completion (def finally + block)" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
+git commit -F /tmp/sd-commit.txt
 ```
 
 ---
@@ -697,7 +845,8 @@ Expected: PASS — `"a|b|c"` (each branch salvages its own draft; no clobber). I
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
 git add packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.*
-git commit -m "test(saveDraft): fork branches salvage their own drafts (branch-local)"
+printf '%s\n' "Test fork branches salvage their own drafts (branch-local)" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
+git commit -F /tmp/sd-commit.txt
 ```
 
 ---
@@ -781,6 +930,8 @@ if (
 
 > Adjust `arg.value ?? arg` to however the AST exposes a positional argument's expression in this codebase (grep how `checkArgsAgainstParams` reads positional arg expressions — match that exactly). The `checkType(expr, expectedType, scope, label, ctx)` signature is the one used in `checkReturnTypesInScope`.
 
+> **Known limitation (state it, don't hide it):** for a `saveDraft` called *directly* inside a bare `guard(...) as { }` block, the enclosing scope's `returnType` is the block's type, which today is `any` (guard's `block` param is `() -> any`). So `info.returnType` is `any`/undefined there and the draft goes **unchecked** in that position — only drafts inside a typed `def`/`node` are checked. This matches the spec's note. Add a one-line caveat to the `saveDraft` docstring (Task 2 Step 5) — e.g. "type-checked against the enclosing function/node's return type" — so the checked scope is explicit. Do NOT attempt block-scope expected-type inference in this task.
+
 - [ ] **Step 4: Run the type-checker test to verify it passes**
 
 Run: `cd packages/agency-lang && pnpm test:run lib/typeChecker/saveDraft.test.ts > /tmp/sd-tc-2.txt 2>&1; tail -20 /tmp/sd-tc-2.txt`
@@ -796,7 +947,8 @@ Expected: the type-checker unit suite is green.
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
 git add packages/agency-lang/lib/typeChecker/checker.ts packages/agency-lang/lib/typeChecker/saveDraft.test.ts
-git commit -m "feat(saveDraft): type-check the draft against the enclosing return type"
+printf '%s\n' "Type-check saveDraft argument against enclosing return type" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
+git commit -F /tmp/sd-commit.txt
 ```
 
 ---
@@ -843,16 +995,18 @@ Expected: green.
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
 git add packages/agency-lang/docs/site/stdlib/thread.md packages/agency-lang/stdlib/
-git commit -m "docs(saveDraft): regenerate stdlib reference"
+printf '%s\n' "Regenerate stdlib reference for saveDraft" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
+git commit -F /tmp/sd-commit.txt
 ```
 
 - [ ] **Step 5: Push and open a PR (only when the user asks)**
 
-Do not push or open a PR unless the user requests it. When they do:
+Do not push or open a PR unless the user requests it. When they do — **rename the branch off the `worktree-` prefix first** (repo convention):
 
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
-git push -u origin worktree-save-draft-guards
+git branch -m save-draft-guards
+git push -u origin save-draft-guards
 ```
 Then open a PR whose body summarizes: the anytime-algorithm motivation, `StateStack.other` storage + clearing rule, outermost-wins/type-safety, and the deferred follow-ups (`finalize`, deep/fork salvage, `sigint`/`sigkill`, LLM-tool exposure, `Both`).
 
@@ -863,13 +1017,15 @@ Then open a PR whose body summarizes: the anytime-algorithm motivation, `StateSt
 **Spec coverage:**
 - `saveDraft(v)` statement-form builtin → Task 2 (Steps 3, 5).
 - Branch-local `StateStack.other` storage keyed by frame depth → Task 1; branch-locality proven in Task 4.
-- Trip read (outermost-set-wins) + sweep → Task 2 (Step 4).
-- Clearing rule (normal completion clears; abort keeps) → Task 3.
+- Trip read (outermost-set-wins) with **guardId ownership** (not shape) + sweep → Task 2 (Steps 4a/4b); propagated-inner-failure fixture proves ownership.
+- **No sweep on the interrupt path** (paused block keeps its drafts) → Task 2 (Step 4b) + interrupt-resume fixture.
+- Clearing rule (normal completion clears; abort/interrupt keeps) → Task 3, **both def frames (Step 5) AND block frames (Step 5b)**; stale-sibling + stale-block fixtures.
 - Additivity (no draft ⇒ failure unchanged) → Task 2 (no-draft test) + Task 6 (guard-cost-trip regression).
-- Type-check against enclosing return type + name-keyed aliasing caveat → Task 5.
-- Interrupt/resume survival → Task 1 serialization round-trip unit test.
+- Time-trip salvage (different delivery path) → Task 2 time-trip fixture.
+- Type-check against enclosing return type + name-keyed aliasing caveat + bare-guard-block `any` limitation → Task 5.
+- Interrupt/resume survival → Task 1 serialization round-trip unit test + Task 2 interrupt-resume execution fixture.
 - Deferred items (`finalize`, deep/fork salvage, `sigint`/`sigkill`, tool exposure, `Both`, root budgets) → out of scope, unchanged; noted in PR body (Task 6).
 
 **Placeholder scan:** every code step shows the code; every test step shows the command and expected output. Two spots say "match the sibling test harness / positional-arg accessor" (Task 5) — these are deliberate: they instruct the engineer to mirror verified existing code rather than invent an API, because the exact harness entry point and AST arg-accessor must match this codebase's conventions.
 
-**Type consistency:** `writeDraft` / `readOutermostDraft` / `sweepDrafts` / `__clearTopFrameDraft` names and signatures are identical across Tasks 1, 2, 3. `_saveDraft` (TS) ↔ `saveDraft` (Agency def) wiring is consistent. `_runGuarded`'s new `isGuardTripFailure` reads `f.error.type` matching `guardFailureData`'s shape from `result.ts`. `entryDepth = stack.stack.length` (captured before `__call`) aligns with `writeDraft` keying at `stack.stack.length - 2` (caller frame) and `__clearTopFrameDraft` at `stack.stack.length - 1` (completing frame) — verified consistent in the spec's depth walk-through.
+**Type consistency:** `writeDraft` / `readOutermostDraft` / `sweepDrafts` / `__clearTopFrameDraft` names and signatures are identical across Tasks 1, 2, 3. `_saveDraft` (TS) ↔ `saveDraft` (Agency def) wiring is consistent. `_runGuarded` gates salvage on `ids.includes(result.error.guardId)` where `guardId` is added to `guardFailureData` in Task 2 Step 4a — ownership, not shape. `entryDepth = stack.stack.length` (captured before `__call`) aligns with `writeDraft` keying at `stack.stack.length - 2` (caller frame), `__clearTopFrameDraft` at `stack.stack.length - 1` (completing frame), and the block clear at the same `length - 1` — verified consistent in the spec's depth walk-through. Interrupt handling matches `__tryCall`'s own `hasInterrupts` passthrough (`result.ts:177`).

--- a/docs/superpowers/plans/2026-07-14-save-draft-guards.md
+++ b/docs/superpowers/plans/2026-07-14-save-draft-guards.md
@@ -31,12 +31,13 @@
 - Modify: `packages/agency-lang/lib/runtime/index.ts` (add one export line)
 
 **Interfaces:**
-- Consumes: `StateStack` from `./state/stateStack.js` (its `stack: State[]` array and `other: Record<string, any>`).
+- Consumes: `StateStack` from `./state/stateStack.js`; `deepClone` (`./utils.js`); `isFailure`/`success`/`ResultValue` (`./result.js`); `hasInterrupts` (`./interrupts.js`).
 - Produces (used by Tasks 2 & 3):
-  - `writeDraft(stack: StateStack, depth: number, value: unknown): void`
-  - `readOutermostDraft(stack: StateStack, entryDepth: number): { value: any } | undefined`
-  - `sweepDrafts(stack: StateStack, entryDepth: number): void`
-  - `__clearTopFrameDraft(stack: StateStack | undefined): void`
+  - `writeCallerDraft(stack: StateStack, value: unknown): void` — deep-clones + keys the caller frame (public write; callers never touch an index).
+  - `draftRegionStart(stack: StateStack): number` — the region marker for a guard entered now.
+  - `salvageOwnTrip(stack, region, ids, result)` — interrupt-passthrough + own-trip salvage + sweep, in one declarative op.
+  - `writeDraft(stack, depth, value)` — low-level depth-keyed write (internal + unit tests).
+  - `readOutermostDraft(stack, region)`, `sweepDrafts(stack, region)`, `__clearTopFrameDraft(stack)`.
 
 - [ ] **Step 1: Write the failing unit test**
 
@@ -45,10 +46,14 @@ Create `packages/agency-lang/lib/runtime/drafts.test.ts`:
 ```ts
 import { describe, it, expect } from "vitest";
 import { StateStack, State } from "./state/stateStack.js";
+import { failure, success } from "./result.js";
 import {
   writeDraft,
+  writeCallerDraft,
+  draftRegionStart,
   readOutermostDraft,
   sweepDrafts,
+  salvageOwnTrip,
   __clearTopFrameDraft,
 } from "./drafts.js";
 
@@ -59,11 +64,10 @@ function stackWithFrames(n: number): StateStack {
 }
 
 describe("draft store", () => {
-  it("writes and reads a single draft (outermost = shallowest >= entryDepth)", () => {
+  it("reads the outermost (shallowest) draft at or above the region", () => {
     const s = stackWithFrames(4);
     writeDraft(s, 2, "code");
     writeDraft(s, 3, "verify");
-    // entryDepth 1: both are under the guard; outermost is depth 2.
     expect(readOutermostDraft(s, 1)?.value).toBe("code");
   });
 
@@ -74,17 +78,16 @@ describe("draft store", () => {
     expect(readOutermostDraft(s, 0)?.value).toBe("second");
   });
 
-  it("returns undefined when nothing is at or above entryDepth", () => {
+  it("returns undefined when nothing is at or above the region", () => {
     const s = stackWithFrames(3);
     writeDraft(s, 1, "shallow");
     expect(readOutermostDraft(s, 2)).toBeUndefined();
   });
 
-  it("sweep deletes every draft at depth >= entryDepth", () => {
+  it("sweep deletes every draft at depth >= region", () => {
     const s = stackWithFrames(4);
     writeDraft(s, 1, "keep");
     writeDraft(s, 2, "drop");
-    writeDraft(s, 3, "drop2");
     sweepDrafts(s, 2);
     expect(readOutermostDraft(s, 0)?.value).toBe("keep");
     expect(readOutermostDraft(s, 2)).toBeUndefined();
@@ -99,6 +102,56 @@ describe("draft store", () => {
     expect(readOutermostDraft(s, 2)).toBeUndefined();
   });
 
+  it("writeCallerDraft keys the caller frame (one below the helper's top)", () => {
+    const s = stackWithFrames(4); // helper 'top' = index 3, caller = index 2
+    writeCallerDraft(s, "from-caller");
+    expect(readOutermostDraft(s, 2)?.value).toBe("from-caller");
+    expect(readOutermostDraft(s, 3)).toBeUndefined();
+  });
+
+  it("writeCallerDraft is a no-op with no caller (module/global scope)", () => {
+    const s = stackWithFrames(1); // callerDepth = -1
+    writeCallerDraft(s, "x");
+    expect(readOutermostDraft(s, 0)).toBeUndefined();
+  });
+
+  it("deep-clones on save (later mutation does not change the salvage)", () => {
+    const s = stackWithFrames(3);
+    const report = { text: "v1" };
+    writeCallerDraft(s, report); // caller = index 1
+    report.text = "v2";
+    expect(readOutermostDraft(s, 1)?.value).toEqual({ text: "v1" });
+  });
+
+  it("draftRegionStart marks the current stack depth", () => {
+    const s = stackWithFrames(3);
+    expect(draftRegionStart(s)).toBe(3);
+  });
+
+  it("salvageOwnTrip salvages ONLY on this guard's own trip", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "best");
+    const ownTrip = failure({ type: "guardFailure", guardId: "g1" });
+    expect(salvageOwnTrip(s, 0, ["g1"], ownTrip)).toEqual(success("best"));
+  });
+
+  it("salvageOwnTrip does NOT salvage a propagated (foreign-id) failure", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "best");
+    const foreign = failure({ type: "guardFailure", guardId: "inner" });
+    // returned untouched; region still swept
+    expect(salvageOwnTrip(s, 0, ["g1"], foreign)).toBe(foreign);
+    expect(readOutermostDraft(s, 0)).toBeUndefined();
+  });
+
+  it("salvageOwnTrip passes interrupts through WITHOUT sweeping", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "best");
+    const interrupts = [{ __type: "interrupt" }] as any;
+    expect(salvageOwnTrip(s, 0, ["g1"], interrupts)).toBe(interrupts);
+    expect(readOutermostDraft(s, 0)?.value).toBe("best"); // NOT swept
+  });
+
   it("survives StateStack serialization round-trip", () => {
     const s = stackWithFrames(3);
     writeDraft(s, 2, { report: "partial" });
@@ -109,12 +162,14 @@ describe("draft store", () => {
   it("tolerates a stack with no drafts", () => {
     const s = stackWithFrames(2);
     expect(readOutermostDraft(s, 0)).toBeUndefined();
-    sweepDrafts(s, 0); // no throw
-    __clearTopFrameDraft(s); // no throw
-    __clearTopFrameDraft(undefined); // no throw
+    sweepDrafts(s, 0);
+    __clearTopFrameDraft(s);
+    __clearTopFrameDraft(undefined);
   });
 });
 ```
+
+> The `salvageOwnTrip` interrupt case constructs a stand-in `Interrupt[]`; confirm the shape `hasInterrupts` recognizes (grep `hasInterrupts` in `lib/runtime/interrupts.ts`) and match it — do not guess the marker.
 
 - [ ] **Step 2: Run the test to verify it fails**
 
@@ -127,69 +182,118 @@ Create `packages/agency-lang/lib/runtime/drafts.ts`:
 
 ```ts
 import type { StateStack } from "./state/stateStack.js";
+import type { ResultValue } from "./result.js";
+import { deepClone } from "./utils.js";
+import { isFailure, success } from "./result.js";
+import { hasInterrupts } from "./interrupts.js";
 
 /** A saved best-so-far value. Wrapped so a stored `null`/`undefined` value is
  *  distinct from "no draft for this frame". */
 type DraftRecord = { value: any };
 
-/** Branch-local, serialized store: frame depth -> its latest draft. Lives in
- *  `StateStack.other` (NOT on `State`) because frames are popped by the unwind
- *  before a guard boundary reads them — `other` outlives frame pops. See
- *  docs/superpowers/specs/2026-07-14-save-draft-guards-design.md. */
-function draftsOf(stack: StateStack): Record<number, DraftRecord> {
-  const other = stack.other as Record<string, any>;
-  if (!other.drafts) other.drafts = {};
-  return other.drafts as Record<number, DraftRecord>;
+// Branch-local, serialized store: frame depth -> its latest draft. Lives in
+// `StateStack.other` (NOT on `State`) because frames are popped by the unwind
+// before a guard boundary reads them — `other` outlives frame pops. Depth
+// arithmetic is centralized here so no caller ever touches a stack index. See
+// docs/superpowers/specs/2026-07-14-save-draft-guards-design.md.
+
+/** The draft map on this stack, or undefined if none written yet. `other` is
+ *  already typed `Record<string, any>`, so no cast is needed. */
+function peekDrafts(stack: StateStack): Record<number, DraftRecord> | undefined {
+  return stack.other.drafts as Record<number, DraftRecord> | undefined;
 }
 
-/** Record `value` as the draft for the frame at `depth` (last call wins). */
+function ensureDrafts(stack: StateStack): Record<number, DraftRecord> {
+  if (!stack.other.drafts) stack.other.drafts = {};
+  return stack.other.drafts as Record<number, DraftRecord>;
+}
+
+/** Depth of the frame that CALLED the current TS helper — the Agency scope
+ *  whose draft this is. Mirrors `StateStack.callerFrame()` (one frame below the
+ *  helper's own top frame). -1 when there is no caller (module-init/global). */
+function callerDepth(stack: StateStack): number {
+  return stack.stack.length - 2;
+}
+
+/** Record the caller frame's best-so-far draft (last call wins). The value is
+ *  DEEP-CLONED at save time so a later mutation of the saved object can't change
+ *  the salvage, and so a live-trip salvage matches a post-resume salvage (which
+ *  reads the checkpoint's clone). Matches Agency's value semantics. */
+export function writeCallerDraft(stack: StateStack, value: unknown): void {
+  const depth = callerDepth(stack);
+  if (depth < 0) return; // no caller: harmless no-op
+  writeDraft(stack, depth, value);
+}
+
+/** Low-level depth-keyed write (used by writeCallerDraft and unit tests). */
 export function writeDraft(stack: StateStack, depth: number, value: unknown): void {
-  draftsOf(stack)[depth] = { value };
+  ensureDrafts(stack)[depth] = { value: deepClone(value) };
 }
 
-/** The outermost draft under a guard: the smallest depth >= `entryDepth` that
- *  has a draft. Undefined if none. Outermost (not deepest) is the type-closest
- *  choice to the guarded block's type — see the spec. */
+/** The region marker for a guard entered now: drafts at depth >= this are
+ *  "under" the guard. A positional marker is inherent (frames pop before the
+ *  boundary reads), but its meaning lives in this named function. */
+export function draftRegionStart(stack: StateStack): number {
+  return stack.stack.length;
+}
+
+/** The outermost draft under a guard: the shallowest depth >= `region`, or
+ *  undefined. Outermost (not deepest) is the type-closest choice — see spec. */
 export function readOutermostDraft(
   stack: StateStack,
-  entryDepth: number,
+  region: number,
 ): DraftRecord | undefined {
-  const drafts = (stack.other as Record<string, any>).drafts as
-    | Record<number, DraftRecord>
-    | undefined;
+  const drafts = peekDrafts(stack);
   if (!drafts) return undefined;
-  let best = Infinity;
-  for (const key of Object.keys(drafts)) {
-    const d = Number(key);
-    if (d >= entryDepth && d < best) best = d;
-  }
-  return best === Infinity ? undefined : drafts[best];
+  const depths = Object.keys(drafts).map(Number).filter((d) => d >= region);
+  return depths.length === 0 ? undefined : drafts[Math.min(...depths)];
 }
 
-/** Delete every draft at depth >= `entryDepth`. Run on BOTH guard outcomes so a
- *  draft never leaks into a later sibling guard or an outer guard. */
-export function sweepDrafts(stack: StateStack, entryDepth: number): void {
-  const drafts = (stack.other as Record<string, any>).drafts as
-    | Record<number, DraftRecord>
-    | undefined;
+/** Delete every draft at depth >= `region`. */
+export function sweepDrafts(stack: StateStack, region: number): void {
+  const drafts = peekDrafts(stack);
   if (!drafts) return;
-  for (const key of Object.keys(drafts)) {
-    if (Number(key) >= entryDepth) delete drafts[Number(key)];
+  for (const d of Object.keys(drafts).map(Number)) {
+    if (d >= region) delete drafts[d];
   }
 }
 
-/** Clear the CURRENT top frame's draft. Called from generated code in the def
- *  `finally` ONLY on normal completion (`__functionCompleted`), so a frame that
- *  is unwinding on an abort keeps its draft for the guard boundary to read. */
+/** Turn a guarded block's settled result into the guard's final result:
+ *   1. a PAUSED block (interrupts) passes through untouched — no sweep, its
+ *      drafts must survive resume;
+ *   2. on THIS guard's OWN trip (failure whose `guardId` is in `ids`), salvage
+ *      the outermost draft in the region;
+ *   3. otherwise return the result unchanged;
+ *   then sweep the region on any settled exit. */
+export function salvageOwnTrip(
+  stack: StateStack,
+  region: number,
+  ids: string[],
+  result: ResultValue | unknown,
+): ResultValue | unknown {
+  if (hasInterrupts(result)) return result;
+  let out = result;
+  const guardId = (isFailure(result) ? (result.error as { guardId?: string }) : undefined)?.guardId;
+  if (guardId !== undefined && ids.includes(guardId)) {
+    const draft = readOutermostDraft(stack, region);
+    if (draft !== undefined) out = success(draft.value);
+  }
+  sweepDrafts(stack, region);
+  return out;
+}
+
+/** Clear the CURRENT top frame's draft. Called from generated code (def
+ *  `finally` on `__functionCompleted`; block try-body on `!runner.halted`), so a
+ *  frame unwinding on an abort/interrupt keeps its draft for the boundary. */
 export function __clearTopFrameDraft(stack: StateStack | undefined): void {
   if (!stack) return;
-  const drafts = (stack.other as Record<string, any>).drafts as
-    | Record<number, DraftRecord>
-    | undefined;
+  const drafts = peekDrafts(stack);
   if (!drafts) return;
   delete drafts[stack.stack.length - 1];
 }
 ```
+
+> Note: `salvageOwnTrip` imports `isFailure`/`success` (`./result.js`) and `hasInterrupts` (`./interrupts.js`). Neither of those imports `drafts.js`, so there's no cycle.
 
 - [ ] **Step 4: Export from the runtime index**
 
@@ -198,8 +302,11 @@ In `packages/agency-lang/lib/runtime/index.ts`, add after the `export { StateSta
 ```ts
 export {
   writeDraft,
+  writeCallerDraft,
+  draftRegionStart,
   readOutermostDraft,
   sweepDrafts,
+  salvageOwnTrip,
   __clearTopFrameDraft,
 } from "./drafts.js";
 ```
@@ -286,9 +393,7 @@ Expected: FAIL — `saveDraft` is not defined / unknown import from `std::thread
 In `packages/agency-lang/lib/stdlib/thread.ts`, add near the guard helpers (after `_popGuard`). First ensure the imports at the top of the file include:
 
 ```ts
-import { writeDraft, readOutermostDraft, sweepDrafts } from "../runtime/drafts.js";
-import { success, isFailure } from "../runtime/result.js";
-import { hasInterrupts } from "../runtime/interrupts.js";
+import { writeCallerDraft, draftRegionStart, salvageOwnTrip } from "../runtime/drafts.js";
 import type { ResultValue } from "../runtime/result.js";
 ```
 
@@ -296,17 +401,14 @@ Then add:
 
 ```ts
 /**
- * Impl of the Agency `saveDraft(value)` builtin. Records a best-so-far value
- * keyed to the CALLER's frame (the Agency function/block that called saveDraft),
- * so a tripping enclosing `guard` can salvage it. `saveDraft` is a thin one-frame
- * `def` wrapper, so the caller is exactly one frame below saveDraft's own frame.
- * With no caller (module-init/global scope) it is a harmless no-op.
+ * Impl of the Agency `saveDraft(value)` builtin. Records a best-so-far value for
+ * the CALLER's frame (the Agency function/block that called saveDraft), so a
+ * tripping enclosing `guard` can salvage it. The draft-store owns all frame
+ * arithmetic; this helper just forwards. No-op with no caller.
  */
 export function _saveDraft(value: unknown): void {
   const { stack } = getRuntimeContext();
-  const callerDepth = stack.stack.length - 2; // saveDraft's frame is on top
-  if (callerDepth < 0) return;
-  writeDraft(stack, callerDepth, value);
+  writeCallerDraft(stack, value);
 }
 ```
 
@@ -337,7 +439,9 @@ return failure(
 In `packages/agency-lang/lib/stdlib/thread.ts`, edit `_runGuarded` with the
 smallest change: **keep the existing `__tryCall(...)` call and its opts verbatim**
 (do not re-assert `checkpoint`/`functionName`/`args` — copy whatever the current
-source passes), capture `entryDepth` before it, and post-process its result:
+source passes), mark the region before it, and hand the result to
+`salvageOwnTrip` (which owns the interrupt-passthrough / own-trip-salvage / sweep
+policy — see Task 1). The function reads as three whats:
 
 ```ts
 export async function _runGuarded(
@@ -345,8 +449,7 @@ export async function _runGuarded(
   block: unknown,
 ): Promise<ResultValue> {
   const { ctx, stack } = getRuntimeContext();
-  // Frames of the block + everything it calls live at indices >= entryDepth.
-  const entryDepth = stack.stack.length;
+  const region = draftRegionStart(stack); // drafts saved under this guard sit at depth >= region
 
   // --- KEEP THE EXISTING __tryCall CALL EXACTLY AS IT IS TODAY ---
   const result = await __tryCall(
@@ -360,23 +463,7 @@ export async function _runGuarded(
   );
   // --- END unchanged call ---
 
-  // The block PAUSED on an interrupt (not done). Pass the interrupts through
-  // untouched and DO NOT sweep — its drafts must survive to resume.
-  if (hasInterrupts(result)) return result;
-
-  // Salvage only when THIS guard tripped: the converted failure carries our
-  // guardId (Step 4a). A propagated inner failure carries a different id and is
-  // returned as-is. A non-guard failure has no guardId → not salvaged.
-  let out: ResultValue = result;
-  if (isFailure(result) && ids.includes((result.error as { guardId?: string })?.guardId as string)) {
-    const draft = readOutermostDraft(stack, entryDepth);
-    if (draft !== undefined) out = success(draft.value);
-  }
-
-  // Clean this guard's region on non-interrupt exits so drafts never leak into a
-  // later sibling guard or an outer guard.
-  sweepDrafts(stack, entryDepth);
-  return out;
+  return salvageOwnTrip(stack, region, ids, result) as ResultValue;
 }
 ```
 
@@ -736,7 +823,10 @@ In `packages/agency-lang/lib/backends/typescriptBuilder.ts`, in the def `finally
 
 ```ts
 ts.statements([
-  ts.raw("if (__functionCompleted) __clearTopFrameDraft(__stateStack())"),
+  ts.if(
+    ts.id("__functionCompleted"),
+    ts.statements([ts.raw("__clearTopFrameDraft(__stateStack())")]),
+  ),
   ts.raw("__stateStack()?.pop()"),
   ...(skipHooks
     ? []
@@ -751,7 +841,7 @@ ts.statements([
 ]),
 ```
 
-(Only the first `ts.raw(...)` line is new; leave the rest of the block exactly as it is.)
+(Only the leading `ts.if(...)` clear is new — block form, not a one-line `if` (the structural linter bans one-line `if`s); leave the rest of the block exactly as it is.)
 
 - [ ] **Step 5b: Clear block frames on normal completion too**
 
@@ -763,11 +853,11 @@ The template's `try` body ends with `return runner.halted ? runner.haltResult : 
 
 ```
 {{{body}}}
-if (!runner.halted) __clearTopFrameDraft(__bsetup.stateStack);
+if (!runner.halted) { __clearTopFrameDraft(__bsetup.stateStack); }
 return runner.halted ? runner.haltResult : undefined;
 ```
 
-Why `!runner.halted`: a normal completion clears; a **halt** (interrupt) keeps the
+(Block braces, not a one-line `if` — the structural linter bans the latter.) Why `!runner.halted`: a normal completion clears; a **halt** (interrupt) keeps the
 draft (so it survives resume — matches the no-sweep-on-interrupt rule); a **trip**
 throws before reaching this line, so the `finally` pops without clearing and the
 draft is kept for the boundary. `__clearTopFrameDraft` is already imported by the
@@ -804,11 +894,20 @@ git commit -F /tmp/sd-commit.txt
 
 **Files:**
 - Create: `packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.agency` (+ `.test.json`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.agency` (+ `.test.json`)
 
 **Interfaces:**
-- Consumes: everything from Tasks 1-3 (no new code — this proves the branch-local property already holds because each branch owns its `StateStack`, hence its own `other.drafts`).
+- Consumes: everything from Tasks 1-3 (no new code — these prove the branch-local property already holds because each branch owns its `StateStack`, hence its own `other.drafts`).
 
-- [ ] **Step 1: Write the test**
+- [ ] **Step 0: Verify the `fork ... as x { }` return idiom first**
+
+Before writing the fixtures, confirm `fork([...]) as x { return ... }` yields an
+array indexable as `results[0]` (it does — see
+`tests/agency/fork/fork-active-thread-isolated.agency`, which does
+`branchIds[0] != parentId`). If the idiom differs in your tree, restructure the
+assertions (e.g. join the branch values via a def) rather than indexing.
+
+- [ ] **Step 1: Write the tests**
 
 Create `packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.agency`. Each fork branch has its OWN guard and saves its OWN draft; the trip in each branch must salvage that branch's value, with no cross-branch clobber:
 
@@ -835,17 +934,45 @@ node main() {
 
 Create `save-draft-fork-isolation.test.json`: `"expectedOutput": "\"a|b|c\""`, `"useTestLLMProvider": true`, `"llmMocks": [{ "return": "pong" }, { "return": "pong" }, { "return": "pong" }]`.
 
-- [ ] **Step 2: Run it**
+Also create `packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.agency` — the complement, pinning the documented v1 scoping that a guard OUTSIDE a fork does NOT salvage branch drafts (branches save on their own stacks, invisible to the parent boundary):
 
-Run: `cd packages/agency-lang && pnpm run agency test tests/agency/guards/save-draft-fork-isolation.agency > /tmp/sd-fork.txt 2>&1; tail -12 /tmp/sd-fork.txt`
-Expected: PASS — `"a|b|c"` (each branch salvages its own draft; no clobber). If it fails with a mixed/duplicated value, drafts are leaking across branches — stop and revisit storage (must be `stack.other`, per-branch).
+```
+import { guard, saveDraft } from "std::thread"
+
+def branch(tag: string): string {
+  saveDraft(tag)          // on the BRANCH's own stack — parent guard can't see it
+  return tag
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const tags = fork(["a", "b"]) as t {
+      return branch(t)
+    }
+    const reply = llm("Reply with: pong")   // parent trips here, after the fork joins
+    return reply
+  }
+  return "${isFailure(result)}"
+}
+```
+
+Create `save-draft-guard-outside-fork.test.json`: `"expectedOutput": "\"true\""`, `"useTestLLMProvider": true`, `"llmMocks": [{ "return": "pong" }]`. (The parent has no draft of its own; the branch drafts live on branch stacks, so the parent trip is a failure. Guards this scoping against a future storage change that would silently flip it.)
+
+- [ ] **Step 2: Run both**
+
+```
+cd packages/agency-lang
+pnpm run agency test tests/agency/guards/save-draft-fork-isolation.agency > /tmp/sd-fork.txt 2>&1; echo "== isolation =="; tail -6 /tmp/sd-fork.txt
+pnpm run agency test tests/agency/guards/save-draft-guard-outside-fork.agency > /tmp/sd-gof.txt 2>&1; echo "== guard-outside-fork =="; tail -6 /tmp/sd-gof.txt
+```
+Expected: isolation PASSes `"a|b|c"` (no clobber); guard-outside-fork PASSes `"true"` (branch drafts not visible to the parent guard). If isolation shows a mixed/duplicated value, drafts are leaking across branches — stop and revisit storage (must be `stack.other`, per-branch).
 
 - [ ] **Step 3: Commit**
 
 ```bash
 cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
-git add packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.*
-printf '%s\n' "Test fork branches salvage their own drafts (branch-local)" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
+git add packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.* packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.*
+printf '%s\n' "Test fork branch-locality and guard-outside-fork scoping" "" "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" > /tmp/sd-commit.txt
 git commit -F /tmp/sd-commit.txt
 ```
 
@@ -891,6 +1018,23 @@ describe("saveDraft argument type-check", () => {
     `);
     expect(diags.some((d) => d.severity === "error")).toBe(true);
   });
+
+  it("does NOT check a draft inside a bare guard block (documented gap)", () => {
+    // The block's return type is `any`, so a type-mismatched draft is not an
+    // error here. This test makes the gap conscious — if block-scope expected
+    // types are added later, update it deliberately.
+    const diags = typeCheckSource(`
+      import { guard, saveDraft } from "std::thread"
+      def f(): string {
+        const r = guard(cost: 1.0) as {
+          saveDraft(42)
+          return "x"
+        }
+        return "y"
+      }
+    `);
+    expect(diags.filter((d) => d.severity === "error")).toHaveLength(0);
+  });
 });
 ```
 
@@ -903,28 +1047,29 @@ Expected: the "rejects" test FAILS (no diagnostic yet); the "accepts" test passe
 
 - [ ] **Step 3: Add the name-keyed check**
 
-In `packages/agency-lang/lib/typeChecker/checker.ts`, find `checkFunctionCallsInScope(info, ctx)` (the per-scope pass that walks calls and invokes `checkSingleFunctionCall`). For each `saveDraft` call with exactly one positional argument and a defined `info.returnType`, reuse the return-assignability helper. Add, at the point where each `FunctionCall` `call` is visited in that pass:
+In `packages/agency-lang/lib/typeChecker/checker.ts`, find `checkFunctionCallsInScope(info, ctx)` (the per-scope pass that walks calls and invokes `checkSingleFunctionCall`). Call a **named** helper for each visited `FunctionCall` `call` (keeps the pass declarative — Addendum 1):
 
 ```ts
-if (
-  call.functionName === "saveDraft" &&
-  info.returnType !== undefined &&
-  call.arguments.length === 1 &&
-  call.arguments[0].type !== "splat" &&
-  call.arguments[0].type !== "named"
-) {
-  // The draft must be assignable to the enclosing scope's return type — the
-  // same contract a `return` obeys. Name-keyed: aliasing `saveDraft` escapes
-  // this (documented v1 limitation).
+checkSaveDraftCall(call, info, ctx);
+```
+
+And add the helper (a single `what`: "the draft must be assignable to the enclosing scope's return type", the same contract a `return` obeys):
+
+```ts
+function checkSaveDraftCall(
+  call: FunctionCall,
+  info: ScopeInfo,
+  ctx: TypeCheckerContext,
+): void {
+  if (call.functionName !== "saveDraft") return;
+  // Bare guard-block scope has no declared return type (it's `any`) — the
+  // documented block-scope gap. Only typed def/node scopes are checked.
+  if (info.returnType === undefined) return;
+  if (call.arguments.length !== 1) return;
   const arg = call.arguments[0];
-  checkType(
-    arg.value ?? arg,
-    info.returnType,
-    info.scope,
-    "the saveDraft() draft value",
-    ctx,
-  );
-  // fall through to normal call checking (arity etc.) as well
+  if (arg.type === "splat" || arg.type === "named") return;
+  // Name-keyed: aliasing `saveDraft` escapes this (documented v1 limitation).
+  checkType(arg.value ?? arg, info.returnType, info.scope, "the saveDraft() draft value", ctx);
 }
 ```
 
@@ -972,18 +1117,28 @@ Expected: build + docs regen succeed. Confirm `saveDraft` now appears in `docs/s
 Run: `grep -n "saveDraft" packages/agency-lang/docs/site/stdlib/thread.md | head`
 Expected: at least one hit with the docstring text.
 
-- [ ] **Step 2: Run the full saveDraft + guards execution subset**
+- [ ] **Step 2: Run the ENTIRE guards suite (required regression sweep)**
 
-Run:
+`_runGuarded` is the function **every** `guard` in the language runs through, and
+this feature changes the failure payload (adds `guardId`). So re-run the whole
+`tests/agency/guards/` directory (~34 fixtures, a couple minutes — the #549
+pattern), not just the new ones:
+
 ```
 cd packages/agency-lang
-for f in tests/agency/guards/save-draft-*.agency; do
+fail=0
+for f in tests/agency/guards/*.agency; do
   pnpm run agency test "$f" > "/tmp/sd-final-$(basename $f).txt" 2>&1
-  echo "== $(basename $f) =="; tail -3 "/tmp/sd-final-$(basename $f).txt"
+  if grep -qiE "fail|error|✗" "/tmp/sd-final-$(basename $f).txt"; then
+    echo "POSSIBLE FAIL: $(basename $f)"; tail -5 "/tmp/sd-final-$(basename $f).txt"; fail=1
+  fi
 done
-pnpm run agency test tests/agency/guards/guard-cost-trip.agency > /tmp/sd-guard-regression.txt 2>&1; echo "== guard-cost-trip (regression) =="; tail -3 /tmp/sd-guard-regression.txt
+echo "sweep done (fail=$fail)"
 ```
-Expected: every `save-draft-*` PASSes AND the pre-existing `guard-cost-trip` still PASSes (additivity — unchanged guard behavior when no draft is saved).
+Expected: every guards fixture PASSes — the new `save-draft-*` behavior AND all
+pre-existing guard fixtures (additivity: unchanged guard behavior when no draft
+is saved, and the additive `guardId` field breaks no existing assertion). Inspect
+any flagged file's saved output before proceeding.
 
 - [ ] **Step 3: Run the runtime + typechecker unit suites**
 
@@ -1024,8 +1179,14 @@ Then open a PR whose body summarizes: the anytime-algorithm motivation, `StateSt
 - Time-trip salvage (different delivery path) → Task 2 time-trip fixture.
 - Type-check against enclosing return type + name-keyed aliasing caveat + bare-guard-block `any` limitation → Task 5.
 - Interrupt/resume survival → Task 1 serialization round-trip unit test + Task 2 interrupt-resume execution fixture.
+- **Value semantics (deep-clone at save)** → `writeCallerDraft` clones (Task 1 Step 3) + clone unit test.
+- **Guard-outside-fork scoping pinned** → Task 4 guard-outside-fork fixture. **Block-scope type-check gap made conscious** → Task 5 test.
+- **Full guards-suite regression** (payload change is safe for all guards) → Task 6 Step 2 whole-directory sweep.
+- **Encapsulation / anti-patterns** (Addendum 1): depth arithmetic centralized in `drafts.ts` (no caller indexes; `writeCallerDraft`/`draftRegionStart`), salvage extracted to `salvageOwnTrip`, checker to `checkSaveDraftCall`, generated `if`s in block form (no lint-banned one-line ifs), declarative `readOutermostDraft` scan, no redundant casts.
 - Deferred items (`finalize`, deep/fork salvage, `sigint`/`sigkill`, tool exposure, `Both`, root budgets) → out of scope, unchanged; noted in PR body (Task 6).
 
 **Placeholder scan:** every code step shows the code; every test step shows the command and expected output. Two spots say "match the sibling test harness / positional-arg accessor" (Task 5) — these are deliberate: they instruct the engineer to mirror verified existing code rather than invent an API, because the exact harness entry point and AST arg-accessor must match this codebase's conventions.
 
-**Type consistency:** `writeDraft` / `readOutermostDraft` / `sweepDrafts` / `__clearTopFrameDraft` names and signatures are identical across Tasks 1, 2, 3. `_saveDraft` (TS) ↔ `saveDraft` (Agency def) wiring is consistent. `_runGuarded` gates salvage on `ids.includes(result.error.guardId)` where `guardId` is added to `guardFailureData` in Task 2 Step 4a — ownership, not shape. `entryDepth = stack.stack.length` (captured before `__call`) aligns with `writeDraft` keying at `stack.stack.length - 2` (caller frame), `__clearTopFrameDraft` at `stack.stack.length - 1` (completing frame), and the block clear at the same `length - 1` — verified consistent in the spec's depth walk-through. Interrupt handling matches `__tryCall`'s own `hasInterrupts` passthrough (`result.ts:177`).
+**Attribution:** the commit steps hardcode `Claude Opus 4.8` in `Co-Authored-By` because that is this session's executing model; **whoever actually executes a task should substitute their own model** in that line (repo convention tracks the executor).
+
+**Type consistency:** `writeCallerDraft` / `draftRegionStart` / `salvageOwnTrip` / `readOutermostDraft` / `sweepDrafts` / `__clearTopFrameDraft` / `writeDraft` names and signatures are identical across Tasks 1, 2, 3; `_runGuarded` calls `salvageOwnTrip(stack, region, ids, result)` and `_saveDraft` calls `writeCallerDraft(stack, value)` — matching the Task 1 exports. `_saveDraft` (TS) ↔ `saveDraft` (Agency def) wiring is consistent. `salvageOwnTrip` gates salvage on `ids.includes(error.guardId)` where `guardId` is added to `guardFailureData` in Task 2 Step 4a — ownership, not shape — and passes interrupts through untouched (matching `__tryCall`'s `hasInterrupts`, `result.ts:177`). All frame arithmetic lives inside `drafts.ts`: `draftRegionStart` = `stack.stack.length` (region marker), `callerDepth` = `length - 2` (the frame that called the one-frame `saveDraft` wrapper, i.e. `callerFrame()`), `__clearTopFrameDraft` clears `length - 1` (the completing frame). Save-key (`length - 2` at save) and clear-key (`length - 1` at that frame's own finally) refer to the same frame — verified consistent in the spec's depth walk-through.

--- a/docs/superpowers/plans/2026-07-14-save-draft-guards.md
+++ b/docs/superpowers/plans/2026-07-14-save-draft-guards.md
@@ -1,0 +1,875 @@
+# `saveDraft` (anytime draft-return on guard trip) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `saveDraft(v)` function so that when a `guard(cost:, time:)` trips, it returns the last saved best-so-far value instead of a `failure` — an anytime-algorithm floor for guarded work.
+
+**Architecture:** Drafts live in **branch-local `StateStack.other.drafts`**, a `Record<frameDepth, {value}>` (branch-local because each fork/race/tool branch owns its `StateStack`; serialized because `other` is). `saveDraft` (a thin Agency `def` over a TS helper) writes the *caller* frame's draft. On a trip, the stdlib guard's `_runGuarded` reads the **outermost** (shallowest-depth) draft under the guard and returns it as a success, then **sweeps** its region. A **clearing rule** — clear a frame's draft on *normal* completion (via the def codegen `finally`), keep it on abort — prevents a completed sibling's stale draft from being salvaged.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime`, `lib/stdlib`), Agency stdlib (`stdlib/thread.agency`), the TypeScript-generator backend (`lib/backends/typescriptBuilder.ts` + `lib/templates/**/*.mustache`), the type checker (`lib/typeChecker`), vitest unit tests, and Agency execution tests (`tests/agency/guards`).
+
+## Global Constraints
+
+- **Design spec:** `docs/superpowers/specs/2026-07-14-save-draft-guards-design.md` — the source of truth. This plan implements it exactly.
+- **Storage is `StateStack.other.drafts`, keyed by frame depth. NEVER on `State` (frames pop before the boundary) and NEVER on the guard object (`CostGuard`/`TimeGuard.cloneForBranch` share/clone across branches).**
+- **Outermost-set-wins** on read (smallest depth ≥ the guard's entry depth).
+- **Additive:** with no `saveDraft` calls, guard behavior is byte-for-byte unchanged.
+- **After any change under `stdlib/` or `lib/`, run `make`** (regenerates stdlib `.js` + runtime). **After editing any `.mustache`, run `pnpm run templates` first.** (per CLAUDE.md)
+- **Agency execution tests run with `pnpm run agency test <file>`**; lib unit tests with `pnpm test:run <file>`. **Save test output to a file** (tests are slow/expensive — redirect and read the file).
+- Banned patterns (per `docs/dev/coding-standards.md`): no dynamic imports; objects not maps; arrays not sets; `type` not `interface`.
+
+---
+
+### Task 1: Draft store runtime module
+
+**Files:**
+- Create: `packages/agency-lang/lib/runtime/drafts.ts`
+- Create: `packages/agency-lang/lib/runtime/drafts.test.ts`
+- Modify: `packages/agency-lang/lib/runtime/index.ts` (add one export line)
+
+**Interfaces:**
+- Consumes: `StateStack` from `./state/stateStack.js` (its `stack: State[]` array and `other: Record<string, any>`).
+- Produces (used by Tasks 2 & 3):
+  - `writeDraft(stack: StateStack, depth: number, value: unknown): void`
+  - `readOutermostDraft(stack: StateStack, entryDepth: number): { value: any } | undefined`
+  - `sweepDrafts(stack: StateStack, entryDepth: number): void`
+  - `__clearTopFrameDraft(stack: StateStack | undefined): void`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `packages/agency-lang/lib/runtime/drafts.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { StateStack, State } from "./state/stateStack.js";
+import {
+  writeDraft,
+  readOutermostDraft,
+  sweepDrafts,
+  __clearTopFrameDraft,
+} from "./drafts.js";
+
+function stackWithFrames(n: number): StateStack {
+  const s = new StateStack();
+  for (let i = 0; i < n; i++) s.stack.push(new State());
+  return s;
+}
+
+describe("draft store", () => {
+  it("writes and reads a single draft (outermost = shallowest >= entryDepth)", () => {
+    const s = stackWithFrames(4);
+    writeDraft(s, 2, "code");
+    writeDraft(s, 3, "verify");
+    // entryDepth 1: both are under the guard; outermost is depth 2.
+    expect(readOutermostDraft(s, 1)?.value).toBe("code");
+  });
+
+  it("last-wins per frame", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "first");
+    writeDraft(s, 2, "second");
+    expect(readOutermostDraft(s, 0)?.value).toBe("second");
+  });
+
+  it("returns undefined when nothing is at or above entryDepth", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 1, "shallow");
+    expect(readOutermostDraft(s, 2)).toBeUndefined();
+  });
+
+  it("sweep deletes every draft at depth >= entryDepth", () => {
+    const s = stackWithFrames(4);
+    writeDraft(s, 1, "keep");
+    writeDraft(s, 2, "drop");
+    writeDraft(s, 3, "drop2");
+    sweepDrafts(s, 2);
+    expect(readOutermostDraft(s, 0)?.value).toBe("keep");
+    expect(readOutermostDraft(s, 2)).toBeUndefined();
+  });
+
+  it("clearTopFrameDraft clears the top frame's draft only", () => {
+    const s = stackWithFrames(3); // top index = 2
+    writeDraft(s, 1, "caller");
+    writeDraft(s, 2, "top");
+    __clearTopFrameDraft(s);
+    expect(readOutermostDraft(s, 0)?.value).toBe("caller");
+    expect(readOutermostDraft(s, 2)).toBeUndefined();
+  });
+
+  it("survives StateStack serialization round-trip", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, { report: "partial" });
+    const restored = StateStack.fromJSON(JSON.parse(JSON.stringify(s.toJSON())));
+    expect(readOutermostDraft(restored, 0)?.value).toEqual({ report: "partial" });
+  });
+
+  it("tolerates a stack with no drafts", () => {
+    const s = stackWithFrames(2);
+    expect(readOutermostDraft(s, 0)).toBeUndefined();
+    sweepDrafts(s, 0); // no throw
+    __clearTopFrameDraft(s); // no throw
+    __clearTopFrameDraft(undefined); // no throw
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/agency-lang && pnpm test:run lib/runtime/drafts.test.ts > /tmp/drafts-test-1.txt 2>&1; tail -30 /tmp/drafts-test-1.txt`
+Expected: FAIL — `Cannot find module './drafts.js'` / exports undefined.
+
+- [ ] **Step 3: Implement the draft store**
+
+Create `packages/agency-lang/lib/runtime/drafts.ts`:
+
+```ts
+import type { StateStack } from "./state/stateStack.js";
+
+/** A saved best-so-far value. Wrapped so a stored `null`/`undefined` value is
+ *  distinct from "no draft for this frame". */
+type DraftRecord = { value: any };
+
+/** Branch-local, serialized store: frame depth -> its latest draft. Lives in
+ *  `StateStack.other` (NOT on `State`) because frames are popped by the unwind
+ *  before a guard boundary reads them — `other` outlives frame pops. See
+ *  docs/superpowers/specs/2026-07-14-save-draft-guards-design.md. */
+function draftsOf(stack: StateStack): Record<number, DraftRecord> {
+  const other = stack.other as Record<string, any>;
+  if (!other.drafts) other.drafts = {};
+  return other.drafts as Record<number, DraftRecord>;
+}
+
+/** Record `value` as the draft for the frame at `depth` (last call wins). */
+export function writeDraft(stack: StateStack, depth: number, value: unknown): void {
+  draftsOf(stack)[depth] = { value };
+}
+
+/** The outermost draft under a guard: the smallest depth >= `entryDepth` that
+ *  has a draft. Undefined if none. Outermost (not deepest) is the type-closest
+ *  choice to the guarded block's type — see the spec. */
+export function readOutermostDraft(
+  stack: StateStack,
+  entryDepth: number,
+): DraftRecord | undefined {
+  const drafts = (stack.other as Record<string, any>).drafts as
+    | Record<number, DraftRecord>
+    | undefined;
+  if (!drafts) return undefined;
+  let best = Infinity;
+  for (const key of Object.keys(drafts)) {
+    const d = Number(key);
+    if (d >= entryDepth && d < best) best = d;
+  }
+  return best === Infinity ? undefined : drafts[best];
+}
+
+/** Delete every draft at depth >= `entryDepth`. Run on BOTH guard outcomes so a
+ *  draft never leaks into a later sibling guard or an outer guard. */
+export function sweepDrafts(stack: StateStack, entryDepth: number): void {
+  const drafts = (stack.other as Record<string, any>).drafts as
+    | Record<number, DraftRecord>
+    | undefined;
+  if (!drafts) return;
+  for (const key of Object.keys(drafts)) {
+    if (Number(key) >= entryDepth) delete drafts[Number(key)];
+  }
+}
+
+/** Clear the CURRENT top frame's draft. Called from generated code in the def
+ *  `finally` ONLY on normal completion (`__functionCompleted`), so a frame that
+ *  is unwinding on an abort keeps its draft for the guard boundary to read. */
+export function __clearTopFrameDraft(stack: StateStack | undefined): void {
+  if (!stack) return;
+  const drafts = (stack.other as Record<string, any>).drafts as
+    | Record<number, DraftRecord>
+    | undefined;
+  if (!drafts) return;
+  delete drafts[stack.stack.length - 1];
+}
+```
+
+- [ ] **Step 4: Export from the runtime index**
+
+In `packages/agency-lang/lib/runtime/index.ts`, add after the `export { StateStack, State } ...` line (around line 30):
+
+```ts
+export {
+  writeDraft,
+  readOutermostDraft,
+  sweepDrafts,
+  __clearTopFrameDraft,
+} from "./drafts.js";
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd packages/agency-lang && pnpm test:run lib/runtime/drafts.test.ts > /tmp/drafts-test-2.txt 2>&1; tail -30 /tmp/drafts-test-2.txt`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
+git add packages/agency-lang/lib/runtime/drafts.ts packages/agency-lang/lib/runtime/drafts.test.ts packages/agency-lang/lib/runtime/index.ts
+git commit -m "feat(saveDraft): branch-local draft store (StateStack.other)"
+```
+
+---
+
+### Task 2: `saveDraft` surface + `_runGuarded` read & sweep
+
+**Files:**
+- Modify: `packages/agency-lang/lib/stdlib/thread.ts` (add `_saveDraft`; modify `_runGuarded`)
+- Modify: `packages/agency-lang/stdlib/thread.agency` (import `_saveDraft`; add `def saveDraft`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-basic.agency` (+ `.test.json`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-no-draft.agency` (+ `.test.json`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-last-wins.agency` (+ `.test.json`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-outermost.agency` (+ `.test.json`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-sequential-guards.agency` (+ `.test.json`)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-nested-guards.agency` (+ `.test.json`)
+
+**Interfaces:**
+- Consumes: `writeDraft`, `readOutermostDraft`, `sweepDrafts` (Task 1); existing `getRuntimeContext`, `__call`, `__tryCall` in `thread.ts`; `success`, `isFailure`, `ResultValue`, `ResultFailure` from `../runtime/result.js`.
+- Produces: the Agency builtin `saveDraft(value)` and the salvage behavior on trip.
+
+- [ ] **Step 1: Write the first failing execution test**
+
+Create `packages/agency-lang/tests/agency/guards/save-draft-basic.agency`:
+
+```
+import { guard, saveDraft } from "std::thread"
+
+// SYNTHETIC_COST = 0.000002 per llm call; limit 0.000001 trips on the first
+// call. saveDraft runs first, so the guard salvages "partial" instead of failing.
+node main() {
+  const result = guard(cost: 0.000001) as {
+    saveDraft("partial")
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) {
+    return "unexpected failure"
+  }
+  return result.value
+}
+```
+
+Create `packages/agency-lang/tests/agency/guards/save-draft-basic.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"partial\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A guard trip after saveDraft returns the saved draft instead of a failure."
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd packages/agency-lang && pnpm run agency test tests/agency/guards/save-draft-basic.agency > /tmp/sd-basic-1.txt 2>&1; tail -30 /tmp/sd-basic-1.txt`
+Expected: FAIL — `saveDraft` is not defined / unknown import from `std::thread` (and even if it compiled, the guard returns a failure, not `"partial"`).
+
+- [ ] **Step 3: Add the `_saveDraft` TS helper**
+
+In `packages/agency-lang/lib/stdlib/thread.ts`, add near the guard helpers (after `_popGuard`). First ensure the imports at the top of the file include:
+
+```ts
+import { writeDraft, readOutermostDraft, sweepDrafts } from "../runtime/drafts.js";
+import { success, isFailure } from "../runtime/result.js";
+import type { ResultValue, ResultFailure } from "../runtime/result.js";
+```
+
+Then add:
+
+```ts
+/**
+ * Impl of the Agency `saveDraft(value)` builtin. Records a best-so-far value
+ * keyed to the CALLER's frame (the Agency function/block that called saveDraft),
+ * so a tripping enclosing `guard` can salvage it. `saveDraft` is a thin one-frame
+ * `def` wrapper, so the caller is exactly one frame below saveDraft's own frame.
+ * With no caller (module-init/global scope) it is a harmless no-op.
+ */
+export function _saveDraft(value: unknown): void {
+  const { stack } = getRuntimeContext();
+  const callerDepth = stack.stack.length - 2; // saveDraft's frame is on top
+  if (callerDepth < 0) return;
+  writeDraft(stack, callerDepth, value);
+}
+```
+
+- [ ] **Step 4: Modify `_runGuarded` to salvage on trip and sweep on exit**
+
+In `packages/agency-lang/lib/stdlib/thread.ts`, replace the body of `_runGuarded` (currently just `return __tryCall(...)`) with:
+
+```ts
+export async function _runGuarded(
+  ids: string[],
+  block: unknown,
+): Promise<ResultValue> {
+  const { ctx, stack } = getRuntimeContext();
+  // Frames of the block + everything it calls live at indices >= entryDepth.
+  const entryDepth = stack.stack.length;
+  const result = await __tryCall(
+    () => __call(block, { type: "positional", args: [] }),
+    {
+      ownedGuardIds: ids,
+      checkpoint: ctx.getResultCheckpoint(),
+      functionName: "guard",
+      args: stack.lastFrame()?.args,
+    },
+  );
+
+  // Salvage: a guardFailureData-shaped failure is produced ONLY by __tryCall's
+  // owned-guard branch, so its presence here means THIS guard tripped. If a
+  // draft was saved under it, return the outermost draft instead of the failure.
+  let out: ResultValue = result;
+  if (isFailure(result) && isGuardTripFailure(result)) {
+    const draft = readOutermostDraft(stack, entryDepth);
+    if (draft !== undefined) out = success(draft.value);
+  }
+
+  // Clean this guard's region on BOTH outcomes so drafts never leak into a
+  // later sibling guard or an outer guard.
+  sweepDrafts(stack, entryDepth);
+  return out;
+}
+
+/** A failure whose error carries GuardFailureData — produced only by the
+ *  owned-guard conversion in __tryCall, i.e. this guard's own trip. */
+function isGuardTripFailure(f: ResultFailure): boolean {
+  const t = (f.error as { type?: string } | null | undefined)?.type;
+  return t === "guardFailure" || t === "timeoutFailure";
+}
+```
+
+- [ ] **Step 5: Wire `saveDraft` into the Agency stdlib**
+
+In `packages/agency-lang/stdlib/thread.agency`, add `_saveDraft` to the existing import from `agency-lang/stdlib-lib/thread.js` (the block that already imports `_pushGuard, _popGuard, _runGuarded`):
+
+```
+  _pushGuard,
+  _popGuard,
+  _runGuarded,
+  _saveDraft,
+```
+
+Then add the exported `def` (place it right after the `guard` def):
+
+```
+export def saveDraft(value: any) {
+  """
+  Record a best-so-far value for the current function or guarded block. If an
+  enclosing `guard(...)` trips before this scope returns, the guard yields the
+  last saved draft instead of a failure — an "anytime" result you can always
+  fall back to. Call it repeatedly as your result improves; the last value
+  wins. With no enclosing guard it is a harmless no-op.
+
+  @param value - The best-so-far value. Should match the enclosing scope's return type.
+  """
+  _saveDraft(value)
+}
+```
+
+- [ ] **Step 6: Rebuild the stdlib**
+
+Run: `cd packages/agency-lang && make > /tmp/sd-make-1.txt 2>&1; tail -15 /tmp/sd-make-1.txt`
+Expected: build completes without errors.
+
+- [ ] **Step 7: Run the basic test to verify it passes**
+
+Run: `cd packages/agency-lang && pnpm run agency test tests/agency/guards/save-draft-basic.agency > /tmp/sd-basic-2.txt 2>&1; tail -20 /tmp/sd-basic-2.txt`
+Expected: PASS — output `"partial"`.
+
+- [ ] **Step 8: Add the remaining behavior tests**
+
+Create these six files (`.agency` + `.test.json` each). All use `useTestLLMProvider: true`.
+
+`save-draft-no-draft.agency` (additivity — trip with no draft still fails):
+
+```
+import { guard } from "std::thread"
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) { return "failed:${result.error.type}" }
+  return "no trip"
+}
+```
+
+`save-draft-no-draft.test.json`:
+
+```json
+{
+  "tests": [
+    { "nodeName": "main", "input": "", "expectedOutput": "\"failed:guardFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }], "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "Additivity: a trip with no saveDraft still returns a failure." }
+  ]
+}
+```
+
+`save-draft-last-wins.agency`:
+
+```
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    saveDraft("first")
+    saveDraft("second")
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}
+```
+
+`save-draft-last-wins.test.json`: same shape, `"expectedOutput": "\"second\""`.
+
+`save-draft-outermost.agency` (outermost across frames → returns the shallow one):
+
+```
+import { guard, saveDraft } from "std::thread"
+
+def verify(): string {
+  saveDraft("verify-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+def code(): string {
+  saveDraft("code-draft")
+  const x = verify()
+  return x
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return code()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}
+```
+
+`save-draft-outermost.test.json`: same shape, `"expectedOutput": "\"code-draft\""`, `"llmMocks": [{ "return": "pong" }]`.
+
+`save-draft-sequential-guards.agency` (the sweep prevents guard B from reading guard A's draft):
+
+```
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const r1 = guard(cost: 0.000001) as {
+    saveDraft("g1-draft")
+    const a = llm("Reply with: pong")
+    return a
+  }
+  const r2 = guard(cost: 0.000001) as {
+    const b = llm("Reply with: pong")
+    return b
+  }
+  let first = "?"
+  if (isSuccess(r1)) { first = r1.value }
+  return "${first}|${isFailure(r2)}"
+}
+```
+
+`save-draft-sequential-guards.test.json`: `"expectedOutput": "\"g1-draft|true\""`, `"llmMocks": [{ "return": "pong" }, { "return": "pong" }]`.
+
+`save-draft-nested-guards.agency` (inner guard's swept draft must NOT be salvaged by the outer trip):
+
+```
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const outer = guard(cost: 0.000003) as {
+    const inner = guard(cost: 0.000001) as {
+      saveDraft("inner-draft")
+      const a = llm("Reply with: pong")
+      return a
+    }
+    // outer saves NO draft of its own; then it trips.
+    const b = llm("Reply with: pong")
+    return b
+  }
+  return "${isFailure(outer)}"
+}
+```
+
+`save-draft-nested-guards.test.json`: `"expectedOutput": "\"true\""`, `"llmMocks": [{ "return": "pong" }, { "return": "pong" }]`. (Inner trips on the first call and salvages `inner-draft`, sweeping its region; the second call pushes the outer over 0.000003 and it trips with no draft of its own — the swept inner draft must not be read, so `outer` is a failure.)
+
+- [ ] **Step 9: Run all six new tests**
+
+Run each and save output, e.g.:
+
+```
+cd packages/agency-lang
+for t in no-draft last-wins outermost sequential-guards nested-guards; do
+  pnpm run agency test tests/agency/guards/save-draft-$t.agency > /tmp/sd-$t.txt 2>&1
+  echo "== $t =="; tail -5 /tmp/sd-$t.txt
+done
+```
+Expected: all PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
+git add packages/agency-lang/lib/stdlib/thread.ts packages/agency-lang/stdlib/thread.agency packages/agency-lang/tests/agency/guards/save-draft-*.agency packages/agency-lang/tests/agency/guards/save-draft-*.test.json packages/agency-lang/stdlib/
+git commit -m "feat(saveDraft): salvage outermost draft on guard trip; sweep region"
+```
+
+---
+
+### Task 3: Clear a frame's draft on normal completion (def codegen)
+
+**Files:**
+- Modify: `packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache` (add `__clearTopFrameDraft` to the runtime import)
+- Modify: `packages/agency-lang/lib/backends/typescriptBuilder.ts` (def `finally`: clear before pop)
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.agency` (+ `.test.json`)
+
+**Interfaces:**
+- Consumes: `__clearTopFrameDraft` (Task 1), exported from `agency-lang/runtime`; the generated `__functionCompleted` local and `__stateStack()` accessor (already in the def `finally`).
+- Produces: every def frame clears its own draft on normal return.
+
+- [ ] **Step 1: Write the failing execution test (stale-sibling)**
+
+Create `packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.agency`:
+
+```
+import { guard, saveDraft } from "std::thread"
+
+// `saver` saves a draft and returns NORMALLY (no llm, no cost). `tripper` then
+// trips before saving anything. Without normal-completion clearing, the guard
+// would wrongly salvage "stale" from `saver`; with it, the guard fails.
+def saver(): string {
+  saveDraft("stale")
+  return "ok"
+}
+
+def tripper(): string {
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const a = saver()
+    const b = tripper()
+    return b
+  }
+  if (isSuccess(result)) { return "leaked:${result.value}" }
+  return "failed"
+}
+```
+
+Create `save-draft-stale-sibling.test.json`: `"expectedOutput": "\"failed\""`, `"useTestLLMProvider": true`, `"llmMocks": [{ "return": "pong" }]`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd packages/agency-lang && pnpm run agency test tests/agency/guards/save-draft-stale-sibling.agency > /tmp/sd-stale-1.txt 2>&1; tail -20 /tmp/sd-stale-1.txt`
+Expected: FAIL — output is `"leaked:stale"` (saver's draft is stale-read because it is never cleared).
+
+- [ ] **Step 3: Add `__clearTopFrameDraft` to the generated runtime import**
+
+In `packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache`, add `__clearTopFrameDraft` to the value-import list (the block ending in `} from "agency-lang/runtime";` around line 28-33). For example change:
+
+```
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+```
+to include it:
+```
+  __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  __clearTopFrameDraft,
+```
+
+- [ ] **Step 4: Recompile templates**
+
+Run: `cd packages/agency-lang && pnpm run templates > /tmp/sd-templates.txt 2>&1; tail -5 /tmp/sd-templates.txt`
+Expected: templates recompiled (no error).
+
+- [ ] **Step 5: Emit the clearing call in the def `finally`**
+
+In `packages/agency-lang/lib/backends/typescriptBuilder.ts`, in the def `finally` statements (around line 2246, the `ts.statements([...])` that begins with `ts.raw("__stateStack()?.pop()")`), insert a clearing statement BEFORE the pop so it runs while the completing frame is still on top:
+
+```ts
+ts.statements([
+  ts.raw("if (__functionCompleted) __clearTopFrameDraft(__stateStack())"),
+  ts.raw("__stateStack()?.pop()"),
+  ...(skipHooks
+    ? []
+    : [
+        ts.if(
+          ts.id("__functionCompleted"),
+          ts.callHook("onFunctionEnd", {
+            // ...unchanged...
+          }),
+        ),
+      ]),
+]),
+```
+
+(Only the first `ts.raw(...)` line is new; leave the rest of the block exactly as it is.)
+
+- [ ] **Step 6: Rebuild**
+
+Run: `cd packages/agency-lang && make > /tmp/sd-make-2.txt 2>&1; tail -15 /tmp/sd-make-2.txt`
+Expected: build completes.
+
+- [ ] **Step 7: Run the stale-sibling test + re-run Task 2 tests (regression)**
+
+```
+cd packages/agency-lang
+pnpm run agency test tests/agency/guards/save-draft-stale-sibling.agency > /tmp/sd-stale-2.txt 2>&1; tail -8 /tmp/sd-stale-2.txt
+for t in basic no-draft last-wins outermost sequential-guards nested-guards; do
+  pnpm run agency test tests/agency/guards/save-draft-$t.agency > /tmp/sd-re-$t.txt 2>&1
+  echo "== $t =="; tail -3 /tmp/sd-re-$t.txt
+done
+```
+Expected: stale-sibling PASSes (`"failed"`); all six earlier tests still PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
+git add packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts packages/agency-lang/lib/backends/typescriptBuilder.ts packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.*
+git commit -m "feat(saveDraft): clear a frame's draft on normal completion (no stale salvage)"
+```
+
+---
+
+### Task 4: Branch-locality execution test
+
+**Files:**
+- Create: `packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.agency` (+ `.test.json`)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3 (no new code — this proves the branch-local property already holds because each branch owns its `StateStack`, hence its own `other.drafts`).
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.agency`. Each fork branch has its OWN guard and saves its OWN draft; the trip in each branch must salvage that branch's value, with no cross-branch clobber:
+
+```
+import { guard, saveDraft } from "std::thread"
+
+def branch(tag: string): string {
+  const r = guard(cost: 0.000001) as {
+    saveDraft(tag)
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(r)) { return "fail" }
+  return r.value
+}
+
+node main() {
+  const results = fork(["a", "b", "c"]) as tag {
+    return branch(tag)
+  }
+  return "${results[0]}|${results[1]}|${results[2]}"
+}
+```
+
+Create `save-draft-fork-isolation.test.json`: `"expectedOutput": "\"a|b|c\""`, `"useTestLLMProvider": true`, `"llmMocks": [{ "return": "pong" }, { "return": "pong" }, { "return": "pong" }]`.
+
+- [ ] **Step 2: Run it**
+
+Run: `cd packages/agency-lang && pnpm run agency test tests/agency/guards/save-draft-fork-isolation.agency > /tmp/sd-fork.txt 2>&1; tail -12 /tmp/sd-fork.txt`
+Expected: PASS — `"a|b|c"` (each branch salvages its own draft; no clobber). If it fails with a mixed/duplicated value, drafts are leaking across branches — stop and revisit storage (must be `stack.other`, per-branch).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
+git add packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.*
+git commit -m "test(saveDraft): fork branches salvage their own drafts (branch-local)"
+```
+
+---
+
+### Task 5: Type-check the `saveDraft` argument
+
+**Files:**
+- Modify: `packages/agency-lang/lib/typeChecker/checker.ts` (name-keyed check against the enclosing return type)
+- Create: `packages/agency-lang/lib/typeChecker/saveDraft.test.ts`
+
+**Interfaces:**
+- Consumes: `scope.returnType` and `checkType(expr, expectedType, scope, contextLabel, ctx)` (both used by `checkReturnTypesInScope`); the per-scope call-checking pass `checkFunctionCallsInScope(info, ctx)` where `info` is the `ScopeInfo` carrying `returnType` and `scope`.
+- Produces: a diagnostic when `saveDraft`'s argument is not assignable to the enclosing scope's return type.
+
+- [ ] **Step 1: Write the failing type-checker test**
+
+Create `packages/agency-lang/lib/typeChecker/saveDraft.test.ts`. Mirror an existing checker test's harness (see the sibling `*.test.ts` files in this directory for the exact `typeCheck`/diagnostics import). The two cases:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { typeCheckSource } from "./testHarness.js"; // use whatever the sibling tests import
+
+describe("saveDraft argument type-check", () => {
+  it("accepts a draft assignable to the enclosing return type", () => {
+    const diags = typeCheckSource(`
+      import { guard, saveDraft } from "std::thread"
+      def f(): string {
+        saveDraft("ok")
+        return "x"
+      }
+    `);
+    expect(diags.filter((d) => d.severity === "error")).toHaveLength(0);
+  });
+
+  it("rejects a draft not assignable to the enclosing return type", () => {
+    const diags = typeCheckSource(`
+      import { guard, saveDraft } from "std::thread"
+      def f(): string {
+        saveDraft(42)
+        return "x"
+      }
+    `);
+    expect(diags.some((d) => d.severity === "error")).toBe(true);
+  });
+});
+```
+
+> Note: if the sibling checker tests use a different harness entry point than `typeCheckSource`/`testHarness.js`, use theirs — grep `lib/typeChecker/*.test.ts` for the import and match it. Do not invent a harness.
+
+- [ ] **Step 2: Run it to verify the reject case fails**
+
+Run: `cd packages/agency-lang && pnpm test:run lib/typeChecker/saveDraft.test.ts > /tmp/sd-tc-1.txt 2>&1; tail -30 /tmp/sd-tc-1.txt`
+Expected: the "rejects" test FAILS (no diagnostic yet); the "accepts" test passes.
+
+- [ ] **Step 3: Add the name-keyed check**
+
+In `packages/agency-lang/lib/typeChecker/checker.ts`, find `checkFunctionCallsInScope(info, ctx)` (the per-scope pass that walks calls and invokes `checkSingleFunctionCall`). For each `saveDraft` call with exactly one positional argument and a defined `info.returnType`, reuse the return-assignability helper. Add, at the point where each `FunctionCall` `call` is visited in that pass:
+
+```ts
+if (
+  call.functionName === "saveDraft" &&
+  info.returnType !== undefined &&
+  call.arguments.length === 1 &&
+  call.arguments[0].type !== "splat" &&
+  call.arguments[0].type !== "named"
+) {
+  // The draft must be assignable to the enclosing scope's return type — the
+  // same contract a `return` obeys. Name-keyed: aliasing `saveDraft` escapes
+  // this (documented v1 limitation).
+  const arg = call.arguments[0];
+  checkType(
+    arg.value ?? arg,
+    info.returnType,
+    info.scope,
+    "the saveDraft() draft value",
+    ctx,
+  );
+  // fall through to normal call checking (arity etc.) as well
+}
+```
+
+> Adjust `arg.value ?? arg` to however the AST exposes a positional argument's expression in this codebase (grep how `checkArgsAgainstParams` reads positional arg expressions — match that exactly). The `checkType(expr, expectedType, scope, label, ctx)` signature is the one used in `checkReturnTypesInScope`.
+
+- [ ] **Step 4: Run the type-checker test to verify it passes**
+
+Run: `cd packages/agency-lang && pnpm test:run lib/typeChecker/saveDraft.test.ts > /tmp/sd-tc-2.txt 2>&1; tail -20 /tmp/sd-tc-2.txt`
+Expected: both tests PASS.
+
+- [ ] **Step 5: Confirm no regression in the checker suite**
+
+Run: `cd packages/agency-lang && pnpm test:run lib/typeChecker > /tmp/sd-tc-suite.txt 2>&1; tail -15 /tmp/sd-tc-suite.txt`
+Expected: the type-checker unit suite is green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
+git add packages/agency-lang/lib/typeChecker/checker.ts packages/agency-lang/lib/typeChecker/saveDraft.test.ts
+git commit -m "feat(saveDraft): type-check the draft against the enclosing return type"
+```
+
+---
+
+### Task 6: Docs, stdlib regen, and full verification
+
+**Files:**
+- Modify: `packages/agency-lang/docs/site/stdlib/thread.md` (regenerated — do not hand-edit; comes from `agency doc`)
+- Verify: whole build + the guard test suite subset.
+
+**Interfaces:**
+- Consumes: the `saveDraft` docstring added in Task 2 (Step 5).
+
+- [ ] **Step 1: Regenerate stdlib docs**
+
+The `saveDraft` docstring in `stdlib/thread.agency` becomes the generated reference page and the tool description. Regenerate:
+
+Run: `cd packages/agency-lang && make > /tmp/sd-make-final.txt 2>&1; tail -15 /tmp/sd-make-final.txt`
+Expected: build + docs regen succeed. Confirm `saveDraft` now appears in `docs/site/stdlib/thread.md`:
+
+Run: `grep -n "saveDraft" packages/agency-lang/docs/site/stdlib/thread.md | head`
+Expected: at least one hit with the docstring text.
+
+- [ ] **Step 2: Run the full saveDraft + guards execution subset**
+
+Run:
+```
+cd packages/agency-lang
+for f in tests/agency/guards/save-draft-*.agency; do
+  pnpm run agency test "$f" > "/tmp/sd-final-$(basename $f).txt" 2>&1
+  echo "== $(basename $f) =="; tail -3 "/tmp/sd-final-$(basename $f).txt"
+done
+pnpm run agency test tests/agency/guards/guard-cost-trip.agency > /tmp/sd-guard-regression.txt 2>&1; echo "== guard-cost-trip (regression) =="; tail -3 /tmp/sd-guard-regression.txt
+```
+Expected: every `save-draft-*` PASSes AND the pre-existing `guard-cost-trip` still PASSes (additivity — unchanged guard behavior when no draft is saved).
+
+- [ ] **Step 3: Run the runtime + typechecker unit suites**
+
+Run: `cd packages/agency-lang && pnpm test:run lib/runtime/drafts.test.ts lib/typeChecker/saveDraft.test.ts > /tmp/sd-unit-final.txt 2>&1; tail -15 /tmp/sd-unit-final.txt`
+Expected: green.
+
+- [ ] **Step 4: Commit any regenerated artifacts**
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
+git add packages/agency-lang/docs/site/stdlib/thread.md packages/agency-lang/stdlib/
+git commit -m "docs(saveDraft): regenerate stdlib reference"
+```
+
+- [ ] **Step 5: Push and open a PR (only when the user asks)**
+
+Do not push or open a PR unless the user requests it. When they do:
+
+```bash
+cd /Users/adityabhargava/agency-lang/.claude/worktrees/save-draft-guards
+git push -u origin worktree-save-draft-guards
+```
+Then open a PR whose body summarizes: the anytime-algorithm motivation, `StateStack.other` storage + clearing rule, outermost-wins/type-safety, and the deferred follow-ups (`finalize`, deep/fork salvage, `sigint`/`sigkill`, LLM-tool exposure, `Both`).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `saveDraft(v)` statement-form builtin → Task 2 (Steps 3, 5).
+- Branch-local `StateStack.other` storage keyed by frame depth → Task 1; branch-locality proven in Task 4.
+- Trip read (outermost-set-wins) + sweep → Task 2 (Step 4).
+- Clearing rule (normal completion clears; abort keeps) → Task 3.
+- Additivity (no draft ⇒ failure unchanged) → Task 2 (no-draft test) + Task 6 (guard-cost-trip regression).
+- Type-check against enclosing return type + name-keyed aliasing caveat → Task 5.
+- Interrupt/resume survival → Task 1 serialization round-trip unit test.
+- Deferred items (`finalize`, deep/fork salvage, `sigint`/`sigkill`, tool exposure, `Both`, root budgets) → out of scope, unchanged; noted in PR body (Task 6).
+
+**Placeholder scan:** every code step shows the code; every test step shows the command and expected output. Two spots say "match the sibling test harness / positional-arg accessor" (Task 5) — these are deliberate: they instruct the engineer to mirror verified existing code rather than invent an API, because the exact harness entry point and AST arg-accessor must match this codebase's conventions.
+
+**Type consistency:** `writeDraft` / `readOutermostDraft` / `sweepDrafts` / `__clearTopFrameDraft` names and signatures are identical across Tasks 1, 2, 3. `_saveDraft` (TS) ↔ `saveDraft` (Agency def) wiring is consistent. `_runGuarded`'s new `isGuardTripFailure` reads `f.error.type` matching `guardFailureData`'s shape from `result.ts`. `entryDepth = stack.stack.length` (captured before `__call`) aligns with `writeDraft` keying at `stack.stack.length - 2` (caller frame) and `__clearTopFrameDraft` at `stack.stack.length - 1` (completing frame) — verified consistent in the spec's depth walk-through.

--- a/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
+++ b/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
@@ -14,6 +14,12 @@ the guard boundary runs (verified: `typescriptBuilder.ts` finally-pop +
 a boundary sweep) is now load-bearing. `#549`/`#550` facts refreshed; aliasing and
 altitude caveats added.
 
+**Second review incorporated (2026-07-14, on the plan):** salvage must key on the
+tripping guard's **`guardId`** (carried on the failure), not on the failure's
+*shape* — otherwise a `return`ed inner failure is wrongly salvaged. And the
+**interrupt path is not a sweep outcome**: a paused block passes its interrupts
+through untouched and keeps its drafts for resume. Both are now in Trip behavior.
+
 ## Problem
 
 Agency `guard(cost:, time:)` blocks cap a section of work. When the block
@@ -244,14 +250,27 @@ owned-guard branch (`lib/runtime/result.ts:205`), reached via the stdlib
 1. The guard records the **stack depth at guard entry** (an index into
    `stack.stack`) so it knows which drafts are "under" it — those keyed at
    depth ≥ entry.
-2. When `_runGuarded`'s trip belongs to one of its `ids`, before returning the
-   failure it reads `stack.other.drafts` at the **smallest key ≥ entry depth**
-   (the shallowest = outermost-set draft under the guard):
+2. **Ownership by `guardId`, not by shape.** A guard-failure-shaped value can
+   reach `_runGuarded` *without this guard tripping* — a block can `return` an
+   inner guard's failure, and `__tryCall` passes returned Results through
+   untouched (`result.ts:177`). So the salvage must fire **only** for this
+   guard's own trip. The converted failure carries the tripping guard's
+   `guardId` (add it to `guardFailureData`; the conversion site at
+   `result.ts:205` already has `guardCause.guardId`), and `_runGuarded` salvages
+   only when `ids.includes(failure.error.guardId)`. When it does, it reads
+   `stack.other.drafts` at the **smallest key ≥ entry depth** (the shallowest =
+   outermost-set draft under the guard):
    - Found → return `success(draft.value)`.
    - None → return the failure, **exactly as today** (fully additive; no
      `saveDraft` calls ⇒ no behavior change).
-3. On **both** outcomes it then **sweeps** — deletes every `drafts` key ≥ entry
-   depth — so nothing leaks into a later sibling or an outer guard.
+   - A failure whose `guardId` is not in `ids` (a propagated inner failure) is
+     returned untouched — never salvaged.
+3. **The interrupt path is not an outcome to sweep.** If the block *paused* on an
+   interrupt, `__tryCall` returns the `Interrupt[]` as a value; `_runGuarded`
+   passes it through and **does not sweep** — the paused block's drafts must
+   survive to resume. Only on a settled (non-interrupt) exit does it **sweep** —
+   delete every `drafts` key ≥ entry depth — so nothing leaks into a later
+   sibling or an outer guard.
 
 ### Clearing rule (load-bearing)
 
@@ -277,12 +296,15 @@ real invariant.** Two cheap levers, each with the signal already in scope:
   return, not on an abort unwind (an unwinding frame must *keep* its draft for the
   boundary to read).
 - **Blocks** (`blockSetup.mustache`): clear the block frame's `drafts` key as the
-  **last statement of the block's `try` body** — a thrown trip skips it; normal
-  completion runs it. (Equivalently, gate on `runner.halted`.)
+  **last statement of the block's `try` body, gated on `!runner.halted`** — a
+  thrown trip skips it (draft kept for the boundary); a **halt/interrupt keeps**
+  the draft (so it survives resume, per the interrupt-path rule above); only
+  normal completion clears. Needed because a block-taking combinator's `as { }`
+  block runs on the same stack and can leave a stale draft for a sibling.
 - **Guard boundary:** the sweep in Trip-behavior step 3 clears the whole region
-  on the way out.
+  on the way out (settled exits only).
 
-Pinned by test 8 (stale-sibling).
+Pinned by tests 8 (stale-sibling, def) and the block-stale fixture.
 
 ### Type checking
 

--- a/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
+++ b/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
@@ -336,7 +336,7 @@ makes drafts common enough that aliasing shows up.
   Combining branch drafts into the fork's array is the deferred fork-array
   salvage, which needs `finalize`.
 
-### The three small decisions
+### The small decisions
 
 1. **Transparent result.** A salvaged draft returns as a normal `success(draft)`
    — the caller cannot tell it was a partial-due-to-trip and does not receive the
@@ -346,6 +346,15 @@ makes drafts common enough that aliasing shows up.
    frame's draft, which simply never gets read. No error; permissive.
 3. **Outermost-set-wins**, not deepest — the type-closest-to-the-block choice
    (see rationale above).
+4. **Deep-clone at save (value semantics).** `saveDraft(v)` stores a
+   `deepClone(v)`, not a reference. Two reasons: (a) mutating the object after
+   saving must not retroactively change the salvage; (b) without it, a *live*
+   trip would salvage the post-mutation object while a *post-interrupt-resume*
+   trip salvages the checkpoint-time clone (`StateStack.toJSON` deep-clones
+   `other`) — the *same program* yielding two different salvage values depending
+   on whether a resume intervened. Cloning at save makes both paths identical and
+   matches Agency's value semantics. (Cost: cloning the best-so-far each call;
+   acceptable — the values are data, not large graphs.)
 
 ## Grounding facts (verified in code)
 

--- a/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
+++ b/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
@@ -1,0 +1,304 @@
+# Design: `saveDraft` — salvage partial work when a guard trips
+
+**Date:** 2026-07-14
+**Status:** ✅ Design agreed in brainstorm; ready for implementation planning.
+**Branch:** `worktree-save-draft-guards`
+
+## Problem
+
+Agency `guard(cost:, time:)` blocks cap a section of work. When the block
+exceeds its budget the guard **trips**: the block never reaches its `return`, and
+`guard(...) as { ... }` yields a `failure(GuardFailureData)`. **All partial work
+is lost.**
+
+The motivating use case: tell an agent *"do this research, but don't spend more
+than five minutes,"* and when the clock runs out, have it **return its best
+answer so far** instead of throwing everything away.
+
+Guards are binary today — like a non-anytime algorithm, they produce nothing
+useful unless they run to completion. We want an *anytime* floor: a value that is
+always returnable, improving as the block runs, and handed back on a trip.
+
+## Prior art / context
+
+- **Anytime algorithms** (Dean & Boddy; Zilberstein): maintain a current-best
+  result that is always returnable; on interrupt, return it. The core discipline
+  — keep the salvageable result *outside* the interrupted step — drives the
+  storage decision below.
+- **The soft-trip guards brainstorm**
+  (`docs/superpowers/specs/2026-07-14-soft-trip-guards-design.md`): proposed an
+  `onSoftTrip(data): T` handler that synthesizes a salvage value via `llm()`.
+  This design supersedes the handler as the *first* increment — `saveDraft` is
+  the smaller, load-bearing primitive underneath it. The handler becomes a later
+  `finalize` block (see [Future work](#future-work)).
+
+## Scope
+
+This is the first slice of a larger idea (*"a piece of code can be interrupted
+at any point and still return some answer"*). We deliberately ship only the
+smallest useful primitive:
+
+**In scope (v1):**
+- A `saveDraft(v)` function that records a best-so-far value on the current
+  frame.
+- On a **guard trip**, the guard returns the last saved draft instead of a
+  failure.
+
+**Explicitly deferred** (each has a home in the model below, not a
+contradiction):
+- `finalize { }` blocks (the salvage/cleanup hook that can synthesize or combine
+  values on abort).
+- **Deep / cross-type salvage** (returning a nested callee's draft through an
+  outer guard) — requires `finalize` to be type-sound (see
+  [Why we don't auto-salvage deep](#why-we-dont-auto-salvage-deep)).
+- **Fork-array salvage** (a `fork` under a guard returning the array of its
+  branches' drafts).
+- `sigint()` / `sigkill()` (functions and tools to trigger interrupt/kill).
+- **`saveDraft` as an LLM tool** (the model checkpointing its own progress).
+- Generalizing beyond guard trips to other abort sources (Esc, `cancel()`,
+  race-loss, lost connection).
+- A `Both` result variant (partial-success-plus-failure) for making a salvaged
+  draft distinguishable from a normal completion.
+
+## Core model
+
+### Drafts are per-frame and per-type
+
+`saveDraft(v)` sets **the current frame's** draft. Because a draft written inside
+`verify()` is a value of `verify`'s return type, and a draft written inside
+`code()` is a value of `code`'s return type, a draft is only meaningful *at its
+own frame's type*.
+
+```
+def main() {
+  guard(time: 5m) as {
+    return code()
+  }
+}
+
+def code() {
+  saveDraft(10)          // draft for code's frame (code's return type)
+  const x = verify()     // trip fires inside verify()
+  return x + 20
+}
+
+def verify() {
+  saveDraft(1)           // draft for verify's frame (verify's return type)
+  // ... trip fires here ...
+  saveDraft(2)
+  return 3
+}
+```
+
+### v1 rule: outermost-set draft under the guard wins
+
+On a trip, as the stack unwinds outward, the **shallowest frame that called
+`saveDraft`** provides the value. In the example the guard returns **`10`**
+(`code`'s draft). `verify`'s `1` is *not* returned in v1.
+
+### Why we don't auto-salvage deep
+
+The reason is **type safety**, and it is the thing that turns "there's no simple
+rule" into a principled one:
+
+- The guard block is `return code()`, so the guard must yield **`code`'s type**.
+- `verify`'s draft is a value of **`verify`'s type**. Returning it through the
+  guard is a type error in the general case (it only *looks* fine in the example
+  because both happen to be numbers).
+- The only sound way to lift `verify`'s draft into `code`'s type is a
+  user-written conversion at the `code` layer. **That conversion is exactly what
+  `finalize` is.** So "salvage as much as possible" is a real goal, but it is
+  only *sound* once each layer can convert its inner salvage to its own type —
+  which is why deep salvage is deferred behind `finalize`, not shipped as an
+  automatic best-effort in v1.
+
+So v1 returns the outermost draft (type-closest to the block), and the type
+checker guarantees each draft is well-typed **for its own frame**. In the common
+pattern — a guard wrapping a single agent call, and that agent calling
+`saveDraft` — the outermost draft's frame type equals the block type, so it is
+type-correct.
+
+### Where `finalize` fits (future, not v1)
+
+The same per-frame drafts compose upward once `finalize` exists. On a trip, each
+frame produces a *salvage*: its `finalize`'s return if it has one, else its last
+draft. A frame's salvage substitutes for its call expression in the parent (so
+`const x = verify()` makes `x` = verify's salvage), letting the parent's
+`finalize` read it and return *its own* type. `fork` composes the same way: each
+branch salvages a `T`, and the fork's salvage is naturally the array of branch
+salvages (matching the fork's `T[]` type) — so no arbitrary scalar merge rule is
+ever needed. v1 lays down the per-frame drafts this future builds on.
+
+## Design details
+
+### Surface
+
+`saveDraft(v)` is a **statement-form** builtin: it records `v` and execution
+continues (a checkpoint, not control flow — like saving in a video game). It does
+not return a value and does not alter control flow.
+
+```
+guard(time: 5m) as {
+  let report = initialReport()
+  saveDraft(report)                 // floor: even an immediate trip returns this
+  while (moreToDo()) {
+    report = refine(report)
+    saveDraft(report)               // last-wins: best-so-far keeps improving
+  }
+  return report
+}
+```
+
+Implemented as a **TypeScript helper** (see
+`docs/site/guide/ts-helpers.html`), the same pattern as `_pushGuard` /
+`withCostGuard`:
+
+```ts
+// reads the ALS frame the runtime installs around each Agency step
+export function saveDraft(value: unknown): void {
+  const { stack } = getRuntimeContext();
+  stack.lastFrame().draft = { value };
+}
+```
+
+`stack.lastFrame()` is the frame of the Agency function that called `saveDraft`
+(a TS helper does not push its own Agency frame), so the draft lands on the
+caller's frame — `code`'s or `verify`'s frame in the example.
+
+Exposed to Agency via a stdlib module import (module TBD during
+implementation — `std::thread` alongside `guard`, or `std::agency`; not
+load-bearing for the design).
+
+### Storage: a per-frame draft slot
+
+The draft lives on the frame (`State`), as a dedicated, wrapped, serialized
+field:
+
+```ts
+// lib/runtime/state/stateStack.ts — class State
+draft?: { value: any };   // wrapped so "no draft" is distinct from "draft is null"
+```
+
+- Serialized in `State.toJSON` / `State.fromJSON` (so it survives
+  interrupt/resume, like `locals`).
+- **Branch-local for free:** each `fork` / `race` / tool-call branch runs on its
+  *own* `StateStack` with its *own* frames, so a branch's draft cannot leak into
+  a sibling. This is the property we must not get wrong, and storing on the frame
+  gives it structurally rather than by convention.
+
+**Never store the draft on the guard object.** `CostGuard.cloneForBranch`
+returns `this` — a shared reference across branches — so a draft on the guard
+would let sibling fork branches clobber each other. The frame is the correct
+owner.
+
+### Trip behavior: read the outermost draft at the guard boundary
+
+The single site that converts a `guardTrip` to a failure is `__tryCall`'s
+owned-guard branch (`lib/runtime/result.ts:211`), reached via the stdlib
+`guard`'s `_runGuarded(ids, block)`. The change:
+
+1. The guard records the **stack depth at guard entry** (an index into
+   `stack.stack`) so the boundary knows which frames are "under" this guard —
+   the frames at that index and above (deeper/on top).
+2. When `_runGuarded`'s trip belongs to one of its `ids`, before returning the
+   failure it scans `stack.stack` from the guard-entry index toward the top and
+   takes the **first (shallowest) frame whose `draft` is set** — the
+   outermost-set draft under the guard.
+   - Draft found → return `success(draft.value)`.
+   - No draft anywhere under the guard → return the failure, **exactly as
+     today** (fully additive; no `saveDraft` calls ⇒ no behavior change).
+
+This relies on the inner frames still being live on `stack.stack` at the
+boundary — see [Correctness to verify](#correctness-to-verify).
+
+### Type checking
+
+`saveDraft(v)` type-checks `v` against the **enclosing function/node's return
+type** (for a bare `guard` block, the block's expected type). This keeps every
+draft well-typed for its own frame and is the same information a future
+`finalize` needs. Modest checker work: resolve the current scope's expected
+return type at the call site.
+
+### Concurrency
+
+- **Branch-locality** is structural (per-frame on per-branch stacks), as above.
+- **A guarded block that forks** and sets drafts in multiple branches is *not*
+  salvaged as a combined value in v1 — that is the deferred fork-array salvage,
+  which needs `finalize`. In v1 such a trip returns the outermost draft on the
+  *guarded* frame (e.g. a `saveDraft` in `code` before the `fork`), or the
+  failure if there is none. Documented, not silently surprising.
+
+### The three small decisions
+
+1. **Transparent result.** A salvaged draft returns as a normal `success(draft)`
+   — the caller cannot tell it was a partial-due-to-trip and does not receive the
+   `GuardFailureData`. This is the honest v1 tradeoff; distinguishability is the
+   future `Both`/partial-signal's job.
+2. **`saveDraft` with no enclosing guard is a harmless no-op** — it sets the
+   frame's draft, which simply never gets read. No error; permissive.
+3. **Outermost-set-wins**, not deepest — the type-closest-to-the-block choice
+   (see rationale above).
+
+## Grounding facts (verified in code)
+
+- Guard trip = `guardTrip` **unwind**, distinct from `RestoreSignal`. An unwind
+  does **not** roll back the `StateStack` (`lib/runtime/errors.ts`,
+  `lib/runtime/result.ts`).
+- `guard()` desugars to `_pushGuard` → `_runGuarded(ids, block)` → `_popGuard`
+  (`stdlib/thread.agency:248`). `_runGuarded` runs the block under `__tryCall`
+  with `ownedGuardIds: ids`; the trip→failure conversion is
+  `lib/runtime/result.ts:205–214`.
+- `CostGuard.cloneForBranch` returns `this` (shared across branches);
+  `TimeGuard` returns `undefined` (`lib/runtime/guard.ts`). ⇒ the draft must not
+  live on the guard.
+- Each branch has its own `StateStack`; `State.toJSON` serializes frame `locals`
+  and `branches`; `StateStack.other` is branch-local and serialized
+  (`lib/runtime/state/stateStack.ts`).
+- The generated function catch rung **re-throws `AgencyAbort` untouched and does
+  not pop the frame** (`functionCatchFailure.mustache`) — the basis for reading
+  live inner frames at the guard boundary.
+- TS helpers read `getRuntimeContext().stack` / the ALS frame
+  (`docs/site/guide/ts-helpers.md`).
+
+## Correctness to verify (do this first in implementation)
+
+**#1 — Are inner frames live on `stack.stack` at the guard boundary?** The design
+reads per-frame drafts at `_runGuarded`. The function catch re-throws aborts
+without popping (evidence above), so they *should* be live. **Confirm
+empirically** with a test: guard trip deep in a call chain
+(`main → code → verify`), assert the boundary reads `code`'s draft (`10`).
+
+- **Fallback if frames are *not* live at the boundary:** persist drafts in
+  branch-local `StateStack.other.drafts` as `{ depth, value }` records keyed to a
+  monotonic per-`State` frame id (so a popped frame's stale entry can't collide
+  with a reused depth), cleared on normal frame return. Same observable
+  semantics; different storage. Choose this only if #1 fails.
+
+**#2 — Interrupt/resume across a saved draft.** A guarded block that saves a
+draft, interrupts (e.g. user input), and resumes must still have the draft on the
+restored frame. Covered by serializing `State.draft`; add a test.
+
+## Test plan
+
+Agency execution tests (no LLM calls needed):
+
+1. **Basic salvage:** guard trips after `saveDraft(x)` in the guarded block →
+   guard returns `success(x)`.
+2. **No draft:** guard trips with no `saveDraft` → `failure`, unchanged
+   (regression guard on additivity).
+3. **Last-wins:** multiple `saveDraft` calls → the last value is returned.
+4. **Outermost-wins across frames:** `main → code(saveDraft 10) → verify(saveDraft
+   1)`, trip inside `verify` → returns `10` (the crux of #1 above).
+5. **Branch-locality:** a `fork` where each branch calls `saveDraft` with its own
+   value → no cross-branch clobber (assert each branch's frame draft is its own).
+6. **Interrupt/resume:** draft survives an interrupt/resume cycle inside the
+   guarded block.
+7. **Cost and time guards both:** salvage works for a cost trip and a time trip.
+
+## Next steps
+
+1. Implementation planning (writing-plans skill) from this spec.
+2. Resolve Correctness item #1 before building the read path.
+3. Land `saveDraft` + storage + trip-read + type check + tests.
+4. Follow-ups (separate specs): `finalize` blocks, then deep/fork salvage, then
+   `sigint`/`sigkill` and tool exposure.

--- a/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
+++ b/docs/superpowers/specs/2026-07-14-save-draft-guards-design.md
@@ -1,8 +1,18 @@
 # Design: `saveDraft` — salvage partial work when a guard trips
 
 **Date:** 2026-07-14
-**Status:** ✅ Design agreed in brainstorm; ready for implementation planning.
+**Status:** ✅ Design agreed in brainstorm; external review incorporated
+(storage pivoted to `StateStack.other` + clearing rule — see history below).
+Ready for implementation planning.
 **Branch:** `worktree-save-draft-guards`
+
+**Review incorporated (2026-07-14):** a Fable-5 review caught that the original
+per-frame storage fails because the def/block `finally` pops every frame *before*
+the guard boundary runs (verified: `typescriptBuilder.ts` finally-pop +
+`blockSetup.mustache`). Storage moved to branch-local `StateStack.other`, and a
+**clearing rule** (clear a frame's draft on normal completion, keep on abort, plus
+a boundary sweep) is now load-bearing. `#549`/`#550` facts refreshed; aliasing and
+altitude caveats added.
 
 ## Problem
 
@@ -39,8 +49,8 @@ at any point and still return some answer"*). We deliberately ship only the
 smallest useful primitive:
 
 **In scope (v1):**
-- A `saveDraft(v)` function that records a best-so-far value on the current
-  frame.
+- A `saveDraft(v)` function that records a best-so-far value keyed to the current
+  frame (stored branch-locally on the stack — see Storage).
 - On a **guard trip**, the guard returns the last saved draft instead of a
   failure.
 
@@ -59,6 +69,30 @@ contradiction):
   race-loss, lost connection).
 - A `Both` result variant (partial-success-plus-failure) for making a salvaged
   draft distinguishable from a normal completion.
+
+**Out of scope, worth stating:** the not-yet-merged `--max-cost` / `--max-time`
+**root budgets** install a guard with **no `_runGuarded` boundary** — a root trip
+exits the process (code 3), so `saveDraft` does **not** salvage a root-budget trip
+in v1. Natural future hook: the budget exit reporter could print the outermost
+draft before exiting.
+
+## Why a primitive, not sugar
+
+A fair objection: if a guard block can already mutate an enclosing `let`, then
+same-frame salvage is expressible today as `let best = …; guard as { …; best = x
+}`. (Whether a plain `as { }` block can mutate an outer `let` deserves a
+two-minute probe during implementation — callback blocks demonstrably can, per the
+`callback-forwarding-child-events` fixture.) Even if it can, `saveDraft`'s real
+payoff is the part that hand-rolling *can't* express:
+
+1. **Callee-side drafts.** A called `def` cannot reach its caller's `let`.
+   `saveDraft` lets `verify()` deep in the call tree record progress that the
+   guard boundary can still find.
+2. **Survival across interrupt/resume**, via serialization into
+   `StateStack.other` — a plain outer `let` is just as serialized, but the point
+   is the primitive owns this, uniformly, for callee frames too.
+3. **The typed substrate `finalize` needs.** Per-frame drafts are the foundation
+   the deferred composition model builds on.
 
 ## Core model
 
@@ -151,65 +185,104 @@ guard(time: 5m) as {
 
 Implemented as a **TypeScript helper** (see
 `docs/site/guide/ts-helpers.html`), the same pattern as `_pushGuard` /
-`withCostGuard`:
+`withCostGuard` — it writes to branch-local stack state (see Storage):
 
 ```ts
 // reads the ALS frame the runtime installs around each Agency step
 export function saveDraft(value: unknown): void {
   const { stack } = getRuntimeContext();
-  stack.lastFrame().draft = { value };
+  const depth = stack.stack.length - 1;            // the calling Agency frame's index
+  (stack.other.drafts ??= {})[depth] = { value };  // wrapped; last-wins per frame
 }
 ```
 
-`stack.lastFrame()` is the frame of the Agency function that called `saveDraft`
-(a TS helper does not push its own Agency frame), so the draft lands on the
-caller's frame — `code`'s or `verify`'s frame in the example.
+`stack.stack.length - 1` is the frame of the Agency function that called
+`saveDraft` (a TS helper does not push its own Agency frame), so the draft is
+attributed to the caller's frame — `code`'s or `verify`'s in the example.
 
 Exposed to Agency via a stdlib module import (module TBD during
 implementation — `std::thread` alongside `guard`, or `std::agency`; not
 load-bearing for the design).
 
-### Storage: a per-frame draft slot
+### Storage: branch-local `StateStack.other`, keyed by frame depth
 
-The draft lives on the frame (`State`), as a dedicated, wrapped, serialized
-field:
+**The draft cannot live on the frame object.** Frames are popped by the unwind
+*before* the guard boundary runs: the generated def wraps body+catch in a `try`
+whose **`finally` pops unconditionally** (`__stateStack()?.pop()`), and blocks do
+the same (`blockSetup.mustache`'s `finally` runs `__bsetup.stateStack.pop()`). A
+`finally` runs even when the `catch` re-throws, so as the trip unwinds,
+`verify`'s, `code`'s, **and the `as { }` block's** frames are all gone from
+`stack.stack` by the time `_runGuarded` converts the trip. A per-frame
+`State.draft` would be unreadable — the block-frame case (a `saveDraft` directly
+in the guard block) is the *first* frame to pop.
+
+Instead, drafts live in **`StateStack.other`**, which *outlives* frame pops, as a
+map keyed by the saving frame's depth:
 
 ```ts
-// lib/runtime/state/stateStack.ts — class State
-draft?: { value: any };   // wrapped so "no draft" is distinct from "draft is null"
+// stack.other.drafts : Record<frameDepth, { value: any }>
 ```
 
-- Serialized in `State.toJSON` / `State.fromJSON` (so it survives
-  interrupt/resume, like `locals`).
 - **Branch-local for free:** each `fork` / `race` / tool-call branch runs on its
-  *own* `StateStack` with its *own* frames, so a branch's draft cannot leak into
-  a sibling. This is the property we must not get wrong, and storing on the frame
-  gives it structurally rather than by convention.
+  *own* `StateStack`, and `other` is per-stack, so a branch's drafts cannot leak
+  into a sibling. This is the property we must not get wrong; `other` gives it
+  structurally (the same mechanism `memoryFrames` / `llmDefaults` /
+  `pendingReplyAttachments` already ride).
+- **Survives interrupt/resume:** `StateStack.toJSON` deep-clones and serializes
+  `other`.
+- **Never on the guard object.** `CostGuard.cloneForBranch` returns `this`
+  (shared across branches), and since #549 `TimeGuard.cloneForBranch` returns a
+  *per-branch* clone — either way a draft on the guard is wrong (shared clobber,
+  or multiplied per branch). `other` is the correct owner.
 
-**Never store the draft on the guard object.** `CostGuard.cloneForBranch`
-returns `this` — a shared reference across branches — so a draft on the guard
-would let sibling fork branches clobber each other. The frame is the correct
-owner.
-
-### Trip behavior: read the outermost draft at the guard boundary
+### Trip behavior: read the outermost draft, then sweep
 
 The single site that converts a `guardTrip` to a failure is `__tryCall`'s
-owned-guard branch (`lib/runtime/result.ts:211`), reached via the stdlib
+owned-guard branch (`lib/runtime/result.ts:205`), reached via the stdlib
 `guard`'s `_runGuarded(ids, block)`. The change:
 
 1. The guard records the **stack depth at guard entry** (an index into
-   `stack.stack`) so the boundary knows which frames are "under" this guard —
-   the frames at that index and above (deeper/on top).
+   `stack.stack`) so it knows which drafts are "under" it — those keyed at
+   depth ≥ entry.
 2. When `_runGuarded`'s trip belongs to one of its `ids`, before returning the
-   failure it scans `stack.stack` from the guard-entry index toward the top and
-   takes the **first (shallowest) frame whose `draft` is set** — the
-   outermost-set draft under the guard.
-   - Draft found → return `success(draft.value)`.
-   - No draft anywhere under the guard → return the failure, **exactly as
-     today** (fully additive; no `saveDraft` calls ⇒ no behavior change).
+   failure it reads `stack.other.drafts` at the **smallest key ≥ entry depth**
+   (the shallowest = outermost-set draft under the guard):
+   - Found → return `success(draft.value)`.
+   - None → return the failure, **exactly as today** (fully additive; no
+     `saveDraft` calls ⇒ no behavior change).
+3. On **both** outcomes it then **sweeps** — deletes every `drafts` key ≥ entry
+   depth — so nothing leaks into a later sibling or an outer guard.
 
-This relies on the inner frames still being live on `stack.stack` at the
-boundary — see [Correctness to verify](#correctness-to-verify).
+### Clearing rule (load-bearing)
+
+Because frames are already popped at the boundary, the reader **cannot validate
+that a draft belongs to a still-live frame**. So a frame's draft must be cleared
+the moment it completes *normally*, or a later trip could salvage a stale value —
+which is worse than a failure:
+
+```
+guard(time: …) as {
+  const a = code()   // saves a draft, returns NORMALLY
+  const b = code()   // trips BEFORE its first saveDraft — must yield failure, not a's draft
+}
+```
+
+A monotonic per-frame id would prevent depth-*collision* but not this: the reader
+still can't tell live from dead. **Reliable clearing on normal completion is the
+real invariant.** Two cheap levers, each with the signal already in scope:
+
+- **Defs:** the generated `finally` already binds `__functionCompleted` (it gates
+  `onFunctionEnd`, `typescriptBuilder.ts` ~2250). Clear this frame's `drafts` key
+  next to the `pop()` **only when `__functionCompleted` is true** — on normal
+  return, not on an abort unwind (an unwinding frame must *keep* its draft for the
+  boundary to read).
+- **Blocks** (`blockSetup.mustache`): clear the block frame's `drafts` key as the
+  **last statement of the block's `try` body** — a thrown trip skips it; normal
+  completion runs it. (Equivalently, gate on `runner.halted`.)
+- **Guard boundary:** the sweep in Trip-behavior step 3 clears the whole region
+  on the way out.
+
+Pinned by test 8 (stale-sibling).
 
 ### Type checking
 
@@ -219,14 +292,27 @@ draft well-typed for its own frame and is the same information a future
 `finalize` needs. Modest checker work: resolve the current scope's expected
 return type at the call site.
 
+**Escape hatch (deliberate v1 line item):** this is a **name-keyed** special case
+— the checker recognizes the `saveDraft` call by name. Aliasing or partial
+application (`const s = saveDraft; s(v)`, passing `saveDraft` as a first-class
+value) **escapes the check silently** — `v` goes unverified, and it is *not* an
+error. This is acceptable for v1 (aliasing a stdlib control primitive is rare),
+but is called out explicitly because the repo has been burned by name-keyed
+detection before (see the `feedback_default_invoke` lesson). Revisit if `finalize`
+makes drafts common enough that aliasing shows up.
+
 ### Concurrency
 
-- **Branch-locality** is structural (per-frame on per-branch stacks), as above.
+- **Branch-locality** is structural: each branch has its own `StateStack`, so its
+  `other.drafts` is separate. A branch's drafts cannot leak into a sibling.
 - **A guarded block that forks** and sets drafts in multiple branches is *not*
-  salvaged as a combined value in v1 — that is the deferred fork-array salvage,
-  which needs `finalize`. In v1 such a trip returns the outermost draft on the
-  *guarded* frame (e.g. a `saveDraft` in `code` before the `fork`), or the
-  failure if there is none. Documented, not silently surprising.
+  salvaged as a combined value in v1 — each branch's drafts live on that branch's
+  own `StateStack.other`, which the parent guard's boundary scan (on the parent
+  stack) never sees. This lands exactly on the intended v1 fork scoping: such a
+  trip returns the outermost draft on the *guarded* (parent) frame — e.g. a
+  `saveDraft` in `code` before the `fork` — or the failure if there is none.
+  Combining branch drafts into the fork's array is the deferred fork-array
+  salvage, which needs `finalize`.
 
 ### The three small decisions
 
@@ -245,60 +331,80 @@ return type at the call site.
   does **not** roll back the `StateStack` (`lib/runtime/errors.ts`,
   `lib/runtime/result.ts`).
 - `guard()` desugars to `_pushGuard` → `_runGuarded(ids, block)` → `_popGuard`
-  (`stdlib/thread.agency:248`). `_runGuarded` runs the block under `__tryCall`
-  with `ownedGuardIds: ids`; the trip→failure conversion is
-  `lib/runtime/result.ts:205–214`.
-- `CostGuard.cloneForBranch` returns `this` (shared across branches);
-  `TimeGuard` returns `undefined` (`lib/runtime/guard.ts`). ⇒ the draft must not
-  live on the guard.
-- Each branch has its own `StateStack`; `State.toJSON` serializes frame `locals`
-  and `branches`; `StateStack.other` is branch-local and serialized
-  (`lib/runtime/state/stateStack.ts`).
-- The generated function catch rung **re-throws `AgencyAbort` untouched and does
-  not pop the frame** (`functionCatchFailure.mustache`) — the basis for reading
-  live inner frames at the guard boundary.
+  (`stdlib/thread.agency`, ~L249). `_runGuarded` runs the block under `__tryCall`
+  with `ownedGuardIds: ids`; the trip→failure conversion is the owned-guard
+  branch of `__tryCall` (`lib/runtime/result.ts`, ~L205).
+- **Frames are popped by the unwind before the boundary.** The def codegen wraps
+  body+catch in a `try` whose `finally` runs `__stateStack()?.pop()`
+  unconditionally (`lib/backends/typescriptBuilder.ts` ~L2241); blocks pop the
+  same way in `blockSetup.mustache`'s `finally`. A `finally` runs when the `catch`
+  re-throws (`functionCatchFailure.mustache` re-throws every `AgencyAbort`), so
+  by the time `_runGuarded` catches, all frames under the guard are gone. **⇒
+  drafts must live in `StateStack.other`, not on `State`.**
+- `CostGuard.cloneForBranch` returns `this` (shared across branches). Since #549,
+  `TimeGuard.cloneForBranch` returns a **per-branch clone** carrying the parent's
+  guardId (`lib/runtime/guard.ts`). ⇒ either way, the draft must **not** live on
+  the guard object.
+- Each branch has its own `StateStack`; `StateStack.other` is branch-local and
+  serialized via `toJSON` (deep-cloned) (`lib/runtime/state/stateStack.ts`).
+- The generated def `finally` binds `__functionCompleted` (gates `onFunctionEnd`,
+  `typescriptBuilder.ts` ~L2250) — the lever for the normal-completion clearing
+  rule.
 - TS helpers read `getRuntimeContext().stack` / the ALS frame
   (`docs/site/guide/ts-helpers.md`).
+- **Not yet on main:** `--max-cost` / `--max-time` root budgets (the #550 branch)
+  install a **root guard with no `_runGuarded` boundary**; a root trip exits the
+  process (code 3) via the budget exit reporter. See Scope for the implication.
 
 ## Correctness to verify (do this first in implementation)
 
-**#1 — Are inner frames live on `stack.stack` at the guard boundary?** The design
-reads per-frame drafts at `_runGuarded`. The function catch re-throws aborts
-without popping (evidence above), so they *should* be live. **Confirm
-empirically** with a test: guard trip deep in a call chain
-(`main → code → verify`), assert the boundary reads `code`'s draft (`10`).
-
-- **Fallback if frames are *not* live at the boundary:** persist drafts in
-  branch-local `StateStack.other.drafts` as `{ depth, value }` records keyed to a
-  monotonic per-`State` frame id (so a popped frame's stale entry can't collide
-  with a reused depth), cleared on normal frame return. Same observable
-  semantics; different storage. Choose this only if #1 fails.
+**#1 — Clearing correctness (the load-bearing one).** The reader cannot validate
+draft liveness (frames are popped), so the design depends on frames reliably
+clearing their `drafts` key on **normal** completion while **keeping** it on an
+abort unwind. Confirm the `__functionCompleted` (def) and end-of-`try` (block)
+levers fire exactly as intended, with the stale-sibling test (test 8) as the
+gate. This replaces the earlier "are frames live at the boundary?" question —
+that is now *resolved* (they are not; hence `other`-storage).
 
 **#2 — Interrupt/resume across a saved draft.** A guarded block that saves a
-draft, interrupts (e.g. user input), and resumes must still have the draft on the
-restored frame. Covered by serializing `State.draft`; add a test.
+draft, interrupts (e.g. user input), and resumes must still have the draft in the
+restored stack. Covered by serializing `StateStack.other`; assert against the
+serialized `other.drafts`, add a test.
 
 ## Test plan
 
 Agency execution tests (no LLM calls needed):
 
-1. **Basic salvage:** guard trips after `saveDraft(x)` in the guarded block →
-   guard returns `success(x)`.
+1. **Basic salvage (draft in the guard block):** guard trips after `saveDraft(x)`
+   directly in the `as { }` block → returns `success(x)`. This is the primary
+   happy path under `other`-storage (it was the *broken* case under the discarded
+   per-frame design — the block frame pops first).
 2. **No draft:** guard trips with no `saveDraft` → `failure`, unchanged
    (regression guard on additivity).
-3. **Last-wins:** multiple `saveDraft` calls → the last value is returned.
+3. **Last-wins:** multiple `saveDraft` calls in a frame → the last value is
+   returned.
 4. **Outermost-wins across frames:** `main → code(saveDraft 10) → verify(saveDraft
-   1)`, trip inside `verify` → returns `10` (the crux of #1 above).
+   1)`, trip inside `verify` → returns `10`.
 5. **Branch-locality:** a `fork` where each branch calls `saveDraft` with its own
-   value → no cross-branch clobber (assert each branch's frame draft is its own).
+   value → no cross-branch clobber (each branch's `other.drafts` is its own).
 6. **Interrupt/resume:** draft survives an interrupt/resume cycle inside the
-   guarded block.
+   guarded block — assert against serialized `StateStack.other.drafts`.
 7. **Cost and time guards both:** salvage works for a cost trip and a time trip.
+8. **Stale-sibling (pins the clearing rule):** `const a = code() /*saves, returns
+   normally*/; const b = code() /*trips before its saveDraft*/` inside one guard →
+   returns `failure`, **not** `a`'s draft.
+9. **Sequential guards don't leak:** guard A trips and salvages; guard B (same
+   function, after A) trips with no `saveDraft` → `failure` (the boundary sweep).
+10. **Nested guards:** inner guard trips and salvages its own draft; the outer
+    guard's *later* trip must not read records from the inner's (swept) region.
 
 ## Next steps
 
 1. Implementation planning (writing-plans skill) from this spec.
-2. Resolve Correctness item #1 before building the read path.
-3. Land `saveDraft` + storage + trip-read + type check + tests.
+2. Build the clearing rule (Correctness #1) alongside the `other`-storage write
+   and the boundary read+sweep — they are one interlocking unit; prove them
+   together with the stale-sibling test (test 8) before anything else.
+3. Land `saveDraft` + `other`-storage + trip read/sweep + clearing + type check +
+   tests.
 4. Follow-ups (separate specs): `finalize` blocks, then deep/fork salvage, then
    `sigint`/`sigkill` and tool exposure.

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -34,7 +34,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L56))
 
 ### Attachment
 
@@ -45,7 +45,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L61))
 
 ### ModelCost
 
@@ -58,7 +58,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L164))
 
 ### GuardFailureData
 
@@ -72,7 +72,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L182))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L183))
 
 ### ThreadMessage
 
@@ -83,7 +83,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L271))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L289))
 
 ### ThreadInfo
 
@@ -99,7 +99,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L276))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L294))
 
 ## Functions
 
@@ -121,7 +121,7 @@ Add a system message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L65))
 
 ### userMessage
 
@@ -141,7 +141,7 @@ Add a user message to the current thread's message history. Use this
 |---|---|---|
 | msg | `string \| (string \| Attachment)[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L76))
 
 ### image
 
@@ -170,7 +170,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L87))
 
 ### file
 
@@ -201,7 +201,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L103))
 
 ### attachToReply
 
@@ -223,7 +223,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L120))
 
 ### assistantMessage
 
@@ -243,7 +243,7 @@ Add an assistant message to the current thread's message history.
 |---|---|---|
 | msg | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L133))
 
 ### getCost
 
@@ -262,7 +262,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L149))
 
 ### getTokens
 
@@ -274,7 +274,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L157))
 
 ### getModelCosts
 
@@ -292,7 +292,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L173))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L174))
 
 ### guard
 
@@ -364,7 +364,33 @@ Run a block under a cost limit, a time limit, or both, aborting the
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L215))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L216))
+
+### saveDraft
+
+```ts
+saveDraft(value: any)
+```
+
+Record a best-so-far value for the current function or guarded block. If an
+  enclosing `guard(...)` trips before this scope returns, the guard yields the
+  last saved draft instead of a failure — an "anytime" result you can always
+  fall back to. Call it repeatedly as your result improves; the last value
+  wins. With no enclosing guard it is a harmless no-op.
+
+  The value is type-checked against the enclosing scope's return type — a
+  function/node body, or a `guard` block (whose return type is inferred from its
+  `return`).
+
+  @param value - The best-so-far value. Should match the enclosing scope's return type.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `any` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L258))
 
 ### listThreads
 
@@ -397,7 +423,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L348))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L366))
 
 ### currentThreadId
 
@@ -412,7 +438,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L401))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L419))
 
 ### getThread
 
@@ -444,4 +470,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L411))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L429))

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2243,6 +2243,13 @@ export class TypeScriptBuilder {
         // runs outside any ALS frame (e.g. a function invoked as a tool
         // without an outer agencyStore.run wrap).
         ts.statements([
+          // On NORMAL completion (not an abort/interrupt unwind), clear this
+          // frame's saveDraft draft so a later sibling can't salvage a stale
+          // value. An unwinding frame keeps its draft for the guard boundary.
+          ts.if(
+            ts.id("__functionCompleted"),
+            ts.statements([ts.raw("__clearTopFrameDraft(__stateStack())")]),
+          ),
           ts.raw("__stateStack()?.pop()"),
           ...(skipHooks
             ? []

--- a/packages/agency-lang/lib/runtime/drafts.test.ts
+++ b/packages/agency-lang/lib/runtime/drafts.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { StateStack, State } from "./state/stateStack.js";
+import { failure, success } from "./result.js";
+import {
+  writeDraft,
+  writeCallerDraft,
+  draftRegionStart,
+  readOutermostDraft,
+  sweepDrafts,
+  salvageOwnTrip,
+  __clearTopFrameDraft,
+} from "./drafts.js";
+
+function stackWithFrames(n: number): StateStack {
+  const s = new StateStack();
+  for (let i = 0; i < n; i++) s.stack.push(new State());
+  return s;
+}
+
+describe("draft store", () => {
+  it("reads the outermost (shallowest) draft at or above the region", () => {
+    const s = stackWithFrames(4);
+    writeDraft(s, 2, "code");
+    writeDraft(s, 3, "verify");
+    expect(readOutermostDraft(s, 1)?.value).toBe("code");
+  });
+
+  it("last-wins per frame", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "first");
+    writeDraft(s, 2, "second");
+    expect(readOutermostDraft(s, 0)?.value).toBe("second");
+  });
+
+  it("returns undefined when nothing is at or above the region", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 1, "shallow");
+    expect(readOutermostDraft(s, 2)).toBeUndefined();
+  });
+
+  it("sweep deletes every draft at depth >= region", () => {
+    const s = stackWithFrames(4);
+    writeDraft(s, 1, "keep");
+    writeDraft(s, 2, "drop");
+    sweepDrafts(s, 2);
+    expect(readOutermostDraft(s, 0)?.value).toBe("keep");
+    expect(readOutermostDraft(s, 2)).toBeUndefined();
+  });
+
+  it("clearTopFrameDraft clears the top frame's draft only", () => {
+    const s = stackWithFrames(3); // top index = 2
+    writeDraft(s, 1, "caller");
+    writeDraft(s, 2, "top");
+    __clearTopFrameDraft(s);
+    expect(readOutermostDraft(s, 0)?.value).toBe("caller");
+    expect(readOutermostDraft(s, 2)).toBeUndefined();
+  });
+
+  it("writeCallerDraft keys the caller frame (one below the helper's top)", () => {
+    const s = stackWithFrames(4); // helper 'top' = index 3, caller = index 2
+    writeCallerDraft(s, "from-caller");
+    expect(readOutermostDraft(s, 2)?.value).toBe("from-caller");
+    expect(readOutermostDraft(s, 3)).toBeUndefined();
+  });
+
+  it("writeCallerDraft is a no-op with no caller (module/global scope)", () => {
+    const s = stackWithFrames(1); // callerDepth = -1
+    writeCallerDraft(s, "x");
+    expect(readOutermostDraft(s, 0)).toBeUndefined();
+  });
+
+  it("deep-clones on save (later mutation does not change the salvage)", () => {
+    const s = stackWithFrames(3);
+    const report = { text: "v1" };
+    writeCallerDraft(s, report); // caller = index 1
+    report.text = "v2";
+    expect(readOutermostDraft(s, 1)?.value).toEqual({ text: "v1" });
+  });
+
+  it("draftRegionStart marks the current stack depth", () => {
+    const s = stackWithFrames(3);
+    expect(draftRegionStart(s)).toBe(3);
+  });
+
+  it("salvageOwnTrip salvages ONLY on this guard's own trip", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "best");
+    const ownTrip = failure({ type: "guardFailure", guardId: "g1" });
+    expect(salvageOwnTrip(s, 0, ["g1"], ownTrip)).toEqual(success("best"));
+  });
+
+  it("salvageOwnTrip does NOT salvage a propagated (foreign-id) failure", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "best");
+    const foreign = failure({ type: "guardFailure", guardId: "inner" });
+    expect(salvageOwnTrip(s, 0, ["g1"], foreign)).toBe(foreign);
+    expect(readOutermostDraft(s, 0)).toBeUndefined(); // region still swept
+  });
+
+  it("salvageOwnTrip passes interrupts through WITHOUT sweeping", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, "best");
+    const interrupts = [{ type: "interrupt", id: "i1" }] as any;
+    expect(salvageOwnTrip(s, 0, ["g1"], interrupts)).toBe(interrupts);
+    expect(readOutermostDraft(s, 0)?.value).toBe("best"); // NOT swept
+  });
+
+  it("survives StateStack serialization round-trip", () => {
+    const s = stackWithFrames(3);
+    writeDraft(s, 2, { report: "partial" });
+    const restored = StateStack.fromJSON(JSON.parse(JSON.stringify(s.toJSON())));
+    expect(readOutermostDraft(restored, 0)?.value).toEqual({ report: "partial" });
+  });
+
+  it("tolerates a stack with no drafts", () => {
+    const s = stackWithFrames(2);
+    expect(readOutermostDraft(s, 0)).toBeUndefined();
+    sweepDrafts(s, 0);
+    __clearTopFrameDraft(s);
+    __clearTopFrameDraft(undefined);
+  });
+});

--- a/packages/agency-lang/lib/runtime/drafts.test.ts
+++ b/packages/agency-lang/lib/runtime/drafts.test.ts
@@ -77,23 +77,27 @@ describe("draft store", () => {
     expect(readOutermostDraft(s, 1)?.value).toEqual({ text: "v1" });
   });
 
-  it("draftRegionStart marks the current stack depth", () => {
+  it("draftRegionStart memoizes the region under its key (resume-stable)", () => {
     const s = stackWithFrames(3);
-    expect(draftRegionStart(s)).toBe(3);
+    expect(draftRegionStart(s, "g1")).toBe(3);
+    // A later call at a deeper stack returns the ORIGINAL marker, not 5.
+    s.stack.push(new State());
+    s.stack.push(new State());
+    expect(draftRegionStart(s, "g1")).toBe(3);
   });
 
   it("salvageOwnTrip salvages ONLY on this guard's own trip", () => {
     const s = stackWithFrames(3);
     writeDraft(s, 2, "best");
     const ownTrip = failure({ type: "guardFailure", guardId: "g1" });
-    expect(salvageOwnTrip(s, 0, ["g1"], ownTrip)).toEqual(success("best"));
+    expect(salvageOwnTrip(s, 0, ["g1"], ownTrip, "g1")).toEqual(success("best"));
   });
 
   it("salvageOwnTrip does NOT salvage a propagated (foreign-id) failure", () => {
     const s = stackWithFrames(3);
     writeDraft(s, 2, "best");
     const foreign = failure({ type: "guardFailure", guardId: "inner" });
-    expect(salvageOwnTrip(s, 0, ["g1"], foreign)).toBe(foreign);
+    expect(salvageOwnTrip(s, 0, ["g1"], foreign, "g1")).toBe(foreign);
     expect(readOutermostDraft(s, 0)).toBeUndefined(); // region still swept
   });
 
@@ -101,7 +105,7 @@ describe("draft store", () => {
     const s = stackWithFrames(3);
     writeDraft(s, 2, "best");
     const interrupts = [{ type: "interrupt", id: "i1" }] as any;
-    expect(salvageOwnTrip(s, 0, ["g1"], interrupts)).toBe(interrupts);
+    expect(salvageOwnTrip(s, 0, ["g1"], interrupts, "g1")).toBe(interrupts);
     expect(readOutermostDraft(s, 0)?.value).toBe("best"); // NOT swept
   });
 

--- a/packages/agency-lang/lib/runtime/drafts.ts
+++ b/packages/agency-lang/lib/runtime/drafts.ts
@@ -1,0 +1,114 @@
+import type { StateStack } from "./state/stateStack.js";
+import type { ResultValue } from "./result.js";
+import { deepClone } from "./utils.js";
+import { isFailure, success } from "./result.js";
+import { hasInterrupts } from "./interrupts.js";
+
+/** A saved best-so-far value. Wrapped so a stored `null`/`undefined` value is
+ *  distinct from "no draft for this frame". */
+type DraftRecord = { value: any };
+
+// Branch-local, serialized store: frame depth -> its latest draft. Lives in
+// `StateStack.other` (NOT on `State`) because frames are popped by the unwind
+// before a guard boundary reads them — `other` outlives frame pops. Depth
+// arithmetic is centralized here so no caller ever touches a stack index. See
+// docs/superpowers/specs/2026-07-14-save-draft-guards-design.md.
+
+/** The draft map on this stack, or undefined if none written yet. `other` is
+ *  already typed `Record<string, any>`, so no cast is needed. */
+function peekDrafts(stack: StateStack): Record<number, DraftRecord> | undefined {
+  return stack.other.drafts as Record<number, DraftRecord> | undefined;
+}
+
+function ensureDrafts(stack: StateStack): Record<number, DraftRecord> {
+  if (!stack.other.drafts) stack.other.drafts = {};
+  return stack.other.drafts as Record<number, DraftRecord>;
+}
+
+/** Depth of the frame that CALLED the current TS helper — the Agency scope
+ *  whose draft this is. Mirrors `StateStack.callerFrame()` (one frame below the
+ *  helper's own top frame). -1 when there is no caller (module-init/global). */
+function callerDepth(stack: StateStack): number {
+  return stack.stack.length - 2;
+}
+
+/** Low-level depth-keyed write (used by writeCallerDraft and unit tests). The
+ *  value is DEEP-CLONED so a later mutation of the saved object can't change the
+ *  salvage, and so a live-trip salvage matches a post-resume salvage (which
+ *  reads the checkpoint's clone). Matches Agency's value semantics. */
+export function writeDraft(stack: StateStack, depth: number, value: unknown): void {
+  ensureDrafts(stack)[depth] = { value: deepClone(value) };
+}
+
+/** Record the caller frame's best-so-far draft (last call wins). */
+export function writeCallerDraft(stack: StateStack, value: unknown): void {
+  const depth = callerDepth(stack);
+  if (depth < 0) return; // no caller: harmless no-op
+  writeDraft(stack, depth, value);
+}
+
+/** The region marker for a guard entered now: drafts at depth >= this are
+ *  "under" the guard. A positional marker is inherent (frames pop before the
+ *  boundary reads), but its meaning lives in this named function. */
+export function draftRegionStart(stack: StateStack): number {
+  return stack.stack.length;
+}
+
+/** The outermost draft under a guard: the shallowest depth >= `region`, or
+ *  undefined. Outermost (not deepest) is the type-closest choice — see spec. */
+export function readOutermostDraft(
+  stack: StateStack,
+  region: number,
+): DraftRecord | undefined {
+  const drafts = peekDrafts(stack);
+  if (!drafts) return undefined;
+  const depths = Object.keys(drafts)
+    .map(Number)
+    .filter((d) => d >= region);
+  return depths.length === 0 ? undefined : drafts[Math.min(...depths)];
+}
+
+/** Delete every draft at depth >= `region`. */
+export function sweepDrafts(stack: StateStack, region: number): void {
+  const drafts = peekDrafts(stack);
+  if (!drafts) return;
+  for (const d of Object.keys(drafts).map(Number)) {
+    if (d >= region) delete drafts[d];
+  }
+}
+
+/** Turn a guarded block's settled result into the guard's final result:
+ *   1. a PAUSED block (interrupts) passes through untouched — no sweep, its
+ *      drafts must survive resume;
+ *   2. on THIS guard's OWN trip (failure whose `guardId` is in `ids`), salvage
+ *      the outermost draft in the region;
+ *   3. otherwise return the result unchanged;
+ *   then sweep the region on any settled exit. */
+export function salvageOwnTrip(
+  stack: StateStack,
+  region: number,
+  ids: string[],
+  result: ResultValue | unknown,
+): ResultValue | unknown {
+  if (hasInterrupts(result)) return result;
+  let out = result;
+  const guardId = (
+    isFailure(result) ? (result.error as { guardId?: string }) : undefined
+  )?.guardId;
+  if (guardId !== undefined && ids.includes(guardId)) {
+    const draft = readOutermostDraft(stack, region);
+    if (draft !== undefined) out = success(draft.value);
+  }
+  sweepDrafts(stack, region);
+  return out;
+}
+
+/** Clear the CURRENT top frame's draft. Called from generated code (def
+ *  `finally` on `__functionCompleted`; block try-body on `!runner.halted`), so a
+ *  frame unwinding on an abort/interrupt keeps its draft for the boundary. */
+export function __clearTopFrameDraft(stack: StateStack | undefined): void {
+  if (!stack) return;
+  const drafts = peekDrafts(stack);
+  if (!drafts) return;
+  delete drafts[stack.stack.length - 1];
+}

--- a/packages/agency-lang/lib/runtime/drafts.ts
+++ b/packages/agency-lang/lib/runtime/drafts.ts
@@ -47,11 +47,25 @@ export function writeCallerDraft(stack: StateStack, value: unknown): void {
   writeDraft(stack, depth, value);
 }
 
-/** The region marker for a guard entered now: drafts at depth >= this are
- *  "under" the guard. A positional marker is inherent (frames pop before the
- *  boundary reads), but its meaning lives in this named function. */
-export function draftRegionStart(stack: StateStack): number {
-  return stack.stack.length;
+function ensureRegions(stack: StateStack): Record<string, number> {
+  if (!stack.other.draftRegions) stack.other.draftRegions = {};
+  return stack.other.draftRegions as Record<string, number>;
+}
+
+/** The region marker for a guard scope, memoized under `key` (the guard's
+ *  id-set). Drafts saved under the guard sit at depth >= this marker. Memoized
+ *  in serialized `other` because re-capturing `stack.stack.length` on resume
+ *  shifts by the restored block frame — the marker must be resume-stable, like
+ *  the guard's own `ids`. Cleared by `clearDraftRegion` on guard exit. */
+export function draftRegionStart(stack: StateStack, key: string): number {
+  const regions = ensureRegions(stack);
+  if (regions[key] === undefined) regions[key] = stack.stack.length;
+  return regions[key];
+}
+
+function clearDraftRegion(stack: StateStack, key: string): void {
+  const regions = stack.other.draftRegions as Record<string, number> | undefined;
+  if (regions) delete regions[key];
 }
 
 /** The outermost draft under a guard: the shallowest depth >= `region`, or
@@ -89,6 +103,7 @@ export function salvageOwnTrip(
   region: number,
   ids: string[],
   result: ResultValue | unknown,
+  key: string,
 ): ResultValue | unknown {
   if (hasInterrupts(result)) return result;
   let out = result;
@@ -100,6 +115,7 @@ export function salvageOwnTrip(
     if (draft !== undefined) out = success(draft.value);
   }
   sweepDrafts(stack, region);
+  clearDraftRegion(stack, key);
   return out;
 }
 

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -28,6 +28,15 @@ export {
   type AgencyStore,
 } from "./asyncContext.js";
 export { StateStack, State } from "./state/stateStack.js";
+export {
+  writeDraft,
+  writeCallerDraft,
+  draftRegionStart,
+  readOutermostDraft,
+  sweepDrafts,
+  salvageOwnTrip,
+  __clearTopFrameDraft,
+} from "./drafts.js";
 export { GlobalStore } from "./state/globalStore.js";
 export { MessageThread } from "./state/messageThread.js";
 export { ThreadStore } from "./state/threadStore.js";

--- a/packages/agency-lang/lib/runtime/result.ts
+++ b/packages/agency-lang/lib/runtime/result.ts
@@ -11,12 +11,17 @@ function guardFailureData(
   dimension: "cost" | "time",
   limit: number,
   spent: number,
+  guardId: string,
 ): {
   type: string;
   maxCost: number | null;
   actualCost: number | null;
   maxTime: number | null;
   actualTime: number | null;
+  // Internal: which guard tripped. Lets the owning `guard`'s salvage path
+  // (saveDraft) distinguish this guard's OWN trip from a propagated inner
+  // failure. Additive — documented consumers read type/maxCost/maxTime/actuals.
+  guardId: string;
 } {
   if (dimension === "time") {
     return {
@@ -25,6 +30,7 @@ function guardFailureData(
       actualCost: null,
       maxTime: limit,
       actualTime: spent,
+      guardId,
     };
   }
   return {
@@ -33,6 +39,7 @@ function guardFailureData(
     actualCost: spent,
     maxTime: null,
     actualTime: null,
+    guardId,
   };
 }
 
@@ -209,7 +216,7 @@ export async function __tryCall(fn: () => any, opts?: FailureOpts): Promise<Resu
         // The cause object is shared by identity with `signal.reason`.
         guardCause.delivered = true;
         return failure(
-          guardFailureData(guardCause.dimension, guardCause.limit, guardCause.spent),
+          guardFailureData(guardCause.dimension, guardCause.limit, guardCause.spent, guardCause.guardId),
           opts,
         );
       }

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -2,6 +2,7 @@ import * as smoltalk from "smoltalk";
 import { agencyStore, getRuntimeContext } from "../runtime/asyncContext.js";
 import type { ReplyAttachmentPart } from "../runtime/replyAttachments.js";
 import { __tryCall, type ResultValue } from "../runtime/result.js";
+import { writeCallerDraft, draftRegionStart, salvageOwnTrip } from "../runtime/drafts.js";
 import { __call } from "../runtime/call.js";
 import { CostGuard, TimeGuard } from "../runtime/guard.js";
 import { normalizeModelUsage, type ModelUsage } from "../runtime/utils.js";
@@ -336,6 +337,17 @@ export async function _popGuard(ids: string[]): Promise<void> {
 }
 
 /**
+ * Impl of the Agency `saveDraft(value)` builtin. Records a best-so-far value for
+ * the CALLER's frame (the Agency function/block that called saveDraft), so a
+ * tripping enclosing `guard` can salvage it. The draft-store owns all frame
+ * arithmetic; this helper just forwards. No-op with no caller.
+ */
+export function _saveDraft(value: unknown): void {
+  const { stack } = getRuntimeContext();
+  writeCallerDraft(stack, value);
+}
+
+/**
  * Run the guarded block under a `try` that owns exactly the guards in `ids`,
  * so a `guardTrip` is converted to a Failure ONLY when it belongs to one of
  * THIS guard()'s guards (an outer guard's trip re-throws past it).
@@ -363,13 +375,18 @@ export async function _runGuarded(
   block: unknown,
 ): Promise<ResultValue> {
   const { ctx, stack } = getRuntimeContext();
+  // Mark the draft region BEFORE running the block: drafts saved by the block
+  // and everything it calls sit at stack depth >= this marker. Keyed by this
+  // guard's id-set so the marker is resume-stable (see draftRegionStart).
+  const regionKey = ids.join(",");
+  const region = draftRegionStart(stack, regionKey);
   // Invoke the block through __call (NOT a plain block()) so it runs through
   // the same Agency call machinery the codegen `try block()` used — that is
   // what lets a guard trip inside the block surface as an AgencyAbort with its
   // guardTrip cause instead of a generic error. `stack.lastFrame()` is
   // guard()'s own frame here (a TS call pushes no agency frame), so `.args`
   // matches what the codegen `try block()` captured via `__stack.args`.
-  return __tryCall(
+  const result = await __tryCall(
     () => __call(block, { type: "positional", args: [] }),
     {
       ownedGuardIds: ids,
@@ -378,4 +395,7 @@ export async function _runGuarded(
       args: stack.lastFrame()?.args,
     },
   );
+  // Interrupts pass through untouched (no sweep — drafts must survive resume);
+  // on THIS guard's own trip salvage the outermost draft; then sweep the region.
+  return salvageOwnTrip(stack, region, ids, result, regionKey) as ResultValue;
 }

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
@@ -8,6 +8,12 @@ __bstack.args[{{{this.paramNameQuoted}}}] = {{{this.paramName}}};
 const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}} });
 try {
 {{{body}}}
+// Clear this block frame's saveDraft draft on NORMAL completion only. `halted`
+// is true for BOTH a normal value-return (`return x` lowers to `runner.halt(x)`)
+// and an interrupt — so gate on the haltResult NOT being interrupts: an
+// interrupt keeps the draft for resume; a thrown trip skips this line and keeps
+// it for the guard boundary.
+if (!hasInterrupts(runner.haltResult)) { __clearTopFrameDraft(__bsetup.stateStack); }
 return runner.halted ? runner.haltResult : undefined;
 } finally {
 // Pop the SAME stack `setupFunction` pushed onto (the ALS-current

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
@@ -13,6 +13,12 @@ __bstack.args[{{{this.paramNameQuoted}}}] = {{{this.paramName}}};
 const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}} });
 try {
 {{{body}}}
+// Clear this block frame's saveDraft draft on NORMAL completion only. \`halted\`
+// is true for BOTH a normal value-return (\`return x\` lowers to \`runner.halt(x)\`)
+// and an interrupt — so gate on the haltResult NOT being interrupts: an
+// interrupt keeps the draft for resume; a thrown trip skips this line and keeps
+// it for the guard boundary.
+if (!hasInterrupts(runner.haltResult)) { __clearTopFrameDraft(__bsetup.stateStack); }
 return runner.halted ? runner.haltResult : undefined;
 } finally {
 // Pop the SAME stack \`setupFunction\` pushed onto (the ALS-current

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -26,6 +26,7 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  __clearTopFrameDraft,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -31,6 +31,7 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, __globals, getRuntimeContext, agencyStore,
+  __clearTopFrameDraft,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   installFetchMock as __installFetchMock,

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -263,7 +263,7 @@ function checkSaveDraftCall(
   ctx: TypeCheckerContext,
 ): void {
   if (call.functionName !== "saveDraft") return;
-  if (info.returnType === undefined) return;
+  if (!info.returnType) return; // no declared/inferred return type in scope
   if (call.arguments.length !== 1) return;
   const arg = call.arguments[0];
   if (arg.type === "splat" || arg.type === "namedArgument") return;

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -245,8 +245,29 @@ function checkFunctionCallsInScope(
       const parent = ancestors[ancestors.length - 1];
       if (parent?.type === "valueAccess") continue;
       checkSingleFunctionCall(node, info.scope, ctx);
+      checkSaveDraftCall(node, info, ctx);
     }
   }
+}
+
+/** `saveDraft(v)` records a best-so-far value that a tripping enclosing `guard`
+ *  yields in place of a failure — so `v` must be assignable to the enclosing
+ *  scope's return type, the same contract a `return` obeys. This covers def/node
+ *  bodies AND guard blocks (a block's return type is inferred from its `return`).
+ *  Only a scope with no inferred/declared return type (`info.returnType`
+ *  undefined) is skipped. Name-keyed: aliasing `saveDraft` (`const s = saveDraft;
+ *  s(v)`) escapes the check (documented v1 limitation). */
+function checkSaveDraftCall(
+  call: FunctionCall,
+  info: ScopeInfo,
+  ctx: TypeCheckerContext,
+): void {
+  if (call.functionName !== "saveDraft") return;
+  if (info.returnType === undefined) return;
+  if (call.arguments.length !== 1) return;
+  const arg = call.arguments[0];
+  if (arg.type === "splat" || arg.type === "namedArgument") return;
+  checkType(arg, info.returnType, info.scope, "the saveDraft() draft value", ctx);
 }
 
 export function isInsideHandler(ancestors: WalkAncestor[]): boolean {

--- a/packages/agency-lang/lib/typeChecker/saveDraft.test.ts
+++ b/packages/agency-lang/lib/typeChecker/saveDraft.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { AgencyConfig } from "../config.js";
+
+function check(source: string, config: Partial<AgencyConfig> = {}) {
+  const parsed = parseAgency(source);
+  if (!parsed.success) {
+    throw new Error(`parse failed: ${parsed.message}`);
+  }
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  const result = typeCheck(parsed.result, config, info);
+  return result.errors
+    .filter((e) => (e.severity ?? "error") === "error")
+    .map((e) => e.message);
+}
+
+describe("saveDraft argument type-check", () => {
+  it("accepts a draft assignable to the enclosing return type", () => {
+    const errors = check(`
+      import { guard, saveDraft } from "std::thread"
+      def f(): string {
+        saveDraft("ok")
+        return "x"
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects a draft not assignable to the enclosing return type", () => {
+    const errors = check(`
+      import { guard, saveDraft } from "std::thread"
+      def f(): string {
+        saveDraft(42)
+        return "x"
+      }
+    `);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("checks a draft inside a guard block against the block's inferred return type", () => {
+    // A guard block's return type is inferred from its `return` (here `string`),
+    // so a matching draft is fine and a mismatched one is flagged — the check is
+    // NOT limited to top-level def/node bodies.
+    const ok = check(`
+      import { guard, saveDraft } from "std::thread"
+      def f(): string {
+        const r = guard(cost: 1.0) as {
+          saveDraft("ok")
+          return "x"
+        }
+        return "y"
+      }
+    `);
+    expect(ok).toHaveLength(0);
+
+    const bad = check(`
+      import { guard, saveDraft } from "std::thread"
+      def f(): string {
+        const r = guard(cost: 1.0) as {
+          saveDraft(42)
+          return "x"
+        }
+        return "y"
+      }
+    `);
+    expect(bad.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -36,6 +36,7 @@ import {
   _pushGuard,
   _popGuard,
   _runGuarded,
+  _saveDraft,
  } from "agency-lang/stdlib-lib/thread.js"
 
 import { _installSlowInputImpl } from "agency-lang/stdlib-lib/builtins.js"
@@ -252,6 +253,22 @@ export def guard(
   const result = _runGuarded(ids, block)
   _popGuard(ids)
   return result
+}
+
+export def saveDraft(value: any) {
+  """
+  Record a best-so-far value for the current function or guarded block. If an
+  enclosing `guard(...)` trips before this scope returns, the guard yields the
+  last saved draft instead of a failure — an "anytime" result you can always
+  fall back to. Call it repeatedly as your result improves; the last value
+  wins. With no enclosing guard it is a harmless no-op.
+
+  The value is type-checked against the enclosing function/node's return type
+  (a draft inside a bare `guard` block is unchecked — the block's type is `any`).
+
+  @param value - The best-so-far value. Should match the enclosing scope's return type.
+  """
+  _saveDraft(value)
 }
 
 /** Test-only seam (import test { _installSlowInput }): install an input()

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -263,8 +263,9 @@ export def saveDraft(value: any) {
   fall back to. Call it repeatedly as your result improves; the last value
   wins. With no enclosing guard it is a harmless no-op.
 
-  The value is type-checked against the enclosing function/node's return type
-  (a draft inside a bare `guard` block is unchecked — the block's type is `any`).
+  The value is type-checked against the enclosing scope's return type — a
+  function/node body, or a `guard` block (whose return type is inferred from its
+  `return`).
 
   @param value - The best-so-far value. Should match the enclosing scope's return type.
   """

--- a/packages/agency-lang/tests/agency/guards/save-draft-basic.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-basic.agency
@@ -1,0 +1,15 @@
+import { guard, saveDraft } from "std::thread"
+
+// SYNTHETIC_COST = 0.000002 per llm call; limit 0.000001 trips on the first
+// call. saveDraft runs first, so the guard salvages "partial" instead of failing.
+node main() {
+  const result = guard(cost: 0.000001) as {
+    saveDraft("partial")
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) {
+    return "unexpected failure"
+  }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-basic.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-basic.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"partial\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A guard trip after saveDraft returns the saved draft instead of a failure."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.agency
@@ -1,0 +1,18 @@
+import { guard, saveDraft } from "std::thread"
+
+def branch(tag: string): string {
+  const r = guard(cost: 0.000001) as {
+    saveDraft(tag)
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(r)) { return "fail" }
+  return r.value
+}
+
+node main() {
+  const results = fork(["a", "b", "c"]) as tag {
+    return branch(tag)
+  }
+  return "${results[0]}|${results[1]}|${results[2]}"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"a|b|c\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }, { "return": "pong" }, { "return": "pong" }],
+      "description": "Each fork branch salvages its own draft; no cross-branch clobber (branch-local other.drafts)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.agency
@@ -1,0 +1,17 @@
+import { guard, saveDraft } from "std::thread"
+
+def branch(tag: string): string {
+  saveDraft(tag)          // on the BRANCH's own stack — parent guard can't see it
+  return tag
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const tags = fork(["a", "b"]) as t {
+      return branch(t)
+    }
+    const reply = llm("Reply with: pong")   // parent trips here, after the fork joins
+    return reply
+  }
+  return "${isFailure(result)}"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A guard OUTSIDE a fork does not salvage branch drafts (they live on branch stacks); the parent trip is a failure."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-interrupt-resume.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-interrupt-resume.agency
@@ -1,0 +1,12 @@
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const result = guard(time: 500ms) as {
+    saveDraft("pre-interrupt")
+    interrupt("continue?")      // pause; harness approves → resume
+    sleep(2000)                 // after resume, exceed 500ms → trip
+    return "done"
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-interrupt-resume.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-interrupt-resume.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pre-interrupt\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }],
+      "description": "The pre-interrupt draft survives an interrupt/resume cycle and is salvaged on a later trip."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-last-wins.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-last-wins.agency
@@ -1,0 +1,12 @@
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    saveDraft("first")
+    saveDraft("second")
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-last-wins.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-last-wins.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"second\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "Multiple saveDraft calls: the last value wins."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-nested-guards.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-nested-guards.agency
@@ -1,0 +1,15 @@
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const outer = guard(cost: 0.000003) as {
+    const inner = guard(cost: 0.000001) as {
+      saveDraft("inner-draft")
+      const a = llm("Reply with: pong")
+      return a
+    }
+    // outer saves NO draft of its own; then it trips.
+    const b = llm("Reply with: pong")
+    return b
+  }
+  return "${isFailure(outer)}"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-nested-guards.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-nested-guards.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }, { "return": "pong" }],
+      "description": "Inner guard salvages and sweeps its region; the outer trip must not read the swept inner draft."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-no-draft.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-no-draft.agency
@@ -1,0 +1,10 @@
+import { guard } from "std::thread"
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) { return "failed:${result.error.type}" }
+  return "no trip"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-no-draft.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-no-draft.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"failed:guardFailure\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "Additivity: a trip with no saveDraft still returns a failure."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-outermost.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-outermost.agency
@@ -1,0 +1,21 @@
+import { guard, saveDraft } from "std::thread"
+
+def verify(): string {
+  saveDraft("verify-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+def code(): string {
+  saveDraft("code-draft")
+  const x = verify()
+  return x
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return code()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-outermost.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-outermost.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"code-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "Outermost-set draft wins across frames: trip inside verify returns code's draft."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-propagated-failure.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-propagated-failure.agency
@@ -1,0 +1,13 @@
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const outer = guard(cost: 10.0) as {           // generous — outer never trips
+    saveDraft("outer-draft")
+    const inner = guard(cost: 0.000001) as {      // inner trips, saves nothing
+      const reply = llm("Reply with: pong")
+      return reply
+    }
+    return inner                                  // deliberately propagate the failure
+  }
+  return "${isFailure(outer)}"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-propagated-failure.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-propagated-failure.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A returned inner-guard failure must NOT be salvaged by the outer guard (guardId ownership, not shape)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-sequential-guards.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-sequential-guards.agency
@@ -1,0 +1,16 @@
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const r1 = guard(cost: 0.000001) as {
+    saveDraft("g1-draft")
+    const a = llm("Reply with: pong")
+    return a
+  }
+  const r2 = guard(cost: 0.000001) as {
+    const b = llm("Reply with: pong")
+    return b
+  }
+  let first = "?"
+  if (isSuccess(r1)) { first = r1.value }
+  return "${first}|${isFailure(r2)}"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-sequential-guards.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-sequential-guards.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"g1-draft|true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }, { "return": "pong" }],
+      "description": "The boundary sweep prevents guard B from reading guard A's draft."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-stale-block.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-stale-block.agency
@@ -1,0 +1,26 @@
+import { guard, saveDraft } from "std::thread"
+
+// A user combinator that runs a block on the CURRENT stack. Its block saves a
+// draft and completes NORMALLY (never cleared without block clearing); then a
+// sibling trips and must NOT salvage the stale block draft.
+def withLabel(block: () -> any = null): any {
+  return block()
+}
+
+def tripper(): string {
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const x = withLabel() as {
+      saveDraft("stale-block")
+      return 1
+    }
+    const b = tripper()
+    return b
+  }
+  if (isSuccess(result)) { return "leaked:${result.value}" }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-stale-block.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-stale-block.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"failed\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A normally-completed combinator block's draft is cleared, so a later trip yields a failure, not the stale block draft."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.agency
@@ -1,0 +1,24 @@
+import { guard, saveDraft } from "std::thread"
+
+// `saver` saves a draft and returns NORMALLY (no llm, no cost). `tripper` then
+// trips before saving anything. Without normal-completion clearing, the guard
+// would wrongly salvage "stale" from `saver`; with it, the guard fails.
+def saver(): string {
+  saveDraft("stale")
+  return "ok"
+}
+
+def tripper(): string {
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const a = saver()
+    const b = tripper()
+    return b
+  }
+  if (isSuccess(result)) { return "leaked:${result.value}" }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"failed\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A normally-completed sibling def's draft is cleared, so a later trip yields a failure, not the stale draft."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-time-trip.agency
+++ b/packages/agency-lang/tests/agency/guards/save-draft-time-trip.agency
@@ -1,0 +1,11 @@
+import { guard, saveDraft } from "std::thread"
+
+node main() {
+  const result = guard(time: 500ms) as {
+    saveDraft("timed-draft")
+    sleep(2000)                 // exceeds 500ms → time trip
+    return "done"
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/save-draft-time-trip.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-time-trip.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"timed-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Salvage on a TIME trip (aborted-leaf delivery path)."
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

`guard(cost:, time:)` blocks are binary today: when the budget trips, the block returns a `failure` and **all partial work is lost**. This adds `saveDraft(v)` — an *anytime-algorithm* floor. Code records a best-so-far value as it works; when an enclosing guard trips, the guard returns the last saved draft instead of a failure.

The motivating case: *"research this, but don't spend more than five minutes"* — when the clock runs out, return the best answer so far rather than nothing.

```
const report = guard(time: 5m) as {
  let r = initialReport()
  saveDraft(r)                 // floor: even an immediate trip returns this
  while (moreToDo()) {
    r = refine(r)
    saveDraft(r)               // last-wins; best-so-far keeps improving
  }
  return r
}
```

With no `saveDraft` calls, guard behavior is byte-for-byte unchanged (additive).

## Design

- **Storage:** branch-local `StateStack.other.drafts`, keyed by frame depth. `other` outlives frame pops (frames are popped by the unwind *before* the guard boundary reads them), serializes for interrupt/resume, and is per-branch so `fork`/`race` branches can't clobber each other. Never on `State` (pops too early) or the guard object (shared/cloned across branches).
- **Value semantics:** drafts are `deepClone`d at save, so a later mutation can't change the salvage and a live-trip salvage matches a post-resume one.
- **Trip read:** on a settled result, `salvageOwnTrip` (1) passes interrupts through untouched — a paused block keeps its drafts for resume, no sweep; (2) salvages the **outermost** (shallowest) draft under the guard **only on this guard's own trip** — identified by a `guardId` now carried on `guardFailureData`, so a *returned* inner-guard failure is never mis-salvaged; (3) sweeps the region.
- **Outermost-wins (not deepest)** is the type-closest choice: a nested callee's draft is its own type, not the guard block's. Deep/cross-type salvage is deferred to a future `finalize`.
- **Clearing rule:** a frame clears its draft on **normal** completion (def `finally` on `__functionCompleted`; block try-body when `haltResult` is not interrupts), and keeps it on an abort/interrupt unwind. Prevents a completed sibling from leaking a stale salvage.
- **Type check:** `saveDraft(v)` is checked against the enclosing scope's return type (def/node bodies *and* guard blocks, whose type is inferred). Name-keyed; aliasing escapes (documented).

## Tests

- Draft-store unit tests (14), checker tests (3), plus 13 execution fixtures: basic salvage, additivity (no-draft), last-wins, outermost-across-frames, sequential-guards, nested-guards, propagated-failure (ownership), time-trip, interrupt-resume, stale-sibling, stale-block, fork-isolation, guard-outside-fork.
- Full `tests/agency/guards/` sweep: **47/47 pass**. Typechecker suite: 1545 pass. `result.ts`: 41 pass.

## Notes / deferred

Spec + plan are in `docs/superpowers/`. Deferred to follow-ups (each with a home in the model): `finalize` blocks, deep/fork-array salvage, `sigint`/`sigkill`, `saveDraft` as an LLM tool, a `Both` result type, and generalizing beyond guard trips (Esc/cancel/race). Root budgets (`--max-cost`/`--max-time`) bypass `_runGuarded`, so v1 doesn't salvage a root-budget trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
