### PR TITLE
verify: execute checks + honor an authoritative expert checklist; drop Feedback.data

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -97,8 +97,7 @@ type error, or the reviewer judged it does not do the task); `error:
 false` is advisory feedback, including typecheck warnings. */
 export type Feedback = {
   error: boolean;
-  feedback: string;
-  data?: any
+  feedback: string
 }
 ```
 
@@ -118,7 +117,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L586))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L603))
 
 ### AST
 
@@ -141,7 +140,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L737))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L754))
 
 ## Effects
 
@@ -458,7 +457,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L383))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L382))
 
 ### review
 
@@ -482,7 +481,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L453))
 
 ### renderFeedback
 
@@ -502,7 +501,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L485))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L484))
 
 ### feedbackHasErrors
 
@@ -523,7 +522,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L497))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L496))
 
 ### failOpenFeedback
 
@@ -543,7 +542,7 @@ Pass a successful feedback list through unchanged; map any failure to
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L514))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L513))
 
 ### syntaxHintFor
 
@@ -564,12 +563,12 @@ A specific syntax reminder to inject next to a diagnostic, or "" when no
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L525))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L524))
 
 ### verify
 
 ```ts
-verify(task: string): Result<Feedback[]>
+verify(task: string, criteria: string[] = []): Result<Feedback[]>
 ```
 
 Reconstruct a task's success criteria, run the produced artifact against
@@ -578,16 +577,20 @@ Reconstruct a task's success criteria, run the produced artifact against
   success) if verification cannot run, so it never blocks.
 
   @param task - The original task description to verify against.
+  @param criteria - Optional authoritative acceptance criteria (e.g. an expert
+    checklist) that verify must check exactly, instead of only re-deriving its
+    own from the task text.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | task | `string` |  |
+| criteria | `string[]` | [] |
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L568))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L582))
 
 ### writeAgency
 
@@ -618,7 +621,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L649))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L666))
 
 ### typecheckFile
 
@@ -643,7 +646,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L717))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L734))
 
 ### parseAST
 
@@ -663,7 +666,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L743))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L760))
 
 ### writeAST
 
@@ -700,7 +703,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L755))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L772))
 
 ### format
 
@@ -720,7 +723,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L777))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L794))
 
 ### formatFile
 
@@ -747,7 +750,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L788))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L805))
 
 ### walkAST
 
@@ -776,7 +779,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L807))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L824))
 
 ### getNodesOfType
 
@@ -798,7 +801,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L827))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L844))
 
 ### getImports
 
@@ -818,7 +821,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L837))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L854))
 
 ### getFunctions
 
@@ -838,7 +841,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L846))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L863))
 
 ### getGraphNodes
 
@@ -858,7 +861,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L855))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L872))
 
 ### filterImports
 
@@ -910,7 +913,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L882))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L899))
 
 ### getVersion
 
@@ -922,4 +925,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L908))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L925))

--- a/packages/agency-lang/docs/site/stdlib/agents/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/coding.md
@@ -16,6 +16,7 @@ General-purpose coding agent: writes, edits, and runs code to complete a
 codingAgent(
   task: string,
   context: string = "",
+  criteria: string[] = [],
   maxAttempts: number = 3,
   maxCost: number = $50.00,
   maxTime: number = 30m,
@@ -28,6 +29,9 @@ General-purpose coding agent. Writes and runs code to complete a task and
 
   @param task - What to build or fix.
   @param context - Optional extra material (data, examples, constraints).
+  @param criteria - Optional authoritative acceptance criteria (e.g. an expert
+    checklist) passed through to `verify` so the strict review checks those
+    exact items, not just its own re-derivation.
   @param maxAttempts - Max verify-and-fix attempts before returning (default 3).
   @param maxCost - Hard spend cap for the whole run (default $50).
   @param maxTime - Hard wall-clock cap for the whole run (default 30 minutes).
@@ -38,6 +42,7 @@ General-purpose coding agent. Writes and runs code to complete a task and
 |---|---|---|
 | task | `string` |  |
 | context | `string` | "" |
+| criteria | `string[]` | [] |
 | maxAttempts | `number` | 3 |
 | maxCost | `number` | $50.00 |
 | maxTime | `number` | 30m |

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/review.agency
@@ -24,8 +24,7 @@ import { filter, map } from "std::array"
 /** Structurally identical to std::agency Feedback. */
 export type Feedback = {
   error: boolean;
-  feedback: string;
-  data?: any
+  feedback: string
 }
 
 export def renderFeedback(feedback: Result<Feedback[]>): string {

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -376,8 +376,7 @@ type error, or the reviewer judged it does not do the task); `error:
 false` is advisory feedback, including typecheck warnings. */
 export type Feedback = {
   error: boolean;
-  feedback: string;
-  data?: any
+  feedback: string
 }
 
 export def mergeFeedback(
@@ -415,10 +414,10 @@ def parseFeedback(source: string): Result<Feedback[]> {
 def reportFeedback(report: TypeCheckReport): Feedback[] {
   const feedback: Feedback[] = []
   for (error in report.errors) {
-    feedback.push({ error: true, feedback: "Error: ${error.message}", data: error })
+    feedback.push({ error: true, feedback: "Error: ${error.message}" })
   }
   for (warning in report.warnings) {
-    feedback.push({ error: false, feedback: "Warning: ${warning.message}", data: warning })
+    feedback.push({ error: false, feedback: "Warning: ${warning.message}" })
   }
   return feedback
 }
@@ -549,23 +548,34 @@ static const verifyTools: any[] = [
   exec.partial(useAgentCwd: true),
 ]
 
-static const verifySysPrompt = """You verify whether a coding task was completed correctly. You do NOT fix anything. Inspect, run, and report.
+static const verifySysPrompt = """You verify whether a coding task was completed correctly. You do NOT fix anything. Inspect, COMPUTE, and report.
 
-The grading tests are hidden and NOT in this environment. Reconstruct the success check from the task's own description and any example usage, then RUN the artifact through it with the `exec` tool. Check the output contract STRICTLY: exact file path and name, exact format (JSON keys, field types, units, signed-vs-unsigned), the task's stated whitespace and trailing-newline requirement (present or absent), and every explicit criterion. A near-miss on the output contract is an error."""
+The grading tests are hidden and NOT in this environment, so you must reconstruct and ACTUALLY RUN every check the task states — never eyeball the artifact.
+
+Method:
+1. Enumerate EVERY explicit success criterion in the task. Two kinds: the output contract (exact file path and name, format, JSON keys, field types, units, signed-vs-unsigned, the stated whitespace / trailing-newline requirement) AND every quantitative rule (lengths, ranges, counts, thresholds, temperatures, GC content, percentages, etc.).
+2. For EACH criterion, use the `exec` tool to COMPUTE the artifact's actual value and compare it to the requirement. If the task names a specific tool or command to compute a value (e.g. a CLI with exact flags), install if needed and run THAT tool — it is the ground truth; do not approximate it with your own estimate.
+3. A criterion you did NOT computationally verify is itself a gap — report it as one. A near-miss on any numeric constraint is an error: report the actual computed value vs. the requirement (e.g. "Tm difference 6.5°C, limit 5°C").
+
+Never say the artifact "appears" or "should" satisfy something. Run it, measure it, and report a concrete pass/fail per criterion with the numbers."""
 
 // The throwing inner: two-phase inspection. `verify` wraps it fail-open.
-def verifyInner(task: string): Feedback[] {
+def verifyInner(task: string, criteria: string[] = []): Feedback[] {
   let items: Feedback[] = []
   thread(label: "verify") {
     systemMessage(verifySysPrompt)
-    const analysis: string = llm("The task was:\n\n${task}\n\nInspect the working directory, run the artifact against the task's own success criteria, and describe what passes and what fails.", { tools: verifyTools })
+    // When a caller supplies an expert checklist, it is authoritative — verify
+    // must check those exact items (with the exact tool/flags/sub-sequence they
+    // name) rather than re-deriving looser criteria of its own.
+    const criteriaBlock = if criteria.length == 0 then "" else "\n\nThese domain-specific acceptance criteria are AUTHORITATIVE — check EACH one exactly as written, using the exact tool, flags, and input sub-sequence it names:\n- ${criteria.join("\n- ")}"
+    const analysis: string = llm("The task was:\n\n${task}${criteriaBlock}\n\nEnumerate every explicit success criterion (including the authoritative ones above, if any), then for EACH one use `exec` to compute the artifact's actual value and compare it to the requirement (run any tool/command named as ground truth). Report a concrete pass/fail per criterion with the computed numbers. A criterion you did not actually compute counts as a failure.", { tools: verifyTools })
     const parsed: Feedback[] = llm("Convert this analysis into Feedback items — one per concrete finding: error=true for an unmet criterion (name it), error=false for a satisfied one. Empty list if you cannot tell.\n\nAnalysis:\n${analysis}")
     items = parsed
   }
   return items
 }
 
-export def verify(task: string): Result<Feedback[]> {
+export def verify(task: string, criteria: string[] = []): Result<Feedback[]> {
   """
   Reconstruct a task's success criteria, run the produced artifact against
   them, and return findings. `error: true` marks an unmet criterion (strict
@@ -573,8 +583,11 @@ export def verify(task: string): Result<Feedback[]> {
   success) if verification cannot run, so it never blocks.
 
   @param task - The original task description to verify against.
+  @param criteria - Optional authoritative acceptance criteria (e.g. an expert
+    checklist) that verify must check exactly, instead of only re-deriving its
+    own from the task text.
   """
-  return failOpenFeedback(try verifyInner(task))
+  return failOpenFeedback(try verifyInner(task, criteria))
 }
 
 type GeneratedCode = {

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -567,7 +567,11 @@ def verifyInner(task: string, criteria: string[] = []): Feedback[] {
     // When a caller supplies an expert checklist, it is authoritative — verify
     // must check those exact items (with the exact tool/flags/sub-sequence they
     // name) rather than re-deriving looser criteria of its own.
-    const criteriaBlock = if criteria.length == 0 then "" else "\n\nThese domain-specific acceptance criteria are AUTHORITATIVE — check EACH one exactly as written, using the exact tool, flags, and input sub-sequence it names:\n- ${criteria.join("\n- ")}"
+    const authoritativeCriteria = """
+
+These domain-specific acceptance criteria are AUTHORITATIVE — check EACH one exactly as written, using the exact tool, flags, and input sub-sequence it names:
+- ${criteria.join("\n- ")}"""
+    const criteriaBlock = if criteria.length == 0 then "" else authoritativeCriteria
     const analysis: string = llm("The task was:\n\n${task}${criteriaBlock}\n\nEnumerate every explicit success criterion (including the authoritative ones above, if any), then for EACH one use `exec` to compute the artifact's actual value and compare it to the requirement (run any tool/command named as ground truth). Report a concrete pass/fail per criterion with the computed numbers. A criterion you did not actually compute counts as a failure.", { tools: verifyTools })
     const parsed: Feedback[] = llm("Convert this analysis into Feedback items — one per concrete finding: error=true for an unmet criterion (name it), error=false for a satisfied one. Empty list if you cannot tell.\n\nAnalysis:\n${analysis}")
     items = parsed

--- a/packages/agency-lang/stdlib/agents/coding.agency
+++ b/packages/agency-lang/stdlib/agents/coding.agency
@@ -27,7 +27,7 @@ static const codingSysPrompt = """You are an expert software engineer. Solve the
 
 static const finalizeReminder = "Before finishing, re-read the task's exact output requirements (filename, format, fields, whitespace, trailing newline) and confirm the artifact on disk matches them exactly."
 
-export def codingAgent(task: string, context: string = "", maxAttempts: number = 3, maxCost: number = $50.00, maxTime: number = 30m): string {
+export def codingAgent(task: string, context: string = "", criteria: string[] = [], maxAttempts: number = 3, maxCost: number = $50.00, maxTime: number = 30m): string {
   """
   General-purpose coding agent. Writes and runs code to complete a task and
   verifies the result against the task's success criteria. Returns a short
@@ -35,6 +35,9 @@ export def codingAgent(task: string, context: string = "", maxAttempts: number =
 
   @param task - What to build or fix.
   @param context - Optional extra material (data, examples, constraints).
+  @param criteria - Optional authoritative acceptance criteria (e.g. an expert
+    checklist) passed through to `verify` so the strict review checks those
+    exact items, not just its own re-derivation.
   @param maxAttempts - Max verify-and-fix attempts before returning (default 3).
   @param maxCost - Hard spend cap for the whole run (default $50).
   @param maxTime - Hard wall-clock cap for the whole run (default 30 minutes).
@@ -48,7 +51,7 @@ export def codingAgent(task: string, context: string = "", maxAttempts: number =
       let attemptsLeft = maxAttempts
       while (!done && attemptsLeft > 0) {
         reply = llm("${msg}\n\n${finalizeReminder}", { tools: codingTools })
-        const fb = verify(task)
+        const fb = verify(task, criteria)
         if (feedbackHasErrors(fb)) {
           msg = "Not done yet. A strict review found:\n\n${renderFeedback(fb)}\n\nFix each problem exactly."
           attemptsLeft = attemptsLeft - 1

--- a/packages/agency-lang/stdlib/agents/expert.agency
+++ b/packages/agency-lang/stdlib/agents/expert.agency
@@ -58,7 +58,7 @@ static const agencySys = """You are an expert in the Agency programming language
 Return the domain-specific knowledge it needs to get the task right:
 - domain: "agency-lang".
 - rules: the Agency conventions, syntax rules, and gotchas that apply to this task — the things a non-expert gets wrong. Be concrete and cite the guide.
-- checklist: concrete, checkable acceptance criteria the finished code must satisfy (compiles/typechecks, uses the right construct, handles failures, etc).
+- checklist: concrete acceptance criteria the finished code must satisfy (compiles/typechecks, uses the right construct, handles failures, etc). For EACH item, state HOW to verify it — the exact command to run (e.g. `agency typecheck <file>`) or the exact construct to look for. Prefer items checkable by running a command.
 
 The bundled docs (docSkill / cliSkill / diagnosticsSkill) are authoritative — consult them rather than guessing. If the task needs no special Agency knowledge, return empty rules and checklist."""
 
@@ -67,7 +67,7 @@ static const domainSys = """You are a domain expert advising a weaker coding age
 Identify the technical domain, then return the knowledge it needs:
 - domain: a short name for the field (e.g. "molecular biology / primer design", "ELF binaries").
 - rules: the key conventions, constraints, and facts that apply — especially the ones a non-expert gets wrong. Be concrete: exact numeric ranges, formats, encodings, common pitfalls.
-- checklist: concrete, checkable acceptance criteria the finished artifact MUST satisfy, each verifiable by inspection or by running the artifact.
+- checklist: concrete acceptance criteria the finished artifact MUST satisfy. For EACH item, state HOW to verify it — the exact command/tool/flags AND the exact input it applies to (which file, which sub-sequence, which bytes). When the task names a ground-truth tool, use it verbatim with its exact flags. Prefer items that can be checked by running a command over ones checked by eye. Be surgical about scope (e.g. "compute Tm on ONLY the annealing portion, not the whole primer").
 
 Use the wikipedia and fetch tools to confirm specifics when unsure. If the task has no special domain constraints, return empty rules and checklist."""
 
@@ -163,7 +163,10 @@ export def expertAgent(task: string, context: string = "", maxCost: number = $20
     if (context != "") {
       solverContext = if solverContext == "" then context else "${solverContext}\n\n${context}"
     }
-    return codingAgent(task, context: solverContext, maxCost: maxCost, maxTime: maxTime)
+    // Pass the expert checklist to the solver's verify step too (not just its
+    // system context), so the SAME authoritative criteria drive both building
+    // and checking — no independent blind spot between solve and verify.
+    return codingAgent(task, context: solverContext, criteria: guidance.checklist, maxCost: maxCost, maxTime: maxTime)
   }
   return unwrapGuard(captured, "Expert")
 }


### PR DESCRIPTION
## What this does

Makes the fresh-eyes `verify` step actually **catch** numeric/quantitative failures instead of describing them, and fixes a structured-output regression on Anthropic. Three linked changes:

### 1. Drop `Feedback.data?: any` (fixes Anthropic 400 on every task)
Provider-native (schema-enforced) structured output rejects an empty `{}` schema. Anthropic returns:
```
output_config.format.schema: Empty schema ({}) that accepts any JSON value is not supported.
```
The only `any` in verify's schema was `Feedback.data`, which serialized to `{}` and **400'd `verifyInner` on every task** (verify silently fail-opened everywhere). `data` was an unused debug escape hatch. Removed from the `std::agency` `Feedback` type and the structurally-identical copy in the review subagent.

### 2. verify executes checks (compute, don't describe)
`verifySysPrompt` + the analysis prompt now require verify to **enumerate every explicit success criterion** and **compute each one with `exec`** — running any ground-truth tool the task names (e.g. `primer3`'s `oligotm` with its exact flags) rather than eyeballing. A criterion it did not actually compute counts as a gap; a numeric near-miss is reported with the actual-vs-required numbers.

### 3. verify honors an authoritative expert checklist
`verify(task, criteria)` gains an optional acceptance checklist. `codingAgent` threads it through to `verify`, and `expertAgent` passes `guidance.checklist` — so the **same** expert criteria drive both building and checking, closing the independent blind spot where the solver and verify each re-derived (and each got wrong) a subtle detail like "compute Tm on the annealing portion only." The expert prompts now demand **executable** checklist items that name the exact tool/flags/sub-sequence to check.

## Why
Observed on Terminal-Bench: verify was 400-ing on every complex task (`Feedback.data` → empty schema), and even once un-broken it *described* rather than *computed*, so it rubber-stamped artifacts that failed the hidden grader (e.g. a primer with Tm just out of range). These changes make verify compute the task's own checks and enforce the expert's precise criteria.

## Notes
- Builds clean (`make`). The `verify`/`codingAgent` signature additions are optional params, so existing callers are unaffected.
- Depends on the already-merged smoltalk native-structured-output upgrade (which is what surfaced the empty-schema limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
