### PR TITLE
Guards follow-ups: labels, top-level saveDraft diagnostic, guide docs

### DIFF
--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -117,6 +117,7 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG6028](tools.md#ag6028) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound. Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
 | [AG6029](tools.md#ag6029) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound (&#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
 | [AG6030](tools.md#ag6030) | Tool '&#123;tool&#125;' will be exposed to the LLM without optional function-typed parameter(s): &#123;params&#125;. The function body must be prepared to run with the declared default for each. |
+| [AG6031](tools.md#ag6031) | saveDraft() cannot be called at module top level — there is no enclosing function, node, or block scope to save a draft for. |
 
 ## Static init, config, and imports
 

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -303,3 +303,13 @@ This is the same problem as an unbound required function-typed tool parameter, w
 A function passed as a tool has optional function-typed parameters that the LLM cannot fill, so they are dropped and the tool runs with each parameter's declared default. This is a warning, not an error, because a default exists — but the body must be prepared to run without those functions.
 
 **How to fix:** confirm the defaults are correct for the tool use, or bind the parameters explicitly with `.partial(...)` if you need specific implementations.
+
+<a id="ag6031"></a>
+
+## AG6031 — saveDraft() cannot be called at module top level — there is no enclosing function, node, or block scope to save a draft for.
+
+*Default severity: error.*
+
+`saveDraft(v)` records a best-so-far value for the scope that calls it, so an enclosing `guard(...)` can return that value if it trips. At module top level there is no enclosing scope: nothing could ever read the draft, and the runtime rejects the call for the same reason.
+
+**How to fix:** move the `saveDraft` call inside the function, node, or `guard` block whose result it is a draft of.

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -29,14 +29,15 @@ Things to note:
 - `result` is a `Result` type. On success, it has the return value. On failure, it has this data:
 
 ```ts
-// "guardFailure" = cost, "timeoutFailure" = time
+// "guardFailure" = cost, "timeoutFailure" = time.
+// Every field is always present; the ones that don't apply are null.
 type GuardFailureData = {
   type: "guardFailure" | "timeoutFailure"
-  label?: string
-  maxCost?: number
-  actualCost?: number
-  maxTime?: number
-  actualTime?: number
+  label: string | null
+  maxCost: number | null
+  actualCost: number | null
+  maxTime: number | null
+  actualTime: number | null
 }
 ```
 

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -32,6 +32,7 @@ Things to note:
 // "guardFailure" = cost, "timeoutFailure" = time
 type GuardFailureData = {
   type: "guardFailure" | "timeoutFailure"
+  label?: string
   maxCost?: number
   actualCost?: number
   maxTime?: number
@@ -43,6 +44,17 @@ type GuardFailureData = {
 
 - `cost:` — a `number` of dollars, eg `$2.0`.
 - `time:` — a `number` of milliseconds (or use the unit literals: `30s`, `5m`, `100ms`, `1h`).
+
+You can also name a guard with `label:`. The label comes back on the failure (`error.label`) and in error messages, so code with several guards can tell which one fired:
+
+```ts
+const result = guard(label: "research", cost: $0.50) as {
+  return research(topic)
+}
+if (isFailure(result)) {
+  print("Guard '" + result.error.label + "' tripped")
+}
+```
 
 These use [unit literals](/guide/basic-syntax.html#unit-literals).
 
@@ -71,6 +83,37 @@ When the clock ticks:
 - `sleep` = yes.
 
 When the time guard fires, any in-flight HTTP requests are cancelled and an abort signal is sent to other code as well.
+
+## Partial results with saveDraft
+
+A tripped guard normally throws the block's work away. `saveDraft` lets you keep a best-so-far value instead. Call it as your result improves; if the guard trips, the guard returns the last saved draft as a **success** instead of a failure.
+
+```ts
+node main() {
+  const result = guard(time: 5m) as {
+    let report = ""
+    for (topic in topics) {
+      report = report + research(topic)
+      saveDraft(report)
+    }
+    return report
+  }
+  // Finished in time: the full report.
+  // Tripped: the report so far.
+  print(result.value)
+}
+```
+
+`saveDraft` is always available — no import needed.
+
+Things to note:
+
+- The last saved value wins. Save early, save often.
+- The draft must match the type your function or block returns. The type checker enforces this, the same way it checks your `return` statements.
+- Each function keeps its own draft. If a function you *call* saved a draft but your code did not, your level returns nothing — a draft only crosses a call boundary when you return the callee's result directly (`return verify()`), because then its value *is* your value. This keeps every salvaged value correctly typed for the guard that receives it.
+- Drafts survive interrupts. If your block pauses for user input and trips after resuming, the draft saved before the pause still counts.
+- With no enclosing guard, `saveDraft` is a harmless no-op. At module top level it is a compile error — there is nothing a draft could ever be returned from.
+- A plain thrown error never returns a draft. Drafts are for budget trips, where the work so far is still trustworthy; unexpected failures stay failures.
 
 ## Nested guards
 

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -83,7 +83,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L271))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L273))
 
 ### ThreadInfo
 
@@ -99,7 +99,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L276))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L278))
 
 ## Functions
 
@@ -300,6 +300,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 guard(
   cost: number | null = null,
   time: number | null = null,
+  label: string | null = null,
   block: () -> any = null,
 ): Result
 ```
@@ -317,6 +318,7 @@ Run a block under a cost limit, a time limit, or both, aborting the
 
   @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null or negative = no cost limit.
   @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null, zero, or negative = no time limit.
+  @param label - Optional name for this guard. On a trip it appears in the failure (`error.label`) and in error messages, so code with several guards can tell which one fired.
   @param block - The work to run under the guard.
 
   Example:
@@ -360,6 +362,7 @@ Run a block under a cost limit, a time limit, or both, aborting the
 |---|---|---|
 | cost | `number \| null` | null |
 | time | `number \| null` | null |
+| label | `string \| null` | null |
 | block | `() => any` | null |
 
 **Returns:** `Result`
@@ -397,7 +400,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L348))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L350))
 
 ### currentThreadId
 
@@ -412,7 +415,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L401))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L403))
 
 ### getThread
 
@@ -444,4 +447,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L411))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L413))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -65,6 +65,7 @@ export type ModelCost = {
 ```ts
 export type GuardFailureData = {
   type: string;
+  label?: string;
   maxCost?: number;
   actualCost?: number;
   maxTime?: number;
@@ -83,7 +84,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L273))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L274))
 
 ### ThreadInfo
 
@@ -99,7 +100,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L278))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L279))
 
 ## Functions
 
@@ -367,7 +368,7 @@ Run a block under a cost limit, a time limit, or both, aborting the
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L215))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L216))
 
 ### listThreads
 
@@ -400,7 +401,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L350))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L351))
 
 ### currentThreadId
 
@@ -415,7 +416,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L403))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L404))
 
 ### getThread
 
@@ -447,4 +448,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L413))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L414))

--- a/packages/agency-lang/lib/runtime/errors.ts
+++ b/packages/agency-lang/lib/runtime/errors.ts
@@ -58,6 +58,10 @@ export type AbortCause =
       limit: number;
       spent: number;
       guardId: string;
+      /** User-facing name from `guard(label: "...")`. Absent when the
+       *  guard was not labeled. Rides the cause so failure messages and
+       *  future trip interrupts can say WHICH guard tripped. */
+      label?: string;
       /**
        * Mutable de-dup flag. A time-guard trip can be delivered by EITHER
        * an aborted leaf op (→ `__tryCall` converts to a Failure) OR the
@@ -157,7 +161,8 @@ export class AgencyAbort extends Error {
  *  still speak exceptions (the graph engine, runBatch join points). */
 export function describeAbortCause(cause: AbortCause): string {
   if (cause.kind === "guardTrip") {
-    return `Guard exceeded its ${cause.dimension} budget: spent ${cause.spent} of limit ${cause.limit}`;
+    const name = cause.label !== undefined ? `Guard "${cause.label}"` : "Guard";
+    return `${name} exceeded its ${cause.dimension} budget: spent ${cause.spent} of limit ${cause.limit}`;
   }
   return `Execution aborted (${cause.kind})`;
 }

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -403,3 +403,49 @@ describe("StateStack guard lifecycle", () => {
     expect(restored.guards[0]).toBeInstanceOf(CostGuard);
   });
 });
+
+describe("guard labels", () => {
+  it("a labeled CostGuard trip carries the label in its message and cause", () => {
+    const g = new CostGuard(1.0, "research");
+    g.charge(2.0);
+    const err = g.check(new StateStack());
+    expect(err).not.toBeNull();
+    expect(err!.message).toContain('guard "research" exceeded');
+    expect(readCause(err!)).toMatchObject({ kind: "guardTrip", label: "research" });
+  });
+
+  it("an unlabeled trip has no label in message or cause", () => {
+    const g = new CostGuard(1.0);
+    g.charge(2.0);
+    const err = g.check(new StateStack());
+    expect(err!.message).not.toContain('"');
+    expect((readCause(err!) as { label?: string }).label).toBeUndefined();
+  });
+
+  it("the label survives a serialization round-trip (both guard kinds)", () => {
+    const cost = CostGuard.fromJSON(
+      JSON.parse(JSON.stringify(new CostGuard(1.0, "budget").toJSON())),
+    );
+    expect(cost.label).toBe("budget");
+    const time = TimeGuard.fromJSON(
+      JSON.parse(JSON.stringify(new TimeGuard(500, "clock").toJSON())) as {
+        timeLimit: number;
+        elapsedMs: number;
+        guardId?: string;
+        label?: string;
+      },
+    );
+    expect(time.label).toBe("clock");
+  });
+
+  it("is absent from JSON when unset", () => {
+    expect("label" in new CostGuard(1.0).toJSON()).toBe(false);
+  });
+
+  it("a TimeGuard branch clone keeps the parent's label", () => {
+    const parent = new TimeGuard(500, "clock");
+    const clone = parent.cloneForBranch(new StateStack(), new StateStack());
+    expect((clone as TimeGuard).label).toBe("clock");
+    expect((clone as TimeGuard).guardId).toBe(parent.guardId);
+  });
+});

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -95,9 +95,14 @@ export type Guard = {
  *  `try` boundary matches on it (ownedGuardIds), and the boundary's id list
  *  is checkpointed too — if the guard got a fresh id on resume they would no
  *  longer match and the trip would escape its guard. */
+type GuardJSONBase = {
+  guardId?: string;
+  label?: string;
+};
+
 export type GuardJSON =
-  | { kind: "cost"; costLimit: number; spent: number; guardId?: string; label?: string }
-  | { kind: "time"; timeLimit: number; elapsedMs: number; guardId?: string; label?: string };
+  | (GuardJSONBase & { kind: "cost"; costLimit: number; spent: number })
+  | (GuardJSONBase & { kind: "time"; timeLimit: number; elapsedMs: number });
 
 /**
  * Cost guard. Trips when its own `spent` counter exceeds `costLimit`.

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -96,8 +96,8 @@ export type Guard = {
  *  is checkpointed too — if the guard got a fresh id on resume they would no
  *  longer match and the trip would escape its guard. */
 export type GuardJSON =
-  | { kind: "cost"; costLimit: number; spent: number; guardId?: string }
-  | { kind: "time"; timeLimit: number; elapsedMs: number; guardId?: string };
+  | { kind: "cost"; costLimit: number; spent: number; guardId?: string; label?: string }
+  | { kind: "time"; timeLimit: number; elapsedMs: number; guardId?: string; label?: string };
 
 /**
  * Cost guard. Trips when its own `spent` counter exceeds `costLimit`.
@@ -152,7 +152,13 @@ export class CostGuard implements Guard {
    *  survive interrupt/resume — see GuardJSON). */
   guardId: string = nextGuardId();
 
-  constructor(public readonly costLimit: number) {}
+  /** `label` is the user-facing name from `guard(label: "...")`. It rides
+   *  the trip cause and the guard failure so users can tell WHICH guard
+   *  tripped; guardId stays the internal identity for ownedGuardIds. */
+  constructor(
+    public readonly costLimit: number,
+    public readonly label?: string,
+  ) {}
 
   install(_stack: StateStack): void {
     /* nothing — no abort controller, no signal composition */
@@ -176,7 +182,13 @@ export class CostGuard implements Guard {
 
   check(_stack: StateStack): GuardExceededError | null {
     if (this.spent <= this.costLimit) return null;
-    return new GuardExceededError("cost", this.costLimit, this.spent, this.guardId);
+    return new GuardExceededError(
+      "cost",
+      this.costLimit,
+      this.spent,
+      this.guardId,
+      this.label,
+    );
   }
 
   /** CostGuards don't compose into `stack.abortSignal`, so they can't
@@ -195,15 +207,19 @@ export class CostGuard implements Guard {
   }
 
   toJSON(): GuardJSON {
-    return {
+    const json: GuardJSON = {
       kind: "cost",
       costLimit: this.costLimit,
       spent: this.spent,
       guardId: this.guardId,
     };
+    if (this.label !== undefined) {
+      json.label = this.label;
+    }
+    return json;
   }
 
-  static fromJSON(j: { costLimit: number; spent: number; guardId?: string }): CostGuard {
+  static fromJSON(j: { costLimit: number; spent: number; guardId?: string; label?: string }): CostGuard {
     // Clean break with the prior `{costAtPush}` JSON shape: refuse to
     // restore a guard whose `spent` is missing rather than silently
     // initializing it to NaN/undefined and producing nonsense trips.
@@ -217,7 +233,7 @@ export class CostGuard implements Guard {
           `runtime; that format is no longer supported.`,
       );
     }
-    const g = new CostGuard(j.costLimit);
+    const g = new CostGuard(j.costLimit, j.label);
     g.spent = j.spent;
     // Restore the serialized id so ownedGuardIds matching survives resume.
     // (Absent only in pre-Increment-2 checkpoints; keep the freshly-minted
@@ -291,7 +307,11 @@ export class TimeGuard implements Guard {
    *  matching breaks). */
   guardId: string = nextGuardId();
 
-  constructor(public readonly timeLimit: number) {}
+  /** See CostGuard's label docstring — same contract. */
+  constructor(
+    public readonly timeLimit: number,
+    public readonly label?: string,
+  ) {}
 
   install(stack: StateStack): void {
     this.installAbortPlumbing(stack);
@@ -349,6 +369,7 @@ export class TimeGuard implements Guard {
       this.timeLimit,
       this.currentElapsed(),
       this.guardId,
+      this.label,
     );
   }
 
@@ -393,7 +414,7 @@ export class TimeGuard implements Guard {
     // branch pauses/resumes independently; resume() on the child stack
     // arms the fresh timer at the branch's first runner step.
     const remaining = Math.max(1, this.timeLimit - this.currentElapsed());
-    const clone = new TimeGuard(remaining);
+    const clone = new TimeGuard(remaining, this.label);
     clone.guardId = this.guardId;
     return clone;
   }
@@ -401,16 +422,20 @@ export class TimeGuard implements Guard {
   toJSON(): GuardJSON {
     // currentElapsed() charges the in-flight window if we're called
     // while running, so the snapshot reflects all elapsed time.
-    return {
+    const json: GuardJSON = {
       kind: "time",
       timeLimit: this.timeLimit,
       elapsedMs: this.currentElapsed(),
       guardId: this.guardId,
     };
+    if (this.label !== undefined) {
+      json.label = this.label;
+    }
+    return json;
   }
 
-  static fromJSON(j: { timeLimit: number; elapsedMs: number; guardId?: string }): TimeGuard {
-    const g = new TimeGuard(j.timeLimit);
+  static fromJSON(j: { timeLimit: number; elapsedMs: number; guardId?: string; label?: string }): TimeGuard {
+    const g = new TimeGuard(j.timeLimit, j.label);
     g.elapsedMs = j.elapsedMs;
     // Restore the serialized id so ownedGuardIds matching survives resume.
     if (j.guardId !== undefined) g.guardId = j.guardId;
@@ -454,6 +479,7 @@ export class TimeGuard implements Guard {
             limit: this.timeLimit,
             spent,
             guardId: this.guardId,
+            label: this.label,
           }),
         ),
       );
@@ -511,10 +537,13 @@ export class GuardExceededError extends AgencyAbort {
     // __tryCall filters on ownedGuardIds, would fail the membership check and
     // escape its own guard. CostGuard.check / TimeGuard.check pass their id.
     guardId: string = "",
+    label?: string,
   ) {
     super(
-      `guard exceeded: ${type} limit ${limit}, spent ${spent}`,
-      makeAbortCause({ kind: "guardTrip", dimension: type, limit, spent, guardId }),
+      label !== undefined
+        ? `guard "${label}" exceeded: ${type} limit ${limit}, spent ${spent}`
+        : `guard exceeded: ${type} limit ${limit}, spent ${spent}`,
+      makeAbortCause({ kind: "guardTrip", dimension: type, limit, spent, guardId, label }),
     );
     this.name = "GuardExceededError";
   }

--- a/packages/agency-lang/lib/runtime/result.ts
+++ b/packages/agency-lang/lib/runtime/result.ts
@@ -12,8 +12,10 @@ function guardFailureData(
   dimension: "cost" | "time",
   limit: number,
   spent: number,
+  label?: string,
 ): {
   type: string;
+  label: string | null;
   maxCost: number | null;
   actualCost: number | null;
   maxTime: number | null;
@@ -22,6 +24,7 @@ function guardFailureData(
   if (dimension === "time") {
     return {
       type: "timeoutFailure",
+      label: label ?? null,
       maxCost: null,
       actualCost: null,
       maxTime: limit,
@@ -30,6 +33,7 @@ function guardFailureData(
   }
   return {
     type: "guardFailure",
+    label: label ?? null,
     maxCost: limit,
     actualCost: spent,
     maxTime: null,
@@ -196,7 +200,7 @@ export async function __tryCall(fn: () => any, opts?: FailureOpts): Promise<Resu
           return success(salvaged.value);
         }
         return failure(
-          guardFailureData(cause.dimension, cause.limit, cause.spent),
+          guardFailureData(cause.dimension, cause.limit, cause.spent, cause.label),
           opts,
         );
       }
@@ -247,7 +251,7 @@ export async function __tryCall(fn: () => any, opts?: FailureOpts): Promise<Resu
         // frame existed to convert it into an AbortedResult. Exceptions
         // carry no partial — the value path above is the salvage path.
         return failure(
-          guardFailureData(guardCause.dimension, guardCause.limit, guardCause.spent),
+          guardFailureData(guardCause.dimension, guardCause.limit, guardCause.spent, guardCause.label),
           opts,
         );
       }

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -259,6 +259,7 @@ function pushGuardImpl(
   stack: StateStack,
   costLimit: number | null,
   timeLimit: number | null,
+  label?: string | null,
 ): string[] {
   if (costLimit == null && timeLimit == null) {
     throw new Error(
@@ -274,7 +275,7 @@ function pushGuardImpl(
   // site instead of branching on "no limit".
   const ids: string[] = [];
   if (costLimit != null && costLimit >= 0) {
-    const g = new CostGuard(costLimit);
+    const g = new CostGuard(costLimit, label ?? undefined);
     stack.pushGuard(g);
     ids.push(g.guardId);
   }
@@ -283,7 +284,7 @@ function pushGuardImpl(
   // meaning "no paid spend" (local-models-only), since check() trips on
   // spent > limit (strict).
   if (timeLimit != null && timeLimit > 0) {
-    const g = new TimeGuard(timeLimit);
+    const g = new TimeGuard(timeLimit, label ?? undefined);
     stack.pushGuard(g);
     ids.push(g.guardId);
   }
@@ -304,9 +305,10 @@ export async function __internal_pushGuard(
 export async function _pushGuard(
   costLimit: number | null,
   timeLimit: number | null,
+  label: string | null = null,
 ): Promise<string[]> {
   const { stack } = getRuntimeContext();
-  return pushGuardImpl(stack, costLimit, timeLimit);
+  return pushGuardImpl(stack, costLimit, timeLimit, label);
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -8,7 +8,7 @@ import {
 } from "../types.js";
 import { walkNodes, isInsideBlock, type WalkAncestor } from "../utils/node.js";
 import { parseMatchValId } from "../matchVal.js";
-import { scopeKey as getScopeKey } from "../compilationUnit.js";
+import { GLOBAL_SCOPE_KEY, scopeKey as getScopeKey } from "../compilationUnit.js";
 import type { Scope as WalkScope } from "../types.js";
 import { formatTypeHint } from "../utils/formatType.js";
 import type { ValueAccess } from "../types/access.js";
@@ -273,6 +273,13 @@ function checkSaveDraftCall(
   if (ctx.functionDefs["saveDraft"] || ctx.nodeDefs["saveDraft"]) return;
   const imported = ctx.importedFunctions["saveDraft"];
   if (imported && !isStdlibSaveDraftOrigin(imported.originFile)) return;
+  // At module top level there is no scope whose salvage the draft could
+  // become. The runtime throws for the same reason; this catches it at
+  // compile time.
+  if (info.scopeKey === GLOBAL_SCOPE_KEY) {
+    ctx.errors.push(diagnostic("saveDraftAtTopLevel", {}, call.loc ?? null));
+    return;
+  }
   if (!info.returnType) return; // no declared/inferred return type in scope
   if (call.arguments.length !== 1) return;
   const first = call.arguments[0];

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -395,6 +395,10 @@ node main() {
 
 **How to fix:** confirm the defaults are correct for the tool use, or bind the parameters explicitly with \`.partial(...)\` if you need specific implementations.`,
 
+  saveDraftAtTopLevel: `\`saveDraft(v)\` records a best-so-far value for the scope that calls it, so an enclosing \`guard(...)\` can return that value if it trips. At module top level there is no enclosing scope: nothing could ever read the draft, and the runtime rejects the call for the same reason.
+
+**How to fix:** move the \`saveDraft\` call inside the function, node, or \`guard\` block whose result it is a draft of.`,
+
   // ---- AG7: static init, config, and imports ----
   exportRequiresStaticConst: `Only \`static const\` declarations can be exported from a module. A plain \`const\`, \`let\`, or other declaration is per-run state and is not part of a module's public surface.
 

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -488,6 +488,12 @@ export const DIAGNOSTICS = {
     message:
       "Tool '{tool}' will be exposed to the LLM without optional function-typed parameter(s): {params}. The function body must be prepared to run with the declared default for each.",
   },
+  saveDraftAtTopLevel: {
+    code: "AG6031",
+    severity: "error",
+    message:
+      "saveDraft() cannot be called at module top level — there is no enclosing function, node, or block scope to save a draft for.",
+  },
   staticReassignedAtTopLevel: {
     code: "AG7004",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/saveDraft.test.ts
+++ b/packages/agency-lang/lib/typeChecker/saveDraft.test.ts
@@ -135,3 +135,27 @@ describe("saveDraft check — import-origin gating", () => {
     expect(errors.length).toBeGreaterThan(0);
   });
 });
+
+describe("saveDraft at module top level (AG6031)", () => {
+  it("errors on a top-level saveDraft call", () => {
+    const errors = check(`
+      saveDraft("nothing-can-read-this")
+
+      node main() {
+        return "x"
+      }
+    `);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain("module top level");
+  });
+
+  it("does not fire inside a def", () => {
+    const errors = check(`
+      def f(): string {
+        saveDraft("ok")
+        return "x"
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -215,6 +215,7 @@ export type GuardFailureData = {
 export def guard(
   cost: number | null = null,
   time: number | null = null,
+  label: string | null = null,
   block: () -> any = null,
 ): Result {
   """
@@ -231,6 +232,7 @@ export def guard(
 
   @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00). null or negative = no cost limit.
   @param time - Maximum compute time in milliseconds (e.g. 30s, 5m, or a raw number). null, zero, or negative = no time limit.
+  @param label - Optional name for this guard. On a trip it appears in the failure (`error.label`) and in error messages, so code with several guards can tell which one fired.
   @param block - The work to run under the guard.
 
   Example:
@@ -248,7 +250,7 @@ export def guard(
   }
   ```
   """
-  const ids = _pushGuard(cost, time)
+  const ids = _pushGuard(cost, time, label)
   const result = _runGuarded(ids, block)
   _popGuard(ids)
   return result

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -181,6 +181,7 @@ export def getModelCosts(): ModelCost[] {
 
 export type GuardFailureData = {
   type: string;
+  label: string | null;
   maxCost: number | null;
   actualCost: number | null;
   maxTime: number | null;

--- a/packages/agency-lang/tests/agency/guards/guard-label.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-label.agency
@@ -1,0 +1,19 @@
+import { guard } from "std::thread"
+
+// guard(label:) names the guard. On a trip the label reaches user code
+// on the failure (error.label) so a scope with several guards can tell
+// which one fired. Unlabeled guards keep a null label.
+node main() {
+  const labeled = guard(label: "research-budget", cost: 0.000001) as {
+    const a = llm("Reply with: pong")
+    return a
+  }
+  const unlabeled = guard(cost: 0.000001) as {
+    const b = llm("Reply with: pong")
+    return b
+  }
+  if (isFailure(labeled) && isFailure(unlabeled)) {
+    return "${labeled.error.label}|${unlabeled.error.label}"
+  }
+  return "unexpected-success"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-label.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-label.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"research-budget|null\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }, { "return": "pong" }],
+      "description": "A labeled guard's trip carries the label on the failure; an unlabeled guard's label is null."
+    }
+  ]
+}


### PR DESCRIPTION
Three small guards/saveDraft follow-ups from the #553 review discussion, bundled per owner request.

## Guard labels

`guard(label: "research", cost: $0.50)` names a guard. On a trip the label rides the `guardTrip` cause and surfaces on the failure (`error.label`, `null` when unlabeled) and in error messages, so code with several guards can tell which one fired. The label serializes with the guard (interrupt/resume) and a `TimeGuard`'s per-branch clone keeps the parent's label, matching how the clone keeps the parent's `guardId`. This is increment 1 of the resumable-guards design, where the label becomes the handler's routing key.

Pinned by `tests/agency/guards/guard-label.agency` (labeled and unlabeled trip side by side) plus unit tests for the message, cause, serialization round-trip, and branch clone.

## AG6031: saveDraft at module top level

The runtime already throws; the checker now catches it at compile time. New registry entry + explanation page under AG6 (calls, tools, and LLM usage), emitted from `checkSaveDraftCall` when the walk is in the synthetic top-level scope. Diagnostics pages regenerated.

## Guards guide: saveDraft + labels

`docs/site/guide/guards.md` gains a "Partial results with saveDraft" section (the anytime-result story, the per-level rule in user terms, interrupt survival, the top-level error, plain-errors-stay-failures), the `label:` parameter with an example, and the `label` field on the failure data. Wording is a draft for your edit — it's your page.

## Testing

Full guards sweep 52/52 (including the new label fixture), typechecker + runtime + codegen suites 3344 green, subprocess sample green, structural lint clean, explanation coverage gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
