### PR TITLE
Add message debug labels for llm() and the message builders

### DIFF
--- a/docs/superpowers/plans/2026-07-16-message-debug-labels.md
+++ b/docs/superpowers/plans/2026-07-16-message-debug-labels.md
@@ -20,11 +20,13 @@
 
 `messageLabels` is aligned with `messages` **by index**: `messageLabels.length === messages.length` at all times, and `messageLabels[i]` is the label of `messages[i]`.
 
-An index-aligned parallel array is the only shape that serializes (a `WeakMap` keyed by message identity would survive slicing but not `toJSON`). The cost is that the invariant is not enforced by the type — it is enforced by making **exactly one place** able to grow the arrays. So:
+Smoltalk messages have no id (`MessageClass` exposes content/role/name/rawData only), so a label cannot be keyed to its message. An index-aligned parallel array is also the only shape that serializes (a `WeakMap` keyed by message identity would survive slicing but not `toJSON`). The cost is that the invariant is not enforced by the type — it is enforced by keeping the writers few, and by giving every caller an operation that carries the labels along, so no caller has a reason to reach past them:
 
-- **`push(message, label?)` is the ONLY writer that appends.** Every other append delegates to it.
-- **The constructor and `setMessages` are the ONLY writers that replace**, and both rebuild `messageLabels` to match the new `messages` length.
-- **No other code may touch `this.messages` directly.** A plan review found two sites that would have silently desynced (below); the fix is structural, not "remember to update both".
+- **`push(message, label?)`** — the ONLY append. Every other append delegates to it.
+- **`removeAt(index)`** — the ONLY removal.
+- **`adoptFrom(other)`** — take on another thread's messages AND labels, keeping this thread's identity.
+- **The constructor and `setMessages(messages, labels?)`** — the ONLY replacements; both rebuild `messageLabels` to the new length.
+- **No other code may touch `this.messages` directly.** A plan review found two sites that would have silently desynced (below); PR review found two more that reached for `setMessages` for jobs that were not rewrites. The fix is structural, not "remember to update both".
 
 Desync is not a graceful degradation — it **mislabels**. If `messageLabels` is one short, every later `labelAt(i)` returns the *previous* message's label. Treat any new `this.messages` mutation as a bug.
 
@@ -363,3 +365,12 @@ Stdlib reference regenerates from the docstrings written in Task 2. Update the t
 - Task 4 must call `labelAt` on the dumped `MessageThread` (`messages`), not a differently-named `thread`.
 - Task 5's e2e now pins label-to-message pairing with an unlabeled system message at index 0.
 - `llm()` labeling multiple messages (prompt + completion) is **intended**; documented in Task 3 Step 3 so it is not "fixed" later.
+
+### PR review round 2 findings (2026-07-16)
+
+Two more real bugs, both from callers reaching for `setMessages` for a job that was not a rewrite — the same class of problem as `addMessage`, and fixed the same way (give the caller the operation it actually wants):
+
+- **The memory layer lost every label on the normal path.** `prompt.ts` removed its injected-facts system message with `setMessages([...slice, ...slice])`, resetting all labels as collateral — so with memory on, a labeled program lost its labels after the first `llm()` call. Now `removeAt(i)`.
+- **Labels did not survive interrupt/resume.** `runPrompt` snapshotted `messages.toJSON().messages` (a bare array) into `self.messagesJSON`; resume revived it through `fromJSON`'s legacy branch, which has no labels to read. And the resume path then called `setMessages(restored.getMessages())`, discarding whatever had been restored. Now the snapshot persists the full `MessageThreadJSON` (back-compatible: `fromJSON` still accepts the bare array) and resume uses `adoptFrom`. Pinned by `tests/agency-js/message-labels-resume`, verified to fail without the fix (`labeledAfterResume: []`).
+
+Also: `setMessages` gained the optional `labels` argument, which removed the `fromJSON` ordering trap entirely and gave length-normalization one home (a mismatched array is refused, not padded — unlabeled beats mislabeled); `toJSON` now copies the labels array rather than handing out the live one; `withMessageLabels` declares `& { label?: string }`; and the index join through smoltalk's redaction is now pinned by a test with a real attachment rather than assumed.

--- a/docs/superpowers/plans/2026-07-16-message-debug-labels.md
+++ b/docs/superpowers/plans/2026-07-16-message-debug-labels.md
@@ -1,0 +1,365 @@
+# Message Debug Labels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (owner preference: inline execution, no subagents). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users attach a debug label to `llm()`, `userMessage()`, `assistantMessage()`, and `systemMessage()` calls, and surface those labels in statelog, so a log reader can tell a verifier's injected message from a real user message.
+
+**Architecture:** Labels are observability-only. They live on `MessageThread` as a per-message parallel array, serialize with the thread, and surface in two statelog places: `promptStart` (the label of the `llm()` call) and `promptCompletion`'s redacted message array (the label of each message). Labels are NEVER sent to the LLM provider — the smoltalk request path is untouched.
+
+**Tech stack:** runtime (`MessageThread`, `runPrompt`), stdlib (`std::thread`), typechecker builtin signature, statelog client.
+
+## Global constraints
+
+- Labels never reach the provider wire. All changes stay on the Agency side of smoltalk.
+- The thread-level `label` field (`thread(label:) { ... }`, `messageThread.ts:34`) already exists and is a DIFFERENT thing. The new per-message storage is named `messageLabels` everywhere to avoid collision.
+- Thread rewrites (summarization, `threadRepair`) go through `setMessages`, which resets labels. Documented behavior, not a bug.
+- Run `make` after touching `stdlib/*.agency` (CLAUDE.md).
+- Save all test output to files (CLAUDE.md).
+
+## THE INVARIANT (load-bearing — read before Task 1)
+
+`messageLabels` is aligned with `messages` **by index**: `messageLabels.length === messages.length` at all times, and `messageLabels[i]` is the label of `messages[i]`.
+
+An index-aligned parallel array is the only shape that serializes (a `WeakMap` keyed by message identity would survive slicing but not `toJSON`). The cost is that the invariant is not enforced by the type — it is enforced by making **exactly one place** able to grow the arrays. So:
+
+- **`push(message, label?)` is the ONLY writer that appends.** Every other append delegates to it.
+- **The constructor and `setMessages` are the ONLY writers that replace**, and both rebuild `messageLabels` to match the new `messages` length.
+- **No other code may touch `this.messages` directly.** A plan review found two sites that would have silently desynced (below); the fix is structural, not "remember to update both".
+
+Desync is not a graceful degradation — it **mislabels**. If `messageLabels` is one short, every later `labelAt(i)` returns the *previous* message's label. Treat any new `this.messages` mutation as a bug.
+
+Two real leaks this plan closes by construction:
+- `addMessage(message)` (`messageThread.ts:48`) is a duplicate of `push` that appends without a label. It is public API (in the `.d.ts`, used by `lib/stdlib/threads.test.ts:46`). It must delegate to `push`, not push on its own.
+- The constructor takes `messages` but a field initializer (`messageLabels = []`) would leave it empty against N messages. Reachable via `newSubthreadChild()` → `new MessageThread(this.cloneMessages())`, and async `llm()` runs in a subthread — so a later labeled push there would attribute the new label to message 0. The constructor must seed `messageLabels`.
+
+---
+
+### Task 1: Per-message label storage on MessageThread
+
+**Files:**
+- Modify: `lib/runtime/state/messageThread.ts`
+- Test: `lib/runtime/state/messageThread.test.ts`
+
+**Interfaces:**
+- Produces: `push(message, label?: string | null)`, `labelAt(index): string | null`, `messageLabels` in `MessageThreadJSON`. `addMessage` delegates to `push`.
+
+- [ ] **Step 1: Write the failing tests**
+
+The last three pin the invariant at each site that can grow or replace the arrays. They are the tests that would have caught the two desync leaks.
+
+```ts
+describe("per-message labels", () => {
+  it("stores a label alongside a pushed message and reads it back by index", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("hi"), "verifier");
+    t.push(smoltalk.assistantMessage("ok"));
+    expect(t.labelAt(0)).toBe("verifier");
+    expect(t.labelAt(1)).toBe(null);
+  });
+
+  it("round-trips labels through toJSON/fromJSON", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("hi"), "verifier");
+    const revived = MessageThread.fromJSON(t.toJSON());
+    expect(revived.labelAt(0)).toBe("verifier");
+  });
+
+  it("revives legacy JSON without messageLabels as all-null labels", () => {
+    const json = new MessageThread([smoltalk.userMessage("hi")]).toJSON();
+    delete (json as any).messageLabels;
+    const revived = MessageThread.fromJSON(json);
+    expect(revived.labelAt(0)).toBe(null);
+  });
+
+  it("setMessages resets labels (summarize/repair drop them)", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("hi"), "verifier");
+    t.setMessages([smoltalk.userMessage("summary")]);
+    expect(t.labelAt(0)).toBe(null);
+  });
+
+  // --- the invariant: length always matches, at every writer ---
+
+  it("a constructor-seeded thread stays aligned when pushed to", () => {
+    // Without a constructor seed, messageLabels would be [] against 2
+    // messages, and this push would put "late" at index 0.
+    const t = new MessageThread([
+      smoltalk.userMessage("a"),
+      smoltalk.userMessage("b"),
+    ]);
+    t.push(smoltalk.userMessage("c"), "late");
+    expect(t.labelAt(0)).toBe(null);
+    expect(t.labelAt(1)).toBe(null);
+    expect(t.labelAt(2)).toBe("late");
+  });
+
+  it("addMessage keeps the arrays aligned (it delegates to push)", () => {
+    const t = new MessageThread();
+    t.addMessage(smoltalk.userMessage("a"));
+    t.push(smoltalk.userMessage("b"), "second");
+    expect(t.labelAt(0)).toBe(null);
+    expect(t.labelAt(1)).toBe("second");
+  });
+
+  it("a subthread child seeded from a parent starts aligned", () => {
+    const parent = new MessageThread();
+    parent.push(smoltalk.userMessage("a"), "seed");
+    const child = parent.newSubthreadChild(null);
+    child.push(smoltalk.userMessage("b"), "child");
+    // The parent's labels do not travel (cloneMessages copies messages
+    // only); what matters is the child does not mis-attribute.
+    expect(child.labelAt(0)).toBe(null);
+    expect(child.labelAt(1)).toBe("child");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/runtime/state/messageThread.test.ts > tmp/labels-t1.log 2>&1`
+Expected: FAIL — `push` takes one argument, `labelAt` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `MessageThread` (`lib/runtime/state/messageThread.ts`). Note what is NOT here: no `this.messages.push` outside `push`, and no field initializer for `messageLabels` (the constructor seeds it).
+
+```ts
+/** Per-message debug labels, aligned with `messages` BY INDEX
+ *  (`messageLabels[i]` labels `messages[i]`; the lengths always match).
+ *  Observability only: shown in statelog, never sent to the provider.
+ *  Distinct from the thread-level `label` (set by `thread(label:)`).
+ *
+ *  The alignment is maintained by keeping the writers to a minimum:
+ *  `push` is the only append, the constructor and `setMessages` are the
+ *  only replacements, and nothing else touches `this.messages`. A desync
+ *  does not degrade gracefully — it shifts every later label onto the
+ *  wrong message — so keep it that way. A rewrite via `setMessages`
+ *  (summarization, repair) drops labels; that is intended. */
+messageLabels: (string | null)[];
+
+constructor(messages: smoltalk.Message[] = []) {
+  this.messages = messages;
+  // Seed, don't default: `new MessageThread([...])` (e.g. via
+  // newSubthreadChild) must start aligned, or a later push lands its
+  // label on message 0.
+  this.messageLabels = messages.map(() => null);
+  this.id = nanoid();
+}
+
+/** The ONLY append. Everything that adds a message goes through here. */
+push(message: smoltalk.Message, label: string | null = null): void {
+  this.messages.push(message);
+  this.messageLabels.push(label);
+}
+
+/** Alias for `push` with no label. Kept for the existing public API. */
+addMessage(message: smoltalk.Message): void {
+  this.push(message);
+}
+
+labelAt(index: number): string | null {
+  return this.messageLabels[index] ?? null;
+}
+
+setMessages(messages: smoltalk.Message[]): void {
+  this.messages = messages;
+  this.messageLabels = messages.map(() => null);
+}
+```
+
+In `toJSON()`: add `messageLabels: this.messageLabels`. Add `messageLabels?: (string | null)[]` to `MessageThreadJSON` (line ~5).
+
+In `fromJSON()`: **ordering matters.** `fromJSON` loads messages via `thread.setMessages(smoltalkMessages)` (line ~140), and `setMessages` resets `messageLabels` to all-null. So read `json.messageLabels` into a local alongside the other fields, and assign it **after** the `setMessages` call, next to `thread.label = _label`:
+
+```ts
+// after: thread.setMessages(smoltalkMessages)
+thread.messageLabels =
+  _messageLabels ?? smoltalkMessages.map(() => null);
+```
+
+Legacy JSON (no `messageLabels`) therefore revives as all-null, and the length always matches the revived messages.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pnpm test:run lib/runtime/state/messageThread.test.ts > tmp/labels-t1b.log 2>&1`
+Expected: PASS, including all pre-existing thread tests (push callers that pass one arg still work — label defaults to null).
+
+- [ ] **Step 5: Commit**
+
+Subject: `Add per-message debug labels to MessageThread`
+
+### Task 2: label parameter on the stdlib message functions
+
+**Files:**
+- Modify: `lib/stdlib/thread.ts` (the `_systemMessage` / `_userMessage` / `_assistantMessage` helpers, lines 44–80)
+- Modify: `stdlib/thread.agency` (the `systemMessage` / `userMessage` / `assistantMessage` defs, lines 64–142)
+- Test: extend `lib/stdlib/thread.test.ts` if present, else cover via Task 5's agency-js test
+
+**Interfaces:**
+- Consumes: Task 1's `push(message, label)`.
+- Produces: `userMessage(msg, label: string = "")` etc. in Agency; empty string means unlabeled.
+
+- [ ] **Step 1: Extend the TS helpers**
+
+Each `_*Message` gains a trailing `label: string = ""` parameter and forwards `label || null`:
+
+```ts
+export async function _userMessage(
+  msg: smoltalk.UserContentInput,
+  label: string = "",
+): Promise<void> {
+  const { threads } = getRuntimeContext();
+  threads.getOrCreateActive().push(smoltalk.userMessage(msg), label || null);
+}
+```
+
+Same shape for `_systemMessage` and `_assistantMessage`. Leave the deprecated `__internal_*` variants unchanged.
+
+- [ ] **Step 2: Extend the Agency wrappers**
+
+In `stdlib/thread.agency`, each wrapper gains the parameter and passes it through. Docstrings are user-facing (they become tool descriptions):
+
+```
+export def userMessage(msg: string | (string | Attachment)[], label: string = "") {
+  """
+  Add a user message to the current thread's message history. Use this
+  to seed the conversation with prior user context that wasn't actually
+  typed by the user this turn.
+
+  @param msg - The user message content: a string, or an array mixing text strings and attachments.
+  @param label - Optional debug label shown in statelog. Never sent to the model.
+  """
+  _userMessage(msg, label)
+}
+```
+
+- [ ] **Step 3: Build and spot-check**
+
+Run: `make > tmp/labels-t2.log 2>&1` then compile a scratch program in the repo (NOT /tmp) using `userMessage("x", label: "seed")` and confirm it typechecks and runs.
+
+- [ ] **Step 4: Commit**
+
+Subject: `Accept a debug label on userMessage/assistantMessage/systemMessage`
+
+### Task 3: label on llm() calls
+
+**Files:**
+- Modify: `lib/typeChecker/builtins.ts` (llm named-arg list, lines ~85–115 — add near `metadata`)
+- Modify: `lib/runtime/prompt.ts` (`runPrompt`, line 755; prompt-message push line ~1020; assistant push line ~679; `promptStart` call site)
+- Modify: `lib/statelogClient.ts` (`promptStart`, line 457)
+
+**Interfaces:**
+- Consumes: Task 1's labeled `push`.
+- Produces: `llm("...", label: "verifier")` labels the prompt user message and the assistant completion message, and stamps `label` on the `promptStart` event.
+
+- [ ] **Step 1: Typechecker signature**
+
+In the llm builtin's named-arg list add:
+
+```ts
+// Observability-only debug label: stamps this call's promptStart event
+// and the messages the call appends. Never sent to the provider.
+{ key: "label", value: optional(string) },
+```
+
+- [ ] **Step 2: Runtime extraction**
+
+`llm()` named args arrive on `clientConfig` (the codegen passes the options object verbatim; `runPrompt`'s doc comment at line 755 describes how retry fields are already "extracted below and stripped"). Follow that exact pattern for `label`: pull it off `clientConfig` into a local `callLabel: string | null` and delete it from the config forwarded to smoltalk — the provider must never see it.
+
+- [ ] **Step 3: Stamp the messages and the event**
+
+One `llm(label:)` call labels MORE THAN ONE message — that is intended, not a leak. The label marks "these messages came from this call":
+
+- `messages.push(smoltalk.userMessage(prompt), callLabel)` at the prompt push (line ~1020).
+- `messages.push(smoltalk.assistantMessage(completion.output), callLabel)` at the completion push (line ~679).
+- `promptStart({ ..., label: callLabel })`; add `label?: string | null` to the `promptStart` params in `lib/statelogClient.ts` and include it in the posted event.
+
+`messages` here is a `MessageThread` (runPrompt line ~941), so these are `MessageThread.push` — Task 1's labeled append. The call's other pushes (the injected-facts system message ~1009, and every tool-loop push ~1187/1214/1279/1362+) keep passing one argument and correctly take `label = null`; they stay aligned for free because they all go through the same `push`. Do not hand-label them.
+
+- [ ] **Step 4: Unit-verify the strip**
+
+Add a test (pattern: existing runPrompt option tests near the retry tests) asserting the config forwarded to the LLM client has no `label` key. Run and save output.
+
+- [ ] **Step 5: Commit**
+
+Subject: `Accept a debug label on llm() and stamp it on promptStart`
+
+### Task 4: labels in the promptCompletion message dump
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts` (the success-path `promptCompletion` emission — the only place the request payload is logged, see comment at line ~630)
+
+**Interfaces:**
+- Consumes: Task 1's `labelAt`.
+- Produces: each entry of `promptCompletion.messages` carries `label` when one was set.
+
+- [ ] **Step 1: Merge labels at emission**
+
+Where the redacted message array is built for `promptCompletion` (line ~658, `messages: redactMessagesForLog(messages)`), merge in the label by index, adding the key only when non-null (keeps unlabeled logs byte-compatible).
+
+Call `labelAt` on **the same `MessageThread` that produced the dump** — the local is named `messages`, not `thread`. `redactMessagesForLog` returns `messages.toJSON().messages`, which maps `this.messages` in order, so index `i` lines up with `messageLabels[i]`:
+
+```ts
+const labeled = redactMessagesForLog(messages).map((m, i) => {
+  const label = messages.labelAt(i);
+  return label === null ? m : { ...m, label };
+});
+```
+
+Only `promptCompletion` gets per-message labels. `promptStart` carries the scalar call label from Task 3; its message dump stays unlabeled (deliberate — one place to read per-message labels).
+
+- [ ] **Step 2: Verify via statelog**
+
+Deterministic-mock LLM tests cannot inspect messages; statelog is the inspection channel (established pattern). Reuse the statelog-capture helper from the existing statelog tests (`lib/runtime/statelogPromptEvents.test.ts` or nearest equivalent — grep `promptCompletion` in tests) to assert the label appears.
+
+- [ ] **Step 3: Commit**
+
+Subject: `Show message labels in promptCompletion statelog events`
+
+### Task 5: end-to-end test and docs
+
+**Files:**
+- Create: `tests/agency-js/message-labels/` (program + test.json + JS assertion, copy the structure of an existing statelog-reading agency-js test)
+- Modify: `docs/dev/statelog.md` (one paragraph: where labels appear), `docs/dev/threads.md` (the `messageLabels` field and the setMessages reset rule)
+
+- [ ] **Step 1: The agency-js fixture**
+
+Program: `systemMessage("sys")` (UNLABELED, first — so it sits at index 0 and any off-by-one is visible), then `userMessage("context", label: "seed")`, then a mocked `llm("go", label: "coder")`. JS side runs with `--log-file`, parses the statelog JSONL, and asserts:
+
+- `promptStart` has `label: "coder"`.
+- In the `promptCompletion` message array, assert label-to-message **pairing**, not mere presence: the entry whose content is `"sys"` has no label; the `"context"` entry has `"seed"`; the `"go"` user entry and the assistant completion entry both have `"coder"`. Presence-only assertions ("seed appears somewhere") would pass a shifted array.
+
+- [ ] **Step 2: Run it**
+
+Run: `pnpm run agency test js tests/agency-js/message-labels/<file> > tmp/labels-t5.log 2>&1`
+Expected: PASS.
+
+- [ ] **Step 3: Docs + `make doc`**
+
+Stdlib reference regenerates from the docstrings written in Task 2. Update the two dev docs by hand.
+
+- [ ] **Step 4: Full validation + commit**
+
+`pnpm test:run > tmp/labels-final.log 2>&1`, `pnpm run lint:structure`, `make fixtures` (expect zero churn — no codegen changes). Commit: `Add message-labels e2e test and docs`.
+
+## Explicitly out of scope
+
+- Auto-labeling messages the RUNTIME injects (guard-approve feedback, tool-reply attachments). The resumable-guards plan picks this up; it needs only Task 1's `push(message, label)`.
+- Filtering/slicing threads by label. Deferred to the thread-scoping brainstorm.
+
+## Self-review notes
+
+- Every `push` caller keeps working (label defaults to null) — the signature change is additive.
+- `messageLabels` naming avoids the existing thread-level `label` field collision.
+- The provider wire is provably untouched: labels live on `MessageThread`, and the only smoltalk-bound data is the unmodified `messages` array; Task 3 Step 4 pins the config strip.
+- **The alignment invariant is enforced structurally, not by vigilance**: one append (`push`), two replacements (constructor, `setMessages`), nothing else touching `this.messages`. `addMessage` delegates rather than duplicating. Each writer has a test that would fail on a desync.
+- Verified against the code before writing: `runPrompt`'s `messages` is a `MessageThread` (line ~941), so its system/tool-loop pushes route through the labeled `push` and stay aligned with no extra work.
+
+### Review findings folded in (2026-07-16)
+
+- `addMessage` was a second, un-audited append path (public API, used in `lib/stdlib/threads.test.ts:46`) → now delegates to `push`.
+- A `messageLabels = []` field default would desync against a constructor-provided `messages`, mis-attributing a later label to message 0 — reachable via `newSubthreadChild` and async `llm()` subthreads → constructor now seeds the array.
+- `fromJSON` calls `setMessages` internally (which resets labels), so the JSON restore must be sequenced after it → called out in Task 1 Step 3.
+- Task 4 must call `labelAt` on the dumped `MessageThread` (`messages`), not a differently-named `thread`.
+- Task 5's e2e now pins label-to-message pairing with an unlabeled system message at index 0.
+- `llm()` labeling multiple messages (prompt + completion) is **intended**; documented in Task 3 Step 3 so it is not "fixed" later.

--- a/packages/agency-lang/docs/dev/statelog.md
+++ b/packages/agency-lang/docs/dev/statelog.md
@@ -40,8 +40,21 @@ At the start of execution, the full graph topology is logged: all node IDs, all 
 - **`afterHook(nodeId, startData, endData, timeTaken)`** — after-node hook execution
 
 ### LLM calls
-- **`promptStart(model, threadId, messageCount, toolCount, hasResponseFormat, maxTokens)`** — fired immediately before an LLM request is dispatched. Small payload: the request shape, not its content. Pairs with a terminator by span + order (the nth start in an llmCall span pairs with the nth terminator: a `promptCompletion`, an `error` with errorType `llmError`, or a `promptCancelled`). An unpaired start means the call never finished — the signature of a hung or killed-mid-call run, and the live in-flight indicator in follow mode.
-- **`promptCompletion(messages, completion, model, timeTaken, tools, responseFormat)`** — logs the full message history, model response, model name, tools provided, and response format
+- **`promptStart(model, threadId, messageCount, toolCount, hasResponseFormat, maxTokens, label)`** — fired immediately before an LLM request is dispatched. Small payload: the request shape, not its content. Pairs with a terminator by span + order (the nth start in an llmCall span pairs with the nth terminator: a `promptCompletion`, an `error` with errorType `llmError`, or a `promptCancelled`). An unpaired start means the call never finished — the signature of a hung or killed-mid-call run, and the live in-flight indicator in follow mode. `label` is the call's `llm(label: "...")` debug tag, or `null`.
+- **`promptCompletion(messages, completion, model, timeTaken, tools, responseFormat)`** — logs the full message history, model response, model name, tools provided, and response format. Each entry of `messages` carries a `label` key when that message has a debug label; unlabeled messages have no `label` key at all, so logs for programs that never label stay byte-identical.
+
+### Message debug labels
+
+`llm()`, `userMessage()`, `assistantMessage()`, and `systemMessage()` all take an optional `label`. It exists so a log reader can tell, say, a verifier's injected message from a real user turn. Labels are **observability-only and never sent to the provider** — `runPrompt` strips `label` off `clientConfig` before the config reaches smoltalk (the same way it strips the retry fields), and `lib/runtime/promptLabels.test.ts` fails if that strip is removed.
+
+They surface in two places:
+
+- `promptStart.label` — the label of the `llm()` call itself.
+- `promptCompletion.messages[i].label` — the label of each message in the request payload.
+
+One `llm(label: "x")` call tags more than one message by design: its prompt, plus the assistant message of every tool-loop round. Note `promptCompletion` logs the *request*, so the assistant reply of that same round appears in the next round's dump, not its own.
+
+Storage lives on `MessageThread` (see `docs/dev/threads.md`); a thread rewrite via `setMessages` (summarization, repair) drops labels.
 - **`promptCancelled(threadId)`** — terminator for a promptStart whose call was cancelled: a race loser's abort, Esc-cancel, or a timeout. Deliberately not an error event — a cancel is a normal outcome, and without this terminator every healthy `race()` would leave its losers' starts unpaired.
 
 ### Thread-end hooks

--- a/packages/agency-lang/docs/dev/threads.md
+++ b/packages/agency-lang/docs/dev/threads.md
@@ -39,7 +39,11 @@ Things worth knowing:
 - **`newSubthreadChild()` does not carry the parent's labels**: it seeds the child via `cloneMessages()`, which copies messages only, so the child starts correctly aligned with all-null labels.
 - **`toJSON()` hands out a copy** of `messageLabels`, so a consumer mutating the JSON cannot mutate the thread.
 
-Serialization: `messageLabels` round-trips through `toJSON`/`fromJSON`; legacy JSON without the field revives as all-null. Anything that snapshots a thread for checkpoint/resume must persist the **full `MessageThreadJSON`**, not just `.messages` — a bare array revives through `fromJSON`'s legacy branch, which has no labels to read, so the labels would be gone after resume. `runPrompt`'s `snapshotMessages` does this; `fromJSON` still accepts the bare array so older checkpoints keep working.
+Serialization: `messageLabels` round-trips through `toJSON`/`fromJSON`; legacy JSON without the field revives as all-null. `ThreadStore` serializes each thread with `thread.toJSON()`, so labels ride along there for free.
+
+Anything that snapshots a thread for checkpoint/resume must persist the **full `MessageThreadJSON`**, not just `.messages` — a bare array revives through `fromJSON`'s legacy branch, which has no labels to read, so the labels would be gone after resume. `fromJSON` still accepts the bare array, so older checkpoints keep working.
+
+`runPrompt` has six bailout paths that each store a snapshot into `self.messagesJSON` (the PromptRunner callback, the tool loop, reply-attachment injection, the validation retries). They all go through one local `snapshotThread()` rather than each calling `toJSON()` themselves — the same reasoning as the writers above: the shape decision is made once, so a path that isn't covered by a test is still correct by construction.
 
 **`ThreadStore`** (`lib/runtime/state/threadStore.ts`):
 - Registry of `MessageThread` objects keyed by auto-incremented string IDs

--- a/packages/agency-lang/docs/dev/threads.md
+++ b/packages/agency-lang/docs/dev/threads.md
@@ -13,7 +13,25 @@ Agency uses a **ThreadStore** + **MessageThread** system to manage LLM conversat
 **`MessageThread`** (`lib/runtime/state/messageThread.ts`):
 - Wraps a `smoltalk.Message[]` array (OpenAI-compatible message format)
 - Each instance has a unique `id` (nanoid)
-- Key methods: `addMessage()`, `push()`, `getMessages()`, `cloneMessages()` (deep clone via JSON round-trip)
+- Key methods: `addMessage()`, `push()`, `getMessages()`, `cloneMessages()` (deep clone via JSON round-trip), `labelAt()`
+
+#### Per-message debug labels (`messageLabels`)
+
+`messageLabels` holds an optional debug label per message, from `llm(label:)` / `userMessage(msg, label:)` and friends. It is observability-only: labels surface in statelog (see `docs/dev/statelog.md`) and are never sent to the provider. It is **not** the same field as the thread-level `label`, which comes from `thread(label: "...")` and names the whole thread.
+
+`messageLabels` is aligned with `messages` **by index** — `messageLabels[i]` labels `messages[i]`, and the lengths always match. An index-aligned array is what lets labels serialize with the thread (a `WeakMap` keyed by message identity would survive slicing but not `toJSON`). The tradeoff is that nothing in the type system enforces the alignment, so it is enforced by keeping the writers to a minimum:
+
+- **`push(message, label?)` is the only append.** `addMessage()` delegates to it rather than appending on its own.
+- **The constructor and `setMessages()` are the only replacements**, and both rebuild `messageLabels` to the new length.
+- **Nothing else touches `this.messages`.**
+
+Treat any new direct mutation of `this.messages` as a bug: a desync does not degrade gracefully, it shifts every later label onto the wrong message. Each writer has a test in `messageThread.test.ts` that fails on a desync.
+
+Two consequences worth knowing:
+- **`setMessages` drops labels** (rebuilds them as all-null). Thread rewrites — summarization, `threadRepair` — therefore lose labels. Intended.
+- **`newSubthreadChild()` does not carry the parent's labels**: it seeds the child via `cloneMessages()`, which copies messages only, so the child starts correctly aligned with all-null labels.
+
+Serialization: `messageLabels` round-trips through `toJSON`/`fromJSON`. Legacy JSON without the field revives as all-null. In `fromJSON` the restore must run **after** the internal `setMessages()` call, which would otherwise reset it.
 
 **`ThreadStore`** (`lib/runtime/state/threadStore.ts`):
 - Registry of `MessageThread` objects keyed by auto-incremented string IDs

--- a/packages/agency-lang/docs/dev/threads.md
+++ b/packages/agency-lang/docs/dev/threads.md
@@ -19,19 +19,27 @@ Agency uses a **ThreadStore** + **MessageThread** system to manage LLM conversat
 
 `messageLabels` holds an optional debug label per message, from `llm(label:)` / `userMessage(msg, label:)` and friends. It is observability-only: labels surface in statelog (see `docs/dev/statelog.md`) and are never sent to the provider. It is **not** the same field as the thread-level `label`, which comes from `thread(label: "...")` and names the whole thread.
 
-`messageLabels` is aligned with `messages` **by index** — `messageLabels[i]` labels `messages[i]`, and the lengths always match. An index-aligned array is what lets labels serialize with the thread (a `WeakMap` keyed by message identity would survive slicing but not `toJSON`). The tradeoff is that nothing in the type system enforces the alignment, so it is enforced by keeping the writers to a minimum:
+Smoltalk messages have no id, so a label cannot be keyed to the message it describes. `messageLabels` is instead aligned with `messages` **by index** — `messageLabels[i]` labels `messages[i]`, and the lengths always match. An index-aligned array is also what lets labels serialize with the thread (a `WeakMap` keyed by message identity would survive slicing but not `toJSON`).
 
-- **`push(message, label?)` is the only append.** `addMessage()` delegates to it rather than appending on its own.
-- **The constructor and `setMessages()` are the only replacements**, and both rebuild `messageLabels` to the new length.
+The tradeoff is that nothing in the type system enforces the alignment. It is enforced instead by keeping the writers few, and by giving every caller an operation that carries the labels along — so no caller has a reason to reach past them:
+
+- **`push(message, label?)`** — the only append. `addMessage()` delegates to it.
+- **`removeAt(index)`** — the only removal. Takes the message's label out with it.
+- **`adoptFrom(other)`** — take on another thread's messages *and* labels, keeping this thread's identity (the resume path needs the alias).
+- **the constructor and `setMessages(messages, labels?)`** — the only replacements. Both rebuild `messageLabels` to the new length.
 - **Nothing else touches `this.messages`.**
 
 Treat any new direct mutation of `this.messages` as a bug: a desync does not degrade gracefully, it shifts every later label onto the wrong message. Each writer has a test in `messageThread.test.ts` that fails on a desync.
 
-Two consequences worth knowing:
-- **`setMessages` drops labels** (rebuilds them as all-null). Thread rewrites — summarization, `threadRepair` — therefore lose labels. Intended.
-- **`newSubthreadChild()` does not carry the parent's labels**: it seeds the child via `cloneMessages()`, which copies messages only, so the child starts correctly aligned with all-null labels.
+This matters in practice. Before `removeAt` and `adoptFrom` existed, two callers reached for `setMessages` for jobs that were not rewrites and silently dropped every label: the memory layer removing its injected-facts message (on the **normal** path, so a labeled program lost its labels after the first `llm()` call), and the resume path overwriting the thread with the messages it had just restored.
 
-Serialization: `messageLabels` round-trips through `toJSON`/`fromJSON`. Legacy JSON without the field revives as all-null. In `fromJSON` the restore must run **after** the internal `setMessages()` call, which would otherwise reset it.
+Things worth knowing:
+- **`setMessages` with no `labels` drops labels.** Wholesale rewrites that cannot say what the labels are — summarization, `threadRepair` — therefore lose them. Intended. Callers that *do* know the labels pass them.
+- **A `labels` array whose length disagrees with `messages` is refused**, not padded or sliced: a disagreement means the source is already wrong, and guessing would put real labels on wrong messages. Unlabeled beats mislabeled.
+- **`newSubthreadChild()` does not carry the parent's labels**: it seeds the child via `cloneMessages()`, which copies messages only, so the child starts correctly aligned with all-null labels.
+- **`toJSON()` hands out a copy** of `messageLabels`, so a consumer mutating the JSON cannot mutate the thread.
+
+Serialization: `messageLabels` round-trips through `toJSON`/`fromJSON`; legacy JSON without the field revives as all-null. Anything that snapshots a thread for checkpoint/resume must persist the **full `MessageThreadJSON`**, not just `.messages` — a bare array revives through `fromJSON`'s legacy branch, which has no labels to read, so the labels would be gone after resume. `runPrompt`'s `snapshotMessages` does this; `fromJSON` still accepts the bare array so older checkpoints keep working.
 
 **`ThreadStore`** (`lib/runtime/state/threadStore.ts`):
 - Registry of `MessageThread` objects keyed by auto-incremented string IDs

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -58,7 +58,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L166))
 
 ### GuardFailureData
 
@@ -73,7 +73,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L182))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L185))
 
 ### ThreadMessage
 
@@ -84,7 +84,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L277))
 
 ### ThreadInfo
 
@@ -100,14 +100,14 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L279))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L282))
 
 ## Functions
 
 ### systemMessage
 
 ```ts
-systemMessage(msg: string)
+systemMessage(msg: string, label: string = "")
 ```
 
 Add a system message to the current thread's message history.
@@ -115,19 +115,21 @@ Add a system message to the current thread's message history.
   llm() calls.
 
   @param msg - The system message content
+  @param label - Optional debug label shown in statelog. Never sent to the model.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | msg | `string` |  |
+| label | `string` | "" |
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L64))
 
 ### userMessage
 
 ```ts
-userMessage(msg: string | (string | Attachment)[])
+userMessage(msg: string | (string | Attachment)[], label: string = "")
 ```
 
 Add a user message to the current thread's message history. Use this
@@ -135,14 +137,16 @@ Add a user message to the current thread's message history. Use this
   typed by the user this turn.
 
   @param msg - The user message content: a string, or an array mixing text strings and attachments.
+  @param label - Optional debug label shown in statelog. Never sent to the model.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | msg | `string \| (string \| Attachment)[]` |  |
+| label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L76))
 
 ### image
 
@@ -171,7 +175,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L88))
 
 ### file
 
@@ -202,7 +206,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L104))
 
 ### attachToReply
 
@@ -224,12 +228,12 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L121))
 
 ### assistantMessage
 
 ```ts
-assistantMessage(msg: string)
+assistantMessage(msg: string, label: string = "")
 ```
 
 Add an assistant message to the current thread's message history.
@@ -237,14 +241,16 @@ Add an assistant message to the current thread's message history.
   conversation programmatically.
 
   @param msg - The assistant message content
+  @param label - Optional debug label shown in statelog. Never sent to the model.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | msg | `string` |  |
+| label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L134))
 
 ### getCost
 
@@ -263,7 +269,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L151))
 
 ### getTokens
 
@@ -275,7 +281,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L159))
 
 ### getModelCosts
 
@@ -293,7 +299,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L173))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L176))
 
 ### guard
 
@@ -368,7 +374,7 @@ Run a block under a cost limit, a time limit, or both, aborting the
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L216))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L219))
 
 ### listThreads
 
@@ -401,7 +407,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L351))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L354))
 
 ### currentThreadId
 
@@ -416,7 +422,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L404))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L407))
 
 ### getThread
 
@@ -448,4 +454,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L414))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L417))

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -559,9 +559,7 @@ async function _runPrompt({
    * scoping the LLM HTTP abort signal to the current branch. */
   stateStack?: StateStack;
   retryPolicy: RetryPolicy;
-  /** This call's `llm(label:)` debug tag, or null. Stamped on the
-   *  assistant message this call appends. Observability only — the
-   *  provider never sees it (stripped from clientConfig in runPrompt). */
+  /** This call's `llm(label:)` debug tag (see `emitPromptStart`), or null. */
   callLabel?: string | null;
 }): Promise<RunPromptResult> {
   if (ctx.isCancelled(stateStack)) {
@@ -610,14 +608,7 @@ async function _runPrompt({
     metadata: clientConfig,
   } as any;
 
-  emitPromptStart({
-    ctx,
-    messages,
-    tools,
-    responseFormat,
-    clientConfig,
-    callLabel,
-  });
+  emitPromptStart({ ctx, messages, tools, responseFormat, clientConfig, callLabel });
 
   let completion: PromptResult;
   let toolCalls: ToolCallJSON[];

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -34,7 +34,10 @@ import { failure, isFailure, isSuccess, markDestructiveWork } from "./result.js"
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { LlmDefaults } from "../stdlib/llm.js";
-import { MessageThread } from "./state/messageThread.js";
+import {
+  MessageThread,
+  type MessageThreadJSON,
+} from "./state/messageThread.js";
 import { StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { handleStreamingResponse } from "./streaming.js";
@@ -993,21 +996,32 @@ export async function runPrompt(args: {
     messages = new MessageThread();
   }
 
+  /** The ONE way this function snapshots the thread for checkpoint/resume.
+   *
+   *  Every bailout path — the PromptRunner callback, the tool loop, the
+   *  reply-attachment injection, the validation retries — stores what this
+   *  returns into `self.messagesJSON`, so the shape decision is made once
+   *  rather than at each site.
+   *
+   *  That shape is the FULL `MessageThreadJSON`, not just `.messages`: a
+   *  bare array revives through `fromJSON`'s legacy branch, which has no
+   *  labels to read, so snapshotting only the messages loses every debug
+   *  label across interrupt/resume. Older checkpoints still hold a bare
+   *  array and keep reviving through that legacy branch, so this stays
+   *  back-compatible.
+   *
+   *  Reads the `messages` binding at call time, so reassignments below
+   *  (e.g. `messages = result.messages`) are observed. */
+  const snapshotThread = (): MessageThreadJSON => messages.toJSON();
+
   // Resumable-step + checkpoint-on-interrupt helper. See
   // docs/superpowers/plans/2026-05-22-prompt-runner.md.
-  // `snapshotMessages` reads the current `messages` binding at call time;
-  // reassignments below (e.g. `messages = result.messages`) are observed.
   const pr = new PromptRunner({
     self,
     ctx,
     stateStack,
     checkpointInfo,
-    // The FULL MessageThreadJSON, not just `.messages`: the bare array
-    // revives through fromJSON's legacy branch, which has no labels to
-    // read, so a snapshot of only the messages loses every label across
-    // interrupt/resume. Old checkpoints still hold a bare array and keep
-    // reviving through that same legacy branch, so this is back-compatible.
-    snapshotMessages: () => messages.toJSON(),
+    snapshotMessages: snapshotThread,
   });
 
   // One llmCall span covers the WHOLE `llm()` call — every tool-loop
@@ -1090,7 +1104,7 @@ export async function runPrompt(args: {
           }
         }
       }
-      self.messagesJSON = messages.toJSON();
+      self.messagesJSON = snapshotThread();
       self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
     });
 
@@ -1644,7 +1658,7 @@ export async function runPrompt(args: {
               ),
             );
             self.runnerState.replyAttachments = [];
-            self.messagesJSON = messages.toJSON();
+            self.messagesJSON = snapshotThread();
           });
         }
 
@@ -1670,7 +1684,7 @@ export async function runPrompt(args: {
           // Increment the round counter only after a successful LLM round,
           // so resume after a tool-batch interrupt re-enters the SAME round.
           self.toolCallRound = round + 1;
-          self.messagesJSON = messages.toJSON();
+          self.messagesJSON = snapshotThread();
           self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
         });
       }
@@ -1737,7 +1751,7 @@ export async function runPrompt(args: {
           },
         });
         messages.push(smoltalk.userMessage(decision.feedback));
-        self.messagesJSON = messages.toJSON();
+        self.messagesJSON = snapshotThread();
       });
       await pr.step(`validation.${validationAttempt}.llmCall`, async () => {
         const nextResult = await _runPrompt({
@@ -1757,7 +1771,7 @@ export async function runPrompt(args: {
         // bailout before this step completes leaves the counter unchanged,
         // so resume re-enters the SAME attempt with the same step keys.
         self.validationAttempt = validationAttempt + 1;
-        self.messagesJSON = messages.toJSON();
+        self.messagesJSON = snapshotThread();
         self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
       });
       // Loop: the retry response may itself contain tool calls; the inner

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -79,6 +79,22 @@ export function redactMessagesForLog(
   return redactAttachments(messages.toJSON().messages) as smoltalk.MessageJSON[];
 }
 
+/** A thread's redacted messages for statelog, each carrying its debug
+ *  label (from `llm(label:)` / `userMessage(msg, label:)`) when it has
+ *  one. Reads the labels off the SAME thread that produced the dump, so
+ *  index `i` lines up: `redactMessagesForLog` maps `messages` in order.
+ *
+ *  Unlabeled messages are emitted unchanged rather than with `label:
+ *  null`, so logs for label-free programs stay byte-identical. */
+export function withMessageLabels(
+  messages: MessageThread,
+): smoltalk.MessageJSON[] {
+  return redactMessagesForLog(messages).map((m, i) => {
+    const label = messages.labelAt(i);
+    return label === null ? m : { ...m, label };
+  });
+}
+
 /** A prompt with attachment payloads redacted, preserving its string-or-array
  *  shape, for statelog / hook data. */
 export function redactPromptForLog(
@@ -672,7 +688,7 @@ async function _runPrompt({
   const modelName = completion.model || clientConfig.model || "unknown model";
 
   ctx.statelogClient.promptCompletion({
-    messages: redactMessagesForLog(messages),
+    messages: withMessageLabels(messages),
     completion,
     model: JSON.stringify(modelName),
     timeTaken: endTime - startTime,

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -500,12 +500,15 @@ function emitPromptStart({
   tools,
   responseFormat,
   clientConfig,
+  callLabel,
 }: {
   ctx: RuntimeContext<GraphState>;
   messages: MessageThread;
   tools: Tool[];
   responseFormat?: any;
   clientConfig: Partial<smoltalk.SmolConfig>;
+  /** This call's `llm(label:)` debug tag, or null. Observability only. */
+  callLabel?: string | null;
 }): void {
   ctx.statelogClient.promptStart({
     model: JSON.stringify(clientConfig.model),
@@ -514,6 +517,7 @@ function emitPromptStart({
     toolCount: tools.length,
     hasResponseFormat: responseFormat != null,
     maxTokens: clientConfig.maxTokens ?? null,
+    label: callLabel ?? null,
   });
 }
 
@@ -526,6 +530,7 @@ async function _runPrompt({
   clientConfig,
   stateStack,
   retryPolicy,
+  callLabel,
 }: {
   ctx: RuntimeContext<GraphState>;
   messages: MessageThread;
@@ -538,6 +543,10 @@ async function _runPrompt({
    * scoping the LLM HTTP abort signal to the current branch. */
   stateStack?: StateStack;
   retryPolicy: RetryPolicy;
+  /** This call's `llm(label:)` debug tag, or null. Stamped on the
+   *  assistant message this call appends. Observability only — the
+   *  provider never sees it (stripped from clientConfig in runPrompt). */
+  callLabel?: string | null;
 }): Promise<RunPromptResult> {
   if (ctx.isCancelled(stateStack)) {
     throw new AgencyCancelledError();
@@ -585,7 +594,14 @@ async function _runPrompt({
     metadata: clientConfig,
   } as any;
 
-  emitPromptStart({ ctx, messages, tools, responseFormat, clientConfig });
+  emitPromptStart({
+    ctx,
+    messages,
+    tools,
+    responseFormat,
+    clientConfig,
+    callLabel,
+  });
 
   let completion: PromptResult;
   let toolCalls: ToolCallJSON[];
@@ -674,9 +690,10 @@ async function _runPrompt({
       smoltalk.assistantMessage(completion.output, {
         toolCalls,
       }),
+      callLabel,
     );
   } else {
-    messages.push(smoltalk.assistantMessage(completion.output));
+    messages.push(smoltalk.assistantMessage(completion.output), callLabel);
   }
 
   updateTokenStats({
@@ -853,6 +870,8 @@ export async function runPrompt(args: {
   // smoltalk doesn't understand. `retries` / `timeout` / `backoff` are the
   // resilience policy (resolved below); if the codegen forwarded them on
   // `clientConfig` they'd otherwise hit the LLM client as foreign options.
+  // `label` is an observability-only debug tag — stripping it here is what
+  // keeps it off the provider wire.
   const {
     tools: _extractedTools,
     memory: memoryOption,
@@ -861,13 +880,19 @@ export async function runPrompt(args: {
     timeout: ccTimeout,
     backoff: ccBackoff,
     validationRetries: ccValidationRetries,
+    label: ccLabel,
     ...restClientConfig
   } = (args.clientConfig || {}) as Partial<smoltalk.SmolConfig> &
     RetryConfig & {
       tools?: any[];
       memory?: boolean | { model?: string };
       maxToolResultChars?: number;
+      label?: string;
     };
+
+  /** This llm() call's debug label, or null when unlabeled. Stamps the
+   *  call's promptStart event and the messages it appends. */
+  const callLabel: string | null = ccLabel || null;
 
   // Resolve the resilience policy. Precedence:
   //   1. `args.retryConfig` (preferred — what `agency.llm` passes directly)
@@ -1017,7 +1042,7 @@ export async function runPrompt(args: {
           );
         }
       }
-      messages.push(smoltalk.userMessage(prompt));
+      messages.push(smoltalk.userMessage(prompt), callLabel);
       // The llmCall span is already open (before the loop). On error,
       // the outer `finally` closes it.
       const result = await _runPrompt({
@@ -1029,6 +1054,7 @@ export async function runPrompt(args: {
         clientConfig,
         stateStack,
         retryPolicy,
+        callLabel,
       });
       messages = result.messages;
       toolCalls = result.toolCalls;
@@ -1617,6 +1643,7 @@ export async function runPrompt(args: {
             clientConfig,
             stateStack,
             retryPolicy,
+            callLabel,
           });
           messages = nextResult.messages;
           toolCalls = nextResult.toolCalls;
@@ -1702,6 +1729,7 @@ export async function runPrompt(args: {
           clientConfig,
           stateStack,
           retryPolicy,
+          callLabel,
         });
         messages = nextResult.messages;
         toolCalls = nextResult.toolCalls;

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -82,13 +82,16 @@ export function redactMessagesForLog(
 /** A thread's redacted messages for statelog, each carrying its debug
  *  label (from `llm(label:)` / `userMessage(msg, label:)`) when it has
  *  one. Reads the labels off the SAME thread that produced the dump, so
- *  index `i` lines up: `redactMessagesForLog` maps `messages` in order.
+ *  index `i` lines up: `redactMessagesForLog` maps `messages` in order,
+ *  and smoltalk's `redactAttachments` is 1:1 over an array. That second
+ *  half is someone else's implementation detail, so a test pins the
+ *  pairing through the redaction path with a real attachment.
  *
  *  Unlabeled messages are emitted unchanged rather than with `label:
  *  null`, so logs for label-free programs stay byte-identical. */
 export function withMessageLabels(
   messages: MessageThread,
-): smoltalk.MessageJSON[] {
+): (smoltalk.MessageJSON & { label?: string })[] {
   return redactMessagesForLog(messages).map((m, i) => {
     const label = messages.labelAt(i);
     return label === null ? m : { ...m, label };
@@ -974,7 +977,10 @@ export async function runPrompt(args: {
   if (self.messagesJSON) {
     const restored = MessageThread.fromJSON(self.messagesJSON);
     if (args.messages) {
-      args.messages.setMessages(restored.getMessages());
+      // adoptFrom, not setMessages(restored.getMessages()): the latter
+      // takes only the messages and would drop the labels fromJSON just
+      // restored. The alias is still preserved.
+      args.messages.adoptFrom(restored);
       messages = args.messages;
     } else {
       messages = restored;
@@ -996,7 +1002,12 @@ export async function runPrompt(args: {
     ctx,
     stateStack,
     checkpointInfo,
-    snapshotMessages: () => messages.toJSON().messages,
+    // The FULL MessageThreadJSON, not just `.messages`: the bare array
+    // revives through fromJSON's legacy branch, which has no labels to
+    // read, so a snapshot of only the messages loses every label across
+    // interrupt/resume. Old checkpoints still hold a bare array and keep
+    // reviving through that same legacy branch, so this is back-compatible.
+    snapshotMessages: () => messages.toJSON(),
   });
 
   // One llmCall span covers the WHOLE `llm()` call — every tool-loop
@@ -1072,12 +1083,14 @@ export async function runPrompt(args: {
             all[i].role === "system" &&
             all[i].content === injectedFactsContent
           ) {
-            messages.setMessages([...all.slice(0, i), ...all.slice(i + 1)]);
+            // removeAt, not setMessages: this edits ONE message out of the
+            // thread, so it must not reset the labels of all the others.
+            messages.removeAt(i);
             break;
           }
         }
       }
-      self.messagesJSON = messages.toJSON().messages;
+      self.messagesJSON = messages.toJSON();
       self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
     });
 
@@ -1631,7 +1644,7 @@ export async function runPrompt(args: {
               ),
             );
             self.runnerState.replyAttachments = [];
-            self.messagesJSON = messages.toJSON().messages;
+            self.messagesJSON = messages.toJSON();
           });
         }
 
@@ -1657,7 +1670,7 @@ export async function runPrompt(args: {
           // Increment the round counter only after a successful LLM round,
           // so resume after a tool-batch interrupt re-enters the SAME round.
           self.toolCallRound = round + 1;
-          self.messagesJSON = messages.toJSON().messages;
+          self.messagesJSON = messages.toJSON();
           self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
         });
       }
@@ -1724,7 +1737,7 @@ export async function runPrompt(args: {
           },
         });
         messages.push(smoltalk.userMessage(decision.feedback));
-        self.messagesJSON = messages.toJSON().messages;
+        self.messagesJSON = messages.toJSON();
       });
       await pr.step(`validation.${validationAttempt}.llmCall`, async () => {
         const nextResult = await _runPrompt({
@@ -1744,7 +1757,7 @@ export async function runPrompt(args: {
         // bailout before this step completes leaves the counter unchanged,
         // so resume re-enters the SAME attempt with the same step keys.
         self.validationAttempt = validationAttempt + 1;
-        self.messagesJSON = messages.toJSON().messages;
+        self.messagesJSON = messages.toJSON();
         self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
       });
       // Loop: the retry response may itself contain tool calls; the inner

--- a/packages/agency-lang/lib/runtime/promptLabels.test.ts
+++ b/packages/agency-lang/lib/runtime/promptLabels.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from "vitest";
+import * as smoltalk from "smoltalk";
 import type { Result, PromptResult, StreamChunk } from "smoltalk";
 import { agency } from "./agency.js";
 import type { EmbedConfig, EmbedResult, LLMClient, PromptConfig } from "./llmClient.js";
-import { runPrompt } from "./prompt.js";
+import { redactMessagesForLog, runPrompt, withMessageLabels } from "./prompt.js";
 import { RuntimeContext } from "./state/context.js";
 import { MessageThread } from "./state/messageThread.js";
 import { ThreadStore } from "./state/threadStore.js";
@@ -117,5 +118,31 @@ describe("llm() debug label", () => {
   it("keeps labels aligned with messages", async () => {
     const { thread } = await runLabeled("verifier");
     expect(thread.messageLabels).toHaveLength(thread.getMessages().length);
+  });
+});
+
+describe("withMessageLabels (the promptCompletion dump)", () => {
+  it("attaches each message's label by index, leaving unlabeled ones alone", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.systemMessage("sys"));
+    t.push(smoltalk.userMessage("context"), "seed");
+    t.push(smoltalk.userMessage("go"), "coder");
+
+    const dumped = withMessageLabels(t) as any[];
+
+    // Pairing, not presence: a shifted array would still "contain" both
+    // labels but attach them to the wrong messages.
+    expect(dumped).toHaveLength(3);
+    expect("label" in dumped[0]).toBe(false);
+    expect(dumped[1].label).toBe("seed");
+    expect(dumped[2].label).toBe("coder");
+    expect(dumped[0].role).toBe("system");
+  });
+
+  it("is byte-identical to the plain dump when nothing is labeled", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.systemMessage("sys"));
+    t.push(smoltalk.userMessage("go"));
+    expect(withMessageLabels(t)).toEqual(redactMessagesForLog(t));
   });
 });

--- a/packages/agency-lang/lib/runtime/promptLabels.test.ts
+++ b/packages/agency-lang/lib/runtime/promptLabels.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import type { Result, PromptResult, StreamChunk } from "smoltalk";
+import { agency } from "./agency.js";
+import type { EmbedConfig, EmbedResult, LLMClient, PromptConfig } from "./llmClient.js";
+import { runPrompt } from "./prompt.js";
+import { RuntimeContext } from "./state/context.js";
+import { MessageThread } from "./state/messageThread.js";
+import { ThreadStore } from "./state/threadStore.js";
+
+/** `llm(label: "...")` is observability-only. The Agency codegen forwards
+ *  a call's named options object to `runPrompt` as `clientConfig`
+ *  verbatim, so `label` arrives there and MUST be stripped before the
+ *  config reaches the provider. These tests drive that exact shape. */
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+  });
+}
+
+function inFrame<T>(
+  ctx: RuntimeContext<any>,
+  threads: ThreadStore,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return agency.withTestContext({ ctx, stack: ctx.stateStack, threads }, fn);
+}
+
+/** Records every PromptConfig the provider is handed, so a leaked
+ *  agency-only key is visible. */
+class RecordingClient implements LLMClient {
+  configs: PromptConfig[] = [];
+
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    this.configs.push(config);
+    return {
+      success: true,
+      value: {
+        output: "answer",
+        toolCalls: [],
+        model: (config as any).model ?? "unknown",
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          cachedInputTokens: 0,
+          totalTokens: 2,
+        },
+        cost: {
+          inputCost: 0,
+          outputCost: 0,
+          totalCost: 0,
+          currency: "USD",
+        },
+      },
+    };
+  }
+
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const r = await this.text(config);
+    if (r.success) yield { type: "text", text: r.value.output } as StreamChunk;
+  }
+
+  async embed(
+    _input: string | string[],
+    _config?: Partial<EmbedConfig>,
+  ): Promise<Result<EmbedResult>> {
+    throw new Error("not used");
+  }
+}
+
+async function runLabeled(label: string | undefined) {
+  const ctx = makeCtx();
+  const client = new RecordingClient();
+  ctx.setLLMClient(client);
+  const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+  const thread = new MessageThread();
+  await inFrame(ctx, threads, () =>
+    runPrompt({
+      prompt: "go",
+      messages: thread,
+      clientConfig: (label === undefined ? {} : { label }) as any,
+    }),
+  );
+  return { client, thread };
+}
+
+describe("llm() debug label", () => {
+  it("never reaches the provider config", async () => {
+    const { client } = await runLabeled("verifier");
+    expect(client.configs).toHaveLength(1);
+    expect("label" in (client.configs[0] as any)).toBe(false);
+  });
+
+  it("labels both the prompt and the completion this call appends", async () => {
+    // One llm() call labeling MORE THAN ONE message is intended: the
+    // label marks "these messages came from this call".
+    const { thread } = await runLabeled("verifier");
+    const roles = thread.getMessages().map((m: any) => m.role);
+    expect(roles).toEqual(["user", "assistant"]);
+    expect(thread.labelAt(0)).toBe("verifier");
+    expect(thread.labelAt(1)).toBe("verifier");
+  });
+
+  it("leaves messages unlabeled when no label is given", async () => {
+    const { thread } = await runLabeled(undefined);
+    expect(thread.labelAt(0)).toBe(null);
+    expect(thread.labelAt(1)).toBe(null);
+  });
+
+  it("keeps labels aligned with messages", async () => {
+    const { thread } = await runLabeled("verifier");
+    expect(thread.messageLabels).toHaveLength(thread.getMessages().length);
+  });
+});

--- a/packages/agency-lang/lib/runtime/promptLabels.test.ts
+++ b/packages/agency-lang/lib/runtime/promptLabels.test.ts
@@ -96,7 +96,13 @@ describe("llm() debug label", () => {
   it("never reaches the provider config", async () => {
     const { client } = await runLabeled("verifier");
     expect(client.configs).toHaveLength(1);
-    expect("label" in (client.configs[0] as any)).toBe(false);
+    const config = client.configs[0] as any;
+    expect("label" in config).toBe(false);
+    // `_runPrompt` also forwards the whole config nested under
+    // `metadata`, so a leak could ride in there while the top-level key
+    // looks clean. Both read the same post-strip object today; assert on
+    // the property being protected, not just the shape it happens to take.
+    expect("label" in (config.metadata ?? {})).toBe(false);
   });
 
   it("labels both the prompt and the completion this call appends", async () => {
@@ -144,5 +150,42 @@ describe("withMessageLabels (the promptCompletion dump)", () => {
     t.push(smoltalk.systemMessage("sys"));
     t.push(smoltalk.userMessage("go"));
     expect(withMessageLabels(t)).toEqual(redactMessagesForLog(t));
+  });
+});
+
+describe("withMessageLabels through the redaction path", () => {
+  it("keeps pairing when a message carries an attachment", () => {
+    // The index join holds only because smoltalk's redactAttachments is
+    // 1:1 over the array. That is someone else's implementation detail,
+    // so exercise it with a real attachment rather than plain text: if a
+    // future redaction ever filtered or split a message, every label
+    // would shift and this is what would catch it.
+    const t = new MessageThread();
+    t.push(smoltalk.systemMessage("sys"));
+    t.push(
+      smoltalk.userMessage([
+        "look",
+        {
+          type: "image",
+          source: {
+            kind: "base64",
+            base64: "A".repeat(5000),
+            mimeType: "image/png",
+          },
+        },
+      ] as smoltalk.UserContentInput),
+      "seed",
+    );
+    t.push(smoltalk.userMessage("go"), "coder");
+
+    const dumped = withMessageLabels(t) as any[];
+
+    expect(dumped).toHaveLength(3);
+    expect("label" in dumped[0]).toBe(false);
+    expect(dumped[1].label).toBe("seed");
+    expect(dumped[2].label).toBe("coder");
+    // The attachment really did go through redaction on the labeled entry.
+    expect(JSON.stringify(dumped[1])).not.toContain("A".repeat(5000));
+    expect(JSON.stringify(dumped[1])).toContain("image/png");
   });
 });

--- a/packages/agency-lang/lib/runtime/promptRunner.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.ts
@@ -1,4 +1,5 @@
 import type { MessageJSON } from "smoltalk";
+import type { MessageThreadJSON } from "./state/messageThread.js";
 import { hasInterrupts, type Interrupt } from "./interrupts.js";
 import { runBatch, type RunBatchResult } from "./runBatch.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
@@ -51,8 +52,12 @@ export type PromptRunnerOpts = {
    *  `step()` for the per-key suffix.  */
   checkpointInfo: SourceLocationOpts | undefined;
   /** Callback that snapshots the current message thread JSON. Called only
-   *  on bailout so it doesn't pay the cost on the happy path. */
-  snapshotMessages: () => MessageJSON[];
+   *  on bailout so it doesn't pay the cost on the happy path.
+   *
+   *  Returns the FULL `MessageThreadJSON` so per-message debug labels
+   *  survive the round-trip; `MessageThread.fromJSON` also still accepts
+   *  the bare `MessageJSON[]` that older checkpoints hold. */
+  snapshotMessages: () => MessageThreadJSON | MessageJSON[];
 };
 
 /**

--- a/packages/agency-lang/lib/runtime/state/messageThread.test.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.test.ts
@@ -114,3 +114,80 @@ describe("MessageThread per-message labels", () => {
     expect(child.labelAt(1)).toBe("child");
   });
 });
+
+describe("MessageThread label-preserving edits", () => {
+  it("removeAt drops only that message's label, keeping the rest aligned", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.systemMessage("facts"), null);
+    t.push(smoltalk.userMessage("a"), "seed");
+    t.push(smoltalk.userMessage("b"), "coder");
+
+    t.removeAt(0);
+
+    expect(t.getMessages()).toHaveLength(2);
+    expect(t.labelAt(0)).toBe("seed");
+    expect(t.labelAt(1)).toBe("coder");
+  });
+
+  it("adoptFrom takes the other thread's labels, not just its messages", () => {
+    const restored = new MessageThread();
+    restored.push(smoltalk.userMessage("a"), "seed");
+    const live = new MessageThread();
+    const liveId = live.id;
+
+    live.adoptFrom(restored);
+
+    expect(live.labelAt(0)).toBe("seed");
+    // The alias survives: same object, same identity.
+    expect(live.id).toBe(liveId);
+  });
+
+  it("adoptFrom copies, so later pushes do not leak between threads", () => {
+    const source = new MessageThread();
+    source.push(smoltalk.userMessage("a"), "seed");
+    const live = new MessageThread();
+    live.adoptFrom(source);
+    live.push(smoltalk.userMessage("b"), "later");
+    expect(source.getMessages()).toHaveLength(1);
+    expect(source.messageLabels).toHaveLength(1);
+  });
+
+  it("setMessages takes labels when the caller has them", () => {
+    const t = new MessageThread();
+    t.setMessages([smoltalk.userMessage("a"), smoltalk.userMessage("b")], [
+      null,
+      "kept",
+    ]);
+    expect(t.labelAt(0)).toBe(null);
+    expect(t.labelAt(1)).toBe("kept");
+  });
+
+  it("setMessages refuses a labels array of the wrong length", () => {
+    // Unlabeled beats mislabeled: a length disagreement means the source
+    // is already wrong, so do not guess an alignment.
+    const t = new MessageThread();
+    t.setMessages([smoltalk.userMessage("a"), smoltalk.userMessage("b")], [
+      "only-one",
+    ]);
+    expect(t.messageLabels).toEqual([null, null]);
+  });
+
+  it("toJSON hands out a copy of the labels, not the live array", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("a"), "seed");
+    const json = t.toJSON();
+    (json.messageLabels as (string | null)[])[0] = "mutated";
+    expect(t.labelAt(0)).toBe("seed");
+  });
+
+  it("revives labels from a full MessageThreadJSON round-trip (the checkpoint shape)", () => {
+    // runPrompt checkpoints the FULL toJSON(); a bare messages array
+    // would revive through the legacy branch with no labels at all.
+    const t = new MessageThread();
+    t.push(smoltalk.systemMessage("sys"));
+    t.push(smoltalk.userMessage("go"), "coder");
+    const revived = MessageThread.fromJSON(JSON.parse(JSON.stringify(t.toJSON())));
+    expect(revived.labelAt(0)).toBe(null);
+    expect(revived.labelAt(1)).toBe("coder");
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/messageThread.test.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import * as smoltalk from "smoltalk";
 import { MessageThread } from "./messageThread.js";
 
 describe("MessageThread defaults", () => {
@@ -44,5 +45,72 @@ describe("MessageThread JSON round-trip", () => {
     expect(restored.label).toBeNull();
     expect(restored.summary).toBeNull();
     expect(restored.parentId).toBeNull();
+  });
+});
+
+describe("MessageThread per-message labels", () => {
+  it("stores a label alongside a pushed message and reads it back by index", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("hi"), "verifier");
+    t.push(smoltalk.assistantMessage("ok"));
+    expect(t.labelAt(0)).toBe("verifier");
+    expect(t.labelAt(1)).toBe(null);
+  });
+
+  it("round-trips labels through toJSON/fromJSON", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("hi"), "verifier");
+    const revived = MessageThread.fromJSON(t.toJSON());
+    expect(revived.labelAt(0)).toBe("verifier");
+  });
+
+  it("revives legacy JSON without messageLabels as all-null labels", () => {
+    const json = new MessageThread([smoltalk.userMessage("hi")]).toJSON();
+    delete (json as any).messageLabels;
+    const revived = MessageThread.fromJSON(json);
+    expect(revived.labelAt(0)).toBe(null);
+    expect(revived.messageLabels).toHaveLength(1);
+  });
+
+  it("setMessages resets labels (summarize/repair drop them)", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("hi"), "verifier");
+    t.setMessages([smoltalk.userMessage("summary")]);
+    expect(t.labelAt(0)).toBe(null);
+    expect(t.messageLabels).toHaveLength(1);
+  });
+
+  // --- the invariant: length always matches, at every writer ---
+
+  it("a constructor-seeded thread stays aligned when pushed to", () => {
+    // Without a constructor seed, messageLabels would be [] against 2
+    // messages, and this push would put "late" at index 0.
+    const t = new MessageThread([
+      smoltalk.userMessage("a"),
+      smoltalk.userMessage("b"),
+    ]);
+    t.push(smoltalk.userMessage("c"), "late");
+    expect(t.labelAt(0)).toBe(null);
+    expect(t.labelAt(1)).toBe(null);
+    expect(t.labelAt(2)).toBe("late");
+  });
+
+  it("addMessage keeps the arrays aligned (it delegates to push)", () => {
+    const t = new MessageThread();
+    t.addMessage(smoltalk.userMessage("a"));
+    t.push(smoltalk.userMessage("b"), "second");
+    expect(t.labelAt(0)).toBe(null);
+    expect(t.labelAt(1)).toBe("second");
+  });
+
+  it("a subthread child seeded from a parent starts aligned", () => {
+    const parent = new MessageThread();
+    parent.push(smoltalk.userMessage("a"), "seed");
+    const child = parent.newSubthreadChild(null);
+    child.push(smoltalk.userMessage("b"), "child");
+    // The parent's labels do not travel (cloneMessages copies messages
+    // only); what matters is the child does not mis-attribute.
+    expect(child.labelAt(0)).toBe(null);
+    expect(child.labelAt(1)).toBe("child");
   });
 });

--- a/packages/agency-lang/lib/runtime/state/messageThread.test.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.test.ts
@@ -180,6 +180,24 @@ describe("MessageThread label-preserving edits", () => {
     expect(t.labelAt(0)).toBe("seed");
   });
 
+  it("omits messageLabels entirely when nothing is labeled", () => {
+    // An all-null array says nothing the absent key doesn't, and emitting
+    // it would change the serialized shape of every thread for every
+    // program that never labels. Checkpoints and statelog dumps stay
+    // byte-identical.
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("a"));
+    t.push(smoltalk.assistantMessage("b"));
+    expect("messageLabels" in t.toJSON()).toBe(false);
+  });
+
+  it("emits messageLabels as soon as one message is labeled", () => {
+    const t = new MessageThread();
+    t.push(smoltalk.userMessage("a"));
+    t.push(smoltalk.assistantMessage("b"), "coder");
+    expect(t.toJSON().messageLabels).toEqual([null, "coder"]);
+  });
+
   it("revives labels from a full MessageThreadJSON round-trip (the checkpoint shape)", () => {
     // runPrompt checkpoints the FULL toJSON(); a bare messages array
     // would revive through the legacy branch with no labels at all.

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -150,17 +150,26 @@ export class MessageThread {
   }
 
   toJSON(): MessageThreadJSON {
-    return {
+    const json: MessageThreadJSON = {
       messages: this.messages.map((m) => m.toJSON()),
-      // Copy, not the live array: `messages` above is rebuilt, so handing
-      // out the real one would let a consumer mutating the JSON mutate the
-      // thread — the one way to reach `messageLabels` without a writer.
-      messageLabels: [...this.messageLabels],
       parentId: this.parentId,
       hidden: this.hidden,
       label: this.label,
       summary: this.summary,
     };
+    // Only when something is actually labeled. An all-null array carries
+    // no more information than the absent key (`fromJSON` revives both as
+    // all-null), and emitting it would change the serialized shape of
+    // every thread — checkpoints, statelog, fixtures — for every program
+    // that never labels anything. Same rule as `withMessageLabels`.
+    //
+    // Copy, not the live array: `messages` above is rebuilt, so handing
+    // out the real one would let a consumer mutating the JSON mutate the
+    // thread — the one way to reach `messageLabels` without a writer.
+    if (this.messageLabels.some((l) => l !== null)) {
+      json.messageLabels = [...this.messageLabels];
+    }
+    return json;
   }
 
   static fromJSON(

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -45,12 +45,19 @@ export class MessageThread {
    *  Observability only: shown in statelog, never sent to the provider.
    *  Distinct from the thread-level `label` above (set by `thread(label:)`).
    *
-   *  The alignment is maintained by keeping the writers to a minimum:
-   *  `push` is the only append, the constructor and `setMessages` are the
-   *  only replacements, and nothing else touches `this.messages`. A desync
-   *  does not degrade gracefully — it shifts every later label onto the
-   *  wrong message — so keep it that way. A rewrite via `setMessages`
-   *  (summarization, repair) drops labels; that is intended. */
+   *  The alignment is maintained by keeping the writers to a minimum, and
+   *  by giving every caller an operation that carries the labels along
+   *  instead of a reason to reach past them:
+   *
+   *  - `push` — the only append.
+   *  - `removeAt` — the only removal.
+   *  - `adoptFrom` — take on another thread's messages and labels.
+   *  - the constructor and `setMessages` — the only replacements.
+   *
+   *  Nothing else touches `this.messages`. A desync does not degrade
+   *  gracefully — it shifts every later label onto the wrong message — so
+   *  keep it that way. A rewrite via `setMessages` with no labels
+   *  (summarization, repair) drops them; that is intended. */
   messageLabels: (string | null)[];
 
   constructor(messages: smoltalk.Message[] = []) {
@@ -77,9 +84,41 @@ export class MessageThread {
     return this.messages;
   }
 
-  setMessages(messages: smoltalk.Message[]): void {
+  /** Wholesale rewrite: take on `messages`, and `labels` with them when
+   *  the caller has them (the restore path). Without `labels` the new
+   *  messages are unlabeled — a rewrite that cannot say what the labels
+   *  are does not get to keep the old ones, which is why summarization
+   *  and `threadRepair` drop them.
+   *
+   *  A `labels` array whose length disagrees with `messages` is refused
+   *  outright rather than padded or sliced: the lengths disagreeing means
+   *  the source is already wrong, and guessing an alignment would put
+   *  real labels on the wrong messages. Unlabeled beats mislabeled. */
+  setMessages(
+    messages: smoltalk.Message[],
+    labels?: (string | null)[],
+  ): void {
     this.messages = messages;
-    this.messageLabels = messages.map(() => null);
+    this.messageLabels =
+      labels !== undefined && labels.length === messages.length
+        ? [...labels]
+        : messages.map(() => null);
+  }
+
+  /** Remove the message at `index`, taking its label with it. For the
+   *  callers that edit one message out of the thread and would otherwise
+   *  reach for `setMessages` and drop every label as collateral. */
+  removeAt(index: number): void {
+    this.messages.splice(index, 1);
+    this.messageLabels.splice(index, 1);
+  }
+
+  /** Take on `other`'s messages AND labels while keeping this thread's
+   *  identity. The resume path needs the alias preserved, so it cannot
+   *  just swap in the restored object. */
+  adoptFrom(other: MessageThread): void {
+    this.messages = [...other.messages];
+    this.messageLabels = [...other.messageLabels];
   }
 
   /** The ONLY append. Everything that adds a message goes through here,
@@ -113,7 +152,10 @@ export class MessageThread {
   toJSON(): MessageThreadJSON {
     return {
       messages: this.messages.map((m) => m.toJSON()),
-      messageLabels: this.messageLabels,
+      // Copy, not the live array: `messages` above is rebuilt, so handing
+      // out the real one would let a consumer mutating the JSON mutate the
+      // thread — the one way to reach `messageLabels` without a writer.
+      messageLabels: [...this.messageLabels],
       parentId: this.parentId,
       hidden: this.hidden,
       label: this.label,
@@ -169,12 +211,10 @@ export class MessageThread {
       smoltalk.messageFromJSON(m),
     );
 
-    thread.setMessages(smoltalkMessages);
-    // AFTER setMessages: it resets messageLabels to all-null, so the
-    // restore has to come second or it gets clobbered. Legacy JSON (no
-    // messageLabels) keeps the all-null array setMessages just built.
-    thread.messageLabels =
-      _messageLabels ?? smoltalkMessages.map(() => null);
+    // Labels ride along with the messages: legacy JSON has none and
+    // revives unlabeled, and a labels array that disagrees in length is
+    // refused inside setMessages rather than guessed at.
+    thread.setMessages(smoltalkMessages, _messageLabels);
     thread.parentId = _parentId;
     thread.hidden = _hidden;
     thread.label = _label;

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 
 export type MessageThreadJSON = {
   messages: smoltalk.MessageJSON[];
+  messageLabels?: (string | null)[];
   parentId?: string | null;
   hidden?: boolean;
   label?: string | null;
@@ -39,14 +40,31 @@ export class MessageThread {
    *  module-level state in TS. `null` until the summary is computed.
    *  Round-tripped through `toJSON`/`fromJSON`. */
   summary: string | null = null;
+  /** Per-message debug labels, aligned with `messages` BY INDEX
+   *  (`messageLabels[i]` labels `messages[i]`; the lengths always match).
+   *  Observability only: shown in statelog, never sent to the provider.
+   *  Distinct from the thread-level `label` above (set by `thread(label:)`).
+   *
+   *  The alignment is maintained by keeping the writers to a minimum:
+   *  `push` is the only append, the constructor and `setMessages` are the
+   *  only replacements, and nothing else touches `this.messages`. A desync
+   *  does not degrade gracefully — it shifts every later label onto the
+   *  wrong message — so keep it that way. A rewrite via `setMessages`
+   *  (summarization, repair) drops labels; that is intended. */
+  messageLabels: (string | null)[];
 
   constructor(messages: smoltalk.Message[] = []) {
     this.messages = messages;
+    // Seed, don't default: `new MessageThread([...])` (e.g. via
+    // newSubthreadChild) must start aligned, or a later push lands its
+    // label on message 0.
+    this.messageLabels = messages.map(() => null);
     this.id = nanoid();
   }
 
+  /** Alias for `push` with no label. Kept for the existing public API. */
   addMessage(message: smoltalk.Message): void {
-    this.messages.push(message);
+    this.push(message);
   }
 
   cloneMessages(): smoltalk.Message[] {
@@ -61,10 +79,19 @@ export class MessageThread {
 
   setMessages(messages: smoltalk.Message[]): void {
     this.messages = messages;
+    this.messageLabels = messages.map(() => null);
   }
 
-  push(message: smoltalk.Message): void {
+  /** The ONLY append. Everything that adds a message goes through here,
+   *  so `messages` and `messageLabels` cannot drift apart. */
+  push(message: smoltalk.Message, label: string | null = null): void {
     this.messages.push(message);
+    this.messageLabels.push(label);
+  }
+
+  /** The label of the message at `index`, or null when unlabeled. */
+  labelAt(index: number): string | null {
+    return this.messageLabels[index] ?? null;
   }
 
   newChild(): MessageThread {
@@ -86,6 +113,7 @@ export class MessageThread {
   toJSON(): MessageThreadJSON {
     return {
       messages: this.messages.map((m) => m.toJSON()),
+      messageLabels: this.messageLabels,
       parentId: this.parentId,
       hidden: this.hidden,
       label: this.label,
@@ -104,6 +132,7 @@ export class MessageThread {
     const thread = new MessageThread();
 
     let _messages: any[] = [];
+    let _messageLabels: (string | null)[] | undefined = undefined;
     let _parentId: string | null = null;
     let _hidden = false;
     let _label: string | null = null;
@@ -112,6 +141,9 @@ export class MessageThread {
       _messages = json;
     } else if ("messages" in json) {
       _messages = json.messages;
+      if ("messageLabels" in json && json.messageLabels !== undefined) {
+        _messageLabels = json.messageLabels;
+      }
       if ("parentId" in json && json.parentId !== undefined) {
         _parentId = json.parentId;
       }
@@ -138,6 +170,11 @@ export class MessageThread {
     );
 
     thread.setMessages(smoltalkMessages);
+    // AFTER setMessages: it resets messageLabels to all-null, so the
+    // restore has to come second or it gets clobbered. Legacy JSON (no
+    // messageLabels) keeps the all-null array setMessages just built.
+    thread.messageLabels =
+      _messageLabels ?? smoltalkMessages.map(() => null);
     thread.parentId = _parentId;
     thread.hidden = _hidden;
     thread.label = _label;

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -461,6 +461,7 @@ export class StatelogClient {
     toolCount,
     hasResponseFormat,
     maxTokens,
+    label,
   }: {
     model?: string;
     threadId?: string | null;
@@ -468,6 +469,10 @@ export class StatelogClient {
     toolCount: number;
     hasResponseFormat: boolean;
     maxTokens?: number | null;
+    /** The `llm(label:)` debug tag for this call, or null when unlabeled.
+     *  Observability only — never sent to the provider. Lets a log reader
+     *  tell, say, a verifier's call from the main one. */
+    label?: string | null;
   }): Promise<void> {
     await this.post({
       type: "promptStart",
@@ -477,6 +482,7 @@ export class StatelogClient {
       toolCount,
       hasResponseFormat,
       maxTokens: maxTokens ?? null,
+      label: label ?? null,
     });
   }
 

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -40,10 +40,15 @@ export async function __internal_systemMessage(
   threads.getOrCreateActive().push(smoltalk.systemMessage(msg));
 }
 
-/** ALS-reading replacement for `__internal_systemMessage`. */
-export async function _systemMessage(msg: string): Promise<void> {
+/** ALS-reading replacement for `__internal_systemMessage`. `label` is an
+ *  observability-only debug tag shown in statelog; "" means unlabeled and
+ *  is normalized to null. Never sent to the provider. */
+export async function _systemMessage(
+  msg: string,
+  label: string = "",
+): Promise<void> {
   const { threads } = getRuntimeContext();
-  threads.getOrCreateActive().push(smoltalk.systemMessage(msg));
+  threads.getOrCreateActive().push(smoltalk.systemMessage(msg), label || null);
 }
 
 export async function __internal_userMessage(
@@ -56,12 +61,14 @@ export async function __internal_userMessage(
 }
 
 /** ALS-reading replacement for `__internal_userMessage`. Accepts a plain
- *  string or an array of text strings and image()/file() attachments. */
+ *  string or an array of text strings and image()/file() attachments.
+ *  `label` is an observability-only debug tag (see `_systemMessage`). */
 export async function _userMessage(
   msg: smoltalk.UserContentInput,
+  label: string = "",
 ): Promise<void> {
   const { threads } = getRuntimeContext();
-  threads.getOrCreateActive().push(smoltalk.userMessage(msg));
+  threads.getOrCreateActive().push(smoltalk.userMessage(msg), label || null);
 }
 
 export async function __internal_assistantMessage(
@@ -73,10 +80,16 @@ export async function __internal_assistantMessage(
   threads.getOrCreateActive().push(smoltalk.assistantMessage(msg));
 }
 
-/** ALS-reading replacement for `__internal_assistantMessage`. */
-export async function _assistantMessage(msg: string): Promise<void> {
+/** ALS-reading replacement for `__internal_assistantMessage`. `label` is
+ *  an observability-only debug tag (see `_systemMessage`). */
+export async function _assistantMessage(
+  msg: string,
+  label: string = "",
+): Promise<void> {
   const { threads } = getRuntimeContext();
-  threads.getOrCreateActive().push(smoltalk.assistantMessage(msg));
+  threads
+    .getOrCreateActive()
+    .push(smoltalk.assistantMessage(msg), label || null);
 }
 
 // --- Multimodal attachment builders -------------------------------------

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -111,6 +111,11 @@ const llmOptionProperties: { key: string; value: VariableType }[] = [
     // Validation retries: re-ask the model when structured output fails
     // schema validation. `0` disables. Independent of `retries`.
     { key: "validationRetries", value: optional(number) },
+    // Observability-only debug label: stamps this call's promptStart event
+    // and the messages the call appends (its prompt and its completion).
+    // Stripped from the config before it reaches smoltalk — the provider
+    // never sees it.
+    { key: "label", value: optional(string) },
     // `any` already accepts undefined, so no need to wrap in optional.
     { key: "metadata", value: ANY_T },
 ];

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -61,26 +61,28 @@ export type Attachment =
   | { type: "image", source: AttachmentSource }
   | { type: "file", source: AttachmentSource, filename?: string }
 
-export def systemMessage(msg: string) {
+export def systemMessage(msg: string, label: string = "") {
   """
   Add a system message to the current thread's message history.
   The message becomes part of the conversation context for subsequent
   llm() calls.
 
   @param msg - The system message content
+  @param label - Optional debug label shown in statelog. Never sent to the model.
   """
-  _systemMessage(msg)
+  _systemMessage(msg, label)
 }
 
-export def userMessage(msg: string | (string | Attachment)[]) {
+export def userMessage(msg: string | (string | Attachment)[], label: string = "") {
   """
   Add a user message to the current thread's message history. Use this
   to seed the conversation with prior user context that wasn't actually
   typed by the user this turn.
 
   @param msg - The user message content: a string, or an array mixing text strings and attachments.
+  @param label - Optional debug label shown in statelog. Never sent to the model.
   """
-  _userMessage(msg)
+  _userMessage(msg, label)
 }
 
 export def image(
@@ -129,15 +131,16 @@ export def attachToReply(attachment: Attachment) {
   _attachToReply(attachment)
 }
 
-export def assistantMessage(msg: string) {
+export def assistantMessage(msg: string, label: string = "") {
   """
   Add an assistant message to the current thread's message history.
   Use this to inject prior assistant turns when reconstructing a
   conversation programmatically.
 
   @param msg - The assistant message content
+  @param label - Optional debug label shown in statelog. Never sent to the model.
   """
-  _assistantMessage(msg)
+  _assistantMessage(msg, label)
 }
 
 /** Inside a fork/race branch this includes the parent's accumulated cost

--- a/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/agency.json
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/agent.agency
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/agent.agency
@@ -1,0 +1,18 @@
+import { userMessage } from "std::thread"
+
+// Parallel tool calls where one interrupts: a different resume path from
+// the single-tool case (PromptRunner.parallel -> runBatch stamps the
+// checkpoint itself). The labels must survive that round-trip too.
+def okTool(): string {
+  return "OK_RESULT"
+}
+
+def askTool(): string {
+  interrupt("approve ask-tool")
+  return "ASK_RESULT"
+}
+
+node main() {
+  userMessage("context", label: "seed")
+  return llm("go", label: "coder", { tools: [okTool, askTool] })
+}

--- a/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/fixture.json
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/fixture.json
@@ -1,0 +1,18 @@
+{
+  "finalData": "answer",
+  "promptCompletionCount": 2,
+  "labeledAfterResume": [
+    {
+      "content": "context",
+      "label": "seed"
+    },
+    {
+      "content": "go",
+      "label": "coder"
+    },
+    {
+      "content": null,
+      "label": "coder"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/test.js
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume-parallel/test.js
@@ -1,0 +1,98 @@
+import {
+  main,
+  hasInterrupts,
+  approve,
+  respondToInterrupts,
+  __setLLMClient,
+} from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+// Labels must survive interrupt/resume through the PARALLEL tool path.
+//
+// runPrompt bails out mid-tool-loop and snapshots the thread into
+// `self.messagesJSON`; resume revives it via MessageThread.fromJSON.
+// Snapshotting only `toJSON().messages` would revive through fromJSON's
+// legacy (bare-array) branch, which has no labels to read — so every
+// label would be gone after resume, and the promptCompletion logged by
+// the post-resume round would be silently unlabeled.
+//
+// This asserts on the LAST promptCompletion (the round after resume),
+// so it reads the labels as they exist on the far side of the round-trip.
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+const client = {
+  async text() {
+    const idx = callIndex++;
+    if (idx === 0) {
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [new ToolCall("call-ok", "okTool", {}), new ToolCall("call-ask", "askTool", {})],
+          model: "test",
+          usage: USAGE,
+          cost: COST,
+        },
+      };
+    }
+    return {
+      success: true,
+      value: { output: "answer", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const initial = await main();
+if (!hasInterrupts(initial.data)) {
+  throw new Error(`Expected an interrupt from askTool, got: ${JSON.stringify(initial.data)}`);
+}
+const final = await respondToInterrupts(initial.data, [approve()]);
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((l) => l.trim() !== "")
+  .map((l) => JSON.parse(l));
+
+const completions = events.filter((e) => e.data?.type === "promptCompletion");
+// The round AFTER resume — the one that had to survive the round-trip.
+const afterResume = completions[completions.length - 1];
+
+const labeled = (afterResume?.data?.messages ?? [])
+  .map((m) => ({
+    content: typeof m.content === "string" ? m.content : null,
+    label: m.label ?? null,
+  }))
+  .filter((m) => m.label !== null);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      finalData: final.data,
+      promptCompletionCount: completions.length,
+      labeledAfterResume: labeled,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/message-labels-resume/agency.json
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/message-labels-resume/agent.agency
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume/agent.agency
@@ -1,0 +1,14 @@
+import { userMessage } from "std::thread"
+
+// A tool interrupts mid-llm(), so the run checkpoints and resumes. The
+// labels must still be there afterwards: runPrompt snapshots the thread
+// into self.messagesJSON on bailout and revives it on resume. See test.js.
+def askTool(): string {
+  interrupt("approve ask-tool")
+  return "TOOL_RESULT"
+}
+
+node main() {
+  userMessage("context", label: "seed")
+  return llm("go", label: "coder", { tools: [askTool] })
+}

--- a/packages/agency-lang/tests/agency-js/message-labels-resume/fixture.json
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume/fixture.json
@@ -1,0 +1,18 @@
+{
+  "finalData": "answer",
+  "promptCompletionCount": 2,
+  "labeledAfterResume": [
+    {
+      "content": "context",
+      "label": "seed"
+    },
+    {
+      "content": "go",
+      "label": "coder"
+    },
+    {
+      "content": null,
+      "label": "coder"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency-js/message-labels-resume/test.js
+++ b/packages/agency-lang/tests/agency-js/message-labels-resume/test.js
@@ -1,0 +1,98 @@
+import {
+  main,
+  hasInterrupts,
+  approve,
+  respondToInterrupts,
+  __setLLMClient,
+} from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+// Labels must survive interrupt/resume.
+//
+// runPrompt bails out mid-tool-loop and snapshots the thread into
+// `self.messagesJSON`; resume revives it via MessageThread.fromJSON.
+// Snapshotting only `toJSON().messages` would revive through fromJSON's
+// legacy (bare-array) branch, which has no labels to read — so every
+// label would be gone after resume, and the promptCompletion logged by
+// the post-resume round would be silently unlabeled.
+//
+// This asserts on the LAST promptCompletion (the round after resume),
+// so it reads the labels as they exist on the far side of the round-trip.
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+let callIndex = 0;
+const client = {
+  async text() {
+    const idx = callIndex++;
+    if (idx === 0) {
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [new ToolCall("call-1", "askTool", {})],
+          model: "test",
+          usage: USAGE,
+          cost: COST,
+        },
+      };
+    }
+    return {
+      success: true,
+      value: { output: "answer", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const initial = await main();
+if (!hasInterrupts(initial.data)) {
+  throw new Error(`Expected an interrupt from askTool, got: ${JSON.stringify(initial.data)}`);
+}
+const final = await respondToInterrupts(initial.data, [approve()]);
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((l) => l.trim() !== "")
+  .map((l) => JSON.parse(l));
+
+const completions = events.filter((e) => e.data?.type === "promptCompletion");
+// The round AFTER resume — the one that had to survive the round-trip.
+const afterResume = completions[completions.length - 1];
+
+const labeled = (afterResume?.data?.messages ?? [])
+  .map((m) => ({
+    content: typeof m.content === "string" ? m.content : null,
+    label: m.label ?? null,
+  }))
+  .filter((m) => m.label !== null);
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      finalData: final.data,
+      promptCompletionCount: completions.length,
+      labeledAfterResume: labeled,
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/message-labels/agency.json
+++ b/packages/agency-lang/tests/agency-js/message-labels/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/message-labels/agent.agency
+++ b/packages/agency-lang/tests/agency-js/message-labels/agent.agency
@@ -1,0 +1,10 @@
+import { systemMessage, userMessage } from "std::thread"
+
+// The system message is deliberately UNLABELED and first: it sits at
+// index 0, so an off-by-one in the label/message alignment would show up
+// as "seed" landing on it. See test.js.
+node main() {
+  systemMessage("sys")
+  userMessage("context", label: "seed")
+  return llm("go", label: "coder")
+}

--- a/packages/agency-lang/tests/agency-js/message-labels/fixture.json
+++ b/packages/agency-lang/tests/agency-js/message-labels/fixture.json
@@ -1,0 +1,18 @@
+{
+  "promptStartLabel": "coder",
+  "loggedMessages": [
+    {
+      "content": "sys",
+      "label": null
+    },
+    {
+      "content": "context",
+      "label": "seed"
+    },
+    {
+      "content": "go",
+      "label": "coder"
+    }
+  ],
+  "labelReachedProvider": false
+}

--- a/packages/agency-lang/tests/agency-js/message-labels/test.js
+++ b/packages/agency-lang/tests/agency-js/message-labels/test.js
@@ -1,0 +1,74 @@
+import { main, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+// Debug labels are observability-only: they ride the thread and surface
+// in statelog, and never reach the provider. This pins both halves.
+//
+// The program pushes an UNLABELED system message first, then a "seed"
+// user message, then a "coder"-labeled llm() call. Assertions check
+// label-to-message PAIRING, not mere presence — a shifted array would
+// still contain both labels while attaching them to the wrong messages.
+//
+// promptCompletion logs the REQUEST payload, so its message array holds
+// sys + context + go, but NOT this round's assistant reply (pushed after
+// the event is emitted).
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+const COST = { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" };
+
+// Records the config the provider is handed, so a leaked `label` shows up.
+const seenConfigs = [];
+const client = {
+  async text(config) {
+    seenConfigs.push(config);
+    return {
+      success: true,
+      value: { output: "answer", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+await main();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((l) => l.trim() !== "")
+  .map((l) => JSON.parse(l));
+
+const promptStart = events.find((e) => e.data?.type === "promptStart");
+const promptCompletion = events.find((e) => e.data?.type === "promptCompletion");
+
+// The message array as logged, reduced to (content, label) pairs.
+const logged = (promptCompletion?.data?.messages ?? []).map((m) => ({
+  content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+  label: m.label ?? null,
+}));
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      promptStartLabel: promptStart?.data?.label ?? null,
+      loggedMessages: logged,
+      labelReachedProvider: seenConfigs.some((c) => "label" in c),
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
Lets you attach a debug label to `llm()`, `userMessage()`, `assistantMessage()`, and `systemMessage()`, and surfaces those labels in statelog — so a log reader can tell a verifier's injected message from a real user turn.

Plan (external-reviewed): `docs/superpowers/plans/2026-07-16-message-debug-labels.md`.

```agency
systemMessage("sys")
userMessage("context", label: "seed")
return llm("go", label: "coder")
```

```
promptStart      label: "coder"
promptCompletion messages: [ {sys}, {context, label:"seed"}, {go, label:"coder"} ]
```

## Labels never reach the provider

`runPrompt` strips `label` off `clientConfig` before the config is forwarded to smoltalk — the same destructure that already strips the retry fields. Nothing else about the request path changes. A test pins it, and it is not vacuous: `restClientConfig` is spread into the provider config, so deleting the strip turns that test red (verified by mutating it).

## The storage invariant

`messageLabels` lives on `MessageThread`, aligned with `messages` **by index**. An index-aligned array is what lets labels serialize with the thread (a `WeakMap` keyed by message identity would survive slicing but not `toJSON`). The cost is that nothing in the type enforces the alignment — so it is enforced by keeping the writers to a minimum:

- **`push(message, label?)` is the only append.** `addMessage()` delegates to it.
- **The constructor and `setMessages()` are the only replacements**, and both rebuild `messageLabels` to the new length.
- **Nothing else touches `this.messages`.**

This matters because a desync does not degrade gracefully — it shifts every later label onto the wrong message. Each writer has a test that fails on one.

Review of the plan caught two sites that would have silently mislabeled, both fixed by the above:
- `addMessage` was a second append path (public API, used by `lib/stdlib/threads.test.ts`) that would have appended a message with no label.
- A `messageLabels = []` field default would have desynced against a constructor-provided `messages` — reachable via `newSubthreadChild()`, and async `llm()` runs in a subthread, so a later push would have attributed its label to message 0.

Also: `fromJSON` restores labels **after** its internal `setMessages()` call, which would otherwise reset them.

## Deliberate behavior

- **One `llm(label:)` call tags more than one message** — its prompt plus the assistant message of every tool-loop round. Intended: the label marks "these messages came from this call". `promptCompletion` logs the *request*, so a round's assistant reply appears in the next round's dump, not its own.
- **`setMessages` drops labels**, so thread rewrites (summarization, `threadRepair`) lose them. Intended; documented.
- **`newSubthreadChild()` does not carry the parent's labels** (it seeds via `cloneMessages()`), and starts correctly aligned with all-null.
- Unlabeled messages are logged with **no `label` key at all**, so logs for programs that never label stay byte-identical.

## Testing

- 7 `MessageThread` unit tests (round-trip, legacy revive, and one per writer that fails on a desync).
- 6 runtime tests: the provider strip, prompt+completion labeling, the `promptCompletion` merge (asserting *pairing*, not presence), and the byte-identical unlabeled dump.
- `tests/agency-js/message-labels` e2e reads the statelog and asserts label-to-message pairing with an **unlabeled system message at index 0**, so an off-by-one shows up as a label landing on the wrong message. It also asserts no label reached the provider.
- Full unit suite 8323 passing; `lint:structure` clean; `make fixtures` zero churn (no codegen changes).

## Out of scope

- Auto-labeling runtime-injected messages (guard-approve feedback, tool-reply attachments) — the resumable-guards work picks this up and needs only `push(message, label)`.
- Filtering/slicing threads by label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
