### PR TITLE
Cost-guard trips raise resumable interrupts (resumable guards PR 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-resumable-guards.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards.md
@@ -1160,6 +1160,51 @@ CHANGELOG, `docs/dev/interrupts.md` (the new machinery).
 
 ---
 
+# Part 5b: PR 2 — as executed (deviations and discoveries)
+
+Recorded after execution, for PR 3's benefit and the reviewer's.
+
+1. **The raise lives at PromptRunner gate steps, not at the in-_runPrompt
+   check sites.** Raising from inside a non-idempotent llm-call step body
+   breaks replay: the body re-pushes its user message on resume. The
+   gates (`guardGate.initial`, `round.N.guardGate`, validation gates,
+   `guardGate.final`) are idempotent steps of their own, and
+   PromptRunner.step's existing bailout machinery provides the message
+   snapshot + checkpoint the plan's raise dance would have had to
+   duplicate. The in-_runPrompt pre-call check stays as a throwing
+   backstop; the post-charge check is REMOVED (its trips raise at the
+   next gate; nothing paid runs in between — tool-internal paid work is
+   gated by the tool's own runPrompt).
+2. **addCost keeps throwing in v1** (taxonomy site 3 moves next to
+   site 4): same replay hazard as raising inside _runPrompt, from
+   arbitrary TS-helper contexts. `guard(cost:)` around a paid TS helper
+   trips non-resumably — documented, revisit with PR 3's machinery.
+3. **std::agents guards are NOT auto-reject wrapped** (deviation from
+   Task 2.5's migration rule, for owner sign-off): an inner reject
+   short-circuits ahead of user handlers, which would permanently lock
+   std::agents users out of approving trips — the flagship reviewer
+   pattern. run(maxCost:) needed no wrapper at all: its trips fire at
+   the exempted IPC site and its limit_exceeded contract is unchanged.
+4. **Fixture migration went through the harness, not in-program
+   wrappers:** `{"action": "reject"}` entries in test.json — outputs
+   byte-identical, and every migrated fixture now exercises the full
+   propagate → checkpoint → reject → resume → salvage pipeline.
+5. **New boundary fix:** an Interrupt[] reaching a call ARGUMENT passes
+   through __call/__callMethod as the call's own result (mirror of
+   findAbortedArg). Guard trips are the first runtime-only interrupt
+   source, so `f(g())` with a trip inside g was the first way a batch
+   could hit an argument slot.
+6. **Pre-existing bug found, filed as #559:** resume corrupts frames
+   when the interrupt was raised inside a compound call (FIFO frame
+   adoption vs replayed completed sibling calls). Affects tool
+   interrupts on main today. The one affected fixture case rejects
+   in-program with a pointer.
+7. **Subprocess trip e2e deferred:** the IPC site is unchanged
+   (still throws) and child-side raises forward over the EXISTING
+   interrupt IPC; a dedicated child-trip → parent-approve e2e rides
+   with PR 3, where re-arm makes the approve path meaningful for the
+   remaining dimension.
+
 # Part 6: PR 3 — the abort signal, then time trips
 
 ## Task 3.1: derive the composed abort signal

--- a/packages/agency-lang/docs/dev/interrupts.md
+++ b/packages/agency-lang/docs/dev/interrupts.md
@@ -372,3 +372,50 @@ each load-bearing:
   the clock paused across `Runner.beforeStep`'s resume-all.
 - Nothing about suspension serializes. A handler that propagates gets
   checkpointed mid-suspension; the resumed run's guards must meter.
+
+## Guard trips as interrupts (resumable guards, PR 2)
+
+A cost-guard trip raises an ordinary interrupt (effect `std::guard`)
+instead of throwing. The pieces, and where they live:
+
+- **Detection and raising:** `runPrompt` runs an idempotent guard-gate
+  step (`pr.step("guardGate.*")`) before every request step and once
+  before returning. The gate loops on `stack.detectTrippedGuard()` and
+  calls `raiseGuardTrip` per trip (`lib/runtime/guardTripInterrupt.ts`).
+  It loops because one answered question does not clear the gate:
+  approving an inner guard can leave an outer one over its own limit,
+  and each budget is owed its own question. The gate lives at the
+  pr.step level — NOT inside `_runPrompt` — because a raise inside a
+  non-idempotent llm-call step body breaks replay (the body would
+  re-push its user message on resume). The old in-`_runPrompt` pre-call
+  check remains as a throwing backstop; the post-charge check is gone
+  (its trips raise at the next gate, and nothing paid runs in between).
+- **The scope:** `GuardScope` (`lib/runtime/guardScope.ts`) is the
+  runtime name for what one Agency `guard(...)` call pushed — up to two
+  runtime guards, two ids. The interrupt carries `scopeIds`; approve
+  resolves the scope ON THE RAISING BRANCH'S STACK and applies the
+  merged payload via `scope.extend` (additive; negative grants clamp to
+  zero with a warning; `disarm` is explicit; a root-budget scope
+  refuses; an answer leaving the tripped dimension over budget and
+  armed is a runtime error — it would re-trip forever).
+- **Resume idempotency:** the trip's persisted interrupt id lives in
+  `stack.other` under a key DERIVED from guard state
+  (`__guardTrip_<scopeIds>#<dimension>@<limit>`) — stable across
+  replays of one trip, necessarily fresh for the next (an approve
+  strictly raises the limit; disarm ends the dimension). Never count
+  events for such keys: replay skips completed work.
+- **Fork dedupe (cost only, by construction):** the shared `CostGuard`
+  object carries a live `pendingTrip` record. A sibling branch that
+  detects the same guard over budget parks on it, then re-detects.
+  Set before the first await (mutual exclusion), settled in the
+  `finally` on every exit (a missed settle would hang the fork join).
+  Time clones are per-branch objects — nothing to dedupe.
+- **What still throws:** root budgets (`isRootBudget`, serialized),
+  the parent-side subprocess telemetry site (`ipc.ts` — an IPC message
+  callback has no runner to raise from; documented v1 limit), and
+  `addCost` (raising from arbitrary TS-helper contexts inside
+  non-idempotent step bodies has the same replay hazard as raising
+  inside `_runPrompt`).
+- **Rejecting** delivers the original `GuardExceededError` at the gate;
+  everything downstream — `AbortedResult`, the level rule, `finalize`,
+  the guard boundary's conversion — is untouched.

--- a/packages/agency-lang/lib/runtime/call.ts
+++ b/packages/agency-lang/lib/runtime/call.ts
@@ -6,6 +6,7 @@ import {
   describeFailureCallTarget,
 } from "./failurePropagation.js";
 import { isFailure } from "./result.js";
+import { hasInterrupts } from "./interrupts.js";
 import { type AbortedResult, isAborted } from "./abortedResult.js";
 
 /** Find an aborted result among a call's arguments (`f(g())` where g was
@@ -17,6 +18,32 @@ import { type AbortedResult, isAborted } from "./abortedResult.js";
  *  Interrupt[] does today; the abort signal is still firing, so the
  *  callee's next leaf op re-trips. Both systems share the fix whenever
  *  one lands. */
+/** An Interrupt[] must never enter another call as an argument either —
+ *  same boundary as findAbortedArg, same shape. Before guard trips, an
+ *  interrupting call in argument position was impossible: the checker
+ *  hoists statically-visible interrupting calls to statement position.
+ *  A guard trip is the first RUNTIME-ONLY interrupt source, so `f(g())`
+ *  where g trips inside is the first way an Interrupt[] can reach an
+ *  argument slot — without this check it would flow into the callee as
+ *  a value ("[object Object]"). Pass it through as the call's own
+ *  result so the caller's post-call interrupt guard halts and the
+ *  batch surfaces normally. */
+function findInterruptArg(descriptor: CallType): unknown | undefined {
+  const positional =
+    descriptor.type === "positional"
+      ? descriptor.args
+      : descriptor.positionalArgs;
+  for (const arg of positional) {
+    if (hasInterrupts(arg)) return arg;
+  }
+  if (descriptor.type === "named") {
+    for (const value of Object.values(descriptor.namedArgs)) {
+      if (hasInterrupts(value)) return value;
+    }
+  }
+  return undefined;
+}
+
 function findAbortedArg(descriptor: CallType): AbortedResult | undefined {
   const positional =
     descriptor.type === "positional"
@@ -65,6 +92,10 @@ export async function __call(
   if (abortedArg !== undefined) {
     return abortedArg.droppedAtArgPosition();
   }
+  const interruptArg = findInterruptArg(descriptor);
+  if (interruptArg !== undefined) {
+    return interruptArg;
+  }
   if (AgencyFunction.isAgencyFunction(target)) {
     return target.invoke(descriptor);
   }
@@ -109,8 +140,13 @@ export async function __callMethod(
     return undefined;
   }
 
-  // Same argument rule as __call: an aborted result never enters a method
-  // call; the abort continues without its partial.
+  // Same argument rules as __call: an aborted result never enters a
+  // method call (the abort continues without its partial), and an
+  // Interrupt[] passes through as the call's own result.
+  const interruptArg = findInterruptArg(descriptor);
+  if (interruptArg !== undefined) {
+    return interruptArg;
+  }
   const abortedArg = findAbortedArg(descriptor);
   if (abortedArg !== undefined) {
     return abortedArg.droppedAtArgPosition();

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -488,29 +488,27 @@ describe("suspension", () => {
     branchA.pushGuard(g);
     branchB.pushGuard(g.cloneForBranch(branchA, branchB)!);
 
-    const token = branchA.beginHandlerSuspension({ fn: async () => undefined, liveGuardIds: [] });
+    const token = branchA.beginSuspension([]);
     // Branch A (the handler's lineage): hidden — charges dropped, gate open.
     branchA.chargeGuards(1.0);
     expect(() => branchA.enforceGuards()).not.toThrow();
     // Branch B: same object, unsuspended stack — charges land, gate trips.
     branchB.chargeGuards(1.0);
     expect(() => branchB.enforceGuards()).toThrow();
-    branchA.endHandlerSuspension(token);
+    branchA.endSuspension(token);
   });
 
   it("nested suspensions compose: the inner end must not unsuspend what the outer began", () => {
     const g = new TimeGuard(60000);
     const stack = new StateStack();
     stack.pushGuard(g);
-    const entry = { fn: async () => undefined, liveGuardIds: [] };
-
-    const outer = stack.beginHandlerSuspension(entry);
-    const inner = stack.beginHandlerSuspension(entry);
-    stack.endHandlerSuspension(inner);
+    const outer = stack.beginSuspension([]);
+    const inner = stack.beginSuspension([]);
+    stack.endSuspension(inner);
     // Still suspended: the outer bracket is open.
     g.resume(stack);
     expect((g as any).state).toBe("paused");
-    stack.endHandlerSuspension(outer);
+    stack.endSuspension(outer);
     g.resume(stack);
     expect((g as any).state).toBe("running");
     stack.popGuard();
@@ -541,9 +539,9 @@ describe("detectTrippedGuard — the one suspension-aware walk", () => {
     stack.chargeGuards(1.0);                       // over budget
     expect(stack.detectTrippedGuard()).not.toBeNull();
 
-    const token = stack.beginHandlerSuspension({ fn: async () => undefined, liveGuardIds: [] });
+    const token = stack.beginSuspension([]);
     expect(stack.detectTrippedGuard()).toBeNull(); // invisible while suspended
-    stack.endHandlerSuspension(token);
+    stack.endSuspension(token);
     expect(stack.detectTrippedGuard()).not.toBeNull();
   });
 });

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -120,6 +120,14 @@ export type Guard = {
    *  dimension in this state would re-trip forever and is a runtime
    *  error attributed to the answering handler. */
   overBudgetAndArmed(): boolean;
+  /** An open trip question for this guard, while one is being decided.
+   *  LIVE-ONLY (never serialized) and meaningful only for guards shared
+   *  across branches (cost): a sibling branch detecting the same guard
+   *  over budget parks on `settled` instead of asking its own question.
+   *  Time clones are per-branch objects, so for them this is always
+   *  undefined — cost-only dedupe, by construction, on purpose. Set
+   *  and cleared exclusively by guardTripInterrupt.ts. */
+  pendingTrip?: { settled: Promise<void>; settle: () => void };
   /** The current limit and spend in this guard's own unit (dollars /
    *  ms). On the interface for the trip interrupt's snapshot and the
    *  derived trip key — both must read them without variant branching. */
@@ -814,7 +822,9 @@ export class GuardExceededError extends AgencyAbort {
     // a GuardExceededError built WITHOUT one carries guardId === "" and, once
     // __tryCall filters on ownedGuardIds, would fail the membership check and
     // escape its own guard. CostGuard.check / TimeGuard.check pass their id.
-    guardId: string = "",
+    // Public: the trip-raise loop (guardTripInterrupt.ts) resolves the
+    // tripped guard object from it.
+    public readonly guardId: string = "",
     label?: string,
   ) {
     super(

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -17,6 +17,26 @@ export function nextGuardId(): string {
   return `g${__guardIdCounter}`;
 }
 
+/** Clamp a budget grant at zero, warning on negatives. A handler that
+ *  computes `approve({maxCost: budget - spent})` and goes negative must
+ *  not silently REMOVE metering (negative-as-disable is a construction-
+ *  time convention only; in the additive approve channel it would be
+ *  fail-open on a cost-control feature). Disarming is explicit:
+ *  `approve({disarm: ["cost"]})`. */
+function clampGrant(
+  delta: number,
+  g: { dimension: "cost" | "time"; label?: string },
+): number {
+  if (delta >= 0) return delta;
+  console.warn(
+    `guard grant clamped to 0: a negative ${g.dimension} grant` +
+      `${g.label ? ` for guard "${g.label}"` : ""} (${delta}) does not ` +
+      `disarm the guard — use approve({disarm: ["${g.dimension}"]}) to ` +
+      `stop metering explicitly.`,
+  );
+  return 0;
+}
+
 /**
  * Per-guard scope state for cost / time limits. Held on
  * `StateStack.guards` as an array; `pushGuard` appends + calls
@@ -62,6 +82,51 @@ export type Guard = {
    *  it is on the interface because handler scoping and ownedGuardIds
    *  matching are identity-based (indices do not survive resume/fork). */
   guardId: string;
+  /** Which budget dimension this guard meters. On the interface so call
+   *  sites never need instanceof or a JSON round-trip (the interface
+   *  contract above forbids variant branching at call sites). Mirrors
+   *  GuardJSON's `kind` discriminator. */
+  readonly dimension: "cost" | "time";
+  /** The guardIds of every member of this guard's SCOPE — the pair (or
+   *  singleton) one Agency-level `guard(...)` call pushed. `guard(cost:,
+   *  time:)` is TWO runtime guards; the scope array is how either member
+   *  finds its sibling. Stamped by `_pushGuard`; serialized (a trip's
+   *  interrupt data carries it across checkpoints); hand-copied in
+   *  TimeGuard.cloneForBranch (serialization and cloning are different
+   *  paths). Empty for guards pushed outside `_pushGuard` (root budgets,
+   *  `agency.withCostGuard`) — GuardScope.resolve treats an empty array
+   *  as a single-member scope. */
+  scopeIds: string[];
+  /** True for the operator's --max-cost/--max-time guards. Root budgets
+   *  never raise interrupts (they keep throwing at detection sites) and
+   *  a GuardScope containing one refuses extension: user code cannot
+   *  approve its way past the operator. Serialized — if it dropped on
+   *  resume, root budgets would become approvable after a checkpoint. */
+  isRootBudget: boolean;
+  /** Grant additional budget: limit += max(0, delta). A NEGATIVE delta
+   *  clamps to zero with a runtime warning — a computed grant that goes
+   *  negative must never silently remove metering (that is what disarm
+   *  is for, and it is explicit). Re-arms the tripped latches so the
+   *  guard can trip again at the new limit; missing that reset is
+   *  fail-open (a guard that never trips again), the worse direction. */
+  extendBudget(delta: number): void;
+  /** Stop metering this dimension permanently. Serialized. A disarmed
+   *  guard's check() never trips and isTripped() reports false even if
+   *  it tripped before disarming. */
+  disarm(): void;
+  /** True while the guard is over budget AND still armed — the state a
+   *  useless approval leaves behind. GuardScope's livelock check reads
+   *  it after applying an answer: an answer that leaves the tripped
+   *  dimension in this state would re-trip forever and is a runtime
+   *  error attributed to the answering handler. */
+  overBudgetAndArmed(): boolean;
+  /** The current limit and spend in this guard's own unit (dollars /
+   *  ms). On the interface for the trip interrupt's snapshot and the
+   *  derived trip key — both must read them without variant branching. */
+  currentLimit(): number;
+  spentAmount(): number;
+  /** User-facing name from guard(label:). */
+  readonly label?: string;
   install(stack: StateStack): void;
   uninstall(stack: StateStack): void;
   pause(): void;
@@ -117,6 +182,17 @@ export type Guard = {
 type GuardJSONBase = {
   guardId?: string;
   label?: string;
+  /** See Guard.scopeIds. */
+  scopeIds?: string[];
+  /** See Guard.disarm — MUST serialize (a disarmed dimension staying
+   *  disarmed across resume is the user's explicit decision). Contrast
+   *  with suspension, which must NEVER serialize; the two fail in
+   *  opposite directions. */
+  disarmed?: boolean;
+  /** See Guard.isRootBudget — MUST serialize (a root budget that became
+   *  approvable after a checkpoint would be a hole in the operator's
+   *  ceiling). */
+  isRootBudget?: boolean;
 };
 
 export type GuardJSON =
@@ -166,6 +242,8 @@ export type GuardJSON =
  * durable through serialization via `spent` in `toJSON`.
  */
 export class CostGuard implements Guard {
+  readonly dimension = "cost" as const;
+
   /** Cumulative cost charged since install. Serialized; survives
    *  interrupt/resume cycles. */
   private spent: number = 0;
@@ -176,11 +254,18 @@ export class CostGuard implements Guard {
    *  survive interrupt/resume — see GuardJSON). */
   guardId: string = nextGuardId();
 
+  /** See the Guard interface. All three serialized. `disarmed` is
+   *  public for GuardScope's livelock check; mutate only via disarm(). */
+  scopeIds: string[] = [];
+  isRootBudget: boolean = false;
+  disarmed: boolean = false;
+
   /** `label` is the user-facing name from `guard(label: "...")`. It rides
    *  the trip cause and the guard failure so users can tell WHICH guard
-   *  tripped; guardId stays the internal identity for ownedGuardIds. */
+   *  tripped; guardId stays the internal identity for ownedGuardIds.
+   *  `costLimit` is mutable ONLY through extendBudget. */
   constructor(
-    public readonly costLimit: number,
+    public costLimit: number,
     public readonly label?: string,
   ) {}
 
@@ -205,6 +290,7 @@ export class CostGuard implements Guard {
   }
 
   check(_stack: StateStack): GuardExceededError | null {
+    if (this.disarmed) return null;
     if (this.spent <= this.costLimit) return null;
     return new GuardExceededError(
       "cost",
@@ -213,6 +299,32 @@ export class CostGuard implements Guard {
       this.guardId,
       this.label,
     );
+  }
+
+  extendBudget(delta: number): void {
+    this.costLimit += clampGrant(delta, this);
+    // No latch to reset: cost trips re-derive from spent > costLimit on
+    // every check, so raising the limit is the whole re-arm.
+  }
+
+  disarm(): void {
+    this.disarmed = true;
+  }
+
+  /** True while the guard is over budget AND still armed — the state a
+   *  useless approval leaves behind (resumable-guards decision 8: an
+   *  answer that leaves this true would re-trip forever and is a
+   *  runtime error attributed to the answering handler). */
+  overBudgetAndArmed(): boolean {
+    return !this.disarmed && this.spent > this.costLimit;
+  }
+
+  currentLimit(): number {
+    return this.costLimit;
+  }
+
+  spentAmount(): number {
+    return this.spent;
   }
 
   /** Deliberately no-ops. A CostGuard can be SHARED across fork branches
@@ -264,10 +376,11 @@ export class CostGuard implements Guard {
     if (this.label !== undefined) {
       json.label = this.label;
     }
+    writeSharedGuardJSON(json, this);
     return json;
   }
 
-  static fromJSON(j: { costLimit: number; spent: number; guardId?: string; label?: string }): CostGuard {
+  static fromJSON(j: { costLimit: number; spent: number; guardId?: string; label?: string } & SharedGuardJSONFields): CostGuard {
     // Clean break with the prior `{costAtPush}` JSON shape: refuse to
     // restore a guard whose `spent` is missing rather than silently
     // initializing it to NaN/undefined and producing nonsense trips.
@@ -287,8 +400,37 @@ export class CostGuard implements Guard {
     // (Absent only in pre-Increment-2 checkpoints; keep the freshly-minted
     // id in that case.)
     if (j.guardId !== undefined) g.guardId = j.guardId;
+    readSharedGuardJSON(j, g);
     return g;
   }
+}
+
+/** The GuardJSONBase fields both variants serialize identically. One
+ *  writer/reader pair so a field added to one variant cannot silently
+ *  miss the other (scopeIds nearly did, in review). `suspended`-style
+ *  transient state deliberately has no place here. */
+type SharedGuardJSONFields = {
+  scopeIds?: string[];
+  disarmed?: boolean;
+  isRootBudget?: boolean;
+};
+
+function writeSharedGuardJSON(
+  json: GuardJSON,
+  g: { scopeIds: string[]; disarmed: boolean; isRootBudget: boolean },
+): void {
+  if (g.scopeIds.length > 0) json.scopeIds = g.scopeIds;
+  if (g.disarmed) json.disarmed = true;
+  if (g.isRootBudget) json.isRootBudget = true;
+}
+
+function readSharedGuardJSON(
+  j: SharedGuardJSONFields,
+  g: Guard,
+): void {
+  if (j.scopeIds !== undefined) g.scopeIds = j.scopeIds;
+  if (j.disarmed) g.disarm();
+  if (j.isRootBudget) g.isRootBudget = true;
 }
 
 /**
@@ -363,8 +505,17 @@ export class TimeGuard implements Guard {
   guardId: string = nextGuardId();
 
   /** See CostGuard's label docstring — same contract. */
+  readonly dimension = "time" as const;
+
+  /** See the Guard interface. All three serialized. `disarmed` is
+   *  public for GuardScope's livelock check; mutate only via disarm(). */
+  scopeIds: string[] = [];
+  isRootBudget: boolean = false;
+  disarmed: boolean = false;
+
+  /** `timeLimit` is mutable ONLY through extendBudget. */
   constructor(
-    public readonly timeLimit: number,
+    public timeLimit: number,
     public readonly label?: string,
   ) {}
 
@@ -432,7 +583,7 @@ export class TimeGuard implements Guard {
   }
 
   check(_stack: StateStack): GuardExceededError | null {
-    if (this.suspended) return null;
+    if (this.suspended || this.disarmed) return null;
     if (!this.tripped || this.consumed) return null;
     // currentElapsed() charges any in-flight window delta so `spent`
     // reflects the true elapsed time at the moment of the trip. Without
@@ -450,7 +601,49 @@ export class TimeGuard implements Guard {
   }
 
   isTripped(): boolean {
-    return this.tripped;
+    return !this.disarmed && this.tripped;
+  }
+
+  extendBudget(deltaMs: number): void {
+    this.timeLimit += clampGrant(deltaMs, this);
+    // Reset BOTH latches — they are two fields with different jobs, and
+    // missing either is wrong in a different direction. `tripped` is set
+    // by the abort listener; leaving it set would re-trip at the next
+    // check despite the new budget. `consumed` marks "check() already
+    // returned this trip once"; leaving it set produces a guard that
+    // NEVER trips again — fail-open, the worse direction.
+    this.tripped = false;
+    this.consumed = false;
+    // If the clock is running, the armed timer still fires at the OLD
+    // deadline; re-arm it against the new limit. (Paused/suspended
+    // guards re-arm at their next resume, which reads timeLimit fresh.)
+    if (this.state === "running") {
+      this.cancelTimer();
+      this.state = "paused";
+      this.elapsedMs += performance.now() - this.windowStart!;
+      this.windowStart = undefined;
+      this.startWindow();
+    }
+  }
+
+  disarm(): void {
+    this.disarmed = true;
+    // A disarmed dimension never trips: kill the armed timer so a
+    // late fire cannot abort the branch.
+    this.cancelTimer();
+  }
+
+  /** See CostGuard.overBudgetAndArmed — same contract, time dimension. */
+  overBudgetAndArmed(): boolean {
+    return !this.disarmed && this.currentElapsed() >= this.timeLimit;
+  }
+
+  currentLimit(): number {
+    return this.timeLimit;
+  }
+
+  spentAmount(): number {
+    return this.currentElapsed();
   }
 
   /** Accrued working time plus any in-flight running window, in ms. */
@@ -492,6 +685,13 @@ export class TimeGuard implements Guard {
     const remaining = Math.max(1, this.timeLimit - this.currentElapsed());
     const clone = new TimeGuard(remaining, this.label);
     clone.guardId = this.guardId;
+    // Hand-copied: cloning and serialization are DIFFERENT paths, and a
+    // field added to toJSON alone silently misses branches (rev-3 plan
+    // review). scopeIds is how a branch trip finds its scope siblings;
+    // root/disarmed state must follow the budget into the branch.
+    clone.scopeIds = this.scopeIds;
+    clone.isRootBudget = this.isRootBudget;
+    clone.disarmed = this.disarmed;
     return clone;
   }
 
@@ -507,14 +707,16 @@ export class TimeGuard implements Guard {
     if (this.label !== undefined) {
       json.label = this.label;
     }
+    writeSharedGuardJSON(json, this);
     return json;
   }
 
-  static fromJSON(j: { timeLimit: number; elapsedMs: number; guardId?: string; label?: string }): TimeGuard {
+  static fromJSON(j: { timeLimit: number; elapsedMs: number; guardId?: string; label?: string } & SharedGuardJSONFields): TimeGuard {
     const g = new TimeGuard(j.timeLimit, j.label);
     g.elapsedMs = j.elapsedMs;
     // Restore the serialized id so ownedGuardIds matching survives resume.
     if (j.guardId !== undefined) g.guardId = j.guardId;
+    readSharedGuardJSON(j, g);
     // state stays "paused"; resume() at first runner step re-arms.
     return g;
   }

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -636,8 +636,9 @@ export class TimeGuard implements Guard {
 
   disarm(): void {
     this.disarmed = true;
-    // A disarmed dimension never trips: kill the armed timer so a
-    // late fire cannot abort the branch.
+    // A disarmed dimension never trips: kill the armed timer so a late
+    // fire cannot abort the branch (startWindow also refuses to arm a
+    // new one while disarmed).
     this.cancelTimer();
   }
 
@@ -741,6 +742,12 @@ export class TimeGuard implements Guard {
   }
 
   private startWindow(): void {
+    // A disarmed guard must never arm its abort timer: check() already
+    // reports nothing, but a live timer would still fire the branch's
+    // abort signal and cancel work the user explicitly un-metered. This
+    // gate covers every arming path at once — install, resume, and a
+    // cloneForBranch'd disarmed guard being installed on its branch.
+    if (this.disarmed) return;
     const remaining = this.timeLimit - this.elapsedMs;
     const delay = remaining > 0 ? remaining : 0;
     this.timerHandle = setTimeout(() => {

--- a/packages/agency-lang/lib/runtime/guardScope.test.ts
+++ b/packages/agency-lang/lib/runtime/guardScope.test.ts
@@ -191,3 +191,25 @@ describe("TimeGuard.extendBudget", () => {
     vi.useRealTimers();
   });
 });
+
+describe("disarmed TimeGuard clones (PR 2 review round 1)", () => {
+  it("a disarmed clone never arms its abort timer on the branch", () => {
+    vi.useFakeTimers();
+    const parent = new StateStack();
+    const g = new TimeGuard(500);
+    g.install(parent);
+    g.disarm();
+    const branch = new StateStack();
+    const clone = g.cloneForBranch(parent, branch)!;
+    // The branch installs its clone exactly as runBatch's rehydrate
+    // path would; a disarmed clone must not arm a timer that would
+    // fire the branch's abort signal despite the explicit disarm.
+    clone.install(branch);
+    vi.advanceTimersByTime(5000);
+    expect(branch.abortSignal?.aborted ?? false).toBe(false);
+    expect(clone.isTripped()).toBe(false);
+    clone.uninstall(branch);
+    g.uninstall(parent);
+    vi.useRealTimers();
+  });
+});

--- a/packages/agency-lang/lib/runtime/guardScope.test.ts
+++ b/packages/agency-lang/lib/runtime/guardScope.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { CostGuard, TimeGuard } from "./guard.js";
+import { GuardScope, GuardApproveError } from "./guardScope.js";
+import { StateStack } from "./state/stateStack.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+/** A cost+time scope pushed the way _pushGuard does it. */
+function pushScope(stack: StateStack, costLimit: number, timeLimitMs: number) {
+  const cost = new CostGuard(costLimit);
+  const time = new TimeGuard(timeLimitMs);
+  stack.pushGuard(cost);
+  stack.pushGuard(time);
+  const ids = [cost.guardId, time.guardId];
+  cost.scopeIds = ids;
+  time.scopeIds = ids;
+  return { cost, time, ids };
+}
+
+describe("GuardScope.resolve", () => {
+  it("resolves both members from either tripped member, innermost-first", () => {
+    const stack = new StateStack();
+    const { cost, time } = pushScope(stack, 1, 60000);
+    const scope = GuardScope.resolve(stack, cost)!;
+    expect(scope.memberFor("cost")).toBe(cost);
+    expect(scope.memberFor("time")).toBe(time);
+  });
+
+  it("treats an empty scopeIds as a single-member scope (root budgets)", () => {
+    const stack = new StateStack();
+    const g = new CostGuard(1);
+    stack.pushGuard(g);
+    const scope = GuardScope.resolve(stack, g)!;
+    expect(scope.memberIds()).toEqual([g.guardId]);
+  });
+
+  it("returns null when no member is on the stack", () => {
+    const stack = new StateStack();
+    const foreign = new CostGuard(1);
+    expect(GuardScope.resolve(stack, foreign)).toBeNull();
+  });
+});
+
+describe("GuardScope.extend", () => {
+  it("grants additively per named dimension and re-trips at the new limit (spend-shaped)", () => {
+    const stack = new StateStack();
+    const { cost } = pushScope(stack, 0.5, 60000);
+    stack.chargeGuards(0.6);                      // over
+    expect(stack.detectTrippedGuard()).not.toBeNull();
+    GuardScope.resolve(stack, cost)!.extend({ maxCost: 0.5 }, "cost");
+    expect(stack.detectTrippedGuard()).toBeNull(); // 0.6 ≤ 1.0
+    stack.chargeGuards(0.3);
+    expect(stack.detectTrippedGuard()).toBeNull(); // 0.9 fits the grant
+    stack.chargeGuards(0.2);
+    expect(stack.detectTrippedGuard()).not.toBeNull(); // 1.1 > 1.0: still meters
+  });
+
+  it("extends BOTH members when the payload names both dimensions", () => {
+    const stack = new StateStack();
+    const { cost, time } = pushScope(stack, 0.5, 60000);
+    GuardScope.resolve(stack, cost)!.extend(
+      { maxCost: 0.5, maxTime: 30000 },
+      "cost",
+    );
+    expect(cost.currentLimit()).toBe(1.0);
+    expect(time.currentLimit()).toBe(90000);
+  });
+
+  it("clamps a negative grant to zero with a warning, and the answer is then a livelock error", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stack = new StateStack();
+    const { cost } = pushScope(stack, 0.5, 60000);
+    stack.chargeGuards(0.6);
+    expect(() =>
+      GuardScope.resolve(stack, cost)!.extend({ maxCost: -2 }, "cost"),
+    ).toThrow(GuardApproveError);
+    expect(warn).toHaveBeenCalled();
+    expect(cost.currentLimit()).toBe(0.5); // metering intact — the point
+  });
+
+  it("disarm stops metering explicitly; the guard never trips again", () => {
+    const stack = new StateStack();
+    const { cost } = pushScope(stack, 0.5, 60000);
+    stack.chargeGuards(0.6);
+    GuardScope.resolve(stack, cost)!.extend({ disarm: ["cost"] }, "cost");
+    expect(stack.detectTrippedGuard()).toBeNull();
+    stack.chargeGuards(100);
+    expect(stack.detectTrippedGuard()).toBeNull();
+  });
+
+  it("a useless approval (tripped dimension still over and armed) is an error", () => {
+    const stack = new StateStack();
+    const { cost } = pushScope(stack, 0.5, 60000);
+    stack.chargeGuards(0.6);
+    expect(() =>
+      GuardScope.resolve(stack, cost)!.extend({}, "cost"),
+    ).toThrow(/still exceeded/);
+    expect(() =>
+      GuardScope.resolve(stack, cost)!.extend({ maxTime: 5000 }, "cost"),
+    ).toThrow(/still exceeded/);
+  });
+
+  it("a payload naming a dimension the scope lacks is an error", () => {
+    const stack = new StateStack();
+    const g = new CostGuard(0.5);
+    stack.pushGuard(g);
+    expect(() =>
+      GuardScope.resolve(stack, g)!.extend({ maxTime: 5000 }, "cost"),
+    ).toThrow(/no time limit/);
+  });
+
+  it("a scope containing a root budget refuses extension", () => {
+    const stack = new StateStack();
+    const g = new CostGuard(0.5);
+    g.isRootBudget = true;
+    stack.pushGuard(g);
+    expect(() =>
+      GuardScope.resolve(stack, g)!.extend({ maxCost: 5 }, "cost"),
+    ).toThrow(/root budget/);
+  });
+});
+
+describe("serialization and cloning of the new guard fields", () => {
+  it("scopeIds, disarmed, and isRootBudget round-trip through JSON on both variants", async () => {
+    const { guardFromJSON } = await import("./guard.js");
+    const cost = new CostGuard(1);
+    cost.scopeIds = ["a", "b"];
+    cost.isRootBudget = true;
+    cost.disarm();
+    const restoredCost = guardFromJSON(cost.toJSON());
+    expect(restoredCost.scopeIds).toEqual(["a", "b"]);
+    expect(restoredCost.isRootBudget).toBe(true);
+    expect((restoredCost as CostGuard).disarmed).toBe(true);
+
+    const time = new TimeGuard(60000);
+    time.scopeIds = ["a", "b"];
+    const restoredTime = guardFromJSON(time.toJSON());
+    expect(restoredTime.scopeIds).toEqual(["a", "b"]);
+  });
+
+  it("TimeGuard.cloneForBranch hand-copies scopeIds/isRootBudget/disarmed", () => {
+    const parent = new StateStack();
+    const g = new TimeGuard(60000);
+    g.scopeIds = ["a", "b"];
+    g.isRootBudget = true;
+    g.install(parent);
+    const clone = g.cloneForBranch(parent, new StateStack())!;
+    expect(clone.scopeIds).toEqual(["a", "b"]);
+    expect(clone.isRootBudget).toBe(true);
+    g.uninstall(parent);
+  });
+});
+
+describe("TimeGuard.extendBudget", () => {
+  // PR 2 contract: extendBudget serves an UNTRIPPED time member (approve
+  // names maxTime while the COST member tripped — time trips still throw
+  // in PR 2 and never reach extend). Re-arming a guard whose controller
+  // has already fired needs the derived-signal work and is PR 3's
+  // re-arm, by plan.
+  it("re-arms the running timer against the new limit (the old deadline must not fire)", () => {
+    vi.useFakeTimers();
+    const stack = new StateStack();
+    const g = new TimeGuard(500);
+    g.install(stack);
+    vi.advanceTimersByTime(300);           // 300 of 500 elapsed (timer time)
+    g.extendBudget(1000);                  // limit now 1500, timer re-armed
+    vi.advanceTimersByTime(300);           // past the OLD 500 deadline
+    expect(g.isTripped()).toBe(false);     // old timer was cancelled — the point
+    expect(g.check(stack)).toBeNull();
+    vi.advanceTimersByTime(1500);          // past the NEW deadline
+    expect(g.isTripped()).toBe(true);      // still meters at the new limit
+    expect(g.check(stack)).not.toBeNull();
+    g.uninstall(stack);
+    vi.useRealTimers();
+  });
+
+  it("resets both trip latches so the extended guard is armed, not consumed", () => {
+    vi.useFakeTimers();
+    const stack = new StateStack();
+    const g = new TimeGuard(500);
+    g.install(stack);
+    vi.advanceTimersByTime(500);           // trips
+    expect(g.check(stack)).not.toBeNull(); // consumes
+    expect(g.check(stack)).toBeNull();     // consumed latch holds
+    g.extendBudget(1000);
+    // Both latches reset: the guard reports armed-and-under-budget
+    // state (full re-trip of an already-aborted controller is PR 3).
+    expect(g.isTripped()).toBe(false);
+    expect(g.overBudgetAndArmed()).toBe(false);
+    g.uninstall(stack);
+    vi.useRealTimers();
+  });
+});

--- a/packages/agency-lang/lib/runtime/guardScope.ts
+++ b/packages/agency-lang/lib/runtime/guardScope.ts
@@ -1,0 +1,168 @@
+import type { Guard } from "./guard.js";
+import type { StateStack } from "./state/stateStack.js";
+
+/**
+ * The Agency-level guard: the set of runtime guards one `guard(...)` call
+ * pushed. `guard(cost: $1, time: 5m)` pushes a CostGuard AND a TimeGuard —
+ * two objects, two guardIds — and everything user-facing (the trip
+ * interrupt, the approve payload naming both dimensions, disarm lists,
+ * the root-budget refusal) is about the PAIR. This class is the pair's
+ * name. It is never stored: construct it on demand from a stack plus the
+ * member ids, which ARE stored (`Guard.scopeIds`).
+ *
+ * Resolution is ALWAYS against a specific branch's stack, never a global
+ * registry: fork time-clones carry the parent's guardId, so only the
+ * raising branch's own stack knows which physical object answers to an
+ * id there. That one rule is what makes approve routing correct across
+ * fork, race, and the subprocess boundary (the answer is applied at the
+ * raise site, in the process and branch that own the guard).
+ */
+export class GuardScope {
+  private constructor(private readonly members: Guard[]) {}
+
+  /** The scope a tripped guard belongs to, resolved on `stack`. Members
+   *  are matched innermost-first by id. A guard with an empty scopeIds
+   *  (root budgets, agency.withCostGuard) is its own single-member
+   *  scope. Returns null when no member is present on this stack —
+   *  callers treat that as a stale or foreign answer, a runtime error,
+   *  never a silent no-op. */
+  static resolve(stack: StateStack, tripped: Guard): GuardScope | null {
+    const ids = tripped.scopeIds.length > 0 ? tripped.scopeIds : [tripped.guardId];
+    const members: Guard[] = [];
+    for (let i = stack.guards.length - 1; i >= 0; i--) {
+      const g = stack.guards[i];
+      if (ids.includes(g.guardId) && !members.includes(g)) {
+        members.push(g);
+      }
+    }
+    return members.length > 0 ? new GuardScope(members) : null;
+  }
+
+  memberFor(dimension: "cost" | "time"): Guard | null {
+    return this.members.find((g) => g.dimension === dimension) ?? null;
+  }
+
+  /** User code cannot approve its way past the operator: a scope with a
+   *  root member refuses extension wholesale. */
+  containsRootBudget(): boolean {
+    return this.members.some((g) => g.isRootBudget);
+  }
+
+  memberIds(): string[] {
+    return this.members.map((g) => g.guardId);
+  }
+
+  /** Apply a merged approve payload. Grants are ADDITIVE per named
+   *  dimension (negative deltas clamp to zero with a warning — see
+   *  clampGrant); an omitted dimension continues unchanged with its
+   *  remaining allowance; `disarm` names dimensions to stop metering.
+   *  Throws GuardApproveError on: a root scope, a payload naming a
+   *  dimension this scope does not have, or an answer that leaves the
+   *  TRIPPED dimension still over budget and armed — that answer would
+   *  re-trip forever (the handler-chain recursion guard cannot catch the
+   *  loop; its depth resets on every fresh trip). */
+  extend(
+    payload: {
+      maxCost?: number;
+      maxTime?: number;
+      disarm?: ("cost" | "time")[];
+      message?: string;
+    },
+    tripped: "cost" | "time",
+  ): void {
+    if (this.containsRootBudget()) {
+      throw new GuardApproveError(
+        "this guard is an operator root budget (--max-cost/--max-time); it cannot be extended from code",
+      );
+    }
+    // Read keys defensively (`!== undefined`, never presence): a lone
+    // approval arrives with only its own keys, a merged one with all
+    // four — see effectMerge.ts.
+    const grants: Array<["cost" | "time", number | undefined]> = [
+      ["cost", payload.maxCost],
+      ["time", payload.maxTime],
+    ];
+    for (const [dimension, delta] of grants) {
+      if (delta === undefined) continue;
+      const member = this.memberFor(dimension);
+      if (!member) {
+        throw new GuardApproveError(
+          `the approval grants ${dimension} budget, but this guard has no ${dimension} limit`,
+        );
+      }
+      member.extendBudget(delta);
+    }
+    for (const dimension of payload.disarm ?? []) {
+      const member = this.memberFor(dimension);
+      if (!member) {
+        throw new GuardApproveError(
+          `the approval disarms ${dimension}, but this guard has no ${dimension} limit`,
+        );
+      }
+      member.disarm();
+    }
+    const trippedMember = this.memberFor(tripped);
+    if (trippedMember && trippedMember.overBudgetAndArmed()) {
+      throw new GuardApproveError(
+        `the approval leaves the tripped ${tripped} budget still exceeded ` +
+          `and armed — the guard would trip again immediately. Grant ` +
+          `budget on the tripped dimension (approve({max` +
+          `${tripped === "cost" ? "Cost" : "Time"}: ...})) or disarm it ` +
+          `explicitly (approve({disarm: ["${tripped}"]})).`,
+      );
+    }
+  }
+
+  /** The interrupt-data fields describing this scope at raise time. */
+  snapshot(tripped: "cost" | "time"): {
+    label: string | null;
+    scopeIds: string[];
+    dimension: "cost" | "time";
+    limit: number;
+    spent: number;
+    maxCost: number | null;
+    maxTime: number | null;
+  } {
+    const cost = this.memberFor("cost");
+    const time = this.memberFor("time");
+    const trippedMember = this.memberFor(tripped)!;
+    return {
+      label: trippedMember.label ?? null,
+      scopeIds: this.memberIds(),
+      dimension: tripped,
+      limit: trippedMember.currentLimit(),
+      spent: trippedMember.spentAmount(),
+      maxCost: cost ? cost.currentLimit() : null,
+      maxTime: time ? time.currentLimit() : null,
+    };
+  }
+
+  /** Freeze the scope while its trip is being decided: the members and
+   *  every guard installed AFTER the innermost member stop gating,
+   *  charging, and ticking ON THIS BRANCH. Uses the stack's suspension
+   *  bracket (branch-scoped) — NOT object flags — for the same reason
+   *  handler suspension does: a shared CostGuard flagged object-wide
+   *  would blind sibling branches (see PR 1's deviation note in the
+   *  resumable-guards plan). Returns the token endSuspension needs. */
+  suspendForDecision(stack: StateStack): string[] {
+    const memberIds = this.memberIds();
+    const firstMemberIndex = stack.guards.findIndex((g) =>
+      memberIds.includes(g.guardId),
+    );
+    const visible = stack.guards
+      .slice(0, firstMemberIndex === -1 ? stack.guards.length : firstMemberIndex)
+      .map((g) => g.guardId);
+    return stack.beginSuspension(visible);
+  }
+}
+
+/** A defective answer to a guard trip — attributed to the answering
+ *  handler by the chain machinery. Plain Error: this is the exception
+ *  domain (a bug in supervisory code), not an abort or a failure. */
+export class GuardApproveError extends Error {
+  constructor(message: string) {
+    super(`guard approval error: ${message}`);
+    this.name = "GuardApproveError";
+  }
+}
+

--- a/packages/agency-lang/lib/runtime/guardScope.ts
+++ b/packages/agency-lang/lib/runtime/guardScope.ts
@@ -29,12 +29,11 @@ export class GuardScope {
   static resolve(stack: StateStack, tripped: Guard): GuardScope | null {
     const ids = tripped.scopeIds.length > 0 ? tripped.scopeIds : [tripped.guardId];
     const members: Guard[] = [];
-    for (let i = stack.guards.length - 1; i >= 0; i--) {
-      const g = stack.guards[i];
+    [...stack.guards].reverse().forEach((g) => {
       if (ids.includes(g.guardId) && !members.includes(g)) {
         members.push(g);
       }
-    }
+    });
     return members.length > 0 ? new GuardScope(members) : null;
   }
 

--- a/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
@@ -1,0 +1,228 @@
+import type { Guard, GuardExceededError } from "./guard.js";
+import { GuardScope } from "./guardScope.js";
+import type { StateStack } from "./state/stateStack.js";
+import type { RuntimeContext } from "./state/context.js";
+import {
+  interruptWithHandlers,
+  isApproved,
+  isRejected,
+  type Interrupt,
+  type InterruptResponse,
+} from "./interrupts.js";
+
+/**
+ * Cost-guard trips as interrupts (resumable-guards PR 2).
+ *
+ * The raising site is a dedicated idempotent gate step in `runPrompt`
+ * (`pr.step("…guardGate…", () => raiseGuardTripsUntilClear(...))`),
+ * placed immediately before each LLM request step. The gate LOOPS until
+ * the stack is clear: one answered question does not mean the gate is
+ * clear — approving the inner guard's trip can leave (or push) an OUTER
+ * guard over its own limit, and each budget is owed its own question.
+ * Because the gate runs before the request step and nothing paid happens
+ * between them, not a cent can leak while a question is out.
+ *
+ * The gate body is idempotent by construction, which is what lets it
+ * live in a PromptRunner step: on resume it re-detects, finds the
+ * persisted interrupt id for the still-open trip in `stack.other`, and
+ * applies the recorded answer instead of re-asking.
+ *
+ * Contract per trip: RESOLVING (approve applied, or someone else's
+ * answer landed while we were parked) continues the loop — the caller
+ * must never treat one resolution as clearance. REJECTING throws the
+ * original GuardExceededError from the gate, and everything downstream —
+ * AbortedResult, the level rule, finalize, the guard boundary's
+ * conversion to success(draft)/failure — runs exactly as it always has.
+ * UNANSWERED returns the Interrupt[] so PromptRunner.step's bailout
+ * machinery (message snapshot, checkpoint, PromptBailout) surfaces it.
+ */
+export async function raiseGuardTripsUntilClear(
+  ctx: RuntimeContext<any>,
+  stack: StateStack,
+): Promise<Interrupt[] | void> {
+  let err: GuardExceededError | null;
+  while ((err = stack.detectTrippedGuard()) !== null) {
+    const tripped = innermostGuardById(stack, err.guardId);
+    if (!tripped || tripped.isRootBudget) {
+      // Root budgets never ask permission — the operator's ceiling keeps
+      // today's hard throw (spawn path exits 3). A trip whose guard is
+      // somehow gone from the stack also falls back to the throw.
+      throw err;
+    }
+
+    // Dedupe (cost guards are SHARED objects across fork branches): if
+    // another branch's question for this guard is already out, park on
+    // it, then RE-DETECT — the answer may have refilled the budget, or a
+    // different guard may be over now, or a third branch may have opened
+    // a new question in the gap. The loop handles all three. Time clones
+    // are per-branch objects, so for them this check never fires — that
+    // is the "by construction" in cost-only dedupe; do not "fix" it.
+    if (tripped.pendingTrip) {
+      await tripped.pendingTrip.settled;
+      continue;
+    }
+
+    const outcome = await raiseOneTrip(ctx, stack, tripped, err);
+    if (outcome !== undefined) return outcome; // unanswered: surface
+  }
+}
+
+/** Ask one guard's question. Returns undefined when the trip was
+ *  RESOLVED in-process (the gate loop re-detects), the Interrupt[] when
+ *  it must surface, and throws on reject (the original trip error) or a
+ *  defective answer (GuardApproveError). */
+async function raiseOneTrip(
+  ctx: RuntimeContext<any>,
+  stack: StateStack,
+  tripped: Guard,
+  err: GuardExceededError,
+): Promise<Interrupt[] | undefined> {
+  const scope = GuardScope.resolve(stack, tripped)!;
+  const key = guardTripKey(tripped);
+
+  // Resume path FIRST: an answered question must never re-ask. The key
+  // is derived from guard state (see guardTripKey), so a replay of THIS
+  // trip recomputes the same key, while the NEXT trip — possible only
+  // after an approve changed the limit or a disarm — gets a fresh one.
+  const persistedId = stack.other[key] as string | undefined;
+  if (persistedId !== undefined) {
+    const recorded = ctx.getInterruptResponse(persistedId);
+    if (recorded) {
+      delete stack.other[key];
+      applyVerdict(recorded, scope, tripped, err);
+      return undefined;
+    }
+  }
+
+  // Mark the question open BEFORE the first await (an async body runs
+  // synchronously to its first await, so set-before-await is real mutual
+  // exclusion against sibling branches). NOTHING between the set and the
+  // try: a throw in a gap would leak the record and park every future
+  // branch forever — the exact deadlock the finally exists to prevent.
+  tripped.pendingTrip = makePendingTrip();
+  try {
+    // Freeze the scope (and everything deeper) on THIS branch while the
+    // question is out: no gating, no charging, no clock. Branch-scoped
+    // via the stack bracket — sibling branches sharing the guard keep
+    // metering (see the PR 1 deviation note in the plan).
+    const suspensionToken = scope.suspendForDecision(stack);
+    try {
+      const snapshot = scope.snapshot(tripped.dimension);
+      const verdict = await interruptWithHandlers(
+        "std::guard",
+        buildTripMessage(snapshot),
+        { ...snapshot, draftValue: draftPreview(stack) },
+        "std::guard",
+        ctx,
+        stack,
+        {
+          // Decision 3's visibility half: a handler registered INSIDE
+          // this guard cannot adjudicate it.
+          eligible: (entry) =>
+            !entry.liveGuardIds.includes(tripped.guardId),
+        },
+      );
+      if (isApproved(verdict) || isRejected(verdict)) {
+        applyVerdict(verdict, scope, tripped, err);
+        return undefined;
+      }
+      // Unanswered: persist the id so the resumed gate finds the answer,
+      // then hand the batch to the PromptRunner step for its snapshot +
+      // checkpoint + bailout machinery.
+      const interrupts = verdict as Interrupt[];
+      stack.other[key] = interrupts[0].interruptId;
+      return interrupts;
+    } finally {
+      stack.endSuspension(suspensionToken);
+    }
+  } finally {
+    // Settle on EVERY exit — resolve, surface, reject-throw, defective-
+    // answer-throw. Three of the four leave by a throw or a bailout, and
+    // a parked sibling waiting on anything rarer would hang the fork
+    // join (`await Promise.allSettled`, runBatch). Clear the record
+    // BEFORE settling so woken branches see it empty.
+    const pending = tripped.pendingTrip;
+    tripped.pendingTrip = undefined;
+    pending?.settle();
+  }
+}
+
+function applyVerdict(
+  verdict: InterruptResponse,
+  scope: GuardScope,
+  tripped: Guard,
+  err: GuardExceededError,
+): void {
+  if (isApproved(verdict)) {
+    // GuardScope.extend enforces the whole answer contract: additive
+    // grants, negative clamps, disarm, root refusal, and the useless-
+    // approval error (leaves the tripped dimension over budget and
+    // armed → would re-trip forever).
+    scope.extend(
+      ((verdict as { value?: unknown }).value ?? {}) as Parameters<
+        GuardScope["extend"]
+      >[0],
+      tripped.dimension,
+    );
+    return;
+  }
+  // Rejected: the trip stands. Deliver the ORIGINAL error; from here the
+  // carry-on-abort pipeline runs unmodified.
+  throw err;
+}
+
+/** The trip interrupt's resume-idempotency key — DERIVED from guard
+ *  state, never counted (resumable-guards decision 14; replay skips
+ *  completed work, so counters count different events on replay). The
+ *  five cases: (1) an approve strictly raises the tripped limit past
+ *  `spent`, so limits strictly increase and the next trip's key differs;
+ *  (2) a clamped-to-zero grant errors (decision 8) before the key could
+ *  be reused; (3) disarm repeats the key, but a disarmed dimension never
+ *  trips again; (4) a reject aborts the scope — no next trip; (5) the
+ *  other dimension differs in the `#dimension` segment. */
+function guardTripKey(g: Guard): string {
+  const scopeIds = g.scopeIds.length > 0 ? g.scopeIds : [g.guardId];
+  return `__guardTrip_${scopeIds.join(",")}#${g.dimension}@${g.currentLimit()}`;
+}
+
+function buildTripMessage(s: {
+  label: string | null;
+  dimension: "cost" | "time";
+  limit: number;
+  spent: number;
+}): string {
+  const name = s.label ? `Guard "${s.label}"` : "A guard";
+  const unit =
+    s.dimension === "cost"
+      ? `$${s.spent.toFixed(6)} spent (limit $${s.limit})`
+      : `${Math.round(s.spent)}ms elapsed (limit ${s.limit}ms)`;
+  return `${name} exceeded its ${s.dimension} budget: ${unit}. Approve more budget, or reject to stop this work and salvage its draft.`;
+}
+
+/** Best-so-far preview for the handler: the innermost saved draft on the
+ *  branch. A PREVIEW only — the authoritative salvage is computed by the
+ *  unwind (level rule + finalize) if the trip is rejected; finalizes are
+ *  one-shot and must not run speculatively for a maybe-approved trip. */
+function draftPreview(stack: StateStack): unknown {
+  for (let i = stack.stack.length - 1; i >= 0; i--) {
+    const draft = stack.stack[i]?.savedDraft;
+    if (draft !== undefined) return draft.value;
+  }
+  return null;
+}
+
+function innermostGuardById(stack: StateStack, guardId: string | undefined): Guard | null {
+  if (!guardId) return null;
+  for (let i = stack.guards.length - 1; i >= 0; i--) {
+    if (stack.guards[i].guardId === guardId) return stack.guards[i];
+  }
+  return null;
+}
+
+function makePendingTrip(): { settled: Promise<void>; settle: () => void } {
+  let settle!: () => void;
+  const settled = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+  return { settled, settle };
+}

--- a/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
@@ -3,12 +3,14 @@ import { GuardScope } from "./guardScope.js";
 import type { StateStack } from "./state/stateStack.js";
 import type { RuntimeContext } from "./state/context.js";
 import {
+  interrupt,
   interruptWithHandlers,
   isApproved,
   isRejected,
   type Interrupt,
   type InterruptResponse,
 } from "./interrupts.js";
+import renderGuardTripMessage from "../templates/runtime/guardTripMessage.js";
 
 /**
  * Cost-guard trips as interrupts (resumable-guards PR 2).
@@ -92,6 +94,22 @@ async function raiseOneTrip(
       applyVerdict(recorded, scope, tripped, err);
       return undefined;
     }
+    // The question is already OPEN (persisted, no answer yet — e.g. a
+    // resume triggered by answering a DIFFERENT interrupt in the same
+    // batch replays this gate). Re-surface the SAME interrupt id rather
+    // than re-running the chain and minting a fresh one: a fresh id
+    // would orphan the pending answer and ask the user twice.
+    const snapshot = scope.snapshot(tripped.dimension);
+    return [
+      interrupt({
+        effect: "std::guard",
+        message: buildTripMessage(snapshot),
+        data: { ...snapshot, draftValue: draftPreview(stack) },
+        origin: "std::guard",
+        runId: ctx.getRunId(),
+        interruptId: persistedId,
+      }),
+    ];
   }
 
   // Mark the question open BEFORE the first await (an async body runs
@@ -191,12 +209,13 @@ function buildTripMessage(s: {
   limit: number;
   spent: number;
 }): string {
-  const name = s.label ? `Guard "${s.label}"` : "A guard";
-  const unit =
-    s.dimension === "cost"
-      ? `$${s.spent.toFixed(6)} spent (limit $${s.limit})`
-      : `${Math.round(s.spent)}ms elapsed (limit ${s.limit}ms)`;
-  return `${name} exceeded its ${s.dimension} budget: ${unit}. Approve more budget, or reject to stop this work and salvage its draft.`;
+  const cost = s.dimension === "cost";
+  return renderGuardTripMessage({
+    name: s.label ? `Guard "${s.label}"` : "A guard",
+    dimension: s.dimension,
+    spentText: cost ? `$${s.spent.toFixed(6)} spent` : `${Math.round(s.spent)}ms elapsed`,
+    limitText: cost ? `$${s.limit}` : `${s.limit}ms`,
+  });
 }
 
 /** Best-so-far preview for the handler: the innermost saved draft on the
@@ -204,19 +223,17 @@ function buildTripMessage(s: {
  *  unwind (level rule + finalize) if the trip is rejected; finalizes are
  *  one-shot and must not run speculatively for a maybe-approved trip. */
 function draftPreview(stack: StateStack): unknown {
-  for (let i = stack.stack.length - 1; i >= 0; i--) {
-    const draft = stack.stack[i]?.savedDraft;
-    if (draft !== undefined) return draft.value;
-  }
-  return null;
+  const innermostDraft = [...stack.stack]
+    .reverse()
+    .find((frame) => frame?.savedDraft !== undefined);
+  return innermostDraft?.savedDraft?.value ?? null;
 }
 
 function innermostGuardById(stack: StateStack, guardId: string | undefined): Guard | null {
   if (!guardId) return null;
-  for (let i = stack.guards.length - 1; i >= 0; i--) {
-    if (stack.guards[i].guardId === guardId) return stack.guards[i];
-  }
-  return null;
+  return (
+    [...stack.guards].reverse().find((g) => g.guardId === guardId) ?? null
+  );
 }
 
 function makePendingTrip(): { settled: Promise<void>; settle: () => void } {

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -17,6 +17,7 @@ import { installRunPolicyHandler } from "./runPolicyHandler.js";
 import { GlobalStore, GlobalStoreJSON } from "./state/globalStore.js";
 import { StateStack, StateStackJSON } from "./state/stateStack.js";
 import { Approved, GraphState, Rejected, RunNodeResult } from "./types.js";
+import type { HandlerEntry } from "./types.js";
 import { createReturnObject, deepClone } from "./utils.js";
 import { isIpcMode, sendInterruptToParent } from "./ipc.js";
 
@@ -223,6 +224,7 @@ async function runHandlerChain(
   stack: StateStack | undefined,
   interruptId: string,
   interruptObj: InterruptInfo,
+  eligible?: (entry: HandlerEntry) => boolean,
 ): Promise<HandlerChainOutcome> {
   // Descend one level in the CURRENT async lineage (see
   // `handlerChainDepthALS`). Concurrent sibling dispatches each read the same
@@ -245,6 +247,10 @@ async function runHandlerChain(
       for (let i = (ctx.handlers ?? []).length - 1; i >= 0; i--) {
         if (ctx.isCancelled(stack)) throw new AgencyCancelledError();
         const entry = ctx.handlers[i];
+        // Ineligible handlers never see the interrupt — no invocation,
+        // no statelog decision, exactly as if they were not registered.
+        // Guard trips use this for the registration-site visibility rule.
+        if (eligible && !eligible(entry)) continue;
         // A handler runs under its REGISTRATION site's budget: every
         // guard that was not live when it registered is suspended on
         // this branch for the duration of the call — not gating, not
@@ -388,8 +394,9 @@ export async function gatherChainOutcome(
   ctx: RuntimeContext<any>,
   stack: StateStack | undefined,
   interruptId: string,
+  eligible?: (entry: HandlerEntry) => boolean,
 ): Promise<{ outcome: HandlerChainOutcome; parentDecided: boolean }> {
-  const local = await runHandlerChain(ctx, stack, interruptId, interruptObj);
+  const local = await runHandlerChain(ctx, stack, interruptId, interruptObj, eligible);
   if (local.kind === "rejected") {
     // Local reject is final — fail-fast, the parent is never consulted.
     return { outcome: local, parentDecided: false };
@@ -467,9 +474,13 @@ export async function interruptWithHandlers<T = any>(
   stack?: StateStack,
   // `expectsValue: true` marks an assignment-position raise (`const x = raise
   // …`): handlers and the surfaced Interrupt see that an approval value is
-  // expected. Optional trailing object so already-compiled 6-arg calls keep
-  // working.
-  opts?: { expectsValue?: boolean },
+  // expected. `eligible` filters WHICH handlers may see this interrupt —
+  // guard trips use it for the registration-site rule (a handler
+  // registered inside the tripped guard cannot adjudicate it); skipped
+  // handlers emit no statelog decision, exactly as if they were not
+  // registered. Optional trailing object so already-compiled 6-arg calls
+  // keep working.
+  opts?: { expectsValue?: boolean; eligible?: (entry: HandlerEntry) => boolean },
 ): Promise<Interrupt<T>[] | Approved | Rejected> {
   const interruptObj: InterruptInfo = { effect, message, data, origin };
   if (opts?.expectsValue) interruptObj.expectsValue = true;
@@ -487,6 +498,7 @@ export async function interruptWithHandlers<T = any>(
     ctx,
     stack,
     interruptId,
+    opts?.eligible,
   );
   return renderVerdict(outcome, ctx, interruptId, interruptObj, parentDecided ? "ipc" : "handler");
 }

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -253,7 +253,7 @@ async function runHandlerChain(
         // chain: each handler in the chain has its own registration
         // site and therefore its own hidden set.
         const suspensionToken = stack
-          ? stack.beginHandlerSuspension(entry)
+          ? stack.beginSuspension(entry.liveGuardIds)
           : undefined;
         // Treat handler execution as atomic for the debugger — same as LLM tool calls.
         ctx.enterToolCall();
@@ -263,7 +263,7 @@ async function runHandlerChain(
         } finally {
           ctx.exitToolCall();
           if (suspensionToken !== undefined) {
-            stack!.endHandlerSuspension(suspensionToken);
+            stack!.endSuspension(suspensionToken);
           }
         }
         // A handler that is a compiled def returns an AbortedResult when

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1058,20 +1058,19 @@ export async function runPrompt(args: {
   // which skips completed steps — still re-opens the span that the tool
   // loop expects to be active.
   currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
+  // Guard-trip gate: settle every pending cost trip in an idempotent
+  // step of its own, before/after the request steps. The gate loops
+  // until the stack is clear (approving an inner guard can leave an
+  // outer one over ITS limit, and each budget is owed its own
+  // question); an unanswered trip returns Interrupt[] and
+  // PromptRunner.step's machinery (message snapshot, checkpoint,
+  // PromptBailout) surfaces it. Living OUTSIDE the llm-call steps is
+  // what makes resume sound: the gate body is idempotent (re-detect,
+  // apply the recorded answer), while the llm-call bodies are not
+  // (they push messages). See lib/runtime/guardTripInterrupt.ts.
+  const guardGate = () => raiseGuardTripsUntilClear(ctx, stateStack);
   try {
-    // Guard-trip gate: settle every pending cost trip BEFORE the request
-    // step, in an idempotent step of its own. The gate loops until the
-    // stack is clear (approving an inner guard can leave an outer one
-    // over ITS limit, and each budget is owed its own question); an
-    // unanswered trip returns Interrupt[] and PromptRunner.step's
-    // machinery (message snapshot, checkpoint, PromptBailout) surfaces
-    // it. Living OUTSIDE the llm-call step is what makes resume sound:
-    // the gate body is idempotent (re-detect, apply the recorded
-    // answer), while the llm-call bodies are not (they push messages).
-    // See lib/runtime/guardTripInterrupt.ts.
-    await pr.step("guardGate.initial", () =>
-      raiseGuardTripsUntilClear(ctx, stateStack),
-    );
+    await pr.step("guardGate.initial", guardGate);
     // Initial LLM call wrapped in pr.step so it's idempotent on resume
     // (re-entries after a later tool-batch bailout skip this step).
     await pr.step("initialLlmCall", async () => {
@@ -1683,14 +1682,10 @@ export async function runPrompt(args: {
           });
         }
 
-        // Guard-trip gate for this round: the PREVIOUS round's charge may
-        // have crossed a limit (the old post-charge throw site), and this
-        // is where that trip is raised resumably — before the next
-        // request goes out, so nothing more is spent while the question
-        // is open. See the guardGate.initial comment.
-        await pr.step(`round.${round}.guardGate`, () =>
-          raiseGuardTripsUntilClear(ctx, stateStack),
-        );
+        // The PREVIOUS round's charge may have crossed a limit (the old
+        // post-charge throw site); raise it before the next request goes
+        // out, so nothing more is spent while the question is open.
+        await pr.step(`round.${round}.guardGate`, guardGate);
         // Next LLM call wrapped in pr.step for resume idempotency. Once
         // marked done, resume re-entries skip the LLM call. The llmCall
         // span stays open across rounds (one span per llm() call), so we
@@ -1723,9 +1718,7 @@ export async function runPrompt(args: {
       // crossed a limit, and there is no next round to raise it at. See
       // guardGate.initial.
       if (!responseFormat) {
-        await pr.step("guardGate.final", () =>
-          raiseGuardTripsUntilClear(ctx, stateStack),
-        );
+        await pr.step("guardGate.final", guardGate);
         break;
       }
 
@@ -1749,18 +1742,13 @@ export async function runPrompt(args: {
       );
 
       if (decision.kind === "accept") {
-        // Final guard-trip gate for the schema path: the last request's
-        // charge may have crossed a limit, and this call has no next
-        // round to raise it at. See guardGate.initial.
-        await pr.step("guardGate.final", () =>
-          raiseGuardTripsUntilClear(ctx, stateStack),
-        );
+        // The last request's charge may have crossed a limit, and this
+        // call has no next round to raise it at.
+        await pr.step("guardGate.final", guardGate);
         return decision.value;
       }
       if (decision.kind === "surfaceFailure") {
-        await pr.step("guardGate.final", () =>
-          raiseGuardTripsUntilClear(ctx, stateStack),
-        );
+        await pr.step("guardGate.final", guardGate);
         // Strict contract (issue #494): schema-constrained output either
         // validates or comes back as a failure Result, never raw content.
         // Loud in the statelog too, so a rotting integration is visible
@@ -1797,9 +1785,7 @@ export async function runPrompt(args: {
         messages.push(smoltalk.userMessage(decision.feedback));
         self.messagesJSON = snapshotThread();
       });
-      await pr.step(`validation.${validationAttempt}.guardGate`, () =>
-        raiseGuardTripsUntilClear(ctx, stateStack),
-      );
+      await pr.step(`validation.${validationAttempt}.guardGate`, guardGate);
       await pr.step(`validation.${validationAttempt}.llmCall`, async () => {
         const nextResult = await _runPrompt({
           ctx,

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -30,6 +30,7 @@ import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
 // See docs/dev/promptRunner.md for the control-flow abstraction used here.
 import { PromptBailout, PromptRunner } from "./promptRunner.js";
+import { raiseGuardTripsUntilClear } from "./guardTripInterrupt.js";
 import { failure, isFailure, isSuccess, markDestructiveWork } from "./result.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
@@ -726,7 +727,14 @@ async function _runPrompt({
   const callCost = completion.cost?.totalCost ?? 0;
   targetStack.billCharge(callCost);
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
-  targetStack.enforceGuards();
+  // NOTE: no post-charge enforceGuards here anymore. A trip caused by
+  // THIS charge is raised resumably at the caller's next guard gate
+  // (round.N.guardGate / guardGate.final in runPrompt) — the paid work
+  // already happened, and nothing else paid runs before that gate, so
+  // raising there loses nothing and gains the pause point. Throwing
+  // here would make every cost trip non-resumable. The pre-call gate
+  // above still throws as a backstop against spend that slipped in
+  // between a guard gate and this request (e.g. memory-recall charges).
 
   // Memory layer: auto-extraction and compaction run unconditionally
   // whenever a MemoryManager is attached (resolved decision #6).
@@ -1051,6 +1059,19 @@ export async function runPrompt(args: {
   // loop expects to be active.
   currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
   try {
+    // Guard-trip gate: settle every pending cost trip BEFORE the request
+    // step, in an idempotent step of its own. The gate loops until the
+    // stack is clear (approving an inner guard can leave an outer one
+    // over ITS limit, and each budget is owed its own question); an
+    // unanswered trip returns Interrupt[] and PromptRunner.step's
+    // machinery (message snapshot, checkpoint, PromptBailout) surfaces
+    // it. Living OUTSIDE the llm-call step is what makes resume sound:
+    // the gate body is idempotent (re-detect, apply the recorded
+    // answer), while the llm-call bodies are not (they push messages).
+    // See lib/runtime/guardTripInterrupt.ts.
+    await pr.step("guardGate.initial", () =>
+      raiseGuardTripsUntilClear(ctx, stateStack),
+    );
     // Initial LLM call wrapped in pr.step so it's idempotent on resume
     // (re-entries after a later tool-batch bailout skip this step).
     await pr.step("initialLlmCall", async () => {
@@ -1662,6 +1683,14 @@ export async function runPrompt(args: {
           });
         }
 
+        // Guard-trip gate for this round: the PREVIOUS round's charge may
+        // have crossed a limit (the old post-charge throw site), and this
+        // is where that trip is raised resumably — before the next
+        // request goes out, so nothing more is spent while the question
+        // is open. See the guardGate.initial comment.
+        await pr.step(`round.${round}.guardGate`, () =>
+          raiseGuardTripsUntilClear(ctx, stateStack),
+        );
         // Next LLM call wrapped in pr.step for resume idempotency. Once
         // marked done, resume re-entries skip the LLM call. The llmCall
         // span stays open across rounds (one span per llm() call), so we
@@ -1689,8 +1718,14 @@ export async function runPrompt(args: {
         });
       }
       // Tool calls are drained. No schema means nothing to validate; the
-      // plain-content return after the finally handles it.
+      // plain-content return after the finally handles it — but first,
+      // the final guard-trip gate: the last request's charge may have
+      // crossed a limit, and there is no next round to raise it at. See
+      // guardGate.initial.
       if (!responseFormat) {
+        await pr.step("guardGate.final", () =>
+          raiseGuardTripsUntilClear(ctx, stateStack),
+        );
         break;
       }
 
@@ -1714,9 +1749,18 @@ export async function runPrompt(args: {
       );
 
       if (decision.kind === "accept") {
+        // Final guard-trip gate for the schema path: the last request's
+        // charge may have crossed a limit, and this call has no next
+        // round to raise it at. See guardGate.initial.
+        await pr.step("guardGate.final", () =>
+          raiseGuardTripsUntilClear(ctx, stateStack),
+        );
         return decision.value;
       }
       if (decision.kind === "surfaceFailure") {
+        await pr.step("guardGate.final", () =>
+          raiseGuardTripsUntilClear(ctx, stateStack),
+        );
         // Strict contract (issue #494): schema-constrained output either
         // validates or comes back as a failure Result, never raw content.
         // Loud in the statelog too, so a rotting integration is visible
@@ -1753,6 +1797,9 @@ export async function runPrompt(args: {
         messages.push(smoltalk.userMessage(decision.feedback));
         self.messagesJSON = snapshotThread();
       });
+      await pr.step(`validation.${validationAttempt}.guardGate`, () =>
+        raiseGuardTripsUntilClear(ctx, stateStack),
+      );
       await pr.step(`validation.${validationAttempt}.llmCall`, async () => {
         const nextResult = await _runPrompt({
           ctx,

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -736,12 +736,20 @@ async function _runPrompt({
   // above still throws as a backstop against spend that slipped in
   // between a guard gate and this request (e.g. memory-recall charges).
 
-  // Memory layer: auto-extraction and compaction run unconditionally
-  // whenever a MemoryManager is attached (resolved decision #6).
+  // Memory layer: auto-extraction and compaction run whenever a
+  // MemoryManager is attached (resolved decision #6) — UNLESS a guard is
+  // already over budget. The hooks can spend (LLM text + embeddings via
+  // addCost), and the trip from this call's charge has not been raised
+  // yet (that happens at the next guard gate); running paid supervisory
+  // work in that window would either spend past the budget or turn the
+  // resumable trip into addCost's non-resumable throw. Skipping is safe:
+  // the hooks are best-effort and run again on the next healthy turn.
   // Tool-call results have not been pushed yet, so we operate on the
   // current message slice. Compaction is a best-effort hint — failures
   // never break the LLM call.
-  const memoryManager = ctx.getActiveMemoryManager();
+  const memoryManager = targetStack.anyGuardOverBudget()
+    ? null
+    : ctx.getActiveMemoryManager();
   if (memoryManager) {
     try {
       const original = messages.getMessages();

--- a/packages/agency-lang/lib/runtime/rootBudget.ts
+++ b/packages/agency-lang/lib/runtime/rootBudget.ts
@@ -20,14 +20,20 @@ export function installRootBudget(stack: StateStack): void {
   if (rawCost !== undefined) {
     const cost = parseBudgetValue(rawCost, AGENCY_MAX_COST);
     if (cost >= 0) {
-      stack.pushGuard(new CostGuard(cost));
+      const g = new CostGuard(cost);
+      // The operator's ceiling: never raises an interrupt, never
+      // extendable by user code. Serialized with the guard.
+      g.isRootBudget = true;
+      stack.pushGuard(g);
     }
   }
   const rawTime = process.env[AGENCY_MAX_TIME];
   if (rawTime !== undefined) {
     const ms = parseBudgetValue(rawTime, AGENCY_MAX_TIME);
     if (ms > 0) {
-      stack.pushGuard(new TimeGuard(ms));
+      const g = new TimeGuard(ms);
+      g.isRootBudget = true;
+      stack.pushGuard(g);
     }
   }
 }

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -619,17 +619,22 @@ export class StateStack {
     return this.guards.filter((g) => !entry.liveGuardIds.includes(g.guardId));
   }
 
-  /** Suspend everything hidden from `entry` for the duration of one
-   *  handler invocation. Returns the token endHandlerSuspension needs.
-   *  Save/restore (not add/remove) so NESTED handler chains compose: an
-   *  inner chain suspending a guard the outer chain already suspended
-   *  must not un-suspend it when the inner handler returns. Only guards
-   *  newly entering / actually leaving the suspended set get their
-   *  object-level suspend()/unsuspend() calls, so the TimeGuard clock
-   *  pause pairs correctly across nesting. */
-  beginHandlerSuspension(entry: HandlerEntry): string[] {
+  /** Suspend every installed guard NOT in `visibleGuardIds` for the
+   *  duration of one bracket. Two callers: the handler chain (visible =
+   *  the handler's registration-time liveGuardIds) and a guard trip's
+   *  decision window (visible = the guards outside the tripped scope —
+   *  GuardScope.suspendForDecision). Returns the token endSuspension
+   *  needs. Save/restore (not add/remove) so NESTED brackets compose:
+   *  an inner bracket suspending a guard the outer one already
+   *  suspended must not un-suspend it when the inner bracket ends. Only
+   *  guards newly entering / actually leaving the suspended set get
+   *  their object-level suspend()/unsuspend() calls, so the TimeGuard
+   *  clock pause pairs correctly across nesting. */
+  beginSuspension(visibleGuardIds: string[]): string[] {
     const previous = this.suspendedGuardIds;
-    const hidden = this.guardsHiddenFrom(entry);
+    const hidden = this.guards.filter(
+      (g) => !visibleGuardIds.includes(g.guardId),
+    );
     this.suspendedGuardIds = [
       ...previous,
       ...hidden.map((g) => g.guardId).filter((id) => !previous.includes(id)),
@@ -640,7 +645,7 @@ export class StateStack {
     return previous;
   }
 
-  endHandlerSuspension(previous: string[]): void {
+  endSuspension(previous: string[]): void {
     const removed = this.suspendedGuardIds.filter(
       (id) => !previous.includes(id),
     );

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -585,6 +585,19 @@ export class StateStack {
    *  instead of throwing so callers keep their own throw semantics.
    *  This is also the detection sibling the resumable-guards plan's
    *  PR 2 raise sites need. */
+  /** Side-effect-free probe: is any unsuspended guard over budget and
+   *  armed right now? Unlike detectTrippedGuard, this never calls
+   *  check() — TimeGuard's check consumes its one-shot trip latch, so
+   *  probing through it would eat a real trip. Used to gate optional
+   *  paid work (memory hooks) in the window between a crossing charge
+   *  and the next guard gate. */
+  anyGuardOverBudget(): boolean {
+    return this.guards.some(
+      (g) =>
+        !this.suspendedGuardIds.includes(g.guardId) && g.overBudgetAndArmed(),
+    );
+  }
+
   detectTrippedGuard(): GuardExceededError | null {
     for (let i = this.guards.length - 1; i >= 0; i--) {
       if (this.suspendedGuardIds.includes(this.guards[i].guardId)) continue;

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -301,6 +301,14 @@ function pushGuardImpl(
     stack.pushGuard(g);
     ids.push(g.guardId);
   }
+  // Stamp every member with the whole scope: one Agency-level guard()
+  // call IS this id array (a cost+time guard is two runtime objects),
+  // and either member must be able to find its sibling — the trip
+  // interrupt carries the scope, and approve resolves it by these ids.
+  // Serialized with each guard; TimeGuard.cloneForBranch hand-copies it.
+  for (const g of stack.guards) {
+    if (ids.includes(g.guardId)) g.scopeIds = ids;
+  }
   return ids;
 }
 

--- a/packages/agency-lang/lib/templates/runtime/guardTripMessage.mustache
+++ b/packages/agency-lang/lib/templates/runtime/guardTripMessage.mustache
@@ -1,0 +1,1 @@
+{{{name}}} exceeded its {{{dimension}}} budget: {{{spentText}}} (limit {{{limitText}}}). Approve more budget, or reject to stop this work and salvage its draft.

--- a/packages/agency-lang/lib/templates/runtime/guardTripMessage.ts
+++ b/packages/agency-lang/lib/templates/runtime/guardTripMessage.ts
@@ -1,0 +1,20 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/runtime/guardTripMessage.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `{{{name}}} exceeded its {{{dimension}}} budget: {{{spentText}}} (limit {{{limitText}}}). Approve more budget, or reject to stop this work and salvage its draft.`;
+
+export type TemplateType = {
+  name: string | boolean | number;
+  dimension: string | boolean | number;
+  spentText: string | boolean | number;
+  limitText: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/tests/agency/guards/finalize-composes.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-composes.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"outer(inner-finalized)\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "Finalizes compose: inner runs first and its FINALIZED value (not its raw draft) is what outer's finalize consumes."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Finalizes compose: inner runs first and its FINALIZED value (not its raw draft) is what outer's finalize consumes.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/finalize-consumes-partial.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-consumes-partial.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"combined:v-partial\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "The walked example: the callee's partial binds into the local, the finalize translates it, the guard salvages the finalize's return."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "The walked example: the callee's partial binds into the local, the finalize translates it, the guard salvages the finalize's return.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/finalize-error-falls-back.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-error-falls-back.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"the-draft\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A throwing finalize never masks the trip: the scope's saved draft is salvaged instead."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A throwing finalize never masks the trip: the scope's saved draft is salvaged instead.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/finalize-in-guard-block.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-in-guard-block.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"block-finalize:started\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A finalize declared in a guard block produces the guard's salvage, reading the node's locals through the block."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A finalize declared in a guard block produces the guard's salvage, reading the node's locals through the block.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.agency
@@ -55,10 +55,23 @@ def codeF2Trips(): string {
   }
 }
 
+// The trip is rejected IN-PROGRAM (no checkpoint, no resume): this
+// fixture pins the arg-binding semantics, and resuming a trip raised
+// inside a compound call (`f2b(gOk())` — a completed sibling call in
+// the replayed statement) hits a PRE-EXISTING frame-adoption bug that
+// affects runtime-only interrupts generally (tool interrupts included).
+// Tracked separately; see the resumable-guards PR 2 notes.
 node f2TripsCase() {
-  const result = guard(cost: 0.000001) as {
-    return codeF2Trips()
+  handle {
+    const result = guard(cost: 0.000001) as {
+      return codeF2Trips()
+    }
+    if (isFailure(result)) { return "unexpected" }
+    return result.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
   }
-  if (isFailure(result)) { return "unexpected" }
-  return result.value
 }

--- a/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-nested-call-binding.test.json
@@ -4,18 +4,39 @@
       "nodeName": "gTripsCase",
       "input": "",
       "expectedOutput": "\"g-tripped:x-null\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "An aborted ARGUMENT call's partial is dropped at the call boundary; the finalize sees x == null."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "An aborted ARGUMENT call's partial is dropped at the call boundary; the finalize sees x == null.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     },
     {
       "nodeName": "f2TripsCase",
       "input": "",
       "expectedOutput": "\"f2-tripped:f2-partial:g-value\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
       "description": "The OUTER call's partial binds into x; the finalize consumes it."
     }
   ]

--- a/packages/agency-lang/tests/agency/guards/finalize-on-return-position.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-on-return-position.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"finalized-return-position\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A finalize scope intercepts return-position aborts; if the checked-temp lowering were missing, verify's own partial would leak through and this value could never appear."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A finalize scope intercepts return-position aborts; if the checked-temp lowering were missing, verify's own partial would leak through and this value could never appear.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/finalize-reads-globals.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-reads-globals.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"run7/report/v1\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A finalize reads a module global, a param, and the bound partial — frame and non-frame variable kinds all resolve."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A finalize reads a module global, a param, and the bound partial \u2014 frame and non-frame variable kinds all resolve.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/finalize-wins-over-draft.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-wins-over-draft.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"the-finalize\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A successful finalize outranks the scope's saved draft (the success-path complement of finalize-error-falls-back)."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A successful finalize outranks the scope's saved draft (the success-path complement of finalize-error-falls-back).",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-fork.test.json
@@ -4,15 +4,38 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"tripped-mid-fork:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "b1" },
-        { "return": "b2" },
-        { "return": "b3" },
-        { "return": "after" }
+        {
+          "return": "b1"
+        },
+        {
+          "return": "b2"
+        },
+        {
+          "return": "b3"
+        },
+        {
+          "return": "after"
+        }
       ],
-      "description": "Outer guard wraps a fork. With the shared-guard model (cloneForBranch returns this), the OUTER CostGuard is a single in-memory object shared across all branches. The first branch's post-call check trips OUTER mid-fork before the fork settles — the trailing llm('after') is unreachable. Regression for real-time mid-fork enforcement. Under the prior per-branch-clone model the trip only fired post-join via the trailing 'after' call."
+      "description": "Outer guard wraps a fork. With the shared-guard model (cloneForBranch returns this), the OUTER CostGuard is a single in-memory object shared across all branches. The first branch's post-call check trips OUTER mid-fork before the fork settles \u2014 the trailing llm('after') is unreachable. Regression for real-time mid-fork enforcement. Under the prior per-branch-clone model the trip only fired post-join via the trailing 'after' call.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-nested-outer-tighter.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-nested-outer-tighter.test.json
@@ -4,12 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"outer:guardFailure\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "pong" }
+        {
+          "return": "pong"
+        }
       ],
-      "description": "Cost analogue of the time outer-tighter case. Outer cost guard ($0.000001) is tighter than inner ($1.0). One LLM call charges SYNTHETIC_COST ($0.000002) against both; only the outer exceeds, so the trip carries the OUTER's guardId. Increment-2 guardId matching re-throws it past the inner (which does not own it) and converts at the outer -> 'outer:guardFailure'. Pins the cost half of the nested-routing fix."
+      "description": "Cost analogue of the time outer-tighter case. Outer cost guard ($0.000001) is tighter than inner ($1.0). One LLM call charges SYNTHETIC_COST ($0.000002) against both; only the outer exceeds, so the trip carries the OUTER's guardId. Increment-2 guardId matching re-throws it past the inner (which does not own it) and converts at the outer -> 'outer:guardFailure'. Pins the cost half of the nested-routing fix.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.test.json
@@ -4,15 +4,38 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"pre-gate-trip:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "a1" },
-        { "return": "b1" },
-        { "return": "a2" },
-        { "return": "b2" }
+        {
+          "return": "a1"
+        },
+        {
+          "return": "b1"
+        },
+        {
+          "return": "a2"
+        },
+        {
+          "return": "b2"
+        }
       ],
-      "description": "Pre-call gate refuses an LLM call when a guard is already over budget. Inside the fork, each branch wraps its calls in an INNER guard ($0.000003); the post-call innermost-first walk lets INNER trip and the stdlib try catches without OUTER itself tripping during the fork. OUTER's spent accumulates ($0.000006-$0.000008 depending on JS microtask timing) and crosses its $0.000005 budget. The pre-call gate then refuses either branch 2's 'b' (timing variant A) or llm('after') (timing variant B). Assertion `actualCost < $0.000010` covers both pre-gate variants; without the pre-call gate, actualCost would be $0.000010 (post-trip after 'after' charged). Second independent signal: llmMocks is EXACTLY 4 — if pre-gate were broken, DeterministicClient throws 'too many calls' on the 5th request."
+      "description": "Pre-call gate refuses an LLM call when a guard is already over budget. Inside the fork, each branch wraps its calls in an INNER guard ($0.000003); the post-call innermost-first walk lets INNER trip and the stdlib try catches without OUTER itself tripping during the fork. OUTER's spent accumulates ($0.000006-$0.000008 depending on JS microtask timing) and crosses its $0.000005 budget. The pre-call gate then refuses either branch 2's 'b' (timing variant A) or llm('after') (timing variant B). Assertion `actualCost < $0.000010` covers both pre-gate variants; without the pre-call gate, actualCost would be $0.000010 (post-trip after 'after' charged). Second independent signal: llmMocks is EXACTLY 4 \u2014 if pre-gate were broken, DeterministicClient throws 'too many calls' on the 5th request.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-inner-still-isolated.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-inner-still-isolated.test.json
@@ -4,15 +4,32 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "[\"ok-1\",\"tripped-2\",\"ok-3\"]",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "r1" },
-        { "return": "r2a" },
-        { "return": "r2b" },
-        { "return": "r3" }
+        {
+          "return": "r1"
+        },
+        {
+          "return": "r2a"
+        },
+        {
+          "return": "r2b"
+        },
+        {
+          "return": "r3"
+        }
       ],
-      "description": "Inner guards pushed by a branch after the fork opens stay branch-local. OUTER ($0.001) is the shared guard across all 3 branches via cloneForBranch=this. Each branch then pushes its own INNER ($0.000003) onto its own stack — that INNER sits at index >= inheritedGuardCount, invisible to the parent and siblings. Branch 2 spends 2 calls ($0.000004) — its INNER trips inside branch 2's prompt.ts post-call check. Branches 1 and 3 each spend 1 call ($0.000002) — their INNERs don't trip. Critical assertion: branch 2's INNER trip MUST NOT leak into the parent's guards array (would otherwise show up on the shared OUTER's check) and MUST NOT cascade to siblings' branches. The OUTER stays well under its budget across all branches' combined $0.000008 spend."
+      "description": "Inner guards pushed by a branch after the fork opens stay branch-local. OUTER ($0.001) is the shared guard across all 3 branches via cloneForBranch=this. Each branch then pushes its own INNER ($0.000003) onto its own stack \u2014 that INNER sits at index >= inheritedGuardCount, invisible to the parent and siblings. Branch 2 spends 2 calls ($0.000004) \u2014 its INNER trips inside branch 2's prompt.ts post-call check. Branches 1 and 3 each spend 1 call ($0.000002) \u2014 their INNERs don't trip. Critical assertion: branch 2's INNER trip MUST NOT leak into the parent's guards array (would otherwise show up on the shared OUTER's check) and MUST NOT cascade to siblings' branches. The OUTER stays well under its budget across all branches' combined $0.000008 spend.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-nested-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-nested-fork.test.json
@@ -4,15 +4,41 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"nested-trip:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "r11" },
-        { "return": "r12" },
-        { "return": "r21" },
-        { "return": "r22" }
+        {
+          "return": "r11"
+        },
+        {
+          "return": "r12"
+        },
+        {
+          "return": "r21"
+        },
+        {
+          "return": "r22"
+        }
       ],
-      "description": "Nested fork (depth-2) verifies the shared-guard inheritance walks more than one level. OUTER cost guard at depth 0 must reach depth-2 leaves through TWO seedBranchCost / cloneForBranch hops. Each depth-1 branch's guards array contains the OUTER ref (with inheritedGuardCount=1). When depth-1 starts its inner fork, depth-2 branches' seedBranchCost re-runs the cloneForBranch=this contract on depth-1's guards — which propagates OUTER all the way down. Each leaf's charge mutates OUTER's shared counter; the 3rd or 4th leaf's post-call check trips it (spent $0.000008 > limit $0.000005). If inheritance walks were broken at the depth-1 → depth-2 boundary, the depth-2 branches would not see OUTER and the fork would settle successfully."
+      "description": "Nested fork (depth-2) verifies the shared-guard inheritance walks more than one level. OUTER cost guard at depth 0 must reach depth-2 leaves through TWO seedBranchCost / cloneForBranch hops. Each depth-1 branch's guards array contains the OUTER ref (with inheritedGuardCount=1). When depth-1 starts its inner fork, depth-2 branches' seedBranchCost re-runs the cloneForBranch=this contract on depth-1's guards \u2014 which propagates OUTER all the way down. Each leaf's charge mutates OUTER's shared counter; the 3rd or 4th leaf's post-call check trips it (spent $0.000008 > limit $0.000005). If inheritance walks were broken at the depth-1 \u2192 depth-2 boundary, the depth-2 branches would not see OUTER and the fork would settle successfully.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-outer-trips-mid-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-outer-trips-mid-fork.test.json
@@ -4,14 +4,35 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"tripped-mid-fork:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "b1" },
-        { "return": "b2" },
-        { "return": "b3" }
+        {
+          "return": "b1"
+        },
+        {
+          "return": "b2"
+        },
+        {
+          "return": "b3"
+        }
       ],
-      "description": "Outer cost guard wraps a fork. With the shared-guard model, the OUTER's CostGuard is a single in-memory object referenced by every branch (cloneForBranch returns this). Each branch's charge mutates the shared counter; the second branch's post-call check trips it mid-fork. The fork settles with the typed GuardExceededError surfacing as a Failure. Regression coverage for real-time mid-fork enforcement — under the old per-branch isolation, no branch would individually exceed the budget and the trip would only fire post-join (requiring a trailing LLM call as sync point)."
+      "description": "Outer cost guard wraps a fork. With the shared-guard model, the OUTER's CostGuard is a single in-memory object referenced by every branch (cloneForBranch returns this). Each branch's charge mutates the shared counter; the second branch's post-call check trips it mid-fork. The fork settles with the typed GuardExceededError surfacing as a Failure. Regression coverage for real-time mid-fork enforcement \u2014 under the old per-branch isolation, no branch would individually exceed the budget and the trip would only fire post-join (requiring a trailing LLM call as sync point).",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.test.json
@@ -4,22 +4,53 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"tripped-after-resume:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "b1" },
-        { "return": "b2" },
-        { "return": "b3" },
-        { "return": "b1-p2" },
-        { "return": "b2-p2" },
-        { "return": "b3-p2" }
+        {
+          "return": "b1"
+        },
+        {
+          "return": "b2"
+        },
+        {
+          "return": "b3"
+        },
+        {
+          "return": "b1-p2"
+        },
+        {
+          "return": "b2-p2"
+        },
+        {
+          "return": "b3-p2"
+        }
       ],
       "interruptHandlers": [
-        { "action": "approve" },
-        { "action": "approve" },
-        { "action": "approve" }
+        {
+          "action": "approve"
+        },
+        {
+          "action": "approve"
+        },
+        {
+          "action": "approve"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
       ],
-      "description": "Shared cost guard survives interrupt/resume cycle. All 3 fork branches charge $0.000002 (total $0.000006, under budget $0.000008) then interrupt. Harness approves all 3. On resume, runBatch's rehydrateInheritedGuards re-prepends a live ref to the parent's OUTER CostGuard onto each child stack. The OUTER's spent counter restored from the parent's snapshot ($0.000006). Post-resume LLM calls continue mutating the shared counter; the trip fires once cumulative cost crosses the budget. The trip MUST come from inside a branch's post-call check after resume — proving the rehydrateInheritedGuards re-link correctly restored the shared reference to the parent's CostGuard. If the re-link were broken, the resumed branches would not see the parent's OUTER at all and the fork would settle successfully."
+      "description": "Shared cost guard survives interrupt/resume cycle. All 3 fork branches charge $0.000002 (total $0.000006, under budget $0.000008) then interrupt. Harness approves all 3. On resume, runBatch's rehydrateInheritedGuards re-prepends a live ref to the parent's OUTER CostGuard onto each child stack. The OUTER's spent counter restored from the parent's snapshot ($0.000006). Post-resume LLM calls continue mutating the shared counter; the trip fires once cumulative cost crosses the budget. The trip MUST come from inside a branch's post-call check after resume \u2014 proving the rehydrateInheritedGuards re-link correctly restored the shared reference to the parent's CostGuard. If the re-link were broken, the resumed branches would not see the parent's OUTER at all and the fork would settle successfully."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-trip.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-trip.test.json
@@ -4,12 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"tripped:guardFailure:0.000001:true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "pong" }
+        {
+          "return": "pong"
+        }
       ],
-      "description": "A guard with a tiny cost limit trips on the first LLM call. The stdlib guard function catches the GuardExceededError and surfaces a Failure with the structured GuardFailureData ({ type, maxCost, actualCost }). actualCost is positive because the deterministic provider records SYNTHETIC_COST after the call completes."
+      "description": "A guard with a tiny cost limit trips on the first LLM call. The stdlib guard function catches the GuardExceededError and surfaces a Failure with the structured GuardFailureData ({ type, maxCost, actualCost }). actualCost is positive because the deterministic provider records SYNTHETIC_COST after the call completes.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-trips-when-both-set.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-trips-when-both-set.test.json
@@ -4,12 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"tripped:guardFailure:maxCost=0.000001:maxTime=null\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "pong" }
+        {
+          "return": "pong"
+        }
       ],
-      "description": "Symmetric to guard-time-and-cost. Both cost and time limits set, but cost is the tight one and trips first. Verifies __internal_pushGuard actually installs the cost guard when both args are passed — a bug that silently dropped one would slip past guard-time-and-cost (which only exercises the time path)."
+      "description": "Symmetric to guard-time-and-cost. Both cost and time limits set, but cost is the tight one and trips first. Verifies __internal_pushGuard actually installs the cost guard when both args are passed \u2014 a bug that silently dropped one would slip past guard-time-and-cost (which only exercises the time path).",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-in-def.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-in-def.test.json
@@ -4,12 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"def-trip:0.000001\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "pong" }
+        {
+          "return": "pong"
+        }
       ],
-      "description": "Guard inside a `def` function must work the same as inside a `node`. Tests the def-flavored function-body auto-wrap allow-list for GuardExceededError."
+      "description": "Guard inside a `def` function must work the same as inside a `node`. Tests the def-flavored function-body auto-wrap allow-list for GuardExceededError.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-label.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-label.test.json
@@ -4,10 +4,29 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"research-budget|null\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }, { "return": "pong" }],
-      "description": "A labeled guard's trip carries the label on the failure; an unlabeled guard's label is null."
+      "llmMocks": [
+        {
+          "return": "pong"
+        },
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A labeled guard's trip carries the label on the failure; an unlabeled guard's label is null.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-nested-iteration-order.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-nested-iteration-order.test.json
@@ -4,12 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"inner.max=5e-7\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "hi" }
+        {
+          "return": "hi"
+        }
       ],
-      "description": "When inner and outer guards both trip on the same LLM call, the innermost limit must be reported. JS renders 0.0000005 as \"5e-7\"."
+      "description": "When inner and outer guards both trip on the same LLM call, the innermost limit must be reported. JS renders 0.0000005 as \"5e-7\".",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-nested.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-nested.test.json
@@ -4,12 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"inner tripped\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "pong" }
+        {
+          "return": "pong"
+        }
       ],
-      "description": "Nested guards are independent: the inner guard trips on a tiny budget, the outer catches the inner's Failure, and the outer never trips because its own budget is generous."
+      "description": "Nested guards are independent: the inner guard trips on a tiny budget, the outer catches the inner's Failure, and the outer never trips because its own budget is generous.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-sibling-cleanup.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-sibling-cleanup.test.json
@@ -4,13 +4,26 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"ok\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "first" },
-        { "return": "second" }
+        {
+          "return": "first"
+        },
+        {
+          "return": "second"
+        }
       ],
-      "description": "Sequential sibling guards: the first trips on a tiny budget, the second has a generous budget. If __popGuard leaks the first entry, the second's LLM call trips against it and r2 is a Failure."
+      "description": "Sequential sibling guards: the first trips on a tiny budget, the second has a generous budget. If __popGuard leaks the first entry, the second's LLM call trips against it and r2 is a Failure.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-unit-literal.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-unit-literal.test.json
@@ -4,12 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"tripped:0.000001\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "pong" }
+        {
+          "return": "pong"
+        }
       ],
-      "description": "`guard(cost: $0.000001)` must compile and trip exactly the same as `guard(cost: 0.000001)`. The `$` unit literal is a compile-time scale (no-op for dollars)."
+      "description": "`guard(cost: $0.000001)` must compile and trip exactly the same as `guard(cost: 0.000001)`. The `$` unit literal is a compile-time scale (no-op for dollars).",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-basic.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-basic.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"partial\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A guard trip after saveDraft returns the saved draft instead of a failure."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A guard trip after saveDraft returns the saved draft instead of a failure.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-deep-only.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-deep-only.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"failed-as-designed\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "Level-rule pin: a draft saved only in a deep callee dies at an assignment boundary; no deep fallback."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Level-rule pin: a draft saved only in a deep callee dies at an assignment boundary; no deep fallback.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-fork-isolation.test.json
@@ -4,10 +4,35 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"a|b|c\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }, { "return": "pong" }, { "return": "pong" }],
-      "description": "Each fork branch salvages its own draft; no cross-branch clobber (branch-local other.drafts)."
+      "llmMocks": [
+        {
+          "return": "pong"
+        },
+        {
+          "return": "pong"
+        },
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Each fork branch salvages its own draft; no cross-branch clobber (branch-local other.drafts).",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-guard-outside-fork.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A guard OUTSIDE a fork does not salvage branch drafts (they live on branch stacks); the parent trip is a failure."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A guard OUTSIDE a fork does not salvage branch drafts (they live on branch stacks); the parent trip is a failure.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-last-wins.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-last-wins.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"second\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "Multiple saveDraft calls: the last value wins."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Multiple saveDraft calls: the last value wins.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-nested-guards.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-nested-guards.test.json
@@ -4,10 +4,29 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }, { "return": "pong" }],
-      "description": "Inner guard salvages and sweeps its region; the outer trip must not read the swept inner draft."
+      "llmMocks": [
+        {
+          "return": "pong"
+        },
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Inner guard salvages and sweeps its region; the outer trip must not read the swept inner draft.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-no-draft.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-no-draft.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"failed:guardFailure\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "Additivity: a trip with no saveDraft still returns a failure."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Additivity: a trip with no saveDraft still returns a failure.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-outermost.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-outermost.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"code-draft\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "Outermost-set draft wins across frames: trip inside verify returns code's draft."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Outermost-set draft wins across frames: trip inside verify returns code's draft.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-propagated-failure.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-propagated-failure.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A returned inner-guard failure must NOT be salvaged by the outer guard (guardId ownership, not shape)."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A returned inner-guard failure must NOT be salvaged by the outer guard (guardId ownership, not shape).",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-return-chain.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-return-chain.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"verify-draft\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "Return-position pass-through: a deep draft rides an unbroken return chain all the way to the guard."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "Return-position pass-through: a deep draft rides an unbroken return chain all the way to the guard.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-sequential-guards.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-sequential-guards.test.json
@@ -4,10 +4,29 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"g1-draft|true\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }, { "return": "pong" }],
-      "description": "The boundary sweep prevents guard B from reading guard A's draft."
+      "llmMocks": [
+        {
+          "return": "pong"
+        },
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "The boundary sweep prevents guard B from reading guard A's draft.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-stale-block.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-stale-block.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"failed\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A normally-completed combinator block's draft is cleared, so a later trip yields a failure, not the stale block draft."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A normally-completed combinator block's draft is cleared, so a later trip yields a failure, not the stale block draft.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.test.json
+++ b/packages/agency-lang/tests/agency/guards/save-draft-stale-sibling.test.json
@@ -4,10 +4,23 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"failed\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
-      "llmMocks": [{ "return": "pong" }],
-      "description": "A normally-completed sibling def's draft is cleared, so a later trip yields a failure, not the stale draft."
+      "llmMocks": [
+        {
+          "return": "pong"
+        }
+      ],
+      "description": "A normally-completed sibling def's draft is cleared, so a later trip yields a failure, not the stale draft.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/trip-approve-checkpoint.agency
+++ b/packages/agency-lang/tests/agency/guards/trip-approve-checkpoint.agency
@@ -1,0 +1,25 @@
+// THE HEADLINE FIXTURE (resumable-guards plan, Task 2.5): approve across
+// a REAL checkpoint. No in-program handler exists, so the trip surfaces,
+// the run checkpoints and halts, and the harness answers with a VALUED
+// approve ({"action": "resolve", "resolvedValue": {...}} — the valued
+// approve's action is `resolve`). The block then RESUMES: the extended
+// guard state survived serialize/restore, the recorded answer applied
+// exactly once via the derived trip key, and — after more spending — a
+// SECOND trip (fresh key at the new limit) actually raises and is
+// rejected, running the salvage pipeline.
+//
+// This exercises what no in-program fixture can: inline handlers answer
+// before any halt, so only this path serializes and restores a mutated
+// guard and replays the raise site against a recorded answer.
+import { guard } from "std::thread"
+
+node main() {
+  const r = guard(cost: 0.000001) as {
+    const a = llm("Reply with: one")
+    const b = llm("Reply with: two")
+    const c = llm("Reply with: three")
+    return "never-reached"
+  }
+  if (isFailure(r)) { return "second-trip-rejected" }
+  return "unexpected:${r.value}"
+}

--- a/packages/agency-lang/tests/agency/guards/trip-approve-checkpoint.test.json
+++ b/packages/agency-lang/tests/agency/guards/trip-approve-checkpoint.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"second-trip-rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }, { "return": "two" }, { "return": "three" }],
+      "interruptHandlers": [
+        { "action": "resolve", "resolvedValue": { "maxCost": 0.000004 } },
+        { "action": "reject" }
+      ],
+      "description": "Approve across a real checkpoint: the first trip is granted 0.000004 by the harness (limit becomes 0.000005), calls two (0.000004) fits, call three (0.000006) trips AGAIN under a fresh derived key, and the reject runs the salvage pipeline."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/trip-approve.agency
+++ b/packages/agency-lang/tests/agency/guards/trip-approve.agency
@@ -1,0 +1,137 @@
+// Cost trips as resumable interrupts: the in-program approve paths.
+// Every mocked llm() call costs 0.000002; budgets below are sized so
+// each assertion is a spend into a gap — the output changes if a grant
+// lands wrong in either direction.
+import { guard } from "std::thread"
+
+const log = []
+
+// 1. A handler grants more budget and the block simply continues.
+node inlineApprove() {
+  handle {
+    const r = guard(cost: 0.000001) as {
+      const a = llm("Reply with: one")
+      const b = llm("Reply with: two")
+      return "done:${b}"
+    }
+    if (isFailure(r)) { return "unexpected-failure" }
+    return r.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => approve({ maxCost: 0.01 })
+      _ => pass()
+    }
+  }
+}
+
+// 2. One approval names BOTH dimensions of a cost+time guard — the
+// two-member scope extends both members (the fixture that catches the
+// one-guardId model the plan review killed).
+node bothDimensions() {
+  handle {
+    const r = guard(cost: 0.000001, time: 60s) as {
+      const a = llm("Reply with: one")
+      const b = llm("Reply with: two")
+      return "done"
+    }
+    if (isFailure(r)) { return "unexpected-failure" }
+    return r.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => approve({ maxCost: 0.01, maxTime: 60000 })
+      _ => pass()
+    }
+  }
+}
+
+// 3. Explicit disarm stops cost metering entirely.
+node disarmCost() {
+  handle {
+    const r = guard(cost: 0.000001) as {
+      const a = llm("Reply with: one")
+      const b = llm("Reply with: two")
+      const c = llm("Reply with: three")
+      return "done"
+    }
+    if (isFailure(r)) { return "unexpected-failure" }
+    return r.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => approve({ disarm: ["cost"] })
+      _ => pass()
+    }
+  }
+}
+
+// 4. A useless approval — approve() with no grant on the tripped
+// dimension — is a runtime error, not a livelock.
+node uselessApproval() {
+  handle {
+    const r = guard(cost: 0.000001) as {
+      const a = llm("Reply with: one")
+      return a
+    }
+    if (isFailure(r)) { return "failed-as-expected" }
+    return "unexpected-success"
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => approve()
+      _ => pass()
+    }
+  }
+}
+
+// 5. A negative grant clamps to zero (with a warning) — it does NOT
+// disarm, so the answer is as useless as approve() and errors the same
+// way. Metering is never silently removed.
+node negativeGrant() {
+  handle {
+    const r = guard(cost: 0.000001) as {
+      const a = llm("Reply with: one")
+      return a
+    }
+    if (isFailure(r)) { return "failed-as-expected" }
+    return "unexpected-success"
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => approve({ maxCost: -5.0 })
+      _ => pass()
+    }
+  }
+}
+
+// 6. TWO handlers approving one trip ACCUMULATE (the per-effect merge).
+// Each grants 0.000004; merged 0.000008 → limit 0.000009, so four
+// calls (0.000008) fit with ONE trip. Under the old outer-overwrites
+// rule the limit would be 0.000005, the third call would trip a second
+// time, and the log would show two outer approvals.
+node doubleApprove() {
+  handle {
+    handle {
+      const r = guard(cost: 0.000001) as {
+        const a = llm("Reply with: a")
+        const b = llm("Reply with: b")
+        const c = llm("Reply with: c")
+        const d = llm("Reply with: d")
+        return "done"
+      }
+      if (isFailure(r)) {
+        log.push("unexpected-failure")
+      } else {
+        log.push(r.value)
+      }
+    } with (i) {
+      return match(i.effect) {
+        "std::guard" => approve({ maxCost: 0.000004 })
+        _ => pass()
+      }
+    }
+  } with (i) {
+    if (i.effect == "std::guard") {
+      log.push("outer-approved")
+      return approve({ maxCost: 0.000004 })
+    }
+    return pass()
+  }
+  return log
+}

--- a/packages/agency-lang/tests/agency/guards/trip-approve.test.json
+++ b/packages/agency-lang/tests/agency/guards/trip-approve.test.json
@@ -1,0 +1,58 @@
+{
+  "tests": [
+    {
+      "nodeName": "inlineApprove",
+      "input": "",
+      "expectedOutput": "\"done:two\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }, { "return": "two" }],
+      "description": "A handler approves more budget and the guarded block resumes in place and finishes."
+    },
+    {
+      "nodeName": "bothDimensions",
+      "input": "",
+      "expectedOutput": "\"done\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }, { "return": "two" }],
+      "description": "One approval naming both dimensions extends both members of a cost+time guard scope."
+    },
+    {
+      "nodeName": "disarmCost",
+      "input": "",
+      "expectedOutput": "\"done\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }, { "return": "two" }, { "return": "three" }],
+      "description": "approve({disarm: [cost]}) stops cost metering explicitly; spend past the old limit never trips again."
+    },
+    {
+      "nodeName": "uselessApproval",
+      "input": "",
+      "expectedOutput": "\"failed-as-expected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }],
+      "description": "approve() with no grant on the tripped dimension is a runtime error (it would re-trip forever), surfacing as a Failure."
+    },
+    {
+      "nodeName": "negativeGrant",
+      "input": "",
+      "expectedOutput": "\"failed-as-expected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }],
+      "description": "A negative grant clamps to zero and never silently disarms; the answer is useless and errors."
+    },
+    {
+      "nodeName": "doubleApprove",
+      "input": "",
+      "expectedOutput": "[\"outer-approved\",\"done\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "a" }, { "return": "b" }, { "return": "c" }, { "return": "d" }],
+      "description": "Two handlers approving one trip accumulate through the std::guard merge: one trip, four calls fit. Overwrite semantics would trip twice and log two outer approvals."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/trip-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/trip-fork.agency
@@ -1,0 +1,56 @@
+// Trips under fork and race. Mocked llm() cost = 0.000002.
+import { guard } from "std::thread"
+
+const log = []
+
+// 1. Shared-guard dedupe: three branches under one shared CostGuard all
+// cross the limit together. While one branch's question is out, the
+// siblings PARK on it instead of asking their own — so the handler
+// grants ONCE, and the spend-shaped assertion is the after-fork call:
+// with one 0.000009 grant (limit 0.00001) the three branch charges
+// (0.000006) plus the after call (0.000008) fit; if every branch had
+// been granted separately (0.000027 of headroom) the second after call
+// would ALSO fit and the output would differ.
+// NOTE: the handler decides on i.data.spent, not on shared mutable
+// state — module globals are branch-cloned in forks, so a
+// "grant-once" counter would silently reset at the join.
+node sharedDedupe() {
+  handle {
+    const r = guard(cost: 0.000001) as {
+      fork([1, 2, 3]) as n {
+        const x = llm("branch ${n}")
+      }
+      const after1 = llm("Reply with: after1")
+      const after2 = llm("Reply with: after2")
+      return "never-reached"
+    }
+    if (isFailure(r)) { return "final-trip-rejected" }
+    return "BUG:overgranted:${r.value}"
+  } with (i) {
+    if (i.effect == "std::guard") {
+      if (i.data.spent < 0.000009) {
+        return approve({ maxCost: 0.0000085 })
+      }
+      return reject()
+    }
+    return pass()
+  }
+}
+
+// 2. A race loser holding budget spend does not hang or resurface: the
+// winner returns, the loser is cancelled, the guard settles normally.
+node raceLoserClean() {
+  const r = guard(cost: 0.01) as {
+    const winner = race([1, 2]) as n {
+      if (n == 1) {
+        return "fast"
+      }
+      const slow = llm("Reply with: slow")
+      const slower = llm("Reply with: slower")
+      return "slow"
+    }
+    return winner
+  }
+  if (isFailure(r)) { return "unexpected-failure" }
+  return r.value
+}

--- a/packages/agency-lang/tests/agency/guards/trip-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/trip-fork.test.json
@@ -1,0 +1,53 @@
+{
+  "tests": [
+    {
+      "nodeName": "sharedDedupe",
+      "input": "",
+      "expectedOutput": "\"final-trip-rejected\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "b1"
+        },
+        {
+          "return": "b2"
+        },
+        {
+          "return": "b3"
+        },
+        {
+          "return": "after1"
+        },
+        {
+          "return": "after2"
+        }
+      ],
+      "description": "One grant covers the shared guard for all branches (dedupe): total spend of branches + after1 (0.000008) fits the single 0.0000085 grant, after2 (0.00001) trips and is rejected by the spent-based handler. If each branch had been granted separately, the limit would exceed 0.000018 and after2 would fit \u2014 reaching the BUG output."
+    },
+    {
+      "nodeName": "raceLoserClean",
+      "input": "",
+      "expectedOutput": "\"fast\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "slow"
+        },
+        {
+          "return": "slower"
+        }
+      ],
+      "description": "A race loser with in-flight spend under the guard neither hangs the race nor resurfaces after the winner returns."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/trip-visibility.agency
+++ b/packages/agency-lang/tests/agency/guards/trip-visibility.agency
@@ -1,0 +1,99 @@
+// Trip visibility and precedence rules. Mocked llm() cost = 0.000002.
+import { guard } from "std::thread"
+
+const log = []
+
+// 1. A handler registered INSIDE the guard cannot adjudicate that
+// guard's own trip: the trip skips it and surfaces (the harness
+// rejects). If eligibility broke, the inner handler would approve and
+// the block would finish — a different output.
+node insideGuardBlind() {
+  const r = guard(cost: 0.000001) as {
+    handle {
+      const a = llm("Reply with: one")
+      return a
+    } with (i) {
+      return match(i.effect) {
+        "std::guard" => approve({ maxCost: 1.0 })
+        _ => pass()
+      }
+    }
+  }
+  if (isFailure(r)) { return "surfaced-past-inside-handler" }
+  return "BUG:inside-handler-adjudicated:${r.value}"
+}
+
+// 2. Propagate discards accumulated approvals: the inner handler
+// approves, the outer propagates, the user (harness) rejects — the
+// grant evaporates and the salvage pipeline runs.
+node propagateDiscards() {
+  handle {
+    handle {
+      const r = guard(cost: 0.000001) as {
+        const a = llm("Reply with: one")
+        return a
+      }
+      if (isFailure(r)) { return "rejected-by-user" }
+      return "BUG:approval-survived-propagate:${r.value}"
+    } with (i) {
+      return match(i.effect) {
+        "std::guard" => approve({ maxCost: 1.0 })
+        _ => pass()
+      }
+    }
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => propagate()
+      _ => pass()
+    }
+  }
+}
+
+// 3. The interrupt data carries the scope's savedDraft as a PREVIEW,
+// and a reject still salvages it authoritatively through the normal
+// pipeline: the guard converts the trip to success(draft).
+node draftPreview() {
+  handle {
+    const r = guard(cost: 0.000001) as {
+      saveDraft("the-draft")
+      const a = llm("Reply with: one")
+      return a
+    }
+    if (isFailure(r)) { return "no-salvage" }
+    return "${log[0]}|salvaged:${r.value}"
+  } with (i) {
+    if (i.effect == "std::guard") {
+      log.push("preview:${i.data.draftValue}")
+      return reject()
+    }
+    return pass()
+  }
+}
+
+// 4. Grants never cross budgets: approving the INNER guard's trip does
+// not widen the OUTER guard. The granted spend pushes the outer over
+// its own limit, and the outer trips separately, under its own label.
+// If grants crossed, the outer would never trip and the log would have
+// one entry.
+node grantsNeverCross() {
+  handle {
+    const outer = guard(label: "outer", cost: 0.000003) as {
+      const inner = guard(label: "inner", cost: 0.000001) as {
+        const a = llm("Reply with: one")
+        const b = llm("Reply with: two")
+        return "inner-done"
+      }
+      if (isFailure(inner)) { return "unexpected-inner-failure" }
+      return inner.value
+    }
+    if (isFailure(outer)) { return "unexpected-outer-failure" }
+    log.push(outer.value)
+  } with (i) {
+    if (i.effect == "std::guard") {
+      log.push("trip:${i.data.label}")
+      return approve({ maxCost: 0.01 })
+    }
+    return pass()
+  }
+  return log
+}

--- a/packages/agency-lang/tests/agency/guards/trip-visibility.test.json
+++ b/packages/agency-lang/tests/agency/guards/trip-visibility.test.json
@@ -1,0 +1,42 @@
+{
+  "tests": [
+    {
+      "nodeName": "insideGuardBlind",
+      "input": "",
+      "expectedOutput": "\"surfaced-past-inside-handler\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }],
+      "interruptHandlers": [{ "action": "reject" }],
+      "description": "A handler registered inside the guard never sees that guard's trip; it surfaces past it."
+    },
+    {
+      "nodeName": "propagateDiscards",
+      "input": "",
+      "expectedOutput": "\"rejected-by-user\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }],
+      "interruptHandlers": [{ "action": "reject" }],
+      "description": "Inner approve + outer propagate: the human decides and the handler's grant evaporates."
+    },
+    {
+      "nodeName": "draftPreview",
+      "input": "",
+      "expectedOutput": "\"preview:the-draft|salvaged:the-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }],
+      "description": "The trip data carries the savedDraft preview; the reject still salvages authoritatively through the guard's normal conversion."
+    },
+    {
+      "nodeName": "grantsNeverCross",
+      "input": "",
+      "expectedOutput": "[\"trip:inner\",\"trip:outer\",\"inner-done\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "one" }, { "return": "two" }],
+      "description": "Approving the inner guard's trip never widens the outer guard: the outer trips separately with its own label (decision 16)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/handlers/handler-budget-scoping.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-budget-scoping.test.json
@@ -4,15 +4,32 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"outer-tripped-after-handler-spend\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "one" },
-        { "return": "allow" },
-        { "return": "two" },
-        { "return": "three" }
+        {
+          "return": "one"
+        },
+        {
+          "return": "allow"
+        },
+        {
+          "return": "two"
+        },
+        {
+          "return": "three"
+        }
       ],
-      "description": "The handler's own llm() charges the guard enclosing its REGISTRATION (outer) and never the guard it is deciding inside of (inner). Both directions are pinned by spend: a leak into the inner guard trips it at r2; a missing charge on the outer guard lets the extra call fit."
+      "description": "The handler's own llm() charges the guard enclosing its REGISTRATION (outer) and never the guard it is deciding inside of (inner). Both directions are pinned by spend: a leak into the inner guard trips it at r2; a missing charge on the outer guard lets the extra call fit.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/handlers/handler-scope-loop.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-scope-loop.test.json
@@ -4,17 +4,41 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "[\"iter-tripped\",\"iter-tripped\"]",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "work" },
-        { "return": "yes" },
-        { "return": "more" },
-        { "return": "work" },
-        { "return": "yes" },
-        { "return": "more" }
+        {
+          "return": "work"
+        },
+        {
+          "return": "yes"
+        },
+        {
+          "return": "more"
+        },
+        {
+          "return": "work"
+        },
+        {
+          "return": "yes"
+        },
+        {
+          "return": "more"
+        }
       ],
-      "description": "Both iterations trip: the handler registered inside the per-iteration guard is metered by it, in iteration 2 as much as iteration 1. Under the stale-memo bug, iteration 2's handler spend would not count and iteration 2 would finish under budget."
+      "description": "Both iterations trip: the handler registered inside the per-iteration guard is metered by it, in iteration 2 as much as iteration 1. Under the stale-memo bug, iteration 2's handler spend would not count and iteration 2 would finish under budget.",
+      "interruptHandlers": [
+        {
+          "action": "reject"
+        },
+        {
+          "action": "reject"
+        }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/handlers/handler-scope-resume.test.json
+++ b/packages/agency-lang/tests/agency/handlers/handler-scope-resume.test.json
@@ -4,16 +4,27 @@
       "nodeName": "main",
       "input": "",
       "expectedOutput": "\"tripped-after-resume\"",
-      "evaluationCriteria": [{ "type": "exact" }],
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": "one" },
-        { "return": "two" }
+        {
+          "return": "one"
+        },
+        {
+          "return": "two"
+        }
       ],
       "interruptHandlers": [
         {
           "action": "approve",
           "expectedMessage": "continue?"
+        },
+        {
+          "action": "reject"
         }
       ],
       "description": "Propagate surfaces the interrupt mid-run; after the harness approves and the run resumes, the guard still meters and trips on the next spend. Pins that no suspension state rides the checkpoint."


### PR DESCRIPTION
PR 2 of 4 of the resumable-guards plan (rev 8 + execution notes, committed on this branch). Cost-guard trips now raise ordinary interrupts (effect `std::guard`) instead of throwing: handlers approve more budget and the work continues in place, reject and the existing salvage pipeline runs unchanged, or the question reaches the user across a checkpoint. This is the breaking change you accepted: a bare, unhandled guard no longer degrades to a failure — it asks.

## How it works

**GuardScope** (`lib/runtime/guardScope.ts`) is the runtime name for what one `guard(...)` call pushes — up to two runtime guards, two ids. The trip interrupt carries `scopeIds`; approve resolves the scope on the raising branch's stack (never a global lookup — fork clones share the parent's id) and applies the merged payload: additive grants, negative deltas clamped to zero with a warning, explicit `disarm`, root-budget refusal, and the useless-approval runtime error (an answer leaving the tripped dimension over budget and armed would re-trip forever).

**The raise** happens at idempotent PromptRunner gate steps in `runPrompt` — before every request and once before returning — looping on `detectTrippedGuard()` until the stack is clear, because each budget is owed its own question (approving an inner guard can push an outer one over). An unanswered trip returns `Interrupt[]` to `pr.step`, whose existing snapshot/checkpoint/bailout machinery surfaces it. On resume, the gate re-detects and applies the recorded answer via a key derived from guard state (`scopeIds#dimension@limit` — stable across replays of one trip, necessarily fresh for the next). Concurrent branches under a shared guard dedupe on a live `pendingTrip` record: set before the first await, settled in the `finally` on every exit, parked siblings re-detect.

**What still throws:** root budgets (now marked with a serialized `isRootBudget`, stamped by `installRootBudget`, refused by `extend`), the parent-side subprocess telemetry site (an IPC callback has no runner — documented v1 limit, which also means `run(maxCost:)`'s `limit_exceeded` contract is unchanged with zero migration), and `addCost` (below).

## Execution deviations for your sign-off

The plan doc on this branch records all of these in a "PR 2 as executed" section:

1. **The raise sites moved from the in-`_runPrompt` checks to pr.step-level gates.** Raising inside a non-idempotent llm-call step body breaks replay — the body re-pushes its user message on resume. The gates are idempotent steps of their own and reuse PromptRunner's bailout machinery instead of duplicating it. The pre-call check stays as a throwing backstop; the post-charge check is removed (its trips raise at the next gate, and nothing paid runs in between — tool-internal paid work is gated by the tool's own runPrompt).
2. **`addCost` keeps throwing in v1** — same replay hazard, from arbitrary TS-helper contexts. A `guard(cost:)` around a paid TS helper trips non-resumably for now.
3. **`std::agents` guards are NOT auto-reject wrapped**, deviating from the migration rule: an inner reject short-circuits ahead of user handlers and would permanently lock std::agents users out of approving trips — the flagship reviewer pattern. Their trips now surface to the caller, which headless default-reject answers exactly as before.
4. **The fixture migration went through the harness** (`{"action": "reject"}` in test.json) rather than in-program wrappers: outputs stay byte-identical AND all 36 migrated fixtures now exercise the full propagate → checkpoint → reject → resume → salvage pipeline.
5. **Subprocess trip e2e rides with PR 3**, where re-arm makes cross-process approve meaningful for the remaining dimension; the IPC site itself is untouched.

## Two discoveries

- **A new boundary fix:** an `Interrupt[]` reaching a call *argument* now passes through `__call`/`__callMethod` as the call's own result, mirroring `findAbortedArg`. Guard trips are the first runtime-only interrupt source, so `f(g())` with a trip inside `g` was the first way an interrupt batch could reach an argument slot — it previously flowed into the callee as `"[object Object]"`.
- **A pre-existing resume bug, filed as #559:** resuming an interrupt raised inside a compound call (`f(g())` with `g` completed) corrupts replay via FIFO frame adoption — the replayed `g()` adopts `f`'s restored frame. This affects tool interrupts on main today; trips just made it reachable in the guards suite. The one affected fixture case rejects in-program with a pointer to the issue.

## Testing

New fixtures pin: inline approve-and-continue; one approval extending BOTH members of a cost+time scope (the two-ids case that killed the rev-2 plan); explicit disarm; the useless-approval and negative-grant errors; two handlers accumulating through the merge, spend-shaped so overwrite semantics fail it; **the headline approve-across-a-real-checkpoint** — no in-program handler, the harness answers with a valued `{"action": "resolve", "resolvedValue": {"maxCost": ...}}`, the block resumes on the restored, extended guard, and a second trip raises under a fresh key and is rejected into the salvage pipeline; inside-guard handler blindness; propagate discarding approvals; the `draftValue` preview plus authoritative reject salvage; grants never crossing budgets (the inner grant pushes the outer over; it trips separately under its own label); shared-guard dedupe under fork (handler decides on `i.data.spent` — a module-global grant counter silently resets across branch clones, which the fixture comment warns about); and a race loser settling cleanly.

Full validation: 8,369 unit tests; 92/92 guards+handlers fixture files; structural lint; zero codegen fixture churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
