### PR TITLE
Interrupt infrastructure for resumable guards: pass(), approval merge, handler scoping

### DIFF
--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev2.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev2.md
@@ -1,0 +1,574 @@
+# Plan review: resumable guards, rev 2 (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (rev 2)
+**Supersedes:** `2026-07-16-resumable-guards-REVIEW.md` (rev 1 review)
+**Verdict:** Much stronger. Every rev-1 blocker is genuinely resolved — not
+papered over — and the PR restructure is the right call. One new blocker: the
+handler-scoping coordinate (`guardDepth`) is not resume-stable, and the plan's
+argument that it needs no checkpoint treatment is unsound. Two more findings are
+worth settling before execution. Fix finding 1 and this is executable.
+
+All line references are `packages/agency-lang/`.
+
+---
+
+## Rev-1 blockers: all resolved
+
+Recording this so the next reader does not re-litigate:
+
+- **Handler budget (rev-1 finding 1)** → decision 5 + Task 1.3. The
+  registration-site rule is a better answer than the three options I sketched,
+  because it generalizes to every effect instead of special-casing `std::guard`.
+- **Aborted-stack handler chain (finding 2)** → PR 3's re-arm-before-dispatch,
+  with `guard.ts:356`/`:453` correctly identified as why the checkpoint-resume
+  precedent does not transfer.
+- **Root marker (finding 3)** → decision 11 + Task 2.1, checked at both the raise
+  site and the approve application. Both checks are needed; good.
+- **Wrong raise site (finding 4)** → Task 2.2 now raises at `prompt.ts:554`/`:699`.
+  The pre-call-gate framing ("raises *instead of* issuing the request — the
+  pending window is zero by construction") is exactly right and is the detail
+  that makes PR 2 sound.
+- **Negative-as-disarm (finding 6)** → decision 4, explicit key + clamp-and-warn.
+- **stdlib migration (finding 7)** → Task 2.5 audit-first.
+- **Frame-keyed trip id (finding 8)** → `stack.other`.
+
+---
+
+## Blocking finding
+
+### 1. `guardDepth` joins a replayed structure to a restored one, so it cannot be resume-stable.
+
+Task 1.3 argues: "Handler stacks are not serialized (rebuilt by deterministic
+replay on resume), so `guardDepth` needs no checkpoint treatment — but add a
+resume-cycle test pinning that replayed registrations record the same depths."
+
+The premise is true and the inference does not follow. The handler stack is
+rebuilt by replay; the **guard array is not** — it is restored wholesale from
+JSON (`stateStack.ts:883`, `stateStack.guards = (json.guards ?? []).map(guardFromJSON)`).
+`guardDepth` is a coordinate joining the two. Only one side is replayed, so its
+value cannot be assumed to survive a resume — and the concrete sequence says it
+does not:
+
+1. Original run: `handle` registers at guard depth 1. The guard installs. Depth
+   becomes 2. The trip raises and checkpoints.
+2. Resume: the stack is restored with **both** guards already in
+   `stack.guards` (the checkpoint was taken at the trip, so the tripped guard is
+   in the snapshot).
+3. Replay re-enters the handle block, `withPushedHandler` (`asyncContext.ts:148`)
+   calls `pushHandler` again — now recording `guardDepth = 2`.
+4. The rule "suspend guards deeper than `entry.guardDepth`" now suspends
+   nothing. The tripped guard is live for the handler's own `reviewerAgent`
+   call, which hits `enforceGuards` (`prompt.ts:554`) and throws.
+
+That is rev-1 finding 1 reappearing after any resume — i.e. after any real
+check-in, which is the feature's whole use case.
+
+Fork makes it worse. `fromJSON` leaves a branch with
+`guards.length < inheritedGuardCount` until `runBatch` re-prepends the parent's
+live references (the comment at `stateStack.ts:875-882` says so explicitly), so
+during resume the indices are transiently meaningless, and after rehydrate every
+branch-owned guard's index has shifted by the inherited count.
+
+**The mirrored coordinate in Task 2.2 is the dangerous one.** "Eligible handlers
+are those registered before the guard installed (the guard records the
+handler-stack depth at install)" — that depth lives on the **guard**, which *is*
+serialized. So it survives a checkpoint verbatim and is then compared against a
+handler stack rebuilt by replay whose length at that moment need not match. If
+the stored depth is too high, handlers registered outside the guard are skipped
+and the trip escapes to the user endpoint with a live handler sitting right
+there. Per CLAUDE.md that is not a bug tier we accept — a handler that must never
+be skipped, silently skipped. The plan's "serialized consideration: none" is
+wrong for this coordinate.
+
+**This exact lesson is already in this workstream.** #551's `draftRegionStart`
+tried to use `stack.stack.length` as a region coordinate and broke on resume for
+the same reason (the restored frame shifted the length by one). The fix that
+worked was: capture identity, memoize it in serialized branch-local state
+(`stack.other`), first-write-wins so replay cannot recompute a different answer.
+
+**Recommendation.** Make the coordinate identity-based and derive both directions
+from it. One entry per handler: the set of `guardId`s live at registration. Then
+
+- handler `i` may see guard `g`'s trip ⟺ `g.guardId ∉ entry_i.liveGuardIds`
+- guards suspended during handler `i` = those whose id is not in
+  `entry_i.liveGuardIds`
+
+One rule, one direction, no second coordinate on the guard, and ids are stable
+across resume and fork by construction (that is why `guardId` is serialized —
+`guard.ts:94-97` — and why time clones carry the parent's id). It still needs the
+memoize-in-`stack.other` treatment so a replayed registration cannot capture a
+post-restore id set; that is the part to design before execution, not to pin with
+a test afterward. As written, Task 1.3's test would be asserting a property the
+code does not have.
+
+Two smaller notes on the same task:
+
+- `pushHandler(fn)` (`context.ts:532`) has no access to a `StateStack` —
+  `ctx.handlers` lives on the context, the guards live on the ALS-resolved
+  per-branch stack. Capturing the id set inside `pushHandler` means reaching
+  through ALS into another object's fields from the context — the cross-object
+  field-reaching pattern the owner flagged as the main issue on #553. Capture in
+  `withPushedHandler` (`asyncContext.ts:143`) and pass it in.
+- The `suspended` flag must be **excluded** from `GuardJSON` while `disarmed`
+  (decision 4) must be **included**. Adjacent fields, opposite rules, and the
+  fail directions differ: a handler that propagates gets checkpointed mid-
+  suspension, and if `suspended` rides the snapshot the guard resumes
+  permanently unmetered. Worth an explicit line in Task 2.1 and a fixture
+  (handler propagates → user answers → resumed run still meters).
+
+---
+
+## Substantive findings
+
+### 2. Concurrent branch trips on a shared cost guard over-grant, and the merge table does not cover it.
+
+Decision 7 merges approvals **within one interrupt's handler chain**. It does not
+merge across concurrent interrupts, and fork case 1 says each branch raises its
+own.
+
+Three branches under a shared `CostGuard` (`cloneForBranch` returns `this`,
+`guard.ts:210`) all cross the limit at their next charge boundary and all raise.
+The handler answers `approve({maxCost: 0.50})` three times — once per interrupt,
+each honestly believing it granted fifty cents. The guard's limit rises by
+$1.50. Nothing in the plan bounds this, and the natural handler (approve a fixed
+top-up per trip) hits it immediately.
+
+Fork case 1's fixture ("after branch A's approve, branch B's raised trip
+re-checks its guard on resume; if the shared guard is no longer over budget, B
+resumes cleanly when answered") describes B *re-checking* but still says B raised
+and B gets answered — so B's approve still applies. The fix is to make the trip
+per-guard rather than per-branch: while an unanswered trip exists for a
+`guardId`, further branches detecting the same guard over budget attach to the
+pending trip instead of raising their own, and on answer they all re-check. This
+belongs in PR 2 with a fixture, and it interacts with decision 10's livelock
+error (a re-checking branch that is still over budget must not be treated as a
+handler that answered badly).
+
+### 3. The merge table's registration surface is v1 scope that costs more than it buys.
+
+Three problems, all with the same fix.
+
+- **Module-global state.** A runtime table `effect → merge` in a new
+  `effectMerge.ts` is per-run state in a TS module global — the standing rule
+  says never (use the per-execution context/GlobalStore). Two runs in one process
+  (the test suite) would share it; module isolation would leak.
+- **Cross-process divergence.** "The cross-process merge routes through the same
+  table" assumes both processes registered the same merges. A subprocess runs an
+  arbitrary program (`stdlib/agency.agency`'s `run()` compiles whatever it is
+  handed). If the child registered `std::guard`'s merge and the parent's program
+  did not, `mergeChainOutcomes` in the parent silently falls back to
+  outer-overwrites — the same interrupt merged one way in-process and another
+  across IPC. Silent, and exactly the kind of thing that surfaces as a
+  nondeterministic budget six months later.
+- **Serialization.** A user-registered merge is user code (an Agency closure)
+  consulted during the handler chain. Function refs across checkpoints are the
+  `FunctionRefReviver` problem that produced #513 and #544; a registry of them
+  consulted at adjudication time inherits that whole surface.
+
+None of this is needed for what v1 ships. The only effect that needs a merge is
+`std::guard`, and its merge is a constant. **Cut `defineInterruptMerge` and the
+`std::effects` module from v1.** Ship `effectMerge.ts` as a built-in lookup —
+`std::guard` → additive, everything else → today's overwrite. That kills all
+three problems, and the registration surface can arrive with the typed-payloads
+work (#555), which is where the shape will actually be informed.
+
+### 4. Time-clone approve is erased at the join.
+
+PR 3 + fork case 2: a branch's time clone trips, the handler approves
+`{maxTime: 5m}`, and Task 2.3 resolves the guard from the raising branch's own
+stack — so the **clone** is extended, correctly. The branch then runs its five
+minutes and joins.
+
+At the join, `runBatch` advances the parent by the max clone working time
+(`guard.ts:404` `addElapsed`, and the `cloneForBranch` docstring at `:409-424`).
+The parent's own `timeLimit` was never extended — the approve went to the clone —
+so the parent's guard is now over budget by roughly the granted amount and trips
+at the next boundary, with no work done in between. The user approved five more
+minutes and got a trip anyway.
+
+Not obviously wrong (the approve was branch-local), but it is surprising enough
+that it needs an owner decision, not an executor's guess: does an approve on a
+clone also extend the parent by the same delta (the parent is the budget the user
+named), or is it branch-local and the join-trip is correct? Either way it wants
+the fixture — fork, time clone trips, approve, join — because today the plan
+would ship whichever behavior falls out.
+
+---
+
+## Smaller notes
+
+- `costLimit` and `timeLimit` are `readonly` (`guard.ts:165`, `:317`) and are
+  read by `toJSON` and `cloneForBranch`. `extendBudget`'s `limit += delta` needs
+  them mutable; trivial, but `cloneForBranch` computing `remaining` from a
+  mutated `timeLimit` is the interaction to keep an eye on for finding 4.
+- Decision 10's livelock check is stated for "the tripped dimension over budget
+  and armed." For cost that is `spent > costLimit`; for time the equivalent is
+  `currentElapsed() >= timeLimit` — worth naming both, since `TimeGuard`'s trip
+  is latch-based (`tripped`/`consumed`) and re-arming with a negative remaining
+  gives `setTimeout(…, 0)`, i.e. a re-trip rather than a clean error.
+- Task 2.2's "eligible handlers are those registered before the guard installed"
+  and decision 5's "a handler registered inside a guarded block cannot see that
+  guard's own trip" are the same rule stated from opposite ends. Say it once,
+  derive both, per finding 1.
+- **Estimate.** PR 1's 2–3 days assumes `guardDepth` is a small change. Making
+  the coordinate resume-stable — plus the full existing handler suite green
+  before new behavior — is more like 4–5. PR 2's 4–5 is right if finding 2 lands
+  there. PR 3's 2–3 is honest about the recomposition.
+
+## What is right
+
+The PR restructure earns its keep: PR 1 is testable with ordinary interrupts and
+would have been the hidden two-thirds of PR 2 otherwise. Raising at the pre-call
+gate for a zero pending window, the explicit disarm key with clamp-and-warn, the
+root marker checked at both sites, the audit-first migration, and the
+`tripped`-vs-`consumed` distinction in Task 2.1 are all correct against the code.
+The fork/race/IPC section remains sound apart from finding 2, which is new
+scope from decision 2 rather than an error in the old analysis. Deferring the
+`effect` syntax and typed payloads to #555 is the right cut.
+
+## Recommended next steps
+
+1. Redesign the scoping coordinate as identity + memoized capture (finding 1),
+   and re-specify Tasks 1.3 and 2.2 around the single derived rule. This is the
+   only thing blocking execution.
+2. Owner decides finding 4 (does a clone approve extend the parent?).
+3. Add the shared-guard trip dedupe to PR 2 (finding 2).
+4. Cut `defineInterruptMerge` from v1; ship the built-in table (finding 3).
+5. Re-estimate PR 1.
+6. Work through the anti-pattern audit below — finding A3 is a correctness gap,
+   not just a style one.
+
+---
+
+# Addendum: audit against `docs/dev/anti-patterns.md`
+
+**Short answer to "is the plan writing declarative interfaces that encapsulate
+complexity?": not yet.** The instinct shows up twice — "factor the raise dance
+into a shared helper" (Task 2.2) and "this needs a dedicated helper" (PR 3) — but
+everywhere else the plan specifies the *how* at each call site rather than naming
+a *what* and hiding the how behind it. Five places, below, with the declarative
+alternative for each. A2 and A3 are the ones that pay for themselves immediately:
+each one deletes a bug I filed above rather than merely tidying it.
+
+The bar here is not abstract. `guard.ts:20-59` already states the contract the
+plan should be extending: *"`StateStack` and `Runner` only ever talk to the
+interface — no `instanceof` checks, no variant-specific branching."* Three of the
+findings below are the plan quietly breaking that promise.
+
+### A1. Suspension is specified as three call-site edits. (*Imperative code everywhere*, *Leaky abstractions*)
+
+Task 1.3: guards deeper than the handler's registration are "skipped by
+`enforceGuards`, excluded from charge accumulation, and their time clocks
+paused." That teaches three separate places what suspension means, and adds a
+`continue`-if-suspended to `enforceGuards` (`stateStack.ts:569`) — a filter at
+the call site standing in for a property of the guard.
+
+Declarative version: suspension is a **guard lifecycle state**, which is exactly
+what the existing interface already models (`install`/`uninstall`/`pause`/`resume`
+/`charge`/`check`). Add `suspend()` / `unsuspend()` to the `Guard` interface. A
+suspended guard's `check()` returns null and its `charge()` no-ops; `TimeGuard`'s
+`suspend()` is `pause()`. **`enforceGuards` and the charge path then do not
+change at all**, and the per-variant differences stay inside the variant, per the
+interface's own contract.
+
+The selection ("which guards does this handler suspend") is a second *what*, and
+it wants its own name too — one function, `stack.guardsHiddenFrom(entry)` or
+similar, that finding 1's identity rule lives inside. The plan currently states
+that rule in prose in two tasks (1.3 and 2.2) from opposite ends, which is how it
+ended up as two mirrored coordinates that have to be kept consistent by hand —
+the *Leaky abstractions* entry almost verbatim: understanding one requires
+reading the other.
+
+### A2. `previousSignal` is order-dependent mutable state, and PR 3 is entirely a symptom of it. (*Order-dependent mutable state*)
+
+This is the highest-leverage item in the audit.
+
+Today the composed abort signal is **accumulated by mutation**: each
+`installAbortPlumbing` saves `previousSignal = stack.abortSignal` and overwrites
+`stack.abortSignal` with `AbortSignal.any([previous, mine])` (`guard.ts:451-460`);
+`uninstall` restores it. The chain of who-composed-what lives implicitly in
+per-guard fields, in install order.
+
+Every hard thing in PR 3 falls out of that choice. "In-place re-arm must restore
+`previousSignal` first, then re-compose"; "with nested time guards the
+composition is a chain, so every composition above the tripped guard rebuilds";
+"this needs a dedicated helper plus a fixture." And the bug I filed in the rev-1
+review — a naive re-install captures the already-aborted composed signal as
+`previousSignal` and poisons the stack permanently — is precisely the failure
+mode the anti-patterns entry predicts: *"Reordering lines breaks things
+silently."*
+
+Declarative version: **derive the signal instead of accumulating it.** The stack
+composes `abortSignal` on demand from its own base signal plus the live
+controllers of its armed guards — one function, `stack.recomputeAbortSignal()`,
+called when the guard array or any guard's armed state changes. `previousSignal`
+is deleted outright. `install`/`uninstall` stop mutating `stack.abortSignal`.
+Re-arm after an approve becomes "the guard is armed again; recompute" — no
+restore-then-recompose ordering, no chain rebuild, nothing above the tripped
+guard to touch, because there is no accumulated chain to repair. The nested-guard
+fixture still earns its place, but as a regression pin rather than the thing
+holding the design together.
+
+This is worth doing even though it touches shipped code. It converts PR 3's
+"genuinely fiddly" from a property of the task into a property of the old
+representation, and it removes a foot-gun that will otherwise be re-discovered by
+whoever adds the third guard variant.
+
+### A3. One Agency guard is two runtime guards, and the interrupt shape hides it. (*Leaky abstractions* — and a correctness gap)
+
+`_pushGuard` returns `string[]`, not a string (`lib/stdlib/thread.ts:263-291`).
+`guard(cost: $1, time: 5m)` pushes a **`CostGuard` and a `TimeGuard` — two
+objects, two `guardId`s** — with the label copied onto both. That is why
+`__tryCall` matches on `ownedGuardIds` (plural) and why `_popGuard` takes an id
+array.
+
+The plan's model does not survive contact with that:
+
+- `data.guardId` is a single id, so it names **one** of the pair.
+- `approve({maxCost: 0.5, maxTime: 60000})` names both dimensions, but Task 2.3
+  resolves *one* guard by that id and applies "additive extends per payload
+  dimension." The sibling guard's id is not in the interrupt data at all, so the
+  other dimension has nothing to apply to.
+- `disarm: ["cost", "time"]` has the same problem.
+- The interrupt data's `maxCost`/`maxTime` "for context" cannot both be filled
+  from the resolved guard — it only knows its own limit.
+- Decision 3 ("an omitted dimension continues unchanged") reads as a statement
+  about one object's two dimensions. There is no such object; the two dimensions
+  are independent guards that already continue independently.
+
+The fix is the abstraction the runtime is missing rather than a patch: the id
+array from `_pushGuard` **is** the Agency-level guard, and nothing names it
+today. Introduce that name — a `GuardScope` over the pushed ids, with
+`extend(payload)`, `disarm(dimensions)`, `snapshot()` (label, configured budgets,
+spent, which dimension tripped), and a single resolver that takes the raising
+branch's `StateStack` plus the scope identity. Then:
+
+- the interrupt carries the scope, `dimension` says which member tripped;
+- Task 2.3's approve application is `scope.extend(mergedPayload)` — one call, no
+  `stack.guards` walk, no innermost-match rule at the call site;
+- the fork/IPC rules the plan repeats in prose across four places ("resolve from
+  the raising branch's own stack, never a global lookup") become one property of
+  one resolver, tested once;
+- the root-marker check (decision 11) has one place to live.
+
+This also removes the last reason for PR 2 and PR 3 to touch `stack.guards`
+directly, which is what keeps `guard.ts`'s no-variant-branching contract intact.
+
+### A4. The merge arm is a three-way state machine over mutable flags. (*Useless special cases*, *Imperative code everywhere*)
+
+Task 1.2 specifies: "no prior approval → hold the value; prior approval + merge
+registered → `held = merge(held, next)`; prior approval + no merge → overwrite."
+That is three branches plus the loop's existing `hasApproval` / `approvedValue`
+mutable pair (`interrupts.ts:282-287`, `:295-297`) — and the third branch is the
+*Useless special cases* entry: "no merge registered" is only special because the
+table is partial.
+
+Declarative version: make the table total (default merge = `(inner, outer) =>
+outer`, which **is** today's overwrite), collect the approvals as the chain
+walks, and render the outcome once:
+
+```ts
+const merge = mergeFor(effect);          // total; default is outer-wins
+const approval = approvals.reduce(merge); // empty → none; one → itself
+```
+
+No special case, no `hasApproval` flag, no "hold" state, and "innermost-first" is
+expressed by the order of the array rather than by prose about argument
+positions. `mergeChainOutcomes`'s double-approve arm calls the same `mergeFor`,
+so the cross-process path is the same code rather than a parallel one that has to
+be kept in sync (*Inconsistent patterns*). This composes with rev-2 finding 3: if
+the table is built-in and total, the module-global registry problem disappears
+along with the special case.
+
+### A5. Two spellings of one verdict. (*Inconsistent patterns*)
+
+Task 1.1 keeps `undefined` working and adds `pass()` — reasonable for
+back-compat, but the chain loop then handles one concept two ways forever.
+Normalize at the boundary: the moment a handler returns, map `undefined` → `pass`
+once, and let everything downstream (the loop, `handlerDecision`, the statelog
+variant) see a single shape. One line, and the back-compat story stops leaking
+into the adjudication logic.
+
+### What the plan already does right
+
+Reuse is good throughout: the `agency.interrupt` dance, the reply-attachments
+pattern for PR 4, `pause()`/`resume()` for the clock freeze, and the existing
+generic statelog events (decision 13) instead of new bespoke ones. No duplicated
+utilities, no dynamic imports, no magic numbers. The problem is narrower than
+"the plan is imperative": it names helpers where it noticed friction, and
+specifies call-site edits everywhere it did not. A2 and A3 are where that costs
+real correctness.
+
+---
+
+# Addendum 2: the test plan
+
+Two questions: would these tests fail if the code broke, and what is missing?
+**Five of the listed tests would pass with a bug I have already filed still
+live**, and the single most important path in the feature — approve after a real
+checkpoint and resume — has no test at all.
+
+## Tests that would not fail when the code breaks
+
+### T1. The shared-guard fixture cannot see the over-grant.
+
+Fork case 1's fixture: "after branch A's approve, branch B's own raised trip
+re-checks its guard on resume; if the shared guard is no longer over budget, B
+resumes cleanly when answered." Every assertion there is about B *not hanging*.
+The over-grant in finding 2 — three branches, three approves of $0.50, limit
+rises $1.50 — satisfies this fixture perfectly. Assert the **resulting limit**
+observably: after the approves settle, a spend that fits one grant but not three
+must trip.
+
+### T2. "Double-approve accumulates via merge" passes when merge is broken.
+
+Merge gives +$1.00, today's overwrite gives +$0.50, and **both let execution
+continue**. If the fixture asserts "the block finished", it passes with the merge
+silently degraded to overwrite — i.e. it pins nothing. It has to spend into the
+gap: after two `approve({maxCost: 0.50})`, a further $0.75 of spend must *not*
+trip. Same for the cross-process merge-parity unit test.
+
+### T3. The resume-cycle test asserts an implementation detail, not the behavior.
+
+Task 1.3: "add a resume-cycle test pinning that replayed registrations record the
+same depths." Two problems. If finding 1 is fixed by moving to identity, "the
+same depths" no longer means anything and the test is dead weight. If depth
+stays, the same depths are exactly what does *not* hold — so the plan lists as a
+pin a test whose job is to fail.
+
+Assert the behavior instead, which is implementation-independent: trip →
+propagate → resume → the handler runs → its own `llm()` is not metered by, and
+not blocked by, the tripped guard. That test catches finding 1 whatever the
+coordinate ends up being.
+
+### T4. The suspension fixture uses an untripped guard, so it covers two of three surfaces.
+
+Task 1.3's fixture is "an ordinary interrupt raised inside `guard(cost:)`" — a
+guard that has *not* tripped. But suspension has three surfaces (the task says
+so): the `enforceGuards` gate, charge accumulation, and the clocks. The pre-call
+gate (`prompt.ts:554`) only refuses when the guard is **already over budget**, so
+an untripped guard cannot exercise it. A suspension that correctly skips charging
+but forgets the gate passes this fixture and then fails on the first real trip —
+which is the only situation the feature exists for.
+
+Needs the tripped variant: guard trips → handler's own `llm()` runs to
+completion.
+
+### T5. The negative-clamp fixture asserts the warning, not the safety property.
+
+"Negative-clamp warning" — the risk decision 4 exists to prevent is *fail-open*:
+metering silently disappearing. A fixture that asserts a warning was printed does
+not assert that the guard still meters. Assert the trip: after a clamped negative
+approve, the guard must still trip on the next overspend. The warning is the
+nice-to-have; the trip is the point.
+
+## Missing tests
+
+### M1. Nothing exercises approve across a real checkpoint. (The headline use case.)
+
+Every approve fixture in Task 2.5 uses an in-program `handle` block. Those answer
+via `interruptWithHandlers` **before** `runner.halt` is ever called
+(`agencyInterrupt.ts:168` vs `:203`) — no halt, no checkpoint, no serialize, no
+restore. So the entire resume path is exercised by exactly one fixture,
+`unhandled-halts`, which halts and never comes back.
+
+That means: the "check-in" story from the spec (run five minutes, look, grant
+more) has no test; `stack.other`'s trip-id resume idempotency (Task 2.2) has no
+test; finding 1 has no test; and every guard-state mutation is only ever tested
+against a live in-memory guard, never a `guardFromJSON` one.
+
+The harness already supports it — `{"action": "resolve", "resolvedValue":
+{"maxCost": 0.5}}` maps to `approve(value)` (`lib/templates/cli/evaluate.ts:47`;
+note the action name for a *valued* approve is `resolve`, not `approve`, which is
+worth telling the executor). Add at minimum: trip with no in-program handler →
+harness approves with a payload → block resumes → later trip still fires. That
+one fixture covers more of the risk than half the current list.
+
+### M2. The root marker has zero tests, and it is the hard safety property.
+
+Decision 11 and Task 2.1 build the marker; the fixture list never mentions it.
+Needs three: an approve naming a root guard's id is refused; a root trip still
+throws rather than raising (the `--max-cost` spawn path, exit 3); and
+`isRootBudget` survives a `toJSON`/`fromJSON` round trip. The third matters
+because the marker is new serialized state, and if it drops on resume, root
+budgets become approvable — silently, and only after a checkpoint.
+
+### M3. Rev 2 dropped rev 1's mutator unit tests.
+
+Task 2.1 lists `guard.test.ts` under Files and then enumerates no tests. Rev 1
+had them: extend-then-check passes under the new limit; disarm survives a
+`toJSON`/`fromJSON` round trip; the time extend resets the latch. That last one is
+exactly the `consumed`-not-reset fail-open the task's own text calls out — the
+plan describes the bug and deletes the test for it. Restore the list and add
+`isRootBudget` + `disarmed` round trips.
+
+### M4. `suspended` must not serialize — no test.
+
+Per the addendum-1 note: a handler that propagates gets checkpointed while guards
+are suspended. Pin it: propagate from inside a handler → user answers → resume →
+the guard still meters. Absent this, a `suspended` flag that leaks into
+`GuardJSON` produces an unmetered run that no other test can see.
+
+### M5. Approve naming both dimensions — the fixture that would have caught A3.
+
+The list has "omitted-dimension-continues", which names one dimension. Nothing
+names *both* (`approve({maxCost: …, maxTime: …})` on a `guard(cost:, time:)`).
+That is precisely the case that breaks on the two-objects-two-ids gap in A3, and
+it is the natural thing a user writes. Add it.
+
+### M6. Others, briefly.
+
+- **`pass()` has no tests at all** (Task 1.1). Its stated motivation is match-arm
+  exhaustiveness, so it wants a typechecker test that a `match` over verdicts is
+  exhaustive with `pass()` present; plus `undefined` still working (the
+  back-compat claim); plus the statelog decision variant.
+- **Time-clone approve → join** (finding 4): no fixture either way.
+- **IPC payload fidelity** is listed as "verify", not as a test. Make it one:
+  disarm arrays and float deltas across the boundary.
+- **Unhandled under `--policy`**: Task 2.4 says policy answers headless runs but
+  lists no fixture. Given decision 1 is a breaking change and `--policy` is half
+  the documented migration path, it needs one. Same for an unhandled trip inside
+  a subprocess child.
+
+## Flakiness
+
+Cost trips are deterministic (synthetic cost); time trips race. #556 already
+carries six wall-clock fixtures (sleep 2000 vs 600ms) and the owner flagged the
+flakiness. Two items in this plan add more of that kind, and one of them cannot
+work as described:
+
+- **"omitted-dimension-continues (cost+time guard: cost trips, approve cost, time
+  later trips with its ORIGINAL remaining allowance)"** — asserting *original
+  remaining allowance* against a wall clock is a race with itself. Either it gets
+  a generous margin and stops discriminating (it would pass if the clock had been
+  reset), or it gets a tight one and flakes. Assert the elapsed accounting as a
+  unit test on the guard, or read it from statelog; keep the fixture to the
+  coarse "the time guard still trips."
+- **PR 3's time approve-resume** is the same shape. The `promptStart`/
+  `promptCancelled` pairing assertion is good and deterministic; the timing part
+  is not.
+
+Rule of thumb worth writing into the plan: if a behavior can be expressed with a
+cost guard, use a cost guard. Reserve wall-clock fixtures for things that are
+irreducibly about time.
+
+## One discipline for the migration
+
+Task 2.5 says the guards sweep "doubles as the breaking-change acceptance test."
+That is only true under a rule the plan does not state: **every migrated
+fixture's expected output must be byte-identical after adding the
+`handle … reject()` wrapper.** If an expected output changes, that is a semantic
+regression to explain, not a diff to accept. Hand-migrating ~29 trip fixtures is
+exactly where a fixture quietly starts passing for a different reason, and the
+sweep is the only thing standing between this change and every shipped guard
+behavior.
+
+## What is good
+
+`reject-runs-salvage (draft and finalize)` is the right regression surface for
+#553/#556. `draftValue` matches the savedDraft, `inside-guard handler does not
+see the trip`, `livelock runtime error`, and `propagate-discards-approvals` each
+pin a specific decision rather than a vibe. Running the full existing
+handler/interrupt suites unchanged *before* adding new behavior tests (PR 1
+validation) is exactly right for a change to safety infrastructure, and the
+race-loser fixture (case 4) is a genuinely non-obvious case to have caught.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev3.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev3.md
@@ -1,0 +1,204 @@
+# Plan review: resumable guards, rev 3 (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (rev 3)
+**Supersedes:** the rev-2 review + its two addenda.
+**Verdict:** Every rev-2 finding, every anti-pattern item, and every test-plan
+item is folded in — correctly, not cosmetically. `GuardScope`, the total merge
+table, suspension-on-the-interface, and the derived signal are all the right
+shape. What is left is smaller and more concrete than last round: **two keying
+bugs that would ship silently, one mechanism that is cancelled out by existing
+runtime behavior, and two design details that need naming.** Findings 1 and 2
+are blocking; the rest are a morning's work.
+
+All line references are `packages/agency-lang/`. Verified against the code today.
+
+---
+
+## Blocking
+
+### 1. "Keyed by the branch-local registration ordinal (replay-stable)" is the same unestablished claim rev 2 made about depth.
+
+Decision 4 and Task 1.3 fix the coordinate (identity, not index) and then key the
+memo by "the handler's per-branch registration ordinal," asserting replay-
+stability in parentheses. That parenthetical is doing all the work, and it does
+not hold either way you can build it:
+
+- **A monotonic counter** (the only way to avoid collisions on push/pop reuse —
+  `withPushedHandler` pops in `finally`, so a naive "current handler-stack
+  length" reuses key 0 for every sibling `handle`) lives in `stack.other`, so it
+  serializes. On replay it keeps counting from the restored value, every
+  registration gets a fresh key, every memo lookup misses, and the capture
+  recomputes against the post-restore stack. That is the rev-2 blocker, intact.
+- **A resetting or callsite-shaped key** collides across loop iterations, and
+  first-write-wins then hands iteration 2 iteration 1's ids. This one is worse
+  than it sounds: `nextGuardId()` mints a **fresh** id per push (`guard.ts:14-18`),
+  so iteration 2's guard ids appear in no earlier iteration's set. A handler
+  registered inside `for (...) { guard(...) as { handle {...} with {...} } }`
+  would compute `guardsHiddenFrom` = "everything not in the stale set" = its own
+  enclosing guard, and suspend the guard it is genuinely inside. Fail-open, on the
+  metering path.
+
+The plan is right that the memo is the #551 lesson; it picked the wrong half of
+it. #551 keyed `stack.other.draftRegions` by **content** (`ids.join(",")`), and
+`agencyInterrupt` keys its replay-stable state by **callsite**
+(`__interrupt_${callsite.stepPath}`, `agencyInterrupt.ts:152`). Neither is an
+ordinal, because an ordinal is a count of things that happened — exactly what
+replay does not reproduce.
+
+Name the key concretely and show it survives both a resume and a loop before
+execution. This is the one item I would not let an executor resolve inline: it is
+the same failure that has now been designed twice, and the second time it wore a
+fix's clothes.
+
+### 2. `__guardTrip_<scope>` auto-approves every later trip of the same scope.
+
+Task 2.2 keys resume idempotency `__guardTrip_<scope>` in `stack.other`. The
+`agency.interrupt` dance it reuses reads that key like this
+(`agencyInterrupt.ts:158-162`):
+
+```ts
+const persistedId = frame.locals[key];
+if (persistedId !== undefined) {
+  const resp = ctx.getInterruptResponse(persistedId);
+  if (resp) return resp;               // <-- short-circuit, no handlers, no checkpoint
+}
+```
+
+A scope-keyed id is stable for the scope's whole lifetime. So trip #2 of the same
+scope finds trip #1's persisted id, finds its recorded response, and **returns the
+first approve verbatim** — no handler chain, no user, no new grant applied
+correctly. A guard approved once is approved forever, silently, and the budget
+stops meaning anything.
+
+The key needs a per-trip generation (`__guardTrip_<scope>:<n>`, bumped when a trip
+is answered and cleared). Rev 2's rationale for scope-keying — "the same trip must
+be answerable no matter which step boundary sees it first" — is satisfied by a
+generation too; it only needs to be stable *within* one trip, not across all of
+them.
+
+Worth saying: **the plan's own headline fixture catches this** ("approve → the
+block resumes → a later trip still fires"). That is exactly the test-plan
+discipline from the last round paying off. Fix the key anyway rather than
+discovering it in execution.
+
+---
+
+## Substantive
+
+### 3. `suspend()` via `pause()` is undone by the Runner on the next step.
+
+Decision 5 says `TimeGuard.suspend()` pauses the clock, and Task 2.2 relies on it:
+"the tripped clock freezes during deliberation."
+
+But `Runner.beforeStep` (`runner.ts:265-267`) does:
+
+```ts
+this.stack?.guards.forEach((g) => g.resume(this.stack!));
+```
+
+unconditionally, at **every step-equivalent entry point** — and a handler body is
+Agency code that executes steps. So the first step inside the handler un-pauses
+every suspended TimeGuard and the clock runs for the whole deliberation. The
+reviewer agent's thinking time is charged to the budget it was called to
+adjudicate.
+
+The fix is one line — `resume()` must no-op while `suspended` — but it has to be
+*stated*, because nothing would catch it: freezing a wall clock is exactly the
+category decision 14 says not to write fixtures for. Suggest making it a property
+of the interface contract in `guard.ts`'s docstring (the lifecycle list at
+`:20-59` is the place: suspension outranks pause/resume) plus a unit test on the
+guard object — `suspend(); resume(stack); assert still paused` — which is
+deterministic and cheap.
+
+### 4. A derived signal recomposes into a *new object*, and in-flight readers keep the old one.
+
+Task 3.1 is right and I still endorse it. One detail it needs: `AbortSignal.any([...])`
+returns a fresh signal each time it is called, so every `recomputeAbortSignal()`
+replaces `stack.abortSignal` with a new object. Anything that already read the
+signal is now listening to a detached one — smoltalk took `ctx.getAbortSignal(stateStack)`
+when the request was issued, and race-loser cancellation holds references too.
+Under today's install/uninstall the swap happens rarely; under the new design it
+happens on every arm, disarm, suspend, and unsuspend, i.e. constantly, and during
+in-flight work by construction (that is the point of the feature).
+
+Fail direction: a guard that arms while a request is in flight cannot cancel it.
+
+The fix keeps the design and makes it better: give the stack **one stable
+`AbortController`** whose signal is `stack.abortSignal` forever, and have
+`recomputeAbortSignal` re-subscribe it to the armed guards' signals rather than
+re-wrap them. References never go stale, `previousSignal` still dies, and re-arm
+is still "recompute." Worth pinning: arm a guard mid-flight → the in-flight op
+still aborts.
+
+### 5. The dedupe marker's placement decides its semantics, and the plan does not say so.
+
+Decision 12 says "dedupe per scope"; Task 2.2 implements it as "the shared guard
+object holds a live (unserialized) pending-trip marker." Two consequences the plan
+should state outright, because an executor reading "per scope" will build it
+differently:
+
+- **It is cost-only, and that is correct.** `CostGuard.cloneForBranch` returns
+  `this` (`guard.ts:210`) so branches share one object and one marker. `TimeGuard`
+  clones are separate objects (`guard.ts:421-424`) carrying separate budgets — N
+  branch trips there are N *real* budgets, and N grants are right, not an
+  over-grant. An executor who hoists the marker onto the scope (as "per scope"
+  implies) would dedupe unrelated time trips and silently under-grant. Say
+  "shared-object dedupe, which is cost-only by construction, and time clones are
+  intentionally exempt."
+- **Unserialized means the over-grant returns across a checkpoint.** Branch trips,
+  propagates to the user, run checkpoints; on resume the marker is gone and the
+  siblings raise again. The window is narrow but it is the resume path, which is
+  the path this feature exists for. Either serialize the marker (and own its
+  cleanup) or document that dedupe is best-effort within a process lifetime.
+
+### 6. `scopeIds` will not reach time clones.
+
+Task 2.1 says each member is stamped with the scope's id array, "serialized on
+`GuardJSON` like `guardId`, so clones and resume keep it." Serialization covers
+resume; it does not cover clones. `TimeGuard.cloneForBranch` (`guard.ts:421-424`)
+builds a fresh object and copies fields **by hand** — `clone.guardId = this.guardId`
+is the only one today. Without an explicit `clone.scopeIds = this.scopeIds`, a
+branch's clone resolves to an empty scope and approve fails on exactly the
+fork path. One line, easy to miss, and `guardId` is the precedent showing the
+pattern is hand-maintained.
+
+---
+
+## Smaller notes
+
+- **Decision 3's breaking change needs a witness.** Task 1.3 requires the existing
+  handler/interrupt suites green on the new entry shape before new tests land —
+  right for safety infrastructure. But if registration-site metering is genuinely
+  breaking for ordinary interrupts, at least one existing fixture should move. If
+  literally nothing changes, treat that as evidence the new path is not reached,
+  not as evidence of safety, and go find why.
+- **Task 3.3 gate:** I agree with the recommendation — the grant follows the
+  budget. The user approved five more minutes against the guard they named; a trip
+  immediately after the join, with no work in between, is the surprising outcome,
+  and "surprising" is expensive in a feature whose whole purpose is a human
+  deciding to continue. The branch-local reading is defensible but the burden of
+  documentation it carries is heavier than the implementation it saves.
+- **Estimates** are now credible. PR 2 at 5–6 days is the right shape given
+  `GuardScope` + dedupe + the audit.
+
+## What is right
+
+The fold is honest. `GuardScope` is the abstraction the runtime was missing and it
+absorbs four rules that were prose (fork resolution, root refusal, livelock,
+snapshot) into one resolver. Cutting `defineInterruptMerge` to #555 while keeping
+a total constant table gets the semantics with none of the surface. Suspension on
+the `Guard` interface leaves `enforceGuards` untouched, which is what the
+interface promised. And the test plan is now the strongest part of the document:
+spend-into-the-gap is the right universal discipline, the headline
+approve-across-a-checkpoint fixture is the one that would have caught the most,
+and it catches finding 2 above for free.
+
+## Recommended next steps
+
+1. Name the memo key concretely and prove it against a resume **and** a loop
+   (finding 1).
+2. Add the trip generation to the interrupt key (finding 2).
+3. Add the three one-liners: `resume()` no-ops while suspended, the stable stack
+   controller, `clone.scopeIds` (findings 3, 4, 6).
+4. State the dedupe marker's cost-only scope and its checkpoint caveat (finding 5).
+5. Owner decides Task 3.3.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev4.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev4.md
@@ -1,0 +1,310 @@
+# Plan review: resumable guards, rev 4 (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (rev 4)
+**Supersedes:** the rev-3 review.
+**Verdict:** The prose rewrite worked — Part 1 is genuinely useful context and
+the trip-site taxonomy is the right instrument for the question it answers. Four
+of the six rev-3 findings are fixed correctly. But **the two blocking ones are
+not fixed; they are re-stated with new mechanisms that fail the same way**, and
+in one case the plan's justifying sentence is contradicted by
+`docs/dev/interrupts.md`. There is also a third enforcement surface the plan does
+not know about, and the change it proposes there would silently stop enforcing.
+
+All line references are `packages/agency-lang/`. Everything below was checked
+against the code and docs today.
+
+---
+
+# The pattern worth naming first
+
+This plan has now tried three times to connect "a handler" to "some guards"
+across a checkpoint, and rev 4 also needs to connect "a trip" to "its answer"
+across one. The four attempts:
+
+1. Rev 2: guard-array **depth**. Killed — joins a replayed structure to a
+   restored one.
+2. Rev 3: a **serialized ordinal counter**. Killed — replay keeps counting, so
+   the memo never hits.
+3. Rev 4: an **in-memory ordinal counter**, reset per process. Killed below.
+4. Rev 4: a **serialized generation counter** for the trip id. Killed below.
+
+Every one is a count of things that happened. That is the common factor, and it
+is why they keep failing: **replay does not re-run what happened. It re-runs the
+path to the checkpoint.** Completed work is skipped on purpose — that is the
+entire function of the step counters (`docs/dev/interrupts.md:18`: "statements
+with lower indices are skipped").
+
+The codebase already has two proven replay-stable keys, and neither counts
+anything:
+
+- `agencyInterrupt` keys persisted interrupt ids by **callsite**, stored **per
+  frame**: `frame.locals[\`__interrupt_${callsite.stepPath}\`]`
+  (`agencyInterrupt.ts:152-162`). The compiler determines the key; execution
+  history does not.
+- #551's `draftRegionStart` keys by **content**: `stack.other.draftRegions[ids.join(",")]`.
+  The data determines the key.
+
+So the rule for this plan, worth writing into it as a constraint rather than
+rediscovering a fifth time: **a key that must survive replay is derived from
+position or from data, never from a count of executions.** Both blockers below
+are the same task, and they should be designed together.
+
+---
+
+# Blocking
+
+## 1. The in-memory ordinal is not replay-stable, and the sentence justifying it is false
+
+Section 1.3b says:
+
+> Replay re-executes every registration of the branch from the top, in the
+> original order (that is what replay is), so the counter reproduces the
+> original ordinals.
+
+That is not what replay is. Replay re-enters the code and **skips completed
+work**:
+
+- `docs/dev/interrupts.md:18` — "On resume, statements with lower indices are
+  skipped, and execution picks up at the right statement."
+- `docs/dev/interrupts.md:157,184` — completed loop iterations are skipped
+  outright: `if (__currentIter_K < __stack.locals.__iteration_K) { __currentIter_K++; continue; }`.
+
+So the registrations that re-execute on replay are only the ones still **open**
+at checkpoint time. Every `handle` block that already finished and popped is
+skipped — and its ordinal disappears from the sequence.
+
+**The simplest break needs no loop at all.** Two sequential handle blocks in a
+node:
+
+```
+handle { setupWork() } with (i) { ... }      // registration ordinal 0, completes, pops
+handle {                                      // registration ordinal 1
+  guard(cost: $1) as { codingAgent(task) }    // trips, propagates, CHECKPOINT
+} with (i) { ... }
+```
+
+Original run: the first block registers at ordinal 0 and pops; the second
+registers at ordinal 1 and memoizes its true id set at `__handlerGuards_1`.
+Resume: the in-memory counter starts at 0, the first statement is skipped
+(completed), so **the second block's registration is now the first one executed**
+and asks for ordinal 0. It hits `__handlerGuards_0` — the *first* block's
+memoized set — and adopts it.
+
+Now `guardsHiddenFrom` computes "every installed guard whose id is not in that
+set." The tripped guard was not live when the first block registered, so it is
+not in the set, so it gets suspended while the second block's handler runs.
+Fail-open metering — the exact bug decision 3 exists to prevent, on the exact
+path (resume) the feature is for.
+
+**The loop case is worse**, because `nextGuardId()` mints fresh ids per push
+(`guard.ts:14-18`): iteration 4's handler would adopt iteration 1's ids, which
+name none of iteration 4's live guards, so *every* enclosing guard gets
+suspended. Task 1.3's test 5 ("loop registration") is aimed at this and is a good
+instinct — but it would only catch it if the fixture checkpoints mid-loop, and as
+written ("two iterations, each pushing its own guard") it may not.
+
+**What to do.** Use the `agencyInterrupt` pattern, which is the same problem
+already solved: store the memo **on the frame, keyed by the registering
+callsite's `stepPath`**, not on the stack keyed by an ordinal. Frames are
+serialized and restored; replay re-enters the same frame and computes the same
+key; a completed sibling's key is a different string, so skipping it costs
+nothing. Whatever you pick, it has to be shown to survive three shapes before
+execution, because these are the shapes that break counters:
+
+1. two sequential `handle` blocks, checkpoint inside the second;
+2. a `handle` inside a loop, checkpoint in a later iteration;
+3. a `handle` inside a recursive function, checkpoint in a deeper call.
+
+(3) is the one that will decide the design: same callsite, different frames — so
+frame-scoped storage handles it and a stack-wide map keyed by callsite alone does
+not.
+
+## 2. The trip generation counter cannot satisfy both of its requirements
+
+Task 2.2 keys the trip interrupt `__guardTrip_<scope>#<generation>`, with
+`generation` a per-scope counter "serialized in `stack.other`, incremented at
+each NEW raise." This is the fix for rev-3's auto-approve-forever bug, and it
+does fix *that* — but it breaks resume idempotency, which is the property the key
+exists to provide.
+
+The key has two requirements, and they pull against each other:
+
+- **Stable across replays of the same trip.** On resume, the pre-call gate
+  re-runs, the guard is still over budget (the approve is applied by the code
+  *after* the raise returns, which has not run yet), so the raise site is
+  re-reached. It must produce the *same* key, find the persisted id, and return
+  the recorded answer. That is the whole mechanism (`agencyInterrupt.ts:158-162`).
+- **Distinct across successive trips.** Otherwise trip #2 finds trip #1's
+  answer — rev-3's blocker.
+
+A counter incremented at raise time fails the first: the replayed raise
+increments again, gets `#1` instead of `#0`, misses the recorded answer, and asks
+the user a second time. Then the resumed run replays again and asks a third time.
+Moving the increment to answer-time fails the same way one step later — any
+subsequent replay re-reaches the raise with the counter already bumped.
+
+**This is blocker 1 again**, which is why they should be designed together. The
+way out is the same: derive the generation instead of counting it. One
+illustration of the shape (not a recommendation — the point is the shape): the
+guard's own `costLimit` is stable for the whole life of a trip and *changes* the
+moment an approve is applied, so a key like `__guardTrip_<scope>@<costLimit>` is
+identical on every replay of one trip and different after a grant. Time and
+disarm complicate it. But it is content-derived, which is the property that
+matters, and it is the #551 pattern.
+
+Worth repeating from the rev-3 review: **the headline fixture catches this**
+("after an approved trip and more spending, the SECOND trip must actually
+raise"). Keep it, and add its twin — after a *propagated* trip is answered and
+the run resumes, the user must not be asked twice.
+
+---
+
+# Substantive
+
+## 3. Cost trips have four enforcement sites, not two — and the proposed change silently disarms two of them
+
+Part 1.1 states that cost guards "trip at exactly two places, both inside
+`runPrompt`," and the taxonomy table in Task 2.2 has exactly three rows. There
+are four callers of `enforceGuards()`:
+
+- `prompt.ts:554` — the pre-call gate (taxonomy row 1). ✅
+- `prompt.ts:699` — the post-charge check (row 2). ✅
+- **`cost.ts:12`** — `addCost(amount)`, the public helper a TS-side paid call
+  site uses so its spend participates in `getCost()` and `guard(cost:)`. Its own
+  docstring says: *"Throws (a guard-trip) if enforcement fails — callers must not
+  swallow it."*
+- **`ipc.ts:897`** — `handleTelemetryMessage`, where a subprocess child's
+  reported cost is billed to the parent's guards. The throw is caught and turned
+  into `killChildSafely(s)` + settle.
+
+Three consequences:
+
+**(a) The `enforceGuards` refactor is not a style choice.** Task 2.2 says to make
+it "RETURN the offending guard rather than throw, or gain a sibling that does;
+pick whichever reads cleaner at both call sites." There are four call sites, and
+two of them are outside the file the task is editing. If `enforceGuards` changes
+in place, `addCost` and the IPC telemetry handler keep calling it, ignore the
+returned guard, and **stop enforcing** — fail-open at the subprocess budget
+boundary, which is the operator-facing one. The sibling is mandatory; the
+existing method must keep throwing.
+
+**(b) The IPC site structurally cannot raise.** `handleTelemetryMessage` is a
+message callback, not a step body: there is no runner in the ALS frame, and
+`agency.interrupt` throws without one (`agencyInterrupt.ts:129-137`). So a
+child's spend tripping the parent's guard has to keep today's hard-kill
+behavior — while an identical trip from an in-process `llm()` becomes
+approvable. That asymmetry is defensible (it mirrors "root budgets stay hard")
+but it is invisible today and needs a row in the taxonomy and a line in
+`guards.md`.
+
+**(c) `addCost` sites can raise but the plan does not say whether they do.**
+They run inside a step body with a live frame, so the machinery would work.
+Leaving them throwing means `guard(cost:)` around a TS-helper paid call behaves
+differently from `guard(cost:)` around `llm()` — same user-visible construct,
+two semantics. Pick one and write it down.
+
+The taxonomy table is the right instrument. It just needs the two missing rows,
+and Part 1.1's "cost only changes when LLM calls happen" needs the correction
+that `addCost` exists precisely because that is not true.
+
+## 4. "Correct-by-reconstruction" relabels the dedupe hole rather than closing it
+
+Task 2.2 says the pending-trip record is live-only, and that losing it across a
+checkpoint is "correct-by-reconstruction: restored branches re-detect and
+re-raise, and the serialized generation counter keeps their keys fresh."
+
+Re-raising is what the dedupe exists to prevent. Three branches re-detect, three
+trips raise, the handler grants $0.50 three times, and the limit rises $1.50 —
+decision 10's over-grant, back, on the resume path. The sentence describes the
+mechanism accurately and then names the outcome the opposite of what it is.
+
+Either serialize enough state to dedupe after a restore, or say plainly:
+"dedupe is best-effort within one process lifetime; across a resume, concurrent
+branches can each obtain a grant." Both are legitimate; only one is written down.
+If it is the second, the shared-guard dedupe fixture should have a resumed twin
+that pins the documented-and-accepted behavior, so nobody later reads the
+over-grant as a regression.
+
+## 5. The signal audit is a vigilance rule, and this plan rejects vigilance rules everywhere else
+
+Task 3.1 replaces the accumulated chain with a rebuilt composite, then adds:
+"grep every reader of `stack.abortSignal` and confirm each reads at use time
+rather than caching across an approve boundary."
+
+That audit is correct today, and it is a standing obligation on every future
+reader — the same "remember to keep these in sync" pattern this plan
+(rightly) refuses elsewhere: suspension went onto the `Guard` interface
+specifically so call sites could not forget, and the merge table was made total
+specifically so no caller has to special-case a gap.
+
+A stable per-stack `AbortController` whose *subscriptions* are rebuilt makes the
+question unaskable: the signal object never changes, so no reader can hold a
+stale one, and the grep never needs repeating. The plan's own argument for why
+minting is safe ("in-flight operations that captured the OLD signal were exactly
+the operations the trip cancelled") is sound for the trip case, but
+`rebuildAbortSignal` is also called on guard push/pop, where it is not obviously
+true, and the getter (`get abortSignal()`) only protects readers that call it at
+use time — which is precisely what the audit is checking. Keep minting if you
+prefer, but then say why vigilance is acceptable here and structural enforcement
+was required for suspension.
+
+## 6. Option A's join rule extends the parent by the wrong quantity
+
+Task 3.3: "`runBatch`'s join reads each clone's granted-delta and extends the
+parent by the **max delta** before `addElapsed`."
+
+The parent is charged the max **working time**, not the max delta, and those can
+belong to different branches. If branch A was granted +5m and worked 15m while
+branch B was granted +8m and finished at 12m, the parent gets charged A's 15m and
+extended by B's 8m — three minutes of headroom nobody consumed. The rule that
+matches Option A's own rationale ("you approved five more minutes of work; you
+get them") is: **extend by the delta granted to the branch whose working time the
+parent is charged.** Worth fixing in the text now; it is the kind of thing that
+ships as written.
+
+---
+
+# Smaller notes
+
+- **Task 1.3a's sentence is cut off**: "…the cross-object field-reaching pattern
+  flagged on" — ends mid-clause (it means #553's review).
+- **Task 1.2's IPC default merge** is subtle and correctly flagged: `(inner,
+  outer) => outer ?? inner` for the default path only, preserving today's
+  "valueless outer approve defers to inner over IPC." Good catch keeping that
+  nuance; the comment it asks for is worth two sentences rather than one, since
+  the in-process default is deliberately *different* (`(_inner, outer) => outer`,
+  unconditional overwrite). Two defaults with one name will confuse someone.
+- **Task 1.1's typechecker claim** ("that is the whole typechecker change")
+  reads right to me: `approve`/`reject`/`propagate` are plain `ANY_T` builtins,
+  and the plan tells the executor to verify by grepping `propagate`'s wiring
+  rather than trusting the claim. That is the right hedge in the right place.
+- **Estimates** are still credible, though blockers 1 and 2 are now one shared
+  design problem rather than two mechanical fixes; if that design takes a day, PR
+  1 is 5–6.
+
+# What is right
+
+The rewrite achieved what it was for. Part 1 means a reader can start at the top
+and arrive at the decisions already knowing why they are the decisions. The
+taxonomy table converts "what happens on a trip" from a paragraph you have to
+trust into a grid you can check — which is exactly how I found the missing rows,
+so it did its job on its first outing. The time-trip analysis in Task 3.2 is the
+strongest single section: (b) and (c) resuming in place with no thread surgery,
+and (a)'s "the loop only ever has a request in flight when every prior `tool_use`
+already has its result appended" — that is the argument that makes re-issue safe,
+and it is proven from the structure rather than asserted.
+
+Rev-3 findings 3 (suspend gates resume), 5 (cost-only dedupe), and 6
+(`cloneForBranch` field copy) are folded correctly and with the reasoning
+attached, which is why they will survive contact with an executor.
+
+# Recommended next steps
+
+1. Design the replay-stable key **once**, for both the handler memo and the trip
+   id, and prove it against sequential blocks, loops, and recursion (blockers 1
+   and 2). This is the whole remaining risk.
+2. Add the two missing enforcement rows to the taxonomy and make the
+   `enforceGuards` sibling mandatory (finding 3).
+3. Decide and state the dedupe-across-resume behavior (finding 4).
+4. Fix the join quantity to "the charged branch's delta" (finding 6).
+5. Owner decides Part 3.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev5.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev5.md
@@ -1,0 +1,250 @@
+# Plan review: resumable guards, rev 5 (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (rev 5)
+**Supersedes:** the rev-4 review.
+**Verdict:** The two key designs are right this time. I tried to break the trip
+key and could not — it is genuinely sound, and decision 14 is the right law to
+have written down. The handler memo design is also right *in every respect except
+where it is installed*: **`withPushedHandler` is not the path Agency `handle`
+blocks take.** They go through `Runner.handle`, which calls `ctx.pushHandler`
+directly. As written, Task 1.3 would capture `liveGuardIds` for TypeScript-
+installed handlers only, and decision 3 would not apply to the construct the
+plan's own walked example uses.
+
+That is one blocker, and the fix is small and makes the design better: the right
+anchor has everything 1.3b asks for and is two lines from where the plan already
+points. Everything else below is a note.
+
+All line references are `packages/agency-lang/`, verified today.
+
+---
+
+# Blocking
+
+## 1. Agency `handle` blocks never reach `withPushedHandler`
+
+Task 1.3a says capture happens in `withPushedHandler` (`asyncContext.ts:143`),
+"the one place that has both the context AND the ALS-resolved stack." That
+function has exactly two callers, and both are TypeScript-side:
+
+- `agency.ts:304` — `agency.withHandler(handler, fn)`, the public TS API.
+- `agencyFunction.ts:267` — the auto-approve handler `preapprove()` wraps around
+  each call.
+
+Agency's own `handle ... with` compiles somewhere else entirely:
+
+```
+handleBlock  →  processHandleBlockWithSteps      (typescriptBuilder.ts:4020-4053)
+             →  ts.runnerHandle({id, handler, body})
+             →  "await runner.handle(<id>, <handler>, async (runner) => {...})"
+                                                       (prettyPrint.ts:370)
+             →  Runner.handle(...)                     (runner.ts:766)
+                  this.ctx.pushHandler(handlerFn);     (runner.ts:778)
+```
+
+`with` modifiers take the same path (`processWithModifier`, :4055). And there is
+a third registration path the plan does not mention: the `withHandler` TSIR node
+(`prettyPrint.ts:389`) emits `getRuntimeContext().ctx.pushHandler(...)` inline
+for top-level static/global init wrappers.
+
+So under Task 1.3 as written, the walked example in Part 2 —
+
+```
+handle { guard(label: "coder", cost: $1.00) as { ... } } with (intr) { ... }
+```
+
+— registers via `Runner.handle`, never touches `withPushedHandler`, and gets no
+`liveGuardIds`. The handler cannot be scoped, cannot be budget-isolated, and
+`guardsHiddenFrom` has nothing to filter on. The entire feature would work only
+for handlers installed from TypeScript.
+
+**The fix is a better anchor, not a bigger one.** `Runner.handle` has everything
+1.3b wants, and more legitimately than `withPushedHandler` does:
+
+| 1.3b needs | `Runner.handle` has |
+|---|---|
+| the branch's guards | `this.stack` — no ALS reach-through |
+| a per-frame store (what makes recursion safe) | `this.frame` |
+| a position key | `this.stepPath(id)` — already called two lines up, at :776, for coverage |
+| a pop point for the delete rule | the existing `finally` at :783-785 |
+
+So 1.3b's sketch becomes, at `runner.ts:778`:
+
+```ts
+const memoKey = `__handlerGuards_${this.stepPath(id)}`;
+let liveGuardIds = this.frame.locals[memoKey] as string[] | undefined;
+if (liveGuardIds === undefined) {
+  liveGuardIds = this.stack.guards.map((g) => g.guardId);   // first write wins
+  this.frame.locals[memoKey] = liveGuardIds;
+}
+this.ctx.pushHandler(handlerFn, liveGuardIds);
+this.path.push(id);
+try {
+  await this.runInScope(() => callback(this));
+} finally {
+  this.path.pop();
+  this.ctx.popHandler();
+  delete this.frame.locals[memoKey];      // the delete-on-pop rule
+}
+```
+
+The `activeCallsite()` / `activeFrame()` helpers in the current sketch disappear;
+the plan's reasoning about *why* (position key, frame-local store, delete on pop)
+is unchanged and still correct.
+
+**Two consequences to write into the task:**
+
+- **The entry-shape change touches all three `pushHandler` callers**, not one.
+  Decide what the other two capture rather than letting a default decide.
+  Empty-set is not neutral: `guardsHiddenFrom` = "every guard whose id is not in
+  the set," so `liveGuardIds: []` means *hide everything*. For the top-level init
+  wrapper that is correct (it registers before any guard exists). For
+  `preapprove()`'s auto-approve it is harmless in practice (its body is
+  `async () => approve()` — nothing to meter) but it should be a stated decision,
+  because "harmless because the body happens to be trivial" is exactly the kind
+  of thing a later change invalidates silently.
+- **`agency.withHandler` is a public TS API** and its handlers are equal
+  participants in the same chain (`agencyInterrupt.ts:24-31` says so
+  explicitly). It has a stack via ALS but no step id, so it needs its own key
+  rule — probably content-derived from the ids themselves, or an explicit
+  "TS-installed handlers capture at call time and do not memoize, because they
+  are not replayed." Either is fine; silence is not.
+
+## 1b. A gift for Part 1.3: the proof is a line of code, not a doc quote
+
+`Runner.handle` opens with:
+
+```ts
+if (this.getCounter() > id) return;      // runner.ts:772
+```
+
+That is decision 14's entire justification, sitting in the function this task
+edits: **a completed `handle` block does not re-register on replay — it returns
+before `pushHandler`.** Every counter design died on exactly this line. Part 1.3
+currently cites `docs/dev/interrupts.md`; cite this too. It converts "replay
+skips completed work" from something a reader takes on faith into something they
+can see, in the code they are about to change.
+
+It also sharpens Part 1.3's own wording: "handlers are re-registered by
+re-executing the code that registered them" is true only for blocks still *open*
+at checkpoint time. Completed ones are skipped, and correctly so — their scope is
+over.
+
+---
+
+# Notes
+
+## 2. The trip key is sound. I tried to break it.
+
+Recording the walk, because it is the kind of thing a future reader will want to
+re-derive and the plan's comment covers only two of the five cases:
+
+- **Stable while the trip is open** — nothing in `scopeIds`, `dimension`, or
+  `currentLimit()` changes until the answer is applied. Replay re-derives the
+  same key and finds the recorded answer. ✅
+- **Distinct after an approve** — decision 8 forces the tripped dimension's limit
+  strictly above `spent`, and `spent` only grows, so limits strictly increase.
+  `@1.00` → `@1.50` → `@1.75`. Never a collision. ✅
+- **A clamped negative delta cannot produce a stale key** — clamping to zero
+  leaves the dimension over budget and armed, so decision 8 errors rather than
+  proceeding with an unchanged key. ✅
+- **Disarm leaves the limit unchanged**, so the key would repeat — but a disarmed
+  dimension never trips again, so there is no next trip to collide with. ✅
+- **The other dimension tripping later** differs in `#dimension`. ✅
+
+One case is load-bearing and unstated, worth a sentence because it looks like a
+bug until you see it: **after an approve, a later replay re-reaching the raise
+site does not re-raise — not because the key matches, but because the guard is no
+longer over budget, so `detectTrippedGuard` returns null and nothing raises at
+all.** Without that, a reader asks "what about the next replay?" and the answer
+is not in the comment.
+
+## 3. Where does the persisted trip id live?
+
+Rev 4 said `stack.other`; rev 5's sketch passes `key` into `raiseRuntimeInterrupt`
+and never says where the id is stored. `agency.interrupt` stores its id in
+`frame.locals` (`agencyInterrupt.ts:158`), which is right for a *callsite*-keyed
+id but wrong here: the raise happens inside `runPrompt`, whose active frame is
+not obviously the trip's owner. Since the key is now globally unique per
+(scope, dimension, limit), `stack.other` is the correct store — branch-local,
+survives frame pops, no frame scoping needed. Say so; the factored dance now
+takes a key AND needs to know which store to use, and that is a new parameter
+neither caller has today.
+
+## 4. The memo's survival depends on the checkpoint being a copy
+
+1.3b's third bullet argues the ordering: the snapshot exists before the unwind's
+`finally` deletes the entry. That is right. But the property that actually
+matters is that `checkpoints.create` **snapshots** `frame.locals` rather than
+aliasing it — if it held a live reference, the delete would reach into the
+snapshot and the memo would vanish exactly when it is needed.
+
+This is #551's lesson stated in reverse ("the serialize path hides the bug; only
+live reuse breaks"), so the odds are good it is already a deep clone. One line to
+verify, and worth an explicit sentence in the plan, because the whole delete-on-pop
+rule rests on it.
+
+## 5. `ctx.handlers` is context-wide; `liveGuardIds` are branch-local
+
+Handlers live on the RuntimeContext (`context.ts:85`), not the stack. Guards live
+on the stack. So a handler registered *inside* fork branch A sits on the shared
+handler stack and will be consulted for an interrupt raised in sibling branch B —
+at which point `guardsHiddenFrom(entry)` compares A's captured ids against B's
+`stack.guards`. Because time clones carry the parent's `guardId` and cost guards
+are shared objects, the overlap is partial and the resulting hidden set is
+arbitrary rather than meaningfully wrong-or-right.
+
+This is pre-existing strangeness (a branch-registered handler being globally
+visible predates this plan), but decision 3 is the first rule that gives it
+teeth. Worth one sentence deciding what it means and one fixture pinning it: a
+handler registered inside one fork branch, an interrupt raised in its sibling.
+
+## 6. Where does the dedupe wait?
+
+Decision 10 and Task 2.2 say a branch detecting the same over-budget guard
+"awaits `settled`." The detection site is synchronous (`detectTrippedGuard():
+Guard | null`, and `enforceGuards` is sync today), so the await has to live at
+the async raise site. It is implied by `raiseGuardTrip` being `async`, but say
+it — the sketch shows the pending record and never shows the wait.
+
+## 7. Small
+
+- The fixture table still calls the headline fixture's mechanism "fresh
+  generation." The generation is gone; it is a fresh derived key now. One word.
+- Task 3.3's `grantedMs` rule is self-consistent in a way worth stating, since it
+  looks arbitrary: the longest branch is necessarily a granted branch (a clone
+  without a grant would have tripped at its own limit rather than running past
+  it), so "the charged branch's grant" is never zero when it matters.
+
+---
+
+# What is right
+
+Decision 14 is the most valuable thing in this document. It is written as a law
+with the failure history attached, which is what will stop the fifth counter from
+being invented in six months. Decision 16 is argued the way a decision should be
+— three independent reasons, one of which ("an ancestor rule would need a root
+carve-out; one rule becoming two is the tell") is a genuinely good piece of
+design taste, and it ends with the UX consequence spelled out rather than
+discovered later.
+
+The taxonomy now has all four cost sites with the IPC one honestly marked as a v1
+limitation and given its own fixture, rather than quietly omitted. The dedupe
+section says plainly that the restore path gives a weaker guarantee and names
+what bounds it — that is the fix I asked for, and it is better than the
+"correct-by-reconstruction" framing it replaces because it tells the truth about
+the trade.
+
+And the signal-freshness contract is now structural rather than a standing audit:
+"there is no way to hold the stale signal AND be alive" is exactly the argument
+that makes the grep unnecessary.
+
+# Recommended next steps
+
+1. Move the capture to `Runner.handle:778`, and decide the rule for the other two
+   `pushHandler` callers (blocker 1).
+2. Cite `runner.ts:772` in Part 1.3 as decision 14's proof (1b).
+3. State where the trip id is stored (note 3), that the checkpoint copies frame
+   locals (note 4), and where the dedupe waits (note 6).
+4. Decide the cross-branch handler-visibility question and pin it (note 5).
+5. Then execute. Nothing else in this plan is unresolved.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev6.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev6.md
@@ -1,0 +1,131 @@
+# Plan review: resumable guards, rev 6 (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (rev 6)
+**Supersedes:** the rev-5 review.
+**Verdict:** Ship it, after one fix. Every rev-5 item is folded, and folded with
+the reasoning attached rather than the conclusion copied. The capture point is
+right, the three-caller rules are explicit, and the `preapprove()` catch is one
+the plan found on its own that I missed. **One finding left: the pending-trip
+record's lifecycle is specified only in prose fragments, and the gap it leaves
+is a fork deadlock on the propagate path** — the feature's headline path. It is
+a paragraph of specification, not a redesign.
+
+All line references are `packages/agency-lang/`, verified today.
+
+---
+
+# The finding
+
+## The `pendingTrip` record can hang a fork, because nothing says who settles it
+
+Task 2.2 says the shared `CostGuard` holds a live `pendingTrip: {key, settled}`
+record, and that "a branch that finds one pending `await`s its `settled` promise,
+then re-checks." What the plan never says is **who resolves `settled`, and on
+which paths**. There are four exits from a raise, and only one of them obviously
+resolves it:
+
+| Exit | Resolves `settled`? |
+|---|---|
+| A handler approves | yes — the raise returns normally |
+| A handler rejects | the raise **throws** `GuardExceededError` |
+| No handler → propagate → checkpoint + halt | the raise **throws** `HaltSignal` and the run stops |
+| The merge/decision-8 error | the raise **throws** |
+
+Three of four leave by a throw, and the propagate case is worse than a throw: the
+answer arrives in a *different run*, after a checkpoint. A parked sibling is
+sitting on a promise that, by construction, nobody in this process will ever
+resolve.
+
+That is a hang, not a slow path. `runBatch`'s fork join is
+`await Promise.allSettled(...)` (`runBatch.ts:602`), so a branch parked forever
+means the join never returns — and the run hangs instead of surfacing branch A's
+interrupt to the user. The reachable case is small and ordinary: a fork, a shared
+cost guard, no in-program handler. Exactly the setup of the plan's own
+`dedupe restore variant` fixture. (`race` is unaffected — `Promise.race` at
+`:703` doesn't wait for the loser.)
+
+**What to specify** — one paragraph in Task 2.2, next to the record:
+
+- **Set it synchronously.** The sketch shows `raiseGuardTrip` *checking* the
+  record but never *setting* it, and the set has to happen before the first
+  `await` or two branches both pass the check and both raise. `resolve` →
+  `containsRootBudget` → `guardTripKey` → **set the record** → `suspendAll` →
+  `await`.
+- **Settle it on every exit,** which means a `finally`, next to the existing
+  `unsuspendAll()`. Approve, reject, decision-8 error, and halt all release the
+  parked siblings.
+- **Decide what a parked branch does when the settle came from a halt.** The
+  natural answer is the one the plan already relies on elsewhere: it re-checks,
+  finds the guard still over budget, and raises its own trip — which propagates
+  too, and concurrent branch interrupts are already supported
+  (`docs/dev/concurrent-interrupts.md`). The user is asked twice, which is
+  exactly the documented v1 trade the dedupe section already owns for the restore
+  case. Say that it is the same trade, arriving by the same door.
+
+The `dedupe restore variant` fixture would catch this — as a hanging test, which
+is the worst way to learn it. Specify the lifecycle and the fixture becomes a
+pin instead of a discovery.
+
+---
+
+# Notes
+
+## The `finally` unsuspends during a propagate — harmless, worth one clause
+
+`raiseGuardTrip`'s `finally { scope.unsuspendAll(); }` runs on the `HaltSignal`
+unwind too, so the scope is unsuspended while the run is halted waiting for a
+human — which reads like it contradicts the bullet above it ("between raise and
+verdict the scope must not tick or gate anything — including during
+propagate-to-user").
+
+It is fine, for a reason worth stating rather than leaving a reader to
+reconstruct: `Runner.halt` already pauses every guard (`runner.ts:253`), so
+nothing ticks regardless; and on resume the guards come back from a checkpoint
+that never carried `suspended`, so the replayed raise re-suspends them. The
+suspension bracket protects the *in-process* deliberation window; the halt
+protects the propagate window. Two mechanisms, one property.
+
+## Small
+
+- Task 1.3's test list has no test for the `preapprove()` → `pass()` rule, though
+  1.3a promises one ("Pin it with a fixture"). It belongs in the Task 1.3 list or
+  the Task 2.5 table; right now it is named in prose and absent from both.
+- `guardTripKey`'s comment covers three of the five cases I walked in the rev-5
+  review. The two missing are cheap to add and are the ones a reader will
+  stumble on: a clamped-to-zero delta can't produce a stale key (decision 8
+  errors first), and disarm leaves the limit unchanged but there is no next trip
+  to collide with.
+
+---
+
+# What is right
+
+The `preapprove()` finding is the kind of thing that makes a plan trustworthy:
+its auto-approve handler answers *every* interrupt with `approve()`, which for a
+trip is `approve({})`, which decision 8 turns into a runtime error — so every
+preapproved tool that tripped a guard would have blown up inside the wrapper.
+Nobody asked for that; the plan found it by taking its own rule seriously across
+all three registration paths. That is what "ruled explicitly" is for.
+
+The cross-branch rule is better than what I asked for. I flagged the arbitrary
+hidden set and asked for *a* rule; the plan noticed that the main use case
+**depends** on cross-branch eligibility — the walked example's handler registers
+before the fork, so branch trips must reach it — and derived a rule that keeps it
+working: evaluate `guardsHiddenFrom` against the raising branch's stack, so
+pre-registration guards (shared cost guards, inherited clones carrying the
+parent's id) still meter the handler, and anything branch-local to the sibling is
+hidden.
+
+And `runner.ts:772` now carries decision 14's proof in Part 1.3, in the function
+the task edits. Four counter designs died on that line. Having it quoted where
+the next person will be tempted to add a fifth is the most durable thing in the
+document.
+
+# Recommended next steps
+
+1. Specify the `pendingTrip` lifecycle: set synchronously before the first await,
+   settle in a `finally` on all four exits, and state what a halt-released branch
+   does.
+2. Add the `preapprove()`-passes fixture to a list, and the two missing key cases
+   to the comment.
+3. Execute PR 1.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev7.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev7.md
@@ -1,0 +1,164 @@
+# Plan review: resumable guards, rev 7 (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (rev 7)
+**Supersedes:** the rev-6 review.
+**Verdict:** The deadlock fix is correct — I walked the concurrency and it holds.
+Two small things remain, both inside the new sketch, both a few lines to fix.
+Neither is a design question. After them, execute.
+
+All line references are `packages/agency-lang/`, verified today.
+
+---
+
+# Findings
+
+## 1. The detect→raise call site needs a loop, and a single check leaks a request
+
+Task 2.2 says: "The prompt/addCost sites move to a new sibling
+(`detectTrippedGuard(): Guard | null`) and call the raise." One detect, one
+raise. The parked-branch line in the sketch has the same shape:
+
+```ts
+if (detectTrippedGuard(stack) !== tripped) return;   // refilled — done
+```
+
+Both assume that once *this* guard's question is answered, the gate is clear. It
+is not, and decision 16 is exactly why:
+
+> If newly granted inner spend later pushes an OUTER guard over its limit, the
+> outer guard trips on its own, raises its own interrupt…
+
+That "on its own" has to happen *somewhere*. With a single check it happens one
+request too late. Concretely, at site 1 (the pre-call gate):
+
+1. The inner guard is over budget. `detectTrippedGuard` returns it, the gate
+   raises, the handler grants $0.50.
+2. `raiseGuardTrip` returns. The gate treats that as "clear" and **sends the
+   request** — while the outer guard is now over its own limit.
+3. The outer guard's question gets asked at the *post-charge* site instead, after
+   the money is spent.
+
+That contradicts the taxonomy's headline claim for site 1, which is the reason
+site 1 raises where it does: *"Nothing is in flight while the question is out,
+and not a cent can leak, because the request was never sent."* A cent can leak —
+one whole request's worth — and it leaks precisely in the case decision 16 was
+written to describe.
+
+The parked-branch `return` is the same bug through a second door: it returns
+"approved" whenever the newly-tripped guard is not the one it was parked on,
+including when a *different* guard is now over budget.
+
+**Fix.** The call site loops until the stack is actually clear:
+
+```ts
+let g: Guard | null;
+while ((g = stack.detectTrippedGuard()) !== null) {
+  await raiseGuardTrip(stack, g, dimensionOf(g));   // returns = this one is settled
+}
+// only now: send the request / book the charge
+```
+
+The parked branch then just returns and lets its caller re-detect, which is what
+its `!== tripped` check was reaching for. Both raising sites need it — the
+post-charge site too, since one charge can push an inner guard and its enclosing
+outer over together, and each is owed its own question. Worth one sentence in
+Task 2.2 saying so, because "raise, then proceed" is what a reader will write
+from the current text.
+
+## 2. The pending record is set outside the `try`, which re-opens the deadlock
+
+The new sketch:
+
+```ts
+const pending = makePendingTrip();
+tripped.pendingTrip = pending;                        // ← set
+
+const interruptKey = guardTripKey(tripped, dimension);  // ← can throw
+scope.suspendAll();                                     // ← can throw
+try {
+  ...
+} finally {
+  scope.unsuspendAll();
+  tripped.pendingTrip = undefined;
+  pending.settle();
+}
+```
+
+There is a three-line window between the set and the `try` where a throw leaks
+the record permanently: never cleared, never settled, so every future branch that
+touches this guard parks forever on a promise with no owner. That is the exact
+deadlock the `finally` was added to prevent, re-entering through the gap in front
+of it. `guardTripKey` calls `currentLimit()` and `suspendAll` walks members —
+neither is obviously infallible, and "obviously infallible today" is not a
+property worth betting a hang on.
+
+**Fix:** move `try` to immediately after the assignment, so the record's lifetime
+and the `finally` are the same region:
+
+```ts
+tripped.pendingTrip = makePendingTrip();
+try {
+  const interruptKey = guardTripKey(tripped, dimension);
+  scope.suspendAll();
+  ...
+} finally {
+  scope.unsuspendAll();          // safe if suspendAll never ran — it is a no-op
+  const p = tripped.pendingTrip;
+  tripped.pendingTrip = undefined;
+  p?.settle();
+}
+```
+
+## Trivial
+
+- `detectTrippedGuard(stack)` in the sketch vs `detectTrippedGuard(): Guard | null`
+  as a `StateStack` method in the Files list — free function in one place, method
+  in the other. Pick one.
+
+---
+
+# The concurrency walk (it holds)
+
+Recording this so the next reader does not have to re-derive it, because the
+"why" is not obvious from the code:
+
+- **Mutual exclusion is real.** `raiseGuardTrip` runs synchronously from its
+  entry to `tripped.pendingTrip = pending` — `resolve`, `containsRootBudget`, the
+  `while` condition on an empty record, `makePendingTrip` are all sync, and an
+  `async` function body executes synchronously until its first `await`. So a
+  second branch entering after the first cannot miss the record. The comment says
+  this; it is correct.
+- **The `while` (not `if`) is load-bearing.** A third branch can claim the record
+  between a parked branch's wake and its re-check, and the loop parks it again.
+- **The wake sees a cleared record.** The `finally` sets `pendingTrip = undefined`
+  *before* `settle()`, so a woken branch's loop condition is false and it proceeds
+  to claim its own.
+- **The halt path releases correctly.** Propagate throws `HaltSignal`, the
+  `finally` still runs, parked siblings wake, re-check, and raise their own trips
+  — which also propagate, and concurrent branch interrupts are already supported.
+  The fork join (`Promise.allSettled`, `runBatch.ts:602`) gets every branch.
+- **Time guards make this code inert for free**, which is worth one clause in the
+  plan: `pendingTrip` lives on the guard object, `TimeGuard.cloneForBranch` gives
+  each branch its own object, so the `while` always sees `undefined` and the
+  dedupe no-ops. Decision 10 says "cost-only by construction" — this is the
+  construction, and saying so stops someone from later "fixing" the missing time
+  dedupe.
+
+# What is right
+
+The fix is not just applied, it is explained where the explanation is needed: the
+`finally` comment names all four exits and says why three of them being throws is
+the whole point. That comment will still be doing its job in a year, when
+somebody wonders why a settle sits next to an unsuspend.
+
+The `guardTripKey` comment now walks all five cases, including the two that look
+like holes until you read them (clamped-to-zero errors before the key is reused;
+disarm repeats the key but has no next trip). And the unsuspend-during-propagate
+clause is exactly the right length — it answers the reader's objection and moves
+on.
+
+# Recommended next steps
+
+1. Loop the detect→raise call sites (finding 1).
+2. Move the `try` up (finding 2).
+3. Execute PR 1.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev8.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW-rev8.md
@@ -1,0 +1,66 @@
+# Plan review: resumable guards, rev 8 (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (rev 8)
+**Supersedes:** the rev-7 review.
+**Verdict: execute.** Both rev-7 fixes are in and correct. I re-walked the
+dedupe with the new shape and it holds. Two nits below — neither blocks, both
+are one line, and the executor can fold them while writing the code.
+
+---
+
+## Verified
+
+- **The loop is at both raising sites**, with the reason attached ("approving the
+  inner guard's trip can leave — or push — the OUTER guard over its own limit,
+  and decision 16 promises that guard its own question"). Decision 16 now has a
+  *where*, which was the whole point.
+- **The parked branch returns and lets the caller re-detect.** This is better
+  than the `!== tripped` check it replaces: it covers both "the answer refilled
+  this guard" and "a different guard is over budget now" with one mechanism
+  instead of two, and it does not have to know which case it is in.
+- **Nothing sits between the set and the `try`.** The record's lifetime and the
+  `finally` are now the same region. The comment says why, in the place where
+  someone would otherwise "clean up" by hoisting `guardTripKey` back out.
+- **The `if`-then-`while` reads redundant but is not.** The `if` decides whether
+  we parked (and therefore whether to return); the `while` handles a third branch
+  claiming the record between our wake and our re-check. Both are needed. Worth
+  leaving as-is.
+- **`unsuspendAll()` is genuinely a safe no-op** when `suspendAll` never ran —
+  `unsuspend()` only clears a flag, and the clock restart is the next
+  `beforeStep`'s job.
+- **The time-guards-inert clause is in**, so nobody "fixes" the missing time
+  dedupe later.
+
+## Two nits
+
+**1. `dimensionOf(g)` should be a property, not a call-site branch.** The new
+loop calls `dimensionOf(g)`, and there is no way to write it today except an
+`instanceof` or a `g.toJSON().kind` round-trip — both of which are the thing
+`guard.ts:20-59` explicitly forbids ("StateStack and Runner only ever talk to the
+interface — no `instanceof` checks, no variant-specific branching"), and the
+thing decision 5 went out of its way to honor for suspension. Add
+`readonly dimension: "cost" | "time"` to the `Guard` interface (`GuardJSON`
+already carries the same discriminator as `kind`), and the loop reads
+`raiseGuardTrip(stack, g, g.dimension)`.
+
+**2. The signature comment is now half-true.** `// returns = approved; throws =
+rejected` was accurate when every return meant an approval. The parked branch now
+also returns, having approved nothing. Operationally both mean the same thing —
+"this question is settled, re-detect" — but only because the caller loops, and a
+future caller reading that comment would reasonably call `raiseGuardTrip` once
+and treat the return as consent. Say what it now means:
+`// returns = this question is settled (approved, or someone else's answer landed) — the caller MUST re-detect; throws = rejected`.
+
+## What is right
+
+Eight revisions in, the thing worth saying is that the document now explains
+itself. The loop carries its own justification, the `finally` names all four
+exits, the key comment walks all five cases, and the memo cites `runner.ts:772`.
+Every one of those is a place where a future reader would otherwise have
+"simplified" something load-bearing. That is the difference between a plan that
+survives execution and one that gets quietly undone by the first person to tidy
+it.
+
+## Next
+
+Execute PR 1. Fold the two nits while writing the code.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards-REVIEW.md
@@ -1,0 +1,228 @@
+# Plan review: resumable guards (2026-07-16)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-16-resumable-guards.md` (DRAFT)
+**Verdict:** Do not execute yet. The decisions section is sound and the risk
+sections (fork/race/IPC) are the best part of the document. But three claims the
+plan treats as settled are contradicted by the code, and one of them
+(the handler's own budget) is a design hole, not a plan bug — it needs an owner
+decision before PR 1 can be scoped honestly.
+
+All line references are `packages/agency-lang/`.
+
+---
+
+## Blocking findings
+
+### 1. The handler runs INSIDE the tripped guard, un-paused. This breaks the flagship example.
+
+This is the big one. Both the spec and the plan assume that once a trip raises,
+the world is frozen while the handler deliberates. It is not.
+
+`interruptWithHandlers` runs the handler chain FIRST and only calls
+`runner.halt(...)` if nobody answered (`agencyInterrupt.ts:168` vs `:203`). So on
+the approve/reject path — the whole point of this feature — **no halt ever
+happens**, which means `Runner.halt`'s `guards.forEach(g => g.pause())`
+(`runner.ts:253`) never runs.
+
+Two consequences:
+
+- **Decision 3's justification is wrong.** "The clock is frozen while the trip
+  waits for an answer" is true only for the propagate-to-user path. On the
+  handler path the TimeGuard keeps ticking while the reviewer agent thinks.
+- **The reviewer-redirect example cannot run.** The handler body executes in the
+  raising branch's async lineage, so `getRuntimeContext().stack` still carries
+  the tripped guard. The reviewer agent's first `llm()` hits the pre-call gate
+  `targetStack.enforceGuards()` (`prompt.ts:554`), which walks `stack.guards`,
+  finds the still-over-budget CostGuard, and throws `GuardExceededError` —
+  *inside the handler chain*, out of the raise site, as an unhandled abort.
+
+So the design owes an answer to a question neither doc asks: **what budget does
+the handler itself run under?** Plausible options — the owner should pick, not
+the executor:
+
+- (a) Disarm the tripped guard for the duration of the handler chain, re-arm per
+  the answer. Simple, but a runaway reviewer agent is then unmetered.
+- (b) Run the handler chain on a stack with the tripped guard's subtree elided.
+- (c) Declare it the user's problem: document that a handler that spends money
+  must wrap its own work in `guard(...)` and cannot use the tripped budget.
+
+Whatever the answer, it changes PR 1's task list. Today's plan has no task for
+it.
+
+### 2. Time trips: the handler chain refuses to run on an aborted stack.
+
+`runHandlerChain` opens each iteration with
+`if (ctx.isCancelled(stack)) throw new AgencyCancelledError()`
+(`interrupts.ts:234`). At a time trip the composed `stack.abortSignal` is
+aborted, so the chain throws before invoking a single handler. The same gate sits
+at the top of `runPrompt` (`prompt.ts:542`), so even if the chain ran, the
+reviewer's LLM call would be refused.
+
+This inverts the plan's Task 3 ordering. The plan says: apply the answer, then
+"re-arm the branch's abort plumbing." For time trips the re-arm must happen
+**before** the handler chain runs, and `reject()` must then re-abort. That is a
+different mechanism, and it lands in PR 2, whose current write-up is four
+bullets long.
+
+### 3. "Root budgets keep throwing... the walk distinguishes them by the existing root marker."
+
+There is no root marker. `installRootBudget` pushes plain
+`new CostGuard(cost)` / `new TimeGuard(ms)` onto the root stack
+(`rootBudget.ts:23,30`) — structurally identical to a user guard. Nothing today
+tells them apart.
+
+This matters because "user code cannot approve its way past the operator's
+ceiling" is the one hard safety property in the design. The marker has to be
+added (a flag on the guard, serialized in `GuardJSON` like `guardId` and
+`disarmed`, checked at the raise site AND in the approve mutator so an approve
+naming a root guard's id is refused). That is a real task in PR 1, currently
+written as a verify-only sentence.
+
+---
+
+## Substantive findings
+
+### 4. PR 1's stated raise site does not fire for PR 1's trips.
+
+Task 2 anchors the raise at `shouldSkip()` (`runner.ts:315`), and the
+architecture line says trips "already surface" there. That is true for time
+trips. It is false for cost trips, which is all of PR 1.
+
+The entire guard walk in `shouldSkip` lives inside
+`if (this.stack?.abortSignal?.aborted && !this.halted)`. `CostGuard` installs no
+AbortController and its `isTripped()` returns a hardcoded `false`
+(`guard.ts:203`, documented at `guard.ts:124-136`). A cost trip never aborts the
+signal, so `shouldSkip` never even walks the guards. Cost trips are thrown by
+`enforceGuards()` (`stateStack.ts:569`) from `prompt.ts` — the pre-call gate at
+`:554` and the post-charge site at `:699`. That is mid-tool-loop, deep inside a
+step body.
+
+So PR 1 has to answer a question the plan skips: turning that throw into
+"mark pending, raise at the next step boundary" means the *pre-call gate* stops
+throwing, and the tool loop will happily issue more requests past budget before
+control returns to a step boundary. Either the raise happens where the trip is
+detected (inside `prompt.ts`, which is where the frames are still alive anyway),
+or the pending window has to be provably zero-cost. This choice is PR 1's
+architecture, and it is currently a sentence pointing at the wrong file.
+
+Related: `shouldSkip` is **sync**. Task 2's "returns true-to-skip only after the
+raise resolves" is not implementable there. `maybeDebugHook` is the async
+step-boundary precedent the plan cites, and it is called from `step()`, not from
+`shouldSkip`.
+
+### 5. The re-arm precedent (`guard.ts:57`) does not transfer.
+
+Task 3 calls the fresh-controller re-arm "the single most load-bearing detail of
+PR 1" and grounds it in checkpoint-resume. Two problems.
+
+First, it is not a PR 1 detail at all — cost trips fire no abort signal, so there
+is nothing to re-arm (see finding 4). It belongs to PR 2.
+
+Second, the precedent is weaker than the plan thinks. `resume()` rebuilds
+plumbing only when `!this.controller` (`guard.ts:356`), which is true after
+deserialization and false for an in-place approve. And `installAbortPlumbing`
+sets `previousSignal = stack.abortSignal` (`guard.ts:453`) — calling it again in
+place would capture the **already-aborted composed signal** as the "previous"
+one, permanently poisoning the stack. An in-place re-arm must restore
+`previousSignal` first, then re-compose.
+
+Worse, with nested time guards the composition is a chain: an inner guard
+installed after the tripped one did `AbortSignal.any([outerComposed, mine])` and
+holds the aborted `outerComposed` as its own `previousSignal`. Un-aborting the
+tripped guard means rebuilding every composition above it. Nothing in the plan
+covers this, and there is no existing helper for it. Suggest a fixture: nested
+time guards, outer trips, approve, inner guard still enforces afterward.
+
+### 6. Negative-as-disarm collides with additive arithmetic. Fail-open direction.
+
+Decisions 2 and 4 put two meanings on one number: `maxCost` is a delta to add,
+except any negative value silently disarms metering entirely. So a handler that
+computes `approve({maxCost: budget - alreadySpent})` disarms the guard the moment
+that expression goes negative. For a cost-control feature, the accidental
+outcome is unbounded spend.
+
+Negative-as-disable is an established convention (`guard(cost: -1)`,
+`rootBudget.ts:22`, the `NO_COST_CAP` idiom in `stdlib/agency.agency:165`), but
+there it decorates a *construction* argument where no arithmetic happens. In an
+additive channel it is a different thing wearing the same clothes. Recommend an
+explicit key (`approve({disarm: ["cost"]})`) or clamping deltas at zero. Cheap
+now, breaking later.
+
+Note also that "disarmed" is a genuinely new third state: today a disabled
+dimension means *no guard was installed at all*, not an installed guard that
+never trips. `disarmed` therefore needs the serialization treatment the plan
+gives it, plus a decision on what `isTripped()` reports for a disarmed guard that
+already tripped once.
+
+### 7. The migration list misses the stdlib's own guard users.
+
+Task 5 scopes the breaking change to `tests/agency/guards/` plus docs. But
+`stdlib/agency.agency:167` wraps subprocess `run()` in `guard(cost: cap)` and
+branches on `guarded is failure(err)` / `err.type == "guardFailure"` to produce
+the `limit_exceeded` shape (`:181-190`). Under uniform-interrupt semantics that
+trip stops being a failure and becomes an interrupt propagating to the user
+endpoint — silently changing `run(maxCost:)`'s contract for every caller.
+
+`std::agents` is the other likely site (guard scoping is load-bearing there).
+Task 5 should start with an audit: `grep -rn "guard(" stdlib/ lib/agents/`, and
+every internal caller that consumes a trip as a value gets an explicit
+`handle ... with { reject() }` wrapper. Right now these would ship as an
+unnoticed regression, since the guards fixture sweep would not catch them.
+
+### 8. `__guardTrip_<guardId>` keyed on `frame.locals` contradicts its own rationale.
+
+Task 2 wants the key on the frame "not by step path — the same trip must be
+answerable no matter which step boundary sees it first." But `frame.locals` is
+per-frame, and different step boundaries live in different frames: an inner
+frame's boundary raises and persists the id, the inner frame returns and pops,
+the outer frame's next boundary sees the same pending trip, misses the lookup,
+and re-raises. Frame-local storage buys nothing that step-path keying does not,
+and loses exactly the property the plan wants. If the id must be branch-scoped,
+put it where branch-scoped state already lives (`stack.other`, which is
+branch-local and serialized).
+
+---
+
+## Smaller notes
+
+- **Open question 1** — yes, option (b). A handler answering `approve({})` should
+  get a runtime error, not a livelock. Note this is only reachable because
+  omitted-continues (decision 3) makes `approve({})` a legal no-op; the error is
+  the price of that uniformity, and it is worth paying.
+- **Open question 4** — `reject()` needs no plumbing changes; `renderVerdict`
+  already carries reject with no value and reject-precedence is unconditional
+  (`interrupts.ts:274`, `mergeChainOutcomes` at `:315`). You can close this now.
+- **Open question 2** — generic events plus payload is right, and it costs
+  nothing to revisit later.
+- `TimeGuard.check()` sets `consumed = true` before returning the trip
+  (`guard.ts:365-371`). Task 1's mutator must reset `consumed` as well as
+  `tripped`, not just "the consumed/tripped latch" as one thing — they are two
+  fields with different jobs, and missing `consumed` produces a guard that never
+  trips again (fail-open) rather than one that re-trips.
+- **Estimate.** 3–4 days for PR 1 is not credible once findings 1, 3, and 4 turn
+  into tasks — the raise mechanism for cost trips is unwritten, the root marker
+  is new work, and the handler-budget decision may add a stack-scoping mechanism.
+  Re-estimate after the owner answers finding 1.
+
+## What the plan gets right
+
+Worth saying: the fork/race/IPC section is the strongest part and I found nothing
+wrong in it. Case 2's rule (resolve approve from the interrupt's own StateStack,
+never a global id lookup) is correct and load-bearing — `cloneForBranch` does
+carry the parent's guardId (`guard.ts:423`). Case 1's shared-cost-guard reasoning
+matches `CostGuard.cloneForBranch` returning `this` (`guard.ts:210`). Case 5's
+"the mutation happens where the answer is applied, in the child that owns the
+guard" is right by construction. Decision 5 (no `thread` in v1) is the right
+scope cut.
+
+## Recommended next steps
+
+1. Owner decides finding 1 (the handler's own budget). Everything else in PR 1
+   is downstream of it.
+2. Rewrite Task 2 around the real cost-trip detection sites in `prompt.ts`, and
+   state explicitly whether the raise is at the detection point or deferred to a
+   step boundary — with the "how much can be spent in the pending window" answer.
+3. Promote the root marker and the abort re-arm out of "verify this" into real
+   tasks, the re-arm in PR 2 where it belongs.
+4. Add the stdlib migration audit to Task 5.
+5. Re-estimate.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards.md
@@ -1,0 +1,1260 @@
+# Resumable Guards Implementation Plan (rev 8)
+
+> **Status:** updated 2026-07-16 after the rev-7 review
+> (`2026-07-16-resumable-guards-REVIEW-rev7.md`), which verified the
+> deadlock fix's concurrency and left two mechanical corrections, both
+> folded: the detect→raise call sites LOOP until the stack is clear (a
+> single check would leak one request past a newly-over outer guard —
+> decision 16's "asks its own question" now has a where), and the
+> pending-trip record's `try` starts on the line after the set (a throw
+> in the gap would have leaked the record and re-opened the deadlock).
+> Every decision is settled. EXECUTION-READY.
+
+**All file paths are relative to `packages/agency-lang/`.**
+
+---
+
+# Part 1: Background — how things work today
+
+You cannot follow this plan without four pieces of context. Each is short.
+
+## 1.1 How a guard trips today
+
+`guard(cost: $1, time: 5m) as { ... }` does NOT create one guard object. It
+creates two: a `CostGuard` and a `TimeGuard`, each with its own `guardId`
+(`lib/stdlib/thread.ts:263-291`, `_pushGuard` returns a `string[]` of ids).
+Both are pushed onto the branch's `StateStack.guards` array. This plan calls
+the pair a **guard scope**. The runtime has no name for it today; PR 2 gives
+it one (`GuardScope`).
+
+The two guards trip in different places:
+
+- **Cost guards** trip wherever cost is charged, via `stack.enforceGuards()`
+  (stateStack.ts:569), which walks the guards and throws
+  `GuardExceededError` if any is over budget. It has FOUR callers, and this
+  plan treats each one explicitly (Task 2.2): the pre-request gate in
+  `runPrompt` (prompt.ts:554); the post-charge check after a completion
+  (prompt.ts:699); `addCost` (`lib/runtime/cost.ts:12`), which is how paid
+  TypeScript helpers charge cost outside of `llm()` — its docstring warns
+  "callers must not swallow it"; and the subprocess telemetry handler
+  (`lib/runtime/ipc.ts:897`), where a child's reported cost charges the
+  parent's guards and a trip kills the child.
+- **Time guards** trip from a timer. When the timer fires, the guard aborts
+  an `AbortController`. That composed abort signal cancels whatever is in
+  flight: an LLM request gets cancelled mid-generation, a `sleep()` wakes up
+  early, and pure Agency code notices at its next step boundary (every
+  compiled statement runs inside `runner.step(...)`, and step entry checks
+  the signal via `shouldSkip`, `lib/runtime/runner.ts:315`).
+
+## 1.2 How an interrupt is raised and answered today
+
+`lib/runtime/agencyInterrupt.ts` documents the whole dance. Short version:
+
+1. The raise site calls `interruptWithHandlers(effect, message, data, ...)`
+   (`lib/runtime/interrupts.ts:422`).
+2. That runs the **handler chain**: every handler on `ctx.handlers`, innermost
+   first. Each handler returns `approve(value)`, `reject()`, `propagate()`,
+   or nothing. Reject short-circuits. Approvals overwrite each other
+   (outermost wins). Any propagate beats any approve.
+3. If the chain settled it, the raise site gets the verdict directly. **No
+   checkpoint happens in this case.** The handler chain runs to completion
+   before the raise site moves — the paused code cannot race its own verdict.
+4. If nobody settled it, the interrupt propagates outward: the run halts,
+   a checkpoint serializes the branch, and the user (CLI prompt, `--policy`,
+   or a TypeScript caller) answers. On resume, the program replays from the
+   top with step counters skipping completed work, and the raise site returns
+   the recorded answer instead of re-raising (resume idempotency, keyed by a
+   persisted interrupt id).
+
+One harness detail that matters for our fixtures: when a test's `test.json`
+answers an interrupt with a value, the action is `"resolve"`, not
+`"approve"` — `{"action": "resolve", "resolvedValue": {...}}` maps to
+`approve(value)` (`lib/templates/cli/evaluate.ts:47`).
+
+## 1.3 How handlers and guards relate at runtime
+
+Handlers live on `ctx.handlers` (context-wide). Guards live on
+`stack.guards` (branch-local). A handler body executes in the raising
+branch's async context, so when the handler calls `llm()`, that call reads
+the SAME stack — and today it is metered and gated by ALL installed guards,
+including the one whose trip the handler is deciding. That is the bug class
+decision 3 (below) fixes.
+
+Two structural facts drive the design:
+
+- **Handlers are replayed; guards are restored.** On resume, a handler
+  whose `handle` block is still OPEN at checkpoint time is re-registered by
+  re-executing its registration (handlers are functions; they cannot be
+  serialized — CLAUDE.md calls them safety infrastructure). A handle block
+  that already COMPLETED is skipped entirely, and correctly so — its scope
+  is over. The proof is one line in the very function this plan edits:
+  `Runner.handle` opens with `if (this.getCounter() > id) return;`
+  (runner.ts:772) — a completed block returns BEFORE `pushHandler`. Guards
+  are the opposite: they are restored wholesale from JSON before replay
+  starts (`stateStack.ts:883`). Any rule that connects "a handler" to
+  "some guards" must survive that asymmetry. Array indices and depth
+  counters do not (rev-2 review). Counters of any kind do not — runner.ts:772
+  is exactly why four counter designs died in review (decision 14). The
+  design below uses guard IDENTITY (ids are serialized and stable) plus a
+  memo whose key reproduces under replay.
+- **`Runner.beforeStep` resumes every guard at every step entry**
+  (runner.ts:265-267). Any "this guard is suspended" state must survive
+  that, or the first step a handler body executes will un-suspend the
+  tripped guard (rev-3 review finding 3).
+
+## 1.4 What already shipped
+
+The salvage pipeline (#553/#554/#556): an aborted scope returns an
+`AbortedResult`; `saveDraft` and `finalize` produce the partial value a
+tripping guard salvages. Nothing in this plan changes any of it. Reject means
+"run that pipeline exactly as today." Guard labels shipped in #554. Message
+debug labels are in flight separately (#557); PR 4 uses them.
+
+---
+
+# Part 2: The decisions
+
+Every numbered decision here is owner-settled.
+
+1. **Trips become ordinary interrupts (effect `std::guard`) — a breaking
+   change.** An unhandled trip propagates like any interrupt: to the
+   TypeScript caller, or to the user endpoint, or (headless, no policy) it
+   halts with the standard unhandled-interrupt error. Code that wants
+   today's "trip returns a failure" wraps the guard:
+   `handle { ... } with (i) { return reject() }`, or answers `std::guard`
+   via `--policy`.
+2. **Approve is additive.** `approve({maxCost: 0.05})` on a guard that spent
+   $1.00 of $1.00 makes the limit $1.05. Naming the other dimension adds to
+   it too. An omitted dimension is untouched and keeps its remaining
+   allowance.
+3. **A handler's registration site decides everything about it.** One rule,
+   two consequences. Each handler remembers *which guard ids were live when
+   it was registered*. Consequence one: a handler can only see trips from
+   guards NOT in that set (you cannot adjudicate a guard you are inside).
+   Consequence two: while the handler runs, guards NOT in that set are
+   suspended — they do not gate, meter, or charge the handler's own work.
+   This applies to handlers of ALL interrupts, not just trips (also
+   breaking, also accepted).
+4. **Disarm is explicit:** `approve({disarm: ["cost"]})`. Negative deltas
+   clamp to zero and warn. (Negative numbers still mean "disabled" at
+   guard *construction* — there they just mean no guard is pushed,
+   thread.ts:272-286 — but the approve channel does arithmetic, and
+   arithmetic that accidentally goes negative must not silently remove
+   metering.)
+5. **`pass()` is a new verdict** meaning "not mine, ask the next handler."
+   `undefined` still works and is normalized to `pass` at the boundary.
+6. **Approvals merge through a built-in, total, per-effect table.**
+   `std::guard` merges additively (sum grants, union disarm lists, join
+   messages). Every other effect merges as `(inner, outer) => outer`, which
+   is byte-for-byte today's behavior. There is NO user registration surface
+   in v1 (it was cut: a runtime registry is banned module-global state, it
+   diverges across subprocess boundaries, and user merge closures would sit
+   on the FunctionRefReviver problem surface — #513/#544). Registration
+   arrives with typed payloads (#555).
+7. **Reject is absolute** (any reject rejects; short-circuits; no payload).
+   **Propagate discards accumulated approvals** in v1.
+8. **A useless approval is a runtime error.** If the merged answer leaves
+   the tripped dimension still over budget and still armed, the run would
+   re-trip forever (the handler-chain recursion guard cannot catch this;
+   its depth counter resets on every fresh trip). The error is attributed to
+   the answering handler. Per dimension: cost is over when
+   `spent > costLimit`; time is over when elapsed working time ≥ `timeLimit`.
+9. **Root budgets stay hard.** `--max-cost`/`--max-time` guards get a
+   serialized `isRootBudget` flag (nothing marks them today —
+   `rootBudget.ts:23,30`). Root trips never raise interrupts; they throw
+   exactly as today (spawn path exits 3). An approve that reaches a root
+   guard is refused.
+10. **Concurrent trips of one shared cost guard dedupe.** Fork branches
+    share one `CostGuard` object (`cloneForBranch` returns `this`,
+    guard.ts:210). Without dedupe, three branches raise three interrupts, a
+    handler grants $0.50 three times, and the limit silently rises $1.50.
+    With dedupe: while a trip for a scope is unanswered, other branches that
+    detect the same over-budget scope wait for that answer instead of
+    raising their own, then re-check. This is **cost-only by construction**
+    — time clones are separate objects with separate budgets, so there is
+    nothing to dedupe.
+11. **No `thread` in the interrupt data (v1).** Handlers that want the
+    conversation use `listThreads()`/`getThread()`. `draftValue` (the
+    guarded scope's `savedDraft` at raise time) IS included.
+12. **Statelog: the generic interrupt events, unchanged.** They already
+    carry `{effect, message, data}`. `pass()` adds one decision-variant
+    string. Approve-payload validation is runtime-only in v1.
+13. **Test disciplines** (from the rev-2 review, all adopted):
+    - Assert budgets by SPENDING INTO THE GAP. "It didn't hang" and "it
+      finished" pass under broken merges and over-grants. After two
+      $0.50 grants, a further $0.75 spend must not trip; in the broken
+      world it must.
+    - If a behavior can be shown with a cost guard, use a cost guard.
+      Wall-clock fixtures only for behavior that is irreducibly about time.
+    - Every migrated fixture's expected output must be BYTE-IDENTICAL after
+      its `handle`+`reject()` wrapper. Any diff is a semantic regression to
+      explain, not to accept.
+14. **Replay-stable keys are derived from POSITION or CONTENT — never from
+    counting events.** This plan got it wrong three times in a row (a depth
+    counter, a serialized counter, an in-memory counter, then a generation
+    counter), and each failed the same way: resume does not re-run events,
+    it re-runs the PATH to the checkpoint, skipping completed statements and
+    completed loop iterations (docs/dev/interrupts.md — "statements with
+    lower indices are skipped"; completed iterations skip via the
+    `__currentIter` comparison). Any counter therefore counts different
+    events on replay than it counted originally. The repo's two proven
+    replay-stable key families: position (the callsite's `stepPath`, stored
+    in the owning frame's locals — how `agency.interrupt` keys its
+    persisted ids) and content (the identity of the thing itself — how #551
+    keyed draft regions by `ids.join(",")`). Tasks 1.3b and 2.2 each use
+    one of these and say why.
+15. **The join rule (Part 3): Option A — the grant follows the budget.**
+    When a fork branch's time-guard clone is extended by an approve, the
+    parent guard is extended too, at the join. Mechanically: the parent is
+    charged the working time of ONE branch (the longest, via `addElapsed`),
+    so the parent's extension is THAT branch's granted delta — not the max
+    delta across branches, which could come from a different branch than
+    the time did. Each clone records its granted total in a serialized
+    field; the join reads it from the branch whose elapsed time it charges.
+16. **Grants never cross budgets.** The clone→parent extension in
+    decision 15 is one budget syncing its instances — the clone IS the
+    guard the user wrote, split by fork isolation. Distinct budgets stay
+    independent: extending an inner guard never touches the guards that
+    enclose it. If newly granted inner spend later pushes an OUTER guard
+    over its limit, the outer guard trips on its own, raises its own
+    interrupt, and is adjudicated by handlers registered outside IT —
+    possibly a human. Three reasons this is the right shape: an enclosing
+    guard is a containment promise, and auto-widening it from inside would
+    make every ceiling meaningless; root budgets are ancestors, and
+    decision 9 forbids extending them (an ancestor rule would need a root
+    carve-out — one rule becoming two is the tell); and each budget's own
+    decision point, with its own label and its own audience, is exactly
+    what the interrupt machinery is for. The guards guide should show the
+    resulting UX pattern: a handler that grants the inner budget may
+    immediately face the outer guard's own trip, which reads as "I approved
+    and it asked again" and is the system working.
+
+---
+
+# Part 3: The join rule (decided: Option A)
+
+The story that forced the decision: you fork three branches under
+`guard(time: 10m)`. Fork gives each branch its own clone of the time guard,
+so one slow branch cannot eat the others' budget. Branch B's clone trips at
+10 minutes. Your handler approves 5 more minutes. The approve extends **B's
+clone** — that is the guard that raised, and resolution is branch-local by
+design. B runs 5 more minutes and finishes.
+
+Now the join. Today, `runBatch` charges the parent guard with the LONGEST
+branch's working time (guard.ts:404, `addElapsed`). B worked 15 minutes. The
+parent's limit is still 10. Without a rule, the parent is now 5 minutes over
+budget and trips at the next step — even though you just approved those 5
+minutes and the work is already done.
+
+**Decided (Option A): the grant follows the budget.** The user approves
+against the guard they wrote, not against a clone they never see; "I
+approved and it tripped anyway, after the work succeeded" is the outcome
+that needs a bug report to understand. Mechanics are in decision 15: the
+parent extends by the granted delta OF THE BRANCH WHOSE TIME IT IS CHARGED
+(the longest branch) — not the max delta across branches, which could come
+from a different branch than the time did. Task 3.3 implements it.
+
+**And the rule stops there (decision 16): grants never cross budgets.**
+The parent extension is one budget syncing its fork instances. A NESTED
+guard is a different budget, and extending an inner guard never widens the
+guards around it — if the granted spend later pushes an outer guard over,
+that guard trips on its own and asks its own question.
+
+---
+
+# Part 4: PR 1 — interrupt infrastructure
+
+Everything in PR 1 works on ordinary interrupts. No guard raises anything
+yet. This is deliberate: the handler machinery is safety infrastructure, and
+we want its changes proven green against the whole existing interrupt suite
+before guards start using it.
+
+## Task 1.1: the `pass()` verdict
+
+**Files:**
+- `lib/runtime/interrupts.ts` (constructors at :34-38, chain loop at :264-292)
+- `lib/runtime/index.ts` (export barrel)
+- `lib/typeChecker/builtins.ts` (:276-294, next to `propagate`)
+- `docs/site/guide/handlers.md`
+- Tests: `lib/runtime/interrupts.test.ts` (or nearest existing chain test
+  file), one typechecker test, one agency execution fixture.
+
+**Runtime.** Add the constructor next to `approve`/`reject`:
+
+```ts
+/** Explicit "not my interrupt — ask the next handler." Identical in
+ *  effect to returning nothing, but usable in value position (a match
+ *  arm must produce a value). */
+export function pass(): InterruptResponse {
+  return { type: "pass" };
+}
+```
+
+Normalize at the boundary so the rest of the chain sees ONE spelling.
+In `runHandlerChain`, immediately after `result = await ctx.handlers[i](...)`:
+
+```ts
+// A handler that returns nothing means "pass". Normalize here so the
+// loop, statelog, and merge logic never see two spellings of it.
+if (result === undefined) {
+  result = { type: "pass" };
+}
+```
+
+Then the existing `if (result === undefined)` arm becomes
+`if (result.type === "pass")`, emitting `handlerDecision` with
+`decision: "pass"` and continuing. (`lib/statelogClient.ts`'s
+`handlerDecision` takes the decision as a string; add the variant to its
+type union if one exists.)
+
+**Typechecker.** One entry in `lib/typeChecker/builtins.ts`, mirroring
+`propagate` exactly:
+
+```ts
+pass: {
+  params: [],
+  returnType: ANY_T,
+  description:
+    "Inside a `handle ... with` block, decline to answer this interrupt and let the next handler decide.",
+},
+```
+
+That is the whole typechecker change. `approve`/`reject`/`propagate` are
+plain builtins returning `ANY_T`; handler return positions already typecheck
+against that; `pass()` slots in identically. No new diagnostic, no new
+checker pass. Verify the wiring end-to-end by grepping how `propagate`
+reaches generated code (runtime export + builtin entry is expected to be
+all of it) and mirror whatever you find.
+
+**Tests.**
+- Chain unit test: a handler returning `pass()` continues the chain; a
+  handler returning `undefined` still continues the chain (back-compat pin);
+  both emit `decision: "pass"`.
+- Typechecker test: a handler whose body is a `match` on
+  `intr.effect` with a `pass()` arm typechecks (this is the motivating
+  case: exhaustiveness needs a value in every arm).
+- Agency fixture: two nested handle blocks; inner passes, outer approves;
+  the interrupt resolves approved.
+
+## Task 1.2: the total merge table
+
+**Files:**
+- Create: `lib/runtime/effectMerge.ts`
+- Modify: `lib/runtime/interrupts.ts` (`runHandlerChain` :264-298,
+  `mergeChainOutcomes` :301-326)
+- Tests: co-located unit tests + one agency fixture.
+
+**The table.** A constant — not a mutable registry:
+
+```ts
+type ApprovalMerge = (inner: any, outer: any) => any;
+
+/** How two approvals of the same interrupt combine. `inner` is the
+ *  approval from the handler closer to the interrupt. Total: every
+ *  effect has a merge; the default IS the historical behavior
+ *  (outermost approval wins). Deliberately a constant — a runtime
+ *  registration surface was cut from v1 (module-global state, silent
+ *  cross-process divergence, function refs across checkpoints). */
+const DEFAULT_MERGE: ApprovalMerge = (_inner, outer) => outer;
+
+const MERGES: Record<string, ApprovalMerge> = {
+  "std::guard": (a, b) => ({
+    maxCost: sumOrUndefined(a?.maxCost, b?.maxCost),
+    maxTime: sumOrUndefined(a?.maxTime, b?.maxTime),
+    disarm: unionOrUndefined(a?.disarm, b?.disarm),
+    message: joinOrUndefined(a?.message, b?.message, "\n"),
+  }),
+};
+
+export function mergeFor(effect: string): ApprovalMerge {
+  return MERGES[effect] ?? DEFAULT_MERGE;
+}
+```
+
+(`sumOrUndefined(a, b)` returns `undefined` when both are undefined,
+otherwise `(a ?? 0) + (b ?? 0)`; likewise the union and join helpers. Write
+them in this file; they are three lines each.)
+
+**The chain.** Replace the `hasApproval`/`approvedValue` mutable pair with
+collect-then-reduce. In `runHandlerChain`, the approve arm becomes
+`approvals.push(result.value)` (plus its existing statelog line), and the
+final rendering becomes:
+
+```ts
+if (hasPropagation) return { kind: "propagated" };
+if (approvals.length > 0) {
+  const merge = mergeFor(interruptObj.effect);
+  return { kind: "approved", value: approvals.reduce(merge) };
+}
+return { kind: "noResponse" };
+```
+
+`approvals` is in chain-walk order, which is innermost-first, so
+`reduce(merge)` applies `merge(inner, outer)` in the documented order.
+
+**Cross-process.** `mergeChainOutcomes(inner, outer)` currently resolves a
+double-approve as `outer.value ?? innerValue`. Replace that arm with
+`mergeFor(effect)(innerValue, outer.value)` — which requires threading the
+effect into the function (it currently takes only the two outcomes; add the
+parameter, update both call sites in `gatherChainOutcome`).
+
+One pre-existing asymmetry to preserve, stated plainly because it means the
+default merge is two functions, not one. In-process, an outer approve with
+no value OVERWRITES an inner approve's value with undefined — that is
+deliberate and documented in the chain. Across IPC, an outer valueless
+approve DEFERS to the inner value, because JSON cannot distinguish "no
+value" from "explicitly undefined." So: the in-process default merge is
+`(inner, outer) => outer`; the IPC default merge is
+`(inner, outer) => outer ?? inner`. `std::guard`'s additive merge is the
+same function on both paths. Put both defaults in `effectMerge.ts` side by
+side with this explanation as the comment.
+
+**Tests.**
+- Unit: `reduce` order (three approvals, non-commutative message join comes
+  out inner-to-outer); default merge = overwrite, pinned against the
+  existing chain tests running unchanged.
+- Agency fixture, spend-shaped per decision 13: two nested handlers each
+  `approve({maxCost: 0.50})` on a `std::guard` interrupt (PR 1 can raise one
+  synthetically from a test helper, or this fixture waits for PR 2 — if it
+  waits, pin the merge with a unit test now and add the fixture to PR 2's
+  list). After both grants, a $0.75 spend must NOT trip. Under a merge
+  silently degraded to overwrite, it must.
+
+## Task 1.3: registration-site scoping
+
+This is the safety-critical task. Read Part 1.3 first.
+
+**Files:**
+- Modify: `lib/runtime/runner.ts` (`Runner.handle` :766-785 — THE capture
+  point; see 1.3a)
+- Modify: `lib/runtime/state/context.ts` (handler entry shape, `pushHandler`
+  :532)
+- Modify: `lib/runtime/agency.ts` (:304, `agency.withHandler`) and
+  `lib/runtime/agencyFunction.ts` (:267, `preapprove`) — the two TS-side
+  registration paths
+- Modify: `lib/ir/prettyPrint.ts` (:389, the `withHandler` TSIR node's
+  inline emission for top-level init)
+- Modify: `lib/runtime/state/stateStack.ts` (new method `guardsHiddenFrom`)
+- Modify: `lib/runtime/guard.ts` (interface + both variants: `suspend()` /
+  `unsuspend()`)
+- Modify: `lib/runtime/interrupts.ts` (chain loop: suspend around each
+  handler invocation)
+- Tests listed at the end of the task.
+
+### 1.3a: what each handler remembers, and WHERE it is captured
+
+The handler entry grows from a bare function to:
+
+```ts
+type HandlerEntry = {
+  fn: HandlerFn;
+  /** guardIds live on the registering branch's stack at registration
+   *  time. Decides which trips this handler may see, and which guards
+   *  are suspended while it runs. See 1.3b for the memo. */
+  liveGuardIds: string[];
+};
+```
+
+`ctx.pushHandler` has THREE callers, and each gets an explicit rule —
+the rev-5 review's blocker was anchoring the capture in a function
+(`withPushedHandler`) that Agency `handle` blocks never call. The real
+registration path for Agency code is:
+
+```
+handleBlock → processHandleBlockWithSteps (typescriptBuilder.ts:4020)
+            → "await runner.handle(<id>, <handler>, ...)"
+            → Runner.handle (runner.ts:766) → ctx.pushHandler (:778)
+```
+
+(`with` modifiers take the same path, :4055.)
+
+1. **`Runner.handle` (runner.ts:778) — Agency `handle` blocks and `with`
+   modifiers. The capture point.** It has everything the memo needs, with
+   no ALS reach-through: `this.stack` (the branch's guards), `this.frame`
+   (the per-frame store that makes recursion safe), `this.stepPath(id)`
+   (the position key — already computed two lines up for coverage), and
+   the existing `finally` (:783-785) for the delete-on-pop rule. The full
+   sketch is in 1.3b.
+2. **`agency.withHandler` (agency.ts:304) — the public TS API** (and
+   `withPushedHandler`, which serves it). Captures the live ids from its
+   ALS stack at call time, with NO memo: TS callers sit outside the
+   replay machinery and own their own re-execution semantics. Document
+   that at the API.
+3. **`preapprove()` (agencyFunction.ts:267) and the top-level-init
+   `withHandler` TSIR emission (prettyPrint.ts:389).** Both register
+   handlers with `liveGuardIds: []`. Empty is NOT a neutral default —
+   `guardsHiddenFrom` reads it as "hide every guard" — so it is a stated
+   decision, not an accident: the init wrapper registers before any guard
+   can exist (correct), and preapprove's body never spends (see next
+   paragraph).
+
+**`preapprove()` must `pass()` on `std::guard`.** Its handler answers
+every interrupt with `approve()` — which for a guard trip is
+`approve({})`, and decision 8 makes that a runtime error. Auto-approving
+work is meaningful; auto-granting budget is not. The preapprove wrapper
+gains one line: `if (intr.effect === "std::guard") return pass();`. Pin it
+with a fixture (a preapproved tool trips a guard: the trip propagates
+outward instead of erroring inside the wrapper).
+
+### 1.3b: why there is a memo, and what its key is
+
+The trap (rev-2, rev-3, AND rev-4 reviews — and the #551 `draftRegionStart`
+bug before all of them): on resume, `stack.guards` is restored from JSON
+BEFORE replay re-runs the `withPushedHandler` calls. So a replayed capture
+sees guards that did not exist when the handler originally registered —
+including the tripped guard itself. The replayed handler would then "know
+about" the tripped guard, suspend nothing, and the whole feature silently
+breaks after any resume (which is the feature's main use case).
+
+Fix: capture is MEMOIZED, first-write-wins. The original run writes the
+true set; a replayed registration finds the memo and uses it; the
+post-restore recomputation never wins.
+
+The memo key must reproduce under replay, and decision 14 is the law here:
+**position or content, never an event count.** Four counting keys have now
+failed review in a row, each for the same reason — replay does not re-run
+events, it re-runs the path to the checkpoint, SKIPPING completed
+statements and completed loop iterations. Concretely, the counter version
+dies with no loop at all: two sequential handle blocks; the first completes
+and is skipped on resume; the second — ordinal 1 in the original run — is
+the FIRST registration the replay executes, asks for ordinal 0, and
+memo-hits the first block's stale set. The tripped guard is not in that
+set, so it gets suspended for a handler that sits inside it. Fail-open.
+
+The design that works is the one `agency.interrupt` already uses for its
+persisted ids (`agencyInterrupt.ts:152`): **key by position — the
+registering callsite's `stepPath` — and store in the registering frame's
+`locals`** (which serialize with the stack). Plus one cleanup rule that
+makes loops safe. In `Runner.handle` (runner.ts:778), where everything
+needed is already a field on `this`:
+
+```ts
+// In Runner.handle, replacing the bare pushHandler at :778:
+const memoKey = `__handlerGuards_${this.stepPath(id)}`;
+let liveGuardIds = this.frame.locals[memoKey] as string[] | undefined;
+if (liveGuardIds === undefined) {
+  liveGuardIds = this.stack.guards.map((g) => g.guardId); // first write wins
+  this.frame.locals[memoKey] = liveGuardIds;
+}
+this.ctx.pushHandler(handlerFn, liveGuardIds);
+this.path.push(id);
+try {
+  await this.runInScope(() => callback(this));
+} finally {
+  this.path.pop();
+  this.ctx.popHandler();                    // existing finally, :783-785
+  delete this.frame.locals[memoKey];        // the cleanup rule — see below
+}
+```
+
+And one line above all of this, already in the function, is decision 14's
+proof: `if (this.getCounter() > id) return;` (runner.ts:772) — a completed
+handle block returns before registering anything on replay. That line is
+what killed every counter design.
+
+Why each hard case is safe:
+
+- **Sequential handle blocks:** different callsites, different `stepPath`s,
+  different keys. No collision, skipped-or-not.
+- **A handle block inside a loop:** every iteration registers from the SAME
+  callsite — which is why a bare callsite key failed rev-3 review
+  (first-write-wins would hand iteration 2 iteration 1's stale set, and
+  since `nextGuardId()` mints fresh ids per push, iteration 2's own guard
+  would be missing from it — fail-open). The cleanup rule fixes it: the
+  memo entry is deleted when the registration POPS, so at most one live
+  registration per callsite holds an entry at any time, and it is always
+  its own. A resume lands inside some iteration; that iteration's entry
+  was written and not yet deleted; the replayed registration memo-hits its
+  own set. Completed iterations deleted their entries before completing.
+- **Does the checkpoint see the entry before the dying process deletes
+  it?** Yes, on two conditions, both stated so the executor verifies
+  rather than assumes. Ordering: the checkpoint serializes at the raise,
+  and the `finally` deletion in the abandoned process runs during the
+  unwind AFTER the snapshot exists. And COPYING: `checkpoints.create` must
+  snapshot `frame.locals` by value, not hold a live reference — an aliased
+  snapshot would feel the delete exactly when the memo is needed. This is
+  #551's lesson in reverse (there, the serialize path hid the bug; here it
+  is the protection), so it is very likely already a deep copy. Verify it
+  in one line before relying on it; the delete-on-pop rule rests on it.
+- **Recursion** (the same handle block callsite in two live frames at
+  once): `frame.locals` is per-frame, so each activation has its own
+  entry. This is exactly why the store is frame locals and not
+  `stack.other` — a branch-global map keyed by callsite would collide
+  across recursive activations.
+- **One registration per step body** is the constraint this inherits, the
+  same one `agency.interrupt` documents for itself. The compiled handle
+  block wrapper satisfies it by construction; assert it in a comment.
+
+Do not test key values or ordinals — test the behavior (rev-2 review T3):
+the resume test below fails under every broken key design we have tried,
+whatever the key is.
+
+### 1.3c: suspension is a guard state, not call-site filters
+
+Add to the `Guard` interface (`guard.ts:20-59`) — and note that interface's
+own contract: StateStack and Runner only ever talk to the interface, no
+variant-specific branching at call sites. Suspension keeps that promise:
+
+```ts
+/** While suspended, a guard is invisible to enforcement: check()
+ *  returns null, charge() is a no-op, and (TimeGuard) the working-time
+ *  clock is paused. resume() DOES NOT clear suspension — Runner's
+ *  beforeStep resumes every guard at every step entry (runner.ts:265),
+ *  and a handler body executes steps; without this rule the first step
+ *  of the handler would silently un-suspend the tripped guard and
+ *  restart its clock. Only unsuspend() clears it.
+ *  NEVER serialized: a handler that propagates gets checkpointed
+ *  mid-suspension, and a suspended flag riding the snapshot would
+ *  resume the run permanently unmetered. */
+suspend(): void;
+unsuspend(): void;
+```
+
+- `CostGuard`: `suspended` boolean; `check()` and `charge()` return early.
+- `TimeGuard`: `suspend()` = pause the clock + set the flag; `resume(stack)`
+  no-ops while the flag is set; `unsuspend()` clears the flag (the next
+  `beforeStep` resume restarts the clock normally).
+- `enforceGuards` (stateStack.ts:569) and the charge path DO NOT CHANGE.
+- `toJSON`: `suspended` is excluded. (`disarmed`, decision 4, is included —
+  adjacent flags, opposite rules, opposite fail directions. Say so in a
+  comment on both.)
+
+Selection is one named method on the stack:
+
+```ts
+/** The guards a given handler must not see or be metered by: every
+ *  installed guard that was NOT live when the handler registered.
+ *  Identity-based on guardId — ids are serialized and survive resume
+ *  and fork (clones keep the parent's id), which array indices do not. */
+guardsHiddenFrom(entry: HandlerEntry): Guard[] {
+  return this.guards.filter((g) => !entry.liveGuardIds.includes(g.guardId));
+}
+```
+
+**The cross-branch rule.** `ctx.handlers` is context-wide (context.ts:85)
+while `liveGuardIds` are branch-local, so a handler registered inside fork
+branch A is consulted for an interrupt raised in sibling branch B. That
+visibility is pre-existing behavior; decision 3 gives it a defined meaning
+rather than an arbitrary one, because `guardsHiddenFrom` always evaluates
+against the RAISING branch's stack: guards that existed before the handler
+registered (shared cost guards; inherited time clones, which keep the
+parent's id) match the captured set and still meter the handler; anything
+newer — including everything branch-local to the sibling — is hidden. Note
+the main use case DEPENDS on cross-branch eligibility: the walked example's
+handler registers before the fork, so branch trips must reach it. One
+fixture pins the sibling case: a handler registered inside branch A,
+answering an interrupt raised in branch B, is metered by the shared
+pre-fork guard and not by B's local guards.
+
+### 1.3d: the chain applies it
+
+In `runHandlerChain`, around each handler invocation (the existing
+`enterToolCall`/`exitToolCall` bracket at interrupts.ts:236-242 shows the
+shape):
+
+```ts
+const hidden = stack ? stack.guardsHiddenFrom(entry) : [];
+hidden.forEach((g) => g.suspend());
+try {
+  result = await entry.fn(interruptObj);
+} finally {
+  hidden.forEach((g) => g.unsuspend());
+}
+```
+
+Per-handler, not per-chain: each handler in the chain has its own
+registration site, so each gets its own hidden set (a handler registered
+between two guards is metered by the outer one and not the inner one —
+the owner's example 3).
+
+Visibility (which trips a handler may see) uses the same set and lands in
+PR 2 Task 2.3, because only trip dispatch consults it.
+
+### Tests for Task 1.3
+
+Gate: the FULL existing handler and interrupt suites green on the new entry
+shape before any of the following are added.
+
+1. **The behavioral resume test** (catches the memo bug whatever the
+   implementation): program with `handle` at node level; inside it, a guard
+   block; inside that, an ordinary interrupt that the handler answers with
+   `propagate()`; harness answers; on resume the SAME handler runs again for
+   a second interrupt and its own mocked-cost `llm()` is neither gated nor
+   charged by the inner guard. Assert the inner guard's spend did not move
+   (spend-shaped, decision 13).
+2. **Tripped-guard suspension**: a guard that is already over budget
+   (mocked cost), an ordinary interrupt raised inside it, the node-level
+   handler's own `llm()` must complete — this exercises the pre-call gate
+   (prompt.ts:554), which only refuses when a guard is ALREADY over budget;
+   an untripped-guard fixture cannot cover it.
+3. **Owner example 3**: handler inside `guard(cost: $20)`, adjudicating
+   work inside a deeper guard: the handler's `llm()` charges the $20 guard
+   (assert by spending it to just under, then over) and never the inner one.
+4. **`suspended` never serializes**: handler propagates mid-suspension →
+   checkpoint → harness answers → resumed run's guard still meters
+   (spend past the limit must trip).
+5. **Loop registration**: a handle block inside a `for` loop across two
+   iterations, each iteration pushing its own guard; the iteration-2 handler
+   is metered by iteration-2's context correctly (pins the memo-key
+   loop-iteration hazard from 1.3b).
+6. **`preapprove()` passes on `std::guard`** — the 1.3a rule. The full
+   trip-shaped fixture lives in Task 2.5's table (trips don't exist until
+   PR 2); what PR 1 can and should pin is the unit-level half: the
+   preapprove wrapper's handler returns `pass` for a `std::guard`-effect
+   interrupt and `approve` for everything else.
+
+---
+
+# Part 5: PR 2 — GuardScope, and cost trips become interrupts
+
+## Task 2.1: `GuardScope` — the runtime object for what `guard(...)` pushes
+
+**What it is.** `guard(cost: $1, time: 5m)` pushes two runtime guards
+(Part 1.1). Everything user-facing — the label, the interrupt, the approve
+payload with both `maxCost` and `maxTime`, disarm lists, the root refusal —
+is about the PAIR. `GuardScope` is the class that represents the pair. It is
+not stored anywhere; it is constructed on demand from a stack plus the
+member ids (which ARE stored).
+
+**Files:**
+- Create: `lib/runtime/guardScope.ts`
+- Modify: `lib/stdlib/thread.ts` (`_pushGuard` :263-291)
+- Modify: `lib/runtime/guard.ts` (new serialized field `scopeIds`; mutators;
+  `isRootBudget`)
+- Modify: `lib/runtime/rootBudget.ts` (:23,30 — stamp `isRootBudget`)
+- Tests: `lib/runtime/guardScope.test.ts`, additions to `guard.test.ts`.
+
+**Wiring the ids.** `_pushGuard` already computes the id array; it now also
+stamps it on each member so the pair can find itself later:
+
+```ts
+// In _pushGuard, after both pushes:
+for (const g of pushed) {
+  g.scopeIds = ids;   // every member knows the whole scope
+}
+```
+
+`scopeIds` is serialized in `GuardJSON` (it must survive resume, same
+reasons as `guardId`, guard.ts:94-97) — and it must ALSO be copied in
+`TimeGuard.cloneForBranch` (guard.ts:421-424 copies fields BY HAND;
+serialization and cloning are different paths, and the rev-3 review caught
+that a field added to one silently misses the other).
+
+**The class:**
+
+```ts
+/** The Agency-level guard: the set of runtime guards one `guard(...)`
+ *  call pushed (cost, time, or both). Constructed on demand from the
+ *  raising branch's stack — NEVER from a global registry, because fork
+ *  clones share the parent's guardId and only the branch's own stack
+ *  knows which physical object answers to an id there. */
+export class GuardScope {
+  private constructor(private members: Guard[]) {}
+
+  /** Resolve on the given stack; innermost match per id. Returns the
+   *  members present there (a branch stack holds clones; the parent
+   *  stack holds originals — both are correct scopes for their branch). */
+  static resolve(stack: StateStack, scopeIds: string[]): GuardScope | null;
+
+  /** The member for a dimension, if this scope has one. */
+  costMember(): CostGuard | null;
+  timeMember(): TimeGuard | null;
+
+  /** True if ANY member is a root budget — the whole scope refuses
+   *  extension (decision 9). */
+  containsRootBudget(): boolean;
+
+  /** Apply a merged approve payload: additive extends (negative deltas
+   *  clamp to zero + runtime warning), then disarms. Throws
+   *  GuardApproveError on: unknown dimension for this scope, a root
+   *  member, or a payload that leaves the tripped dimension still over
+   *  budget and armed (decision 8, checked against `tripped`). */
+  extend(payload: ApprovePayload, tripped: "cost" | "time"): void;
+
+  /** The interrupt-data fields: label, per-dimension limits and spend,
+   *  which dimension tripped. */
+  snapshot(tripped: "cost" | "time"): GuardTripData;
+
+  suspendAll(): void;    // raise-time freeze, PR 2 Task 2.2
+  unsuspendAll(): void;
+}
+```
+
+**Guard mutators** (on the variants, called only by `GuardScope.extend`):
+
+- `CostGuard.extendBudget(delta)`: `costLimit += max(0, delta)`; clear the
+  tripped latch. `costLimit` is `readonly` today (guard.ts:165) — make it
+  mutable.
+- `TimeGuard.extendBudget(deltaMs)`: same, AND reset **both** `tripped` and
+  `consumed` (guard.ts:365-371 sets `consumed` before returning the trip;
+  resetting only one produces a guard that never trips again — fail-open,
+  the worse direction). `timeLimit` mutable (was readonly, guard.ts:317);
+  note `cloneForBranch` computes remaining from `timeLimit`, which is the
+  Part 3 decision's mechanical hook.
+- `disarm(dimension)`: serialized `disarmed` flag; a disarmed guard's
+  `check()` never trips and `isTripped()` reports false.
+- `isRootBudget`: serialized; stamped by `installRootBudget`.
+
+**Unit tests** (restored from rev 1 plus the review's additions): extend
+then spend-under passes, spend-over trips (both dimensions); time extend
+re-trips after the new allowance (proves both latches reset); disarm and
+`isRootBudget` survive `toJSON`/`fromJSON`; a scope containing a root member
+refuses `extend`; `scopeIds` survives BOTH serialization and
+`cloneForBranch`; negative delta clamps, warns, and the guard still trips on
+the next overspend (the warning is secondary — the metering surviving is
+the point).
+
+## Task 2.2: raise cost trips at their detection sites
+
+**Where trips are detected, and what happens at each site.** This is the
+taxonomy the plan owes. Cost has FOUR detection sites (Part 1.1), and the
+rev-4 review caught that pretending there are two would have silently
+disarmed the other two. Time is PR 3.
+
+| # | Context | Detected by | Under this plan | On approve |
+|---|---------|-------------|-----------------|------------|
+| 1 | Cost, about to send an LLM request | pre-call `enforceGuards` (prompt.ts:554) | raise INSTEAD of sending | the request that was about to go out simply goes out |
+| 2 | Cost, a completion just charged past the limit | post-charge check (prompt.ts:699) | raise after booking the charge | the tool loop continues into its next round |
+| 3 | Cost, a paid TS helper charging outside llm() | `addCost` (cost.ts:12) | raise at the charge | the helper's caller continues in place |
+| 4 | Cost, a subprocess child's telemetry charging the parent's guard | `ipc.ts:897` | KEEPS today's hard path (kill the child, `limit_exceeded`) — documented v1 limitation | n/a in v1 |
+| 5 | Time, anywhere (PR 3) | timer → abort signal | depends on what was in flight — see PR 3 | see PR 3 |
+
+Plainly: site 1 means "the model wants to keep going but the next request
+would spend past the budget — ask first, send after." Nothing is in flight
+while the question is out, and not a cent can leak, because the request was
+never sent. Site 2 means "the response we just paid for crossed the line" —
+the response is already on the thread; approving just lets the loop
+continue. Site 3 keeps `guard(cost:)` uniform: without it, the same guard
+would be approvable around `llm()` but hard-fail around a paid TypeScript
+helper. All three run inside normal step-body async context (interrupts
+raised by tools already work exactly this way), so raising there needs no
+new machinery.
+
+Site 4 is the one that CANNOT raise in v1: the telemetry handler is an IPC
+message callback with no runner in its async context, and the raise dance
+requires one (`agencyInterrupt.ts:129-137` throws without it). So a parent
+guard tripped by child telemetry keeps today's behavior — the child is
+killed and `run()` reports `limit_exceeded`. Document it in the guards
+guide, pin it with a fixture, and file the follow-up (the child's OWN
+guards raise in-child as normal, so this only affects a parent budget
+enforced across the process boundary).
+
+**`enforceGuards` keeps throwing.** The prompt/addCost sites move to a new
+sibling — a `StateStack` METHOD, `stack.detectTrippedGuard(): Guard | null`
+(one spelling, everywhere) — and call the raise; the IPC site keeps calling
+the throwing `enforceGuards` untouched. Rev 4 said "make it return OR add a
+sibling, whichever reads cleaner" — that choice is now forced: changing
+`enforceGuards` itself to return would silently disarm the callers this
+plan does not rewrite. Fail-open at a budget boundary; the sibling is
+mandatory.
+
+**The raising sites LOOP; a single check leaks a request.** One answered
+question does not mean the gate is clear: approving the inner guard's trip
+can leave — or push — the OUTER guard over its own limit, and decision 16
+promises that guard its own question. A raise-once-then-proceed gate would
+send the request while the outer guard is over budget and ask the outer
+question one request too late, at the post-charge site — contradicting
+site 1's headline that not a cent can leak. So both raising sites are:
+
+```ts
+let g: Guard | null;
+while ((g = stack.detectTrippedGuard()) !== null) {
+  await raiseGuardTrip(stack, g, dimensionOf(g)); // returns = this one settled
+}
+// only now: send the request / book the charge
+```
+
+The post-charge site needs the same loop for the same reason: one charge
+can push an inner guard and its enclosing outer over together, and each is
+owed its own question.
+
+**Root guards at every site:** if the over-budget guard `isRootBudget`, do
+what happens today — throw `GuardExceededError`. The operator's ceiling
+never asks permission. (That is all "root-marked guards keep throwing"
+meant.)
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts` (:554, :699), `lib/runtime/cost.ts` (:12),
+  `lib/runtime/state/stateStack.ts` (add `detectTrippedGuard`;
+  `enforceGuards` unchanged)
+- Create: `lib/runtime/guardTripInterrupt.ts` (the raise + answer module)
+- Modify: `lib/runtime/agencyInterrupt.ts` (factor the raise dance —
+  persisted-id check, `interruptWithHandlers`, checkpoint, halt — into a
+  helper both callers share)
+
+**The raise, sketched:**
+
+```ts
+// In guardTripInterrupt.ts
+export async function raiseGuardTrip(
+  stack: StateStack,
+  tripped: Guard,                   // the member that crossed its limit
+  dimension: "cost" | "time",
+): Promise<void> {                  // returns = approved; throws = rejected
+  const scope = GuardScope.resolve(stack, tripped.scopeIds)!;
+  if (scope.containsRootBudget()) {
+    throw tripped.buildExceededError(stack);      // hard ceiling
+  }
+  // Dedupe (decision 10, cost only). If another branch's trip for this
+  // guard is already open, park on it, then RETURN — the caller's
+  // detect→raise loop re-checks the whole stack, which covers both "the
+  // answer refilled this guard" and "a different guard is over budget
+  // now". (`while`, not `if`: a third branch can claim the record
+  // between our wake and our re-check.) If we are first, SET the record
+  // before the first await: an async body runs synchronously until its
+  // first await, so set-before-await is real mutual exclusion here.
+  if (tripped.pendingTrip !== undefined) {
+    while (tripped.pendingTrip !== undefined) {
+      await tripped.pendingTrip.settled;
+    }
+    return;                                // caller's loop re-detects
+  }
+  tripped.pendingTrip = makePendingTrip(); // {settled: Promise, settle: () => void}
+  // NOTHING between the set and the try: a throw in that gap would leak
+  // the record — never cleared, never settled — and every future branch
+  // would park forever, the exact deadlock the finally exists to prevent.
+  try {
+    const interruptKey = guardTripKey(tripped, dimension);        // see below
+    scope.suspendAll();             // freeze clocks + enforcement while deciding
+    const verdict = await raiseRuntimeInterrupt({   // the factored dance
+      key: interruptKey,
+      effect: "std::guard",
+      message: buildTripMessage(scope, dimension),
+      data: { ...scope.snapshot(dimension), draftValue: readSavedDraft(stack) },
+      eligible: (entry) => !entry.liveGuardIds.includes(tripped.guardId),
+    });
+    if (verdict.type === "approve") {
+      scope.extend(verdict.value ?? {}, dimension); // throws the decision-8 error
+      return;
+    }
+    throw tripped.buildExceededError(stack);        // reject → today's pipeline
+  } finally {
+    // ALL cleanups run on EVERY exit — and there are four: approve
+    // (return), reject (throw GuardExceededError), the decision-8 error
+    // (throw), and propagate (throw HaltSignal after checkpoint+halt).
+    // Settling here is what keeps a fork from deadlocking: three of the
+    // four exits leave by a throw, and the propagate answer arrives in a
+    // DIFFERENT RUN — a parked sibling waiting for anything else would
+    // wait forever, and runBatch's join (`await Promise.allSettled`,
+    // runBatch.ts:602) would hang the whole run instead of surfacing the
+    // interrupt. Clear the record BEFORE settling so woken branches see
+    // it empty; unsuspendAll is a safe no-op if suspendAll never ran.
+    scope.unsuspendAll();
+    const p = tripped.pendingTrip;
+    tripped.pendingTrip = undefined;
+    p?.settle();
+  }
+}
+```
+
+**What a parked branch does when the settle came from a halt:** it wakes,
+re-checks, finds the guard still over budget, and raises its own trip —
+which also propagates. Concurrent branch interrupts are already supported
+(`docs/dev/concurrent-interrupts.md`); the user is asked once per branch.
+That is the SAME documented trade the dedupe section already accepts for
+the restore case, arriving by the same door: the dedupe's guarantee is
+"never a silent double-application of one answer," not "never a second
+question."
+
+**Why unsuspending during a propagate is safe** (the `finally` runs on the
+`HaltSignal` unwind too, which looks like it contradicts "the scope must
+not tick while the question is out"): `Runner.halt` already pauses every
+guard (runner.ts:253), so nothing ticks while the run is halted; and
+`suspended` never serializes, so the checkpoint carries clean guards and
+the replayed raise re-suspends them on resume. The suspension bracket
+protects the in-process deliberation window; the halt protects the
+propagate window. Two mechanisms, one property.
+
+Details that are not optional:
+
+- **The interrupt key is DERIVED from guard state — not counted**
+  (decision 14; this was the rev-4 review's second blocker). The key must
+  satisfy two properties at once. It must be STABLE across replays of one
+  trip: the resume-idempotency machinery (agencyInterrupt.ts:158-162) finds
+  the recorded answer by this key, and a key that changes on replay — which
+  is what a counter does, because the replayed raise increments again —
+  misses the answer and asks the user the same question forever. And it
+  must be DISTINCT across different trips of the same scope: a key that
+  never changes (`__guardTrip_<scope>` alone) makes trip #2 find trip #1's
+  recorded approval and auto-approve forever (the rev-3 blocker in the
+  other direction). A derived key gives both:
+
+  ```ts
+  function guardTripKey(g: Guard, dimension: "cost" | "time"): string {
+    // Stable while THIS trip is open (nothing below changes until it is
+    // answered), and necessarily different for the NEXT trip. The five
+    // cases: (1) an approved trip extended the tripped dimension, and
+    // decision 8 forces the new limit strictly past `spent`, which only
+    // grows — so limits strictly increase, @1.00 → @1.50, never a
+    // collision; (2) a clamped-to-zero negative delta cannot produce a
+    // stale key, because clamping leaves the dimension over budget and
+    // armed, and decision 8 ERRORS before this key is ever reused;
+    // (3) disarm leaves the limit unchanged, so the key WOULD repeat —
+    // but a disarmed dimension never trips again, so there is no next
+    // trip to collide with; (4) a rejected trip aborts the scope, no
+    // next trip; (5) the other dimension tripping later differs in
+    // `dimension`.
+    return `__guardTrip_${g.scopeIds.join(",")}#${dimension}@${g.currentLimit()}`;
+  }
+  ```
+
+  The headline fixture (Task 2.5) exercises both properties: the recorded
+  answer must apply exactly once across the resume, and after more
+  spending, the SECOND trip (new limit → new key) must actually raise.
+
+  Two statements the rev-5 review asked for, because readers will need
+  them. First, WHERE the persisted id lives: in `stack.other`, not
+  `frame.locals`. `agency.interrupt` uses frame locals because its key is
+  callsite-scoped; the trip key is globally unique per
+  (scope, dimension, limit) and the raise happens inside `runPrompt`,
+  whose active frame is not the trip's owner — branch-local serialized
+  storage that survives frame pops is the right store. The factored raise
+  dance therefore takes the store as a parameter (frame locals for the
+  `agency.interrupt` caller, `stack.other` for trips). Second, the case
+  that looks like a bug until you see it: AFTER an approve, a later replay
+  that re-reaches the raise site does not re-raise — not because a key
+  matched, but because the extended guard is no longer over budget, so
+  `detectTrippedGuard` returns null and nothing raises at all.
+- **`eligible`** implements decision 3's visibility half: the chain skips
+  handlers whose `liveGuardIds` contains the tripped guard (they are inside
+  it). This is a parameter of the factored dance, defaulting to
+  "everyone" for ordinary interrupts.
+- **Suspension bracket at the raise**, in addition to Task 1.3's per-handler
+  bracket: between raise and verdict the scope must not tick or gate
+  anything — including during propagate-to-user, where no handler is
+  running. `suspended` not serializing (Task 1.3c) is what makes the
+  checkpoint-during-propagate case safe.
+- **The pending-trip dedupe (decision 10, cost only):** the shared
+  `CostGuard` object holds a live (unserialized) `pendingTrip` record
+  whose full lifecycle is IN the sketch above — set synchronously with
+  the `try` starting on the very next line (the ordering is the mutual
+  exclusion; the adjacency is what keeps a throw from leaking the
+  record), settled in the `finally` on all four exits (that is the
+  fork-deadlock fix), parked branches return on wake and their caller's
+  detect→raise loop re-checks the whole stack. Detection stays
+  synchronous (`stack.detectTrippedGuard()`); the wait lives only in the
+  async raise site. And the "by construction" in cost-only is literal:
+  `pendingTrip` lives on the guard OBJECT, and `TimeGuard.cloneForBranch`
+  gives each branch its own object, so for time guards the check always
+  sees `undefined` and the dedupe no-ops. That is intended — time clones
+  are separate real budgets with nothing to dedupe — so do not "fix" the
+  missing time dedupe later. Across a checkpoint the live record is gone; what
+  bounds over-granting there is the derived key: one recorded answer can
+  only ever satisfy one key, and a key names one scope-state
+  (`dimension@limit`), so a restored branch re-raising is asking a real,
+  new question at the new state — the user is consulted again, never
+  silently double-billed a grant. The rev-4 review is right that this is a
+  weaker guarantee than the live dedupe (the user can be ASKED more than
+  once around a restore); that is the documented v1 trade, pinned by the
+  dedupe fixture's restore variant.
+
+## Task 2.3: answering
+
+Covered by the sketch above; what remains is the plumbing contract:
+
+- Approve applies **the merged payload** (Task 1.2 already merged the
+  chain); `GuardScope.extend` enforces clamps, disarms, root refusal, and
+  the decision-8 error.
+- Reject throws the original `GuardExceededError` from the raise point. From
+  there, nothing new: `__tryCall` conversion, `AbortedResult`, level rule,
+  `finalize`, `success(draft)`/failure — the #553/#556 pipeline, untouched.
+- Unknown scope on an approve (id not on the raising branch's stack — can
+  only happen via IPC confusion or a stale answer) is a runtime error on the
+  response, not a silent no-op.
+
+## Task 2.4: the unhandled path
+
+Because the trip is an ordinary interrupt, propagation, `--policy`, and the
+TS-caller path should mostly already work; this task pins them and adds the
+one real piece of UI:
+
+- CLI prompt rendering for `std::guard`: show label, dimension,
+  spent/limit, and accept an amount (maps to `approve({<dimension>: n})`).
+- Fixtures: unhandled trip under `--policy` reject (headless migration
+  path); unhandled trip inside a subprocess child (forwards to the parent
+  endpoint like any interrupt, #398).
+
+## Task 2.5: the breaking-change migration and the fixture list
+
+**Audit first:** `grep -rn "guard(" stdlib/ lib/agents/`. Two known
+consumers of trip-as-failure that MUST be wrapped or their contracts
+silently change:
+
+- `stdlib/agency.agency:167` — `run(maxCost:)` wraps the subprocess in
+  `guard(cost: cap)` and maps the trip to a `limit_exceeded` failure
+  (:181-190). Wrap in `handle ... with (i) { ... reject() ... }` so the
+  contract holds.
+- `std::agents` — guard scoping is load-bearing there; audit each site.
+
+**Migrate `tests/agency/guards/`** under the byte-identical rule
+(decision 13).
+
+**New fixtures** (beyond those named in earlier tasks):
+
+| Fixture | Pins |
+|---|---|
+| approve-resumes-inline | handler grants, block finishes, result correct |
+| approve-across-checkpoint (HEADLINE) | no in-program handler; harness answers `{"action":"resolve","resolvedValue":{"maxCost":0.5}}`; block resumes; a LATER trip still raises (fresh derived key at the new limit; guard state survived serialize/restore) |
+| both-dimensions approve | `approve({maxCost, maxTime})` on `guard(cost:, time:)` — the two-member scope actually extends both members |
+| omitted-dimension-continues | cost trips; approve cost only; the TIME guard still trips later (fixture asserts only "still trips"; the exact remaining-allowance arithmetic is a unit test — wall-clock margins per decision 13) |
+| explicit disarm | `approve({disarm:["cost"]})` stops cost metering; spend past old limit does not trip |
+| negative-clamp | guard still trips after a clamped negative approve |
+| double-approve spend-gap | two $0.50 grants; $0.75 more spend passes; $1.25 trips |
+| shared-guard dedupe | 3 branches, one shared CostGuard, one handler granting $0.50/trip: spend fitting ONE grant passes; spend requiring $1.50 of headroom trips |
+| propagate-discards-approvals | inner approves, outer propagates, user rejects → salvage pipeline |
+| inside-guard handler blind | handler registered inside the guard never sees its trip; trip surfaces outward |
+| livelock error | handler answers `approve({})` → runtime error naming the handler |
+| reject-runs-salvage | draft AND finalize variants — the #553/#556 regression surface |
+| draftValue preview | `intr.data.draftValue` equals the scope's savedDraft at raise |
+| root trio | approve naming a root scope refused; root trip still exits 3 on the spawn path; `isRootBudget` round-trips |
+| race-loser trip | a branch with a raised, unanswered trip loses a `race`: no hang, no post-win surfacing (verify against `runBatch.runRace` cancellation) |
+| IPC fidelity | disarm arrays and float deltas across the subprocess boundary, asserted by spend |
+| addCost-site raise | a paid TS helper (not llm()) crosses the budget: the trip raises and is approvable, same as around llm() (taxonomy site 3) |
+| child-telemetry stays hard | a child's telemetry trips the parent's guard: child killed, `run()` reports `limit_exceeded` — pins the documented v1 limitation (site 4) |
+| grants-never-cross-budgets | nested guards; approving the inner trip pushes the region over the OUTER limit: the outer guard trips separately, with its own label (decision 16) |
+| dedupe restore variant | shared-guard trip open at checkpoint; harness answers; restored branches re-check or re-ask, and total granted headroom is what the answers say — never a silent double-application of one answer |
+| preapprove passes on trips | a `preapprove()`d tool trips a guard: the trip propagates past the auto-approve wrapper instead of erroring inside it (Task 1.3a) |
+| sibling-branch handler | a handler registered inside fork branch A answers an interrupt raised in branch B: metered by the shared pre-fork guard, hidden from B's local guards (the cross-branch rule, Task 1.3) |
+
+Docs: `docs/site/guide/guards.md` (user-facing semantics + migration),
+CHANGELOG, `docs/dev/interrupts.md` (the new machinery).
+
+---
+
+# Part 6: PR 3 — the abort signal, then time trips
+
+## Task 3.1: derive the composed abort signal
+
+**The problem being removed.** Today every guard install mutates
+`stack.abortSignal`: it saves the previous value in `previousSignal`
+(guard.ts:453) and overwrites the stack's signal with
+`AbortSignal.any([previous, mine])`. Uninstall restores. The composition
+order lives implicitly in per-guard fields — order-dependent mutable state.
+Re-arming a tripped guard in place means restoring `previousSignal` first,
+then re-composing, then rebuilding every composition that was layered above
+it. Get the order wrong and you capture the already-aborted composed signal
+as "previous," permanently poisoning the stack (the rev-1 review bug).
+
+**The replacement.** The stack OWNS one composite. Guards stop touching
+`stack.abortSignal` entirely:
+
+```ts
+/** stack.abortSignal is derived: one stable controller per rebuild,
+ *  aborted when the base signal or ANY armed, unsuspended guard's own
+ *  controller aborts. rebuildAbortSignal() mints a NEW composite (an
+ *  aborted controller cannot be un-aborted) and re-subscribes the
+ *  current armed set. In-flight operations that captured the OLD
+ *  signal were exactly the operations the trip cancelled — new work
+ *  reads the getter and sees the new composite. */
+rebuildAbortSignal(): void;
+get abortSignal(): AbortSignal;
+```
+
+Called when the guard array changes (push/pop/rehydrate) and when a guard's
+armed state changes (trip approved → re-arm). `previousSignal` is deleted.
+`installAbortPlumbing`/uninstall shrink to managing the guard's OWN
+controller.
+
+The freshness contract is structural, not a vigilance rule: `abortSignal`
+is a GETTER, and the rebuilt composite is what it returns from the moment
+of the rebuild. An operation captures the signal when it starts (that is
+how AbortSignal is used everywhere in the runtime already); an operation
+that captured the OLD composite was, by definition, in flight when the trip
+fired — which means it is exactly the operation the trip cancelled. New
+work started after the approve reads the getter and gets the live
+composite. No reader audit is needed because there is no way to hold the
+stale signal AND be alive.
+
+The nested-guards fixture rides here as a regression pin: two nested time
+guards, outer trips, approve, inner still cancels its own work later.
+
+## Task 3.2: time trips
+
+The taxonomy row 3 from Task 2.2, now in full. A timer fire can catch the
+branch in three places, and only ONE of them needs anything clever:
+
+- **(a) An LLM request is in flight.** The signal cancels it (today's
+  behavior, `promptCancelled` statelog pairing intact). `runPrompt`'s
+  cancellation path recognizes the cause as a guard trip, and instead of
+  rethrowing: rebuild the signal (Task 3.1 — the chain and `runPrompt`
+  refuse aborted stacks, interrupts.ts:234 / prompt.ts:542, so re-arm MUST
+  precede dispatch), then raise. On approve, **re-issue the request from the
+  current thread state.** This is safe against your tool-call question by
+  construction: the loop only ever has a request in flight when every prior
+  `tool_use` already has its result appended (results are appended before
+  the next request is issued). The cancelled request produced no assistant
+  message. So "re-issue" means: send the exact same conversation again. The
+  cancelled generation's partial output is honestly gone and the retry is a
+  fresh request; that cost is charged like any request.
+- **(b) A tool is executing** (Agency code inside a tool call). The abort
+  surfaces at the tool code's next step boundary or leaf op. Raise there;
+  on approve the tool CONTINUES where it paused, finishes, and its result is
+  appended to the thread normally — identical shape to a tool that raised
+  an ordinary interrupt and got resumed. No thread surgery; there is never a
+  dangling unanswered `tool_use`, because the tool call completes on resume.
+- **(c) Plain Agency code between LLM calls** (a loop, a `sleep`). Same as
+  (b): the abort surfaces at a step boundary or the aborted `sleep`; raise;
+  on approve, continue in place.
+
+So: (b) and (c) resume in place with zero message-thread involvement; only
+(a) re-issues, and (a) cannot have pending tool results by construction.
+Reject in all three: rebuild-then-re-abort, throw the trip at the raise
+point, salvage pipeline as always.
+
+Fixture discipline (decision 13): the deterministic assertions are statelog
+pairing (`promptStart`/`promptCancelled`) and spend-shaped re-trip checks;
+wall-clock margins only where the behavior is irreducibly temporal.
+
+## Task 3.3: the join rule (decision 15)
+
+`TimeGuard.extendBudget` records the clone's granted total in a serialized
+field (`grantedMs`, riding `GuardJSON` and the clone-serialization path
+that already carries clones across checkpoints). At the join, `runBatch`
+charges the parent with ONE branch's working time — the longest — so the
+parent's extension is THAT branch's `grantedMs`, applied before
+`addElapsed`. Not the max grant across branches: the time and the grant
+must come from the same branch, or a short branch with a big grant would
+widen the parent for time nobody spent. The rule is self-consistent in a
+way worth noticing: the longest branch is necessarily a granted branch
+whenever it matters, because a clone without a grant would have tripped at
+its own limit instead of running past it.
+
+Fixture: fork; one branch's clone trips; approve 5 more minutes; branch
+finishes; join; the parent does not trip (spend-shaped where possible per
+decision 13, wall-clock margins only for the irreducible part). And the
+decision-16 boundary: the parent's ENCLOSING guard, if any, is untouched —
+if the extra granted time pushes it over, it trips with its own label.
+
+---
+
+# Part 7: PR 4 — the feedback channel
+
+Small by design; everything it needs exists by now.
+
+- `approve({message})`: the merged message (Task 1.2 joins multiples with
+  newlines) goes into a branch-local pending queue; the tool loop drains the
+  queue into the thread as a user-role message before the next model request
+  — the exact reply-attachments pattern (`docs/dev/reply-attachments.md`),
+  whose injection point already exists.
+- Injected messages are pushed with an auto-label (`guard:<label>`) via
+  `MessageThread.push(message, label)` from #557, so statelog and thread
+  dumps distinguish reviewer feedback from real user messages.
+- Outside an LLM loop, the message waits and lands on the branch's next
+  `llm()` call.
+- Fixtures: message lands as user-role before the next request (statelog
+  message dump), auto-label present, two approvals' messages both present in
+  order.
+
+---
+
+# Part 8: Estimates and sequencing
+
+| PR | Contents | Estimate |
+|---|---|---|
+| 1 | pass(), merge table, registration-site scoping | 4–5 days (1.3 is safety-critical and carries the suite-green gate) |
+| 2 | GuardScope, cost trips, dedupe, migration | 5–6 days (the audit + ~29 fixture migrations are real work) |
+| 3 | signal derivation, time trips, join rule | 3–4 days (3.1 front-loads what the old representation was hiding) |
+| 4 | feedback channel | 1 day |
+
+Each PR gets its own review round. PR 1 and the #557 labels PR are
+independent and can land in either order; PR 4 needs both.

--- a/docs/superpowers/plans/2026-07-16-resumable-guards.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards.md
@@ -859,10 +859,15 @@ site 1's headline that not a cent can leak. So both raising sites are:
 ```ts
 let g: Guard | null;
 while ((g = stack.detectTrippedGuard()) !== null) {
-  await raiseGuardTrip(stack, g, dimensionOf(g)); // returns = this one settled
+  await raiseGuardTrip(stack, g, g.dimension);
 }
 // only now: send the request / book the charge
 ```
+
+(`dimension` is a new readonly property on the `Guard` interface —
+`"cost" | "time"`, the same discriminator `GuardJSON` already carries as
+`kind`. A `dimensionOf(g)` helper would need `instanceof` or a JSON
+round-trip, both forbidden by the interface contract at guard.ts:20-59.)
 
 The post-charge site needs the same loop for the same reason: one charge
 can push an inner guard and its enclosing outer over together, and each is
@@ -890,7 +895,10 @@ export async function raiseGuardTrip(
   stack: StateStack,
   tripped: Guard,                   // the member that crossed its limit
   dimension: "cost" | "time",
-): Promise<void> {                  // returns = approved; throws = rejected
+): Promise<void> {
+  // returns = this question is settled (approved, or someone else's answer
+  // landed while we were parked) — the caller MUST re-detect, never treat
+  // a return as consent to proceed; throws = rejected.
   const scope = GuardScope.resolve(stack, tripped.scopeIds)!;
   if (scope.containsRootBudget()) {
     throw tripped.buildExceededError(stack);      // hard ceiling

--- a/docs/superpowers/plans/2026-07-16-resumable-guards.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards.md
@@ -608,6 +608,19 @@ whatever the key is.
 > `scope.suspendAll()` at the raise site must use the SAME stack-scoped
 > bracket, for the same reason: the raising branch's deliberation must
 > not blind siblings sharing the guard.
+>
+> **Second execution note (PR 1 review round):** because CostGuard's
+> object cannot decline its own `check()`, EVERY trip-detection walk
+> must consult the stack's suspension set. `Runner.shouldSkip` had its
+> own private `check()` walk that did not — a suspended over-budget
+> cost guard would have thrown its trip out of the handler that
+> suspended it whenever the abort signal was live (normal state in
+> PR 2's deliberations). Fixed by collapsing both walks into ONE
+> suspension-aware method: `StateStack.detectTrippedGuard():
+> GuardExceededError | null` — which is ALSO the detection sibling
+> Task 2.2 needs, already landed. PR 2's raising sites loop on it as
+> planned; it returns the error (which carries the guardId) rather
+> than the guard.
 
 Add to the `Guard` interface (`guard.ts:20-59`) — and note that interface's
 own contract: StateStack and Runner only ever talk to the interface, no

--- a/docs/superpowers/plans/2026-07-16-resumable-guards.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards.md
@@ -591,6 +591,24 @@ whatever the key is.
 
 ### 1.3c: suspension is a guard state, not call-site filters
 
+> **AS IMPLEMENTED (PR 1) — one deviation, found during execution.** An
+> object-level `suspended` flag is WRONG for CostGuard: the object can be
+> SHARED across fork branches (`cloneForBranch` returns `this`), so
+> flagging it would drop sibling branches' charges and open their gates
+> while one branch's handler deliberates — fail-open on the shared
+> budget, in exactly the window a handler is thinking. Cost suspension is
+> therefore STACK-scoped: `StateStack.suspendedGuardIds` (in-memory,
+> branch-local, never serialized), consulted inside `enforceGuards` and
+> `chargeGuards`, bracketed by `beginHandlerSuspension`/
+> `endHandlerSuspension` (save/restore, so nested chains compose).
+> `Guard.suspend()`/`unsuspend()` remain on the interface for the
+> per-branch-object state: TimeGuard pauses its clock and pins `resume()`
+> to a no-op (beforeStep resumes all guards every step); CostGuard's are
+> deliberate no-ops with the explanation in place. PR 2's
+> `scope.suspendAll()` at the raise site must use the SAME stack-scoped
+> bracket, for the same reason: the raising branch's deliberation must
+> not blind siblings sharing the guard.
+
 Add to the `Guard` interface (`guard.ts:20-59`) — and note that interface's
 own contract: StateStack and Runner only ever talk to the interface, no
 variant-specific branching at call sites. Suspension keeps that promise:

--- a/packages/agency-lang/docs/dev/interrupts.md
+++ b/packages/agency-lang/docs/dev/interrupts.md
@@ -320,3 +320,55 @@ Overrides are applied via the shared `applyOverrides` helper in `lib/runtime/rew
 | `lib/runtime/state/stateStack.ts` | `State.clearLocalsWithPrefix()` for loop reset |
 | `lib/templates/backends/typescriptGenerator/` | Mustache templates: `blockSetup`, `runnerIfElse`, `imports`, etc. |
 | `tests/agency/substeps/` | Integration tests for all block types |
+
+## Handler verdicts, merge, and registration-site scoping
+
+Three pieces of the handler chain live in the runtime (added for the
+resumable-guards work; see `docs/superpowers/plans/2026-07-16-resumable-guards.md`):
+
+**The `pass()` verdict.** A handler that returns nothing means "no
+opinion." `pass()` is the same verdict as a value, so match arms can
+express it. The chain normalizes `undefined` to `{type: "pass"}` the
+moment a handler returns (`runHandlerChain`, `lib/runtime/interrupts.ts`),
+so statelog and the verdict logic only ever see one spelling.
+
+**Per-effect approval merge.** When several handlers approve one
+interrupt, the values combine through `mergeFor(effect)`
+(`lib/runtime/effectMerge.ts`). The table is total and CONSTANT — no
+registration surface, on purpose: a runtime registry would be per-run
+state in a module global, it would silently diverge across the subprocess
+boundary, and user merge closures would sit on the function-refs-across-
+checkpoints surface. The default merge reproduces the historical
+outer-overwrites behavior byte-for-byte; `std::guard` accumulates. The
+cross-process path (`mergeChainOutcomes`) uses the same table via
+`mergeForIpc`, whose default differs one notch (a valueless outer approve
+defers to the inner value, because JSON cannot distinguish "no value"
+from an explicit undefined).
+
+**Registration-site scoping.** Every handler entry on `ctx.handlers`
+carries `liveGuardIds` — the guard ids live on the registering branch's
+stack at registration time (`HandlerEntry`, `lib/runtime/types.ts`).
+While a handler runs, the raising branch suspends every installed guard
+NOT in that set (`StateStack.beginHandlerSuspension`): the handler's own
+work is metered by its registration site's guards only. Key mechanics,
+each load-bearing:
+
+- The capture point is `Runner.handle` (`lib/runtime/runner.ts`) — the
+  path Agency `handle` blocks actually take. TS callers capture at call
+  time in `withPushedHandler`; `preapprove()`, the top-level init
+  wrappers, and the `--policy` handler register with an explicit `[]`.
+- The captured set is memoized first-write-wins in the registering
+  frame's locals, keyed by the callsite's step path, deleted on pop. On
+  resume the guard array is restored from JSON BEFORE replay re-runs the
+  registration, so a fresh capture would see guards that did not exist
+  at the original registration. Never key this by counting events —
+  replay skips completed statements and iterations (`Runner.handle`
+  returns before `pushHandler` for a completed block), so counters count
+  different events on replay. Position or content only.
+- Cost-guard suspension is STACK-scoped (`suspendedGuardIds`, consulted
+  by `enforceGuards`/`chargeGuards`), not a flag on the guard object: a
+  shared CostGuard flagged object-wide would blind sibling branches.
+  TimeGuard suspension is object-scoped (clones are per-branch) and pins
+  the clock paused across `Runner.beforeStep`'s resume-all.
+- Nothing about suspension serializes. A handler that propagates gets
+  checkpointed mid-suspension; the resumed run's guards must meter.

--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -181,6 +181,21 @@ Now, all of their interrupts get rejected. As long as all destructive actions ar
 
 Besides `approve` and `reject,` the other keyword is `propagate.` `propagate` means "I don't want to reject the interrupt, but I don't want anyone to be able to programmatically approve it either. I want to make sure it always goes to a user for approval or rejection."
 
+## Pass
+
+`pass()` means "not my interrupt — ask the next handler." It has the same effect as returning nothing, but it is a real value, so you can use it where a value is required. The common case is a `match` over the interrupt's effect: every arm must produce a value, and `pass()` is how an arm says it has no opinion.
+
+```ts
+handle {
+  doWork()
+} with (data) {
+  return match(data.effect) {
+    "std::read" => approve()
+    _ => pass()
+  }
+}
+```
+
 ## The rules of handlers
 
 The rules of handlers are thus:
@@ -188,7 +203,28 @@ The rules of handlers are thus:
 2. Otherwise, if any handler propagates, the interrupt propagates to the user for a decision.
 3. Otherwise, if a handler approves, the interrupt is approved.
 
-Of course, a handler doesn't need to approve, reject, or propagate. It can simply choose to log the interrupt data, print out the lyrics to "A Day in the Life," or whatever. If no handler approves, rejects, or propagates, by default, the interrupt propagates up to the user for a decision.
+Of course, a handler doesn't need to approve, reject, or propagate. It can `pass()`, log the interrupt data, print out the lyrics to "A Day in the Life," or whatever. If no handler approves, rejects, or propagates, by default, the interrupt propagates up to the user for a decision.
+
+### When several handlers approve
+
+If more than one handler approves the same interrupt, their approval values combine. How they combine depends on the interrupt's effect. For most effects, the outermost handler's value wins — that is the historical behavior, unchanged. Effects whose approvals carry data that should accumulate define their own merge: `std::guard` approvals (guard budget grants, in a coming release) add their grants together instead of overwriting.
+
+## A handler runs on its own budget
+
+A handler belongs to the place where it was registered. When a handler runs, its work — including its own `llm()` calls — is metered by the guards that enclosed the `handle` block itself, never by guards installed deeper. In this example, the handler's `llm()` call charges the outer `$20` guard and is invisible to the inner `$1` guard, even though the interrupt was raised inside it:
+
+```ts
+guard(cost: $20.00) as {
+  handle {
+    guard(cost: $1.00) as {
+      riskyWork()   // raises an interrupt
+    }
+  } with (data) {
+    const opinion = llm("should this proceed?")  // charges the $20 guard only
+    return approve()
+  }
+}
+```
 
 ## Handlers can't raise interrupts
 

--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -181,21 +181,6 @@ Now, all of their interrupts get rejected. As long as all destructive actions ar
 
 Besides `approve` and `reject,` the other keyword is `propagate.` `propagate` means "I don't want to reject the interrupt, but I don't want anyone to be able to programmatically approve it either. I want to make sure it always goes to a user for approval or rejection."
 
-## Pass
-
-`pass()` means "not my interrupt — ask the next handler." It has the same effect as returning nothing, but it is a real value, so you can use it where a value is required. The common case is a `match` over the interrupt's effect: every arm must produce a value, and `pass()` is how an arm says it has no opinion.
-
-```ts
-handle {
-  doWork()
-} with (data) {
-  return match(data.effect) {
-    "std::read" => approve()
-    _ => pass()
-  }
-}
-```
-
 ## The rules of handlers
 
 The rules of handlers are thus:
@@ -203,28 +188,7 @@ The rules of handlers are thus:
 2. Otherwise, if any handler propagates, the interrupt propagates to the user for a decision.
 3. Otherwise, if a handler approves, the interrupt is approved.
 
-Of course, a handler doesn't need to approve, reject, or propagate. It can `pass()`, log the interrupt data, print out the lyrics to "A Day in the Life," or whatever. If no handler approves, rejects, or propagates, by default, the interrupt propagates up to the user for a decision.
-
-### When several handlers approve
-
-If more than one handler approves the same interrupt, their approval values combine. How they combine depends on the interrupt's effect. For most effects, the outermost handler's value wins — that is the historical behavior, unchanged. Effects whose approvals carry data that should accumulate define their own merge: `std::guard` approvals (guard budget grants, in a coming release) add their grants together instead of overwriting.
-
-## A handler runs on its own budget
-
-A handler belongs to the place where it was registered. When a handler runs, its work — including its own `llm()` calls — is metered by the guards that enclosed the `handle` block itself, never by guards installed deeper. In this example, the handler's `llm()` call charges the outer `$20` guard and is invisible to the inner `$1` guard, even though the interrupt was raised inside it:
-
-```ts
-guard(cost: $20.00) as {
-  handle {
-    guard(cost: $1.00) as {
-      riskyWork()   // raises an interrupt
-    }
-  } with (data) {
-    const opinion = llm("should this proceed?")  // charges the $20 guard only
-    return approve()
-  }
-}
-```
+Of course, a handler doesn't need to approve, reject, or propagate. It can simply choose to log the interrupt data, print out the lyrics to "A Day in the Life," or whatever. If no handler approves, rejects, or propagates, by default, the interrupt propagates up to the user for a decision.
 
 ## Handlers can't raise interrupts
 

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -386,7 +386,10 @@ export function printTs(node: TsNode, indent = 0): string {
       // instead of producing a cryptic "Cannot read 'pushHandler' of
       // undefined". Handlers are safety infrastructure — failing loud
       // here is preferable to silently skipping registration.
-      return `getRuntimeContext().ctx.pushHandler(${handler});\n${ind(indent)}try {\n${body}\n${ind(indent)}} finally {\n${ind(indent + 1)}getRuntimeContext().ctx.popHandler();\n${ind(indent)}}`;
+      // liveGuardIds: [] — an explicit decision, not a default. These
+      // wrappers register during top-level init, before any guard can
+      // exist, so "hide every guard" is vacuously correct.
+      return `getRuntimeContext().ctx.pushHandler(${handler}, []);\n${ind(indent)}try {\n${body}\n${ind(indent)}} finally {\n${ind(indent + 1)}getRuntimeContext().ctx.popHandler();\n${ind(indent)}}`;
     }
 
     case "runnerDebugger": {

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -1,5 +1,6 @@
 import type { TsNode, TsParam, TsScopedVar, TsImportName } from "./tsIR.js";
 import renderRunnerIfElse from "../templates/backends/typescriptGenerator/runnerIfElse.js";
+import renderWithHandlerWrapper from "../templates/backends/typescriptGenerator/withHandlerWrapper.js";
 import renderAgencyFunctionWrap from "../templates/ir/agencyFunctionWrap.js";
 
 const INDENT = "  ";
@@ -388,8 +389,14 @@ export function printTs(node: TsNode, indent = 0): string {
       // here is preferable to silently skipping registration.
       // liveGuardIds: [] — an explicit decision, not a default. These
       // wrappers register during top-level init, before any guard can
-      // exist, so "hide every guard" is vacuously correct.
-      return `getRuntimeContext().ctx.pushHandler(${handler}, []);\n${ind(indent)}try {\n${body}\n${ind(indent)}} finally {\n${ind(indent + 1)}getRuntimeContext().ctx.popHandler();\n${ind(indent)}}`;
+      // exist, so "hide every guard" is vacuously correct. (The []
+      // itself lives in the template.)
+      return renderWithHandlerWrapper({
+        handler,
+        body,
+        indent: ind(indent),
+        indentInner: ind(indent + 1),
+      });
     }
 
     case "runnerDebugger": {

--- a/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
+++ b/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
@@ -33,7 +33,7 @@ export function makeMockCtx(opts: {
     _toolCallDepth: 0,
     runId: null,
     traceConfig: {},
-    pushHandler(fn: any) { this.handlers.push(fn); },
+    pushHandler(fn: any, liveGuardIds: string[] = []) { this.handlers.push({ fn, liveGuardIds }); },
     popHandler() { this.handlers.pop(); },
     isCancelled() { return false; },
     enterToolCall() { this._toolCallDepth++; },

--- a/packages/agency-lang/lib/runtime/agencyFunction.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.test.ts
@@ -736,3 +736,50 @@ describe("rename()", () => {
     expect(result).toEqual(["/tmp", "a.txt"]);
   });
 });
+
+describe("preapprove verdict shape", () => {
+  it("auto-approves ordinary interrupts but PASSES on std::guard trips", async () => {
+    const ctx = makeMockCtx();
+    let handler: any;
+    const fn = AgencyFunction.create({
+      name: "tool",
+      module: "test",
+      fn: async () => {
+        handler = ctx.handlers[ctx.handlers.length - 1].fn;
+        return "x";
+      },
+      params: [],
+      toolDefinition: null,
+    }, {}).preapprove();
+
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () =>
+      fn.invoke({ type: "positional", args: [] }),
+    );
+    // Ordinary interrupt: auto-approved.
+    expect((await handler({ effect: "std::bash" })).type).toBe("approve");
+    // A guard trip: pass — a bare approve would be approve({}), which
+    // grants no budget and the trip machinery treats as a runtime
+    // error. Budget questions belong to outer handlers or the user.
+    expect((await handler({ effect: "std::guard" })).type).toBe("pass");
+  });
+
+  it("registers with an explicit empty liveGuardIds (above any guard)", async () => {
+    const ctx = makeMockCtx();
+    let entry: any;
+    const fn = AgencyFunction.create({
+      name: "tool",
+      module: "test",
+      fn: async () => {
+        entry = ctx.handlers[ctx.handlers.length - 1];
+        return "x";
+      },
+      params: [],
+      toolDefinition: null,
+    }, {}).preapprove();
+
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () =>
+      fn.invoke({ type: "positional", args: [] }),
+    );
+    expect(entry.liveGuardIds).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { stripBoundParams } from "./stripBoundParams.js";
-import { approve } from "./interrupts.js";
+import { approve, pass } from "./interrupts.js";
 import { agencyStore, withPushedHandler } from "./asyncContext.js";
 import { withCallDepth } from "./callDepth.js";
 import { checkFailureArgs } from "./failurePropagation.js";
@@ -261,11 +261,22 @@ export class AgencyFunction {
     // Doing the wrap here — rather than branching inside `invoke()` —
     // keeps the per-call hot path branch-free.
     const original = this._fn;
+    // The auto-approve must PASS on std::guard interrupts (guard trips,
+    // once guards raise them): approving work is meaningful, but a bare
+    // approve on a trip is approve({}) — no budget granted — which the
+    // trip machinery treats as a runtime error. Budget questions are for
+    // outer handlers or the user, never a tool's auto-approve wrapper.
+    const autoApprove = async (intr: { effect: string }) =>
+      intr.effect === "std::guard" ? pass() : approve();
     const wrapped = (...args: any[]) => {
       const ctx = agencyStore.getStore()?.ctx;
       if (!ctx) return original(...args);
-      return withPushedHandler(ctx, async () => approve(), () =>
+      // liveGuardIds: [] is an explicit decision, not a default — this
+      // handler conceptually registers above any guard (its body never
+      // spends, so the hide-everything reading is also harmless).
+      return withPushedHandler(ctx, autoApprove, () =>
         Promise.resolve(original(...args)),
+        [],
       );
     };
     return new AgencyFunction({

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -266,6 +266,13 @@ export class AgencyFunction {
     // approve on a trip is approve({}) — no budget granted — which the
     // trip machinery treats as a runtime error. Budget questions are for
     // outer handlers or the user, never a tool's auto-approve wrapper.
+    //
+    // TODO(owner, resumable-guards PR 2): revisit this branch once the
+    // trip approve semantics land — the owner flagged it as possibly
+    // temporary. The case to re-check before removing it: a lone
+    // approve({}) (nobody else granting) must not turn a trip into the
+    // useless-approval runtime error where a pass would have let it
+    // propagate to someone who can actually grant budget.
     const autoApprove = async (intr: { effect: string }) =>
       intr.effect === "std::guard" ? pass() : approve();
     const wrapped = (...args: any[]) => {

--- a/packages/agency-lang/lib/runtime/asyncContext.ts
+++ b/packages/agency-lang/lib/runtime/asyncContext.ts
@@ -144,8 +144,19 @@ export async function withPushedHandler<T>(
   ctx: RuntimeContext<any>,
   handler: HandlerFn,
   fn: () => Promise<T>,
+  liveGuardIds?: string[],
 ): Promise<T> {
-  ctx.pushHandler(handler);
+  // TS-side registration captures the live guard set AT CALL TIME, with
+  // no memo: TS callers sit outside the checkpoint replay machinery and
+  // own their own re-execution semantics (unlike Agency handle blocks,
+  // which memoize in Runner.handle). An explicit `liveGuardIds` wins —
+  // preapprove() passes [] because its handler registers conceptually
+  // above any guard (and its body never spends).
+  const captured =
+    liveGuardIds ??
+    agencyStore.getStore()?.stack?.guards.map((g) => g.guardId) ??
+    [];
+  ctx.pushHandler(handler, captured);
   try {
     return await fn();
   } finally {

--- a/packages/agency-lang/lib/runtime/effectMerge.test.ts
+++ b/packages/agency-lang/lib/runtime/effectMerge.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { mergeFor, mergeForIpc } from "./effectMerge.js";
+import { interruptWithHandlers, mergeChainOutcomes, pass } from "./interrupts.js";
+import { RuntimeContext } from "./state/context.js";
+
+describe("mergeFor — the table is total", () => {
+  it("an unregistered effect keeps the historical overwrite, including a valueless outer clobbering an inner value", () => {
+    const merge = mergeFor("std::bash");
+    expect(merge("inner", "outer")).toBe("outer");
+    expect(merge("inner", undefined)).toBe(undefined);
+  });
+
+  it("the IPC default defers to the inner value when the outer is valueless", () => {
+    const merge = mergeForIpc("std::bash");
+    expect(merge("inner", "outer")).toBe("outer");
+    expect(merge("inner", undefined)).toBe("inner");
+  });
+});
+
+describe("mergeFor(std::guard) — approvals accumulate", () => {
+  const merge = mergeFor("std::guard");
+
+  it("sums grants per dimension and leaves untouched dimensions undefined", () => {
+    expect(merge({ maxCost: 0.5 }, { maxCost: 0.5, maxTime: 60000 })).toEqual({
+      maxCost: 1.0,
+      maxTime: 60000,
+      disarm: undefined,
+      message: undefined,
+    });
+  });
+
+  it("unions disarm lists without duplicates", () => {
+    expect(
+      merge({ disarm: ["cost"] }, { disarm: ["cost", "time"] }).disarm,
+    ).toEqual(["cost", "time"]);
+  });
+
+  it("joins messages in inner-to-outer order (merge is not commutative)", () => {
+    const three = [{ message: "a" }, { message: "b" }, { message: "c" }];
+    expect(three.reduce(merge).message).toBe("a\nb\nc");
+  });
+
+  it("is the same function on the IPC path — guard grants accumulate across processes", () => {
+    expect(mergeForIpc("std::guard")).toBe(merge);
+  });
+});
+
+describe("the chain merges approvals through the effect table", () => {
+  const makeCtx = (handlers: any[]): RuntimeContext<any> => {
+    const ctx = new RuntimeContext({
+      statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+      smoltalkDefaults: {},
+      dirname: process.cwd(),
+    });
+    ctx.handlers = handlers;
+    ctx.runId = "test-run";
+    return ctx;
+  };
+
+  it("two std::guard approvals accumulate instead of overwriting", async () => {
+    const ctx = makeCtx([
+      async () => ({ type: "approve", value: { maxCost: 0.5, message: "outer says go" } }),
+      async () => ({ type: "approve", value: { maxCost: 0.5 } }),
+    ]);
+    const verdict = await interruptWithHandlers("std::guard", "m", {}, "o", ctx);
+    expect(verdict).toEqual({
+      type: "approve",
+      value: {
+        maxCost: 1.0,
+        maxTime: undefined,
+        disarm: undefined,
+        message: "outer says go",
+      },
+    });
+  });
+
+  it("an unregistered effect keeps outer-overwrites, valueless outer included", async () => {
+    const ctx = makeCtx([
+      async () => ({ type: "approve", value: undefined }),
+      async () => ({ type: "approve", value: 42 }),
+    ]);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    expect(verdict).toEqual({ type: "approve", value: undefined });
+  });
+
+  it("passes between approvals do not disturb the merge", async () => {
+    const ctx = makeCtx([
+      async () => ({ type: "approve", value: { maxCost: 0.25 } }),
+      async () => pass(),
+      async () => ({ type: "approve", value: { maxCost: 0.75 } }),
+    ]);
+    const verdict = (await interruptWithHandlers(
+      "std::guard", "m", {}, "o", ctx,
+    )) as any;
+    expect(verdict.value.maxCost).toBe(1.0);
+  });
+});
+
+describe("mergeChainOutcomes routes double-approves through the table", () => {
+  it("std::guard grants accumulate across the process boundary", () => {
+    const merged = mergeChainOutcomes(
+      "std::guard",
+      { kind: "approved", value: { maxCost: 0.5 } },
+      { kind: "approved", value: { maxCost: 0.5 } },
+    );
+    expect(merged).toEqual({
+      kind: "approved",
+      value: { maxCost: 1.0, maxTime: undefined, disarm: undefined, message: undefined },
+    });
+  });
+});

--- a/packages/agency-lang/lib/runtime/effectMerge.test.ts
+++ b/packages/agency-lang/lib/runtime/effectMerge.test.ts
@@ -52,7 +52,7 @@ describe("the chain merges approvals through the effect table", () => {
       smoltalkDefaults: {},
       dirname: process.cwd(),
     });
-    ctx.handlers = handlers;
+    ctx.handlers = handlers.map((fn: any) => ({ fn, liveGuardIds: [] }));
     ctx.runId = "test-run";
     return ctx;
   };

--- a/packages/agency-lang/lib/runtime/effectMerge.ts
+++ b/packages/agency-lang/lib/runtime/effectMerge.ts
@@ -1,0 +1,90 @@
+/**
+ * How two approvals of the same interrupt combine.
+ *
+ * When several handlers in a chain approve one interrupt, their approval
+ * values have to become one value. Historically that was "the outermost
+ * approval overwrites" — which was never designed, it just fell out of the
+ * chain loop, and it breaks the first time an approval carries data that
+ * should accumulate (a guard trip's budget grants). The merge is now a
+ * per-effect definition, looked up here.
+ *
+ * The table is TOTAL: every effect has a merge, and the default IS the
+ * historical behavior, so effects without an entry are byte-compatible
+ * with the old chain. `inner` is always the approval from the handler
+ * closer to the interrupt; merges need not be commutative (message
+ * concatenation is not).
+ *
+ * This is deliberately a CONSTANT, not a registration surface. A runtime
+ * registry would be per-run state in a module global (banned), it would
+ * silently diverge across the subprocess boundary (child registers a
+ * merge, parent does not → the same interrupt merges differently in-process
+ * and over IPC), and user-supplied merge closures would sit on the
+ * function-refs-across-checkpoints problem surface (#513/#544). A user
+ * registration surface arrives with typed interrupt payloads (#555).
+ */
+
+export type ApprovalMerge = (inner: any, outer: any) => any;
+
+/** In-process default: the outer approval overwrites, INCLUDING an outer
+ *  approve() with no value overwriting an inner value with undefined.
+ *  That is the documented historical chain behavior. */
+const DEFAULT_MERGE: ApprovalMerge = (_inner, outer) => outer;
+
+/** Cross-process default: the outer approval wins, but a VALUELESS outer
+ *  approval defers to the inner value. Weaker than the in-process rule on
+ *  purpose and from before this module existed: the outcome travels as
+ *  JSON, which cannot distinguish "no value" from an explicit undefined,
+ *  so a valueless parent approve must not clobber a child's value. */
+const DEFAULT_MERGE_IPC: ApprovalMerge = (inner, outer) => outer ?? inner;
+
+function sumOrUndefined(a?: number, b?: number): number | undefined {
+  if (a === undefined && b === undefined) return undefined;
+  return (a ?? 0) + (b ?? 0);
+}
+
+function unionOrUndefined(a?: string[], b?: string[]): string[] | undefined {
+  if (a === undefined && b === undefined) return undefined;
+  const merged: string[] = [...(a ?? [])];
+  for (const item of b ?? []) {
+    if (!merged.includes(item)) merged.push(item);
+  }
+  return merged;
+}
+
+function joinOrUndefined(
+  a: string | undefined,
+  b: string | undefined,
+  sep: string,
+): string | undefined {
+  if (a === undefined && b === undefined) return undefined;
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return a + sep + b;
+}
+
+/** std::guard approvals accumulate: budget grants add, disarm lists
+ *  union, messages concatenate in inner-to-outer order. Two handlers
+ *  each granting $0.50 means $1.00 of new budget, not a coin flip over
+ *  which fifty cents survives. */
+const mergeGuardApprovals: ApprovalMerge = (a, b) => ({
+  maxCost: sumOrUndefined(a?.maxCost, b?.maxCost),
+  maxTime: sumOrUndefined(a?.maxTime, b?.maxTime),
+  disarm: unionOrUndefined(a?.disarm, b?.disarm),
+  message: joinOrUndefined(a?.message, b?.message, "\n"),
+});
+
+const MERGES: Record<string, ApprovalMerge> = {
+  "std::guard": mergeGuardApprovals,
+};
+
+/** The merge for an effect's approvals within one process's chain. */
+export function mergeFor(effect: string): ApprovalMerge {
+  return MERGES[effect] ?? DEFAULT_MERGE;
+}
+
+/** The merge for combining a child process's approval with the parent's
+ *  (mergeChainOutcomes). Same table; only the DEFAULT differs — see the
+ *  two default constants above for why. */
+export function mergeForIpc(effect: string): ApprovalMerge {
+  return MERGES[effect] ?? DEFAULT_MERGE_IPC;
+}

--- a/packages/agency-lang/lib/runtime/effectMerge.ts
+++ b/packages/agency-lang/lib/runtime/effectMerge.ts
@@ -65,7 +65,19 @@ function joinOrUndefined(
 /** std::guard approvals accumulate: budget grants add, disarm lists
  *  union, messages concatenate in inner-to-outer order. Two handlers
  *  each granting $0.50 means $1.00 of new budget, not a coin flip over
- *  which fifty cents survives. */
+ *  which fifty cents survives.
+ *
+ *  Shape note for consumers: every key of the merged payload is
+ *  OPTIONAL. `approvals.reduce(merge)` never calls the merge for a lone
+ *  approval, so one handler's `{maxCost: 0.5}` arrives as-is, while two
+ *  handlers' arrive as the full four-key shape with the untouched keys
+ *  explicitly undefined. Read keys defensively
+ *  (`payload.maxCost !== undefined`), never by presence (`"maxTime" in
+ *  payload`).
+ *
+ *  Future improvement (owner): let users define an effect's merge as
+ *  AGENCY code — arrives with the typed-payloads work (#555), which
+ *  also owns the serialization story a user-supplied merge needs. */
 const mergeGuardApprovals: ApprovalMerge = (a, b) => ({
   maxCost: sumOrUndefined(a?.maxCost, b?.maxCost),
   maxTime: sumOrUndefined(a?.maxTime, b?.maxTime),

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -449,3 +449,80 @@ describe("guard labels", () => {
     expect((clone as TimeGuard).guardId).toBe(parent.guardId);
   });
 });
+
+describe("suspension", () => {
+  it("a suspended TimeGuard ignores beforeStep-style resume() calls", () => {
+    const g = new TimeGuard(60000);
+    const stack = new StateStack();
+    g.install(stack);
+    g.suspend();
+    // Runner.beforeStep resumes every guard at every step entry — a
+    // handler body executes steps, so this MUST stay a no-op while
+    // suspended or the clock restarts mid-deliberation.
+    g.resume(stack);
+    expect(g.snapshotElapsed()).toBe(g.snapshotElapsed()); // clock frozen: no running window
+    expect((g as any).state).toBe("paused");
+    g.unsuspend();
+    g.resume(stack);
+    expect((g as any).state).toBe("running");
+    g.uninstall(stack);
+  });
+
+  it("a suspended TimeGuard's check() reports nothing even when tripped", () => {
+    const g = new TimeGuard(60000);
+    (g as any).tripped = true;
+    g.suspend();
+    expect(g.check(new StateStack())).toBeNull();
+    g.unsuspend();
+    expect(g.check(new StateStack())).not.toBeNull();
+  });
+
+  it("CostGuard suspension is stack-scoped, never object-scoped: the shared object still meters sibling branches", () => {
+    // The same CostGuard object appears on two branch stacks
+    // (cloneForBranch returns `this`). Suspending it FOR A HANDLER on
+    // branch A must not blind branch B's enforcement or charging.
+    const g = new CostGuard(0.5);
+    const branchA = new StateStack();
+    const branchB = new StateStack();
+    branchA.pushGuard(g);
+    branchB.pushGuard(g.cloneForBranch(branchA, branchB)!);
+
+    const token = branchA.beginHandlerSuspension({ fn: async () => undefined, liveGuardIds: [] });
+    // Branch A (the handler's lineage): hidden — charges dropped, gate open.
+    branchA.chargeGuards(1.0);
+    expect(() => branchA.enforceGuards()).not.toThrow();
+    // Branch B: same object, unsuspended stack — charges land, gate trips.
+    branchB.chargeGuards(1.0);
+    expect(() => branchB.enforceGuards()).toThrow();
+    branchA.endHandlerSuspension(token);
+  });
+
+  it("nested suspensions compose: the inner end must not unsuspend what the outer began", () => {
+    const g = new TimeGuard(60000);
+    const stack = new StateStack();
+    stack.pushGuard(g);
+    const entry = { fn: async () => undefined, liveGuardIds: [] };
+
+    const outer = stack.beginHandlerSuspension(entry);
+    const inner = stack.beginHandlerSuspension(entry);
+    stack.endHandlerSuspension(inner);
+    // Still suspended: the outer bracket is open.
+    g.resume(stack);
+    expect((g as any).state).toBe("paused");
+    stack.endHandlerSuspension(outer);
+    g.resume(stack);
+    expect((g as any).state).toBe("running");
+    stack.popGuard();
+  });
+
+  it("guardsHiddenFrom hides exactly the guards not live at registration", () => {
+    const before = new CostGuard(1);
+    const after = new CostGuard(1);
+    const stack = new StateStack();
+    stack.pushGuard(before);
+    const entry = { fn: async () => undefined, liveGuardIds: [before.guardId] };
+    stack.pushGuard(after);
+    const hidden = stack.guardsHiddenFrom(entry);
+    expect(hidden.map((g) => g.guardId)).toEqual([after.guardId]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -458,9 +458,10 @@ describe("suspension", () => {
     g.suspend();
     // Runner.beforeStep resumes every guard at every step entry — a
     // handler body executes steps, so this MUST stay a no-op while
-    // suspended or the clock restarts mid-deliberation.
+    // suspended or the clock restarts mid-deliberation. `state`
+    // staying "paused" is the deterministic signal that resume() was
+    // ignored.
     g.resume(stack);
-    expect(g.snapshotElapsed()).toBe(g.snapshotElapsed()); // clock frozen: no running window
     expect((g as any).state).toBe("paused");
     g.unsuspend();
     g.resume(stack);
@@ -524,5 +525,25 @@ describe("suspension", () => {
     stack.pushGuard(after);
     const hidden = stack.guardsHiddenFrom(entry);
     expect(hidden.map((g) => g.guardId)).toEqual([after.guardId]);
+  });
+});
+
+describe("detectTrippedGuard — the one suspension-aware walk", () => {
+  it("a suspended over-budget CostGuard does not report its trip; unsuspended it does", () => {
+    // Pins the review finding on PR #558: Runner.shouldSkip used to run
+    // its own check() walk without consulting suspendedGuardIds, so a
+    // suspended over-budget cost guard could throw its trip out of the
+    // very handler that suspended it. Both shouldSkip and enforceGuards
+    // now route through this walk.
+    const g = new CostGuard(0.5);
+    const stack = new StateStack();
+    stack.pushGuard(g);
+    stack.chargeGuards(1.0);                       // over budget
+    expect(stack.detectTrippedGuard()).not.toBeNull();
+
+    const token = stack.beginHandlerSuspension({ fn: async () => undefined, liveGuardIds: [] });
+    expect(stack.detectTrippedGuard()).toBeNull(); // invisible while suspended
+    stack.endHandlerSuspension(token);
+    expect(stack.detectTrippedGuard()).not.toBeNull();
   });
 });

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -58,6 +58,10 @@ export function nextGuardId(): string {
  * runner step after deserialization.
  */
 export type Guard = {
+  /** Stable serialized identity — see GuardJSON. Both variants carry it;
+   *  it is on the interface because handler scoping and ownedGuardIds
+   *  matching are identity-based (indices do not survive resume/fork). */
+  guardId: string;
   install(stack: StateStack): void;
   uninstall(stack: StateStack): void;
   pause(): void;
@@ -69,6 +73,21 @@ export type Guard = {
    *  here. */
   charge(amount: number): void;
   check(stack: StateStack): GuardExceededError | null;
+  /** While suspended, a guard is invisible to enforcement: `check()`
+   *  returns null, `charge()` is a no-op, and (TimeGuard) the working-
+   *  time clock is paused. Used while an interrupt HANDLER runs: a
+   *  handler's own work is metered by its registration site's guards,
+   *  never by guards installed deeper (see HandlerEntry.liveGuardIds).
+   *  `resume()` DOES NOT clear suspension — `Runner.beforeStep`
+   *  resumes every guard at every step entry, and a handler body
+   *  executes steps; without this rule the handler's first step would
+   *  silently un-suspend the guard and restart its clock. Only
+   *  `unsuspend()` clears it. NEVER serialized: a handler that
+   *  propagates gets checkpointed mid-suspension, and a suspended
+   *  flag riding the snapshot would resume the run permanently
+   *  unmetered. */
+  suspend(): void;
+  unsuspend(): void;
   /** True iff this guard's limit has been exceeded — even if `check`
    *  has already returned the trip once. Lets `Runner.shouldSkip`
    *  distinguish a still-aborted signal that originated from a
@@ -196,6 +215,22 @@ export class CostGuard implements Guard {
     );
   }
 
+  /** Deliberately no-ops. A CostGuard can be SHARED across fork branches
+   *  (cloneForBranch returns `this`), so an object-level suspended flag
+   *  would blind SIBLING branches too: their charges would drop and
+   *  their gates would open while one branch's handler deliberates —
+   *  fail-open on the shared budget. Cost suspension is therefore
+   *  branch-scoped, on the StateStack (`suspendedGuardIds`), where the
+   *  enforce/charge walks consult it. Only per-branch-object state
+   *  belongs here, which for cost is nothing. */
+  suspend(): void {
+    /* nothing — see above */
+  }
+
+  unsuspend(): void {
+    /* nothing — see above */
+  }
+
   /** CostGuards don't compose into `stack.abortSignal`, so they can't
    *  be the cause of a stuck abort. Always returns false — the
    *  isTripped check in `Runner.shouldSkip` is for guards (like
@@ -306,6 +341,13 @@ export class TimeGuard implements Guard {
    *  steps (popGuard) on its way out. */
   private consumed: boolean = false;
 
+  /** See the Guard interface. Object-level suspension is CORRECT for
+   *  time (unlike cost): time clones are per-branch objects, so pausing
+   *  this object's clock affects exactly one branch. Deliberately NOT
+   *  in toJSON — a snapshot taken mid-suspension (a handler that
+   *  propagates to the user) must revive a guard that meters. */
+  private suspended: boolean = false;
+
   /** Stable id threaded into the emitted `guardTrip` cause. Not `readonly`
    *  so `fromJSON` can restore the serialized id across interrupt/resume
    *  (see GuardJSON — the id must outlive a checkpoint or ownedGuardIds
@@ -350,6 +392,13 @@ export class TimeGuard implements Guard {
   }
 
   resume(stack: StateStack): void {
+    // While suspended, resume() must NOT restart the clock:
+    // Runner.beforeStep resumes every guard at every step entry, and an
+    // interrupt handler's body executes steps — without this gate the
+    // handler's first step would silently un-suspend the guard it is
+    // adjudicating and its deliberation time would be billed. Only
+    // unsuspend() re-enables resumption.
+    if (this.suspended) return;
     if (this.state === "running") return;
     // After deserialization, controller is undefined — re-establish
     // plumbing. (toJSON only serializes elapsedMs + timeLimit.)
@@ -357,11 +406,25 @@ export class TimeGuard implements Guard {
     this.startWindow();
   }
 
+  /** Pause the clock and pin it paused across beforeStep's resume-all.
+   *  See resume() and the Guard interface. */
+  suspend(): void {
+    this.pause();
+    this.suspended = true;
+  }
+
+  unsuspend(): void {
+    // The clock restarts at the next beforeStep resume, not here — the
+    // suspension bracket sits in runtime code, outside any step.
+    this.suspended = false;
+  }
+
   charge(_amount: number): void {
     /* nothing — TimeGuard accumulates wall-clock time, not LLM cost */
   }
 
   check(_stack: StateStack): GuardExceededError | null {
+    if (this.suspended) return null;
     if (!this.tripped || this.consumed) return null;
     // currentElapsed() charges any in-flight window delta so `spent`
     // reflects the true elapsed time at the moment of the trip. Without

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -222,7 +222,15 @@ export class CostGuard implements Guard {
    *  fail-open on the shared budget. Cost suspension is therefore
    *  branch-scoped, on the StateStack (`suspendedGuardIds`), where the
    *  enforce/charge walks consult it. Only per-branch-object state
-   *  belongs here, which for cost is nothing. */
+   *  belongs here, which for cost is nothing.
+   *
+   *  CONSEQUENCE: because this is a no-op, this object cannot decline a
+   *  check() on its own — every cost-suspension decision lives in
+   *  StateStack.suspendedGuardIds, and any check() call site that does
+   *  not go through the stack's suspension-aware walk
+   *  (detectTrippedGuard / enforceGuards / chargeGuards) DOES NOT honor
+   *  suspension. Do not add a direct check() walk; route through the
+   *  stack. */
   suspend(): void {
     /* nothing — see above */
   }

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -83,6 +83,7 @@ export {
   isApproved,
   approve,
   reject,
+  pass,
   interruptWithHandlers,
   respondToInterrupts,
 } from "./interrupts.js";

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -6,6 +6,7 @@ import {
   mergeChainOutcomes,
   interruptWithHandlers,
   gatherChainOutcome,
+  pass,
 } from "./interrupts.js";
 import { RuntimeContext } from "./state/context.js";
 
@@ -285,5 +286,57 @@ describe("reportUnhandledInterrupts", () => {
     const printed = err.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(printed).toContain('Interrupt "std::read" was not handled');
     expect(printed).toContain('Interrupt "std::edit" was not handled');
+  });
+});
+
+describe("pass()", () => {
+  const makeCtx = (handlers: any[]): RuntimeContext<any> => {
+    const ctx = new RuntimeContext({
+      statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+      smoltalkDefaults: {},
+      dirname: process.cwd(),
+    });
+    ctx.handlers = handlers;
+    // The surfaced path stamps the run id onto the Interrupt (renderVerdict →
+    // ctx.getRunId()), which a real run sets when the exec context is created.
+    ctx.runId = "test-run";
+    return ctx;
+  };
+
+  it("a handler returning pass() defers to the next handler", async () => {
+    const ctx = makeCtx([
+      async () => ({ type: "approve", value: "outer" }), // outer (walked last)
+      async () => pass(),                                // inner (walked first)
+    ]);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    expect(verdict).toEqual({ type: "approve", value: "outer" });
+  });
+
+  it("a handler returning undefined still defers (back-compat)", async () => {
+    const ctx = makeCtx([
+      async () => ({ type: "approve", value: "outer" }),
+      async () => undefined,
+    ]);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    expect(verdict).toEqual({ type: "approve", value: "outer" });
+  });
+
+  it("pass() and undefined both emit a handlerDecision of pass", async () => {
+    const ctx = makeCtx([
+      async () => ({ type: "approve", value: "ok" }),
+      async () => undefined,
+      async () => pass(),
+    ]);
+    const decisions = vi.spyOn(ctx.statelogClient, "handlerDecision");
+    await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    const kinds = decisions.mock.calls.map((c) => c[0].decision);
+    expect(kinds).toEqual(["pass", "pass", "approve"]);
+  });
+
+  it("every handler passing surfaces the interrupt", async () => {
+    const ctx = makeCtx([async () => pass(), async () => pass()]);
+    const verdict = await interruptWithHandlers("std::bash", "m", {}, "o", ctx);
+    expect(Array.isArray(verdict)).toBe(true);
+    expect((verdict as any)[0].effect).toBe("std::bash");
   });
 });

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -27,7 +27,7 @@ describe("interruptWithHandlers resolvedBy attribution (IPC mode)", () => {
       smoltalkDefaults: {},
       dirname: process.cwd(),
     });
-    ctx.handlers = handlers;
+    ctx.handlers = handlers.map((fn: any) => ({ fn, liveGuardIds: [] }));
     return ctx;
   };
 
@@ -115,7 +115,7 @@ describe("interruptWithHandlers expectsValue", () => {
       smoltalkDefaults: {},
       dirname: process.cwd(),
     });
-    ctx.handlers = handlers;
+    ctx.handlers = handlers.map((fn: any) => ({ fn, liveGuardIds: [] }));
     // The surfaced path stamps the run id onto the Interrupt (renderVerdict →
     // ctx.getRunId()), which a real run sets when the exec context is created.
     ctx.runId = "test-run";
@@ -296,7 +296,7 @@ describe("pass()", () => {
       smoltalkDefaults: {},
       dirname: process.cwd(),
     });
-    ctx.handlers = handlers;
+    ctx.handlers = handlers.map((fn: any) => ({ fn, liveGuardIds: [] }));
     // The surfaced path stamps the run id onto the Interrupt (renderVerdict →
     // ctx.getRunId()), which a real run sets when the exec context is created.
     ctx.runId = "test-run";

--- a/packages/agency-lang/lib/runtime/interrupts.test.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.test.ts
@@ -165,32 +165,32 @@ describe("mergeChainOutcomes", () => {
   const silent = { kind: "noResponse" } as const;
 
   it("outer reject wins over inner approve", () => {
-    expect(mergeChainOutcomes(approvedA, rejected)).toEqual(rejected);
+    expect(mergeChainOutcomes("std::bash", approvedA, rejected)).toEqual(rejected);
   });
 
   it("inner reject wins regardless of outer", () => {
-    expect(mergeChainOutcomes(rejected, approvedA)).toEqual(rejected);
+    expect(mergeChainOutcomes("std::bash", rejected, approvedA)).toEqual(rejected);
   });
 
   it("any propagate beats approve", () => {
-    expect(mergeChainOutcomes(propagated, approvedA)).toEqual(propagated);
-    expect(mergeChainOutcomes(approvedA, propagated)).toEqual(propagated);
+    expect(mergeChainOutcomes("std::bash", propagated, approvedA)).toEqual(propagated);
+    expect(mergeChainOutcomes("std::bash", approvedA, propagated)).toEqual(propagated);
   });
 
   it("inner approve + outer silence = approve (the regression fix)", () => {
-    expect(mergeChainOutcomes(approvedA, silent)).toEqual(approvedA);
+    expect(mergeChainOutcomes("std::bash", approvedA, silent)).toEqual(approvedA);
   });
 
   it("outer approved value wins; falls back to inner value", () => {
-    expect(mergeChainOutcomes(approvedA, approvedB)).toEqual(approvedB);
-    expect(mergeChainOutcomes(approvedA, approvedNoValue)).toEqual({
+    expect(mergeChainOutcomes("std::bash", approvedA, approvedB)).toEqual(approvedB);
+    expect(mergeChainOutcomes("std::bash", approvedA, approvedNoValue)).toEqual({
       kind: "approved",
       value: "a",
     });
   });
 
   it("total silence stays noResponse for the caller to map to propagate", () => {
-    expect(mergeChainOutcomes(silent, silent)).toEqual(silent);
+    expect(mergeChainOutcomes("std::bash", silent, silent)).toEqual(silent);
   });
 });
 

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -39,6 +39,14 @@ export function reject(value?: any): InterruptResponse {
   return { type: "reject", value } as any;
 }
 
+/** Explicit "not my interrupt — ask the next handler." Identical in effect
+ *  to a handler returning nothing, but usable in value position (a match
+ *  arm must produce a value). Returning `undefined` keeps working; the
+ *  chain normalizes it to this shape at the boundary. */
+export function pass(): InterruptResponse {
+  return { type: "pass" } as any;
+}
+
 export type InterruptData = {
   // messages that have been exchanged in the prompt function
   // up till this interrupt was triggered. This is needed to restore
@@ -250,6 +258,12 @@ async function runHandlerChain(
         if (isAborted(result)) {
           throw result.toError();
         }
+        // A handler that returns nothing means "pass". Normalize here so
+        // the loop, statelog, and merge logic never see two spellings of
+        // the same verdict.
+        if (result === undefined) {
+          result = { type: "pass" };
+        }
         // Pre-bind the interrupt summary once so all handlerDecision /
         // interruptResolved events from this dispatch carry the same
         // {effect, message, data} payload — lets log readers see *what*
@@ -261,8 +275,8 @@ async function runHandlerChain(
           message: interruptObj.message,
           data: interruptObj.data,
         };
-        if (result === undefined) {
-          ctx.statelogClient.handlerDecision({ interruptId, handlerIndex: i, decision: "none", interrupt: interruptSummary });
+        if (result.type === "pass") {
+          ctx.statelogClient.handlerDecision({ interruptId, handlerIndex: i, decision: "pass", interrupt: interruptSummary });
           continue;
         }
         if (result.type === "reject") {
@@ -286,7 +300,7 @@ async function runHandlerChain(
           continue;
         }
         throw new Error(
-          `Handler returned invalid result type: ${JSON.stringify(result)}. Expected "approve", "reject", "propagate", or undefined.`,
+          `Handler returned invalid result type: ${JSON.stringify(result)}. Expected "approve", "reject", "propagate", "pass", or undefined.`,
         );
       }
     } finally {

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -244,13 +244,27 @@ async function runHandlerChain(
     try {
       for (let i = (ctx.handlers ?? []).length - 1; i >= 0; i--) {
         if (ctx.isCancelled(stack)) throw new AgencyCancelledError();
+        const entry = ctx.handlers[i];
+        // A handler runs under its REGISTRATION site's budget: every
+        // guard that was not live when it registered is suspended on
+        // this branch for the duration of the call — not gating, not
+        // charging, clock paused (see HandlerEntry and
+        // StateStack.beginHandlerSuspension). Per handler, not per
+        // chain: each handler in the chain has its own registration
+        // site and therefore its own hidden set.
+        const suspensionToken = stack
+          ? stack.beginHandlerSuspension(entry)
+          : undefined;
         // Treat handler execution as atomic for the debugger — same as LLM tool calls.
         ctx.enterToolCall();
         let result: any;
         try {
-          result = await ctx.handlers[i](interruptObj);
+          result = await entry.fn(interruptObj);
         } finally {
           ctx.exitToolCall();
+          if (suspensionToken !== undefined) {
+            stack!.endHandlerSuspension(suspensionToken);
+          }
         }
         // A handler that is a compiled def returns an AbortedResult when
         // an abort stops it mid-run (compiled frames convert aborts to

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -8,6 +8,7 @@ import {
   RestoreSignal,
 } from "./errors.js";
 import { isAborted } from "./abortedResult.js";
+import { mergeFor, mergeForIpc } from "./effectMerge.js";
 import { applyOverrides } from "./rewind.js";
 import { Checkpoint } from "./state/checkpointStore.js";
 import { RuntimeContext } from "./state/context.js";
@@ -233,8 +234,11 @@ async function runHandlerChain(
     throw new HandlerRecursionError(interruptObj.effect, MAX_HANDLER_CHAIN_DEPTH);
   }
   return handlerChainDepthALS.run(depth, async () => {
-    let approvedValue: any = undefined;
-    let hasApproval = false;
+    // Approvals collect in chain-walk order (innermost handler first) and
+    // are merged once at the end via the effect's merge (effectMerge.ts).
+    // For effects with no specific merge the default reproduces the
+    // historical behavior exactly: the outermost approval overwrites.
+    const approvals: any[] = [];
     let hasPropagation = false;
     const chainSpanId = ctx.statelogClient.startSpan("handlerChain");
     try {
@@ -295,8 +299,7 @@ async function runHandlerChain(
         }
         if (result.type === "approve") {
           ctx.statelogClient.handlerDecision({ interruptId, handlerIndex: i, decision: "approve", value: result.value, interrupt: interruptSummary });
-          hasApproval = true;
-          approvedValue = result.value;
+          approvals.push(result.value);
           continue;
         }
         throw new Error(
@@ -307,7 +310,12 @@ async function runHandlerChain(
       ctx.statelogClient.endSpan(chainSpanId); // end handlerChain span
     }
     if (hasPropagation) return { kind: "propagated" };
-    if (hasApproval) return { kind: "approved", value: approvedValue };
+    if (approvals.length > 0) {
+      return {
+        kind: "approved",
+        value: approvals.reduce(mergeFor(interruptObj.effect)),
+      };
+    }
     return { kind: "noResponse" };
   });
 }
@@ -315,14 +323,14 @@ async function runHandlerChain(
 /** Merge two chain-segment outcomes with single-process precedence:
  * reject > propagate > approve > noResponse. `inner` is the segment closer
  * to the interrupt (e.g. the child process), `outer` the segment farther
- * from it (e.g. the parent). On double-approve the OUTER value wins,
- * falling back to the inner value via `??`. Note this is deliberately
- * WEAKER than the in-process chain (which overwrites unconditionally, so
- * an outer approve-with-no-value clears an inner injected value): the
+ * from it (e.g. the parent). A double-approve merges through the EFFECT's
+ * approval merge (effectMerge.ts) — std::guard grants accumulate; every
+ * other effect keeps the historical IPC default, where the outer value
+ * wins but a VALUELESS outer approve defers to the inner value (the
  * outcome travels as JSON, which cannot distinguish an absent value from
- * an explicit undefined, so a valueless outer approve defers to the
- * inner value instead. */
+ * an explicit undefined). */
 export function mergeChainOutcomes(
+  effect: string,
   inner: HandlerChainOutcome,
   outer: HandlerChainOutcome,
 ): HandlerChainOutcome {
@@ -333,7 +341,10 @@ export function mergeChainOutcomes(
   }
   if (outer.kind === "approved") {
     const innerValue = inner.kind === "approved" ? inner.value : undefined;
-    return { kind: "approved", value: outer.value ?? innerValue };
+    return {
+      kind: "approved",
+      value: mergeForIpc(effect)(innerValue, outer.value),
+    };
   }
   if (inner.kind === "approved") return inner;
   return { kind: "noResponse" };
@@ -372,7 +383,7 @@ export async function gatherChainOutcome(
   if (isIpcMode()) {
     const parentOutcome = await sendInterruptToParent(interruptObj, interruptId);
     return {
-      outcome: mergeChainOutcomes(local, parentOutcome),
+      outcome: mergeChainOutcomes(interruptObj.effect, local, parentOutcome),
       parentDecided: parentOutcome.kind !== "noResponse",
     };
   }

--- a/packages/agency-lang/lib/runtime/runPolicyHandler.ts
+++ b/packages/agency-lang/lib/runtime/runPolicyHandler.ts
@@ -208,12 +208,16 @@ function loadEnvPolicy(): Policy | null {
 // (runNode) and the resume entry (respondToInterrupts) so the never-
 // serialized root handler is re-installed on a resumed leg too.
 export function installRunPolicyHandler(execCtx: {
-  pushHandler: (h: HandlerFn) => void;
+  pushHandler: (h: HandlerFn, liveGuardIds: string[]) => void;
 }): void {
   if (isIpcMode()) return;
   const policy = loadEnvPolicy();
   if (!policy) return;
-  execCtx.pushHandler(makeRunPolicyHandler(policy));
+  // liveGuardIds: [] — explicit: the --policy handler registers at run
+  // start, before any guard exists, and it is the outermost supervisory
+  // layer; a policy answering an interrupt is never metered or gated by
+  // user guards.
+  execCtx.pushHandler(makeRunPolicyHandler(policy), []);
 }
 
 // The user endpoint for a CLI-driven run: called by the generated bootstrap

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -769,19 +769,44 @@ export class Runner {
     callback: (runner: Runner) => Promise<void>,
   ): Promise<void> {
     if (this.shouldSkip()) return;
+    // A COMPLETED handle block returns here, before pushHandler — its
+    // scope is over and its handler stays gone on replay. This line is
+    // also why the guard-set memo below cannot be keyed by counting
+    // registrations: replay skips completed registrations, so a counter
+    // counts different events than the original run did. Keys must be
+    // POSITION (stepPath, here) or content — never an event count.
     if (this.getCounter() > id) return;
 
     if (await this.maybeDebugHook(id)) return;
 
     this.ctx.coverageCollector?.hit(this.moduleId, this.scopeName, this.stepPath(id));
 
-    this.ctx.pushHandler(handlerFn);
+    // Which guards were live when this handler registered? Decides the
+    // handler's budget scoping (HandlerEntry.liveGuardIds). Memoized
+    // FIRST-WRITE-WINS in the registering frame's locals: on resume,
+    // stack.guards is restored from JSON BEFORE this replayed
+    // registration runs, so a fresh capture here would see guards that
+    // did not exist at the original registration — including a guard
+    // whose trip this handler is supposed to adjudicate. The memo makes
+    // the original capture the durable one. Keyed by stepPath (position)
+    // per the note above; stored per-frame so recursive activations of
+    // the same handle block each get their own entry; DELETED on pop so
+    // a loop's next iteration (same stepPath, new guards) writes fresh.
+    const memoKey = `__handlerGuards_${this.stepPath(id)}`;
+    let liveGuardIds = this.frame.locals[memoKey] as string[] | undefined;
+    if (liveGuardIds === undefined) {
+      liveGuardIds = this.stack ? this.stack.guards.map((g) => g.guardId) : [];
+      this.frame.locals[memoKey] = liveGuardIds;
+    }
+
+    this.ctx.pushHandler(handlerFn, liveGuardIds);
     this.path.push(id);
     try {
       await this.runInScope(() => callback(this));
     } finally {
       this.path.pop();
       this.ctx.popHandler();
+      delete this.frame.locals[memoKey];
     }
 
     if (this.halted) return;

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -330,12 +330,14 @@ export class Runner {
           this._matchExit !== null
         );
       }
-      // Walk innermost-first so the deepest guard reports its trip
-      // first. Mirrors the order in prompt.ts's cost-check loop.
-      for (let i = this.stack.guards.length - 1; i >= 0; i--) {
-        const err = this.stack.guards[i].check(this.stack);
-        if (err) throw err;
-      }
+      // THE shared trip walk (innermost-first, suspension-aware) — the
+      // same one enforceGuards throws from. Routing through it matters:
+      // a private loop here would call check() directly and miss the
+      // stack's suspendedGuardIds consult, letting a suspended
+      // over-budget CostGuard throw its trip out of the handler that
+      // suspended it whenever the abort signal is live.
+      const err = this.stack.detectTrippedGuard();
+      if (err) throw err;
       const guardOwnsAbort = this.stack.guards.some((g) => g.isTripped());
       if (!guardOwnsAbort) {
         this.halt(undefined);

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -22,7 +22,7 @@ import { GlobalStore } from "../state/globalStore.js";
 import { StateStack } from "../state/stateStack.js";
 import { TraceWriter } from "../trace/traceWriter.js";
 import type { TraceConfig } from "../trace/types.js";
-import type { HandlerFn } from "../types.js";
+import type { HandlerEntry, HandlerFn } from "../types.js";
 import {
   applyRuntimeConfigOverridesToContextArgs,
   getRuntimeConfigOverrides,
@@ -82,7 +82,7 @@ export class RuntimeContext<T> {
   checkpoints: CheckpointStore;
   callbacks: AgencyCallbacks;
   onStreamLock: boolean;
-  handlers: HandlerFn[];
+  handlers: HandlerEntry[];
   locks: Record<string, Promise<void>>;
   lockOwners: Record<string, string>;
   lockWaiters: Record<string, string[]>;
@@ -528,8 +528,15 @@ export class RuntimeContext<T> {
   async threads. But we could just replace all calls to `forkStack`
   with `new StateStack()`.
   */
-  pushHandler(fn: HandlerFn): void {
-    this.handlers.push(fn);
+  /** Register a handler. `liveGuardIds` is REQUIRED and each caller
+   *  must decide it explicitly (an empty array is NOT neutral — it
+   *  means "hide every guard from this handler", which is correct only
+   *  for handlers registered before any guard can exist, like the
+   *  --policy handler and top-level init wrappers). Agency handle
+   *  blocks capture it in Runner.handle; TS callers capture at call
+   *  time in withPushedHandler. See HandlerEntry. */
+  pushHandler(fn: HandlerFn, liveGuardIds: string[]): void {
+    this.handlers.push({ fn, liveGuardIds });
   }
   popHandler(): void {
     this.handlers.pop();

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -1,4 +1,5 @@
 import type { Guard, GuardJSON } from "../guard.js";
+import type { HandlerEntry } from "../types.js";
 import type { ReplyAttachmentPart } from "../replyAttachments.js";
 import { guardFromJSON, TimeGuard } from "../guard.js";
 import { sendCostTelemetryToParent } from "../costTelemetry.js";
@@ -569,8 +570,65 @@ export class StateStack {
   enforceGuards(): void {
     this.assertNoParkedGuards();
     for (let i = this.guards.length - 1; i >= 0; i--) {
+      if (this.suspendedGuardIds.includes(this.guards[i].guardId)) continue;
       const err = this.guards[i].check(this);
       if (err) throw err;
+    }
+  }
+
+  /** guardIds suspended ON THIS BRANCH while an interrupt handler runs:
+   *  a handler's work is metered by the guards of its REGISTRATION site
+   *  (HandlerEntry.liveGuardIds), so everything deeper is invisible to
+   *  enforcement and charging for the duration of the handler call.
+   *  Branch-local twice over, on purpose: never serialized (a snapshot
+   *  taken mid-suspension — a handler that propagates — must revive
+   *  guards that meter), and never a flag on the guard OBJECT for cost
+   *  (a shared CostGuard flagged object-wide would drop SIBLING
+   *  branches' charges and open their gates while one branch's handler
+   *  deliberates). TimeGuard clocks are per-branch objects and pause
+   *  via Guard.suspend(). */
+  private suspendedGuardIds: string[] = [];
+
+  /** The guards a handler must not see or be metered by: every
+   *  installed guard that was NOT live when the handler registered.
+   *  Identity-based on guardId — ids are serialized and survive resume
+   *  and fork (time clones keep the parent's id), which array indices
+   *  do not. Evaluated against THIS stack, the raising branch's: a
+   *  handler registered in a sibling branch is still metered by shared
+   *  and inherited guards that predate it, and hidden from everything
+   *  branch-local here. */
+  guardsHiddenFrom(entry: HandlerEntry): Guard[] {
+    return this.guards.filter((g) => !entry.liveGuardIds.includes(g.guardId));
+  }
+
+  /** Suspend everything hidden from `entry` for the duration of one
+   *  handler invocation. Returns the token endHandlerSuspension needs.
+   *  Save/restore (not add/remove) so NESTED handler chains compose: an
+   *  inner chain suspending a guard the outer chain already suspended
+   *  must not un-suspend it when the inner handler returns. Only guards
+   *  newly entering / actually leaving the suspended set get their
+   *  object-level suspend()/unsuspend() calls, so the TimeGuard clock
+   *  pause pairs correctly across nesting. */
+  beginHandlerSuspension(entry: HandlerEntry): string[] {
+    const previous = this.suspendedGuardIds;
+    const hidden = this.guardsHiddenFrom(entry);
+    this.suspendedGuardIds = [
+      ...previous,
+      ...hidden.map((g) => g.guardId).filter((id) => !previous.includes(id)),
+    ];
+    for (const g of hidden) {
+      if (!previous.includes(g.guardId)) g.suspend();
+    }
+    return previous;
+  }
+
+  endHandlerSuspension(previous: string[]): void {
+    const removed = this.suspendedGuardIds.filter(
+      (id) => !previous.includes(id),
+    );
+    this.suspendedGuardIds = previous;
+    for (const g of this.guards) {
+      if (removed.includes(g.guardId)) g.unsuspend();
     }
   }
 
@@ -611,7 +669,10 @@ export class StateStack {
    */
   chargeGuards(amount: number): void {
     this.assertNoParkedGuards();
-    for (const g of this.guards) g.charge(amount);
+    for (const g of this.guards) {
+      if (this.suspendedGuardIds.includes(g.guardId)) continue;
+      g.charge(amount);
+    }
   }
 
   /**

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -1,4 +1,4 @@
-import type { Guard, GuardJSON } from "../guard.js";
+import type { Guard, GuardExceededError, GuardJSON } from "../guard.js";
 import type { HandlerEntry } from "../types.js";
 import type { ReplyAttachmentPart } from "../replyAttachments.js";
 import { guardFromJSON, TimeGuard } from "../guard.js";
@@ -569,11 +569,29 @@ export class StateStack {
    */
   enforceGuards(): void {
     this.assertNoParkedGuards();
+    const err = this.detectTrippedGuard();
+    if (err) throw err;
+  }
+
+  /** THE guard-trip walk: innermost-first, suspension-aware. Every
+   *  caller that asks "did a guard trip?" goes through here —
+   *  `enforceGuards` (the throwing form) and `Runner.shouldSkip` (which
+   *  re-throws an undelivered trip at step boundaries). One walk, one
+   *  suspension rule: a walk that skipped the `suspendedGuardIds`
+   *  consult would let a suspended, over-budget CostGuard throw its
+   *  trip out of the very handler that suspended it (CostGuard's
+   *  object-level suspend() is a deliberate no-op — see guard.ts — so
+   *  the object cannot decline on its own). Returns the trip error
+   *  instead of throwing so callers keep their own throw semantics.
+   *  This is also the detection sibling the resumable-guards plan's
+   *  PR 2 raise sites need. */
+  detectTrippedGuard(): GuardExceededError | null {
     for (let i = this.guards.length - 1; i >= 0; i--) {
       if (this.suspendedGuardIds.includes(this.guards[i].guardId)) continue;
       const err = this.guards[i].check(this);
-      if (err) throw err;
+      if (err) return err;
     }
+    return null;
   }
 
   /** guardIds suspended ON THIS BRANCH while an interrupt handler runs:

--- a/packages/agency-lang/lib/runtime/types.ts
+++ b/packages/agency-lang/lib/runtime/types.ts
@@ -35,6 +35,7 @@ export type TokenStats = {
 export type Rejected = { type: "reject"; value?: any };
 export type Approved = { type: "approve"; value?: any };
 export type Propagated = { type: "propagate" };
+export type Passed = { type: "pass" };
 
 export type HandlerFn = (
   interrupt: {
@@ -46,7 +47,23 @@ export type HandlerFn = (
     // approval value is expected. See Interrupt.expectsValue.
     expectsValue?: boolean;
   },
-) => Promise<Approved | Rejected | Propagated | undefined>;
+) => Promise<Approved | Rejected | Propagated | Passed | undefined>;
+
+/** One registered handler on `ctx.handlers`. A handler belongs to the
+ *  scope where it was registered: `liveGuardIds` records which guards
+ *  were live on the registering branch's stack at that moment, and that
+ *  set decides both which guard trips the handler may adjudicate (only
+ *  guards NOT in the set — you cannot adjudicate a guard you are inside)
+ *  and which guards are suspended while the handler runs (also the
+ *  guards not in the set: a handler's own work spends its registration
+ *  site's budget, never a budget it is deciding about). Identity-based
+ *  on guardId — ids are serialized and survive resume and fork, which
+ *  array indices and registration counts do not (see the resumable-
+ *  guards plan, decision 14). */
+export type HandlerEntry = {
+  fn: HandlerFn;
+  liveGuardIds: string[];
+};
 
 /* tokenstats
 {

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -950,7 +950,7 @@ export class StatelogClient {
   }: {
     interruptId: string;
     handlerIndex: number;
-    decision: "approve" | "reject" | "propagate" | "none";
+    decision: "approve" | "reject" | "propagate" | "pass" | "none";
     value?: any;
     /** Optional summary of the interrupt being decided on. Carries
      *  `effect`, `message`, and `data` so log consumers can see *what*

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -46,6 +46,7 @@ const getDirname = () => __dirname;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -51,6 +51,7 @@ const getDirname = () => __dirname;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/withHandlerWrapper.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/withHandlerWrapper.mustache
@@ -1,0 +1,6 @@
+getRuntimeContext().ctx.pushHandler({{{handler}}}, []);
+{{{indent}}}try {
+{{{body}}}
+{{{indent}}}} finally {
+{{{indentInner}}}getRuntimeContext().ctx.popHandler();
+{{{indent}}}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/withHandlerWrapper.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/withHandlerWrapper.ts
@@ -1,0 +1,25 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/backends/typescriptGenerator/withHandlerWrapper.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `getRuntimeContext().ctx.pushHandler({{{handler}}}, []);
+{{{indent}}}try {
+{{{body}}}
+{{{indent}}}} finally {
+{{{indentInner}}}getRuntimeContext().ctx.popHandler();
+{{{indent}}}}`;
+
+export type TemplateType = {
+  handler: string | boolean | number;
+  indent: string | boolean | number;
+  body: string | boolean | number;
+  indentInner: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -297,6 +297,12 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
     description:
       "Inside a `handle ... with` block, pass the interrupt up to the next handler in the chain.",
   },
+  pass: {
+    params: [],
+    returnType: ANY_T,
+    description:
+      "Inside a `handle ... with` block, decline to answer this interrupt and let the next handler decide.",
+  },
 
   // --- Checkpointing ---
   checkpoint: {

--- a/packages/agency-lang/tests/agency/handlers/handle-pass.agency
+++ b/packages/agency-lang/tests/agency/handlers/handle-pass.agency
@@ -1,0 +1,60 @@
+// pass() — the explicit "not my interrupt, ask the next handler" verdict.
+// Identical in effect to a handler returning nothing, but usable in value
+// position: a match arm must produce a value, and every other verdict
+// (approve/reject/propagate) is a decision.
+const log = []
+
+def foo() {
+  log.push("foo start")
+  return interrupt("check")
+  log.push("foo end")
+  return "foo result"
+}
+
+def passHandler(data) {
+  return pass()
+}
+
+// 1. Inner pass, outer approve — the pass defers, the outer decides.
+node testInnerPassOuterApprove() {
+  handle {
+    handle {
+      const result = foo()
+      log.push(result)
+    } with (data) {
+      return pass()
+    }
+  } with (data) {
+    return approve()
+  }
+  return log
+}
+
+// 2. pass() from a match arm — the motivating case: the arm must produce
+// a value, and "no opinion" is now expressible as one.
+node testPassInMatchArm() {
+  handle {
+    handle {
+      const result = foo()
+      log.push(result)
+    } with (data) {
+      return match(data.effect) {
+        "std::guard" => reject()
+        _ => pass()
+      }
+    }
+  } with (data) {
+    return approve()
+  }
+  return log
+}
+
+// 3. Every handler passes — the interrupt reaches the user, exactly like
+// a handler that returns nothing.
+node testAllPass() {
+  handle {
+    const result = foo()
+    log.push(result)
+  } with passHandler
+  return log
+}

--- a/packages/agency-lang/tests/agency/handlers/handle-pass.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handle-pass.test.json
@@ -1,0 +1,43 @@
+{
+  "tests": [
+    {
+      "nodeName": "testInnerPassOuterApprove",
+      "description": "Inner pass() defers; the outer handler approves and the work completes",
+      "input": "",
+      "expectedOutput": "[\"foo start\",\"foo end\",\"foo result\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "testPassInMatchArm",
+      "description": "pass() as a match-arm value — no opinion is expressible where a value is required",
+      "input": "",
+      "expectedOutput": "[\"foo start\",\"foo end\",\"foo result\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    },
+    {
+      "nodeName": "testAllPass",
+      "description": "Every handler passes — the interrupt reaches the user like an unanswered one",
+      "input": "",
+      "expectedOutput": "[\"foo start\",\"foo end\",\"foo result\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "check"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-budget-scoping.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-budget-scoping.agency
@@ -1,0 +1,45 @@
+// A handler runs under its REGISTRATION site's budget. Each mocked llm()
+// call costs exactly 0.000002 (SYNTHETIC_COST in deterministicClient.ts),
+// so the guard limits below are sized in fractions of calls and every
+// assertion is a spend into a gap: the output changes if a charge lands
+// on the wrong guard in EITHER direction.
+//
+// Shape: the outer guard encloses the handler's registration, the inner
+// guard does not. The handler's own llm() must charge the outer guard
+// and must NOT charge the inner one.
+import { guard } from "std::thread"
+
+def work() {
+  const r1 = llm("Reply with: one")
+  const check = interrupt("more?")
+  // 2 calls total inside the inner guard (2.25 allowed): succeeds only
+  // if the handler's call did NOT bill the inner guard.
+  const r2 = llm("Reply with: two")
+  return "inner-done"
+}
+
+node main() {
+  // 3.25 calls' worth. Body spends r1 + handler + r2 = 3 calls, so the
+  // one extra call below trips it — but only because the HANDLER's call
+  // counted. Without the handler charge the total would be 3 and fit.
+  const outer = guard(cost: 0.0000065) as {
+    handle {
+      // 2.25 calls' worth: r1 + r2 fit; r1 + handler + r2 would not.
+      const inner = guard(cost: 0.0000045) as {
+        return work()
+      }
+      if (isFailure(inner)) {
+        return "inner-tripped: handler charge leaked into the inner guard"
+      }
+      const extra = llm("Reply with: three")
+      return "no-trip: handler charge missing from the outer guard"
+    } with (data) {
+      const opinion = llm("Reply with: allow")
+      return approve()
+    }
+  }
+  if (isFailure(outer)) {
+    return "outer-tripped-after-handler-spend"
+  }
+  return outer.value
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-budget-scoping.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-budget-scoping.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"outer-tripped-after-handler-spend\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "allow" },
+        { "return": "two" },
+        { "return": "three" }
+      ],
+      "description": "The handler's own llm() charges the guard enclosing its REGISTRATION (outer) and never the guard it is deciding inside of (inner). Both directions are pinned by spend: a leak into the inner guard trips it at r2; a missing charge on the outer guard lets the extra call fit."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-scope-loop.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-scope-loop.agency
@@ -1,0 +1,40 @@
+// The registration-memo loop hazard (resumable-guards plan, Task 1.3b):
+// a handle block inside a loop registers once per iteration from the SAME
+// callsite, and each iteration pushes its own FRESH guard (new guardId).
+// The memo entry must be deleted when a registration pops, or iteration 2
+// would inherit iteration 1's stale guard set — iteration 2's guard would
+// be missing from it, so the handler would treat the guard it is INSIDE
+// as hidden and its spend would stop counting. Fail-open.
+//
+// Here the handler registers INSIDE the per-iteration guard, so its
+// llm() spend MUST count against that guard. Sized so the handler's
+// charge is the difference between tripping and fitting: body spends 2
+// calls, handler adds a 3rd, limit is 2.25 calls' worth.
+import { guard } from "std::thread"
+
+def work() {
+  const a = llm("Reply with: work")
+  const check = interrupt("go?")
+  const b = llm("Reply with: more")
+  return "iter-done"
+}
+
+node main() {
+  const results = []
+  for (i in [1, 2]) {
+    const r = guard(cost: 0.0000045) as {
+      handle {
+        return work()
+      } with (data) {
+        const opinion = llm("Reply with: yes")
+        return approve()
+      }
+    }
+    if (isFailure(r)) {
+      results.push("iter-tripped")
+    } else {
+      results.push(r.value)
+    }
+  }
+  return results
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-scope-loop.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-scope-loop.test.json
@@ -1,0 +1,20 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"iter-tripped\",\"iter-tripped\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "work" },
+        { "return": "yes" },
+        { "return": "more" },
+        { "return": "work" },
+        { "return": "yes" },
+        { "return": "more" }
+      ],
+      "description": "Both iterations trip: the handler registered inside the per-iteration guard is metered by it, in iteration 2 as much as iteration 1. Under the stale-memo bug, iteration 2's handler spend would not count and iteration 2 would finish under budget."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-scope-resume.agency
+++ b/packages/agency-lang/tests/agency/handlers/handler-scope-resume.agency
@@ -1,0 +1,35 @@
+// Suspension must never survive a checkpoint (resumable-guards plan,
+// Task 1.3 test 4). The handler here PROPAGATES, so the interrupt
+// surfaces to the harness while the handler-suspension machinery has
+// been engaged and released around the handler call. After the harness
+// approves and the run resumes, the guard must still meter: the second
+// llm() pushes spend past the 1.25-call limit and the guard trips.
+//
+// If suspension state leaked into the snapshot in any form (a flag on
+// the guard, the stack's suspended-id set), the resumed guard would be
+// blind and the run would finish under budget — a different output.
+// This also exercises the registration memo across a real restore: the
+// resumed run replays the handle registration and must reconstruct the
+// same scoping.
+import { guard } from "std::thread"
+
+def work() {
+  const a = llm("Reply with: one")
+  const check = interrupt("continue?")
+  const b = llm("Reply with: two")
+  return "done"
+}
+
+node main() {
+  handle {
+    const r = guard(cost: 0.0000025) as {
+      return work()
+    }
+    if (isFailure(r)) {
+      return "tripped-after-resume"
+    }
+    return r.value
+  } with (data) {
+    return propagate()
+  }
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-scope-resume.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-scope-resume.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped-after-resume\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "continue?"
+        }
+      ],
+      "description": "Propagate surfaces the interrupt mid-run; after the harness approves and the run resumes, the guard still meters and trips on the next spend. Pins that no suspension state rides the checkpoint."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveBlock.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/destructiveNested.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -84,6 +84,7 @@ __initializeGlobals(__globalCtx);
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -98,6 +98,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/intersectionTypes.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlockBlockArms.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchExpression.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recursiveTypes.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaChaining.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -84,6 +84,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeOperators.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/utilityTypes.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -83,6 +83,7 @@ const graph = __globalCtx.graph;
 export function approve(value?: any) { return { type: "approve" as const, value }; }
 export function reject(value?: any) { return { type: "reject" as const, value }; }
 function propagate() { return { type: "propagate" as const }; }
+function pass() { return { type: "pass" as const }; }
 
 // Interrupt and rewind re-exports bound to this module's context
 export { interrupt, isInterrupt, hasInterrupts, isDebugger };


### PR DESCRIPTION
PR 1 of 4 of the resumable-guards plan (`docs/superpowers/plans/2026-07-16-resumable-guards.md`, rev 8, committed on this branch with its full review trail). This PR upgrades the interrupt machinery itself and changes no guard behavior: everything here is exercised by ordinary interrupts, so the handler chain's changes are proven against the existing suites before guard trips start using them in PR 2.

## The three pieces

**`pass()` — an explicit "not my interrupt" verdict.** Identical in effect to a handler returning nothing, but usable in value position, which a `match` arm requires. The chain normalizes `undefined` to `pass` the moment a handler returns, so the loop, statelog (`decision: "pass"`), and merge logic see one spelling. Typechecker entry mirrors `propagate`.

**Per-effect approval merge.** When several handlers approve one interrupt, the values now combine through `mergeFor(effect)` (`lib/runtime/effectMerge.ts`) instead of the outermost silently overwriting. The table is total and CONSTANT — deliberately no registration surface (a runtime registry is per-run module-global state, diverges silently across the subprocess boundary, and would put user closures on the function-refs-across-checkpoints surface). The default merge IS the historical overwrite, byte-for-byte, so every existing effect is unchanged; `std::guard` accumulates (grants sum, disarm lists union, messages join). The cross-process merge (`mergeChainOutcomes`, now taking the effect) uses the same table, with its one historical asymmetry (valueless outer approve defers to inner over IPC) preserved and documented.

**Registration-site handler scoping.** A handler belongs to the scope where it was registered. Each entry on `ctx.handlers` carries `liveGuardIds` — the guards live at its registration — and while the handler runs, the raising branch suspends every guard not in that set: the handler's own `llm()` calls are metered by its registration site's guards only. The capture point is `Runner.handle` (where Agency `handle` blocks actually register), memoized first-write-wins in the registering frame's locals keyed by step path, deleted on pop — the design the plan spent four review rounds getting right (position keys, never event counts; `Runner.handle` returns before `pushHandler` for completed blocks on replay). All five `pushHandler` callers decide their guard set explicitly, including one the plan reviews had missed: the `--policy` handler (registered before any guard exists, `[]`).

## Two things review should look at hardest

**1. A deviation from the reviewed plan, found during implementation: cost-guard suspension is stack-scoped, not an object flag.** The plan specified `suspended` on the guard object with `check()`/`charge()` early-returns. That is fail-open for `CostGuard`: the object is SHARED across fork branches (`cloneForBranch` returns `this`), so an object flag would drop sibling branches' charges and open their gates while one branch's handler deliberates. Implemented instead as `StateStack.suspendedGuardIds` (branch-local, in-memory, never serialized), consulted inside `enforceGuards`/`chargeGuards` — call sites unchanged — with a save/restore bracket so nested handler chains compose. `TimeGuard` keeps the object-level flag (clones are per-branch objects) and pins its clock paused across `Runner.beforeStep`'s resume-all. The plan doc on this branch records the deviation where PR 2 will read it, because `scope.suspendAll()` at the raise site must use the same stack-scoped bracket.

**2. `preapprove()` now passes on `std::guard`.** Its auto-approve answers every interrupt with a bare `approve()` — which for a guard trip is `approve({})`, a grant of nothing that the trip machinery (PR 2) treats as a runtime error. Budget questions belong to outer handlers or the user, never a tool's auto-approve wrapper. One line, two unit tests.

## Honest coverage note

The "handler blocked by an already-over-budget guard" scenario (the pre-call-gate half of suspension) is unreachable in this PR: cost trips still THROW at the charging moment, so the over-budget-but-still-running state does not exist until PR 2 makes trips raise. That surface gets its real fixtures there. What this PR pins with spend-into-the-gap fixtures: charge scoping in both directions (a leak into the hidden guard trips it; a missing charge on the registration-site guard lets an extra call fit), the loop-iteration memo hazard, and that no suspension state survives a propagate-and-resume.

## Validation

- 8,354 unit tests green (baseline 8,333 + the new ones), including the full existing handler/interrupt suites on the new entry shape before any new behavior tests were added.
- Full guards fixture sweep: 64/64. Full handlers fixture sweep green, including 4 new fixtures (`handle-pass`, `handler-budget-scoping`, `handler-scope-loop`, `handler-scope-resume`).
- Structural lint clean; `make fixtures` zero churn beyond the one added `pass()` line in the generated imports preamble.
- Checkpoint-copies-frame-locals verified (`State.toJSON` deep-clones `locals`), which the memo's delete-on-pop rule rests on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
