### PR TITLE
Add finalize blocks: compute a scope's partial result when a guard stops it

### DIFF
--- a/docs/superpowers/plans/2026-07-16-finalize-keyword.md
+++ b/docs/superpowers/plans/2026-07-16-finalize-keyword.md
@@ -1,0 +1,306 @@
+# The `finalize` Keyword Implementation Plan (PR B, re-planned for revision 3)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task in the main session (owner preference: no subagent-driven development). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `finalize { ... }` blocks: when an abort stops a scope, its finalize runs with the scope's locals — including the aborted callee's partial bound into the local it was headed for — and the finalize's return becomes the scope's forced return value.
+
+**Architecture:** This plan supersedes the PR-B tasks in `2026-07-15-save-draft-carry-on-abort.md`, which were written against the exception transport. Under revision 3 (aborts travel as `AbortedResult` return values), a frame stops at three kinds of compiled site — its own catch, the post-call aborted check, and (new lowering, finalize scopes only) a checked temp at return-position calls — across FOUR emission points the executor edits: `functionCatchFailure.mustache`, `blockSetup.mustache`, `assignmentAbortedGuard`, and `processReturnStatement`. Finalize plugs into those stop sites via one runtime method, `AbortedResult.withFinalize`, which replaces the partial with the finalize's return and falls back to the existing partial if the finalize fails. The locals binding is nearly free: at an assignment site the callee's aborted result is ALREADY in the local; the check unwraps it (via `partialValueOrNull()` — never by field-reaching) before the finalize runs.
+
+**Incorporates the external review** (`2026-07-16-finalize-keyword-REVIEW.md`): the return-expression smuggling hole is closed by a checker rule (rule 6 below) rather than lowering — hoisting a whole return expression to statement position cannot help (the aborted value is consumed INSIDE the expression before any check runs), and hoisting each call subexpression individually would break short-circuit evaluation (`a || f()` must not evaluate f unconditionally). The fork-boundary drop is documented and pinned; the transitive no-interrupts map gets an explicit imported-function verification; the partial unwrap is encapsulated behind a method.
+
+**Tech Stack:** parser (`lib/parsers/parsers.ts`, tarsec), AST (`lib/types/`), formatter (`lib/backends/agencyGenerator.ts`), type checker (`lib/typeChecker/`), codegen (`lib/backends/typescriptBuilder.ts` + `lib/templates/backends/typescriptGenerator/`), runtime (`lib/runtime/abortedResult.ts`), vitest + Agency execution tests.
+
+## Global Constraints
+
+- **Design spec (source of truth):** `docs/superpowers/specs/2026-07-15-save-draft-carry-on-abort-redesign.md`, revision 3 — the `finalize` section AND the level-rule section. Before any code, run the Task F0 drift check.
+- **One deliberate scope narrowing vs the spec (owner sign-off in review):** v1 finalize works in **defs and guard blocks only**. The spec's "works in nodes" sentence predates the value transport: above node level aborts are exceptions again and nothing consumes a node's partial (root budgets are deferred), so a node finalize would compute a value nobody reads. The checker rejects it with a message saying so.
+- **Branch mechanics:** branch `finalize-keyword` off origin/main after PR #554 merges (or cut from `guards-followups` if #554 is still open — rebase before pushing). Worktree: reuse `guards-followups` or create fresh.
+- Commits: message in a temp file + `git commit -F`; plain imperative subjects; Co-Authored-By line for the EXECUTING model; re-check `git branch --show-current` before every commit.
+- After `stdlib/` or `lib/` changes run `make`; after `.mustache` edits run `pnpm run templates` first and commit regenerated `.ts` with sources. Run `make fixtures` after codegen changes and commit the `.mjs` companions.
+- Run the FULL `tests/agency/guards/` sweep plus the subprocess sample (`nested-pause-resume`, `run-max-cost`, `pause-fork-mixed`) before the PR. Save all test output to files.
+- Banned patterns per `docs/dev/coding-standards.md` / `docs/dev/anti-patterns.md`. In particular: methods on the object, not free functions taking it; no nested ternaries; every try/catch logs or rethrows.
+- `docs/site/guide/guards.md` edits: draft freely but flag the wording as the owner's to edit (established convention).
+- Update `docs/dev/saveDraft.md` (it promises a finalize update) in the same PR.
+
+---
+
+## Task F0: Drift check (before any code)
+
+Re-read the spec's finalize section and confirm these decisions are still what the doc says. STOP on any mismatch:
+
+1. `finalize` is a KEYWORD (grammar, next to `handle`), not a stdlib function — it must run in the scope's own frame to see locals.
+2. At most one per scope, top level of the body only, position free (convention: last).
+3. The finalize reads locals; the aborted callee's partial is bound into the local its call was assigning. In `const x = f(g())`: g aborting leaves `x` null (argument-position drop happens at the call boundary before f runs); f aborting leaves `x` holding f's partial.
+4. Body rules: a finalize error never masks the trip (fall back to the saved draft, else nothing, and log); no interrupts (statically checked, transitively); no `saveDraft` inside; v1 computational-only (the tripped guard's signal still fires, so leaf ops inside the finalize cancel — that is documented, not shielded).
+5. The finalize's return type checks against the enclosing scope's return type; inside the body every local reads as possibly-null.
+
+Also reproduce the walked example by hand under revision 3 mechanics: `code` calls `verify` via `const x = verify()`; verify aborts with partial `"v-partial"`; the statement-site check binds `x = "v-partial"`, runs code's finalize, which returns `"combined:v-partial"`; the guard salvages that. If your trace disagrees, stop.
+
+---
+
+### Task F1: Parser + AST + formatter for `finalize { }`
+
+**Files:**
+- Create: `lib/types/finalizeBlock.ts`
+- Modify: `lib/types.ts` (add to the `AgencyNode` union; find where `HandleBlock` is registered and mirror it)
+- Modify: `lib/parsers/parsers.ts` (statement parser; mirror `handleBlockParser`, minus the `with` suffix)
+- Modify: `lib/backends/agencyGenerator.ts` (formatter arm; grep `handleBlock` for the precedent)
+- Test: `lib/parsers/finalizeBlock.test.ts` (mirror `lib/parsers/handleBlock.test.ts`'s harness exactly)
+
+**Interfaces:**
+- Produces: AST node `{ type: "finalizeBlock"; body: AgencyNode[]; loc }` parseable at statement position inside def and block bodies. F2–F4 consume it.
+
+- [ ] **Step 1: Write the failing parser tests** (in `lib/parsers/finalizeBlock.test.ts`, using `handleBlock.test.ts`'s `normalizeCode` harness):
+
+```ts
+import { finalizeBlockParser, bodyParser } from "./parsers.js";
+
+describe("finalizeBlockParser", () => {
+  it("parses a finalize block with a return", () => {
+    const result = finalizeBlockParser(normalizeCode(`finalize {\n  return "a"\n}`));
+    expect(result.success).toBe(true);
+    expect(result.result.type).toBe("finalizeBlock");
+    expect(result.result.body).toHaveLength(1);
+  });
+
+  it("parses inside a def body, landing a finalizeBlock node in the body", () => {
+    const result = bodyParser(normalizeCode(`saveDraft("d")\nfinalize {\n  return "a"\n}`));
+    expect(result.success).toBe(true);
+    const kinds = result.result.map((n) => n.type);
+    expect(kinds).toContain("finalizeBlock");
+  });
+
+  it("parses a multi-statement body, an empty finalize, and finalize-not-last", () => {
+    expect(finalizeBlockParser(normalizeCode(`finalize {\n  const a = 1\n  return a\n}`)).success).toBe(true);
+    expect(finalizeBlockParser(normalizeCode(`finalize {\n}`)).success).toBe(true);
+    const notLast = bodyParser(normalizeCode(`finalize {\n  return "a"\n}\nsaveDraft("d")`));
+    expect(notLast.success).toBe(true);
+    expect(notLast.result.map((n) => n.type)).toContain("finalizeBlock");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure** — `pnpm test:run lib/parsers/finalizeBlock.test.ts`, expected: `finalizeBlockParser` is not exported.
+- [ ] **Step 3: Implement.** `lib/types/finalizeBlock.ts`:
+
+```ts
+import { AgencyNode, BaseNode } from "../types.js";
+
+/** `finalize { ... }` — runs when an abort stops the enclosing scope; its
+ *  return becomes the scope's forced return value (the salvage a guard
+ *  receives). A declaration, not control flow: position in the body does
+ *  not matter, and at most one is allowed per scope. */
+export type FinalizeBlock = BaseNode & {
+  type: "finalizeBlock";
+  body: AgencyNode[];
+};
+```
+
+Parser: copy `handleBlockParser`'s structure for keyword-then-braced-body, keyword `finalize`, no binder and no `with` clause. Register in the same statement-alternatives list `handleBlockParser` sits in. Check how `handle` avoids capturing a variable named `handle` and match that treatment.
+- [ ] **Step 4: Formatter arm** — every `switch`/dispatch on `handleBlock` in `agencyGenerator.ts` gets a `finalizeBlock` arm printing `finalize {`, the indented body, `}`. Add an AUTOMATED round-trip case to `lib/backends/agencyGenerator.test.ts` (parse → generate → parse, finalize block survives byte-stable) — a manual `pnpm run fmt` probe pins nothing against regressions. Probe additionally by hand: `pnpm run ast tmp/finalize-probe.agency` and `pnpm run fmt tmp/finalize-probe.agency` on the walked example.
+- [ ] **Step 5: Run parser + generator suites** — `pnpm test:run lib/parsers lib/backends/agencyGenerator.test.ts`, green. Commit: `Parse and format finalize blocks`.
+
+### Task F2: Checker rules
+
+**Files:**
+- Modify: `lib/typeChecker/checker.ts` (structural checks + return-type check), `lib/typeChecker/interruptAnalysis.ts` (no-interrupts rule)
+- Modify: `lib/typeChecker/diagnostics.ts` + `lib/typeChecker/diagnosticExplanations.ts` (new AG6 codes; run `make diagnostics-docs` after)
+- Test: `lib/typeChecker/finalize.test.ts` (same harness as `saveDraft.test.ts`)
+
+**Interfaces:**
+- Consumes: `finalizeBlock` AST (F1); `info.returnType`; `interruptEffectsByFunction` (already computed by `analyzeInterruptsFromScopes` — this is what makes the no-interrupts rule TRANSITIVE for free).
+- Produces: five rules, each with its own registry entry (message text final at implementation time, one entry per rule):
+  1. return-type: finalize `return`s check against the enclosing scope's return type (reuse the machinery `checkReturnTypesInScope` applies to the scope's own returns).
+  2. structural: at most one finalize per scope; top level of the body only.
+  3. no interrupts: neither a direct `interrupt(...)` in the body nor a call to a function with a non-empty `interruptEffectsByFunction` entry. EXPLICIT VERIFICATION, not an assumption: confirm the map is populated for IMPORTED functions (stdlib and cross-file), not just same-unit defs — write a test where the finalize calls an imported interrupting function (e.g. `input` from the prelude). If imported callees are NOT covered, say so in the rule's explanation page ("direct and same-file transitive calls are checked; imported calls are caught at runtime") and rely on F3's runtime backstop — documented, not silent.
+  4. no `saveDraft` in the body.
+  5. placement: defs and guard/`as {}` blocks only; a finalize in a NODE body errors with "finalize in a node has no effect: nothing above a node consumes a partial result yet".
+  6. return shape (finalize scopes only): a `return` expression that CONTAINS an Agency call must BE a single direct call. `return f(x)` and `return someVar` are fine; `return "x:" + f()`, `return [f()]`, `return {k: f()}` error with "assign the call to a local first, then return the local". WHY AN ERROR AND WHY HERE: an aborted value consumed inside an expression bakes garbage into the return before any stop site can fire, silently skipping the finalize — and no lowering fixes it (whole-expression hoisting checks too late; per-call hoisting breaks short-circuit evaluation). Restricting the return shape makes F4 Step 4's direct-call lowering exhaustive. The equivalent gap at ASSIGNMENT sites (`const x = "a:" + f()`) stays in the documented shared envelope with interrupts — the checker rule covers returns only, the finalize-skip vector.
+
+- [ ] **Step 1: Write the failing checker tests**, one accept and one reject per rule. Reject cases (each expects ≥1 error):
+
+```
+def f(): string { finalize { return 42 } return "x" }                              // rule 1
+def f(): string { finalize { return "a" } finalize { return "b" } return "x" }     // rule 2
+def f(): string { if (true) { finalize { return "a" } } return "x" }               // rule 2
+def f(): string { finalize { interrupt("no") return "a" } return "x" }             // rule 3, direct
+def asker(): string { interrupt("ask") return "a" }
+def f(): string { finalize { return asker() } return "x" }                         // rule 3, transitive
+def f(): string { finalize { saveDraft("no") return "a" } return "x" }             // rule 4
+node main() { finalize { return "a" } return "x" }                                 // rule 5
+def g2(): string { return "ok" }
+def f(): string { finalize { return "a" } return "x:${g2()}" }                     // rule 6: call embedded in a return expression
+def f(): string { finalize { return "a" } }                                        // definite-returns: still errors (finalize is not a normal-path return)
+```
+
+Accept cases (zero errors each): the spec's walked example (finalize returning a string in a `(): string` def); a finalize directly inside a `guard(...) as { }` block; a finalize that is NOT the last statement of the body (position is free); `return g2()` — a direct call in return position — inside a finalize scope (rule 6 permits it).
+
+EVERY reject case must assert the SPECIFIC diagnostic code of its rule, not "≥1 error" — the harness returns `e.code` alongside `e.message`. This matters most for rule 1 (the ordinary return-type checker may also flag `return 42`, so a generic assertion would stay green with the finalize rule entirely broken) and rule 3 (a generic interrupt diagnostic is not the finalize diagnostic).
+- [ ] **Step 2: Run to confirm every reject case currently passes with zero diagnostics** (the red state), then implement rule by rule, registry entry by registry entry. The explanations Record is exhaustive-by-type: the compiler forces each explanation.
+- [ ] **Step 3 — DECISION GATE (nullable locals).** The spec: inside a finalize body every local reads as `T | null` (any statement might not have run). Investigate whether flow narrowing (`docs/dev/typechecker/narrowing/`) supports a scope-level "all locals nullable here" context cheaply — the finalize body is a distinct region of the SAME scope, so check whether the flow graph can seed the region with widened bindings. If cheap: implement + two tests (unguarded use errors under strict settings; a `!= null` check narrows). If invasive: STOP and present the owner options (a) invasive-now (b) document-and-defer with a tracking issue. Do not silently pick (b). Acknowledge the UX cost either way: all-locals-nullable is sound but conservative — a local definitely assigned before any trippable call still demands a null check inside the finalize; the owner weighs that against the implementation cost. WHICHEVER branch the gate takes, pin the SHIPPED semantics with a test — if the decision is defer, add the test that documents today's (unchecked) behavior so the eventual change is visible.
+- [ ] **Step 4:** `pnpm test:run lib/typeChecker` green; `make diagnostics-docs`; commit: `Type-check finalize blocks`.
+
+### Task F3: Runtime — `AbortedResult.withFinalize`
+
+**Files:**
+- Modify: `lib/runtime/abortedResult.ts`
+- Test: `lib/runtime/abortedResult.test.ts`
+
+**Interfaces:**
+- Consumes: the existing `AbortedResult` (immutable, cause-by-identity, self-logging).
+- Produces: `withFinalize(finalize: () => Promise<unknown>, scopeName: string): Promise<AbortedResult>` — called at every stop site of a finalize-bearing scope, AFTER `fromError`/`carryThrough` built the draft-or-nothing instance — and `partialValueOrNull(): unknown`, the ONLY way generated code reads a partial (the `{ value }` wrapper that distinguishes a saved null from no-partial is internal to the class; mirrors what `deliver()` does internally). Codegen must never touch `.partial` fields directly.
+
+- [ ] **Step 1: Write the failing unit tests** (extend the existing stub-statelog harness):
+
+```ts
+describe("AbortedResult.withFinalize", () => {
+  it("replaces the partial with the finalize's return", async () => { /* fromError with draft "d"; withFinalize(async () => "f"); expect partial {value:"f"}; cause identity preserved */ });
+  it("a finalize returning null is a real partial", async () => { /* partial {value:null} */ });
+  it("falls back to the existing partial when the finalize throws, and logs", async () => { /* withFinalize(async () => { throw new Error("boom") }) → same partial as before; one statelog error-ish event; the returned instance is usable */ });
+  it("treats an interrupting finalize as a failure (backstop)", async () => { /* finalize resolves to an Interrupt[]-shaped value; hasInterrupts → fallback like a throw */ });
+  it("treats an aborted finalize as a failure (backstop)", async () => { /* finalize resolves to an AbortedResult (a def it called was aborted — the signal is still firing); isAborted → fallback */ });
+  it("emits a carried event for the finalize's partial", async () => { /* action "carried" with the finalize value's preview */ });
+  it("with NO prior partial: a successful finalize becomes the partial", async () => { /* fromError with no draft; withFinalize(async () => "f") → partial {value:"f"} */ });
+  it("with NO prior partial: a throwing finalize leaves no partial and does not crash", async () => { /* partial stays undefined; one failure log; instance usable */ });
+});
+
+describe("AbortedResult.partialValueOrNull", () => {
+  it("returns the partial's value", () => { /* draft "d" → "d" */ });
+  it("returns a saved null (a real partial)", () => { /* draft null → null */ });
+  it("returns null when there is no partial", () => { /* fromError with no draft → null */ });
+});
+```
+
+- [ ] **Step 2: Implement.** Sketch (final shape may adjust to the file's existing private helpers):
+
+```ts
+  /** A finalize-bearing scope is stopping: run its finalize and make the
+   *  return this scope's partial. A finalize failure never masks the trip
+   *  — the abort continues with the partial this instance already holds
+   *  (the saved draft, or nothing) and the failure is logged. Two failure
+   *  shapes are backstops for what the checker already forbids or the
+   *  fired signal produces: a finalize that resolves to interrupts, or to
+   *  an aborted result of its own. */
+  async withFinalize(
+    finalize: () => Promise<unknown>,
+    scopeName: string,
+  ): Promise<AbortedResult> {
+    let value: unknown;
+    try {
+      value = await finalize();
+    } catch (finalizeError) {
+      this.logFinalizeFailure(scopeName, finalizeError);
+      return this;
+    }
+    if (hasInterrupts(value) || isAborted(value)) {
+      this.logFinalizeFailure(scopeName, value);
+      return this;
+    }
+    return new AbortedResult(this.cause, { value }, this.unwindSpanId)
+      .logged("carried", /* frame-less variant — see note */);
+  }
+```
+
+Note: `logged` currently takes a frame for the args preview; add a frame-optional path or pass the frame through `withFinalize` — decide against the file, keep one logging chokepoint. `logFinalizeFailure` posts through the statelog client's `error` event with `errorType: "finalizeError"` (check the client's existing `error()` signature and match it).
+- [ ] **Step 3:** `pnpm test:run lib/runtime/abortedResult.test.ts` green. Commit: `Add AbortedResult.withFinalize`.
+
+### Task F4: Codegen — compile the body, wire the three stop sites
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts` (`buildFunctionBody` / `processFunctionDefinition`: strip the finalizeBlock from the statement stream, compile it to a `__finalize` closure; `assignmentAbortedGuard`: finalize-aware variant with local binding; `processReturnStatement`: checked-temp lowering for return-position calls in finalize scopes)
+- Modify: `lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache` (+ regenerated `.ts`): `{{#hasFinalize}}` branch
+- Modify: `lib/templates/backends/typescriptGenerator/blockSetup.mustache`: same branch for blocks
+- Test: fixture regen (`make fixtures`) + the F5 execution fixtures
+
+**Interfaces:**
+- Consumes: `finalizeBlock` AST (F1); `withFinalize` (F3).
+- Produces: in finalize-bearing scopes only — everywhere else compiles byte-identically to today (verify via `make fixtures` producing no diffs for existing fixtures once the templates' no-finalize branch renders the current text).
+
+- [ ] **Step 1: Compile the finalize body to `__finalize`.** VERIFY FIRST (this was rev 2's explicit gate and it still holds): read how `handleBlock`'s inline-handler body compiles (`typescriptBuilder.ts` case "handleBlock", ~L624) and mirror that closure shape. Target shape in `setupStmts`:
+
+```ts
+const __finalize = async (): Promise<any> => {
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: <moduleId>, scopeName: "<fn>#finalize" });
+  /* compiled finalize statements — `return x` lowers to runner.halt(x), the block lowering */
+  return runner.halted ? runner.haltResult : undefined;
+};
+```
+
+The distinct `scopeName` keeps its `__substep_*` keys from colliding with the body's. Interrupts are statically impossible (F2), and the runtime backstop (F3) covers what slips through.
+
+HOW THE FINALIZE SEES THE SCOPE'S VARIABLES — the rule is: EVERY pass that walks a scope body treats `finalizeBlock.body` as same-scope statements (like an `if` body), never as a new scope (unlike an `as {}` block or a handler body). Three enforcement points, each independently checkable:
+
+1. Scope ANNOTATION (the preprocessor/symbol-table pass that stamps each variable reference with its scope kind and blockDepth) must descend into `finalizeBlock.body`. This is what makes locals/params resolve to the frame, enclosing-block references resolve to the right `__bframe_*` depth, and globals/statics keep compiling through their ALS-resolved accessors (`__globals()`, `__readStatic`) — globals never touch the frame, so they work in the finalize for free, including branch-isolated globals inside a fork.
+2. DEFINITE-RETURNS must IGNORE `finalizeBlock.body` — the inverse direction. A finalize `return` is a forced-return computation, not a normal-path return: `def f(): string { finalize { return "a" } }` with no real return must STILL error, and a finalize must never satisfy the definite-returns pass. Add a checker test for exactly that source.
+3. The generic walkers (`walkNodes` and any pass that switches on statement node types — prunePreludeShadows, hoistBodyTypeAliases, interrupt analysis) must see inside the node. Grep for `handleBlock` arms as the checklist of switch sites; decide same-scope vs ignore per pass and write the decision down in a comment at each arm.
+
+Then, in codegen: compile the finalize's statements under the FUNCTION's variable scope (do NOT push a block scope in the ScopeManager for it). Locals live on the frame, so `x` in the finalize body must compile to `__stack.locals.x` — the same slot the body wrote and the same slot the statement-site check binds the callee's partial into. The Runner's `"<fn>#finalize"` scopeName is ONLY a step-counter namespace; variable resolution must be the function's. If a block scope were pushed, references would resolve against a fresh `__bstack` and see nothing — the exact failure that forced finalize to be a keyword instead of a stdlib block function. For a finalize in a guard BLOCK, the same rule with the block's own scope and `__bstack`. Verify by compiling the F0 walked example and checking the finalize body's `x` compiles to the frame slot, then pin behaviorally with `finalize-consumes-partial`. Resume composes for free: the def's setup re-runs in deserialize mode and recreates `__finalize` over the RESTORED frame (`finalize-after-resume` pins this).
+- [ ] **Step 2: The frame-catch site.** `functionCatchFailure.mustache` rung becomes:
+
+```
+if (__error instanceof AgencyAbort) {
+{{#hasFinalize}}
+  return await AbortedResult.fromError(__error, __stack, {{{functionName}}}).withFinalize(__finalize, {{{functionName}}});
+{{/hasFinalize}}
+{{^hasFinalize}}
+  return AbortedResult.fromError(__error, __stack, {{{functionName}}});
+{{/hasFinalize}}
+}
+```
+
+Same branch structure in `blockSetup.mustache`'s catch. Pass `hasFinalize` from the builder at both render sites.
+- [ ] **Step 3: The statement site with binding.** In `assignmentAbortedGuard`, when the current scope has a finalize AND the guarded value is an assignment's local (not the bare-call temp), emit:
+
+```ts
+if (isAborted(<varRef>)) {
+  const __abortedCallee = <varRef>;
+  <varRef> = __abortedCallee.partialValueOrNull();
+  runner.halt(await __abortedCallee.carryThrough(__stack, "<scope>").withFinalize(__finalize, "<scope>"));
+  return;
+}
+```
+
+(`partialValueOrNull()` — never `.partial` field-reaching in generated code; the `{ value }` wrapper is the class's internal detail, and a leak here gets baked into every finalize-scope fixture.) For the bare-call temp there is nothing to bind — same emission minus the middle assignment. At implementation, check whether the two variants collapse into one emission; if they stay split, the split is genuine (one has a local to rebind). Blocks use `__bstack`. Track "current scope has a finalize" on the ScopeManager entry (set when F1's node is stripped in Step 1; blocks likewise).
+- [ ] **Step 4: Return-position calls in finalize scopes get a checked temp.** In `processReturnStatement`, when the scope has a finalize and the return value is a function call, lower `return f(...)` to a temp + the same aborted check (no local to bind), so the finalize ALWAYS speaks for its scope — pass-through would silently skip it. This lowering is exhaustive BECAUSE of F2 rule 6: any other call-embedding return shape in a finalize scope is a compile error, so a direct call is the only call-bearing return that reaches codegen. Scopes without a finalize keep today's halt-through lowering, byte-identical.
+
+Also add a short comment + plan note for the FORK boundary: a finalize inside a forked branch runs when the branch aborts, but `startInvoke`'s `.then` drops the partial at the boundary (`atForkBoundary`) — the finalize's salvage is discarded exactly like a branch's saveDraft. Consistent, deliberate, and pinned by the `finalize-inside-fork` fixture; a future fork-array salvage is the principled extension.
+- [ ] **Step 5:** `pnpm run templates && make && make fixtures`. Confirm existing fixtures' `.mjs` companions show NO diff (`git status`) — the no-finalize path must be unchanged. Run the full guards sweep — all green. Commit: `Compile finalize blocks into the three stop sites`.
+
+### Task F5: Execution fixtures
+
+**Files:** create in `tests/agency/guards/` (all with `useTestLLMProvider` + `llmMocks` where an llm call drives the trip; `guard(cost: 0.000001)` + one mocked call = the standard trip):
+
+- [ ] `finalize-consumes-partial.agency` — the walked example: verify saves `"v-partial"` and trips; `code`'s `const x = verify()` binds it; code's finalize returns `"combined:${x}"` (guarding for null); guard salvages `"combined:v-partial"`. THE load-bearing fixture; its expected value comes from the spec.
+- [ ] `finalize-nested-call-binding.agency` — two nodes: g trips inside `const x = f2(g())` → finalize sees `x == null` → `"g-tripped:x-null"`; f2 trips after g succeeded → finalize sees f2's partial → `"f2-tripped:<partial>"`.
+- [ ] `finalize-error-falls-back.agency` — the finalize throws; the scope saved a draft first; the guard salvages the DRAFT and the run does not crash.
+- [ ] `finalize-in-guard-block.agency` — finalize directly inside `guard(...) as { ... }`; its return is the salvage.
+- [ ] `finalize-on-return-position.agency` — finalize-bearing def whose trip escapes through `return verify()`; the finalize still runs (Step F4.4) and its return wins. THE FINALIZE'S RETURN MUST BE A VALUE THE PASS-THROUGH PATH COULD NEVER PRODUCE (e.g. prefix it `"finalized:"` while verify's partial has no prefix) — otherwise an omitted Step F4.4 lets verify's own partial through and the test stays green.
+- [ ] `finalize-not-run-on-success.agency` — no trip: the finalize never executes (pin with a side effect the finalize would perform — e.g. the finalize returns a sentinel the node would surface).
+- [ ] `finalize-after-resume.agency` — interrupt/resume inside the scope, then a trip; the finalize runs with the restored locals.
+- [ ] `finalize-reads-globals.agency` — the finalize reads a module global (and a param) alongside the bound partial; pins that non-frame variable kinds resolve inside the finalize.
+- [ ] `finalize-composes.agency` — outer def (with finalize) calls inner def (with finalize) via `const x = inner()`; inner trips. Pin the ordering end-to-end: inner's finalize runs first, outer's local `x` binds INNER'S FINALIZED value (not inner's raw draft — make them distinguishable), outer's finalize consumes it, the guard salvages outer's result. This is the plan's "composition falls out of value propagation" claim under test.
+- [ ] `finalize-wins-over-draft.agency` — a scope with BOTH a saveDraft and a successful finalize; the guard salvages the finalize's return, not the draft (the success-path complement of `finalize-error-falls-back`).
+- [ ] `finalize-cancel-not-salvaged.agency` — the scope is stopped by a NON-guard abort (agency-js test with a cancel, or a raceLoser shape): the finalize may compute, but nothing converts the abort to a success — the run terminates as a cancel does today. Pins that salvage stays guard-only.
+- [ ] `finalize-inside-fork.agency` — a finalize-bearing def trips inside a fork branch under an outer guard; the branch's finalized partial is dropped at the fork boundary and the guard fails. Pins the F4 fork note.
+- [ ] At least one fixture above must trip on `time:` rather than `cost:` (the time trip arrives via the abort signal cancelling a leaf op — a different path into the frame catch than a cost trip). If none naturally does, flip `finalize-after-resume` to a time trip.
+- [ ] Run all seven + the FULL guards sweep + the subprocess sample. Commit: `Pin finalize semantics with execution fixtures`.
+
+### Task F6: Docs + PR
+
+- [ ] Update `docs/dev/saveDraft.md`: replace the "will be extended when finalize lands" note with a finalize section (the three stop sites, `withFinalize`, the binding-is-free insight, the fallback rule); adjust the files table.
+- [ ] `docs/site/guide/guards.md`: draft a short finalize subsection under "Partial results with saveDraft" (flag wording as the owner's to edit).
+- [ ] Commit this plan file. Push; open the PR titled `Add finalize blocks: translate a partial before the guard receives it`. Body: the walked example with values, the three stop sites, the body rules, the nullable-locals decision (from F2's gate), the node-scope narrowing vs the spec (explicitly for owner sign-off), and the deferred items (shielding + grace budget, fork-array salvage).
+
+---
+
+## Self-Review
+
+**Spec coverage:** keyword surface + one-per-scope + top-level-only → F1/F2; return-type + no-interrupts (transitive, via `interruptEffectsByFunction`) + no-saveDraft → F2; nullable locals → F2 decision gate (not silent); never-mask-the-trip + computational-v1 backstops → F3; locals binding incl. `f(g())` both directions → F4 Step 3 + F5 fixture; runs at the frame catch AND statement sites AND return position → F4 Steps 2-4 + F5 fixtures (`finalize-on-return-position` pins the case naive pass-through would miss); composition (inner finalize before outer) needs no work — it falls out of values propagating one level at a time; works in guard blocks → F4 Step 2 + F5 fixture; NODES deliberately excluded with a checker error — flagged as the one spec deviation, for owner review.
+
+**Placeholder scan:** F3 Step 1 test bodies are outlined in comments rather than full code — deliberate: they extend an existing harness whose helper names the executor must reuse (`withStubStatelog`, `abortedWithDraft`), and each comment names the exact assertion. F4 Step 1 carries the same VERIFY-against-handle gate rev 2 had, now with the file/line anchor.
+
+**Type consistency:** `withFinalize(finalize, scopeName)` matches all three emission sites; `__finalize: () => Promise<any>` matches the closure built in F4 Step 1; `hasFinalize` is the template flag at both render sites; the F5 expected strings match F0's walked-example values.
+
+**Review-round incorporation (2026-07-16-finalize-keyword-REVIEW.md):** return-expression smuggling → F2 rule 6 (checker error; lowering rejected with reasons) + reject test; fork-boundary drop → F4 note + `finalize-inside-fork`; transitive-map coverage → F2 explicit verification + imported-callee test; `.partial` field-reaching → `partialValueOrNull()` in F3, called in F4 Step 3; exact-diagnostic-code assertions in F2; F1 body-node + breadth + automated formatter round-trip; distinct finalize output in `finalize-on-return-position`; composition, wins-over-draft, cancel-not-salvaged, and time-trip coverage in F5; `withFinalize` no-prior-partial unit cases; nullable-locals pinned whichever branch the gate takes; emission-point count corrected to four.
+
+**Known risks, named:** (1) the nullable-locals gate may be invasive — it has an explicit stop; (2) the return-position temp lowering changes fixture output ONLY for finalize scopes — F4 Step 5's no-diff check pins that; (3) `logged`'s frame parameter needs a frame-less variant for `withFinalize` — small refactor inside one file, flagged in F3, and it must remain the SINGLE logging chokepoint (one method, frame-optional), not a fork of it.

--- a/packages/agency-lang/docs/dev/saveDraft.md
+++ b/packages/agency-lang/docs/dev/saveDraft.md
@@ -7,8 +7,7 @@ under the hood, the trade-offs behind the design, and the nuances that
 are easy to miss. User-facing docs live in the guide; this is for people
 changing the implementation.
 
-This doc covers the first increment (the salvage mechanism). It will be
-extended when `finalize` blocks land in the follow-up PR.
+This doc covers the salvage mechanism and the `finalize` keyword.
 
 ## The core idea: an aborted function returns its draft
 
@@ -63,6 +62,60 @@ the checker already matched to the scope; argument position — the one
 place a wrongly-typed value could sneak through — is dropped at the
 boundary. So a guard only ever sees a value typed for its own block.
 
+## finalize: translating a partial instead of replacing it
+
+`finalize { ... }` lets a scope compute its partial result when an abort
+stops it, instead of only returning a pre-saved draft. The body reads the
+scope's locals — including the aborted callee's partial, bound into the
+local its call was assigning — and its `return` becomes the scope's
+forced return value.
+
+Mechanically, finalize plugs into the three stop sites:
+
+- **The frame catch** calls
+  `AbortedResult.fromError(...).withFinalize(__finalize, name)`.
+- **The post-call check** first binds the callee's partial into the
+  assigned local (`partialValueOrNull()`), then stops through
+  `carryThrough(...).withFinalize(...)` — which is why the finalize can
+  just read the local.
+- **Direct-call returns get a checked temp** (finalize scopes only):
+  plain halt-through pass-through would silently skip the finalize.
+  This lowering is exhaustive because AG6036 rejects any other
+  call-bearing return shape in a finalize scope.
+
+`withFinalize` owns the failure rule: a finalize that throws — or
+resolves to interrupts or to an aborted result of its own — never masks
+the trip; the abort continues with the saved draft, or nothing, and the
+failure is logged as a `finalizeError`.
+
+The `__finalize` closure runs a fresh Runner on the SAME frame as its
+container, so locals resolve without any passing. Two non-obvious
+consequences:
+
+- **Step ids live in a disjoint range** (`FINALIZE_STEP_BASE`). Runner
+  step counters are frame-keyed (`frame.step` at the top level, path-only
+  keys nested), so small ids would collide with the main body's counters
+  and silently skip finalize steps.
+- **`fromError` marks a guard trip's cause `delivered`.** Converting the
+  exception into a value IS the delivery; without the mark, a
+  leaf-delivered time trip (the signal still aborted, the cause not yet
+  consumed) makes `Runner.shouldSkip` re-throw inside the finalize's
+  first step and kill pure computation. In-flight leaf ops inside a
+  finalize still cancel via the signal itself — that is the
+  "computational-only" rule: write finalize bodies as pure computation
+  over locals.
+
+The checker enforces six rules (AG6032-AG6036, AG3016): one finalize per
+scope, top level only, defs and guard blocks only (a node finalize would
+compute a partial nothing above a node consumes), no `saveDraft` inside,
+no interrupts (transitive for same-file callees; an imported
+interrupting callee is caught by the runtime backstop instead), and the
+return-shape rule above. Inside a finalize body every local reads as
+`T | null` — the flow graph seeds the body as a side branch off the
+scope START with every local widened, since any statement might not have
+run — and the side branch never touches the main flow, so a finalize
+`return` cannot satisfy definite-returns.
+
 ## Important files
 
 | File | Role |
@@ -79,6 +132,9 @@ boundary. So a guard only ever sees a value typed for its own block.
 | `lib/runtime/runBatch.ts` | `startInvoke`'s `.then`: aborted branch value → rejection, partial dropped |
 | `lib/runtime/interrupts.ts` | Handler chain rethrows an aborted handler verdict as the abort it is |
 | `lib/typeChecker/checker.ts` | `checkSaveDraftCall`: draft type vs enclosing return type |
+| `lib/typeChecker/finalizeChecks.ts` | The finalize-specific checker rules |
+| `lib/typeChecker/flowBuilder.ts` | The finalize flow rule: side branch, nullable locals, definite-returns exemption |
+| `lib/parsers/parsers.ts` + `lib/types/finalizeBlock.ts` | The `finalize { }` grammar and AST node |
 | `lib/statelogClient.ts` | The `abortUnwind` span type and `abortSalvage` event |
 
 ## Trade-offs made, and the designs we rejected

--- a/packages/agency-lang/docs/site/diagnostics/effects.md
+++ b/packages/agency-lang/docs/site/diagnostics/effects.md
@@ -156,10 +156,12 @@ A value raises an effect that the target type's `raises` clause does not allow. 
 
 <a id="ag3016"></a>
 
-## AG3016 — A finalize block cannot raise interrupts: it runs while an abort is stopping the scope, with nothing to resume back to. '&#123;callee&#125;' can interrupt.
+## AG3016 — '&#123;callee&#125;' can interrupt, and a finalize block cannot contain interrupts. A finalize runs while its scope shuts down, so there is nothing to resume.
 
 *Default severity: error.*
 
-A finalize block runs at the moment an abort stops its scope — outside the step machinery that interrupts pause and resume through. An interrupt raised there would have nothing to resume back to. This checks transitively for functions defined in your own files: calling one that can interrupt is as forbidden as a direct `interrupt(...)`. An IMPORTED function that interrupts is not visible to this static check; at runtime the finalize is treated as failed and the scope falls back to its saved draft.
+An interrupt pauses the program and waits for an answer. When the answer arrives, the program resumes from the paused step. A finalize block runs while an abort shuts its scope down, so there is no step to resume from. That is why a finalize cannot interrupt, and cannot call a function that interrupts.
 
-**How to fix:** keep the finalize computational — combine the locals you already have. Anything that needs a human belongs in the normal body, before the work that can trip.
+The check follows calls into functions defined in your own files. It cannot see into imported functions. If an imported function interrupts inside a finalize at runtime, the finalize counts as failed and the scope falls back to its saved draft.
+
+**How to fix:** only compute values inside the finalize, using the variables you already have. If you need to ask the user something, ask in the normal body, before the work that can trip.

--- a/packages/agency-lang/docs/site/diagnostics/effects.md
+++ b/packages/agency-lang/docs/site/diagnostics/effects.md
@@ -153,3 +153,13 @@ A value is being used where the target type limits which effects may be raised, 
 A value raises an effect that the target type's `raises` clause does not allow. The target restricts the effect set, and this value steps outside it.
 
 **How to fix:** add the effect to the target type's clause, or use a target type that permits it.
+
+<a id="ag3016"></a>
+
+## AG3016 — A finalize block cannot raise interrupts: it runs while an abort is stopping the scope, with nothing to resume back to. '&#123;callee&#125;' can interrupt.
+
+*Default severity: error.*
+
+A finalize block runs at the moment an abort stops its scope — outside the step machinery that interrupts pause and resume through. An interrupt raised there would have nothing to resume back to. This checks transitively for functions defined in your own files: calling one that can interrupt is as forbidden as a direct `interrupt(...)`. An IMPORTED function that interrupts is not visible to this static check; at runtime the finalize is treated as failed and the scope falls back to its saved draft.
+
+**How to fix:** keep the finalize computational — combine the locals you already have. Anything that needs a human belongs in the normal body, before the work that can trip.

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -61,6 +61,7 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG3013](effects.md#ag3013) | &#123;kind&#125; '&#123;name&#125;' raises effect '&#123;effect&#125;', which exceeds its declared 'raises &#123;declared&#125;'. Add '&#123;effect&#125;' to the clause. |
 | [AG3014](effects.md#ag3014) | &#123;who&#125; may raise any effect (its type has no 'raises' clause), which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add a 'raises' clause to the value's type. |
 | [AG3015](effects.md#ag3015) | &#123;who&#125; raises effect '&#123;effect&#125;', which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add '&#123;effect&#125;' to the clause, or use a target type that allows it. |
+| [AG3016](effects.md#ag3016) | A finalize block cannot raise interrupts: it runs while an abort is stopping the scope, with nothing to resume back to. '&#123;callee&#125;' can interrupt. |
 
 ## Names, scope, and reserved words
 
@@ -118,6 +119,11 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG6029](tools.md#ag6029) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound (&#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
 | [AG6030](tools.md#ag6030) | Tool '&#123;tool&#125;' will be exposed to the LLM without optional function-typed parameter(s): &#123;params&#125;. The function body must be prepared to run with the declared default for each. |
 | [AG6031](tools.md#ag6031) | saveDraft() cannot be called at module top level — there is no enclosing function, node, or block scope to save a draft for. |
+| [AG6032](tools.md#ag6032) | A scope can declare at most one finalize block. Merge the branches into the first one. |
+| [AG6033](tools.md#ag6033) | A finalize block must sit at the top level of its function or block body, not inside `&#123;construct&#125;`. A finalize is a declaration — it is always active, so nesting it in control flow has no meaning. |
+| [AG6034](tools.md#ag6034) | saveDraft() has no effect inside a finalize block: the finalize's return IS the scope's partial result. Return the value instead. |
+| [AG6035](tools.md#ag6035) | A finalize block in a node has no effect: nothing above a node consumes a partial result yet. Put the finalize in a function or guard block instead. |
+| [AG6036](tools.md#ag6036) | In a scope with a finalize block, a return expression that contains a call must BE a single direct call. Assign the call to a local first, then return the local — otherwise an aborted call's partial would be consumed inside the expression before the finalize can run. |
 
 ## Static init, config, and imports
 

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -61,7 +61,7 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG3013](effects.md#ag3013) | &#123;kind&#125; '&#123;name&#125;' raises effect '&#123;effect&#125;', which exceeds its declared 'raises &#123;declared&#125;'. Add '&#123;effect&#125;' to the clause. |
 | [AG3014](effects.md#ag3014) | &#123;who&#125; may raise any effect (its type has no 'raises' clause), which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add a 'raises' clause to the value's type. |
 | [AG3015](effects.md#ag3015) | &#123;who&#125; raises effect '&#123;effect&#125;', which exceeds the 'raises &lt;&#123;allowed&#125;&gt;' allowed by type '&#123;type&#125;'. Add '&#123;effect&#125;' to the clause, or use a target type that allows it. |
-| [AG3016](effects.md#ag3016) | A finalize block cannot raise interrupts: it runs while an abort is stopping the scope, with nothing to resume back to. '&#123;callee&#125;' can interrupt. |
+| [AG3016](effects.md#ag3016) | '&#123;callee&#125;' can interrupt, and a finalize block cannot contain interrupts. A finalize runs while its scope shuts down, so there is nothing to resume. |
 
 ## Names, scope, and reserved words
 
@@ -119,11 +119,11 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG6029](tools.md#ag6029) | Tool '&#123;tool&#125;' has required function-typed parameter '&#123;param&#125;' is unbound (&#123;type&#125;). Bind it with .partial(&#123;param&#125;: &lt;value&gt;) before passing as a tool. |
 | [AG6030](tools.md#ag6030) | Tool '&#123;tool&#125;' will be exposed to the LLM without optional function-typed parameter(s): &#123;params&#125;. The function body must be prepared to run with the declared default for each. |
 | [AG6031](tools.md#ag6031) | saveDraft() cannot be called at module top level — there is no enclosing function, node, or block scope to save a draft for. |
-| [AG6032](tools.md#ag6032) | A scope can declare at most one finalize block. Merge the branches into the first one. |
-| [AG6033](tools.md#ag6033) | A finalize block must sit at the top level of its function or block body, not inside `&#123;construct&#125;`. A finalize is a declaration — it is always active, so nesting it in control flow has no meaning. |
-| [AG6034](tools.md#ag6034) | saveDraft() has no effect inside a finalize block: the finalize's return IS the scope's partial result. Return the value instead. |
-| [AG6035](tools.md#ag6035) | A finalize block in a node has no effect: nothing above a node consumes a partial result yet. Put the finalize in a function or guard block instead. |
-| [AG6036](tools.md#ag6036) | In a scope with a finalize block, a return expression that contains a call must BE a single direct call. Assign the call to a local first, then return the local — otherwise an aborted call's partial would be consumed inside the expression before the finalize can run. |
+| [AG6032](tools.md#ag6032) | A scope can declare at most one finalize block. Combine the logic into one block. |
+| [AG6033](tools.md#ag6033) | A finalize block cannot go inside &#123;construct&#125;. Declare it at the top level of the function or block body. A finalize is always active, so nesting it in control flow has no meaning. |
+| [AG6034](tools.md#ag6034) | saveDraft() has no effect inside a finalize block. The value the finalize returns is already the partial result. Return the value instead. |
+| [AG6035](tools.md#ag6035) | A finalize block cannot go in a node body. Nothing above a node consumes a partial result yet. Put the finalize in a function or a guard block instead. |
+| [AG6036](tools.md#ag6036) | This scope has a finalize block, so a return expression cannot bury a call inside a bigger expression. If the call were stopped, the expression would consume its partial result before the finalize could run. Assign the call to a local first, then return the local. |
 
 ## Static init, config, and imports
 

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -313,3 +313,64 @@ A function passed as a tool has optional function-typed parameters that the LLM 
 `saveDraft(v)` records a best-so-far value for the scope that calls it, so an enclosing `guard(...)` can return that value if it trips. At module top level there is no enclosing scope: nothing could ever read the draft, and the runtime rejects the call for the same reason.
 
 **How to fix:** move the `saveDraft` call inside the function, node, or `guard` block whose result it is a draft of.
+
+<a id="ag6032"></a>
+
+## AG6032 — A scope can declare at most one finalize block. Merge the branches into the first one.
+
+*Default severity: error.*
+
+Only one finalize block per scope: when the scope is stopped, exactly one computation produces its partial result. Two blocks would need merge rules.
+
+**How to fix:** combine the logic into a single finalize; branch inside it if needed.
+
+<a id="ag6033"></a>
+
+## AG6033 — A finalize block must sit at the top level of its function or block body, not inside `&#123;construct&#125;`. A finalize is a declaration — it is always active, so nesting it in control flow has no meaning.
+
+*Default severity: error.*
+
+A finalize is a declaration, not a statement: if the scope has one, it is always active. Nesting it inside an `if`, a loop, or a match arm would make it conditionally armed, which needs "was it armed?" bookkeeping the language deliberately avoids.
+
+**How to fix:** move the finalize to the top level of the function or block body (convention: last), and branch INSIDE the finalize instead.
+
+<a id="ag6034"></a>
+
+## AG6034 — saveDraft() has no effect inside a finalize block: the finalize's return IS the scope's partial result. Return the value instead.
+
+*Default severity: error.*
+
+Inside a finalize, the scope's partial result is being computed right now — the finalize's return value is that result. Saving a draft there is meaningless.
+
+**How to fix:** `return` the value from the finalize instead of calling `saveDraft`.
+
+<a id="ag6035"></a>
+
+## AG6035 — A finalize block in a node has no effect: nothing above a node consumes a partial result yet. Put the finalize in a function or guard block instead.
+
+*Default severity: error.*
+
+Salvaged partial results are consumed by an enclosing `guard`, and guards cannot span nodes — above a node there is only the graph engine, which does not consume partials (root budgets may, later). A finalize declared directly in a node body would compute a value nobody reads.
+
+**How to fix:** put the finalize inside the function or `guard` block doing the guarded work.
+
+<a id="ag6036"></a>
+
+## AG6036 — In a scope with a finalize block, a return expression that contains a call must BE a single direct call. Assign the call to a local first, then return the local — otherwise an aborted call's partial would be consumed inside the expression before the finalize can run.
+
+*Default severity: error.*
+
+When a call inside a return expression is aborted, its aborted result is consumed by the surrounding expression (concatenated, wrapped in an array, ...) before any check can run — so the finalize would be silently skipped and garbage returned. A direct `return f(x)` is safe: the compiler intercepts it. Anything more complex is not interceptable without breaking evaluation order.
+
+**How to fix:** assign the call to a local first, then return the local:
+
+```agency
+def f(): string {
+  const part = verify()
+  return "combined: " + part
+
+  finalize {
+    return "partial: " + part
+  }
+}
+```

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -316,51 +316,53 @@ A function passed as a tool has optional function-typed parameters that the LLM 
 
 <a id="ag6032"></a>
 
-## AG6032 — A scope can declare at most one finalize block. Merge the branches into the first one.
+## AG6032 — A scope can declare at most one finalize block. Combine the logic into one block.
 
 *Default severity: error.*
 
-Only one finalize block per scope: when the scope is stopped, exactly one computation produces its partial result. Two blocks would need merge rules.
+When a scope is stopped, one finalize computes its partial result. A second finalize block would leave the result ambiguous.
 
-**How to fix:** combine the logic into a single finalize; branch inside it if needed.
+**How to fix:** combine the logic into one finalize block. Branch inside it if you need to.
 
 <a id="ag6033"></a>
 
-## AG6033 — A finalize block must sit at the top level of its function or block body, not inside `&#123;construct&#125;`. A finalize is a declaration — it is always active, so nesting it in control flow has no meaning.
+## AG6033 — A finalize block cannot go inside &#123;construct&#125;. Declare it at the top level of the function or block body. A finalize is always active, so nesting it in control flow has no meaning.
 
 *Default severity: error.*
 
-A finalize is a declaration, not a statement: if the scope has one, it is always active. Nesting it inside an `if`, a loop, or a match arm would make it conditionally armed, which needs "was it armed?" bookkeeping the language deliberately avoids.
+A finalize is a declaration, not a statement. If the scope has one, it is always active. Nesting it inside an `if`, a loop, or a match arm would arm it conditionally, and the language would then need to track whether it was armed. The language avoids that bookkeeping.
 
-**How to fix:** move the finalize to the top level of the function or block body (convention: last), and branch INSIDE the finalize instead.
+**How to fix:** move the finalize to the top level of the function or block body. Put it last, by convention. Branch inside the finalize instead.
 
 <a id="ag6034"></a>
 
-## AG6034 — saveDraft() has no effect inside a finalize block: the finalize's return IS the scope's partial result. Return the value instead.
+## AG6034 — saveDraft() has no effect inside a finalize block. The value the finalize returns is already the partial result. Return the value instead.
 
 *Default severity: error.*
 
-Inside a finalize, the scope's partial result is being computed right now — the finalize's return value is that result. Saving a draft there is meaningless.
+Inside a finalize, you are computing the scope's partial result right now. The value the finalize returns is that result. Saving a draft there does nothing.
 
 **How to fix:** `return` the value from the finalize instead of calling `saveDraft`.
 
 <a id="ag6035"></a>
 
-## AG6035 — A finalize block in a node has no effect: nothing above a node consumes a partial result yet. Put the finalize in a function or guard block instead.
+## AG6035 — A finalize block cannot go in a node body. Nothing above a node consumes a partial result yet. Put the finalize in a function or a guard block instead.
 
 *Default severity: error.*
 
-Salvaged partial results are consumed by an enclosing `guard`, and guards cannot span nodes — above a node there is only the graph engine, which does not consume partials (root budgets may, later). A finalize declared directly in a node body would compute a value nobody reads.
+An enclosing `guard` consumes salvaged partial results, and a guard cannot span nodes. Above a node there is only the graph engine, and the graph engine does not consume partials. A finalize declared directly in a node body would compute a value nobody reads.
 
-**How to fix:** put the finalize inside the function or `guard` block doing the guarded work.
+**How to fix:** put the finalize inside the function or `guard` block that does the guarded work.
 
 <a id="ag6036"></a>
 
-## AG6036 — In a scope with a finalize block, a return expression that contains a call must BE a single direct call. Assign the call to a local first, then return the local — otherwise an aborted call's partial would be consumed inside the expression before the finalize can run.
+## AG6036 — This scope has a finalize block, so a return expression cannot bury a call inside a bigger expression. If the call were stopped, the expression would consume its partial result before the finalize could run. Assign the call to a local first, then return the local.
 
 *Default severity: error.*
 
-When a call inside a return expression is aborted, its aborted result is consumed by the surrounding expression (concatenated, wrapped in an array, ...) before any check can run — so the finalize would be silently skipped and garbage returned. A direct `return f(x)` is safe: the compiler intercepts it. Anything more complex is not interceptable without breaking evaluation order.
+Suppose a guard stops a call that sits inside a return expression. The surrounding expression consumes the stopped call's result before any check can run: the result gets concatenated, wrapped in an array, and so on. The finalize would be skipped and the function would return garbage.
+
+A direct `return f(x)` is safe, because the compiler intercepts it. Method and index calls do not count as direct: `return obj.method()` and `return arr[i]()` need the same fix as any other complex return. Nothing more complex than a single direct call can be intercepted without changing evaluation order.
 
 **How to fix:** assign the call to a local first, then return the local:
 

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -139,7 +139,7 @@ If `expand` was stopped mid-way, its own partial (whatever it saved or finalized
 
 Things to note:
 
-- A finalize runs only on a guard trip — never on success, and never for a plain thrown error.
+- A finalize never runs on success, and never for a plain thrown error. It runs when the scope is aborted, but only a guard trip salvages its value; an abort for any other reason (like losing a `race`) discards it.
 - Inside a finalize, every variable might not have been assigned yet, so each one reads as possibly-null. Check with `!= null` before using them.
 - Keep finalize bodies computational. The guard that tripped is still aborting, so an `llm()` or `sleep()` inside the finalize gets cancelled; combine the values you already have.
 - One finalize per function or block, at the top level of its body. Convention: put it last.

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -116,6 +116,36 @@ Things to note:
 - With no enclosing guard, `saveDraft` is a harmless no-op. At module top level it is a compile error — there is nothing a draft could ever be returned from.
 - A plain thrown error never returns a draft. Drafts are for budget trips, where the work so far is still trustworthy; unexpected failures stay failures.
 
+### Computing the partial with finalize
+
+Sometimes the best partial result is not a value you saved along the way, but something you compute from what you have at the moment the guard trips. A `finalize` block does that: it runs only if the scope is stopped, sees the scope's variables, and its `return` becomes the salvaged value.
+
+```ts
+def research(topic: string): string {
+  const outline = draftOutline(topic)
+  const full = expand(outline)     // guard trips in here
+  return full
+
+  finalize {
+    if (outline != null) {
+      return "OUTLINE ONLY: " + outline
+    }
+    return "nothing yet"
+  }
+}
+```
+
+If `expand` was stopped mid-way, its own partial (whatever it saved or finalized) lands in `full`, and your finalize can use it.
+
+Things to note:
+
+- A finalize runs only on a guard trip — never on success, and never for a plain thrown error.
+- Inside a finalize, every variable might not have been assigned yet, so each one reads as possibly-null. Check with `!= null` before using them.
+- Keep finalize bodies computational. The guard that tripped is still aborting, so an `llm()` or `sleep()` inside the finalize gets cancelled; combine the values you already have.
+- One finalize per function or block, at the top level of its body. Convention: put it last.
+- If both a `saveDraft` and a finalize exist, the finalize wins; if the finalize itself fails, the saved draft is used instead.
+- In a function with a finalize, a `return` expression that contains a call must be just the call (`return f(x)`). Anything more complex is a compile error — assign to a local first.
+
 ## Nested guards
 
 Guards are scoped — an inner trip does **not** trip an outer guard:

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -1097,3 +1097,36 @@ describe("AgencyGenerator - destructive/seq blocks", () => {
     expect(output).not.toContain("destructive {");
   });
 });
+
+describe("finalize block formatting", () => {
+  it("round-trips a finalize block byte-stably", () => {
+    const source = `def f(): string {
+  const x = worker()
+  return x
+
+  finalize {
+    if (x != null) {
+      return "combined:\${x}"
+    }
+    return "no-inner"
+  }
+}
+`;
+    const parsed = parseAgency(source);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const generated = new AgencyGenerator().generate(parsed.result).output;
+    // The formatted block, exactly as the arm should print it.
+    expect(generated).toContain(
+      `  finalize {\n    if (x != null) {\n      return "combined:\${x}"\n    }\n    return "no-inner"\n  }`,
+    );
+    // And it survives a reparse as a real finalizeBlock node (the full
+    // program is not byte-round-trippable because parseAgency injects the
+    // prelude import each pass — pre-existing, unrelated to finalize).
+    const reparsed = parseAgency(generated);
+    expect(reparsed.success).toBe(true);
+    if (!reparsed.success) return;
+    const regenerated = new AgencyGenerator().generate(reparsed.result).output;
+    expect(regenerated).toContain("finalize {");
+  });
+});

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -63,6 +63,7 @@ import {
 import { expressionToString } from "@/utils/node.js";
 import { Keyword } from "@/types/keyword.js";
 import { HandleBlock } from "@/types/handleBlock.js";
+import { FinalizeBlock } from "@/types/finalizeBlock.js";
 import { Tag } from "@/types/tag.js";
 import { NewExpression } from "@/types/newExpression.js";
 import {
@@ -496,6 +497,8 @@ export class AgencyGenerator {
         return this.processMessageThread(node);
       case "handleBlock":
         return this.processHandleBlock(node);
+      case "finalizeBlock":
+        return this.processFinalizeBlock(node);
       case "withModifier":
         return `${this.processNode(node.statement)} with ${node.handlerName}`;
       case "staticStatement":
@@ -1662,6 +1665,13 @@ export class AgencyGenerator {
     return this.indentStr(
       `handle {\n${bodyCodeStr}${this.indentStr("}")} with ${handlerStr}`,
     );
+  }
+
+  protected processFinalizeBlock(node: FinalizeBlock): string {
+    this.increaseIndent();
+    const bodyCodeStr = this.renderBody(node.body);
+    this.decreaseIndent();
+    return this.indentStr(`finalize {\n${bodyCodeStr}${this.indentStr("}")}`);
   }
 
   protected processSkill(node: Skill): string {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -6,6 +6,7 @@ import {
   Assignment,
   BlockType,
   Expression,
+  FinalizeBlock,
   Keyword,
   Literal,
   NamedArgument,
@@ -1766,7 +1767,13 @@ export class TypeScriptBuilder {
     const parentScopeName = this.scopes.currentName();
     this.scopes.push({ type: "block", blockName });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
-    const bodyParts = this.processBodyAsParts(block.body);
+    const { rest, finalize } = this.extractFinalize(block.body);
+    this.finalizePresence.push(finalize !== undefined);
+    const bodyParts = this.processBodyAsParts(rest);
+    const finalizeDecl = finalize
+      ? this.buildFinalizeClosure(finalize, blockName, "__bstack")
+      : undefined;
+    this.finalizePresence.pop();
     this._sourceMapBuilder.enterScope(this.moduleId, parentScopeName);
     this.scopes.pop();
 
@@ -1781,6 +1788,14 @@ export class TypeScriptBuilder {
       scopeName: JSON.stringify(blockName),
       frameVar: `__bframe_${blockName}`,
       body: bodyStr,
+      // Pre-rendered (see the def-catch note): empty/plain strings keep
+      // the no-finalize block output byte-identical.
+      finalizeDecl:
+        finalizeDecl !== undefined ? printTs(finalizeDecl, 0) + "\n" : "",
+      abortReturn:
+        finalize !== undefined
+          ? `return await AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)}).withFinalize(__finalize, ${JSON.stringify(blockName)});`
+          : `return AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)});`,
     });
 
     const blockFn = ts.arrowFn(
@@ -1811,7 +1826,13 @@ export class TypeScriptBuilder {
     const parentScopeName = this.scopes.currentName();
     this.scopes.push({ type: "block", blockName });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
-    const bodyParts = this.processBodyAsParts(block.body);
+    const { rest, finalize } = this.extractFinalize(block.body);
+    this.finalizePresence.push(finalize !== undefined);
+    const bodyParts = this.processBodyAsParts(rest);
+    const finalizeDecl = finalize
+      ? this.buildFinalizeClosure(finalize, blockName, "__bstack")
+      : undefined;
+    this.finalizePresence.pop();
     this._sourceMapBuilder.enterScope(this.moduleId, parentScopeName);
     this.scopes.pop();
 
@@ -1826,6 +1847,14 @@ export class TypeScriptBuilder {
       scopeName: JSON.stringify(blockName),
       frameVar: `__bframe_${blockName}`,
       body: bodyStr,
+      // Pre-rendered (see the def-catch note): empty/plain strings keep
+      // the no-finalize block output byte-identical.
+      finalizeDecl:
+        finalizeDecl !== undefined ? printTs(finalizeDecl, 0) + "\n" : "",
+      abortReturn:
+        finalize !== undefined
+          ? `return await AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)}).withFinalize(__finalize, ${JSON.stringify(blockName)});`
+          : `return AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)});`,
     });
 
     const blockFn = ts.arrowFn(
@@ -2069,6 +2098,10 @@ export class TypeScriptBuilder {
     skipHooks?: boolean;
     hoistedAliases?: TsNode[];
     inDestructiveFunction?: boolean;
+    /** The compiled `__finalize` closure declaration, when the def
+     *  declared a finalize block. Placed in the setup so the catch (and
+     *  the post-call guards inside the body) can call it. */
+    finalizeDecl?: TsNode;
   }): TsNode[] {
     const { functionName, parameters, bodyCode, skipHooks } = opts;
     const hoistedAliases = opts.hoistedAliases ?? [];
@@ -2190,6 +2223,9 @@ export class TypeScriptBuilder {
             ],
           }),
         ];
+    if (opts.finalizeDecl !== undefined) {
+      setupStmts.push(opts.finalizeDecl);
+    }
     setupStmts.push(
       ts.tryCatch(
         ts.statements([
@@ -2235,6 +2271,12 @@ export class TypeScriptBuilder {
         ts.raw(
           renderFunctionCatchFailure.default({
             functionName: JSON.stringify(functionName),
+            // Pre-rendered so the no-finalize output is byte-identical to
+            // the pre-finalize compiler (no mustache section whitespace).
+            abortReturn:
+              opts.finalizeDecl !== undefined
+                ? `return await AbortedResult.fromError(__error, __stack, ${JSON.stringify(functionName)}).withFinalize(__finalize, ${JSON.stringify(functionName)});`
+                : `return AbortedResult.fromError(__error, __stack, ${JSON.stringify(functionName)});`,
           }),
         ),
         "__error",
@@ -2266,6 +2308,49 @@ export class TypeScriptBuilder {
     return setupStmts;
   }
 
+  /** True when the innermost function/block scope being compiled declared
+   *  a finalize. Pushed/popped in lockstep with this.scopes by the def and
+   *  block compilers; drives the finalize-aware post-call guard and the
+   *  return-position temp lowering. */
+  private finalizePresence: boolean[] = [];
+
+  private currentScopeHasFinalize(): boolean {
+    return this.finalizePresence[this.finalizePresence.length - 1] === true;
+  }
+
+  /** Split a body into its statements and its (at most one — the checker
+   *  enforces that) top-level finalize block. Defensive: extras beyond the
+   *  first are dropped here but already rejected by AG6032. */
+  private extractFinalize(body: AgencyNode[]): {
+    rest: AgencyNode[];
+    finalize: FinalizeBlock | undefined;
+  } {
+    const rest = body.filter((n) => n.type !== "finalizeBlock");
+    const finalize = body.find(
+      (n): n is FinalizeBlock => n.type === "finalizeBlock",
+    );
+    return { rest, finalize };
+  }
+
+  /** Compile a finalize body into the `__finalize` closure declaration.
+   *  Runs on the SAME frame as its container (locals live on the frame,
+   *  so the body sees them directly); the fresh Runner's "#finalize"
+   *  scope name keeps its step counters from colliding with the body's. */
+  private buildFinalizeClosure(
+    finalize: FinalizeBlock,
+    containerName: string,
+    frameVar: string,
+  ): TsNode {
+    const parts = this.processBodyAsParts(finalize.body, 1);
+    const bodyStr = parts.map((n) => printTs(n, 1)).join("\n");
+    return ts.raw(
+      `const __finalize = async (): Promise<any> => {\n` +
+        `  const runner = new Runner(__ctx, ${frameVar}, { state: ${frameVar}, moduleId: ${JSON.stringify(this.moduleId)}, scopeName: ${JSON.stringify(containerName + "#finalize")} });\n` +
+        bodyStr +
+        `\n  return runner.halted ? runner.haltResult : undefined;\n};`,
+    );
+  }
+
   private processFunctionDefinition(node: FunctionDefinition): TsNode {
     this.scopes.push({ type: "function", functionName: node.functionName });
     this._sourceMapBuilder.enterScope(this.moduleId, node.functionName);
@@ -2276,10 +2361,20 @@ export class TypeScriptBuilder {
     // Hoist body-local type aliases to the function's outer scope so
     // every runner.step closure can reference the generated zod schemas.
     const hoistedAliases = this.hoistBodyTypeAliases(node.body);
+    // A finalize is a declaration, not a statement: strip it from the
+    // statement stream and compile it into the __finalize closure the
+    // stop sites call. finalizePresence drives the finalize-aware
+    // post-call guard + return-position lowering while the body compiles.
+    const { rest, finalize } = this.extractFinalize(node.body);
+    this.finalizePresence.push(finalize !== undefined);
     // Body steps occupy substep ids 1..N — id 0 is reserved for the
     // onFunctionStart hook (wrapped in `runner.hook` for substep-counter
     // idempotency on resume).
-    const bodyCode = this.processBodyAsParts(node.body, 1);
+    const bodyCode = this.processBodyAsParts(rest, 1);
+    const finalizeDecl = finalize
+      ? this.buildFinalizeClosure(finalize, functionName, "__stack")
+      : undefined;
+    this.finalizePresence.pop();
     this.scopes.inDestructiveFunction = prevDestructive;
     this.scopes.pop();
 
@@ -2306,6 +2401,7 @@ export class TypeScriptBuilder {
       skipHooks: false,
       hoistedAliases,
       inDestructiveFunction: !!node.markers?.destructive,
+      finalizeDecl,
     });
 
     const funcDecl = ts.functionDecl(
@@ -2498,7 +2594,9 @@ export class TypeScriptBuilder {
       const tempVar = this.insideHandlerBody
         ? `__funcResult_${this.handlerFuncResultCounter++}`
         : "__funcResult";
-      const guard = this.assignmentInterruptGuard(ts.id(tempVar));
+      const guard = this.assignmentInterruptGuard(ts.id(tempVar), {
+        bindOnAborted: false,
+      });
       return ts.statements([
         ts.constDecl(tempVar, callNode),
         ...(guard ? [guard] : []),
@@ -3154,6 +3252,9 @@ export class TypeScriptBuilder {
         ]);
       }
       const valueNode = this.processNode(node.value);
+      if (this.isFinalizeInterceptedReturn(node.value)) {
+        return this.finalizeReturnLowering(valueNode, (v) => ts.runnerHalt(v));
+      }
       return ts.runnerHalt(valueNode);
     }
 
@@ -3208,7 +3309,49 @@ export class TypeScriptBuilder {
       ]);
     }
     const valueNode = this.processNode(node.value);
+    if (this.isFinalizeInterceptedReturn(node.value)) {
+      return this.finalizeReturnLowering(valueNode, (v) =>
+        ts.functionReturn(this.maybeWrapReturnValidation(v)),
+      );
+    }
     return ts.functionReturn(this.maybeWrapReturnValidation(valueNode));
+  }
+
+  /** In a finalize-bearing scope, a direct-call return must stop at the
+   *  finalize instead of passing an aborted result through (pass-through
+   *  would silently skip the finalize). AG6036 guarantees a direct call
+   *  is the only call-bearing return shape that reaches codegen here;
+   *  `return llm(...)` hoists through its own path and cannot produce an
+   *  AbortedResult. */
+  private isFinalizeInterceptedReturn(value: AgencyNode): boolean {
+    if (!this.currentScopeHasFinalize()) return false;
+    return value.type === "functionCall" && value.functionName !== "llm";
+  }
+
+  /** Lower `return <call>` to a checked temp: interrupts still halt
+   *  through the temp unchanged, an aborted result runs the finalize
+   *  (nothing to bind — the value was headed for the return), and a
+   *  normal value returns exactly as before. */
+  private finalizeReturnLowering(
+    valueNode: TsNode,
+    emit: (value: TsNode) => TsNode,
+  ): TsNode {
+    const scopeType = this.scopes.current().type;
+    const frameVar = scopeType === "block" ? "__bstack" : "__stack";
+    const scopeName = JSON.stringify(this.scopes.currentName());
+    return ts.statements([
+      ts.constDecl("__returnTemp", valueNode),
+      ts.if(
+        ts.raw("isAborted(__returnTemp)"),
+        ts.statements([
+          ts.raw(
+            `runner.halt(await __returnTemp.carryThrough(${frameVar}, ${scopeName}).withFinalize(__finalize, ${scopeName}))`,
+          ),
+          ts.return(),
+        ]),
+      ),
+      emit(ts.id("__returnTemp")),
+    ]);
   }
 
   private processAssignment(node: Assignment): TsNode {
@@ -3273,8 +3416,13 @@ export class TypeScriptBuilder {
    * Returns null only at global scope for the interrupt half; the aborted
    * check still applies there (an abort during module init should crash
    * init, not become data in a global). */
-  private assignmentInterruptGuard(varRef: TsNode): TsNode | null {
-    const abortedGuard = this.assignmentAbortedGuard(varRef);
+  private assignmentInterruptGuard(
+    varRef: TsNode,
+    opts?: { bindOnAborted?: boolean },
+  ): TsNode | null {
+    const abortedGuard = this.assignmentAbortedGuard(varRef, {
+      bindOnAborted: opts?.bindOnAborted !== false,
+    });
     if (this.scopes.current().type === "global") return abortedGuard;
     if (this.insideHandlerBody) {
       return ts.statements([
@@ -3316,8 +3464,17 @@ export class TypeScriptBuilder {
    * salvage rule); handler bodies and every other scope rebuild the
    * exception — handlers run outside the runner-step machinery (there is
    * no runner to halt), and nothing above compiled code consumes aborted
-   * values. */
-  private assignmentAbortedGuard(varRef: TsNode): TsNode {
+   * values.
+   *
+   * In a finalize-bearing scope, the stop runs the finalize — and when
+   * the guarded value is a real local (`bindOnAborted`), the callee's
+   * partial is first bound into it via partialValueOrNull(), so the
+   * finalize reads it like any other local. Bare-call temps have nothing
+   * to bind. */
+  private assignmentAbortedGuard(
+    varRef: TsNode,
+    opts?: { bindOnAborted?: boolean },
+  ): TsNode {
     const scopeType = this.scopes.current().type;
     const expr = this.str(varRef);
     if (
@@ -3326,6 +3483,23 @@ export class TypeScriptBuilder {
     ) {
       const frameVar = scopeType === "block" ? "__bstack" : "__stack";
       const scopeName = JSON.stringify(this.scopes.currentName());
+      if (this.currentScopeHasFinalize()) {
+        const bind =
+          opts?.bindOnAborted === true
+            ? [ts.raw(`${expr} = __abortedCallee.partialValueOrNull()`)]
+            : [];
+        return ts.if(
+          ts.raw(`isAborted(${expr})`),
+          ts.statements([
+            ts.raw(`const __abortedCallee = ${expr}`),
+            ...bind,
+            ts.raw(
+              `runner.halt(await __abortedCallee.carryThrough(${frameVar}, ${scopeName}).withFinalize(__finalize, ${scopeName}))`,
+            ),
+            ts.return(),
+          ]),
+        );
+      }
       return ts.if(
         ts.raw(`isAborted(${expr})`),
         ts.statements([

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2314,6 +2314,11 @@ export class TypeScriptBuilder {
    *  return-position temp lowering. */
   private finalizePresence: boolean[] = [];
 
+  /** Step-id base for compiled finalize bodies — far above anything a
+   *  main body can reach, so the shared frame's counters never collide.
+   *  See buildFinalizeClosure. */
+  private static readonly FINALIZE_STEP_BASE = 1000000;
+
   private currentScopeHasFinalize(): boolean {
     return this.finalizePresence[this.finalizePresence.length - 1] === true;
   }
@@ -2341,7 +2346,18 @@ export class TypeScriptBuilder {
     containerName: string,
     frameVar: string,
   ): TsNode {
-    const parts = this.processBodyAsParts(finalize.body, 1);
+    // The finalize's Runner shares the container's FRAME (locals live
+    // there), and Runner step counters are frame-keyed: the top-level
+    // counter IS frame.step and nested keys are path-only (no scope
+    // name). Small ids would collide with the main body's counters —
+    // frame.step has already advanced past them, silently skipping the
+    // finalize's steps. A disjoint id base fixes both the top-level
+    // counter and every nested path; advancing the dying frame's step
+    // past the base is inert, because an aborted frame never resumes.
+    const parts = this.processBodyAsParts(
+      finalize.body,
+      TypeScriptBuilder.FINALIZE_STEP_BASE,
+    );
     const bodyStr = parts.map((n) => printTs(n, 1)).join("\n");
     return ts.raw(
       `const __finalize = async (): Promise<any> => {\n` +

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -6,7 +6,6 @@ import {
   Assignment,
   BlockType,
   Expression,
-  FinalizeBlock,
   Keyword,
   Literal,
   NamedArgument,
@@ -115,6 +114,10 @@ import { StepPathTracker } from "./typescriptBuilder/stepPathTracker.js";
 import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
 import { functionContainsDestructiveBlock } from "./functionContainsDestructiveBlock.js";
 import { DestructiveTracking } from "./typescriptBuilder/destructiveTracking.js";
+import {
+  FinalizeCodegen,
+  type CompiledScopeFinalize,
+} from "./typescriptBuilder/finalizeCodegen.js";
 import { PipeChainEmitter } from "./typescriptBuilder/pipeChainEmitter.js";
 import { AssignmentEmitter } from "./typescriptBuilder/assignmentEmitter.js";
 import {
@@ -219,6 +222,7 @@ export class TypeScriptBuilder {
   private tracking: DestructiveTracking;
   private pipes: PipeChainEmitter;
   private assigns: AssignmentEmitter;
+  private finalize: FinalizeCodegen;
 
   // Config
   private agencyConfig: AgencyConfig = {};
@@ -346,6 +350,9 @@ export class TypeScriptBuilder {
       resolveBlockFrameVar: (blockDepth: number) =>
         this.scopes.blockFrameVar(blockDepth),
     });
+    this.finalize = new FinalizeCodegen(this.scopes, moduleId, (body, stepBase) =>
+      this.processBodyAsParts(body, stepBase),
+    );
     this.moduleId = moduleId;
     this.outputFile = outputFile;
     this.initPlan = initPlan;
@@ -1767,17 +1774,18 @@ export class TypeScriptBuilder {
     const parentScopeName = this.scopes.currentName();
     this.scopes.push({ type: "block", blockName });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
-    const { rest, finalize } = this.extractFinalize(block.body);
-    this.finalizePresence.push(finalize !== undefined);
-    const bodyParts = this.processBodyAsParts(rest);
-    const finalizeDecl = finalize
-      ? this.buildFinalizeClosure(finalize, blockName, "__bstack")
-      : undefined;
-    this.finalizePresence.pop();
+    const compiledFinalize = this.finalize.compileScope({
+      body: block.body,
+      scopeName: blockName,
+      errorVar: "__blockError",
+      compileBodyRest: (rest) => this.processBodyAsParts(rest),
+    });
     this._sourceMapBuilder.enterScope(this.moduleId, parentScopeName);
     this.scopes.pop();
 
-    const bodyStr = bodyParts.map((n) => printTs(n, 1)).join("\n");
+    const bodyStr = compiledFinalize.bodyCode
+      .map((n) => printTs(n, 1))
+      .join("\n");
 
     const blockSetupCode = renderBlockSetup.default({
       params: block.params.map((p) => ({
@@ -1788,14 +1796,8 @@ export class TypeScriptBuilder {
       scopeName: JSON.stringify(blockName),
       frameVar: `__bframe_${blockName}`,
       body: bodyStr,
-      // Pre-rendered (see the def-catch note): empty/plain strings keep
-      // the no-finalize block output byte-identical.
-      finalizeDecl:
-        finalizeDecl !== undefined ? printTs(finalizeDecl, 0) + "\n" : "",
-      abortReturn:
-        finalize !== undefined
-          ? `return await AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)}).withFinalize(__finalize, ${JSON.stringify(blockName)});`
-          : `return AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)});`,
+      finalizeDecl: compiledFinalize.declText,
+      abortReturn: compiledFinalize.abortReturn,
     });
 
     const blockFn = ts.arrowFn(
@@ -1826,17 +1828,18 @@ export class TypeScriptBuilder {
     const parentScopeName = this.scopes.currentName();
     this.scopes.push({ type: "block", blockName });
     this._sourceMapBuilder.enterScope(this.moduleId, blockName);
-    const { rest, finalize } = this.extractFinalize(block.body);
-    this.finalizePresence.push(finalize !== undefined);
-    const bodyParts = this.processBodyAsParts(rest);
-    const finalizeDecl = finalize
-      ? this.buildFinalizeClosure(finalize, blockName, "__bstack")
-      : undefined;
-    this.finalizePresence.pop();
+    const compiledFinalize = this.finalize.compileScope({
+      body: block.body,
+      scopeName: blockName,
+      errorVar: "__blockError",
+      compileBodyRest: (rest) => this.processBodyAsParts(rest),
+    });
     this._sourceMapBuilder.enterScope(this.moduleId, parentScopeName);
     this.scopes.pop();
 
-    const bodyStr = bodyParts.map((n) => printTs(n, 1)).join("\n");
+    const bodyStr = compiledFinalize.bodyCode
+      .map((n) => printTs(n, 1))
+      .join("\n");
 
     const blockSetupCode = renderBlockSetup.default({
       params: block.params.map((p) => ({
@@ -1847,14 +1850,8 @@ export class TypeScriptBuilder {
       scopeName: JSON.stringify(blockName),
       frameVar: `__bframe_${blockName}`,
       body: bodyStr,
-      // Pre-rendered (see the def-catch note): empty/plain strings keep
-      // the no-finalize block output byte-identical.
-      finalizeDecl:
-        finalizeDecl !== undefined ? printTs(finalizeDecl, 0) + "\n" : "",
-      abortReturn:
-        finalize !== undefined
-          ? `return await AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)}).withFinalize(__finalize, ${JSON.stringify(blockName)});`
-          : `return AbortedResult.fromError(__blockError, __bstack, ${JSON.stringify(blockName)});`,
+      finalizeDecl: compiledFinalize.declText,
+      abortReturn: compiledFinalize.abortReturn,
     });
 
     const blockFn = ts.arrowFn(
@@ -2098,10 +2095,11 @@ export class TypeScriptBuilder {
     skipHooks?: boolean;
     hoistedAliases?: TsNode[];
     inDestructiveFunction?: boolean;
-    /** The compiled `__finalize` closure declaration, when the def
-     *  declared a finalize block. Placed in the setup so the catch (and
-     *  the post-call guards inside the body) can call it. */
-    finalizeDecl?: TsNode;
+    /** The def's compiled finalize (FinalizeCodegen.compileScope). The
+     *  closure declaration goes in the setup so the catch (and the
+     *  post-call guards inside the body) can call it; the abort return
+     *  goes in the catch template. */
+    finalize: CompiledScopeFinalize;
   }): TsNode[] {
     const { functionName, parameters, bodyCode, skipHooks } = opts;
     const hoistedAliases = opts.hoistedAliases ?? [];
@@ -2223,8 +2221,8 @@ export class TypeScriptBuilder {
             ],
           }),
         ];
-    if (opts.finalizeDecl !== undefined) {
-      setupStmts.push(opts.finalizeDecl);
+    if (opts.finalize.decl !== undefined) {
+      setupStmts.push(opts.finalize.decl);
     }
     setupStmts.push(
       ts.tryCatch(
@@ -2271,12 +2269,7 @@ export class TypeScriptBuilder {
         ts.raw(
           renderFunctionCatchFailure.default({
             functionName: JSON.stringify(functionName),
-            // Pre-rendered so the no-finalize output is byte-identical to
-            // the pre-finalize compiler (no mustache section whitespace).
-            abortReturn:
-              opts.finalizeDecl !== undefined
-                ? `return await AbortedResult.fromError(__error, __stack, ${JSON.stringify(functionName)}).withFinalize(__finalize, ${JSON.stringify(functionName)});`
-                : `return AbortedResult.fromError(__error, __stack, ${JSON.stringify(functionName)});`,
+            abortReturn: opts.finalize.abortReturn,
           }),
         ),
         "__error",
@@ -2308,65 +2301,6 @@ export class TypeScriptBuilder {
     return setupStmts;
   }
 
-  /** True when the innermost function/block scope being compiled declared
-   *  a finalize. Pushed/popped in lockstep with this.scopes by the def and
-   *  block compilers; drives the finalize-aware post-call guard and the
-   *  return-position temp lowering. */
-  private finalizePresence: boolean[] = [];
-
-  /** Step-id base for compiled finalize bodies — far above anything a
-   *  main body can reach, so the shared frame's counters never collide.
-   *  See buildFinalizeClosure. */
-  private static readonly FINALIZE_STEP_BASE = 1000000;
-
-  private currentScopeHasFinalize(): boolean {
-    return this.finalizePresence[this.finalizePresence.length - 1] === true;
-  }
-
-  /** Split a body into its statements and its (at most one — the checker
-   *  enforces that) top-level finalize block. Defensive: extras beyond the
-   *  first are dropped here but already rejected by AG6032. */
-  private extractFinalize(body: AgencyNode[]): {
-    rest: AgencyNode[];
-    finalize: FinalizeBlock | undefined;
-  } {
-    const rest = body.filter((n) => n.type !== "finalizeBlock");
-    const finalize = body.find(
-      (n): n is FinalizeBlock => n.type === "finalizeBlock",
-    );
-    return { rest, finalize };
-  }
-
-  /** Compile a finalize body into the `__finalize` closure declaration.
-   *  Runs on the SAME frame as its container (locals live on the frame,
-   *  so the body sees them directly); the fresh Runner's "#finalize"
-   *  scope name keeps its step counters from colliding with the body's. */
-  private buildFinalizeClosure(
-    finalize: FinalizeBlock,
-    containerName: string,
-    frameVar: string,
-  ): TsNode {
-    // The finalize's Runner shares the container's FRAME (locals live
-    // there), and Runner step counters are frame-keyed: the top-level
-    // counter IS frame.step and nested keys are path-only (no scope
-    // name). Small ids would collide with the main body's counters —
-    // frame.step has already advanced past them, silently skipping the
-    // finalize's steps. A disjoint id base fixes both the top-level
-    // counter and every nested path; advancing the dying frame's step
-    // past the base is inert, because an aborted frame never resumes.
-    const parts = this.processBodyAsParts(
-      finalize.body,
-      TypeScriptBuilder.FINALIZE_STEP_BASE,
-    );
-    const bodyStr = parts.map((n) => printTs(n, 1)).join("\n");
-    return ts.raw(
-      `const __finalize = async (): Promise<any> => {\n` +
-        `  const runner = new Runner(__ctx, ${frameVar}, { state: ${frameVar}, moduleId: ${JSON.stringify(this.moduleId)}, scopeName: ${JSON.stringify(containerName + "#finalize")} });\n` +
-        bodyStr +
-        `\n  return runner.halted ? runner.haltResult : undefined;\n};`,
-    );
-  }
-
   private processFunctionDefinition(node: FunctionDefinition): TsNode {
     this.scopes.push({ type: "function", functionName: node.functionName });
     this._sourceMapBuilder.enterScope(this.moduleId, node.functionName);
@@ -2377,20 +2311,15 @@ export class TypeScriptBuilder {
     // Hoist body-local type aliases to the function's outer scope so
     // every runner.step closure can reference the generated zod schemas.
     const hoistedAliases = this.hoistBodyTypeAliases(node.body);
-    // A finalize is a declaration, not a statement: strip it from the
-    // statement stream and compile it into the __finalize closure the
-    // stop sites call. finalizePresence drives the finalize-aware
-    // post-call guard + return-position lowering while the body compiles.
-    const { rest, finalize } = this.extractFinalize(node.body);
-    this.finalizePresence.push(finalize !== undefined);
-    // Body steps occupy substep ids 1..N — id 0 is reserved for the
-    // onFunctionStart hook (wrapped in `runner.hook` for substep-counter
-    // idempotency on resume).
-    const bodyCode = this.processBodyAsParts(rest, 1);
-    const finalizeDecl = finalize
-      ? this.buildFinalizeClosure(finalize, functionName, "__stack")
-      : undefined;
-    this.finalizePresence.pop();
+    const compiledFinalize = this.finalize.compileScope({
+      body: node.body,
+      scopeName: functionName,
+      errorVar: "__error",
+      // Body steps occupy substep ids 1..N — id 0 is reserved for the
+      // onFunctionStart hook (wrapped in `runner.hook` for substep-counter
+      // idempotency on resume).
+      compileBodyRest: (rest) => this.processBodyAsParts(rest, 1),
+    });
     this.scopes.inDestructiveFunction = prevDestructive;
     this.scopes.pop();
 
@@ -2413,11 +2342,11 @@ export class TypeScriptBuilder {
     const setupStmts = this.buildFunctionBody({
       functionName,
       parameters,
-      bodyCode,
+      bodyCode: compiledFinalize.bodyCode,
       skipHooks: false,
       hoistedAliases,
       inDestructiveFunction: !!node.markers?.destructive,
-      finalizeDecl,
+      finalize: compiledFinalize,
     });
 
     const funcDecl = ts.functionDecl(
@@ -3269,7 +3198,9 @@ export class TypeScriptBuilder {
       }
       const valueNode = this.processNode(node.value);
       if (this.isFinalizeInterceptedReturn(node.value)) {
-        return this.finalizeReturnLowering(valueNode, (v) => ts.runnerHalt(v));
+        return this.finalize.interceptedReturn(valueNode, (v) =>
+          ts.runnerHalt(v),
+        );
       }
       return ts.runnerHalt(valueNode);
     }
@@ -3326,7 +3257,7 @@ export class TypeScriptBuilder {
     }
     const valueNode = this.processNode(node.value);
     if (this.isFinalizeInterceptedReturn(node.value)) {
-      return this.finalizeReturnLowering(valueNode, (v) =>
+      return this.finalize.interceptedReturn(valueNode, (v) =>
         ts.functionReturn(this.maybeWrapReturnValidation(v)),
       );
     }
@@ -3340,34 +3271,8 @@ export class TypeScriptBuilder {
    *  `return llm(...)` hoists through its own path and cannot produce an
    *  AbortedResult. */
   private isFinalizeInterceptedReturn(value: AgencyNode): boolean {
-    if (!this.currentScopeHasFinalize()) return false;
+    if (!this.finalize.isActive()) return false;
     return value.type === "functionCall" && value.functionName !== "llm";
-  }
-
-  /** Lower `return <call>` to a checked temp: interrupts still halt
-   *  through the temp unchanged, an aborted result runs the finalize
-   *  (nothing to bind — the value was headed for the return), and a
-   *  normal value returns exactly as before. */
-  private finalizeReturnLowering(
-    valueNode: TsNode,
-    emit: (value: TsNode) => TsNode,
-  ): TsNode {
-    const scopeType = this.scopes.current().type;
-    const frameVar = scopeType === "block" ? "__bstack" : "__stack";
-    const scopeName = JSON.stringify(this.scopes.currentName());
-    return ts.statements([
-      ts.constDecl("__returnTemp", valueNode),
-      ts.if(
-        ts.raw("isAborted(__returnTemp)"),
-        ts.statements([
-          ts.raw(
-            `runner.halt(await __returnTemp.carryThrough(${frameVar}, ${scopeName}).withFinalize(__finalize, ${scopeName}))`,
-          ),
-          ts.return(),
-        ]),
-      ),
-      emit(ts.id("__returnTemp")),
-    ]);
   }
 
   private processAssignment(node: Assignment): TsNode {
@@ -3499,7 +3404,7 @@ export class TypeScriptBuilder {
     ) {
       const frameVar = scopeType === "block" ? "__bstack" : "__stack";
       const scopeName = JSON.stringify(this.scopes.currentName());
-      if (this.currentScopeHasFinalize()) {
+      if (this.finalize.isActive()) {
         const bind =
           opts?.bindOnAborted === true
             ? [ts.raw(`${expr} = __abortedCallee.partialValueOrNull()`)]
@@ -3509,10 +3414,7 @@ export class TypeScriptBuilder {
           ts.statements([
             ts.raw(`const __abortedCallee = ${expr}`),
             ...bind,
-            ts.raw(
-              `runner.halt(await __abortedCallee.carryThrough(${frameVar}, ${scopeName}).withFinalize(__finalize, ${scopeName}))`,
-            ),
-            ts.return(),
+            ...this.finalize.stopScope("__abortedCallee"),
           ]),
         );
       }

--- a/packages/agency-lang/lib/backends/typescriptBuilder/finalizeCodegen.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/finalizeCodegen.ts
@@ -1,0 +1,184 @@
+import { ts } from "../../ir/builders.js";
+import { printTs } from "../../ir/prettyPrint.js";
+import type { TsNode } from "../../ir/tsIR.js";
+import type { AgencyNode } from "../../types.js";
+import type { FinalizeBlock } from "../../types/finalizeBlock.js";
+import type { ScopeManager } from "./scopeManager.js";
+
+/** Everything a scope's compilation needs from its (possible) finalize
+ *  block. Produced by FinalizeCodegen.compileScope for every function and
+ *  block scope, whether or not one was declared. */
+export type CompiledScopeFinalize = {
+  /** The scope's compiled statements, with the finalize stripped. */
+  bodyCode: TsNode[];
+  /** The `const __finalize = ...` closure declaration, or undefined when
+   *  the scope declared no finalize. */
+  decl: TsNode | undefined;
+  /** `decl` rendered for the setup templates; "" when there is no
+   *  finalize. Pre-rendered strings (not mustache sections) keep the
+   *  no-finalize output byte-identical to the pre-finalize compiler. */
+  declText: string;
+  /** The catch-site abort return statement. With a finalize it runs the
+   *  closure first (`.withFinalize`); without one it returns the plain
+   *  AbortedResult. */
+  abortReturn: string;
+};
+
+/**
+ * Compiles `finalize { ... }` blocks: the statement-stream split, the
+ * `__finalize` closure, and the abort stop sites that run it. Extracted
+ * from TypeScriptBuilder so every finalize emission lives in one place.
+ *
+ * The model: a finalize is a declaration, not a statement. compileScope
+ * strips it from the scope's statement stream and compiles it into a
+ * `const __finalize = ...` closure. Three stop sites call the closure
+ * through `AbortedResult.withFinalize`:
+ *
+ *   1. the frame catch — `abortReturn`, rendered into the catch template;
+ *   2. the post-call aborted guard — `stopScope`, emitted by the
+ *      builder's assignmentAbortedGuard;
+ *   3. the return-position temp check — `interceptedReturn`.
+ *
+ * The closure runs on the container's own frame: locals live there, so
+ * the finalize body reads them with zero passing. Runner step counters
+ * are frame-keyed, so the closure's statements compile at STEP_BASE, a
+ * disjoint id range the main body can never reach. Small ids would
+ * collide with counters the main body already advanced past, silently
+ * skipping the finalize's steps. Advancing the dying frame's counter past
+ * the base is inert, because an aborted frame never resumes.
+ */
+export class FinalizeCodegen {
+  /** Step-id base for compiled finalize bodies — far above anything a
+   *  main body can reach. See the class doc. */
+  private static readonly STEP_BASE = 1000000;
+
+  /** One entry per function/block scope being compiled, true when that
+   *  scope declared a finalize. Pushed/popped by compileScope, in
+   *  lockstep with the builder's scope stack. */
+  private presence: boolean[] = [];
+
+  constructor(
+    private readonly scopes: ScopeManager,
+    private readonly moduleId: string,
+    /** TypeScriptBuilder.processBodyAsParts — compiles statements with
+     *  step ids starting at `stepBase`. */
+    private readonly compileBody: (
+      body: AgencyNode[],
+      stepBase: number,
+    ) => TsNode[],
+  ) {}
+
+  /**
+   * Compile a scope's body, separating out its finalize block. Call with
+   * the scope already pushed on the ScopeManager; `compileBodyRest` runs
+   * between the presence push/pop so the finalize-aware return and
+   * post-call lowerings see the right flag while the body compiles.
+   */
+  compileScope(args: {
+    body: AgencyNode[];
+    scopeName: string;
+    /** The catch template's error binding: `__error` in function catches,
+     *  `__blockError` in block catches. */
+    errorVar: string;
+    /** Compiles the scope's own statements (the stream minus the
+     *  finalize). Owns the step base: functions start at 1 (id 0 is the
+     *  onFunctionStart hook), blocks at 0. */
+    compileBodyRest: (rest: AgencyNode[]) => TsNode[];
+  }): CompiledScopeFinalize {
+    // Defensive split: extras beyond the first finalize are dropped here
+    // but already rejected by AG6032.
+    const rest = args.body.filter((n) => n.type !== "finalizeBlock");
+    const finalize = args.body.find(
+      (n): n is FinalizeBlock => n.type === "finalizeBlock",
+    );
+    this.presence.push(finalize !== undefined);
+    const bodyCode = args.compileBodyRest(rest);
+    const decl = finalize ? this.closure(finalize, args.scopeName) : undefined;
+    this.presence.pop();
+    return {
+      bodyCode,
+      decl,
+      declText: decl !== undefined ? printTs(decl, 0) + "\n" : "",
+      abortReturn: this.abortReturn(
+        args.scopeName,
+        args.errorVar,
+        finalize !== undefined,
+      ),
+    };
+  }
+
+  /** True when the innermost function/block scope being compiled declared
+   *  a finalize. Drives the finalize-aware post-call guard and the
+   *  return-position lowering. */
+  isActive(): boolean {
+    return this.presence[this.presence.length - 1] === true;
+  }
+
+  /** The statements every in-body stop site emits: halt the scope with
+   *  the aborted result after running the finalize over it, then leave
+   *  the step body. carryThrough applies the salvage rule (drop the
+   *  callee's partial, carry this scope's own draft) before the finalize
+   *  runs; the finalize's value then outranks the draft. */
+  stopScope(abortedVar: string): TsNode[] {
+    const scope = JSON.stringify(this.scopes.currentName());
+    return [
+      ts.raw(
+        `runner.halt(await ${abortedVar}.carryThrough(${this.frameVar()}, ${scope}).withFinalize(__finalize, ${scope}))`,
+      ),
+      ts.return(),
+    ];
+  }
+
+  /** Lower `return <call>` to a checked temp. A normal value returns
+   *  exactly as before. An interrupt result passes through the temp as
+   *  the return value, for the caller's post-call check to handle. An
+   *  aborted result stops here and runs the finalize — pass-through would
+   *  silently skip it. Nothing binds into a local: the value was headed
+   *  for the return. */
+  interceptedReturn(
+    valueNode: TsNode,
+    emit: (value: TsNode) => TsNode,
+  ): TsNode {
+    return ts.statements([
+      ts.constDecl("__returnTemp", valueNode),
+      ts.if(
+        ts.raw("isAborted(__returnTemp)"),
+        ts.statements(this.stopScope("__returnTemp")),
+      ),
+      emit(ts.id("__returnTemp")),
+    ]);
+  }
+
+  /** Compile the finalize body into the `__finalize` closure. The fresh
+   *  Runner shares the container's frame and gets a "#finalize" scope
+   *  name; the disjoint step base (see the class doc) is what actually
+   *  keeps its counters from colliding with the main body's. */
+  private closure(finalize: FinalizeBlock, scopeName: string): TsNode {
+    const parts = this.compileBody(finalize.body, FinalizeCodegen.STEP_BASE);
+    const bodyStr = parts.map((n) => printTs(n, 1)).join("\n");
+    const frameVar = this.frameVar();
+    return ts.raw(
+      `const __finalize = async (): Promise<any> => {\n` +
+        `  const runner = new Runner(__ctx, ${frameVar}, { state: ${frameVar}, moduleId: ${JSON.stringify(this.moduleId)}, scopeName: ${JSON.stringify(scopeName + "#finalize")} });\n` +
+        bodyStr +
+        `\n  return runner.halted ? runner.haltResult : undefined;\n};`,
+    );
+  }
+
+  private abortReturn(
+    scopeName: string,
+    errorVar: string,
+    hasFinalize: boolean,
+  ): string {
+    const scope = JSON.stringify(scopeName);
+    const fromError = `AbortedResult.fromError(${errorVar}, ${this.frameVar()}, ${scope})`;
+    return hasFinalize
+      ? `return await ${fromError}.withFinalize(__finalize, ${scope});`
+      : `return ${fromError};`;
+  }
+
+  /** The frame variable generated scopes bind their own frame to. */
+  private frameVar(): string {
+    return this.scopes.current().type === "block" ? "__bstack" : "__stack";
+  }
+}

--- a/packages/agency-lang/lib/lowering/patternLowering.ts
+++ b/packages/agency-lang/lib/lowering/patternLowering.ts
@@ -16,6 +16,7 @@ import type {
   Expression,
   ForLoop,
   FunctionCall,
+  FinalizeBlock,
   FunctionDefinition,
   HandleBlock,
   IfElse,
@@ -101,6 +102,12 @@ class PatternLowerer {
         return this.lowerMatchBlock(node);
       case "forLoop":
         return [this.lowerForLoop(node)];
+      case "finalizeBlock": {
+        // Same-scope statements: expression-position match/if inside the
+        // finalize lowers exactly like anywhere else in the scope.
+        const fb = node as FinalizeBlock;
+        return [{ ...fb, body: this.lowerBody(fb.body) }];
+      }
       case "handleBlock": {
         // Descend both the guarded body and the inline handler body. Non-inline
         // handlers have no body to descend.

--- a/packages/agency-lang/lib/parsers/finalizeBlock.test.ts
+++ b/packages/agency-lang/lib/parsers/finalizeBlock.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { finalizeBlockParser, bodyParser } from "./parsers.js";
+import { normalizeCode } from "@/index.js";
+
+describe("finalizeBlockParser", () => {
+  it("parses a finalize block with a return", () => {
+    const result = finalizeBlockParser(normalizeCode(`finalize {\n  return "a"\n}`));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("finalizeBlock");
+      expect(result.result.body).toHaveLength(1);
+    }
+  });
+
+  it("parses inside a def body, landing a finalizeBlock node in the body", () => {
+    const result = bodyParser(
+      normalizeCode(`saveDraft("d")\nfinalize {\n  return "a"\n}`),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const kinds = result.result.map((n) => n.type);
+      expect(kinds).toContain("finalizeBlock");
+    }
+  });
+
+  it("does not match `finalize` as a prefix of an identifier like `finalizer`", () => {
+    const result = bodyParser(normalizeCode("finalizer(data)\n"));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.map((n) => n.type)).toContain("functionCall");
+    }
+  });
+
+  it("parses a multi-statement body, an empty finalize, and finalize-not-last", () => {
+    expect(
+      finalizeBlockParser(
+        normalizeCode(`finalize {\n  const a = 1\n  return a\n}`),
+      ).success,
+    ).toBe(true);
+    expect(finalizeBlockParser(normalizeCode(`finalize {\n}`)).success).toBe(
+      true,
+    );
+    const notLast = bodyParser(
+      normalizeCode(`finalize {\n  return "a"\n}\nsaveDraft("d")`),
+    );
+    expect(notLast.success).toBe(true);
+    if (notLast.success) {
+      expect(notLast.result.map((n) => n.type)).toContain("finalizeBlock");
+    }
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -143,6 +143,7 @@ import { ExportFromStatement, NamedExportBody } from "../types/exportFromStateme
 import { DefaultCase, MatchBlock, MatchBlockCase } from "../types/matchBlock.js";
 import { MessageThread } from "@/types/messageThread.js";
 import { HandleBlock } from "@/types/handleBlock.js";
+import { FinalizeBlock } from "@/types/finalizeBlock.js";
 import { WithModifier } from "@/types/withModifier.js";
 import { StaticStatement } from "@/types/staticStatement.js";
 import {
@@ -3991,6 +3992,7 @@ const _bodyNodeParser: Parser<AgencyNode> = memo("bodyNodeParser", or(
   lazy(() => ifParser),
   lazy(() => messageThreadParser),
   lazy(() => handleBlockParser),
+  lazy(() => finalizeBlockParser),
   debuggerParser,
   multiLineCommentParser,
   commentParser,
@@ -4224,6 +4226,29 @@ export const handleBlockParser: Parser<HandleBlock> = withLoc(memo(
     str("with"),
     optionalSpaces,
     capture(or(inlineHandlerParser, functionRefHandlerParser), "handler"),
+  ),
+));
+
+/** `finalize { ... }` — keyword block, no binder and no `with` clause.
+ *  Mirrors handleBlockParser's keyword handling: the word-boundary check
+ *  keeps an identifier like `finalizer(...)` parsing as a call. */
+export const finalizeBlockParser: Parser<FinalizeBlock> = withLoc(memo(
+  "finalizeBlockParser",
+  seqC(
+    set("type", "finalizeBlock"),
+    str("finalize"),
+    not(varNameChar),
+    optionalSpaces,
+    captureCaptures(
+      parseError(
+        "expected `{` to open finalize block body",
+        char("{"),
+        optionalSpacesOrNewline,
+        capture(bodyParser, "body"),
+        optionalSpacesOrNewline,
+        char("}"),
+      ),
+    ),
   ),
 ));
 

--- a/packages/agency-lang/lib/preprocessors/liftCallbacks.ts
+++ b/packages/agency-lang/lib/preprocessors/liftCallbacks.ts
@@ -183,6 +183,9 @@ function transformStatement(
     case "messageThread":
       node.body = transformBody(node.body, scopeName, lifted, nextName);
       return node;
+    case "finalizeBlock":
+      node.body = transformBody(node.body, scopeName, lifted, nextName);
+      return node;
     case "handleBlock":
       node.body = transformBody(node.body, scopeName, lifted, nextName);
       if (node.handler.kind === "inline") {

--- a/packages/agency-lang/lib/runtime/abortedResult.test.ts
+++ b/packages/agency-lang/lib/runtime/abortedResult.test.ts
@@ -51,6 +51,10 @@ function withStubStatelog<T>(fn: () => T): {
       events.push(e);
       return Promise.resolve();
     },
+    error(e: RecordedEvent): Promise<void> {
+      events.push(e);
+      return Promise.resolve();
+    },
   };
   const ctx = { statelogClient: client } as any;
   const result = runInTestContext(
@@ -255,5 +259,118 @@ describe("previewForLog", () => {
     const cyclic: any = {};
     cyclic.self = cyclic;
     expect(previewForLog(cyclic)).toBe("[object Object]");
+  });
+});
+
+describe("AbortedResult.partialValueOrNull", () => {
+  it("returns the partial's value", () => {
+    const aborted = AbortedResult.fromError(
+      abortError(),
+      frameWithDraft("d"),
+      "code",
+    );
+    expect(aborted.partialValueOrNull()).toBe("d");
+  });
+
+  it("returns a saved null (a real partial)", () => {
+    const aborted = AbortedResult.fromError(
+      abortError(),
+      frameWithDraft(null),
+      "code",
+    );
+    expect(aborted.partialValueOrNull()).toBe(null);
+  });
+
+  it("returns null when there is no partial", () => {
+    const aborted = AbortedResult.fromError(abortError(), new State(), "code");
+    expect(aborted.partialValueOrNull()).toBe(null);
+  });
+});
+
+describe("AbortedResult.withFinalize", () => {
+  it("replaces the partial with the finalize's return, cause by identity", async () => {
+    const cause = tripCause();
+    const aborted = AbortedResult.fromError(
+      abortError(cause),
+      frameWithDraft("draft"),
+      "code",
+    );
+    const finalized = await aborted.withFinalize(async () => "finalized", "code");
+    expect(finalized.partialValueOrNull()).toBe("finalized");
+    expect(finalized.cause).toBe(cause);
+  });
+
+  it("a finalize returning null is a real partial", async () => {
+    const aborted = AbortedResult.fromError(
+      abortError(),
+      frameWithDraft("draft"),
+      "code",
+    );
+    const finalized = await aborted.withFinalize(async () => null, "code");
+    expect(finalized.partial).toEqual({ value: null });
+  });
+
+  it("falls back to the saved draft when the finalize throws, and logs", async () => {
+    const { result, events } = withStubStatelog(async () => {
+      const aborted = AbortedResult.fromError(
+        abortError(),
+        frameWithDraft("draft"),
+        "code",
+      );
+      return aborted.withFinalize(async () => {
+        throw new Error("boom");
+      }, "code");
+    });
+    const finalized = await result;
+    expect(finalized.partialValueOrNull()).toBe("draft");
+    expect(events.some((e) => e.errorType === "finalizeError")).toBe(true);
+  });
+
+  it("with NO prior partial: a successful finalize becomes the partial", async () => {
+    const aborted = AbortedResult.fromError(abortError(), new State(), "code");
+    const finalized = await aborted.withFinalize(async () => "f", "code");
+    expect(finalized.partialValueOrNull()).toBe("f");
+  });
+
+  it("with NO prior partial: a throwing finalize leaves no partial and does not crash", async () => {
+    const aborted = AbortedResult.fromError(abortError(), new State(), "code");
+    const finalized = await aborted.withFinalize(async () => {
+      throw new Error("boom");
+    }, "code");
+    expect(finalized.partial).toBeUndefined();
+    expect(finalized.partialValueOrNull()).toBe(null);
+  });
+
+  it("treats an interrupting finalize result as a failure (backstop)", async () => {
+    const aborted = AbortedResult.fromError(
+      abortError(),
+      frameWithDraft("draft"),
+      "code",
+    );
+    const fakeInterrupts = [
+      { type: "interrupt", interruptId: "i1", effect: "std::x", message: "m" },
+    ];
+    const finalized = await aborted.withFinalize(async () => fakeInterrupts, "code");
+    expect(finalized.partialValueOrNull()).toBe("draft");
+  });
+
+  it("treats an aborted finalize result as a failure (backstop)", async () => {
+    const aborted = AbortedResult.fromError(
+      abortError(),
+      frameWithDraft("draft"),
+      "code",
+    );
+    const nested = AbortedResult.fromError(abortError(), new State(), "inner");
+    const finalized = await aborted.withFinalize(async () => nested, "code");
+    expect(finalized.partialValueOrNull()).toBe("draft");
+  });
+
+  it("emits a carried event for the finalize's partial", async () => {
+    const { result, events } = withStubStatelog(async () => {
+      const aborted = AbortedResult.fromError(abortError(), new State(), "code");
+      return aborted.withFinalize(async () => "f", "code");
+    });
+    await result;
+    expect(events.map((e) => e.action)).toContain("carried");
   });
 });

--- a/packages/agency-lang/lib/runtime/abortedResult.test.ts
+++ b/packages/agency-lang/lib/runtime/abortedResult.test.ts
@@ -374,3 +374,12 @@ describe("AbortedResult.withFinalize", () => {
     expect(events.map((e) => e.action)).toContain("carried");
   });
 });
+
+describe("AbortedResult.fromError marks a guard trip delivered", () => {
+  it("sets the cause's delivered flag so later steps on the aborted signal run", () => {
+    const cause = tripCause();
+    expect(cause.kind === "guardTrip" && cause.delivered).toBeFalsy();
+    AbortedResult.fromError(abortError(cause), new State(), "code");
+    expect(cause.kind === "guardTrip" && cause.delivered).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/runtime/abortedResult.ts
+++ b/packages/agency-lang/lib/runtime/abortedResult.ts
@@ -73,6 +73,17 @@ export class AbortedResult {
     frame: State,
     scopeName: string,
   ): AbortedResult {
+    // Converting the exception into a value IS the trip's delivery: from
+    // here the abort travels the value pipeline. Marking the cause
+    // delivered (shared by identity with the abort signal's reason)
+    // tells Runner.shouldSkip not to re-throw the same trip at later
+    // steps on the still-aborted signal — the guard's own cleanup steps,
+    // and a finalize's steps, must run. Without this, a leaf-delivered
+    // time trip kills a finalize's first step. In-flight leaf ops still
+    // cancel via the signal itself (the computational-only rule).
+    if (error.agencyCause.kind === "guardTrip") {
+      error.agencyCause.delivered = true;
+    }
     const result = new AbortedResult(
       error.agencyCause,
       frame.savedDraft,

--- a/packages/agency-lang/lib/runtime/abortedResult.ts
+++ b/packages/agency-lang/lib/runtime/abortedResult.ts
@@ -5,6 +5,7 @@ import {
 } from "./errors.js";
 import type { State } from "./state/stateStack.js";
 import { agencyStore } from "./asyncContext.js";
+import { hasInterrupts } from "./interrupts.js";
 import type { StatelogClient } from "../statelogClient.js";
 
 const TRUNCATE_AT = 500;
@@ -109,6 +110,57 @@ export class AbortedResult {
     return this.dropped("clearedAtFork");
   }
 
+  /** The partial's value, or null when there is no partial. The ONLY way
+   *  generated code reads a partial: the `{ value }` wrapper (which keeps
+   *  a saved null distinct from no-partial) is internal to this class. */
+  partialValueOrNull(): unknown {
+    return this.partial !== undefined ? this.partial.value : null;
+  }
+
+  /** A finalize-bearing scope is stopping: run its finalize, and its
+   *  return becomes the scope's partial. A finalize failure never masks
+   *  the trip — the abort continues with the partial this instance
+   *  already holds (the saved draft, or nothing) and the failure is
+   *  logged. Two extra failure shapes are backstops: a finalize that
+   *  resolves to interrupts (the checker forbids what it can see, but an
+   *  IMPORTED interrupting callee is invisible to it), and one that
+   *  resolves to an aborted result of its own (the tripped guard's
+   *  signal is still firing, so a callee inside the finalize can be
+   *  stopped). */
+  async withFinalize(
+    finalize: () => Promise<unknown>,
+    scopeName: string,
+  ): Promise<AbortedResult> {
+    let value: unknown;
+    try {
+      value = await finalize();
+    } catch (finalizeError) {
+      this.logFinalizeFailure(scopeName, finalizeError);
+      return this;
+    }
+    if (hasInterrupts(value) || isAborted(value)) {
+      this.logFinalizeFailure(scopeName, value);
+      return this;
+    }
+    return new AbortedResult(this.cause, { value }, this.unwindSpanId).logged(
+      "carried",
+      undefined,
+      scopeName,
+    );
+  }
+
+  /** A failed finalize is a footnote to the trip, never its replacement:
+   *  log it and keep the abort's existing story. */
+  private logFinalizeFailure(scopeName: string, failure: unknown): void {
+    const client = statelogClient();
+    client?.error?.({
+      errorType: "finalizeError",
+      message:
+        failure instanceof Error ? failure.message : previewForLog(failure),
+      functionName: scopeName,
+    });
+  }
+
   /** The guard that owns this trip is converting it into a Result.
    *  Emits the closing statelog event and ends the unwind span. Returns
    *  the partial to salvage, or undefined for no salvage. */
@@ -160,7 +212,7 @@ export class AbortedResult {
    *  (with the span id filled in), keeping construction declarative. */
   private logged(
     action: "carried",
-    frame: State,
+    frame: State | undefined,
     scopeName: string,
     droppedPartial?: { value: unknown },
   ): AbortedResult {
@@ -178,7 +230,7 @@ export class AbortedResult {
       action: gained !== undefined ? action : "erased",
       scopeName,
       spanId,
-      functionArgs: previewForLog(frame.args),
+      functionArgs: frame !== undefined ? previewForLog(frame.args) : undefined,
       partial: shown !== undefined ? previewForLog(shown.value) : undefined,
     });
     if (spanId === this.unwindSpanId) {

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1225,7 +1225,7 @@ export class StatelogClient {
     sourceLocation,
     tools,
   }: {
-    errorType: "toolError" | "llmError" | "runtimeError" | "validationError" | "limitExceeded" | "structuredOutput";
+    errorType: "toolError" | "llmError" | "runtimeError" | "validationError" | "limitExceeded" | "structuredOutput" | "finalizeError";
     message: string;
     functionName?: string;
     /** Tool-failure classification for the tool loop's retry policy. */

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
@@ -6,7 +6,7 @@ const {{{frameVar}}} = __bstack;
 __bstack.args[{{{this.paramNameQuoted}}}] = {{{this.paramName}}};
 {{/params}}
 const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}} });
-try {
+{{{finalizeDecl}}}try {
 {{{body}}}
 return runner.halted ? runner.haltResult : undefined;
 } catch (__blockError) {
@@ -15,7 +15,7 @@ return runner.halted ? runner.haltResult : undefined;
 // saved draft. This is how a saveDraft placed directly inside a guard
 // block reaches the guard. Other errors keep throwing as before.
 if (__blockError instanceof AgencyAbort) {
-  return AbortedResult.fromError(__blockError, __bstack, {{{scopeName}}});
+  {{{abortReturn}}}
 }
 throw __blockError;
 } finally {

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
@@ -11,7 +11,7 @@ const {{{frameVar}}} = __bstack;
 __bstack.args[{{{this.paramNameQuoted}}}] = {{{this.paramName}}};
 {{/params}}
 const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}} });
-try {
+{{{finalizeDecl}}}try {
 {{{body}}}
 return runner.halted ? runner.haltResult : undefined;
 } catch (__blockError) {
@@ -20,7 +20,7 @@ return runner.halted ? runner.haltResult : undefined;
 // saved draft. This is how a saveDraft placed directly inside a guard
 // block reaches the guard. Other errors keep throwing as before.
 if (__blockError instanceof AgencyAbort) {
-  return AbortedResult.fromError(__blockError, __bstack, {{{scopeName}}});
+  {{{abortReturn}}}
 }
 throw __blockError;
 } finally {
@@ -44,7 +44,9 @@ export type TemplateType = {
   }[];
   moduleId: string | boolean | number;
   scopeName: string | boolean | number;
+  finalizeDecl: string | boolean | number;
   body: string | boolean | number;
+  abortReturn: string | boolean | number;
 };
 
 const render = (args: TemplateType) => {

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
@@ -14,7 +14,7 @@ if (__error instanceof AgencyAbort) {
   // if it saved one. The caller's post-call check spots the marker and
   // stops too, so the abort travels up the stack as a plain value, the
   // same way interrupts do. See lib/runtime/abortedResult.ts.
-  return AbortedResult.fromError(__error, __stack, {{{functionName}}});
+  {{{abortReturn}}}
 }
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
@@ -19,7 +19,7 @@ if (__error instanceof AgencyAbort) {
   // if it saved one. The caller's post-call check spots the marker and
   // stops too, so the abort travels up the stack as a plain value, the
   // same way interrupts do. See lib/runtime/abortedResult.ts.
-  return AbortedResult.fromError(__error, __stack, {{{functionName}}});
+  {{{abortReturn}}}
 }
 // Surface the underlying exception via logger + statelog before
 // converting to a Failure. Without this, a caller that doesn't
@@ -51,6 +51,7 @@ return failure(
 `;
 
 export type TemplateType = {
+  abortReturn: string | boolean | number;
   functionName: string | boolean | number;
 };
 

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -399,27 +399,31 @@ node main() {
 
 **How to fix:** move the \`saveDraft\` call inside the function, node, or \`guard\` block whose result it is a draft of.`,
 
-  finalizeInterrupts: `A finalize block runs at the moment an abort stops its scope — outside the step machinery that interrupts pause and resume through. An interrupt raised there would have nothing to resume back to. This checks transitively for functions defined in your own files: calling one that can interrupt is as forbidden as a direct \`interrupt(...)\`. An IMPORTED function that interrupts is not visible to this static check; at runtime the finalize is treated as failed and the scope falls back to its saved draft.
+  finalizeInterrupts: `An interrupt pauses the program and waits for an answer. When the answer arrives, the program resumes from the paused step. A finalize block runs while an abort shuts its scope down, so there is no step to resume from. That is why a finalize cannot interrupt, and cannot call a function that interrupts.
 
-**How to fix:** keep the finalize computational — combine the locals you already have. Anything that needs a human belongs in the normal body, before the work that can trip.`,
+The check follows calls into functions defined in your own files. It cannot see into imported functions. If an imported function interrupts inside a finalize at runtime, the finalize counts as failed and the scope falls back to its saved draft.
 
-  finalizeDuplicate: `Only one finalize block per scope: when the scope is stopped, exactly one computation produces its partial result. Two blocks would need merge rules.
+**How to fix:** only compute values inside the finalize, using the variables you already have. If you need to ask the user something, ask in the normal body, before the work that can trip.`,
 
-**How to fix:** combine the logic into a single finalize; branch inside it if needed.`,
+  finalizeDuplicate: `When a scope is stopped, one finalize computes its partial result. A second finalize block would leave the result ambiguous.
 
-  finalizeNotTopLevel: `A finalize is a declaration, not a statement: if the scope has one, it is always active. Nesting it inside an \`if\`, a loop, or a match arm would make it conditionally armed, which needs "was it armed?" bookkeeping the language deliberately avoids.
+**How to fix:** combine the logic into one finalize block. Branch inside it if you need to.`,
 
-**How to fix:** move the finalize to the top level of the function or block body (convention: last), and branch INSIDE the finalize instead.`,
+  finalizeNotTopLevel: `A finalize is a declaration, not a statement. If the scope has one, it is always active. Nesting it inside an \`if\`, a loop, or a match arm would arm it conditionally, and the language would then need to track whether it was armed. The language avoids that bookkeeping.
 
-  finalizeSaveDraft: `Inside a finalize, the scope's partial result is being computed right now — the finalize's return value is that result. Saving a draft there is meaningless.
+**How to fix:** move the finalize to the top level of the function or block body. Put it last, by convention. Branch inside the finalize instead.`,
+
+  finalizeSaveDraft: `Inside a finalize, you are computing the scope's partial result right now. The value the finalize returns is that result. Saving a draft there does nothing.
 
 **How to fix:** \`return\` the value from the finalize instead of calling \`saveDraft\`.`,
 
-  finalizeInNode: `Salvaged partial results are consumed by an enclosing \`guard\`, and guards cannot span nodes — above a node there is only the graph engine, which does not consume partials (root budgets may, later). A finalize declared directly in a node body would compute a value nobody reads.
+  finalizeInNode: `An enclosing \`guard\` consumes salvaged partial results, and a guard cannot span nodes. Above a node there is only the graph engine, and the graph engine does not consume partials. A finalize declared directly in a node body would compute a value nobody reads.
 
-**How to fix:** put the finalize inside the function or \`guard\` block doing the guarded work.`,
+**How to fix:** put the finalize inside the function or \`guard\` block that does the guarded work.`,
 
-  finalizeReturnShape: `When a call inside a return expression is aborted, its aborted result is consumed by the surrounding expression (concatenated, wrapped in an array, ...) before any check can run — so the finalize would be silently skipped and garbage returned. A direct \`return f(x)\` is safe: the compiler intercepts it. Anything more complex is not interceptable without breaking evaluation order.
+  finalizeReturnShape: `Suppose a guard stops a call that sits inside a return expression. The surrounding expression consumes the stopped call's result before any check can run: the result gets concatenated, wrapped in an array, and so on. The finalize would be skipped and the function would return garbage.
+
+A direct \`return f(x)\` is safe, because the compiler intercepts it. Method and index calls do not count as direct: \`return obj.method()\` and \`return arr[i]()\` need the same fix as any other complex return. Nothing more complex than a single direct call can be intercepted without changing evaluation order.
 
 **How to fix:** assign the call to a local first, then return the local:
 

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -399,6 +399,41 @@ node main() {
 
 **How to fix:** move the \`saveDraft\` call inside the function, node, or \`guard\` block whose result it is a draft of.`,
 
+  finalizeInterrupts: `A finalize block runs at the moment an abort stops its scope — outside the step machinery that interrupts pause and resume through. An interrupt raised there would have nothing to resume back to. This checks transitively for functions defined in your own files: calling one that can interrupt is as forbidden as a direct \`interrupt(...)\`. An IMPORTED function that interrupts is not visible to this static check; at runtime the finalize is treated as failed and the scope falls back to its saved draft.
+
+**How to fix:** keep the finalize computational — combine the locals you already have. Anything that needs a human belongs in the normal body, before the work that can trip.`,
+
+  finalizeDuplicate: `Only one finalize block per scope: when the scope is stopped, exactly one computation produces its partial result. Two blocks would need merge rules.
+
+**How to fix:** combine the logic into a single finalize; branch inside it if needed.`,
+
+  finalizeNotTopLevel: `A finalize is a declaration, not a statement: if the scope has one, it is always active. Nesting it inside an \`if\`, a loop, or a match arm would make it conditionally armed, which needs "was it armed?" bookkeeping the language deliberately avoids.
+
+**How to fix:** move the finalize to the top level of the function or block body (convention: last), and branch INSIDE the finalize instead.`,
+
+  finalizeSaveDraft: `Inside a finalize, the scope's partial result is being computed right now — the finalize's return value is that result. Saving a draft there is meaningless.
+
+**How to fix:** \`return\` the value from the finalize instead of calling \`saveDraft\`.`,
+
+  finalizeInNode: `Salvaged partial results are consumed by an enclosing \`guard\`, and guards cannot span nodes — above a node there is only the graph engine, which does not consume partials (root budgets may, later). A finalize declared directly in a node body would compute a value nobody reads.
+
+**How to fix:** put the finalize inside the function or \`guard\` block doing the guarded work.`,
+
+  finalizeReturnShape: `When a call inside a return expression is aborted, its aborted result is consumed by the surrounding expression (concatenated, wrapped in an array, ...) before any check can run — so the finalize would be silently skipped and garbage returned. A direct \`return f(x)\` is safe: the compiler intercepts it. Anything more complex is not interceptable without breaking evaluation order.
+
+**How to fix:** assign the call to a local first, then return the local:
+
+\`\`\`agency
+def f(): string {
+  const part = verify()
+  return "combined: " + part
+
+  finalize {
+    return "partial: " + part
+  }
+}
+\`\`\``,
+
   // ---- AG7: static init, config, and imports ----
   exportRequiresStaticConst: `Only \`static const\` declarations can be exported from a module. A plain \`const\`, \`let\`, or other declaration is per-run state and is not part of a module's public surface.
 

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -433,7 +433,7 @@ export const DIAGNOSTICS = {
     code: "AG3016",
     severity: "error",
     message:
-      "A finalize block cannot raise interrupts: it runs while an abort is stopping the scope, with nothing to resume back to. '{callee}' can interrupt.",
+      "'{callee}' can interrupt, and a finalize block cannot contain interrupts. A finalize runs while its scope shuts down, so there is nothing to resume.",
   },
   undefinedFunction: {
     code: "AG4004",
@@ -504,31 +504,31 @@ export const DIAGNOSTICS = {
     code: "AG6032",
     severity: "error",
     message:
-      "A scope can declare at most one finalize block. Merge the branches into the first one.",
+      "A scope can declare at most one finalize block. Combine the logic into one block.",
   },
   finalizeNotTopLevel: {
     code: "AG6033",
     severity: "error",
     message:
-      "A finalize block must sit at the top level of its function or block body, not inside `{construct}`. A finalize is a declaration — it is always active, so nesting it in control flow has no meaning.",
+      "A finalize block cannot go inside {construct}. Declare it at the top level of the function or block body. A finalize is always active, so nesting it in control flow has no meaning.",
   },
   finalizeSaveDraft: {
     code: "AG6034",
     severity: "error",
     message:
-      "saveDraft() has no effect inside a finalize block: the finalize's return IS the scope's partial result. Return the value instead.",
+      "saveDraft() has no effect inside a finalize block. The value the finalize returns is already the partial result. Return the value instead.",
   },
   finalizeInNode: {
     code: "AG6035",
     severity: "error",
     message:
-      "A finalize block in a node has no effect: nothing above a node consumes a partial result yet. Put the finalize in a function or guard block instead.",
+      "A finalize block cannot go in a node body. Nothing above a node consumes a partial result yet. Put the finalize in a function or a guard block instead.",
   },
   finalizeReturnShape: {
     code: "AG6036",
     severity: "error",
     message:
-      "In a scope with a finalize block, a return expression that contains a call must BE a single direct call. Assign the call to a local first, then return the local — otherwise an aborted call's partial would be consumed inside the expression before the finalize can run.",
+      "This scope has a finalize block, so a return expression cannot bury a call inside a bigger expression. If the call were stopped, the expression would consume its partial result before the finalize could run. Assign the call to a local first, then return the local.",
   },
   staticReassignedAtTopLevel: {
     code: "AG7004",

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -429,6 +429,12 @@ export const DIAGNOSTICS = {
     message:
       "{who} raises effect '{effect}', which exceeds the 'raises <{allowed}>' allowed by type '{type}'. Add '{effect}' to the clause, or use a target type that allows it.",
   },
+  finalizeInterrupts: {
+    code: "AG3016",
+    severity: "error",
+    message:
+      "A finalize block cannot raise interrupts: it runs while an abort is stopping the scope, with nothing to resume back to. '{callee}' can interrupt.",
+  },
   undefinedFunction: {
     code: "AG4004",
     severity: "error",
@@ -493,6 +499,36 @@ export const DIAGNOSTICS = {
     severity: "error",
     message:
       "saveDraft() cannot be called at module top level — there is no enclosing function, node, or block scope to save a draft for.",
+  },
+  finalizeDuplicate: {
+    code: "AG6032",
+    severity: "error",
+    message:
+      "A scope can declare at most one finalize block. Merge the branches into the first one.",
+  },
+  finalizeNotTopLevel: {
+    code: "AG6033",
+    severity: "error",
+    message:
+      "A finalize block must sit at the top level of its function or block body, not inside `{construct}`. A finalize is a declaration — it is always active, so nesting it in control flow has no meaning.",
+  },
+  finalizeSaveDraft: {
+    code: "AG6034",
+    severity: "error",
+    message:
+      "saveDraft() has no effect inside a finalize block: the finalize's return IS the scope's partial result. Return the value instead.",
+  },
+  finalizeInNode: {
+    code: "AG6035",
+    severity: "error",
+    message:
+      "A finalize block in a node has no effect: nothing above a node consumes a partial result yet. Put the finalize in a function or guard block instead.",
+  },
+  finalizeReturnShape: {
+    code: "AG6036",
+    severity: "error",
+    message:
+      "In a scope with a finalize block, a return expression that contains a call must BE a single direct call. Assign the call to a local first, then return the local — otherwise an aborted call's partial would be consumed inside the expression before the finalize can run.",
   },
   staticReassignedAtTopLevel: {
     code: "AG7004",

--- a/packages/agency-lang/lib/typeChecker/finalize.test.ts
+++ b/packages/agency-lang/lib/typeChecker/finalize.test.ts
@@ -83,6 +83,40 @@ describe("finalize checker — rule 2: one per scope, top level only", () => {
     ).toContain("AG6033");
   });
 
+  it("rejects a finalize nested in a thread block (AG6033)", () => {
+    // messageThread was missing from the old hand-kept ancestor list; the
+    // check now derives "wraps statements" from bodySlots, so every
+    // body-bearing construct rejects by default.
+    expect(
+      codes(`
+      def f(): string {
+        thread {
+          finalize {
+            return "a"
+          }
+        }
+        return "x"
+      }
+    `),
+    ).toContain("AG6033");
+  });
+
+  it("names the construct with its keyword, not the AST type name", () => {
+    const errors = check(`
+      def f(): string {
+        if (true) {
+          finalize {
+            return "a"
+          }
+        }
+        return "x"
+      }
+    `);
+    const ag6033 = errors.find((e) => e.code === "AG6033");
+    expect(ag6033?.message).toContain("an `if` statement");
+    expect(ag6033?.message).not.toContain("ifElse");
+  });
+
   it("accepts a finalize that is not the last statement", () => {
     const errors = check(`
       def f(): string {

--- a/packages/agency-lang/lib/typeChecker/finalize.test.ts
+++ b/packages/agency-lang/lib/typeChecker/finalize.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+/** Errors as {code, message} so every reject case can assert the SPECIFIC
+ *  diagnostic — a generic "some error fired" would stay green with the
+ *  finalize rule broken (e.g. rule 1 masked by the ordinary return check). */
+function check(source: string): { code: string; message: string }[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) {
+    throw new Error(`parse failed: ${parsed.message}`);
+  }
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  const result = typeCheck(parsed.result, {}, info);
+  return result.errors
+    .filter((e) => (e.severity ?? "error") === "error")
+    .map((e) => ({ code: e.code ?? "", message: e.message }));
+}
+
+function codes(source: string): string[] {
+  return check(source).map((e) => e.code);
+}
+
+describe("finalize checker — rule 1: return type", () => {
+  it("accepts a finalize whose return matches the enclosing return type", () => {
+    const errors = check(`
+      def f(): string {
+        finalize {
+          return "ok"
+        }
+        return "x"
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("rejects a finalize return that mismatches the enclosing return type", () => {
+    // The existing return-type machinery reaches the finalize body (same
+    // scope), so the code is the ordinary assignability diagnostic.
+    const result = check(`
+      def f(): string {
+        finalize {
+          return 42
+        }
+        return "x"
+      }
+    `);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.some((e) => e.code.startsWith("AG2"))).toBe(true);
+  });
+});
+
+describe("finalize checker — rule 2: one per scope, top level only", () => {
+  it("rejects a second finalize in the same scope (AG6032)", () => {
+    expect(
+      codes(`
+      def f(): string {
+        finalize {
+          return "a"
+        }
+        finalize {
+          return "b"
+        }
+        return "x"
+      }
+    `),
+    ).toContain("AG6032");
+  });
+
+  it("rejects a finalize nested in an if (AG6033)", () => {
+    expect(
+      codes(`
+      def f(): string {
+        if (true) {
+          finalize {
+            return "a"
+          }
+        }
+        return "x"
+      }
+    `),
+    ).toContain("AG6033");
+  });
+
+  it("accepts a finalize that is not the last statement", () => {
+    const errors = check(`
+      def f(): string {
+        finalize {
+          return "a"
+        }
+        return "x"
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe("finalize checker — rule 3: no interrupts (AG3016)", () => {
+  it("rejects a direct interrupt", () => {
+    expect(
+      codes(`
+      def f(): string {
+        finalize {
+          interrupt("no")
+          return "a"
+        }
+        return "x"
+      }
+    `),
+    ).toContain("AG3016");
+  });
+
+  it("rejects a TRANSITIVE interrupt (calling a def that interrupts)", () => {
+    expect(
+      codes(`
+      def asker(): string {
+        interrupt("ask")
+        return "a"
+      }
+
+      def f(): string {
+        finalize {
+          return asker()
+        }
+        return "x"
+      }
+    `),
+    ).toContain("AG3016");
+  });
+});
+
+describe("finalize checker — rule 4: no saveDraft (AG6034)", () => {
+  it("rejects saveDraft inside a finalize", () => {
+    expect(
+      codes(`
+      def f(): string {
+        finalize {
+          saveDraft("no")
+          return "a"
+        }
+        return "x"
+      }
+    `),
+    ).toContain("AG6034");
+  });
+});
+
+describe("finalize checker — rule 5: defs and blocks only (AG6035)", () => {
+  it("rejects a finalize in a node body", () => {
+    expect(
+      codes(`
+      node main() {
+        finalize {
+          return "a"
+        }
+        return "x"
+      }
+    `),
+    ).toContain("AG6035");
+  });
+
+  it("accepts a finalize inside a guard block", () => {
+    const errors = check(`
+      import { guard } from "std::thread"
+
+      node main() {
+        const r = guard(cost: 1.0) as {
+          finalize {
+            return "partial"
+          }
+          return "full"
+        }
+        return "done"
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe("finalize checker — rule 6: return shape in finalize scopes (AG6036)", () => {
+  it("rejects a call embedded in a return expression", () => {
+    expect(
+      codes(`
+      def g2(): string {
+        return "ok"
+      }
+
+      def f(): string {
+        finalize {
+          return "a"
+        }
+        return "x:\${g2()}"
+      }
+    `),
+    ).toContain("AG6036");
+  });
+
+  it("accepts a direct call in return position", () => {
+    const errors = check(`
+      def g2(): string {
+        return "ok"
+      }
+
+      def f(): string {
+        finalize {
+          return "a"
+        }
+        return g2()
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("does not restrict returns in scopes WITHOUT a finalize", () => {
+    const errors = check(`
+      def g2(): string {
+        return "ok"
+      }
+
+      def f(): string {
+        return "x:\${g2()}"
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe("finalize checker — definite returns", () => {
+  it("a finalize return does not satisfy definite-returns", () => {
+    const result = check(`
+      def f(): string {
+        finalize {
+          return "a"
+        }
+      }
+    `);
+    // notAllPathsReturn defaults to warn; look at ALL diagnostics.
+    const parsed = parseAgency(`
+      def f(): string {
+        finalize {
+          return "a"
+        }
+      }
+    `);
+    if (!parsed.success) throw new Error("parse failed");
+    const info = buildCompilationUnit(parsed.result, undefined, undefined, "");
+    const all = typeCheck(parsed.result, {}, info);
+    expect(all.errors.some((e) => e.name === "notAllPathsReturn")).toBe(true);
+    void result;
+  });
+});
+
+describe("finalize checker — rule 3 coverage boundary (documented)", () => {
+  it("does NOT statically catch an imported interrupting callee — the runtime backstop covers it", () => {
+    // interruptEffectsByFunction is built from the compilation unit's own
+    // scopes, so a prelude/imported function that raises (like read) is
+    // invisible to the static rule. This is DOCUMENTED in the AG3016
+    // explanation, and AbortedResult.withFinalize treats an interrupting
+    // finalize result as a finalize failure at runtime. If this test ever
+    // starts failing because AG3016 appears, the static rule grew
+    // cross-file coverage — update the explanation and flip this pin.
+    const result = codes(`
+      def f(): string {
+        finalize {
+          const content = read("notes.txt")
+          return "x"
+        }
+        return "y"
+      }
+    `);
+    expect(result).not.toContain("AG3016");
+  });
+});
+
+describe("finalize checker — locals are nullable inside the finalize body", () => {
+  it("an unguarded local read fails the return-type check (T | null)", () => {
+    const result = check(`
+      def g2(): string {
+        return "ok"
+      }
+
+      def f(): string {
+        const x = g2()
+        return x
+
+        finalize {
+          return x
+        }
+      }
+    `);
+    expect(result.some((e) => e.code.startsWith("AG2"))).toBe(true);
+  });
+
+  it("a != null check narrows the local back", () => {
+    const errors = check(`
+      def g2(): string {
+        return "ok"
+      }
+
+      def f(): string {
+        const x = g2()
+        return x
+
+        finalize {
+          if (x != null) {
+            return x
+          }
+          return "fallback"
+        }
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/finalizeChecks.ts
+++ b/packages/agency-lang/lib/typeChecker/finalizeChecks.ts
@@ -2,26 +2,28 @@ import type { AgencyNode } from "../types.js";
 import type { FinalizeBlock } from "../types/finalizeBlock.js";
 import type { ReturnStatement } from "../types/returnStatement.js";
 import { walkNodes, type WalkAncestor } from "../utils/node.js";
+import { bodySlots } from "../utils/bodySlots.js";
 import { diagnostic } from "./diagnostics.js";
 import type { ScopeInfo, TypeCheckerContext } from "./types.js";
 import type { InterruptEffect } from "../symbolTable.js";
 import { isInScope } from "./checker.js";
 
-/** Ancestor types that make a finalize "nested in control flow" — a
- *  finalize is a declaration, so it may only sit at the top level of a
- *  function body or a trailing `as { }` block body. */
-const CONTROL_FLOW_ANCESTORS = [
-  "ifElse",
-  "forLoop",
-  "whileLoop",
-  "matchBlock",
-  "handleBlock",
-  "parallelBlock",
-  "seqBlock",
-  "withModifier",
-  "staticStatement",
-  "finalizeBlock",
-];
+/** User-facing phrase for each statement construct that can wrap a
+ *  finalize, used in the AG6033 message. A body-bearing node type with no
+ *  entry here gets the generic phrase — never its internal type name. */
+const CONSTRUCT_PHRASES: Record<string, string> = {
+  ifElse: "an `if` statement",
+  forLoop: "a `for` loop",
+  whileLoop: "a `while` loop",
+  matchBlock: "a `match` arm",
+  handleBlock: "a `handle` block",
+  parallelBlock: "a `parallel` block",
+  seqBlock: "a `seq` block",
+  withModifier: "a `with` statement",
+  staticStatement: "a `static` statement",
+  finalizeBlock: "another `finalize` block",
+  messageThread: "a `thread` block",
+};
 
 /**
  * The finalize-specific checker rules (the return-TYPE rule needs no code
@@ -55,7 +57,7 @@ export function checkFinalizeBlocks(
     for (const { node, ancestors, scopes: walkScopes } of walkNodes(info.body)) {
       if (!isInScope(walkScopes, info)) continue;
       if (node.type === "finalizeBlock") {
-        const nesting = controlFlowAncestor(ancestors);
+        const nesting = nestingConstruct(ancestors);
         if (nesting !== undefined) {
           ctx.errors.push(
             diagnostic("finalizeNotTopLevel", { construct: nesting }, node.loc ?? null),
@@ -99,15 +101,24 @@ export function checkFinalizeBlocks(
   }
 }
 
-/** The innermost control-flow ancestor BELOW the container boundary, or
- *  undefined when the finalize sits directly in a scope or block body.
- *  Scanning stops at a blockArgument: a finalize at the top of a block is
- *  legal no matter what surrounds the block. */
-function controlFlowAncestor(ancestors: WalkAncestor[]): string | undefined {
+/** The construct phrase for the innermost statement wrapping the
+ *  finalize, or undefined when the finalize sits directly in a scope or
+ *  block body. Scanning stops at a blockArgument: a finalize at the top
+ *  of a block is legal no matter what surrounds the block. Any other
+ *  ancestor that carries a statement body counts as nesting. bodySlots is
+ *  the source of truth for "carries a statement body", so a new
+ *  body-bearing node type is rejected here by default instead of slipping
+ *  through a hand-kept list (messageThread once did). */
+function nestingConstruct(ancestors: WalkAncestor[]): string | undefined {
   for (let i = ancestors.length - 1; i >= 0; i--) {
     const a = ancestors[i];
     if (a.type === "blockArgument") return undefined;
-    if (CONTROL_FLOW_ANCESTORS.includes(a.type)) return a.type;
+    // Scope roots are boundaries, not nesting; their bodies are walked as
+    // their own ScopeInfo.
+    if (a.type === "function" || a.type === "graphNode") return undefined;
+    if (bodySlots(a as AgencyNode).length > 0) {
+      return CONSTRUCT_PHRASES[a.type] ?? "a nested block";
+    }
   }
   return undefined;
 }

--- a/packages/agency-lang/lib/typeChecker/finalizeChecks.ts
+++ b/packages/agency-lang/lib/typeChecker/finalizeChecks.ts
@@ -1,0 +1,174 @@
+import type { AgencyNode } from "../types.js";
+import type { FinalizeBlock } from "../types/finalizeBlock.js";
+import type { ReturnStatement } from "../types/returnStatement.js";
+import { walkNodes, type WalkAncestor } from "../utils/node.js";
+import { diagnostic } from "./diagnostics.js";
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import type { InterruptEffect } from "../symbolTable.js";
+import { isInScope } from "./checker.js";
+
+/** Ancestor types that make a finalize "nested in control flow" — a
+ *  finalize is a declaration, so it may only sit at the top level of a
+ *  function body or a trailing `as { }` block body. */
+const CONTROL_FLOW_ANCESTORS = [
+  "ifElse",
+  "forLoop",
+  "whileLoop",
+  "matchBlock",
+  "handleBlock",
+  "parallelBlock",
+  "seqBlock",
+  "withModifier",
+  "staticStatement",
+  "finalizeBlock",
+];
+
+/**
+ * The finalize-specific checker rules (the return-TYPE rule needs no code
+ * here: finalize bodies are same-scope statements, so the ordinary return
+ * checking already reaches them).
+ *
+ *  - one finalize per container, top level only (AG6032 / AG6033)
+ *  - no interrupts, direct or transitive (AG3016)
+ *  - no saveDraft inside (AG6034)
+ *  - functions and blocks only, not nodes (AG6035)
+ *  - in a finalize-bearing container, a return expression containing a
+ *    call must BE a single direct call (AG6036) — anything else consumes
+ *    an aborted callee inside the expression before the finalize can run.
+ */
+export function checkFinalizeBlocks(
+  scopes: ScopeInfo[],
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
+  ctx: TypeCheckerContext,
+): void {
+  for (const info of scopes) {
+    if (info.name === "top-level") continue;
+    const isNode = !!ctx.nodeDefs[info.name];
+
+    // One walk collects finalize blocks and return statements, each keyed
+    // by its container: the scope body itself, or the innermost trailing
+    // block (`blockArgument` ancestor). Containers are compared by
+    // identity — the scope body's key is the ScopeInfo itself.
+    const finalizesByContainer: { container: object; node: FinalizeBlock }[] = [];
+    const returnsByContainer: { container: object; node: ReturnStatement }[] = [];
+
+    for (const { node, ancestors, scopes: walkScopes } of walkNodes(info.body)) {
+      if (!isInScope(walkScopes, info)) continue;
+      if (node.type === "finalizeBlock") {
+        const nesting = controlFlowAncestor(ancestors);
+        if (nesting !== undefined) {
+          ctx.errors.push(
+            diagnostic("finalizeNotTopLevel", { construct: nesting }, node.loc ?? null),
+          );
+          continue;
+        }
+        const container = innermostBlockContainer(ancestors) ?? info;
+        if (container === info && isNode) {
+          ctx.errors.push(diagnostic("finalizeInNode", {}, node.loc ?? null));
+          continue;
+        }
+        finalizesByContainer.push({ container, node });
+        checkFinalizeBody(node, interruptEffectsByFunction, ctx);
+      }
+      if (node.type === "returnStatement" && !insideFinalize(ancestors)) {
+        const container = innermostBlockContainer(ancestors) ?? info;
+        returnsByContainer.push({ container, node });
+      }
+    }
+
+    // Rule: at most one finalize per container.
+    const seen: object[] = [];
+    for (const { container, node } of finalizesByContainer) {
+      if (seen.includes(container)) {
+        ctx.errors.push(diagnostic("finalizeDuplicate", {}, node.loc ?? null));
+      } else {
+        seen.push(container);
+      }
+    }
+
+    // Rule: return shape, in finalize-bearing containers only.
+    for (const { container, node } of returnsByContainer) {
+      const hasFinalize = finalizesByContainer.some((f) => f.container === container);
+      if (!hasFinalize) continue;
+      if (!node.value) continue;
+      if (node.value.type === "functionCall") continue; // direct call: interceptable
+      if (containsCall(node.value)) {
+        ctx.errors.push(diagnostic("finalizeReturnShape", {}, node.loc ?? null));
+      }
+    }
+  }
+}
+
+/** The innermost control-flow ancestor BELOW the container boundary, or
+ *  undefined when the finalize sits directly in a scope or block body.
+ *  Scanning stops at a blockArgument: a finalize at the top of a block is
+ *  legal no matter what surrounds the block. */
+function controlFlowAncestor(ancestors: WalkAncestor[]): string | undefined {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const a = ancestors[i];
+    if (a.type === "blockArgument") return undefined;
+    if (CONTROL_FLOW_ANCESTORS.includes(a.type)) return a.type;
+  }
+  return undefined;
+}
+
+/** The innermost trailing-block ancestor, if the node sits inside one. */
+function innermostBlockContainer(ancestors: WalkAncestor[]): object | undefined {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    if (ancestors[i].type === "blockArgument") return ancestors[i];
+  }
+  return undefined;
+}
+
+function insideFinalize(ancestors: WalkAncestor[]): boolean {
+  return ancestors.some((a) => a.type === "finalizeBlock");
+}
+
+/** Body rules: no interrupts (direct or via a callee that can interrupt),
+ *  no saveDraft. */
+function checkFinalizeBody(
+  finalize: FinalizeBlock,
+  interruptEffectsByFunction: Record<string, InterruptEffect[]>,
+  ctx: TypeCheckerContext,
+): void {
+  for (const { node } of walkNodes(finalize.body)) {
+    if (node.type === "interruptStatement") {
+      ctx.errors.push(
+        diagnostic("finalizeInterrupts", { callee: "interrupt" }, node.loc ?? null),
+      );
+    }
+    if (node.type === "functionCall") {
+      if (node.functionName === "saveDraft") {
+        ctx.errors.push(diagnostic("finalizeSaveDraft", {}, node.loc ?? null));
+        continue;
+      }
+      const effects = interruptEffectsByFunction[node.functionName];
+      if (effects && effects.length > 0) {
+        ctx.errors.push(
+          diagnostic(
+            "finalizeInterrupts",
+            { callee: node.functionName },
+            node.loc ?? null,
+          ),
+        );
+      }
+    }
+  }
+}
+
+/** True when the expression subtree contains any call — a plain
+ *  functionCall, or a value-access chain element that IS a call. The
+ *  chain check matters: `arr[0]()` has no functionCall node (the #553
+ *  review's soundness hole), only a `kind: "call"` chain element. */
+function containsCall(expr: AgencyNode): boolean {
+  for (const { node } of walkNodes([expr])) {
+    if (node.type === "functionCall") return true;
+    if (node.type === "valueAccess") {
+      const chain = (node as { chain?: { kind?: string }[] }).chain ?? [];
+      if (chain.some((c) => c.kind === "call" || c.kind === "methodCall")) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -8,13 +8,19 @@ import { analyzeCondition } from "./narrowing.js";
 import {
   type FlowNode,
   type FlowEnvironment,
+  type Reference,
   wrapFacts,
   mergeFlows,
   widenAtLoopBackEdge,
   chainToSegments,
   declaredPathType,
   freshMemo,
+  typeAt,
+  uniteTypes,
+  referenceKey,
 } from "./flow.js";
+import { isAnyType } from "./utils.js";
+import { NULL_T } from "./primitives.js";
 
 /**
  * The flow node after an access-chain write (`obj.field = x`, `arr[0] = x`): a
@@ -359,6 +365,28 @@ export function buildFlowGraph(
   env: FlowEnvironment,
 ): FlowNode {
   return nodes.reduce<FlowNode>((flow, node) => {
+    if (node.type === "finalizeBlock") {
+      // A finalize is a declaration: position-free, and NOT dead code
+      // after an unconditional return (which turns `flow` to exit). Its
+      // body is a side branch off the scope's START — when the finalize
+      // runs, any statement might not have executed, so no positional
+      // narrowing applies. Every scope-declared local is widened to
+      // `T | null` (reusing the loop-widening node); a `!= null` check
+      // inside the finalize narrows back through ordinary machinery.
+      // The main flow passes through untouched, so a finalize `return`
+      // never satisfies checkDefiniteReturns.
+      const start: FlowNode = { kind: "start", scope: env.scope };
+      const widened: Record<string, ScopeType> = Object.create(null);
+      for (const name of env.scope.declaredNames()) {
+        const ref: Reference = { variable: name, chain: [] };
+        const declared = typeAt(ref, start, env);
+        widened[referenceKey(ref)] = isAnyType(declared)
+          ? declared
+          : uniteTypes([declared, NULL_T], env.typeAliases);
+      }
+      buildFlowGraph(node.body, { kind: "loop", prev: start, widened }, env);
+      return flow;
+    }
     if (flow.kind === "exit") {
       return flow;
     }

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -40,6 +40,7 @@ import {
   checkCallbackBodyInterrupts,
   checkHandlerBodyInterrupts,
 } from "./interruptAnalysis.js";
+import { checkFinalizeBlocks } from "./finalizeChecks.js";
 import { checkAllRaises } from "./functionTypeRaises.js";
 import { checkMatchExhaustiveness } from "./matchExhaustiveness.js";
 import { computeMatchExprTypes } from "./matchExprTypes.js";
@@ -327,6 +328,7 @@ export class TypeChecker {
     // Reject `interrupt` inside any callback body. Callbacks fire as
     // side effects; their body cannot pause execution.
     checkCallbackBodyInterrupts(scopes, interruptEffectsByFunction, ctx);
+    checkFinalizeBlocks(scopes, interruptEffectsByFunction, ctx);
 
     // Reject handlers whose body may itself raise an interrupt — that
     // re-enters the handler chain and recurses (see HandlerRecursionError).

--- a/packages/agency-lang/lib/typeChecker/scope.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.ts
@@ -116,6 +116,13 @@ export class Scope {
     return this.parent?.isConst(name) ?? false;
   }
 
+  /** Names declared directly in THIS scope (not parents). Used by the
+   *  finalize flow rule to widen every local to `T | null` inside a
+   *  finalize body — any statement might not have run when it executes. */
+  declaredNames(): string[] {
+    return Object.keys(this.vars);
+  }
+
   has(name: string): boolean {
     return this.lookup(name) !== undefined;
   }

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -501,6 +501,10 @@ export function walkScopeBody(
           walkScopeBody(caseItem.body, scope, ctx);
         }
         break;
+      case "finalizeBlock":
+        // Same scope: the finalize reads the enclosing scope's locals.
+        walkScopeBody(node.body, scope, ctx);
+        break;
       case "handleBlock":
         walkScopeBody(node.body, scope, ctx);
         if (node.handler.kind === "inline") {

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -69,6 +69,7 @@ export * from "./types/parallelBlock.js";
 export * from "./types/markDestructiveRan.js";
 export * from "./types/forLoop.js";
 export * from "./types/handleBlock.js";
+export * from "./types/finalizeBlock.js";
 export * from "./types/keyword.js";
 export * from "./types/debuggerStatement.js";
 export * from "./types/blockArgument.js";

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -30,6 +30,7 @@ import { ParallelBlock, SeqBlock } from "./types/parallelBlock.js";
 import { MarkDestructiveRan } from "./types/markDestructiveRan.js";
 import { AwaitPending } from "./types/awaitPending.js";
 import { HandleBlock } from "./types/handleBlock.js";
+import { FinalizeBlock } from "./types/finalizeBlock.js";
 import { DebuggerStatement } from "./types/debuggerStatement.js";
 import { WithModifier } from "./types/withModifier.js";
 import { StaticStatement } from "./types/staticStatement.js";
@@ -328,6 +329,7 @@ export type AgencyNode =
   | ForLoop
   | AwaitPending
   | HandleBlock
+  | FinalizeBlock
   | WithModifier
   | StaticStatement
   | DebuggerStatement

--- a/packages/agency-lang/lib/types/finalizeBlock.ts
+++ b/packages/agency-lang/lib/types/finalizeBlock.ts
@@ -1,0 +1,12 @@
+import type { AgencyNode, BaseNode } from "../types.js";
+
+/** `finalize { ... }` — runs when an abort stops the enclosing scope; its
+ *  return becomes the scope's forced return value (the salvage a guard
+ *  receives). A declaration, not control flow: position in the body does
+ *  not matter, and at most one is allowed per scope. The body compiles in
+ *  the SAME variable scope as the enclosing function or block, so it
+ *  reads the scope's locals directly. */
+export type FinalizeBlock = BaseNode & {
+  type: "finalizeBlock";
+  body: AgencyNode[];
+};

--- a/packages/agency-lang/lib/utils/bodySlots.ts
+++ b/packages/agency-lang/lib/utils/bodySlots.ts
@@ -22,6 +22,7 @@ import type { WhileLoop } from "../types/whileLoop.js";
 import type { ForLoop } from "../types/forLoop.js";
 import type { MatchBlock, MatchBlockCase } from "../types/matchBlock.js";
 import type { HandleBlock } from "../types/handleBlock.js";
+import type { FinalizeBlock } from "../types/finalizeBlock.js";
 import type { ParallelBlock, SeqBlock } from "../types/parallelBlock.js";
 import type { BlockArgument } from "../types/blockArgument.js";
 import type { FunctionCall } from "../types/function.js";
@@ -131,6 +132,18 @@ export function bodySlots(node: AgencyNode): BodySlot[] {
         });
       }
       return slots;
+    }
+    case "finalizeBlock": {
+      // Same-scope statements (like an if body): the finalize reads the
+      // enclosing scope's locals, so every walker and rewriter must
+      // descend into it as part of that scope.
+      const n = node as FinalizeBlock;
+      return [
+        {
+          body: n.body,
+          write: (owner, body) => ({ ...owner, body }) as AgencyNode,
+        },
+      ];
     }
     case "parallelBlock":
       return [bodyField(node as ParallelBlock)];

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -354,6 +354,8 @@ export function* getAllVariablesInBody(
       yield* getAllVariablesInBody(node.body);
     } else if (node.type === "messageThread") {
       yield* getAllVariablesInBody(node.body);
+    } else if (node.type === "finalizeBlock") {
+      yield* getAllVariablesInBody(node.body);
     } else if (node.type === "handleBlock") {
       yield* getAllVariablesInBody(node.body);
       if (node.handler.kind === "inline") {

--- a/packages/agency-lang/tests/agency/guards/finalize-after-resume.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-after-resume.agency
@@ -1,0 +1,27 @@
+import { guard } from "std::thread"
+
+// Interrupt, resume, then a TIME trip (the abort-signal delivery path,
+// distinct from a cost trip's post-call check). The finalize runs with
+// the RESTORED locals: progress was assigned before the pause and must
+// survive serialization into the finalize.
+def work(): string {
+  const progress = "pre-interrupt"
+  interrupt("continue?")
+  sleep(2000)
+  return "done"
+
+  finalize {
+    if (progress != null) {
+      return "resumed-finalize:${progress}"
+    }
+    return "lost-locals"
+  }
+}
+
+node main() {
+  const result = guard(time: 600ms) as {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-after-resume.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-after-resume.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"resumed-finalize:pre-interrupt\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [{ "action": "approve" }],
+      "description": "A time trip after an interrupt/resume runs the finalize over the RESTORED frame; the pre-pause local survives into it."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-composes.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-composes.agency
@@ -1,0 +1,34 @@
+import { guard } from "std::thread"
+
+// Composition ordering: inner's finalize runs first; outer's local binds
+// INNER'S FINALIZED value (distinguishable from inner's raw draft); the
+// guard salvages outer's finalize result.
+def inner(): string {
+  saveDraft("inner-raw-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize {
+    return "inner-finalized"
+  }
+}
+
+def outer(): string {
+  const x = inner()
+  return x
+
+  finalize {
+    if (x != null) {
+      return "outer(${x})"
+    }
+    return "outer(nothing)"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return outer()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-composes.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-composes.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"outer(inner-finalized)\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "Finalizes compose: inner runs first and its FINALIZED value (not its raw draft) is what outer's finalize consumes."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-consumes-partial.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-consumes-partial.agency
@@ -1,0 +1,31 @@
+import { guard } from "std::thread"
+
+// THE load-bearing fixture — the spec's walked example, values verbatim:
+// verify saves "v-partial" and trips; code's statement-site check binds
+// it into x; code's finalize consumes x; the guard salvages the
+// finalize's return.
+def verify(): string {
+  saveDraft("v-partial")
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+def code(): string {
+  const x = verify()
+  return x
+
+  finalize {
+    if (x != null) {
+      return "combined:${x}"
+    }
+    return "no-inner"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return code()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-consumes-partial.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-consumes-partial.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"combined:v-partial\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "The walked example: the callee's partial binds into the local, the finalize translates it, the guard salvages the finalize's return."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-error-falls-back.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-error-falls-back.agency
@@ -1,0 +1,23 @@
+import { guard } from "std::thread"
+
+// The finalize divides by reading a missing property — it throws. The
+// trip is never masked: the guard salvages the DRAFT the scope saved,
+// and the run does not crash.
+def work(): string {
+  saveDraft("the-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize {
+    const broken: any = null
+    return broken.field
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected-failure" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-error-falls-back.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-error-falls-back.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"the-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A throwing finalize never masks the trip: the scope's saved draft is salvaged instead."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-in-guard-block.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-in-guard-block.agency
@@ -1,0 +1,16 @@
+import { guard } from "std::thread"
+
+// A finalize directly inside the guard block: its return is the salvage.
+node main() {
+  let progress = "started"
+  const result = guard(cost: 0.000001) as {
+    const reply = llm("Reply with: pong")
+    return reply
+
+    finalize {
+      return "block-finalize:${progress}"
+    }
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-in-guard-block.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-in-guard-block.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"block-finalize:started\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A finalize declared in a guard block produces the guard's salvage, reading the node's locals through the block."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-inside-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-inside-fork.agency
@@ -1,0 +1,25 @@
+import { guard } from "std::thread"
+
+// A finalize-bearing def trips INSIDE a fork branch under an outer
+// guard. The branch's finalized partial is dropped at the fork boundary
+// (exactly like a branch's saveDraft), so the outer guard fails.
+def branchWork(tag: string): string {
+  saveDraft("draft-${tag}")
+  sleep(2000)
+  return tag
+
+  finalize {
+    return "branch-finalize-${tag}"
+  }
+}
+
+node main() {
+  const result = guard(time: 600ms) as {
+    const tags = fork(["a"]) as t {
+      return branchWork(t)
+    }
+    return "joined"
+  }
+  if (isFailure(result)) { return "failed-no-branch-salvage" }
+  return "leaked:${result.value}"
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-inside-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-inside-fork.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"failed-no-branch-salvage\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A branch's finalized partial is dropped at the fork boundary, exactly like a branch draft; the outer guard fails."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.agency
@@ -1,0 +1,64 @@
+import { guard } from "std::thread"
+
+// f2(g()) both directions. When g aborts, the call boundary drops its
+// partial before f2 runs, so the finalize sees x == null. When f2 aborts
+// (g already succeeded), x holds f2's partial.
+def gTrips(): string {
+  saveDraft("g-partial")
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+def f2a(v: string): string {
+  return "f2a:${v}"
+}
+
+def codeGTrips(): string {
+  const x = f2a(gTrips())
+  return x
+
+  finalize {
+    if (x != null) {
+      return "leak:${x}"
+    }
+    return "g-tripped:x-null"
+  }
+}
+
+node gTripsCase() {
+  const result = guard(cost: 0.000001) as {
+    return codeGTrips()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}
+
+def gOk(): string {
+  return "g-value"
+}
+
+def f2b(v: string): string {
+  saveDraft("f2-partial:${v}")
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+def codeF2Trips(): string {
+  const x = f2b(gOk())
+  return x
+
+  finalize {
+    if (x != null) {
+      return "f2-tripped:${x}"
+    }
+    return "x-null"
+  }
+}
+
+node f2TripsCase() {
+  const result = guard(cost: 0.000001) as {
+    return codeF2Trips()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "gTripsCase",
+      "input": "",
+      "expectedOutput": "\"g-tripped:x-null\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "An aborted ARGUMENT call's partial is dropped at the call boundary; the finalize sees x == null."
+    },
+    {
+      "nodeName": "f2TripsCase",
+      "input": "",
+      "expectedOutput": "\"f2-tripped:f2-partial:g-value\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "The OUTER call's partial binds into x; the finalize consumes it."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-not-run-on-success.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-not-run-on-success.agency
@@ -1,0 +1,20 @@
+import { guard } from "std::thread"
+
+// No trip: the finalize must never execute. Its return value is a
+// sentinel that could only surface if it wrongly ran and salvaged.
+def work(): string {
+  const reply = llm("Reply with: pong")
+  return "done:${reply}"
+
+  finalize {
+    return "finalize-ran-wrongly"
+  }
+}
+
+node main() {
+  const result = guard(cost: 1.0) as {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected-failure" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-not-run-on-success.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-not-run-on-success.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"done:pong\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "Without a trip the finalize never runs; the normal return value comes through."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-on-return-position.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-on-return-position.agency
@@ -1,0 +1,27 @@
+import { guard } from "std::thread"
+
+// The trip escapes through `return verify()`. Plain pass-through would
+// deliver verify's OWN partial ("v-partial") — the finalize must
+// intercept, and its output is a value the pass-through path could
+// never produce.
+def verify(): string {
+  saveDraft("v-partial")
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+def code(): string {
+  return verify()
+
+  finalize {
+    return "finalized-return-position"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return code()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-on-return-position.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-on-return-position.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"finalized-return-position\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A finalize scope intercepts return-position aborts; if the checked-temp lowering were missing, verify's own partial would leak through and this value could never appear."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-race-loser-not-salvaged.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-race-loser-not-salvaged.agency
@@ -1,0 +1,29 @@
+import { guard } from "std::thread"
+
+// A NON-guard abort (race loss) stops a finalize-bearing def. The
+// finalize may compute, but nothing converts a race loss into a
+// success: the race returns the winner's value, the loser's finalize
+// output must never appear, and the run must not crash.
+def slowLoser(): string {
+  saveDraft("loser-draft")
+  sleep(5000)
+  return "loser-finished"
+
+  finalize {
+    return "loser-finalize-leaked"
+  }
+}
+
+def fastWinner(): string {
+  return "winner"
+}
+
+node main() {
+  const result = race(["slow", "fast"]) as which {
+    if (which == "slow") {
+      return slowLoser()
+    }
+    return fastWinner()
+  }
+  return result
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-race-loser-not-salvaged.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-race-loser-not-salvaged.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"winner\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A race loser's finalize never becomes a success anywhere: the winner's value returns and the loser's abort stays an abort."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-reads-globals.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-reads-globals.agency
@@ -1,0 +1,31 @@
+import { guard } from "std::thread"
+
+// Non-frame variable kinds resolve inside a finalize: a module global
+// and a param, alongside the bound partial.
+const label = "report"
+
+def verify(): string {
+  saveDraft("v1")
+  const reply = llm("Reply with: pong")
+  return reply
+}
+
+def work(prefix: string): string {
+  const x = verify()
+  return x
+
+  finalize {
+    if (x != null) {
+      return "${prefix}/${label}/${x}"
+    }
+    return "empty"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return work("run7")
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-reads-globals.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-reads-globals.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"run7/report/v1\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A finalize reads a module global, a param, and the bound partial — frame and non-frame variable kinds all resolve."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-wins-over-draft.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-wins-over-draft.agency
@@ -1,0 +1,21 @@
+import { guard } from "std::thread"
+
+// A scope with BOTH a saveDraft and a successful finalize: the guard
+// salvages the finalize's return, not the draft.
+def work(): string {
+  saveDraft("the-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize {
+    return "the-finalize"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) as {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-wins-over-draft.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-wins-over-draft.test.json
@@ -1,0 +1,13 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"the-finalize\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A successful finalize outranks the scope's saved draft (the success-path complement of finalize-error-falls-back)."
+    }
+  ]
+}


### PR DESCRIPTION
Adds `finalize { ... }` blocks: when an abort stops a scope, its finalize runs with the scope's locals — including the aborted callee's partial, bound into the local its call was assigning — and the finalize's return becomes the scope's forced return value (the salvage a guard receives).

Plan (external-reviewed): `docs/superpowers/plans/2026-07-16-finalize-keyword.md`. Design: the finalize section of the carry-on-abort spec, revision 3.

```
def code(): Report {
  const x = verify()      // trip happens inside verify
  return x

  finalize {
    if (x != null) { return mergePartial(x) }   // x holds verify's partial
    return outlineOnly()
  }
}
```

## How it works

- **The `__finalize` closure runs on the container's own frame** — locals live on the frame, so the body reads them with zero passing; a fresh Runner's `#finalize` scope name namespaces nothing but its own bookkeeping. Two frame-sharing subtleties the fixtures caught: finalize step ids compile in a **disjoint range** (Runner counters are frame-keyed; small ids collided with the main body's and silently skipped finalize steps), and **`fromError` now marks a guard trip's cause `delivered`** (converting the exception into the value IS the delivery; otherwise a leaf-delivered time trip left `shouldSkip` re-throwing inside the finalize's first step, killing pure computation).
- **Three stop sites call one runtime method**, `AbortedResult.withFinalize`: the frame catch, the post-call check (which first binds the callee's partial into the local via `partialValueOrNull()` — the `{value}` wrapper stays inside the class), and a checked temp at direct-call returns in finalize scopes, because plain pass-through would silently skip the finalize.
- **`withFinalize` owns the failure rule**: a finalize that throws — or resolves to interrupts or an aborted result of its own — never masks the trip; the abort continues with the saved draft, or nothing, logged as a `finalizeError`.

## Checker (six rules, each with its own code + explanation page)

AG6032 one per scope · AG6033 top level only · AG3016 no interrupts (transitive for same-file callees via `interruptEffectsByFunction`; an **imported** interrupting callee is not statically visible — documented in the explanation, pinned by a test, caught by the runtime backstop) · AG6034 no saveDraft inside · AG6035 defs and guard blocks only · AG6036 return shape: in a finalize scope, a return expression containing a call must BE a single direct call — anything else consumes an aborted callee inside the expression before the finalize can run, and no lowering fixes that without breaking short-circuit evaluation.

Two flow-graph properties: the finalize body is a **side branch off the scope START** (handled in the fold before the exit shortcut — a finalize after an unconditional return is a declaration, not dead code, and its `return` never satisfies definite-returns), and the side branch seeds **every local widened to `T | null`** (any statement might not have run; `!= null` narrows back).

## One deliberate deviation from the spec, for sign-off

v1 rejects finalize in **node** bodies (AG6035). The spec's "works in nodes" sentence predates the value transport: above a node, aborts are exceptions again and nothing consumes a node's partial until root budgets land — a node finalize would compute a value nobody reads.

## Testing

- 12 execution fixtures: the walked example verbatim, both `f(g())` directions, error-fallback vs finalize-wins-over-draft, in-guard-block, return-position interception (with an output pass-through could never produce), not-run-on-success, after-resume (a TIME trip over the restored frame), reads-globals, **composes** (inner finalize first; outer consumes inner's finalized value), race-loser-never-salvaged, inside-fork (branch partial drops at the boundary).
- Full guards sweep 64/64; subprocess sample; agency-js pin; 4,958 runtime/typechecker/codegen/parser unit tests; lint clean.
- The no-finalize path is byte-identical: `make fixtures` produces zero churn (catch branches are builder-pre-rendered strings, not mustache sections).

## Docs

`docs/dev/saveDraft.md` gains its promised finalize section; `docs/site/guide/guards.md` gains a finalize subsection under saveDraft — wording is a draft for your edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
