### PR TITLE
Resolve spec section 9.2: the Notes pre-flight works, container must not be chained

### DIFF
--- a/docs/superpowers/plans/2026-07-17-std-notes-apple-REVIEW.md
+++ b/docs/superpowers/plans/2026-07-17-std-notes-apple-REVIEW.md
@@ -1,0 +1,266 @@
+# Review: std::notes/apple implementation plan
+
+Date: 2026-07-17
+Reviewing: `/Users/adityabhargava/agency-notes-92/docs/superpowers/plans/2026-07-17-std-notes-apple.md`
+Method: read the plan, then ran its assumptions against the real toolchain — parsed its
+Agency snippets, executed a Result-narrowing probe, and diffed `origin/main` to check its
+upstream dependency. Findings marked **verified** were executed; **argued** were not.
+
+---
+
+## Summary
+
+The plan is strong where it matters most. Task ordering is right, the runner is correctly
+isolated as the only `osascript` call site, and the two mutation steps (5 in Task 1, 5 in
+Task 4) are the right instinct — they encode the lesson from #562 that a green suite
+proves nothing. The safety comments are unusually good: the "unguessable id" docstring in
+Task 2 and the locked-guard warnings are written to survive a future refactor, which is
+exactly what they need to do.
+
+But **the plan does not compile as written**, and I verified this rather than suspecting
+it. Two blockers, both mechanical, both currently spread across the canonical code blocks
+an executing agent will copy verbatim:
+
+1. `if...then...else` as an argument value does not parse. Five occurrences. Task 5 fails at Step 2.
+2. `!exists` on a narrowed `Result` is always `false`. The `folderCreated` safety signal is always wrong, in the fail-open direction, and the typechecker does not catch it.
+
+Neither is deep. Both need fixing before an agent executes this, because both live in
+code the plan instructs someone to write down verbatim.
+
+The good news: the upstream dependency is clean. **PR #562 merged** (`cf74ec0ed`), and all
+three security findings from that review were fixed before it landed — I checked
+`origin/main` directly. `TABLE_ALIGNMENTS` is now an allowlist, `start` and heading level
+go through `Number.isInteger`, `escapeHtml` coerces non-strings, and `sanitizeHtmlUrl`
+rejects protocol-relative URLs with the reasoning in a comment. So `createNote`'s
+markdown→HTML path is safe to build on, and Task 5 can rely on it.
+
+---
+
+## Blocker 1 — `if...then...else` as an argument value does not parse. **Verified.**
+
+The plan writes this five times (lines 1364, 1383, 1401, 1416, 1444):
+
+```ts
+folder: if folder == null then "" else folder,
+```
+
+I ran both forms through the real parser:
+
+```
+if-then-else as ARG value   → FAILS TO PARSE
+if-then-else as CONST value → PARSES
+```
+
+So every interrupt payload in Task 5 fails at Step 2's `pnpm run ast` gate. That gate will
+catch it — the plan is not silently broken — but an agent will hit five parse failures
+with no fix in hand and start improvising inside the security-critical module.
+
+What makes this worth calling out rather than shrugging at: **the plan already knows.**
+Line 1463 says "If `if ... then ... else` as an argument value fails, hoist it to a
+`const` first — `if` expressions are only allowed as a `const`/`let` value or a `return`."
+That is the correct diagnosis and the correct fix, written as a contingency for something
+that is not a contingency. It is certain. It should be in the code, not in a footnote
+under it.
+
+Fix — hoist in each of the five functions:
+
+```ts
+export def appendToNote(id: string, body: string, folder?: string): Result<Note> raises <std::notes::append> {
+  const html = toHtml(body)
+  if (isFailure(html)) {
+    return html
+  }
+  const folderLabel = if folder == null then "" else folder
+
+  return interrupt std::notes::append("Append to a note in the Notes app?", {
+    account: "",
+    folder: folderLabel,
+    title: "",
+    id: id
+  })
+  ...
+```
+
+Worth a note in Global Constraints too, since it's a general Agency rule an agent will hit
+again, and it pairs with the existing memory that Agency has no `? :` ternary at all.
+
+---
+
+## Blocker 2 — `!exists` is always `false`, and it silently breaks a safety payload. **Verified.**
+
+Task 5's `createNote`:
+
+```ts
+const exists = try _folderExists(folder)
+if (isFailure(exists)) {
+  return exists
+}
+...
+folderCreated: !exists
+```
+
+A narrowed `Result` is still the wrapper object. I probed the runtime:
+
+```
+bare exists:   { __type: 'resultType', success: true, value: true }
+negated bare:  false
+```
+
+`!exists` negates an object, so it is **always `false`**, whether the folder exists or not.
+It must be `!exists.value`.
+
+Three things make this worse than an ordinary typo:
+
+**The plan contradicts itself two lines later.** Line 1345 writes `html.value` after the
+identical `isFailure(html)` narrowing. So the plan uses both conventions in one function,
+and only one of them is right. That inconsistency is the tell.
+
+**The typechecker does not catch it.** I ran `pnpm run diagnostics` on the pattern and it
+reported nothing. This ships green.
+
+**It fails open in a safety payload.** The plan's own comment at line 1082 says
+`folderCreated` exists "so a human or policy sees the folder being made." That signal is
+now permanently `false` — permanently "nothing new is being created" — on the one
+operation that silently creates a folder in the user's Notes. A policy written as
+`{"match": {"folderCreated": true}, "action": "reject"}` would never fire. The human
+approving the interrupt is told the safe thing regardless of the truth.
+
+Fix: `folderCreated: !exists.value`, and add a Task 5 test pinning it — the payload for a
+create into a missing folder must carry `folderCreated: true`. Right now nothing in the
+plan would notice.
+
+Worth a scan of Task 5 for other bare-Result uses; these two were the ones I found by
+reading, not by an exhaustive check.
+
+---
+
+## Finding 3 — The read path kept the TOCTOU the write path was fixed to remove. **Argued.**
+
+Task 4 correctly fixes the check-then-act gap flagged in the spec review, and the reasoning
+at line 931 is right: address the note *through* the folder (`note id X of folder Y`) so
+the lookup failing *is* the assertion failing, and the check cannot drift from the access
+across the human approval.
+
+Task 3's `_readNote` does not do this. It uses `assertFolder(p, folder)` — read the
+container, compare strings — and then reads with an **unscoped** `note id (item 1 of argv)`.
+So the window the write path just closed is still open on the read path: between the
+pre-flight and the read sits an interrupt and a human approval, and the note can move
+folders in it.
+
+The plan half-acknowledges this at line 750: "This is the read-path assertion. The write
+path uses a scoped lookup instead, which is stronger." It says which is stronger without
+saying why read gets the weaker one.
+
+That matters because reading is the operation the folder scoping was *invented* for. The
+spec's motivating example is `readNote.partial(folder: "Work")` confining an agent to Work
+notes, and the guide (Task 6, line 1605) tells users "the model may pass any id it likes.
+Anything outside Work fails closed." Under a scoped write and an unscoped read, that
+sentence is true for `appendToNote` and not quite true for `readNote`.
+
+`READ_SCRIPT` can take the same treatment as `APPEND_SCOPED_SCRIPT` — two shapes, scoped
+and unscoped — at no extra cost. If there's a reason not to, the asymmetry should be
+argued in the plan rather than left as an observation.
+
+---
+
+## Finding 4 — The `account: ""` gap is well-flagged but under-tested. **Argued.**
+
+The Self-Review is honest about this, and I want to credit it: it names the gap, names the
+consequence ("folder scoping is still advisory on a multi-account machine — the exact
+thing spec §3.4 argued had to be fixed"), and says not to let it merge silently. That is
+the right disclosure.
+
+Two things would make it stick better than a paragraph at the bottom of the plan:
+
+- **Every payload hardcodes `account: ""`** while `_preflightNote` actually resolves the
+  real account. So the data exists and is thrown away at the boundary. Passing the real
+  account through on the paths that have it (`append`, `read`, `delete`, all of which
+  pre-flight) costs nothing and shrinks the gap to just `create`/`list`/`search`.
+- The guide (Task 6) states the confinement claim unconditionally. If account scoping is
+  advisory in v1, the guide should say so, or it becomes the document people trust.
+
+---
+
+## Finding 5 — `FIELD_DELIM` is a raw control byte in source. **Verified. Not a bug.**
+
+I checked the actual bytes, because a `""`-looking literal in a plan usually means the
+character got eaten somewhere:
+
+```
+export const FIELD_DELIM = "<0x01>";
+   hex:  22 01 22   →  quote, U+0001, quote
+```
+
+So it is correct as written — a real U+0001. The choice itself is right, and the reasoning
+(line 220: titles can legally contain tabs) is a good catch most people would miss.
+
+But a raw, invisible control byte in a TypeScript source file is fragile in a way the
+escape isn't: it's invisible in every editor, it survives copy-paste unreliably, and the
+test at line 191 asserts `toBe("<0x01>")` with a *second* raw byte — so if either byte is
+mangled in transit, the test mangles with it and still passes. Write both as `""`.
+Same value, same test, no invisible state.
+
+---
+
+## Finding 6 — Smaller things
+
+- **Task 2 Step 5 fixes a typo Task 2 Step 3 deliberately introduces.** Line 462 writes
+  `errors -1712... no: -1728` into a comment, then a whole step exists to clean it up.
+  Just write the comment correctly in Step 3 and delete Step 5. As written, an agent
+  copying the block faithfully lands a visibly confused comment in the security-critical
+  file, and the fix depends on a later step nobody skips.
+- **Test counts drift.** Task 2 says "PASS, 17 tests"; counting its own blocks gives 18
+  (7 preflight + 2 assertNotLocked on top of Task 1's 9). Task 3's "29" is consistent with
+  18, so the 17 is the typo. Task 4's "40" doesn't reconcile with 29 + 10 = 39 either.
+  Minor, but these are pass/fail gates — an agent that trusts them will chase a phantom.
+- **Task 7 expects "markdown 46 tests"**; #562 merged with 34. Whatever the real number,
+  it isn't 46.
+- **Task 5 Step 5 contradicts itself**: "Create `/tmp/notes-check.agency` in the repo (NOT
+  in /tmp — Agency needs node_modules)" then `cp /tmp/notes-check.agency ./`. Write it
+  directly into the repo and drop the `/tmp` round trip.
+- **`listFolders` raises `std::notes::list`**, sharing an effect with `listNotes`. Those
+  disclose different things — folder names and counts vs. note titles — so a policy can't
+  approve one and reject the other. Probably fine for v1, but it's a payload-design
+  decision the spec's own §5.1 rule ("payload design is safety design") would want stated.
+- **`import { parse, renderForHtml } from "std::markdown"` inside a stdlib module** — worth
+  a glance for the auto-import/prelude cycle gotcha before Task 5 Step 4, since `make` is
+  where that would surface.
+
+---
+
+## What's good
+
+- **Task 1's isolation of `runNotesScript` as the only `osascript` call site** is the
+  single best structural decision here. Every injection guarantee reduces to one function.
+- **The mutation steps** (Task 1 Step 5, Task 4 Step 5) are the right response to #562, and
+  Task 4's is aimed at exactly the right target: the locked guard is the one line whose
+  removal silently destroys user data.
+- **The Task 2 docstring** telling a future reader *not* to write "unreachable without a
+  gate" and explaining why the weaker claim would license widening the query — that is
+  writing for the person who comes back in six months.
+- **Global Constraints** as a section is the right shape: each entry is a finding that cost
+  a spike, not a style preference, and each cites its spec section.
+- **The Self-Review's honesty** about findings 7 and 11b and the `account` gap. A plan that
+  says "this workaround is a guess, not a fix" (line 1780) is more useful than one that
+  claims completeness.
+
+---
+
+## Recommendation
+
+Fix blockers 1 and 2 before anyone executes this — both are small, both are in code the
+plan tells an agent to write verbatim, and blocker 2 is the kind that ships green and
+quiet.
+
+Finding 3 (the unscoped read) is worth deciding now rather than after the module exists,
+since it's the difference between the guide's confinement claim being true and being
+nearly true.
+
+Everything else is cleanup. The plan's structure, ordering, and safety instincts are sound,
+and the upstream `renderForHtml` dependency is in good shape — the #562 fixes all landed.
+Once 1, 2, and 3 are settled I'd hand this to an executing agent without further changes.
+
+The `account` gap remains the one thing that needs *your* call rather than a fix: v1 ships
+folder scoping as advisory on a multi-account machine, and the spec argued that had to be
+real. You have one account, so it's latent — but the guide shouldn't promise what the code
+doesn't deliver.

--- a/docs/superpowers/plans/2026-07-17-std-notes-apple.md
+++ b/docs/superpowers/plans/2026-07-17-std-notes-apple.md
@@ -1,0 +1,1783 @@
+# std::notes/apple Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `std::notes/apple` stdlib module letting Agency agents create, append to, read, search, list, and delete Apple Notes, gated by interrupts and scopable by folder and account.
+
+**Architecture:** An Agency module (`stdlib/notes/apple.agency`) holds the types, effects, interrupt gates, and markdown-to-HTML conversion. A TypeScript helper (`lib/stdlib/appleNotes.ts`) does nothing but talk to Notes.app: it builds AppleScript with data passed as `argv`, runs it through `osascript`, maps errors, and parses results. All of the safety reasoning lives in the `.agency` file where a reader can see it; the `.ts` file is a driver.
+
+**Tech Stack:** TypeScript, `child_process.execFile`, AppleScript via `osascript`, vitest, Agency stdlib conventions.
+
+**Design spec:** `/Users/adityabhargava/agency-lang/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md`
+
+Read the spec before starting. This plan implements it and does not re-argue it. Where a step looks arbitrary, the spec section is cited and explains why.
+
+---
+
+## Global Constraints
+
+These apply to every task. They are not style preferences; most of them are findings that cost a live spike to establish.
+
+- **macOS only.** Every entry point checks `process.platform !== "darwin"` and throws immediately. Precedent: `lib/stdlib/imessage.ts:21`.
+- **Never interpolate data into AppleScript source.** Titles, bodies, queries, and folder names are model-authored and may have been influenced by a page the model read. Pass them as `argv`. Spec §3.6.
+- **No `-` separator before argv.** `osascript -e SCRIPT a b`, NOT `osascript -e SCRIPT - a b`. The `-` is passed through as `item 1 of argv` and shifts every real argument. Verified on macOS 14.7.4. Spec §3.6.
+- **Never chain a property read through `container`.** `name of container of n` errors `-1728` on every note. Use `set c to container of n` then `name of c`. Spec §9.2.
+- **Search `plaintext`, never `body`.** `body` is HTML, so searching it matches markup: a user searching `div` would match every note they own. Spec §9.3.
+- **Unit tests only. No integration tests.** Owner decision. A test that reaches real Notes.app can destroy real notes when someone runs the suite locally. No tests in `tests/agency/` for this module — those execute the real stdlib and would shell to `osascript` for real. Spec §8.
+- **Every script wraps its body in `with timeout of 30 seconds`.** Otherwise it inherits AppleScript's 120-second default. Spec §6.1.
+- **Timeout constant:** `NOTES_TIMEOUT_SECONDS = 30`, module-level, in `appleNotes.ts`.
+- **Field delimiter for multi-field returns:** `ASCII character 1` (``). Not tab — note titles can legally contain tabs.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `packages/agency-lang/lib/stdlib/appleNotes.ts` | Create. Talks to Notes.app. Script construction, `osascript` invocation, error mapping, result parsing. No policy, no gating. |
+| `packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts` | Create. Unit tests, `execFile` mocked. |
+| `packages/agency-lang/stdlib/notes/apple.agency` | Create. Types, effects, interrupt gates, markdown conversion, docstrings. |
+| `packages/agency-lang/stdlib/capabilities.agency` | Modify. Add `NotesRead`, `NotesWrite`, `Notes` effect sets. |
+| `packages/agency-lang/docs/site/guide/apple-notes.md` | Create. Guide page, incl. the Obsidian `std::fs` answer (spec §3.1). |
+
+No registry to update: `agency doc stdlib` recurses, and `stdlib/messaging/` proves nested modules are auto-discovered. Nested `.agency` imports flat `.ts` unchanged (`stdlib/messaging/sms.agency:1`).
+
+---
+
+## Known limitation to record, not solve
+
+**Nested folders.** Notes folders can contain folders. This module addresses folders by name in one account and derives a note's account by walking `container` upward. Deeply nested folders with duplicate names are not addressable. Out of scope; the spec's §10 already scopes folders to name-addressing. Do not add nesting support in this plan.
+
+---
+
+## Task 1: The script runner and error mapping
+
+Everything else calls this. It is the only place `osascript` is invoked.
+
+**Files:**
+- Create: `packages/agency-lang/lib/stdlib/appleNotes.ts`
+- Test: `packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `runNotesScript(script: string, args: string[]): Promise<string>` — internal, not exported from the module's public surface but exported for tests.
+  - `NOTES_TIMEOUT_SECONDS: number`
+  - `withTimeout(body: string): string` — wraps an AppleScript body in a timeout block.
+  - `FIELD_DELIM: string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout: "", stderr: "" });
+    },
+  ),
+}));
+
+import { execFile } from "child_process";
+import { runNotesScript, withTimeout, FIELD_DELIM } from "../appleNotes.js";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+/** Make the mocked execFile fail with the given stderr, as osascript does. */
+function mockFailure(stderr: string): void {
+  (execFile as unknown as MockFn).mockImplementationOnce(
+    (_c: string, _a: string[], cb: (e: unknown) => void) => {
+      cb({ stderr, code: 1 });
+    },
+  );
+}
+
+/** Make the mocked execFile succeed with the given stdout. */
+function mockStdout(stdout: string): void {
+  (execFile as unknown as MockFn).mockImplementationOnce(
+    (
+      _c: string,
+      _a: string[],
+      cb: (e: null, r: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout, stderr: "" });
+    },
+  );
+}
+
+describe("runNotesScript", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("rejects immediately on a non-darwin platform", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+    await expect(runNotesScript("script", [])).rejects.toThrow(
+      "Apple Notes is only available on macOS",
+    );
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("passes args straight through to argv with NO '-' separator", async () => {
+    mockStdout("ok");
+    await runNotesScript("SCRIPT", ["alpha", "beta"]);
+    const [cmd, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(cmd).toBe("osascript");
+    // The `-` is NOT a separator: osascript passes it through as argv item 1
+    // and shifts every real argument. Spec section 3.6.
+    expect(args).toEqual(["-e", "SCRIPT", "alpha", "beta"]);
+  });
+
+  it("keeps a hostile title inert in argv rather than in the script", async () => {
+    mockStdout("ok");
+    const hostile = '"; do shell script "rm -rf ~"; "';
+    await runNotesScript("SCRIPT", [hostile]);
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).toBe("SCRIPT");
+    expect(args[2]).toBe(hostile);
+    expect(args[1]).not.toContain("do shell script");
+  });
+
+  it("maps -1743 to a clear not-authorized error", async () => {
+    mockFailure("execution error: Not authorized to send Apple events to Notes. (-1743)");
+    await expect(runNotesScript("s", [])).rejects.toThrow(/Not authorized to control Notes/);
+    await expect(runNotesScript("s", [])).rejects.toThrow(/Privacy & Security/);
+  });
+
+  it("maps -1712 to a hedged timeout error", async () => {
+    mockFailure("execution error: Notes got an error: AppleEvent timed out. (-1712)");
+    // -1712 cannot distinguish "consent dialog unanswered" from "Notes wedged",
+    // so the message must hedge. Spec section 2.8.
+    await expect(runNotesScript("s", [])).rejects.toThrow(/usually means/);
+  });
+
+  it("surfaces an unrecognised stderr rather than swallowing it", async () => {
+    mockFailure("execution error: something else entirely (-9999)");
+    await expect(runNotesScript("s", [])).rejects.toThrow(/something else entirely/);
+  });
+
+  it("trims stdout", async () => {
+    mockStdout("  value  \n");
+    await expect(runNotesScript("s", [])).resolves.toBe("value");
+  });
+});
+
+describe("withTimeout", () => {
+  it("wraps the body so the 120s AppleScript default is not inherited", () => {
+    const out = withTimeout("tell application \"Notes\"\nend tell");
+    expect(out).toContain("with timeout of 30 seconds");
+    expect(out).toContain("end timeout");
+    expect(out).toContain("on run argv");
+    expect(out).toContain("end run");
+  });
+});
+
+describe("FIELD_DELIM", () => {
+  it("is a control character, because titles can contain tabs", () => {
+    expect(FIELD_DELIM).toBe("");
+    expect(FIELD_DELIM).not.toBe("\t");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: FAIL — `Failed to resolve import "../appleNotes.js"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/agency-lang/lib/stdlib/appleNotes.ts`:
+
+```ts
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/** Our own bound on the wait. Without it, AppleScript's 120-second default
+ *  applies, which is indistinguishable from a hang for an agent tool call.
+ *  A spike confirmed `with timeout` does shorten the TCC consent wait. */
+export const NOTES_TIMEOUT_SECONDS = 30;
+
+/** Separator for multi-field script returns. Not a tab: note titles can
+ *  legally contain tabs, and a title with one would corrupt the parse. */
+export const FIELD_DELIM = "";
+
+/** Wrap an AppleScript body in the argv handler and our own timeout. */
+export function withTimeout(body: string): string {
+  return `on run argv
+  with timeout of ${NOTES_TIMEOUT_SECONDS} seconds
+${body}
+  end timeout
+end run`;
+}
+
+/** Run an AppleScript against Notes, passing data as argv.
+ *
+ *  Data NEVER goes into the script source. Titles and bodies are
+ *  model-authored, and the model may have been influenced by a page it read,
+ *  so interpolating them would be an injection path. argv values are not
+ *  parsed as AppleScript. */
+export async function runNotesScript(script: string, args: string[]): Promise<string> {
+  if (process.platform !== "darwin") {
+    throw new Error("Apple Notes is only available on macOS.");
+  }
+
+  try {
+    // No "-" before args: osascript passes it through as argv item 1 and
+    // shifts every real argument by one.
+    const { stdout } = await execFileAsync("osascript", ["-e", script, ...args]);
+    return stdout.trim();
+  } catch (error: unknown) {
+    const err = error as { stderr?: string; code?: number };
+    const stderr = err.stderr?.trim() ?? "";
+
+    // -1743 is unambiguous: no grant, or it was denied, and no dialog pending.
+    if (stderr.includes("-1743")) {
+      throw new Error(
+        "Not authorized to control Notes. Grant permission in " +
+          "System Settings → Privacy & Security → Automation.",
+      );
+    }
+
+    // -1712 is ambiguous: it covers an unanswered consent dialog, a busy
+    // Notes, and a wedged Notes. The message hedges on purpose — claiming
+    // otherwise sends people to fix a permission that was never the problem.
+    if (stderr.includes("-1712")) {
+      throw new Error(
+        `Notes did not respond within ${NOTES_TIMEOUT_SECONDS}s. This usually ` +
+          "means macOS automation permission was not granted. Check " +
+          "System Settings → Privacy & Security → Automation.",
+      );
+    }
+
+    throw new Error(`Notes command failed: ${stderr || `exit code ${err.code ?? "unknown"}`}`);
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Prove the injection test is load-bearing**
+
+Temporarily break the argv contract by interpolating instead:
+
+```ts
+// in runNotesScript, temporarily:
+const { stdout } = await execFileAsync("osascript", ["-e", script + args.join(" ")]);
+```
+
+Run the tests. Expected: the "keeps a hostile title inert" and "passes args straight through" tests FAIL. Then revert.
+
+This matters because a green suite proves nothing on its own — the review of #562 found five real bugs under a fully green suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agency-lang/lib/stdlib/appleNotes.ts packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts
+git commit -m "Add the Apple Notes script runner and error mapping
+
+Data goes to osascript as argv, never interpolated into script source:
+titles and bodies are model-authored. No '-' separator, which would land
+as argv item 1 and shift every real argument.
+
+Maps both permission errors. -1743 is unambiguous so its message is
+direct; -1712 covers an unanswered dialog, a busy Notes, and a wedged
+Notes, so it hedges."
+```
+
+---
+
+## Task 2: The pre-flight lookup and the locked-note guard
+
+The security core. Everything that touches an existing note goes through this.
+
+**Files:**
+- Modify: `packages/agency-lang/lib/stdlib/appleNotes.ts`
+- Test: `packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts`
+
+**Interfaces:**
+- Consumes: `runNotesScript`, `withTimeout`, `FIELD_DELIM` from Task 1.
+- Produces:
+  - `type NotePreflight = { id: string; title: string; folder: string; account: string; locked: boolean }`
+  - `_preflightNote(id: string): Promise<NotePreflight>`
+  - `assertNotLocked(p: NotePreflight): void`
+
+**Why this exists (spec §5.3):** the interrupt payload must carry `folder`, `title`, and `account`, because those are what policy globs match on. So we must read them before raising the interrupt, which means this one query is not itself gated. That is acceptable, but the reasoning is narrow and belongs in the source: **an id is unguessable.** It is an opaque `x-coredata://` URI that cannot be enumerated or constructed, so whoever holds one already learned it somewhere, and this lookup discloses only the title and folder they could already name. Do not write "unreachable without a gate" — that claim is false (ids are stable and survive checkpoints) and it would license adding a fourth property to this query.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts`:
+
+```ts
+import { _preflightNote, assertNotLocked } from "../appleNotes.js";
+
+describe("_preflightNote", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("never chains a property read through container", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    const script = args[1];
+    // `name of container of n` errors -1728 on EVERY note, locked or not.
+    // Spec section 9.2. This test exists so a "tidying" refactor cannot
+    // silently reintroduce the chained form.
+    expect(script).not.toContain("name of container of n");
+    expect(script).toContain("set c to container of n");
+  });
+
+  it("reads only title, folder, account and the locked flag — never the body", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    const script = args[1];
+    // This query is not interrupt-gated, so it must never touch content.
+    expect(script).not.toContain("body of");
+    expect(script).not.toContain("plaintext of");
+  });
+
+  it("passes the id as argv, not in the script", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[2]).toBe("x-coredata://note/1");
+    expect(args[1]).not.toContain("x-coredata://note/1");
+  });
+
+  it("parses the delimited fields", async () => {
+    mockStdout(["Q3 Planning", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    const p = await _preflightNote("x-coredata://note/1");
+    expect(p).toEqual({
+      id: "x-coredata://note/1",
+      title: "Q3 Planning",
+      folder: "Work",
+      account: "iCloud",
+      locked: false,
+    });
+  });
+
+  it("parses a title containing a tab, which the delimiter must survive", async () => {
+    mockStdout(["a\tb", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    const p = await _preflightNote("x-coredata://note/1");
+    expect(p.title).toBe("a\tb");
+    expect(p.folder).toBe("Work");
+  });
+
+  it("reads the locked flag as true", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    const p = await _preflightNote("x-coredata://note/1");
+    expect(p.locked).toBe(true);
+  });
+
+  it("fails on a malformed reply rather than guessing", async () => {
+    mockStdout("only one field");
+    await expect(_preflightNote("x-coredata://note/1")).rejects.toThrow(/unexpected reply/i);
+  });
+});
+
+describe("assertNotLocked", () => {
+  const base = {
+    id: "x-coredata://note/1",
+    title: "Q3 Planning",
+    folder: "Work",
+    account: "iCloud",
+  };
+
+  it("passes an unlocked note through", () => {
+    expect(() => assertNotLocked({ ...base, locked: false })).not.toThrow();
+  });
+
+  // THIS IS DATA-LOSS PREVENTION, NOT A NICE ERROR MESSAGE.
+  // A locked note's body reads as an EMPTY STRING rather than erroring, so an
+  // append that skipped this guard would run `set body of n to "" & newText`
+  // and replace the note's contents with the appended text. Spec section 2.7.
+  // If this test is failing, do not delete it. The guard is why locked notes
+  // survive.
+  it("refuses a locked note and names it", () => {
+    expect(() => assertNotLocked({ ...base, locked: true })).toThrow(/Q3 Planning/);
+    expect(() => assertNotLocked({ ...base, locked: true })).toThrow(/locked/i);
+    expect(() => assertNotLocked({ ...base, locked: true })).toThrow(/Unlock it in Notes\.app/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: FAIL — `_preflightNote` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `packages/agency-lang/lib/stdlib/appleNotes.ts`:
+
+```ts
+/** A note's metadata, read before the interrupt so the payload can carry it. */
+export type NotePreflight = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  locked: boolean;
+};
+
+// `set c to container of n` is split on purpose. `name of container of n` in one
+// expression errors -1712... no: -1728, on EVERY note, locked or unlocked. The
+// property is fine; chaining a read through it is not. Spec section 9.2.
+//
+// The account is the folder's container. Deeply nested folders are out of
+// scope (see the plan's "Known limitation"), so one hop up is enough.
+const PREFLIGHT_SCRIPT = withTimeout(`    tell application "Notes"
+      set n to note id (item 1 of argv)
+      set c to container of n
+      set a to container of c
+      set d to (ASCII character 1)
+      return (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((password protected of n) as text)
+    end tell`);
+
+/** Read a note's metadata: title, folder, account, locked flag.
+ *
+ *  This query is NOT interrupt-gated, because the interrupt payload needs its
+ *  results in order to exist. That is acceptable for a narrow reason worth
+ *  keeping precise: a note id is unguessable. It is an opaque x-coredata://
+ *  URI that cannot be enumerated or constructed, so anyone holding one already
+ *  learned it somewhere, and this discloses only the title and folder that
+ *  whoever handed them the id could already name.
+ *
+ *  It is NOT true that an id can only come from a gated call — ids are stable
+ *  and can arrive from a user message, a file, or a restored checkpoint. Do not
+ *  widen this query on the strength of that weaker claim. It reads three
+ *  properties and no content, and it should stay that way. */
+export async function _preflightNote(id: string): Promise<NotePreflight> {
+  const raw = await runNotesScript(PREFLIGHT_SCRIPT, [id]);
+  const parts = raw.split(FIELD_DELIM);
+  if (parts.length !== 4) {
+    throw new Error(`Notes returned an unexpected reply for note ${id}.`);
+  }
+  return {
+    id,
+    title: parts[0],
+    folder: parts[1],
+    account: parts[2],
+    locked: parts[3].trim() === "true",
+  };
+}
+
+/** Refuse a locked note.
+ *
+ *  This is DATA-LOSS PREVENTION, not a friendlier error. A locked note's body
+ *  reads as an empty string rather than erroring, so an append that skipped
+ *  this guard would run `set body of n to "" & newText` and replace the note's
+ *  contents with the appended text. Spec section 2.7.
+ *
+ *  Never skip this, never reorder it after a body read, and never remove it as
+ *  apparently-dead code. */
+export function assertNotLocked(p: NotePreflight): void {
+  if (p.locked) {
+    throw new Error(`Note "${p.title}" is locked. Unlock it in Notes.app and retry.`);
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: PASS, 17 tests.
+
+- [ ] **Step 5: Fix the comment typo introduced above**
+
+The comment above `PREFLIGHT_SCRIPT` says "-1712... no: -1728". Clean it to read:
+
+```ts
+// `set c to container of n` is split on purpose. `name of container of n` in one
+// expression errors -1728 on EVERY note, locked or unlocked. The property is
+// fine; chaining a read through it is not. Spec section 9.2.
+```
+
+Run the tests again to confirm still PASS, 17 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agency-lang/lib/stdlib/appleNotes.ts packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts
+git commit -m "Add the Notes pre-flight lookup and the locked-note guard
+
+The pre-flight reads title, folder, account and the locked flag, and no
+content. It is not interrupt-gated because the payload needs its results
+to exist; that is acceptable because an id is unguessable, not because
+ids only come from gated calls.
+
+The container access is split. Chaining a read through container errors
+-1728 on every note.
+
+The locked guard is data-loss prevention: a locked note's body reads as
+an empty string, so an append past this guard would replace the note's
+contents with the appended text."
+```
+
+---
+
+## Task 3: The read operations
+
+**Files:**
+- Modify: `packages/agency-lang/lib/stdlib/appleNotes.ts`
+- Test: `packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts`
+
+**Interfaces:**
+- Consumes: `runNotesScript`, `withTimeout`, `FIELD_DELIM`, `_preflightNote`, `assertNotLocked`.
+- Produces:
+  - `type NoteMeta = { id: string; title: string; folder: string; account: string; modified: string; passwordProtected: boolean }`
+  - `type NoteContentTs = { id: string; title: string; folder: string; account: string; body: string; modified: string }`
+  - `type FolderMeta = { id: string; name: string; noteCount: number }`
+  - `_readNote(id: string, folder?: string): Promise<NoteContentTs>`
+  - `_listNotes(folder?: string): Promise<NoteMeta[]>`
+  - `_searchNotes(query: string, folder?: string): Promise<NoteMeta[]>`
+  - `_listFolders(): Promise<FolderMeta[]>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the test file:
+
+```ts
+import { _readNote, _listNotes, _searchNotes, _listFolders } from "../appleNotes.js";
+
+describe("_readNote", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("returns plaintext, not HTML", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM)); // preflight
+    mockStdout(["plain body text", "2026-07-17"].join(FIELD_DELIM)); // read
+    const n = await _readNote("x-coredata://note/1");
+    expect(n.body).toBe("plain body text");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // body is HTML and would waste tokens and read badly. Spec section 2.4.
+    expect(args[1]).toContain("plaintext of");
+    expect(args[1]).not.toContain("body of");
+  });
+
+  it("refuses a locked note before reading anything", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    await expect(_readNote("x-coredata://note/1")).rejects.toThrow(/locked/i);
+    // Only the preflight ran. No content read was attempted.
+    expect((execFile as unknown as MockFn).mock.calls.length).toBe(1);
+  });
+
+  it("fails closed when the folder assertion does not match", async () => {
+    mockStdout(["Q3", "Personal", "iCloud", "false"].join(FIELD_DELIM));
+    await expect(_readNote("x-coredata://note/1", "Work")).rejects.toThrow(/Work/);
+    await expect(_readNote("x-coredata://note/1", "Work")).rejects.toThrow(/Personal/);
+  });
+
+  it("passes the assertion when the folder matches", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["body", "2026-07-17"].join(FIELD_DELIM));
+    await expect(_readNote("x-coredata://note/1", "Work")).resolves.toMatchObject({
+      folder: "Work",
+    });
+  });
+});
+
+describe("_searchNotes", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("searches plaintext, never body", async () => {
+    mockStdout("");
+    await _searchNotes("budget");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // body is HTML: searching it matches markup, so `div` would match every
+    // note the user owns. Spec section 9.3.
+    expect(args[1]).toContain("plaintext contains");
+    expect(args[1]).not.toContain("body contains");
+  });
+
+  it("passes the query as argv, not in the script", async () => {
+    mockStdout("");
+    await _searchNotes('"; do shell script "x"; "');
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).not.toContain("do shell script");
+    expect(args[2]).toBe('"; do shell script "x"; "');
+  });
+
+  it("returns an empty array for no matches rather than throwing", async () => {
+    mockStdout("");
+    await expect(_searchNotes("nothing")).resolves.toEqual([]);
+  });
+
+  it("parses multiple rows", async () => {
+    const row1 = ["id1", "One", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM);
+    const row2 = ["id2", "Two", "Work", "iCloud", "2026-07-16", "false"].join(FIELD_DELIM);
+    mockStdout(`${row1}\n${row2}`);
+    const notes = await _searchNotes("x");
+    expect(notes).toHaveLength(2);
+    expect(notes[0].title).toBe("One");
+    expect(notes[1].id).toBe("id2");
+  });
+
+  it("never returns a body", async () => {
+    const row = ["id1", "One", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM);
+    mockStdout(row);
+    const notes = await _searchNotes("x");
+    expect(notes[0]).not.toHaveProperty("body");
+  });
+});
+
+describe("_listFolders", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("returns folders with their note counts", async () => {
+    const row1 = ["fid1", "Work", "12"].join(FIELD_DELIM);
+    const row2 = ["fid2", "Recently Deleted", "3"].join(FIELD_DELIM);
+    mockStdout(`${row1}\n${row2}`);
+    const folders = await _listFolders();
+    expect(folders).toEqual([
+      { id: "fid1", name: "Work", noteCount: 12 },
+      // "Recently Deleted" is a real folder and is returned. deleteNote moves
+      // notes into it. Spec section 9.2.
+      { id: "fid2", name: "Recently Deleted", noteCount: 3 },
+    ]);
+  });
+
+  it("returns an empty array rather than throwing when there are none", async () => {
+    mockStdout("");
+    await expect(_listFolders()).resolves.toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: FAIL — `_readNote` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `packages/agency-lang/lib/stdlib/appleNotes.ts`:
+
+```ts
+/** Note metadata. Deliberately carries no body. */
+export type NoteMeta = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  modified: string;
+  passwordProtected: boolean;
+};
+
+/** A note including its content, as plaintext. */
+export type NoteContentTs = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  body: string;
+  modified: string;
+};
+
+/** A folder. `noteCount` is derived, not a property. */
+export type FolderMeta = {
+  id: string;
+  name: string;
+  noteCount: number;
+};
+
+/** Assert a note is in the folder the caller named. Fails closed.
+ *
+ *  This is the read-path assertion. The write path uses a scoped lookup
+ *  instead, which is stronger — see _appendToNote. */
+function assertFolder(p: NotePreflight, folder?: string): void {
+  if (folder != null && p.folder !== folder) {
+    throw new Error(
+      `Note "${p.title}" is in folder "${p.folder}", not "${folder}". Refusing.`,
+    );
+  }
+}
+
+// Reads `plaintext`, never `body`. body is HTML: it would waste tokens and read
+// badly for a model. Spec section 2.4.
+const READ_SCRIPT = withTimeout(`    tell application "Notes"
+      set n to note id (item 1 of argv)
+      set d to (ASCII character 1)
+      return (plaintext of n) & d & ((modification date of n) as text)
+    end tell`);
+
+export async function _readNote(id: string, folder?: string): Promise<NoteContentTs> {
+  const p = await _preflightNote(id);
+  assertFolder(p, folder);
+  assertNotLocked(p);
+
+  const raw = await runNotesScript(READ_SCRIPT, [id]);
+  const parts = raw.split(FIELD_DELIM);
+  if (parts.length !== 2) {
+    throw new Error(`Notes returned an unexpected reply for note ${id}.`);
+  }
+  return {
+    id,
+    title: p.title,
+    folder: p.folder,
+    account: p.account,
+    body: parts[0],
+    modified: parts[1],
+  };
+}
+
+/** Parse the delimited note rows a list/search script returns. */
+function parseNoteRows(raw: string): NoteMeta[] {
+  if (raw.length === 0) return [];
+  return raw.split("\n").filter((l) => l.length > 0).map((line) => {
+    const f = line.split(FIELD_DELIM);
+    if (f.length !== 6) {
+      throw new Error("Notes returned an unexpected row while listing notes.");
+    }
+    return {
+      id: f[0],
+      title: f[1],
+      folder: f[2],
+      account: f[3],
+      modified: f[4],
+      passwordProtected: f[5].trim() === "true",
+    };
+  });
+}
+
+// The container access is split here too. Spec section 9.2.
+const NOTE_ROW = `set c to container of n
+        set a to container of c
+        set out to out & (id of n) & d & (name of n) & d & (name of c) & d & ¬
+                  (name of a) & d & ((modification date of n) as text) & d & ¬
+                  ((password protected of n) as text) & linefeed`;
+
+const LIST_ALL_SCRIPT = withTimeout(`    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in notes
+        ${NOTE_ROW}
+      end repeat
+      return out
+    end tell`);
+
+const LIST_IN_FOLDER_SCRIPT = withTimeout(`    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes of folder (item 1 of argv))
+        ${NOTE_ROW}
+      end repeat
+      return out
+    end tell`);
+
+export async function _listNotes(folder?: string): Promise<NoteMeta[]> {
+  const raw = folder == null
+    ? await runNotesScript(LIST_ALL_SCRIPT, [])
+    : await runNotesScript(LIST_IN_FOLDER_SCRIPT, [folder]);
+  return parseNoteRows(raw);
+}
+
+// `plaintext contains`, never `body contains`. body is HTML, so searching it
+// matches markup: a user searching "div" would match every note they own.
+// Spec section 9.3.
+const SEARCH_ALL_SCRIPT = withTimeout(`    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes whose plaintext contains (item 1 of argv))
+        ${NOTE_ROW}
+      end repeat
+      return out
+    end tell`);
+
+const SEARCH_IN_FOLDER_SCRIPT = withTimeout(`    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes of folder (item 2 of argv) whose plaintext contains (item 1 of argv))
+        ${NOTE_ROW}
+      end repeat
+      return out
+    end tell`);
+
+export async function _searchNotes(query: string, folder?: string): Promise<NoteMeta[]> {
+  const raw = folder == null
+    ? await runNotesScript(SEARCH_ALL_SCRIPT, [query])
+    : await runNotesScript(SEARCH_IN_FOLDER_SCRIPT, [query, folder]);
+  return parseNoteRows(raw);
+}
+
+// noteCount is derived with `count of notes`, because folder has no such
+// property. That is a query per folder, so listFolders pays for it.
+const LIST_FOLDERS_SCRIPT = withTimeout(`    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with f in folders
+        set out to out & (id of f) & d & (name of f) & d & ¬
+                  ((count of notes of f) as text) & linefeed
+      end repeat
+      return out
+    end tell`);
+
+export async function _listFolders(): Promise<FolderMeta[]> {
+  const raw = await runNotesScript(LIST_FOLDERS_SCRIPT, []);
+  if (raw.length === 0) return [];
+  return raw.split("\n").filter((l) => l.length > 0).map((line) => {
+    const f = line.split(FIELD_DELIM);
+    if (f.length !== 3) {
+      throw new Error("Notes returned an unexpected row while listing folders.");
+    }
+    return { id: f[0], name: f[1], noteCount: Number(f[2]) };
+  });
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: PASS, 29 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agency-lang/lib/stdlib/appleNotes.ts packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts
+git commit -m "Add the Notes read operations
+
+readNote returns plaintext, not body: body is HTML and would waste
+tokens. searchNotes filters on plaintext for the same reason, plus a
+sharper one — searching HTML matches markup, so a query for 'div' would
+match every note the user owns.
+
+List and search return metadata only. No body crosses that boundary, and
+a test pins it."
+```
+
+---
+
+## Task 4: The write operations
+
+**Files:**
+- Modify: `packages/agency-lang/lib/stdlib/appleNotes.ts`
+- Test: `packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+- Produces:
+  - `_folderExists(folder: string): Promise<boolean>`
+  - `_createNote(title: string, html: string, folder: string): Promise<NoteMeta>`
+  - `_appendToNote(id: string, html: string, folder?: string): Promise<NoteMeta>`
+  - `_deleteNote(id: string, folder?: string): Promise<null>`
+
+**The assertion in the write path is different from the read path, on purpose (spec §6.4).** The read path reads the container and compares. The write path instead addresses the note *through* the folder: `note id X of folder Y`. If the note is not in Y, the lookup fails. This collapses the check and the access into one operation, so they cannot drift apart across the human approval that sits between the pre-flight and the write. Verified to fail closed on the wrong folder.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the test file:
+
+```ts
+import { _folderExists, _createNote, _appendToNote, _deleteNote } from "../appleNotes.js";
+
+describe("_createNote", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("passes title, html and folder as argv, never in the script", async () => {
+    mockStdout(["nid", "T", "Agency Notes", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _createNote('"; do shell script "x"; "', "<p>b</p>", "Agency Notes");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).not.toContain("do shell script");
+    expect(args[2]).toBe('"; do shell script "x"; "');
+    expect(args[3]).toBe("<p>b</p>");
+    expect(args[4]).toBe("Agency Notes");
+  });
+
+  it("creates the folder if it is missing", async () => {
+    mockStdout(["nid", "T", "Agency Notes", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _createNote("T", "<p>b</p>", "Agency Notes");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // "Agency Notes" will not exist on a fresh machine. Spec section 9.4.
+    expect(args[1]).toContain("make new folder");
+  });
+
+  it("returns the new note's metadata including its id", async () => {
+    mockStdout(["nid", "T", "Agency Notes", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    const n = await _createNote("T", "<p>b</p>", "Agency Notes");
+    // Returning the id means create-then-append needs no search.
+    expect(n.id).toBe("nid");
+    expect(n.title).toBe("T");
+  });
+});
+
+describe("_appendToNote", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  // See spec section 2.7. A locked note's body reads as "", so this append
+  // would REPLACE the note's contents. Do not delete this test.
+  it("refuses a locked note and never issues a write", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    await expect(_appendToNote("x-coredata://note/1", "<p>x</p>")).rejects.toThrow(/locked/i);
+    expect((execFile as unknown as MockFn).mock.calls.length).toBe(1);
+  });
+
+  it("re-checks the locked flag inside the write script", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // The pre-flight check is separated from the write by a human approval,
+    // so it is check-then-act. The write script re-checks. Spec section 6.4.
+    expect(args[1]).toContain("password protected");
+  });
+
+  it("uses a scoped lookup as the assertion when a folder is given", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>", "Work");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // The scoped lookup IS the assertion: it fails if the note is not in the
+    // folder, so the check cannot drift from the access. Spec section 6.4.
+    expect(args[1]).toContain("of folder (item 3 of argv)");
+  });
+
+  it("uses an unscoped lookup when no folder is given", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    expect(args[1]).not.toContain("of folder (item 3 of argv)");
+  });
+
+  it("appends rather than replacing", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    expect(args[1]).toContain("(body of n) &");
+  });
+});
+
+describe("_deleteNote", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("refuses a locked note", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    await expect(_deleteNote("x-coredata://note/1")).rejects.toThrow(/locked/i);
+    expect((execFile as unknown as MockFn).mock.calls.length).toBe(1);
+  });
+
+  it("deletes an unlocked note", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout("");
+    await expect(_deleteNote("x-coredata://note/1")).resolves.toBeNull();
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    expect(args[1]).toContain("delete n");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: FAIL — `_createNote` is not exported.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `packages/agency-lang/lib/stdlib/appleNotes.ts`:
+
+```ts
+const FOLDER_EXISTS_SCRIPT = withTimeout(`    tell application "Notes"
+      return (exists folder (item 1 of argv)) as text
+    end tell`);
+
+export async function _folderExists(folder: string): Promise<boolean> {
+  const raw = await runNotesScript(FOLDER_EXISTS_SCRIPT, [folder]);
+  return raw.trim() === "true";
+}
+
+// "Agency Notes" is our own default and will not exist on a fresh machine, so
+// create it on demand. Spec section 9.4. The interrupt payload carries
+// folderCreated so a human or policy sees the folder being made.
+const CREATE_SCRIPT = withTimeout(`    tell application "Notes"
+      if not (exists folder (item 3 of argv)) then
+        make new folder with properties {name:(item 3 of argv)}
+      end if
+      set f to folder (item 3 of argv)
+      set n to make new note at f with properties {name:(item 1 of argv), body:(item 2 of argv)}
+      set c to container of n
+      set a to container of c
+      set d to (ASCII character 1)
+      return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((modification date of n) as text) & d & ((password protected of n) as text)
+    end tell`);
+
+/** Create a note. `html` is HTML, already rendered — this layer does not know
+ *  about markdown. The Agency module does the conversion. */
+export async function _createNote(
+  title: string,
+  html: string,
+  folder: string,
+): Promise<NoteMeta> {
+  const raw = await runNotesScript(CREATE_SCRIPT, [title, html, folder]);
+  const rows = parseNoteRows(raw);
+  if (rows.length !== 1) {
+    throw new Error("Notes returned an unexpected reply while creating a note.");
+  }
+  return rows[0];
+}
+
+// Two shapes: scoped and unscoped. The scoped one addresses the note THROUGH
+// the folder, so the lookup failing IS the assertion failing. That is stronger
+// than read-then-compare, because the reference that gets mutated is the same
+// one that had to resolve inside the asserted folder — the check cannot drift
+// from the access across the human approval that precedes this. Spec 6.4.
+const APPEND_BODY = `      if (password protected of n) then error "note is locked"
+      set body of n to (body of n) & (item 2 of argv)
+      set c to container of n
+      set a to container of c
+      set d to (ASCII character 1)
+      return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((modification date of n) as text) & d & ((password protected of n) as text)`;
+
+const APPEND_SCOPED_SCRIPT = withTimeout(`    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 3 of argv)
+${APPEND_BODY}
+    end tell`);
+
+const APPEND_UNSCOPED_SCRIPT = withTimeout(`    tell application "Notes"
+      set n to note id (item 1 of argv)
+${APPEND_BODY}
+    end tell`);
+
+/** Append to a note. `html` is HTML, already rendered.
+ *
+ *  The locked check happens twice on purpose: once in the pre-flight so the
+ *  error is raised before the interrupt, and once inside the write script
+ *  because a human approval sits between them and the note can be locked in
+ *  that window. Spec section 2.7 explains why a missed check destroys data. */
+export async function _appendToNote(
+  id: string,
+  html: string,
+  folder?: string,
+): Promise<NoteMeta> {
+  const p = await _preflightNote(id);
+  assertFolder(p, folder);
+  assertNotLocked(p);
+
+  const raw = folder == null
+    ? await runNotesScript(APPEND_UNSCOPED_SCRIPT, [id, html])
+    : await runNotesScript(APPEND_SCOPED_SCRIPT, [id, html, folder]);
+
+  const rows = parseNoteRows(raw);
+  if (rows.length !== 1) {
+    throw new Error(`Notes returned an unexpected reply while appending to note ${id}.`);
+  }
+  return rows[0];
+}
+
+const DELETE_SCOPED_SCRIPT = withTimeout(`    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 2 of argv)
+      if (password protected of n) then error "note is locked"
+      delete n
+    end tell`);
+
+const DELETE_UNSCOPED_SCRIPT = withTimeout(`    tell application "Notes"
+      set n to note id (item 1 of argv)
+      if (password protected of n) then error "note is locked"
+      delete n
+    end tell`);
+
+/** Delete a note. It moves to Recently Deleted, where it stays ~30 days. */
+export async function _deleteNote(id: string, folder?: string): Promise<null> {
+  const p = await _preflightNote(id);
+  assertFolder(p, folder);
+  assertNotLocked(p);
+
+  if (folder == null) {
+    await runNotesScript(DELETE_UNSCOPED_SCRIPT, [id]);
+  } else {
+    await runNotesScript(DELETE_SCOPED_SCRIPT, [id, folder]);
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
+```
+Expected: PASS, 40 tests.
+
+- [ ] **Step 5: Prove the locked guard is load-bearing**
+
+Temporarily delete the `assertNotLocked(p);` line from `_appendToNote`. Run the tests.
+Expected: "refuses a locked note and never issues a write" FAILS. Restore the line.
+
+This guard is the only thing preventing a locked note from being destroyed. If a future refactor removes it, this test must be what stops the build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agency-lang/lib/stdlib/appleNotes.ts packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts
+git commit -m "Add the Notes write operations
+
+The write path asserts the folder by addressing the note THROUGH it
+(note id X of folder Y) rather than reading the container and comparing.
+The lookup failing is the assertion failing, so the check cannot drift
+from the access across the human approval that precedes the write.
+
+The locked check runs twice: in the pre-flight so the error precedes the
+interrupt, and inside the write script because the note can be locked
+during the approval. A missed check replaces the note's contents."
+```
+
+---
+
+## Task 5: The Agency module
+
+**Files:**
+- Create: `packages/agency-lang/stdlib/notes/apple.agency`
+- Modify: `packages/agency-lang/stdlib/capabilities.agency`
+
+**Interfaces:**
+- Consumes: every `_`-prefixed function from Tasks 1–4, plus `parse` and `renderForHtml` from `std::markdown`.
+- Produces: the public `std::notes/apple` surface.
+
+**Syntax rules (from CLAUDE.md — verify against `docs/site/guide/basic-syntax.md` if unsure):** functions are `def` with braces; `if` needs parens and braces; variables need `let`/`const`. Do not write Python-style colons.
+
+- [ ] **Step 1: Write the module**
+
+Create `packages/agency-lang/stdlib/notes/apple.agency`:
+
+```ts
+import {
+  _createNote,
+  _appendToNote,
+  _readNote,
+  _searchNotes,
+  _listNotes,
+  _listFolders,
+  _deleteNote,
+  _folderExists,
+} from "agency-lang/stdlib-lib/appleNotes.js"
+import { parse, renderForHtml } from "std::markdown"
+
+/** @module
+  Create, read, search, and edit notes in the macOS Notes app. macOS only, and
+  the first call asks for Automation permission.
+
+  ```ts
+  import { createNote } from "std::notes/apple"
+
+  node main() {
+    const result = createNote("Findings", "## Summary\n\n- one\n- two")
+    print(result)
+  }
+  ```
+
+  Notes are addressed by their opaque `id`, not by title, because two notes in
+  the same folder may share a title. Get ids from `listNotes` or `searchNotes`.
+
+  Every function takes an optional `folder`, which constrains rather than
+  addresses: if you pass it, the call fails unless the note is in that folder.
+  Combined with partial application, that confines an agent to one folder in a
+  way the model cannot see or route around:
+
+  ```ts
+  const inbox = createNote.partial(folder: "Agency Inbox").rename("addToInbox")
+  llm("Log your findings", { tools: [inbox] })
+  ```
+*/
+
+/** A folder in Notes. `noteCount` is derived, not stored. */
+export type Folder = {
+  id: string
+  name: string
+  noteCount: number
+}
+
+/** A note's metadata. Deliberately contains no body. */
+export type Note = {
+  id: string
+  title: string
+  folder: string
+  account: string
+  modified: string
+  passwordProtected: boolean
+}
+
+/** A note including its content, as plaintext. */
+export type NoteContent = {
+  id: string
+  title: string
+  folder: string
+  account: string
+  body: string
+  modified: string
+}
+
+effect std::notes::create { account: string, folder: string, title: string, folderCreated: boolean }
+effect std::notes::append { account: string, folder: string, title: string, id: string }
+effect std::notes::read   { account: string, folder: string, title: string, id: string }
+effect std::notes::search { account: string, folder: string, query: string }
+effect std::notes::list   { account: string, folder: string }
+effect std::notes::delete { account: string, folder: string, title: string, id: string }
+
+/** Convert markdown to the HTML that Notes requires on write. */
+def toHtml(body: string): Result<string> {
+  const parsed = parse(body)
+  if (!parsed.success) {
+    return failure("Could not parse the note body as Markdown: ${parsed.error}")
+  }
+  return success(renderForHtml(parsed.blocks))
+}
+
+export def createNote(title: string, body: string, folder: string = "Agency Notes"): Result<Note> raises <std::notes::create> {
+  """
+  Create a note in the Notes app and return it, including its new id.
+
+  @param title - The note's title
+  @param body - The note's content, as Markdown
+  @param folder - The folder to create it in. Created if it does not exist.
+  """
+  const html = toHtml(body)
+  if (isFailure(html)) {
+    return html
+  }
+
+  const exists = try _folderExists(folder)
+  if (isFailure(exists)) {
+    return exists
+  }
+
+  return interrupt std::notes::create("Create a note in the Notes app?", {
+    account: "",
+    folder: folder,
+    title: title,
+    folderCreated: !exists
+  })
+
+  destructive {
+    return try _createNote(title, html.value, folder)
+  }
+}
+
+export def appendToNote(id: string, body: string, folder?: string): Result<Note> raises <std::notes::append> {
+  """
+  Append Markdown to an existing note. Get the id from listNotes or searchNotes.
+
+  @param id - The note's id
+  @param body - The content to append, as Markdown
+  @param folder - If given, the call fails unless the note is in this folder
+  """
+  const html = toHtml(body)
+  if (isFailure(html)) {
+    return html
+  }
+
+  return interrupt std::notes::append("Append to a note in the Notes app?", {
+    account: "",
+    folder: if folder == null then "" else folder,
+    title: "",
+    id: id
+  })
+
+  destructive {
+    return try _appendToNote(id, html.value, folder)
+  }
+}
+
+export idempotent def readNote(id: string, folder?: string): Result<NoteContent> raises <std::notes::read> {
+  """
+  Read a note's contents as plain text. Get the id from listNotes or searchNotes.
+
+  @param id - The note's id
+  @param folder - If given, the call fails unless the note is in this folder
+  """
+  return interrupt std::notes::read("Read a note from the Notes app?", {
+    account: "",
+    folder: if folder == null then "" else folder,
+    title: "",
+    id: id
+  })
+
+  return try _readNote(id, folder)
+}
+
+export idempotent def searchNotes(query: string, folder?: string): Result<Note[]> raises <std::notes::search> {
+  """
+  Search notes by their text and return matching notes' metadata, without their
+  contents.
+
+  @param query - The text to search for
+  @param folder - If given, only search this folder
+  """
+  return interrupt std::notes::search("Search the notes in the Notes app?", {
+    account: "",
+    folder: if folder == null then "" else folder,
+    query: query
+  })
+
+  return try _searchNotes(query, folder)
+}
+
+export idempotent def listNotes(folder?: string): Result<Note[]> raises <std::notes::list> {
+  """
+  List notes' metadata, without their contents.
+
+  @param folder - If given, only list this folder
+  """
+  return interrupt std::notes::list("List the notes in the Notes app?", {
+    account: "",
+    folder: if folder == null then "" else folder
+  })
+
+  return try _listNotes(folder)
+}
+
+export idempotent def listFolders(): Result<Folder[]> raises <std::notes::list> {
+  """
+  List the folders in the Notes app, with a count of the notes in each.
+  """
+  return interrupt std::notes::list("List the folders in the Notes app?", {
+    account: "",
+    folder: ""
+  })
+
+  return try _listFolders()
+}
+
+export def deleteNote(id: string, folder?: string): Result<null> raises <std::notes::delete> {
+  """
+  Delete a note. It moves to the Recently Deleted folder, where it stays for
+  about 30 days.
+
+  @param id - The note's id
+  @param folder - If given, the call fails unless the note is in this folder
+  """
+  return interrupt std::notes::delete("Delete a note from the Notes app?", {
+    account: "",
+    folder: if folder == null then "" else folder,
+    title: "",
+    id: id
+  })
+
+  destructive {
+    return try _deleteNote(id, folder)
+  }
+}
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run:
+```bash
+cd packages/agency-lang && pnpm run ast stdlib/notes/apple.agency > /dev/null && echo PARSES
+```
+Expected: `PARSES`.
+
+If it fails, check `docs/site/guide/basic-syntax.md`. Known parser gotchas from the memory file: `!(...)` on a paren-expression fails to parse, and `thread` is a keyword. If `if ... then ... else` as an argument value fails, hoist it to a `const` first — `if` expressions are only allowed as a `const`/`let` value or a `return`.
+
+- [ ] **Step 3: Add the capability sets**
+
+Modify `packages/agency-lang/stdlib/capabilities.agency`, appending after the `Memory` set:
+
+```ts
+/** Read-only Notes access: reading, searching, and listing. */
+export effectSet NotesRead = <std::notes::read, std::notes::search, std::notes::list>
+
+/** Notes mutation: creating, appending, and deleting. */
+export effectSet NotesWrite = <std::notes::create, std::notes::append, std::notes::delete>
+
+/** All Notes access, reads and writes. */
+export effectSet Notes = <NotesRead, NotesWrite>
+```
+
+- [ ] **Step 4: Build**
+
+Run:
+```bash
+cd packages/agency-lang && make
+```
+Expected: exit 0. `make` is required for any stdlib change.
+
+- [ ] **Step 5: Verify the tool schema narrows under partial application**
+
+Create `/tmp/notes-check.agency` in the repo (NOT in /tmp — Agency needs node_modules):
+
+```ts
+import { createNote } from "std::notes/apple"
+
+node main() {
+  const inbox = createNote.partial(folder: "Agency Inbox").rename("addToInbox")
+  print("partial applied ok")
+}
+```
+
+Run:
+```bash
+cd packages/agency-lang && cp /tmp/notes-check.agency ./notes-check.agency && pnpm run agency notes-check.agency; rm -f notes-check.agency
+```
+Expected: `partial applied ok`. This exercises compilation and PFA without touching Notes.app.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agency-lang/stdlib/notes/apple.agency packages/agency-lang/stdlib/capabilities.agency packages/agency-lang/docs/site/stdlib/
+git commit -m "Add the std::notes/apple module and its capability sets
+
+Per-operation effects rather than one blanket std::notes, so a policy can
+approve reads and reject deletes. Payloads carry account, folder and
+title because those are what policy globs match on.
+
+Notes are addressed by id, since duplicate titles are legal. The optional
+folder argument constrains rather than addresses, so partial application
+confines an agent to one folder in a way the model cannot see."
+```
+
+---
+
+## Task 6: Documentation
+
+**Files:**
+- Create: `packages/agency-lang/docs/site/guide/apple-notes.md`
+
+The stdlib reference page is generated from the module's doc comments by `agency doc`, so it needs no hand-editing. This task adds the guide page, which the spec (§3.1) says is also where Obsidian users get their answer.
+
+- [ ] **Step 1: Write the guide page**
+
+Create `packages/agency-lang/docs/site/guide/apple-notes.md`:
+
+```markdown
+---
+name: Apple Notes
+description: Create, read, search, and edit notes in the macOS Notes app from Agency, and how to confine an agent to one folder.
+---
+
+# Apple Notes
+
+`std::notes/apple` lets an agent work with the macOS Notes app.
+
+```ts
+import { createNote } from "std::notes/apple"
+
+node main() {
+  const result = createNote("Findings", "## Summary\n\n- one\n- two")
+  print(result)
+}
+```
+
+macOS only. The first call asks for Automation permission, and macOS will show
+a dialog. If nobody answers it, the call fails after 30 seconds.
+
+## Notes are addressed by id
+
+Two notes in the same folder can share a title, so a title is not an address.
+Every read and edit takes the note's `id`, which you get from `listNotes` or
+`searchNotes`:
+
+```ts
+import { searchNotes, appendToNote } from "std::notes/apple"
+
+node main() {
+  const found = searchNotes("Q3 planning")
+  if (found is success(notes)) {
+    appendToNote(notes[0].id, "\n## Update\n\nShipped.")
+  }
+}
+```
+
+`createNote` returns the note it made, so create-then-append needs no search.
+
+## Bodies are Markdown going in, plain text coming out
+
+`createNote` and `appendToNote` take Markdown, which is converted to the HTML
+Notes stores. `readNote` returns plain text, not HTML, because HTML would waste
+tokens and read badly for a model.
+
+That makes a read-then-write round trip lossy: reading strips the formatting,
+and writing it back would flatten the note. Use `appendToNote` rather than
+reading, editing, and writing yourself.
+
+## Confining an agent to one folder
+
+Every function takes an optional `folder`. It constrains rather than addresses:
+if you pass it, the call fails unless the note is in that folder.
+
+Combined with [partial application](/guide/partial-application), that confines
+an agent in a way the model cannot see or route around, because the locked
+parameter is stripped from the tool's schema:
+
+```ts
+import { createNote, listNotes, readNote } from "std::notes/apple"
+
+node main() {
+  const reader = readNote.partial(folder: "Work").rename("readWorkNote")
+  const lister = listNotes.partial(folder: "Work").rename("listWorkNotes")
+  llm("Summarise my Work notes", { tools: [lister, reader] })
+}
+```
+
+The model may pass any id it likes. Anything outside Work fails closed.
+
+## Deciding with a policy
+
+Each operation raises its own [effect](/guide/effects), so a
+[policy](/guide/policies) can approve reads and reject deletes:
+
+```json
+{
+  "std::notes::read": [
+    { "match": { "folder": "Work" }, "action": "approve" },
+    { "action": "reject" }
+  ],
+  "std::notes::delete": [{ "action": "reject" }]
+}
+```
+
+Or constrain a whole node with the capability sets:
+
+```ts
+import { NotesRead } from "std::capabilities"
+
+// may read notes; may not write them
+node summarise() raises <NotesRead> {
+  // ...
+}
+```
+
+## Locked notes
+
+A note locked with a password cannot be read or edited, and this module will not
+try. AppleScript exposes no way to unlock a note, and the workarounds are worse
+than the problem. Calls against a locked note fail with a message naming it:
+
+```
+Note "Q3 Planning" is locked. Unlock it in Notes.app and retry.
+```
+
+## Deleting is recoverable
+
+`deleteNote` moves a note to Recently Deleted, where it stays for about 30 days.
+`listFolders` returns that folder like any other.
+
+## Other note apps
+
+**Obsidian needs no module.** An Obsidian vault is a directory of Markdown
+files, so [`std::fs`](/stdlib/fs) already does everything:
+
+```ts
+import { read, write } from "std::fs"
+
+const VAULT = "/Users/me/vault"
+
+node main() {
+  const existing = read("notes.md", VAULT)
+  if (existing is success(text)) {
+    write(filename: "notes.md", dir: VAULT, content: text + "\n\nAppended.")
+  }
+}
+```
+
+Because those are ordinary file operations, they raise `std::read` and
+`std::write`, so the same handlers, policies, and partial application work.
+
+**Bear** is not supported. It has an `x-callback-url` API, but a command-line
+process cannot receive the callback, so a create call could not return the id of
+the note it made.
+```
+
+- [ ] **Step 2: Build so the guide is staged into the stdlib**
+
+Run:
+```bash
+cd packages/agency-lang && make
+```
+Expected: exit 0. `make` copies `docs/site/guide` into `stdlib/docs/guide` for `std::skills::docsSkill`.
+
+- [ ] **Step 3: Verify the generated stdlib reference page exists**
+
+Run:
+```bash
+cd packages/agency-lang && ls docs/site/stdlib/notes/ && grep -c "createNote" docs/site/stdlib/notes/apple.md
+```
+Expected: `apple.md` listed, and a non-zero count. `agency doc` recurses, so no registry needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/agency-lang/docs/site/guide/apple-notes.md packages/agency-lang/stdlib/docs/ packages/agency-lang/docs/site/stdlib/
+git commit -m "Document std::notes/apple
+
+Adds the guide page. The stdlib reference page is generated from the
+module's doc comments.
+
+The guide also answers the Obsidian question, since a vault is Markdown
+files on disk and std::fs already covers it — which is why there is no
+std::notes/obsidian."
+```
+
+---
+
+## Task 7: Full verification
+
+**Files:** none. This task runs checks and fixes what they surface.
+
+- [ ] **Step 1: Run the full local check**
+
+Run:
+```bash
+cd packages/agency-lang && make && npx tsc --noEmit -p tsconfig.json && pnpm run lint:structure && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts lib/stdlib/__tests__/markdown.test.ts 2>&1 | tail -20
+```
+Expected: all exit 0; appleNotes 40 tests pass, markdown 46 tests pass.
+
+Save the output to a file rather than rerunning — the suites here are slow:
+```bash
+... 2>&1 | tee /tmp/notes-verify.txt
+```
+
+- [ ] **Step 2: Audit the diff against the anti-patterns doc**
+
+Read `docs/dev/anti-patterns.md` and `docs/dev/coding-standards.md`, then re-read your own diff against them. Look specifically for: free functions that should be methods, cross-object field-reaching, and imperative code where declarative would read better. This is a required step, not a suggestion.
+
+- [ ] **Step 3: Confirm no test can reach real Notes.app**
+
+Run:
+```bash
+cd packages/agency-lang && grep -rn "osascript" lib/stdlib/__tests__/appleNotes.test.ts | grep -v "toBe\|toEqual\|expect" || echo "NONE — good"
+ls tests/agency/notes* 2>/dev/null && echo "PROBLEM: agency tests for notes exist" || echo "NONE — good"
+```
+Expected: both report good. Every test mocks `execFile`; nothing shells out. A test that reached Notes.app could destroy real notes when someone runs the suite locally.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "Fix issues surfaced by the verification pass"
+```
+
+---
+
+## Self-Review
+
+Checked against the spec:
+
+| Spec section | Task |
+|---|---|
+| §3.6 argv, no `-` separator | 1 (tested) |
+| §2.8 both error codes | 1 (tested) |
+| §6.1 `with timeout` | 1 |
+| §5.3 pre-flight, split container | 2 (tested) |
+| §2.7 locked = data loss | 2, 4 (tested, mutation-verified) |
+| §2.4 read plaintext, write HTML | 3, 5 (tested) |
+| §9.3 search plaintext not body | 3 (tested) |
+| §6.4 scoped-lookup assertion | 4 (tested) |
+| §9.4 create folder on demand | 4, 5 (tested) |
+| §4.2 signatures, typed Results, `raises` | 5 |
+| §5.1 six effects, payloads incl. `account` | 5 |
+| §5.2 three capability sets | 5 |
+| §5.4 `idempotent` on reads | 5 |
+| §3.1 Obsidian answer | 6 |
+| §8 unit tests only | 7 (verified) |
+
+**Review findings from spec §12, applied:**
+
+| # | Where |
+|---|---|
+| 2 | Task 5 — `search` payload has `folder` and `account` |
+| 4 | Task 4 — scoped lookup, plus locked re-check in the write script |
+| 5 | Task 5 — `raises` on all seven |
+| 6 | Task 5 — `idempotent` on reads, per `git.agency` |
+| 8 | Task 5 — `Result<Note>`, `Result<Note[]>`, `Result<NoteContent>` |
+| 9 | Task 2 — the "unguessable id" argument in the docstring, not "unreachable" |
+
+**Two findings from §12 are NOT yet handled, and are the highest-risk gaps in this plan:**
+
+- **Finding 7 (fail-open risk).** Optional parameters widen to `T | null`, so a payload's `folder` is `null` when omitted. What a policy glob does when matched against `null` is unverified. If `{"match": {"folder": "Work"}}` silently fails to match and falls through to a later approve rule, that is a fail-open on `listNotes()` with no arguments — the call with the widest reach. This plan works around it by passing `""` instead of `null` in the payloads, which is a guess, not a fix. **Before merging: verify what `checkPolicy` does with an empty string and with null, then write a test in `lib/stdlib/__tests__/` pinning it.** If `""` matches a `"Work"` glob, the workaround is worse than the bug.
+- **Finding 11b.** Whether `renderForHtml` should drop raw HTML silently or emit a diagnostic. Currently silent. Not blocking.
+
+**Known gap:** `account` is threaded through the types and payloads but the Agency layer passes `""` for it, because the TS layer derives the account from the note rather than accepting one. The `account` *argument* from spec §4.2 is not implemented. This plan delivers account as an output field, not as an input filter. That is a deliberate scope cut for a first version, and it means folder scoping is still advisory on a multi-account machine — the exact thing spec §3.4 argued had to be fixed. **The owner has one account (§9.4), so this is latent rather than live, but it must be either implemented or explicitly deferred in the spec before this ships.** Do not let it merge silently.

--- a/docs/superpowers/plans/2026-07-17-std-notes-apple.md
+++ b/docs/superpowers/plans/2026-07-17-std-notes-apple.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** TypeScript, `child_process.execFile`, AppleScript via `osascript`, vitest, Agency stdlib conventions.
 
-**Design spec:** `/Users/adityabhargava/agency-lang/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md`
+**Design spec:** `/Users/adityabhargava/agency-notes-92/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md` (the copy in this worktree, so Task 6's spec edits land on the branch)
 
 Read the spec before starting. This plan implements it and does not re-argue it. Where a step looks arbitrary, the spec section is cited and explains why.
 
@@ -27,7 +27,7 @@ These apply to every task. They are not style preferences; most of them are find
 - **Every script wraps its body in `with timeout of 30 seconds`.** Otherwise it inherits AppleScript's 120-second default. Spec §6.1.
 - **Timeout constant:** `NOTES_TIMEOUT_SECONDS = 30`, module-level, in `appleNotes.ts`.
 - **Payload fields are always strings, never null.** An omitted optional `folder` reaches the payload as `""`. Measured, not stylistic — see "Why empty strings, not null" below.
-- **Field delimiter for multi-field returns:** `ASCII character 1` (``). Not tab — note titles can legally contain tabs.
+- **Field delimiter for multi-field returns:** `ASCII character 1`, written in TS source as the `\u0001` escape — never as a raw byte, which is invisible in an editor and survives copy-paste unreliably. Not tab — note titles can legally contain tabs.
 
 ---
 
@@ -236,6 +236,11 @@ describe("runNotesScript", () => {
   });
 
   it("maps -1743 to a clear not-authorized error", async () => {
+    // Two awaited calls below, and mockFailure queues with
+    // mockImplementationOnce — so queue it twice. vi.clearAllMocks() does NOT
+    // clear the factory's default success implementation, so a second call
+    // with nothing queued would RESOLVE and the assertion would fail.
+    mockFailure("execution error: Not authorized to send Apple events to Notes. (-1743)");
     mockFailure("execution error: Not authorized to send Apple events to Notes. (-1743)");
     await expect(runNotesScript("s", [])).rejects.toThrow(/Not authorized to control Notes/);
     await expect(runNotesScript("s", [])).rejects.toThrow(/Privacy & Security/);
@@ -271,7 +276,7 @@ describe("withTimeout", () => {
 
 describe("FIELD_DELIM", () => {
   it("is a control character, because titles can contain tabs", () => {
-    expect(FIELD_DELIM).toBe("");
+    expect(FIELD_DELIM).toBe("\u0001");
     expect(FIELD_DELIM).not.toBe("\t");
   });
 });
@@ -301,8 +306,10 @@ const execFileAsync = promisify(execFile);
 export const NOTES_TIMEOUT_SECONDS = 30;
 
 /** Separator for multi-field script returns. Not a tab: note titles can
- *  legally contain tabs, and a title with one would corrupt the parse. */
-export const FIELD_DELIM = "";
+ *  legally contain tabs, and a title with one would corrupt the parse.
+ *  Written as an escape, never a raw byte: a raw U+0001 is invisible in
+ *  every editor and survives copy-paste unreliably. */
+export const FIELD_DELIM = "\u0001";
 
 /** Wrap an AppleScript body in the argv handler and our own timeout. */
 export function withTimeout(body: string): string {
@@ -412,6 +419,8 @@ The security core. Everything that touches an existing note goes through this.
   - `assertNotLocked(p: NotePreflight): void`
 
 **Why this exists (spec §5.3):** the interrupt payload must carry `folder`, `title`, and `account`, because those are what policy globs match on. So we must read them before raising the interrupt, which means this one query is not itself gated. That is acceptable, but the reasoning is narrow and belongs in the source: **an id is unguessable.** It is an opaque `x-coredata://` URI that cannot be enumerated or constructed, so whoever holds one already learned it somewhere, and this lookup discloses only the title and folder they could already name. Do not write "unreachable without a gate" — that claim is false (ids are stable and survive checkpoints) and it would license adding a fourth property to this query.
+
+The consumer of this query is Task 5's `preflight` helper, which calls it before raising each append/read/delete interrupt and builds the payload from its result. If that call is ever removed, this query loses its reason to exist ungated — the two must stay together.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -646,7 +655,7 @@ Run:
 ```bash
 cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
 ```
-Expected: PASS, 19 tests.
+Expected: PASS, 20 tests.
 
 - [ ] **Step 5: Prove the locked guard is load-bearing**
 
@@ -737,6 +746,10 @@ describe("_readNote", () => {
   });
 
   it("fails closed when the folder assertion does not match", async () => {
+    // Two calls, so queue the preflight reply twice — the mock is queue-once,
+    // and the second call would otherwise read the factory default ("") and
+    // fail on parsing instead of on the folder.
+    mockStdout(["Q3", "Personal", "iCloud", "false"].join(FIELD_DELIM));
     mockStdout(["Q3", "Personal", "iCloud", "false"].join(FIELD_DELIM));
     await expect(_readNote("x-coredata://note/1", "Work")).rejects.toThrow(/Work/);
     await expect(_readNote("x-coredata://note/1", "Work")).rejects.toThrow(/Personal/);
@@ -748,6 +761,51 @@ describe("_readNote", () => {
     await expect(_readNote("x-coredata://note/1", "Work")).resolves.toMatchObject({
       folder: "Work",
     });
+  });
+
+  it("uses a scoped lookup for the read when a folder is given", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["body", "2026-07-17"].join(FIELD_DELIM));
+    await _readNote("x-coredata://note/1", "Work");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // Same treatment as the write path (spec section 6.4): a note that moved
+    // folders during the approval fails to resolve instead of being read.
+    expect(args[1]).toContain("of folder (item 2 of argv)");
+    expect(args[3]).toBe("Work");
+  });
+});
+
+describe("_listNotes", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("lists all notes when no folder is given", async () => {
+    const row = ["id1", "One", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM);
+    mockStdout(row);
+    const notes = await _listNotes();
+    expect(notes).toHaveLength(1);
+    expect(notes[0].title).toBe("One");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).not.toContain("of folder");
+  });
+
+  it("scopes to the folder when one is given, passed as argv", async () => {
+    mockStdout("");
+    await _listNotes("Work");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).toContain("notes of folder (item 1 of argv)");
+    expect(args[2]).toBe("Work");
+  });
+
+  it("returns an empty array rather than throwing when there are none", async () => {
+    mockStdout("");
+    await expect(_listNotes()).resolves.toEqual([]);
   });
 });
 
@@ -886,8 +944,12 @@ export type FolderMeta = {
 
 /** Assert a note is in the folder the caller named. Fails closed.
  *
- *  This is the read-path assertion. The write path uses a scoped lookup
- *  instead, which is stronger — see _appendToNote. */
+ *  This compare is the fail-fast check with the readable error message. It is
+ *  NOT the authoritative assertion: on both the read and write paths the
+ *  actual access addresses the note THROUGH the folder (`note id X of folder
+ *  Y`), so the lookup failing is the assertion failing, and the check cannot
+ *  drift from the access across the human approval that sits between the
+ *  pre-flight and the access. */
 function assertFolder(p: NotePreflight, folder?: string): void {
   if (folder != null && p.folder !== folder) {
     throw new Error(
@@ -898,8 +960,21 @@ function assertFolder(p: NotePreflight, folder?: string): void {
 
 // Reads `plaintext`, never `body`. body is HTML: it would waste tokens and read
 // badly for a model. Spec section 2.4.
-const READ_SCRIPT = withTimeout(`    tell application "Notes"
+//
+// Two shapes, like the write path (spec section 6.4): when the caller asserted
+// a folder, the read addresses the note THROUGH it, so a note that moved
+// folders during the human approval fails to resolve instead of being read.
+// An unscoped read would leave open on the read path the exact window the
+// write path closes — and reading is the operation folder confinement was
+// invented for.
+const READ_UNSCOPED_SCRIPT = withTimeout(`    tell application "Notes"
       set n to note id (item 1 of argv)
+      set d to (ASCII character 1)
+      return (plaintext of n) & d & ((modification date of n) as text)
+    end tell`);
+
+const READ_SCOPED_SCRIPT = withTimeout(`    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 2 of argv)
       set d to (ASCII character 1)
       return (plaintext of n) & d & ((modification date of n) as text)
     end tell`);
@@ -909,7 +984,9 @@ export async function _readNote(id: string, folder?: string): Promise<NoteConten
   assertFolder(p, folder);
   assertNotLocked(p);
 
-  const raw = await runNotesScript(READ_SCRIPT, [id]);
+  const raw = folder == null
+    ? await runNotesScript(READ_UNSCOPED_SCRIPT, [id])
+    : await runNotesScript(READ_SCOPED_SCRIPT, [id, folder]);
   const parts = raw.split(FIELD_DELIM);
   if (parts.length !== 2) {
     throw new Error(`Notes returned an unexpected reply for note ${id}.`);
@@ -1051,7 +1128,7 @@ Run:
 ```bash
 cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
 ```
-Expected: PASS, 29 tests.
+Expected: PASS, 36 tests.
 
 - [ ] **Step 5: Commit**
 
@@ -1092,6 +1169,30 @@ Append to the test file:
 
 ```ts
 import { _folderExists, _createNote, _appendToNote, _deleteNote } from "../appleNotes.js";
+
+describe("_folderExists", () => {
+  const originalPlatform = process.platform;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("passes the folder as argv and parses a true reply", async () => {
+    mockStdout("true");
+    await expect(_folderExists("Agency Notes")).resolves.toBe(true);
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).toContain("exists folder (item 1 of argv)");
+    expect(args[2]).toBe("Agency Notes");
+  });
+
+  it("parses a false reply", async () => {
+    mockStdout("false");
+    await expect(_folderExists("No Such Folder")).resolves.toBe(false);
+  });
+});
 
 describe("_createNote", () => {
   const originalPlatform = process.platform;
@@ -1346,7 +1447,7 @@ Run:
 ```bash
 cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
 ```
-Expected: PASS, 40 tests.
+Expected: PASS, 48 tests.
 
 - [ ] **Step 5: Prove the locked guard is load-bearing**
 
@@ -1383,6 +1484,23 @@ during the approval. A missed check replaces the note's contents."
 - Consumes: every `_`-prefixed function from Tasks 1–4, plus `parse` and `renderForHtml` from `std::markdown`.
 - Produces: the public `std::notes/apple` surface.
 
+**The append/read/delete payloads are built from the pre-flight.** This is the
+whole point of Task 2's ungated `_preflightNote` query, so it must not be
+dropped in a refactor: the caller hands these functions an opaque
+`x-coredata://` id and nothing else, so without a pre-flight the interrupt
+payload could only carry that id and empty strings. A human approving a delete
+would see nothing identifying the note, and a policy like
+`{"match": {"folder": "Work"}, "action": "approve"}` could never match, because
+the payload's `folder` would be `""` — which matches no glob, not even `"*"`
+(see "Why empty strings, not null"). So `appendToNote`, `readNote`, and
+`deleteNote` each call the `preflight` helper below before raising their
+interrupt, and the payload carries the note's real `title`, `folder`, and
+`account`. The helper also refuses a folder-assertion mismatch *before* the
+interrupt, which keeps the payload honest: the folder a human approves is the
+note's real folder, never an asserted folder the note is not actually in. The
+TypeScript layer re-asserts the folder and the locked flag after approval; the
+helper is for payload truth and fail-fast, not the safety guard.
+
 **Syntax rules (from CLAUDE.md — verify against `docs/site/guide/basic-syntax.md` if unsure):** functions are `def` with braces; `if` needs parens and braces; variables need `let`/`const`. Do not write Python-style colons.
 
 - [ ] **Step 1: Write the module**
@@ -1399,6 +1517,7 @@ import {
   _listFolders,
   _deleteNote,
   _folderExists,
+  _preflightNote,
 } from "agency-lang/stdlib-lib/appleNotes.js"
 import { parse, renderForHtml } from "std::markdown"
 
@@ -1472,6 +1591,38 @@ def toHtml(body: string): Result<string> {
   return success(renderForHtml(parsed.blocks))
 }
 
+/** What the pre-flight lookup returns. Re-declared natively because record
+    types imported from TypeScript are opaque to the typechecker. */
+type Preflight = {
+  id: string
+  title: string
+  folder: string
+  account: string
+  locked: boolean
+}
+
+/** Look the note up before raising the interrupt, so the payload can carry its
+    real title, folder, and account — the fields a policy glob matches on and a
+    human reads before approving. Without this, the payload would hold an opaque
+    id and empty strings, and no policy could ever match an append, read, or
+    delete.
+
+    Refusing a folder-assertion mismatch here, before the interrupt, keeps the
+    payload honest: the folder shown to the approver is always the note's real
+    folder. The TypeScript layer re-asserts the folder (by scoped lookup on
+    writes) and the locked flag after the approval — that re-check is the
+    safety guard; this one exists for payload truth and a fail-fast error. */
+def preflight(id: string, folder: string | null): Result<Preflight> {
+  const p = try _preflightNote(id)
+  if (isFailure(p)) {
+    return p
+  }
+  if (folder != null && p.value.folder != folder) {
+    return failure("Note ${p.value.title} is in folder ${p.value.folder}, not ${folder}. Refusing.")
+  }
+  return p
+}
+
 export def createNote(title: string, body: string, folder: string = "Agency Notes"): Result<Note> raises <std::notes::create> {
   """
   Create a note in the Notes app and return it, including its new id.
@@ -1490,11 +1641,15 @@ export def createNote(title: string, body: string, folder: string = "Agency Note
     return exists
   }
 
+  // exists is the Result from `try`, so negate the VALUE. `!exists` would
+  // negate the always-truthy success object and folderCreated would silently
+  // always read false. Precedent for .value after an isFailure guard:
+  // stdlib/agency.agency (compileResult.value).
   return interrupt std::notes::create("Create a note in the Notes app?", {
     account: "",
     folder: folder,
     title: title,
-    folderCreated: !exists
+    folderCreated: !exists.value
   })
 
   destructive {
@@ -1515,10 +1670,15 @@ export def appendToNote(id: string, body: string, folder?: string): Result<Note>
     return html
   }
 
+  const p = preflight(id, folder)
+  if (isFailure(p)) {
+    return p
+  }
+
   return interrupt std::notes::append("Append to a note in the Notes app?", {
-    account: "",
-    folder: if folder == null then "" else folder,
-    title: "",
+    account: p.value.account,
+    folder: p.value.folder,
+    title: p.value.title,
     id: id
   })
 
@@ -1534,10 +1694,15 @@ export idempotent def readNote(id: string, folder?: string): Result<NoteContent>
   @param id - The note's id
   @param folder - If given, the call fails unless the note is in this folder
   """
+  const p = preflight(id, folder)
+  if (isFailure(p)) {
+    return p
+  }
+
   return interrupt std::notes::read("Read a note from the Notes app?", {
-    account: "",
-    folder: if folder == null then "" else folder,
-    title: "",
+    account: p.value.account,
+    folder: p.value.folder,
+    title: p.value.title,
     id: id
   })
 
@@ -1552,9 +1717,11 @@ export idempotent def searchNotes(query: string, folder?: string): Result<Note[]
   @param query - The text to search for
   @param folder - If given, only search this folder
   """
+  const payloadFolder = if folder == null then "" else folder
+
   return interrupt std::notes::search("Search the notes in the Notes app?", {
     account: "",
-    folder: if folder == null then "" else folder,
+    folder: payloadFolder,
     query: query
   })
 
@@ -1567,9 +1734,11 @@ export idempotent def listNotes(folder?: string): Result<Note[]> raises <std::no
 
   @param folder - If given, only list this folder
   """
+  const payloadFolder = if folder == null then "" else folder
+
   return interrupt std::notes::list("List the notes in the Notes app?", {
     account: "",
-    folder: if folder == null then "" else folder
+    folder: payloadFolder
   })
 
   return try _listNotes(folder)
@@ -1595,10 +1764,15 @@ export def deleteNote(id: string, folder?: string): Result<null> raises <std::no
   @param id - The note's id
   @param folder - If given, the call fails unless the note is in this folder
   """
+  const p = preflight(id, folder)
+  if (isFailure(p)) {
+    return p
+  }
+
   return interrupt std::notes::delete("Delete a note from the Notes app?", {
-    account: "",
-    folder: if folder == null then "" else folder,
-    title: "",
+    account: p.value.account,
+    folder: p.value.folder,
+    title: p.value.title,
     id: id
   })
 
@@ -1658,7 +1832,7 @@ cd packages/agency-lang && pnpm run ast stdlib/notes/apple.agency > /dev/null &&
 ```
 Expected: `PARSES`.
 
-If it fails, check `docs/site/guide/basic-syntax.md`. Known parser gotchas from the memory file: `!(...)` on a paren-expression fails to parse, and `thread` is a keyword. If `if ... then ... else` as an argument value fails, hoist it to a `const` first — `if` expressions are only allowed as a `const`/`let` value or a `return`.
+If it fails, check `docs/site/guide/basic-syntax.md`. Known parser gotchas from the memory file: `!(...)` on a paren-expression fails to parse, and `thread` is a keyword. Every `if ... then ... else` expression in the module is already hoisted to a `const` (`payloadFolder`) rather than written inline in an object literal, because `if` expressions are only reliably allowed as a `const`/`let` value or a `return` — do not inline them back while tidying.
 
 - [ ] **Step 3: Add the capability sets**
 
@@ -1685,7 +1859,7 @@ Expected: exit 0. `make` is required for any stdlib change.
 
 - [ ] **Step 5: Verify the tool schema narrows under partial application**
 
-Create `/tmp/notes-check.agency` in the repo (NOT in /tmp — Agency needs node_modules):
+Create `notes-check.agency` directly in `packages/agency-lang/` (not in /tmp — Agency files only run where node_modules is available):
 
 ```ts
 import { createNote } from "std::notes/apple"
@@ -1698,7 +1872,7 @@ node main() {
 
 Run:
 ```bash
-cd packages/agency-lang && cp /tmp/notes-check.agency ./notes-check.agency && pnpm run agency notes-check.agency; rm -f notes-check.agency
+cd packages/agency-lang && pnpm run agency notes-check.agency; rm -f notes-check.agency
 ```
 Expected: `partial applied ok`. This exercises compilation and PFA without touching Notes.app.
 
@@ -1710,7 +1884,10 @@ git commit -m "Add the std::notes/apple module and its capability sets
 
 Per-operation effects rather than one blanket std::notes, so a policy can
 approve reads and reject deletes. Payloads carry account, folder and
-title because those are what policy globs match on.
+title because those are what policy globs match on. For append, read and
+delete the payload is built from the ungated pre-flight lookup, so the
+approver sees the note's real title and folder rather than an opaque id,
+and a folder-scoped policy can match a call that passed only an id.
 
 Notes are addressed by id, since duplicate titles are legal. The optional
 folder argument constrains rather than addresses, so partial application
@@ -1817,6 +1994,16 @@ Each operation raises its own [effect](/guide/effects), so a
 }
 ```
 
+`readNote`, `appendToNote`, and `deleteNote` look the note up before raising
+their interrupt, so the payload carries the note's real `title`, `folder`, and
+`account` even when the call passed only an id. The rule above therefore
+matches a bare `readNote(id)` for a note that lives in Work.
+
+One v1 limit: only those three calls populate `account`. `createNote`,
+`searchNotes`, and `listNotes` send it as an empty string, and an empty string
+matches no glob — not even `"*"` — so a rule that matches on `account` never
+applies to them. Match on `folder` instead.
+
 Or constrain a whole node with the capability sets:
 
 ```ts
@@ -1869,7 +2056,22 @@ process cannot receive the callback, so a create call could not return the id of
 the note it made.
 ```
 
-- [ ] **Step 2: Build so the guide is staged into the stdlib**
+- [ ] **Step 2: Write the two v1 limits into the spec**
+
+Edit `/Users/adityabhargava/agency-notes-92/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md`:
+
+1. Add a "v1 limits" note recording both deliberate limits from this plan's
+   "Two v1 limits" section: nested folder paths are unsupported (`listFolders`
+   returns top-level folders only), and `account` is an output field, not an
+   input filter. The spec currently promises an `account` argument (§4.2); it
+   must stop promising what the code does not build.
+2. The spec header still says "awaiting owner review" — that is stale (the
+   review happened and its findings are folded in). Fix it while in the file.
+
+This step exists because a spec that overpromises is how the next person
+reintroduces the gap. It must land in the same PR as the module.
+
+- [ ] **Step 3: Build so the guide is staged into the stdlib**
 
 Run:
 ```bash
@@ -1877,7 +2079,7 @@ cd packages/agency-lang && make
 ```
 Expected: exit 0. `make` copies `docs/site/guide` into `stdlib/docs/guide` for `std::skills::docsSkill`.
 
-- [ ] **Step 3: Verify the generated stdlib reference page exists**
+- [ ] **Step 4: Verify the generated stdlib reference page exists**
 
 Run:
 ```bash
@@ -1885,10 +2087,10 @@ cd packages/agency-lang && ls docs/site/stdlib/notes/ && grep -c "createNote" do
 ```
 Expected: `apple.md` listed, and a non-zero count. `agency doc` recurses, so no registry needed.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add packages/agency-lang/docs/site/guide/apple-notes.md packages/agency-lang/stdlib/docs/ packages/agency-lang/docs/site/stdlib/
+git add packages/agency-lang/docs/site/guide/apple-notes.md packages/agency-lang/stdlib/docs/ packages/agency-lang/docs/site/stdlib/ docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md
 git commit -m "Document std::notes/apple
 
 Adds the guide page. The stdlib reference page is generated from the
@@ -1911,7 +2113,7 @@ Run:
 ```bash
 cd packages/agency-lang && make && npx tsc --noEmit -p tsconfig.json && pnpm run lint:structure && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts lib/stdlib/__tests__/markdown.test.ts 2>&1 | tail -20
 ```
-Expected: all exit 0; appleNotes 40 tests pass, markdown 46 tests pass.
+Expected: all exit 0; appleNotes 48 tests pass, and the markdown suite passes (verify the count empirically — do not chase a number written here).
 
 Save the output to a file rather than rerunning — the suites here are slow:
 ```bash
@@ -1949,7 +2151,7 @@ Checked against the spec:
 | §3.6 argv, no `-` separator | 1 (tested) |
 | §2.8 both error codes | 1 (tested) |
 | §6.1 `with timeout` | 1 |
-| §5.3 pre-flight, split container | 2 (tested) |
+| §5.3 pre-flight, split container, payloads built from it | 2, 5 (tested) |
 | §2.7 locked = data loss | 2, 4 (tested, mutation-verified) |
 | §2.4 read plaintext, write HTML | 3, 5 (tested) |
 | §9.3 search plaintext not body | 3 (tested) |
@@ -1982,6 +2184,67 @@ Checked against the spec:
 **Two deliberate v1 limits**, both measured, both documented above under "Two v1 limits":
 
 - **Nested folder paths are unsupported.** `listFolders` returns top-level folders only, which is honest rather than the flat-and-wrong alternative. Nested folders stay reachable by bare name, ambiguously — Notes' own behaviour.
-- **The `account` argument is not implemented.** `account` is an output field, not an input filter, so folder scoping stays advisory on a multi-account machine. The owner has one account, so this is latent. **Both limits must be written into the spec before this merges, so the spec stops promising what the code does not build.**
+- **The `account` argument is not implemented.** `account` is an output field, not an input filter, so folder scoping stays advisory on a multi-account machine. The owner has one account, so this is latent. Task 6 Step 2 writes both limits into the spec, so the spec stops promising what the code does not build.
 
 **The account BUG, as distinct from the missing argument, is fixed** in Task 2's `ACCOUNT_WALK`. One hop up from a note's folder lands on `Archived`, not `iCloud`, for anything nested. That was wrong and silently so.
+
+---
+
+## Plan review round 1 (2026-07-17), findings applied
+
+An external review of this plan checked its claims against the codebase. What
+it verified as correct: the `return interrupt` + `destructive` idiom
+(`stdlib/messaging/imessage.agency:33-43`), the double-return read idiom
+(`gitStatus`, `stdlib/git.agency:154-155`), the `effectSet` syntax, the
+`"agency-lang/stdlib-lib/*.js"` import path, the `ParseResult` shape
+(`stdlib/markdown.agency:223-228`), optional `?` params (confirmed via
+`pnpm run ast`), and the picomatch measurements (re-run: `isMatch("", "*")` is
+`false`, `null` throws). Six findings needed fixes, all folded in above:
+
+1. **The append/read/delete interrupt payloads were hollow** — `title: ""` and
+   `account: ""` hardcoded, `_preflightNote` never called before the interrupt.
+   That defeated spec §5.3 and Task 2's own rationale: a human approving a
+   delete saw only an opaque id, and a folder policy could never match a call
+   that passed only an id. Fixed in Task 5 with the `preflight` helper, which
+   also refuses a folder-assertion mismatch before the interrupt so the payload
+   folder is always the note's real folder.
+2. **`folderCreated: !exists` negated the Result object, not the boolean** —
+   always-truthy success object, so the flag would silently always read false.
+   Fixed to `!exists.value`.
+3. **Two tests queued one mock but made two calls** (the -1743 test and
+   `_readNote`'s folder-assertion test). `vi.clearAllMocks()` does not clear
+   the factory default, so the second call resolved and the assertion failed.
+   Fixed by queueing per call.
+4. **`_listNotes` and `_folderExists` had no tests**, and the expected test
+   counts in Tasks 2–4 were wrong. Tests added; counts now 20 / 35 / 47.
+5. **The spec edit the self-review demanded had no step.** Now Task 6 Step 2.
+6. **Inline `if ... then ... else` in object literals** was a known parse risk
+   used five times. The pre-flight fix removed three; the rest are hoisted to
+   `const payloadFolder`. Also fixed the self-contradictory /tmp wording in
+   Task 5 Step 5, and documented in the guide that an `account` match never
+   applies to the calls that send `account` as `""`.
+
+## Plan review round 2 (2026-07-17), findings applied
+
+A second, independent review (`2026-07-17-std-notes-apple-REVIEW.md`, written
+against the pre-round-1 plan) verified its two blockers — inline
+`if/then/else` does not parse, and `!exists` is always false — both already
+fixed in round 1. Two of its further findings were adopted:
+
+1. **The read path kept the TOCTOU the write path closes** (its Finding 3).
+   `_readNote` asserted the folder by compare, then read with an unscoped
+   `note id X` — so a note that moved folders during the human approval was
+   still read. Reading is the operation folder confinement was invented for,
+   and the guide's "anything outside Work fails closed" claim has to be true
+   for reads too. Fixed: `_readNote` now has scoped and unscoped script shapes
+   like `_appendToNote`, with a test. `assertFolder` stays as the fail-fast
+   readable error; its comment now says the scoped lookup is the authoritative
+   assertion on both paths. Counts now 36 / 48.
+2. **`FIELD_DELIM` was a raw invisible control byte in source** (its Finding
+   5). If the byte is mangled in transit, the test's own expected value
+   mangles with it and still passes. Both are now the `\u0001` escape.
+
+Its Finding 4 (thread the real account through payloads that pre-flight) was
+already covered by round 1's payload fix. Its remaining notes — `listFolders`
+sharing `std::notes::list` with `listNotes`, and `renderForHtml`'s silent
+raw-HTML drop (spec finding 11b) — stay open as accepted v1 decisions.

--- a/docs/superpowers/plans/2026-07-17-std-notes-apple.md
+++ b/docs/superpowers/plans/2026-07-17-std-notes-apple.md
@@ -26,6 +26,7 @@ These apply to every task. They are not style preferences; most of them are find
 - **Unit tests only. No integration tests.** Owner decision. A test that reaches real Notes.app can destroy real notes when someone runs the suite locally. No tests in `tests/agency/` for this module — those execute the real stdlib and would shell to `osascript` for real. Spec §8.
 - **Every script wraps its body in `with timeout of 30 seconds`.** Otherwise it inherits AppleScript's 120-second default. Spec §6.1.
 - **Timeout constant:** `NOTES_TIMEOUT_SECONDS = 30`, module-level, in `appleNotes.ts`.
+- **Payload fields are always strings, never null.** An omitted optional `folder` reaches the payload as `""`. Measured, not stylistic — see "Why empty strings, not null" below.
 - **Field delimiter for multi-field returns:** `ASCII character 1` (``). Not tab — note titles can legally contain tabs.
 
 ---
@@ -44,9 +45,91 @@ No registry to update: `agency doc stdlib` recurses, and `stdlib/messaging/` pro
 
 ---
 
-## Known limitation to record, not solve
+## Why empty strings, not null, in payloads
 
-**Nested folders.** Notes folders can contain folders. This module addresses folders by name in one account and derives a note's account by walking `container` upward. Deeply nested folders with duplicate names are not addressable. Out of scope; the spec's §10 already scopes folders to name-addressing. Do not add nesting support in this plan.
+Review finding #7 worried that an omitted `folder` reaching a policy as `null`
+could fail open. It cannot — but not for the reason the finding guessed, so the
+measurement is recorded here rather than left to a future reader to redo.
+
+`stdlib/policy.agency:72`: a rule passes only if *every key in `match` is present
+in the interrupt's `data` and its value matches the glob*. Patterns are picomatch
+globs. Measured:
+
+| Pattern | Value | Result |
+|---|---|---|
+| `"Work"` | `""` | `false` |
+| `"*"` | `""` | **`false`** |
+| `"**"` | `""` | `false` |
+| `"*"` | `"Work"` | `true` |
+| `"Work"` | `null` | **THROWS** — `Expected input to be a string` |
+
+Two consequences:
+
+1. **`""` is safe.** An empty folder matches *nothing*, not even a catch-all
+   `"*"`. So `{"match": {"folder": "*"}, "action": "approve"}` does not approve a
+   `listNotes()` with no folder; it falls through to the next rule. The fail-open
+   finding #7 feared cannot occur.
+2. **`null` would crash the policy check**, not fail open, because picomatch
+   throws on a non-string.
+
+So passing `""` is load-bearing rather than a stylistic default. Never let a
+`null` reach a payload field a policy can match on. Task 5 pins consequence 1
+with a test.
+
+---
+
+## Two v1 limits, measured and deliberate
+
+Both are recorded here so the code and the spec agree. Neither is a guess; a
+live probe settled each.
+
+### Nested folders are not addressable by path
+
+Notes folders nest, and the owner's account has them: `Archived` contains
+`2010s`, `2017`, and `2019`.
+
+Three measured facts shape what v1 does:
+
+1. **`folders` flattens.** A bare `repeat with f in folders` returns 14 folders
+   on the owner's machine, with `Archived` and its three children side by side
+   and nothing marking the difference. So a naive `listFolders` reports `2017`
+   as a peer of `Recently Deleted`, which is false.
+2. **A nested folder resolves by bare name.** `folder "2017"` resolves from the
+   top level. So name addressing is *ambiguous* rather than broken: two folders
+   sharing a name in different parents resolve arbitrarily.
+3. **`/` is legal in a folder name.** Verified by creating one. So `/` cannot be
+   a path separator without escaping, and paths are a real design job rather
+   than a string join.
+
+**v1 therefore returns only top-level folders from `listFolders`** (Task 3),
+using the `class of c is account` test. That is honest and limited rather than
+flat and wrong. Nested folders remain reachable by bare name, ambiguously, which
+is the pre-existing Notes behaviour rather than something we invent.
+
+Do not add path support in this plan.
+
+### The `account` argument is not implemented
+
+Spec §4.2 gives every function an optional `account`. This plan delivers
+`account` as an **output** field on `Note` and in every payload, but not as an
+input filter. So folder scoping stays advisory on a multi-account machine, which
+is what spec §3.4 argued had to be fixed.
+
+The owner has exactly one account (§9.4), so this is latent rather than live.
+It must be recorded in the spec as a v1 limit, not left as a promise the code
+does not keep.
+
+### But the account BUG is fixed here
+
+Distinct from the missing argument, and not optional. Deriving the account with
+one hop up from the note's folder is **wrong for any nested folder**:
+`container of folder "2017"` is `Archived`, not `iCloud`. Measured. Left alone,
+every note under `Archived` would carry `"Archived"` in its `account` payload
+field, and a policy matching `{"account": "iCloud"}` would silently stop
+matching.
+
+Task 2 fixes it with a bounded upward walk, verified to reach `iCloud` from
+`Archived/2017` in 2 hops.
 
 ---
 
@@ -323,6 +406,7 @@ The security core. Everything that touches an existing note goes through this.
 **Interfaces:**
 - Consumes: `runNotesScript`, `withTimeout`, `FIELD_DELIM` from Task 1.
 - Produces:
+  - `ACCOUNT_WALK: string` — an AppleScript snippet, reused by Tasks 3 and 4.
   - `type NotePreflight = { id: string; title: string; folder: string; account: string; locked: boolean }`
   - `_preflightNote(id: string): Promise<NotePreflight>`
   - `assertNotLocked(p: NotePreflight): void`
@@ -358,6 +442,28 @@ describe("_preflightNote", () => {
     // silently reintroduce the chained form.
     expect(script).not.toContain("name of container of n");
     expect(script).toContain("set c to container of n");
+  });
+
+  it("walks up to the account rather than assuming one hop", async () => {
+    mockStdout(["Q3", "2017", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    const script = args[1];
+    // A folder's container is its PARENT FOLDER when nested, not the account.
+    // Measured: `container of folder "2017"` is "Archived", not "iCloud". One
+    // hop would put a folder name in the account field, and a policy matching
+    // {"account": "iCloud"} would silently stop matching.
+    expect(script).toContain("class of a) is account");
+    expect(script).toContain("set a to container of a");
+  });
+
+  it("fails closed if the account walk does not reach an account", async () => {
+    mockStdout(["Q3", "2017", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // The walk is bounded. If it never lands on an account, error rather than
+    // returning a folder name as the account.
+    expect(args[1]).toContain("Could not resolve the account");
   });
 
   it("reads only title, folder, account and the locked flag — never the body", async () => {
@@ -457,16 +563,34 @@ export type NotePreflight = {
   locked: boolean;
 };
 
+/** Walk from a folder (`c`) up to its account, leaving it in `a`.
+ *
+ *  A folder's container is its PARENT FOLDER when nested, not the account.
+ *  Measured: `container of folder "2017"` is `Archived`, not `iCloud`. One hop
+ *  up is wrong for any nested folder, and wrong silently — the account field
+ *  would hold a folder name and every {"account": "iCloud"} policy would quietly
+ *  stop matching.
+ *
+ *  Bounded, and fails closed rather than returning a folder as an account.
+ *  Verified to reach iCloud from Archived/2017 in 2 hops. */
+export const ACCOUNT_WALK = `      set a to container of c
+      set acctFound to false
+      repeat 10 times
+        if (class of a) is account then
+          set acctFound to true
+          exit repeat
+        end if
+        set a to container of a
+      end repeat
+      if not acctFound then error "Could not resolve the account for this note."`;
+
 // `set c to container of n` is split on purpose. `name of container of n` in one
-// expression errors -1712... no: -1728, on EVERY note, locked or unlocked. The
-// property is fine; chaining a read through it is not. Spec section 9.2.
-//
-// The account is the folder's container. Deeply nested folders are out of
-// scope (see the plan's "Known limitation"), so one hop up is enough.
+// expression errors -1728 on EVERY note, locked or unlocked. The property is
+// fine; chaining a read through it is not. Spec section 9.2.
 const PREFLIGHT_SCRIPT = withTimeout(`    tell application "Notes"
       set n to note id (item 1 of argv)
       set c to container of n
-      set a to container of c
+${ACCOUNT_WALK}
       set d to (ASCII character 1)
       return (name of n) & d & (name of c) & d & (name of a) & d & ¬
              ((password protected of n) as text)
@@ -522,19 +646,22 @@ Run:
 ```bash
 cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/appleNotes.test.ts
 ```
-Expected: PASS, 17 tests.
+Expected: PASS, 19 tests.
 
-- [ ] **Step 5: Fix the comment typo introduced above**
+- [ ] **Step 5: Prove the locked guard is load-bearing**
 
-The comment above `PREFLIGHT_SCRIPT` says "-1712... no: -1728". Clean it to read:
+Temporarily change `assertNotLocked` to a no-op:
 
 ```ts
-// `set c to container of n` is split on purpose. `name of container of n` in one
-// expression errors -1728 on EVERY note, locked or unlocked. The property is
-// fine; chaining a read through it is not. Spec section 9.2.
+export function assertNotLocked(_p: NotePreflight): void {
+  return;
+}
 ```
 
-Run the tests again to confirm still PASS, 17 tests.
+Run the tests. Expected: "refuses a locked note and names it" FAILS. Restore.
+
+This guard is the only thing standing between a locked note and destruction
+(spec §2.7). If a refactor deletes it, that test must be what stops the build.
 
 - [ ] **Step 6: Commit**
 
@@ -698,6 +825,18 @@ describe("_listFolders", () => {
     ]);
   });
 
+  it("asks Notes for top-level folders only", async () => {
+    mockStdout("");
+    await _listFolders();
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // A bare `repeat with f in folders` flattens the hierarchy: it returns
+    // "Archived" and its children "2010s"/"2017"/"2019" side by side with
+    // nothing marking the difference, so "2017" reads as a peer of "Recently
+    // Deleted". That is false, and an agent would act on it. Filtering to
+    // folders whose container is an account is honest and limited instead.
+    expect(args[1]).toContain("(class of c) is account");
+  });
+
   it("returns an empty array rather than throwing when there are none", async () => {
     mockStdout("");
     await expect(_listFolders()).resolves.toEqual([]);
@@ -804,9 +943,10 @@ function parseNoteRows(raw: string): NoteMeta[] {
   });
 }
 
-// The container access is split here too. Spec section 9.2.
+// The container access is split here too (spec 9.2), and the account is walked
+// rather than assumed to be one hop up.
 const NOTE_ROW = `set c to container of n
-        set a to container of c
+${ACCOUNT_WALK}
         set out to out & (id of n) & d & (name of n) & d & (name of c) & d & ¬
                   (name of a) & d & ((modification date of n) as text) & d & ¬
                   ((password protected of n) as text) & linefeed`;
@@ -864,14 +1004,30 @@ export async function _searchNotes(query: string, folder?: string): Promise<Note
   return parseNoteRows(raw);
 }
 
+// TOP-LEVEL FOLDERS ONLY, on purpose.
+//
+// A bare `repeat with f in folders` FLATTENS the hierarchy: on a machine with
+// an "Archived" folder containing "2010s", "2017" and "2019", it returns all
+// four side by side with nothing marking the difference. Reporting "2017" as a
+// peer of "Recently Deleted" is simply false, and an agent would act on it.
+//
+// So filter to folders whose container is an account. That is honest and
+// limited rather than flat and wrong. Nested folders stay reachable by bare
+// name (`folder "2017"` does resolve), ambiguously — which is Notes' own
+// behaviour, not something we introduce. Path support is out of scope for v1;
+// see the plan's "Two v1 limits".
+//
 // noteCount is derived with `count of notes`, because folder has no such
 // property. That is a query per folder, so listFolders pays for it.
 const LIST_FOLDERS_SCRIPT = withTimeout(`    tell application "Notes"
       set d to (ASCII character 1)
       set out to ""
       repeat with f in folders
-        set out to out & (id of f) & d & (name of f) & d & ¬
-                  ((count of notes of f) as text) & linefeed
+        set c to container of f
+        if (class of c) is account then
+          set out to out & (id of f) & d & (name of f) & d & ¬
+                    ((count of notes of f) as text) & linefeed
+        end if
       end repeat
       return out
     end tell`);
@@ -1087,7 +1243,7 @@ const CREATE_SCRIPT = withTimeout(`    tell application "Notes"
       set f to folder (item 3 of argv)
       set n to make new note at f with properties {name:(item 1 of argv), body:(item 2 of argv)}
       set c to container of n
-      set a to container of c
+${ACCOUNT_WALK}
       set d to (ASCII character 1)
       return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
              ((modification date of n) as text) & d & ((password protected of n) as text)
@@ -1116,7 +1272,7 @@ export async function _createNote(
 const APPEND_BODY = `      if (password protected of n) then error "note is locked"
       set body of n to (body of n) & (item 2 of argv)
       set c to container of n
-      set a to container of c
+${ACCOUNT_WALK}
       set d to (ASCII character 1)
       return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
              ((modification date of n) as text) & d & ((password protected of n) as text)`;
@@ -1452,6 +1608,48 @@ export def deleteNote(id: string, folder?: string): Result<null> raises <std::no
 }
 ```
 
+- [ ] **Step 1b: Pin the empty-string payload behaviour with a test**
+
+Create `packages/agency-lang/lib/stdlib/__tests__/notesPolicy.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import picomatch from "picomatch";
+
+// std::notes/apple passes "" for an omitted optional `folder`, never null.
+// This test exists so nobody "tidies" that into null, and so the reasoning
+// survives: an empty folder must match NOTHING, so a catch-all {"folder": "*"}
+// approve rule cannot approve a listNotes() with no folder.
+describe("policy globs against an omitted folder", () => {
+  it("an empty folder does not match a specific glob", () => {
+    expect(picomatch.isMatch("", "Work")).toBe(false);
+  });
+
+  it("an empty folder does not match a catch-all glob", () => {
+    // The load-bearing one. If this ever becomes true, listNotes() with no
+    // folder — the widest-reaching call in the module — starts matching any
+    // {"folder": "*"} approve rule, and the payload design needs rethinking.
+    expect(picomatch.isMatch("", "*")).toBe(false);
+    expect(picomatch.isMatch("", "**")).toBe(false);
+  });
+
+  it("a real folder still matches", () => {
+    expect(picomatch.isMatch("Work", "*")).toBe(true);
+    expect(picomatch.isMatch("Work", "Work")).toBe(true);
+  });
+
+  it("null throws, which is why payloads never carry it", () => {
+    expect(() => picomatch.isMatch(null as unknown as string, "Work")).toThrow();
+  });
+});
+```
+
+Run:
+```bash
+cd packages/agency-lang && npx vitest run lib/stdlib/__tests__/notesPolicy.test.ts
+```
+Expected: PASS, 4 tests.
+
 - [ ] **Step 2: Verify it parses**
 
 Run:
@@ -1775,9 +1973,15 @@ Checked against the spec:
 | 8 | Task 5 — `Result<Note>`, `Result<Note[]>`, `Result<NoteContent>` |
 | 9 | Task 2 — the "unguessable id" argument in the docstring, not "unreachable" |
 
-**Two findings from §12 are NOT yet handled, and are the highest-risk gaps in this plan:**
+| 7 | Resolved by measurement, not worked around. See "Why empty strings, not null". `""` matches nothing including `"*"`, so the feared fail-open cannot occur; `null` would throw. Task 5 step 1b pins it. |
 
-- **Finding 7 (fail-open risk).** Optional parameters widen to `T | null`, so a payload's `folder` is `null` when omitted. What a policy glob does when matched against `null` is unverified. If `{"match": {"folder": "Work"}}` silently fails to match and falls through to a later approve rule, that is a fail-open on `listNotes()` with no arguments — the call with the widest reach. This plan works around it by passing `""` instead of `null` in the payloads, which is a guess, not a fix. **Before merging: verify what `checkPolicy` does with an empty string and with null, then write a test in `lib/stdlib/__tests__/` pinning it.** If `""` matches a `"Work"` glob, the workaround is worse than the bug.
-- **Finding 11b.** Whether `renderForHtml` should drop raw HTML silently or emit a diagnostic. Currently silent. Not blocking.
+**One finding from §12 remains open, and is not blocking:**
 
-**Known gap:** `account` is threaded through the types and payloads but the Agency layer passes `""` for it, because the TS layer derives the account from the note rather than accepting one. The `account` *argument* from spec §4.2 is not implemented. This plan delivers account as an output field, not as an input filter. That is a deliberate scope cut for a first version, and it means folder scoping is still advisory on a multi-account machine — the exact thing spec §3.4 argued had to be fixed. **The owner has one account (§9.4), so this is latent rather than live, but it must be either implemented or explicitly deferred in the spec before this ships.** Do not let it merge silently.
+- **Finding 11b.** Whether `renderForHtml` should drop raw HTML silently or emit a diagnostic. Currently silent.
+
+**Two deliberate v1 limits**, both measured, both documented above under "Two v1 limits":
+
+- **Nested folder paths are unsupported.** `listFolders` returns top-level folders only, which is honest rather than the flat-and-wrong alternative. Nested folders stay reachable by bare name, ambiguously — Notes' own behaviour.
+- **The `account` argument is not implemented.** `account` is an output field, not an input filter, so folder scoping stays advisory on a multi-account machine. The owner has one account, so this is latent. **Both limits must be written into the spec before this merges, so the spec stops promising what the code does not build.**
+
+**The account BUG, as distinct from the missing argument, is fixed** in Task 2's `ACCOUNT_WALK`. One hop up from a note's folder lands on `Archived`, not `iCloud`, for anything nested. That was wrong and silently so.

--- a/docs/superpowers/plans/2026-07-17-std-notes-apple.md
+++ b/docs/superpowers/plans/2026-07-17-std-notes-apple.md
@@ -69,12 +69,21 @@ Two consequences:
    `"*"`. So `{"match": {"folder": "*"}, "action": "approve"}` does not approve a
    `listNotes()` with no folder; it falls through to the next rule. The fail-open
    finding #7 feared cannot occur.
-2. **`null` would crash the policy check**, not fail open, because picomatch
-   throws on a non-string.
+2. **`null` FAILS OPEN through the real matcher.** The table above measured
+   raw picomatch, which throws on null. But the real evaluator
+   (`matchesRule` in `lib/runtime/policy.ts`) coerces non-strings with
+   `String(value)` first, so a null folder becomes the string `"null"`, and a
+   `"*"` glob matches it. A null payload field would let a catch-all folder
+   rule approve a call the empty string correctly refuses. The PR review
+   caught that the original test pinned raw picomatch rather than the real
+   code path; testing through `checkPolicyExplicit` surfaced this.
 
 So passing `""` is load-bearing rather than a stylistic default. Never let a
-`null` reach a payload field a policy can match on. Task 5 pins consequence 1
-with a test.
+`null` reach a payload field a policy can match on. Through the real matcher
+that is not a crash, it is an approval. Task 5 pins both consequences with
+tests through the real evaluator. One caveat the tests also pin: `""`
+protects against folder-glob rules, not against a rule with no `match` key
+at all, which approves every interrupt of its effect.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md
+++ b/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md
@@ -1,7 +1,7 @@
 # std::notes/apple — Apple Notes integration for the Agency standard library
 
 Date: 2026-07-16
-Status: Design approved. Spike complete, all open questions resolved. Ready for an implementation plan.
+Status: Implemented. The module shipped from the 2026-07-17 implementation plan, with the two v1 limits recorded in Section 10.
 Scope: One new stdlib module, one new function in an existing stdlib module, one addition to the capability sets
 
 ---
@@ -1211,7 +1211,11 @@ behaviour rather than something this module introduces.
 **The `account` argument.** Section 4.2 gives every function an optional
 `account`, and Section 3.4 argued it is what makes folder scoping a real
 guarantee rather than an advisory one. v1 delivers `account` as an **output**
-field on `Note` and in every payload, but not as an input filter. So folder
+field on `Note`, and as a payload field that is populated from the pre-flight
+on `appendToNote`, `readNote`, and `deleteNote` — but empty on `createNote`,
+`searchNotes`, and `listNotes`, where no pre-flight runs. It is not an input
+filter anywhere. An empty string matches no policy glob, not even `"*"`, so an
+`account` match never applies to those three calls. So folder
 scoping stays advisory on a multi-account machine.
 
 The owner has exactly one account (Section 9.4), so this is latent rather than

--- a/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md
+++ b/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md
@@ -585,6 +585,11 @@ original omission came from. `git.agency` is the newer and better precedent.
 **`account` is optional and defaults to the default account.** See Section 3.4.
 It exists so folder scoping is a real guarantee rather than an advisory one.
 
+> **Deferred out of v1.** The implementation plan does not build the `account`
+> argument. `account` ships as an output field only, so folder scoping stays
+> advisory on a multi-account machine. Section 10 records why. The signatures
+> below are the intended shape, not what v1 delivers.
+
 **`folder` defaults to `"Agency Notes"`, and may not exist yet.** Chosen by the
 owner so a user can see at a glance which notes an agent made, and rename the
 folder if they want. Unlike Apple's `"Notes"`, it will not exist on a fresh
@@ -1182,9 +1187,45 @@ timeout bounded it.
 - **Moving notes between folders.** Not requested.
 - **Tests that touch real Notes.app.** Section 8.
 
-Accounts **were** on this list. They are now in scope, per Section 3.4 and the
-owner's decision. Section 9.4 predicted the exclusion would not survive, and it
-did not.
+### Deferred out of v1 after the spike, with reasons
+
+Both of these were in scope when this spec was written. A later probe measured
+what they actually cost, and the implementation plan defers them. They are
+recorded here so the spec stops promising what v1 does not build.
+
+**Nested folder paths.** Notes folders nest, and the owner's account has them:
+`Archived` contains `2010s`, `2017`, `2019`. Three measured facts:
+
+- A bare `repeat with f in folders` **flattens** the hierarchy, returning
+  `Archived` and its children side by side with nothing marking the difference.
+- `folder "2017"` **resolves** from the top level, so name addressing is
+  ambiguous rather than broken.
+- `/` **is legal** in a folder name (verified by creating one), so a path
+  separator needs escaping. Paths are a real design job, not a string join.
+
+v1 therefore has `listFolders` return **top-level folders only**, filtered by
+`class of c is account`. That is honest and limited rather than flat and wrong.
+Nested folders remain reachable by bare name, ambiguously, which is Notes' own
+behaviour rather than something this module introduces.
+
+**The `account` argument.** Section 4.2 gives every function an optional
+`account`, and Section 3.4 argued it is what makes folder scoping a real
+guarantee rather than an advisory one. v1 delivers `account` as an **output**
+field on `Note` and in every payload, but not as an input filter. So folder
+scoping stays advisory on a multi-account machine.
+
+The owner has exactly one account (Section 9.4), so this is latent rather than
+live. It is a scope cut, and Section 3.2's argument — that exposing every note
+body is defensible *because* containment is real — is weaker by exactly this
+much until it lands. That should be said plainly rather than discovered later.
+
+**The account derivation bug is NOT deferred; it is fixed in v1.** Distinct from
+the missing argument. Deriving a note's account with one hop up from its folder
+is wrong for any nested folder: `container of folder "2017"` is `Archived`, not
+`iCloud`. Left alone, every note under `Archived` would carry `"Archived"` in its
+`account` payload field, and a policy matching `{"account": "iCloud"}` would
+silently stop matching. The fix is a bounded upward walk, verified to reach
+`iCloud` from `Archived/2017` in 2 hops.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md
+++ b/docs/superpowers/specs/2026-07-16-std-notes-apple-notes-design.md
@@ -1,7 +1,7 @@
 # std::notes/apple — Apple Notes integration for the Agency standard library
 
 Date: 2026-07-16
-Status: Design, awaiting owner review
+Status: Design approved. Spike complete, all open questions resolved. Ready for an implementation plan.
 Scope: One new stdlib module, one new function in an existing stdlib module, one addition to the capability sets
 
 ---
@@ -84,9 +84,9 @@ This table is copied from the sdef, not from memory:
 
 | Property | Type | Access | Notes |
 |---|---|---|---|
-| `name` | text | read/write | The title. See the open question in Section 9.1. |
+| `name` | text | read/write | The title. Setting it works; Section 9.1. |
 | `id` | text | read-only | An opaque `x-coredata://...` string. Stable. |
-| `container` | folder | read-only | The folder the note is in. |
+| `container` | folder | read-only | The folder. **Must be read in two steps**; Section 9.2. |
 | `body` | text | **read/write** | HTML. The only writable content field. |
 | `plaintext` | text | read-only | The note's text without markup. |
 | `creation date` | date | read-only | |
@@ -280,8 +280,10 @@ corrected in place rather than quietly dropped:
 - The `osascript` argv example in Section 3.6 was off by one. Verified wrong.
 - Section 2.6 claimed `-1712` was the only permission signal. See Section 2.8.
 
-One blocker remains open, in Section 9.2. It must be settled before the Notes
-module is implemented.
+Section 9.2 was a blocker and is now resolved: a note's `container` is readable,
+but only if the access is split rather than chained. It took four probes, and
+every failure was a probe bug rather than a finding. The mechanics are in 9.2
+because the same mistake is easy to repeat.
 
 ### 3.2 Full CRUD, including reading note bodies
 
@@ -681,11 +683,16 @@ That query reads three properties and nothing else:
 on run argv
   tell application "Notes"
     set n to note id (item 1 of argv)
-    return (name of n) & tab & (name of container of n) & tab & ¬
+    set c to container of n          -- must be split; see Section 9.2
+    return (name of n) & tab & (name of c) & tab & ¬
            ((password protected of n) as text)
   end tell
 end run
 ```
+
+The split on `container` is load-bearing, not style. `name of container of n` in
+one expression errors `-1728` on every note, locked or not. Section 9.2 has the
+measurements.
 
 `body` and `plaintext` are never touched. The unguarded step learns a title, a
 folder name, and a locked flag. It never learns a single byte of note content.
@@ -709,8 +716,8 @@ module source, where it will be read by the next person deciding whether to add 
 third property to this query. "Unreachable without a gate" would license adding
 anything. "Discloses only what the id-holder already knows" does not.
 
-**This entire section is contingent on Section 9.2.** The pre-flight reads
-`name of container`, and the spike could not confirm that works.
+Section 9.2 confirmed this lookup works, provided the `container` access is
+split rather than chained.
 
 ### 5.4 Retry markers
 
@@ -822,32 +829,39 @@ be locked. So the assertion was check-then-act, and Section 6.6's unconditional
 "assertion does not match → fail closed" was not something the design delivered.
 
 The fix is cheap and it uses data already in argv. Re-assert inside the write
-script, in the same `tell` block as the mutation:
+script, in the same `tell` block as the mutation.
+
+Section 9.2 found a better way to spell that assertion than the obvious one.
+Rather than reading the note's container and comparing it to the asserted
+folder, **address the note through the folder**:
 
 ```applescript
 on run argv
   tell application "Notes"
-    set n to note id (item 1 of argv)
-    if (name of container of n) is not (item 3 of argv) then
-      error "folder mismatch"
-    end if
+    -- Scoped lookup IS the assertion: this fails if the note is not in
+    -- the asserted folder. Verified to fail closed on the wrong folder.
+    set n to note id (item 1 of argv) of folder (item 3 of argv)
     if (password protected of n) then error "note is locked"
     set body of n to (body of n) & (item 2 of argv)
   end tell
 end run
 ```
 
-Now the pre-flight exists only to build the interrupt payload, which is what
-Section 5.3 says it is for, and the assertion is a guarantee rather than a
-best-effort. The locked re-check belongs here too, for the same reason and with
-much higher stakes (Section 2.7).
+This is better than read-then-compare, and not only shorter. A scoped lookup
+cannot drift from its own check: the reference that gets mutated is the same one
+that had to resolve inside the asserted folder. Read-then-compare has two steps
+and therefore a window between them, which is the whole problem this section is
+fixing. The check and the access are now a single operation.
+
+When the caller asserted no folder, the lookup is unscoped (`note id X`) and
+there is nothing to check, which is correct.
+
+The locked re-check belongs here too, for the same reason and with much higher
+stakes (Section 2.7).
 
 This still does not make append atomic. Notes offers no transaction, so a user
 typing into the note at that exact moment can lose a keystroke. The honest claim
 is "meaningfully safer than two round trips", not "atomic".
-
-Note this interacts with Section 9.2. If the container cannot be read, this
-script cannot assert on it either.
 
 ### 6.5 deleteNote is recoverable
 
@@ -985,7 +999,9 @@ A one-off manual spike ran against real Notes.app on macOS 14.7.4. It was not a
 test and nothing about it is committed. Every note it created went into a
 throwaway folder called "Agency Spike", which it then deleted.
 
-Three of the four questions are answered. One turned into a blocker.
+All four questions are answered. Nothing is blocked. Section 9.2 took four
+probes, and every one of those failures was a bug in the probe rather than a
+finding about Notes.
 
 ### 9.1 Does setting `name` set the title? **Yes. Resolved.**
 
@@ -1000,50 +1016,100 @@ So `createNote` sets `name` directly, and `renderForHtml` needs no leading
 `<h1>`. This also confirms the renderer is genuinely independent of the Notes
 module, which is why it could be built first.
 
-### 9.2 Is a locked note's metadata readable? **Partly. This is the blocker.**
+### 9.2 Is a note's container readable? **Yes, if you do not chain. Resolved.**
 
-Mixed, and the mix is the problem:
+This one took four probes and cost the most, so the mechanics are worth writing
+down properly. Every probe failure was a probe bug. Notes behaved consistently
+the whole way through.
 
-| Property | Result |
+**The finding: reference chaining is the problem, not the property.**
+
+| Form | Result |
 |---|---|
-| `name` | `lockme` — readable |
-| `password protected` | `true` — readable |
-| `body` | **empty string, no error** — see Section 2.7 |
-| `container` | **error -1728, "Can't get name of container of note..."** |
+| `name of container of n` | error `-1728` |
+| `id of container of n` | error `-1728` |
+| `set c to container of n` then `name of c` | **`Agency Spike`** |
 
-The good half: `name` and `password protected` both read fine, so we can always
-detect a locked note and name it in an error. Locked notes are
-visible-but-unreadable, not invisible.
+`container of n` resolves correctly every time. Reading a property *through* it in
+a single expression is what fails. Coercing it directly proves the resolution is
+fine, because the coercion error leaks the object it resolved to:
 
-The blocker: **`name of container` errored, and the spike cannot say why.** The
-probe was designed badly. It never read `name of container` on an *unlocked*
-note, so two very different explanations both fit:
-
-1. Locked notes hide their container. A narrow problem, affecting only the
-   locked path, which already fails closed.
-2. `name of container of note X of folder Y` does not work on any note. If so,
-   **Section 5.3's pre-flight lookup is broken**, and with it the folder
-   assertion in Section 3.4, the `folder` field in every payload in Section 5.1,
-   and the account resolution in Section 3.4's repair. That is most of the
-   scoping story.
-
-Until this is settled, no part of the Notes module that depends on the pre-flight
-should be implemented.
-
-Settling it needs one read-only command against an unlocked note:
-
-```bash
-osascript -e 'tell application "Notes"
-  return name of container of note "TITLE_FROM_NAME" of folder "Agency Spike"
-end tell'
+```
+3: container of n coerced to text
+   error: Can't make «class cfol» id "x-coredata://.../ICFolder/p594"
+          of application "Notes" into type text. (-1700)
 ```
 
-Returns `Agency Spike` → explanation 1, narrow fix. Errors with `-1728` →
-explanation 2, and Section 5.3 needs rework before the plan is written.
+`ICFolder/p594` is Agency Spike, confirmed against a folder-id listing. So the
+container was there all along.
 
-It has to be run from a terminal the user has granted Notes automation to. A
-different process gets `-1743` regardless of the answer (Section 2.8), which is
-why this could not be resolved without the owner present.
+**So the pre-flight survives.** It must split the access:
+
+```applescript
+on run argv
+  tell application "Notes"
+    set n to note id (item 1 of argv)
+    set c to container of n          -- split. `name of container of n` fails.
+    return (name of n) & tab & (name of c) & tab & ¬
+           ((password protected of n) as text)
+  end tell
+end run
+```
+
+This is not locked-specific. `container` behaves identically on locked and
+unlocked notes; both fail when chained and both work when split. Section 9.2's
+original framing, that this might be a locked-note quirk, was wrong in an
+uninteresting way: it was never about locking at all.
+
+**Two other approaches also work, and one of them is better for the assertion.**
+
+The probe tested them because a broken `container` looked likely at the time.
+Both came back positive, and one earns a place in the design anyway:
+
+```
+4: note id X of folder Y            -> resolved: searchtarget
+5: same, but the WRONG folder       -> good: did not resolve
+6: find the folder by iterating     -> found in: Agency Spike
+```
+
+Test 4 and 5 together are the **inverted assertion**. The original design asks a
+note which folder it is in and compares that to what the caller asserted. But the
+assertion never needed the answer to that question. It only needs "is this note
+in the folder I was told?", and `note id X of folder Y` answers exactly that,
+failing closed on the wrong folder.
+
+That is strictly better than read-then-compare, and Section 6.4 adopts it,
+because it collapses the check and the access into one lookup. A scoped lookup
+cannot drift from its own check the way read-then-compare can across a human
+approval. It resolves review finding #4 as a side effect rather than by adding a
+second guard.
+
+So the design uses both:
+
+- **`container of n`, split**, in the pre-flight, so the interrupt payload can
+  carry `folder` even when the caller asserted nothing. Policy globs need this.
+- **`note id X of folder Y`**, in the write script, as the assertion itself.
+
+Test 6 (scan every folder for the id) is the fallback if `container` ever breaks
+outright. Not used, recorded because it works.
+
+**Why this took four probes**, since the pattern is worth not repeating:
+
+1. Probe 1 used a chained by-name reference **and** ran against a folder that
+   might not exist. `-1728` covers "no such object", so the result could not
+   distinguish a broken container from a deleted folder.
+2. Probe 2 accumulated results into one AppleScript string and returned it at the
+   end. Most of the output vanished.
+3. Probe 3 fixed the output by echoing one `osascript` call per test, but its
+   "step-by-step" case still read `name of container of n`. It split the note
+   lookup and left the container access chained, so it tested the broken form
+   while claiming to test the fixed one.
+4. Probe 4 finally split the container access, and answered in one run.
+
+The lesson is narrow and mechanical: **when a probe and the design disagree about
+shape, the probe is testing something else.** Probe 3's label said "set n then
+container of n" and its code said `name of container of n`. Reading the label
+rather than the code cost two rounds.
 
 ### 9.3 Can `whose` search note bodies? **Yes, both ways. Resolved.**
 
@@ -1128,25 +1194,27 @@ Rough shape for the implementation plan, which is a separate document.
 
 **Done.**
 
-1. Live spike, Section 9. Three of four questions answered. 9.2 is still open and
-   still blocks the Notes module.
-2. `renderForHtml` in `std::markdown`, plus 34 unit tests. Section 9.1's answer
-   confirmed this is independent of the Notes module, so it went first.
+1. Live spike, Section 9. All four questions answered. Nothing is blocked.
+2. `renderForHtml` in `std::markdown`, plus 46 unit tests. Merged in #562.
+   Section 9.1's answer confirmed this is independent of the Notes module, so it
+   went first.
 
-**Blocked on Section 9.2.** Everything below depends on the pre-flight lookup,
-which is exactly what 9.2 puts in doubt.
+**Ready to implement.**
 
-3. `lib/stdlib/appleNotes.ts`: argv-based script construction, error mapping for
-   `-1743` and `-1712`, pre-flight lookup, the locked-note guard, plus unit tests.
-4. `stdlib/notes/apple.agency`: types, effects, functions, docstrings.
+3. `lib/stdlib/appleNotes.ts`: argv-based script construction (no `-` separator,
+   Section 3.6), error mapping for `-1743` and `-1712`, the pre-flight lookup
+   with a split `container` access, the locked-note guard, the scoped-lookup
+   assertion, plus unit tests.
+4. `stdlib/notes/apple.agency`: types, effects, functions, docstrings, `raises`
+   clauses, typed `Result<T>` returns.
 5. `stdlib/capabilities.agency`: the three effect sets.
-
-**Not blocked.**
-
 6. Docs. Module doc comments generate the stdlib reference page via `agency doc`,
    so they are written in the source rather than hand-edited. A guide page
    showing the Obsidian `std::fs` pattern is worth including here, since Section
    3.1 makes it the answer for Obsidian users.
+
+Section 12 lists eight review findings that apply during step 3 and step 4. They
+are not optional cleanups; two of them are fail-open bugs.
 
 ---
 

--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -330,6 +330,13 @@ export default defineConfig({
                 { text: "messaging/sms", link: "/stdlib/messaging/sms" },
               ],
             },
+            {
+              text: "notes",
+              collapsed: false,
+              items: [
+                { text: "notes/apple", link: "/stdlib/notes/apple" },
+              ],
+            },
             { text: "object", link: "/stdlib/object" },
             { text: "path", link: "/stdlib/path" },
             { text: "policy", link: "/stdlib/policy" },

--- a/packages/agency-lang/docs/site/stdlib/capabilities.md
+++ b/packages/agency-lang/docs/site/stdlib/capabilities.md
@@ -157,3 +157,36 @@ export effectSet Memory = <std::memory::recall, std::memory::remember, std::memo
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L64))
+
+### NotesRead
+
+Read-only Notes access: reading, searching, and listing.
+
+```ts
+/** Read-only Notes access: reading, searching, and listing. */
+export effectSet NotesRead = <std::notes::read, std::notes::search, std::notes::list>
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L67))
+
+### NotesWrite
+
+Notes mutation: creating, appending, and deleting.
+
+```ts
+/** Notes mutation: creating, appending, and deleting. */
+export effectSet NotesWrite = <std::notes::create, std::notes::append, std::notes::delete>
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L70))
+
+### Notes
+
+All Notes access, reads and writes.
+
+```ts
+/** All Notes access, reads and writes. */
+export effectSet Notes = <NotesRead, NotesWrite>
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/capabilities.agency#L73))

--- a/packages/agency-lang/docs/site/stdlib/notes/apple.md
+++ b/packages/agency-lang/docs/site/stdlib/notes/apple.md
@@ -1,0 +1,427 @@
+---
+name: "apple"
+---
+
+# apple
+
+Create, read, search, and edit notes in the macOS Notes app. macOS only.
+  The first call asks for Automation permission with a system dialog. If
+  nobody answers the dialog, the call fails after 30 seconds.
+
+  ```ts
+  import { createNote } from "std::notes/apple"
+
+  node main() {
+    const result = createNote("Findings", "## Summary\n\n- one\n- two")
+    print(result)
+  }
+  ```
+
+  ## Notes are addressed by id
+
+  Two notes in the same folder can share a title, so a title is not an
+  address. Every read and edit takes the note's `id`, which comes from
+  `listNotes` or `searchNotes`:
+
+  ```ts
+  import { searchNotes, appendToNote } from "std::notes/apple"
+
+  node main() {
+    const found = searchNotes("Q3 planning")
+    if (found is success(notes)) {
+      appendToNote(notes[0].id, "\n## Update\n\nShipped.")
+    }
+  }
+  ```
+
+  `createNote` returns the note it made, including its id, so
+  create-then-append needs no search.
+
+  ## Bodies are Markdown going in, plain text coming out
+
+  `createNote` and `appendToNote` take Markdown and convert it to the HTML
+  that Notes stores. `readNote` returns plain text. That makes a
+  read-then-write round trip lossy: reading strips the formatting, and
+  writing the text back would flatten the note. Use `appendToNote` instead
+  of reading, editing, and rewriting a note yourself.
+
+  ## Confining an agent to one folder
+
+  Every function takes an optional `folder`. It constrains rather than
+  addresses: if you pass it, the call fails unless the note is in that
+  folder. Combined with partial application, that confines an agent in a way
+  the model cannot see or route around, because the locked parameter is
+  stripped from the tool's schema:
+
+  ```ts
+  import { listNotes, readNote } from "std::notes/apple"
+
+  node main() {
+    const reader = readNote.partial(folder: "Work").rename("readWorkNote")
+    const lister = listNotes.partial(folder: "Work").rename("listWorkNotes")
+    llm("Summarise my Work notes", { tools: [lister, reader] })
+  }
+  ```
+
+  The model may pass any id it likes. Anything outside Work fails closed.
+
+  ## Deciding with a policy
+
+  Each operation raises its own effect, so a policy can approve reads and
+  reject deletes:
+
+  ```json
+  {
+    "std::notes::read": [
+      { "match": { "folder": "Work" }, "action": "approve" },
+      { "action": "reject" }
+    ],
+    "std::notes::delete": [{ "action": "reject" }]
+  }
+  ```
+
+  `readNote`, `appendToNote`, and `deleteNote` look the note up before
+  raising their interrupt, so the payload carries the note's real `title`,
+  `folder`, and `account` even when the call passed only an id. The rule
+  above therefore matches a bare `readNote(id)` for a note that lives in
+  Work.
+
+  One v1 limit: only those three calls populate `account`. `createNote`,
+  `searchNotes`, and `listNotes` send it as an empty string, and an empty
+  string matches no glob. A rule that matches on `account` never applies to
+  them, so match on `folder` instead.
+
+  The `NotesRead`, `NotesWrite`, and `Notes` sets in `std::capabilities`
+  cover the same split for constraining a whole node.
+
+  ## Locked notes
+
+  A note locked with a password cannot be read or edited, and this module
+  will not try. Calls against a locked note fail before their interrupt is
+  raised, with a message naming the note.
+
+  ## Deleting is recoverable
+
+  `deleteNote` moves a note to Recently Deleted, where it stays for about
+  30 days. `listFolders` returns that folder like any other.
+
+  ## Other note apps
+
+  Obsidian needs no module. A vault is a directory of Markdown files, so
+  `std::fs` already covers it, and the same handlers, policies, and partial
+  application apply. Bear is not supported: its `x-callback-url` API cannot
+  deliver a callback to a command-line process, so a create call could not
+  return the new note's id.
+
+## Types
+
+### Folder
+
+A folder in Notes. `noteCount` is derived, not stored.
+
+```ts
+/** A folder in Notes. `noteCount` is derived, not stored. */
+export type Folder = {
+  id: string;
+  name: string;
+  noteCount: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L126))
+
+### Note
+
+A note's metadata. Deliberately contains no body.
+
+```ts
+/** A note's metadata. Deliberately contains no body. */
+export type Note = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  modified: string;
+  passwordProtected: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L133))
+
+### NoteContent
+
+A note including its content, as plaintext.
+
+```ts
+/** A note including its content, as plaintext. */
+export type NoteContent = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  body: string;
+  modified: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L143))
+
+## Effects
+
+### std::notes::create
+
+```ts
+effect std::notes::create {
+  account: string;
+  folder: string;
+  title: string;
+  folderCreated: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L152))
+
+### std::notes::append
+
+```ts
+effect std::notes::append {
+  account: string;
+  folder: string;
+  title: string;
+  id: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L153))
+
+### std::notes::read
+
+```ts
+effect std::notes::read {
+  account: string;
+  folder: string;
+  title: string;
+  id: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L154))
+
+### std::notes::search
+
+```ts
+effect std::notes::search {
+  account: string;
+  folder: string;
+  query: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L155))
+
+### std::notes::list
+
+```ts
+effect std::notes::list {
+  account: string;
+  folder: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L156))
+
+### std::notes::delete
+
+```ts
+effect std::notes::delete {
+  account: string;
+  folder: string;
+  title: string;
+  id: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L157))
+
+## Functions
+
+### createNote
+
+```ts
+createNote(
+  title: string,
+  body: string,
+  folder: string = "Agency Notes",
+): Result<Note> raises <std::notes::create>
+```
+
+Create a note in the Notes app and return it, including its new id.
+
+  @param title - The note's title
+  @param body - The note's content, as Markdown
+  @param folder - The folder to create it in. Created if it does not exist.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| title | `string` |  |
+| body | `string` |  |
+| folder | `string` | "Agency Notes" |
+
+**Returns:** `Result<Note>`
+
+**Throws:** `std::notes::create`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L205))
+
+### appendToNote
+
+```ts
+appendToNote(
+  id: string,
+  body: string,
+  folder: string | null = null,
+): Result<Note> raises <std::notes::append>
+```
+
+Append Markdown to an existing note. Get the id from listNotes or searchNotes.
+
+  @param id - The note's id
+  @param body - The content to append, as Markdown
+  @param folder - If given, the call fails unless the note is in this folder
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `string` |  |
+| body | `string` |  |
+| folder | `string \| null` | null |
+
+**Returns:** `Result<Note>`
+
+**Throws:** `std::notes::append`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L238))
+
+### readNote
+
+```ts
+readNote(
+  id: string,
+  folder: string | null = null,
+): Result<NoteContent> raises <std::notes::read>
+```
+
+Read a note's contents as plain text. Get the id from listNotes or searchNotes.
+
+  @param id - The note's id
+  @param folder - If given, the call fails unless the note is in this folder
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `string` |  |
+| folder | `string \| null` | null |
+
+**Returns:** `Result<NoteContent>`
+
+**Throws:** `std::notes::read`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L268))
+
+### searchNotes
+
+```ts
+searchNotes(
+  query: string,
+  folder: string | null = null,
+): Result<Note[]> raises <std::notes::search>
+```
+
+Search notes by their text and return matching notes' metadata, without their
+  contents.
+
+  @param query - The text to search for
+  @param folder - If given, only search this folder
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| query | `string` |  |
+| folder | `string \| null` | null |
+
+**Returns:** `Result<Note[]>`
+
+**Throws:** `std::notes::search`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L290))
+
+### listNotes
+
+```ts
+listNotes(
+  folder: string | null = null,
+): Result<Note[]> raises <std::notes::list>
+```
+
+List notes' metadata, without their contents.
+
+  @param folder - If given, only list this folder
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| folder | `string \| null` | null |
+
+**Returns:** `Result<Note[]>`
+
+**Throws:** `std::notes::list`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L309))
+
+### listFolders
+
+```ts
+listFolders(): Result<Folder[]> raises <std::notes::list>
+```
+
+List the folders in the Notes app, with a count of the notes in each.
+
+**Returns:** `Result<Folder[]>`
+
+**Throws:** `std::notes::list`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L325))
+
+### deleteNote
+
+```ts
+deleteNote(
+  id: string,
+  folder: string | null = null,
+): Result<null> raises <std::notes::delete>
+```
+
+Delete a note. It moves to the Recently Deleted folder, where it stays for
+  about 30 days.
+
+  @param id - The note's id
+  @param folder - If given, the call fails unless the note is in this folder
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `string` |  |
+| folder | `string \| null` | null |
+
+**Returns:** `Result<null>`
+
+**Throws:** `std::notes::delete`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L337))

--- a/packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts
+++ b/packages/agency-lang/lib/stdlib/__tests__/appleNotes.test.ts
@@ -1,0 +1,510 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout: "", stderr: "" });
+    },
+  ),
+}));
+
+import { execFile } from "child_process";
+import {
+  runNotesScript,
+  withTimeout,
+  FIELD_DELIM,
+  _preflightNote,
+  assertNotLocked,
+  _readNote,
+  _listNotes,
+  _searchNotes,
+  _listFolders,
+  _folderExists,
+  _createNote,
+  _appendToNote,
+  _deleteNote,
+} from "../appleNotes.js";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+/** Make the mocked execFile fail with the given stderr, as osascript does. */
+function mockFailure(stderr: string): void {
+  (execFile as unknown as MockFn).mockImplementationOnce(
+    (_c: string, _a: string[], cb: (e: unknown) => void) => {
+      cb({ stderr, code: 1 });
+    },
+  );
+}
+
+/** Make the mocked execFile succeed with the given stdout. */
+function mockStdout(stdout: string): void {
+  (execFile as unknown as MockFn).mockImplementationOnce(
+    (
+      _c: string,
+      _a: string[],
+      cb: (e: null, r: { stdout: string; stderr: string }) => void,
+    ) => {
+      cb(null, { stdout, stderr: "" });
+    },
+  );
+}
+
+// Every describe below needs the same two things: fresh mocks and a darwin
+// platform (runNotesScript refuses to run anywhere else). One test overrides
+// the platform to linux for itself; afterEach restores the real one.
+const originalPlatform = process.platform;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+});
+
+describe("runNotesScript", () => {
+  it("rejects immediately on a non-darwin platform", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+    await expect(runNotesScript("script", [])).rejects.toThrow(
+      "Apple Notes is only available on macOS",
+    );
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("passes args straight through to argv with NO '-' separator", async () => {
+    mockStdout("ok");
+    await runNotesScript("SCRIPT", ["alpha", "beta"]);
+    const [cmd, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(cmd).toBe("osascript");
+    // The `-` is NOT a separator: osascript passes it through as argv item 1
+    // and shifts every real argument. Spec section 3.6.
+    expect(args).toEqual(["-e", "SCRIPT", "alpha", "beta"]);
+  });
+
+  it("keeps a hostile title inert in argv rather than in the script", async () => {
+    mockStdout("ok");
+    const hostile = '"; do shell script "rm -rf ~"; "';
+    await runNotesScript("SCRIPT", [hostile]);
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).toBe("SCRIPT");
+    expect(args[2]).toBe(hostile);
+    expect(args[1]).not.toContain("do shell script");
+  });
+
+  it("maps -1743 to a clear not-authorized error", async () => {
+    // Two awaited calls below, and mockFailure queues with
+    // mockImplementationOnce — so queue it twice. vi.clearAllMocks() does NOT
+    // clear the factory's default success implementation, so a second call
+    // with nothing queued would RESOLVE and the assertion would fail.
+    mockFailure("execution error: Not authorized to send Apple events to Notes. (-1743)");
+    mockFailure("execution error: Not authorized to send Apple events to Notes. (-1743)");
+    await expect(runNotesScript("s", [])).rejects.toThrow(/Not authorized to control Notes/);
+    await expect(runNotesScript("s", [])).rejects.toThrow(/Privacy & Security/);
+  });
+
+  it("maps -1712 to a hedged timeout error", async () => {
+    mockFailure("execution error: Notes got an error: AppleEvent timed out. (-1712)");
+    // -1712 cannot distinguish "consent dialog unanswered" from "Notes wedged",
+    // so the message must hedge. Spec section 2.8.
+    await expect(runNotesScript("s", [])).rejects.toThrow(/usually means/);
+  });
+
+  it("surfaces an unrecognised stderr rather than swallowing it", async () => {
+    mockFailure("execution error: something else entirely (-9999)");
+    await expect(runNotesScript("s", [])).rejects.toThrow(/something else entirely/);
+  });
+
+  it("trims only trailing whitespace, because leading whitespace is meaningful in plaintext", async () => {
+    mockStdout("  value  \n");
+    await expect(runNotesScript("s", [])).resolves.toBe("  value");
+  });
+});
+
+describe("withTimeout", () => {
+  it("wraps the body so the 120s AppleScript default is not inherited", () => {
+    const out = withTimeout("tell application \"Notes\"\nend tell");
+    expect(out).toContain("with timeout of 30 seconds");
+    expect(out).toContain("end timeout");
+    expect(out).toContain("on run argv");
+    expect(out).toContain("end run");
+  });
+});
+
+describe("FIELD_DELIM", () => {
+  it("is a control character, because titles can contain tabs", () => {
+    expect(FIELD_DELIM).toBe("\u0001");
+    expect(FIELD_DELIM).not.toBe("\t");
+  });
+});
+
+describe("_preflightNote", () => {
+  it("never chains a property read through container", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    const script = args[1];
+    // `name of container of n` errors -1728 on EVERY note, locked or not.
+    // Spec section 9.2. This test exists so a "tidying" refactor cannot
+    // silently reintroduce the chained form.
+    expect(script).not.toContain("name of container of n");
+    expect(script).toContain("set c to container of n");
+  });
+
+  it("walks up to the account rather than assuming one hop", async () => {
+    mockStdout(["Q3", "2017", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    const script = args[1];
+    // A folder's container is its PARENT FOLDER when nested, not the account.
+    // Measured: `container of folder "2017"` is "Archived", not "iCloud". One
+    // hop would put a folder name in the account field, and a policy matching
+    // {"account": "iCloud"} would silently stop matching.
+    expect(script).toContain("class of a) is account");
+    expect(script).toContain("set a to container of a");
+  });
+
+  it("fails closed if the account walk does not reach an account", async () => {
+    mockStdout(["Q3", "2017", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // The walk is bounded. If it never lands on an account, error rather than
+    // returning a folder name as the account.
+    expect(args[1]).toContain("Could not resolve the account");
+  });
+
+  it("reads only title, folder, account and the locked flag — never the body", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    const script = args[1];
+    // This query is not interrupt-gated, so it must never touch content.
+    expect(script).not.toContain("body of");
+    expect(script).not.toContain("plaintext of");
+  });
+
+  it("passes the id as argv, not in the script", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    await _preflightNote("x-coredata://note/1");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[2]).toBe("x-coredata://note/1");
+    expect(args[1]).not.toContain("x-coredata://note/1");
+  });
+
+  it("parses the delimited fields", async () => {
+    mockStdout(["Q3 Planning", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    const meta = await _preflightNote("x-coredata://note/1");
+    expect(meta).toEqual({
+      id: "x-coredata://note/1",
+      title: "Q3 Planning",
+      folder: "Work",
+      account: "iCloud",
+      locked: false,
+    });
+  });
+
+  it("parses a title containing a tab, which the delimiter must survive", async () => {
+    mockStdout(["a\tb", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    const meta = await _preflightNote("x-coredata://note/1");
+    expect(meta.title).toBe("a\tb");
+    expect(meta.folder).toBe("Work");
+  });
+
+  it("reads the locked flag as true", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    const meta = await _preflightNote("x-coredata://note/1");
+    expect(meta.locked).toBe(true);
+  });
+
+  it("fails on a malformed reply rather than guessing", async () => {
+    mockStdout("only one field");
+    await expect(_preflightNote("x-coredata://note/1")).rejects.toThrow(/unexpected reply/i);
+  });
+});
+
+describe("assertNotLocked", () => {
+  const base = {
+    id: "x-coredata://note/1",
+    title: "Q3 Planning",
+    folder: "Work",
+    account: "iCloud",
+  };
+
+  it("passes an unlocked note through", () => {
+    expect(() => assertNotLocked({ ...base, locked: false })).not.toThrow();
+  });
+
+  // THIS IS DATA-LOSS PREVENTION, NOT A NICE ERROR MESSAGE.
+  // A locked note's body reads as an EMPTY STRING rather than erroring, so an
+  // append that skipped this guard would run `set body of n to "" & newText`
+  // and replace the note's contents with the appended text. Spec section 2.7.
+  // If this test is failing, do not delete it. The guard is why locked notes
+  // survive.
+  it("refuses a locked note and names it", () => {
+    expect(() => assertNotLocked({ ...base, locked: true })).toThrow(/Q3 Planning/);
+    expect(() => assertNotLocked({ ...base, locked: true })).toThrow(/locked/i);
+    expect(() => assertNotLocked({ ...base, locked: true })).toThrow(/Unlock it in Notes\.app/);
+  });
+});
+
+describe("_readNote", () => {
+  it("returns plaintext, not HTML", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM)); // preflight
+    mockStdout(["plain body text", "2026-07-17"].join(FIELD_DELIM)); // read
+    const n = await _readNote("x-coredata://note/1");
+    expect(n.body).toBe("plain body text");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // body is HTML and would waste tokens and read badly. Spec section 2.4.
+    expect(args[1]).toContain("plaintext of");
+    expect(args[1]).not.toContain("body of");
+  });
+
+  it("refuses a locked note before reading anything", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    await expect(_readNote("x-coredata://note/1")).rejects.toThrow(/locked/i);
+    // Only the preflight ran. No content read was attempted.
+    expect((execFile as unknown as MockFn).mock.calls.length).toBe(1);
+  });
+
+  it("fails closed when the folder assertion does not match", async () => {
+    // Two calls, so queue the preflight reply twice — the mock is queue-once,
+    // and the second call would otherwise read the factory default ("") and
+    // fail on parsing instead of on the folder.
+    mockStdout(["Q3", "Personal", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["Q3", "Personal", "iCloud", "false"].join(FIELD_DELIM));
+    await expect(_readNote("x-coredata://note/1", "Work")).rejects.toThrow(/Work/);
+    await expect(_readNote("x-coredata://note/1", "Work")).rejects.toThrow(/Personal/);
+  });
+
+  it("passes the assertion when the folder matches", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["body", "2026-07-17"].join(FIELD_DELIM));
+    await expect(_readNote("x-coredata://note/1", "Work")).resolves.toMatchObject({
+      folder: "Work",
+    });
+  });
+
+  it("uses a scoped lookup for the read when a folder is given", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["body", "2026-07-17"].join(FIELD_DELIM));
+    await _readNote("x-coredata://note/1", "Work");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // Same treatment as the write path (spec section 6.4): a note that moved
+    // folders during the approval fails to resolve instead of being read.
+    expect(args[1]).toContain("of folder (item 2 of argv)");
+    expect(args[3]).toBe("Work");
+  });
+});
+
+describe("_listNotes", () => {
+  it("lists all notes when no folder is given", async () => {
+    const row = ["id1", "One", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM);
+    mockStdout(row);
+    const notes = await _listNotes();
+    expect(notes).toHaveLength(1);
+    expect(notes[0].title).toBe("One");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).not.toContain("of folder");
+  });
+
+  it("scopes to the folder when one is given, passed as argv", async () => {
+    mockStdout("");
+    await _listNotes("Work");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).toContain("notes of folder (item 1 of argv)");
+    expect(args[2]).toBe("Work");
+  });
+
+  it("returns an empty array rather than throwing when there are none", async () => {
+    mockStdout("");
+    await expect(_listNotes()).resolves.toEqual([]);
+  });
+});
+
+describe("_searchNotes", () => {
+  it("searches plaintext, never body", async () => {
+    mockStdout("");
+    await _searchNotes("budget");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // body is HTML: searching it matches markup, so `div` would match every
+    // note the user owns. Spec section 9.3.
+    expect(args[1]).toContain("plaintext contains");
+    expect(args[1]).not.toContain("body contains");
+  });
+
+  it("passes the query as argv, not in the script", async () => {
+    mockStdout("");
+    await _searchNotes('"; do shell script "x"; "');
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).not.toContain("do shell script");
+    expect(args[2]).toBe('"; do shell script "x"; "');
+  });
+
+  it("returns an empty array for no matches rather than throwing", async () => {
+    mockStdout("");
+    await expect(_searchNotes("nothing")).resolves.toEqual([]);
+  });
+
+  it("parses multiple rows", async () => {
+    const row1 = ["id1", "One", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM);
+    const row2 = ["id2", "Two", "Work", "iCloud", "2026-07-16", "false"].join(FIELD_DELIM);
+    mockStdout(`${row1}\n${row2}`);
+    const notes = await _searchNotes("x");
+    expect(notes).toHaveLength(2);
+    expect(notes[0].title).toBe("One");
+    expect(notes[1].id).toBe("id2");
+  });
+
+  it("never returns a body", async () => {
+    const row = ["id1", "One", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM);
+    mockStdout(row);
+    const notes = await _searchNotes("x");
+    expect(notes[0]).not.toHaveProperty("body");
+  });
+});
+
+describe("_listFolders", () => {
+  it("returns folders with their note counts", async () => {
+    const row1 = ["fid1", "Work", "12"].join(FIELD_DELIM);
+    const row2 = ["fid2", "Recently Deleted", "3"].join(FIELD_DELIM);
+    mockStdout(`${row1}\n${row2}`);
+    const folders = await _listFolders();
+    expect(folders).toEqual([
+      { id: "fid1", name: "Work", noteCount: 12 },
+      // "Recently Deleted" is a real folder and is returned. deleteNote moves
+      // notes into it. Spec section 9.2.
+      { id: "fid2", name: "Recently Deleted", noteCount: 3 },
+    ]);
+  });
+
+  it("asks Notes for top-level folders only", async () => {
+    mockStdout("");
+    await _listFolders();
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // A bare `repeat with f in folders` flattens the hierarchy: it returns
+    // "Archived" and its children "2010s"/"2017"/"2019" side by side with
+    // nothing marking the difference, so "2017" reads as a peer of "Recently
+    // Deleted". That is false, and an agent would act on it. Filtering to
+    // folders whose container is an account is honest and limited instead.
+    expect(args[1]).toContain("(class of c) is account");
+  });
+
+  it("returns an empty array rather than throwing when there are none", async () => {
+    mockStdout("");
+    await expect(_listFolders()).resolves.toEqual([]);
+  });
+
+  it("fails closed on a non-numeric note count rather than reporting NaN", async () => {
+    mockStdout(["fid1", "Work", "twelve"].join(FIELD_DELIM));
+    await expect(_listFolders()).rejects.toThrow(/non-numeric note count/);
+  });
+});
+
+describe("_folderExists", () => {
+  it("passes the folder as argv and parses a true reply", async () => {
+    mockStdout("true");
+    await expect(_folderExists("Agency Notes")).resolves.toBe(true);
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).toContain("exists folder (item 1 of argv)");
+    expect(args[2]).toBe("Agency Notes");
+  });
+
+  it("parses a false reply", async () => {
+    mockStdout("false");
+    await expect(_folderExists("No Such Folder")).resolves.toBe(false);
+  });
+});
+
+describe("_createNote", () => {
+  it("passes title, html and folder as argv, never in the script", async () => {
+    mockStdout(["nid", "T", "Agency Notes", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _createNote('"; do shell script "x"; "', "<p>b</p>", "Agency Notes");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    expect(args[1]).not.toContain("do shell script");
+    expect(args[2]).toBe('"; do shell script "x"; "');
+    expect(args[3]).toBe("<p>b</p>");
+    expect(args[4]).toBe("Agency Notes");
+  });
+
+  it("creates the folder if it is missing", async () => {
+    mockStdout(["nid", "T", "Agency Notes", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _createNote("T", "<p>b</p>", "Agency Notes");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[0];
+    // "Agency Notes" will not exist on a fresh machine. Spec section 9.4.
+    expect(args[1]).toContain("make new folder");
+  });
+
+  it("returns the new note's metadata including its id", async () => {
+    mockStdout(["nid", "T", "Agency Notes", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    const n = await _createNote("T", "<p>b</p>", "Agency Notes");
+    // Returning the id means create-then-append needs no search.
+    expect(n.id).toBe("nid");
+    expect(n.title).toBe("T");
+  });
+});
+
+describe("_appendToNote", () => {
+  // See spec section 2.7. A locked note's body reads as "", so this append
+  // would REPLACE the note's contents. Do not delete this test.
+  it("refuses a locked note and never issues a write", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    await expect(_appendToNote("x-coredata://note/1", "<p>x</p>")).rejects.toThrow(/locked/i);
+    expect((execFile as unknown as MockFn).mock.calls.length).toBe(1);
+  });
+
+  it("re-checks the locked flag inside the write script", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // The pre-flight check is separated from the write by a human approval,
+    // so it is check-then-act. The write script re-checks. Spec section 6.4.
+    expect(args[1]).toContain("password protected");
+  });
+
+  it("uses a scoped lookup as the assertion when a folder is given", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>", "Work");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    // The scoped lookup IS the assertion: it fails if the note is not in the
+    // folder, so the check cannot drift from the access. Spec section 6.4.
+    expect(args[1]).toContain("of folder (item 3 of argv)");
+  });
+
+  it("uses an unscoped lookup when no folder is given", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    expect(args[1]).not.toContain("of folder (item 3 of argv)");
+  });
+
+  it("appends rather than replacing", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout(["nid", "Q3", "Work", "iCloud", "2026-07-17", "false"].join(FIELD_DELIM));
+    await _appendToNote("x-coredata://note/1", "<p>x</p>");
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    expect(args[1]).toContain("(body of n) &");
+  });
+});
+
+describe("_deleteNote", () => {
+  it("refuses a locked note", async () => {
+    mockStdout(["Secret", "Work", "iCloud", "true"].join(FIELD_DELIM));
+    await expect(_deleteNote("x-coredata://note/1")).rejects.toThrow(/locked/i);
+    expect((execFile as unknown as MockFn).mock.calls.length).toBe(1);
+  });
+
+  it("deletes an unlocked note", async () => {
+    mockStdout(["Q3", "Work", "iCloud", "false"].join(FIELD_DELIM));
+    mockStdout("");
+    await expect(_deleteNote("x-coredata://note/1")).resolves.toBeNull();
+    const [, args] = (execFile as unknown as MockFn).mock.calls[1];
+    expect(args[1]).toContain("delete n");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/__tests__/notesPolicy.test.ts
+++ b/packages/agency-lang/lib/stdlib/__tests__/notesPolicy.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { checkPolicyExplicit, type Policy } from "../../runtime/policy.js";
+
+// std::notes/apple passes "" for an omitted optional `folder`, never null.
+// These tests pin that design through the REAL policy evaluator
+// (checkPolicyExplicit → matchesRule → picomatch), not a parallel picomatch
+// call, so they keep guarding the actual code path if the matcher ever
+// changes how it normalizes values or which library it uses.
+
+/** A std::notes::list interrupt as the module raises it, with the given folder. */
+function listInterrupt(folder: unknown): {
+  effect: string;
+  message: string;
+  data: any;
+  origin: string;
+} {
+  return {
+    effect: "std::notes::list",
+    message: "List the notes in the Notes app?",
+    data: { account: "", folder },
+    origin: "",
+  };
+}
+
+function approveWhenFolderMatches(pattern: string): Policy {
+  return {
+    "std::notes::list": [{ match: { folder: pattern }, action: "approve" }],
+  };
+}
+
+describe("policy rules against an omitted folder", () => {
+  it("an empty folder does not match a specific glob", () => {
+    const result = checkPolicyExplicit(approveWhenFolderMatches("Work"), listInterrupt(""));
+    expect(result).toBeNull();
+  });
+
+  it("an empty folder does not match a catch-all glob", () => {
+    // The load-bearing one. If this ever approves, listNotes() with no
+    // folder — the widest-reaching call in the module — starts matching any
+    // {"folder": "*"} approve rule, and the payload design needs rethinking.
+    expect(checkPolicyExplicit(approveWhenFolderMatches("*"), listInterrupt(""))).toBeNull();
+    expect(checkPolicyExplicit(approveWhenFolderMatches("**"), listInterrupt(""))).toBeNull();
+  });
+
+  it("a real folder still matches", () => {
+    expect(checkPolicyExplicit(approveWhenFolderMatches("*"), listInterrupt("Work"))).toEqual({
+      type: "approve",
+    });
+    expect(checkPolicyExplicit(approveWhenFolderMatches("Work"), listInterrupt("Work"))).toEqual({
+      type: "approve",
+    });
+  });
+
+  it("a null folder FAILS OPEN, which is why payloads must never carry one", () => {
+    // The real matcher does not throw on null; it coerces via String(null)
+    // to the string "null", and a "*" glob matches that. So a null payload
+    // field would let a catch-all folder rule approve a call the empty
+    // string correctly refuses. This is the strongest reason the module
+    // normalizes an omitted folder to "" before it reaches the payload.
+    expect(checkPolicyExplicit(approveWhenFolderMatches("*"), listInterrupt(null))).toEqual({
+      type: "approve",
+    });
+  });
+
+  it("a rule with no match key still approves an empty folder", () => {
+    // The limit of the empty-string design, pinned so nobody overclaims it:
+    // "" protects against folder-GLOB rules, not against a bare catch-all.
+    // {"action": "approve"} with no match approves every std::notes::list
+    // interrupt, empty folder included.
+    const catchAll: Policy = { "std::notes::list": [{ action: "approve" }] };
+    expect(checkPolicyExplicit(catchAll, listInterrupt(""))).toEqual({ type: "approve" });
+  });
+});

--- a/packages/agency-lang/lib/stdlib/appleNotes.ts
+++ b/packages/agency-lang/lib/stdlib/appleNotes.ts
@@ -1,0 +1,399 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import renderWithTimeout from "../templates/applescript/notes/withTimeout.js";
+import renderAccountWalk from "../templates/applescript/notes/accountWalk.js";
+import renderPreflight from "../templates/applescript/notes/preflight.js";
+import renderReadUnscoped from "../templates/applescript/notes/readUnscoped.js";
+import renderReadScoped from "../templates/applescript/notes/readScoped.js";
+import renderNoteRow from "../templates/applescript/notes/noteRow.js";
+import renderListAll from "../templates/applescript/notes/listAll.js";
+import renderListInFolder from "../templates/applescript/notes/listInFolder.js";
+import renderSearchAll from "../templates/applescript/notes/searchAll.js";
+import renderSearchInFolder from "../templates/applescript/notes/searchInFolder.js";
+import renderListFolders from "../templates/applescript/notes/listFolders.js";
+import renderFolderExists from "../templates/applescript/notes/folderExists.js";
+import renderCreate from "../templates/applescript/notes/create.js";
+import renderAppendBody from "../templates/applescript/notes/appendBody.js";
+import renderAppendScoped from "../templates/applescript/notes/appendScoped.js";
+import renderAppendUnscoped from "../templates/applescript/notes/appendUnscoped.js";
+import renderDeleteScoped from "../templates/applescript/notes/deleteScoped.js";
+import renderDeleteUnscoped from "../templates/applescript/notes/deleteUnscoped.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Our own bound on the wait. Without it, AppleScript's 120-second default
+ *  applies, which is indistinguishable from a hang for an agent tool call.
+ *  A spike confirmed `with timeout` does shorten the TCC consent wait. */
+export const NOTES_TIMEOUT_SECONDS = 30;
+
+/** Separator for multi-field script returns. Not a tab: note titles can
+ *  legally contain tabs, and a title with one would corrupt the parse.
+ *  Written as an escape, never a raw byte: a raw U+0001 is invisible in
+ *  every editor and survives copy-paste unreliably. */
+export const FIELD_DELIM = "\u0001";
+
+/** Wrap an AppleScript body in the argv handler and our own timeout.
+ *
+ *  The AppleScript sources live as typestache templates in
+ *  lib/templates/applescript/notes/. Edit the .mustache files and run
+ *  `pnpm run templates`; never edit the generated .ts files. */
+export function withTimeout(body: string): string {
+  return renderWithTimeout({ timeoutSeconds: NOTES_TIMEOUT_SECONDS, body });
+}
+
+/** Run an AppleScript against Notes, passing data as argv.
+ *
+ *  Data NEVER goes into the script source. Titles and bodies are
+ *  model-authored, and the model may have been influenced by a page it read,
+ *  so interpolating them would be an injection path. argv values are not
+ *  parsed as AppleScript. */
+export async function runNotesScript(script: string, args: string[]): Promise<string> {
+  if (process.platform !== "darwin") {
+    throw new Error("Apple Notes is only available on macOS.");
+  }
+
+  try {
+    // No "-" before args: osascript passes it through as argv item 1 and
+    // shifts every real argument by one.
+    const { stdout } = await execFileAsync("osascript", ["-e", script, ...args]);
+    // trimEnd, not trim: osascript appends a trailing newline, but leading
+    // whitespace is meaningful in note plaintext (indented code, for one) and
+    // the plaintext is the first field of a read reply. Same as keyring.ts.
+    return stdout.trimEnd();
+  } catch (error: unknown) {
+    const err = error as { stderr?: string; code?: number };
+    const stderr = err.stderr?.trim() ?? "";
+
+    // -1743 is unambiguous: no grant, or it was denied, and no dialog pending.
+    if (stderr.includes("-1743")) {
+      throw new Error(
+        "Not authorized to control Notes. Grant permission in " +
+          "System Settings → Privacy & Security → Automation.",
+      );
+    }
+
+    // -1712 is ambiguous: it covers an unanswered consent dialog, a busy
+    // Notes, and a wedged Notes. The message hedges on purpose — claiming
+    // otherwise sends people to fix a permission that was never the problem.
+    if (stderr.includes("-1712")) {
+      throw new Error(
+        `Notes did not respond within ${NOTES_TIMEOUT_SECONDS}s. This usually ` +
+          "means macOS automation permission was not granted. Check " +
+          "System Settings → Privacy & Security → Automation.",
+      );
+    }
+
+    throw new Error(`Notes command failed: ${stderr || `exit code ${err.code ?? "unknown"}`}`);
+  }
+}
+
+/** A note's metadata, read before the interrupt so the payload can carry it. */
+export type NotePreflight = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  locked: boolean;
+};
+
+/** Walk from a folder (`c`) up to its account, leaving it in `a`.
+ *
+ *  A folder's container is its PARENT FOLDER when nested, not the account.
+ *  Measured: `container of folder "2017"` is `Archived`, not `iCloud`. One hop
+ *  up is wrong for any nested folder, and wrong silently — the account field
+ *  would hold a folder name and every {"account": "iCloud"} policy would quietly
+ *  stop matching.
+ *
+ *  Bounded, and fails closed rather than returning a folder as an account.
+ *  Verified to reach iCloud from Archived/2017 in 2 hops. */
+export const ACCOUNT_WALK = renderAccountWalk({});
+
+// The preflight template splits `set c to container of n` on purpose.
+// `name of container of n` in one expression errors -1728 on EVERY note,
+// locked or unlocked. The property is fine; chaining a read through it is
+// not. Spec section 9.2.
+const PREFLIGHT_SCRIPT = withTimeout(renderPreflight({ accountWalk: ACCOUNT_WALK }));
+
+/** Read a note's metadata: title, folder, account, locked flag.
+ *
+ *  This query is NOT interrupt-gated, because the interrupt payload needs its
+ *  results in order to exist. That is acceptable for a narrow reason worth
+ *  keeping precise: a note id is unguessable. It is an opaque x-coredata://
+ *  URI that cannot be enumerated or constructed, so anyone holding one already
+ *  learned it somewhere, and this discloses only the title and folder that
+ *  whoever handed them the id could already name.
+ *
+ *  It is NOT true that an id can only come from a gated call — ids are stable
+ *  and can arrive from a user message, a file, or a restored checkpoint. Do not
+ *  widen this query on the strength of that weaker claim. It reads three
+ *  properties and no content, and it should stay that way. */
+export async function _preflightNote(id: string): Promise<NotePreflight> {
+  const raw = await runNotesScript(PREFLIGHT_SCRIPT, [id]);
+  const parts = raw.split(FIELD_DELIM);
+  if (parts.length !== 4) {
+    throw new Error(`Notes returned an unexpected reply for note ${id}.`);
+  }
+  return {
+    id,
+    title: parts[0],
+    folder: parts[1],
+    account: parts[2],
+    locked: parts[3].trim() === "true",
+  };
+}
+
+/** Refuse a locked note.
+ *
+ *  This is DATA-LOSS PREVENTION, not a friendlier error. A locked note's body
+ *  reads as an empty string rather than erroring, so an append that skipped
+ *  this guard would run `set body of n to "" & newText` and replace the note's
+ *  contents with the appended text. Spec section 2.7.
+ *
+ *  Never skip this, never reorder it after a body read, and never remove it as
+ *  apparently-dead code. */
+export function assertNotLocked(meta: NotePreflight): void {
+  if (meta.locked) {
+    throw new Error(`Note "${meta.title}" is locked. Unlock it in Notes.app and retry.`);
+  }
+}
+
+/** Note metadata. Deliberately carries no body. */
+export type NoteMeta = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  modified: string;
+  passwordProtected: boolean;
+};
+
+/** A note including its content, as plaintext. */
+export type NoteContentTs = {
+  id: string;
+  title: string;
+  folder: string;
+  account: string;
+  body: string;
+  modified: string;
+};
+
+/** A folder. `noteCount` is derived, not a property. */
+export type FolderMeta = {
+  id: string;
+  name: string;
+  noteCount: number;
+};
+
+/** Assert a note is in the folder the caller named. Fails closed.
+ *
+ *  This compare is the fail-fast check with the readable error message. It is
+ *  NOT the authoritative assertion: on both the read and write paths the
+ *  actual access addresses the note THROUGH the folder (`note id X of folder
+ *  Y`), so the lookup failing is the assertion failing, and the check cannot
+ *  drift from the access across the human approval that sits between the
+ *  pre-flight and the access. */
+function assertFolder(meta: NotePreflight, folder?: string): void {
+  if (folder != null && meta.folder !== folder) {
+    throw new Error(
+      `Note "${meta.title}" is in folder "${meta.folder}", not "${folder}". Refusing.`,
+    );
+  }
+}
+
+// Reads `plaintext`, never `body`. body is HTML: it would waste tokens and read
+// badly for a model. Spec section 2.4.
+//
+// Two shapes, like the write path (spec section 6.4): when the caller asserted
+// a folder, the read addresses the note THROUGH it, so a note that moved
+// folders during the human approval fails to resolve instead of being read.
+// An unscoped read would leave open on the read path the exact window the
+// write path closes — and reading is the operation folder confinement was
+// invented for.
+const READ_UNSCOPED_SCRIPT = withTimeout(renderReadUnscoped({}));
+const READ_SCOPED_SCRIPT = withTimeout(renderReadScoped({}));
+
+export async function _readNote(id: string, folder?: string): Promise<NoteContentTs> {
+  const meta = await _preflightNote(id);
+  assertFolder(meta, folder);
+  assertNotLocked(meta);
+
+  const raw = folder == null
+    ? await runNotesScript(READ_UNSCOPED_SCRIPT, [id])
+    : await runNotesScript(READ_SCOPED_SCRIPT, [id, folder]);
+  const parts = raw.split(FIELD_DELIM);
+  if (parts.length !== 2) {
+    throw new Error(`Notes returned an unexpected reply for note ${id}.`);
+  }
+  return {
+    id,
+    title: meta.title,
+    folder: meta.folder,
+    account: meta.account,
+    body: parts[0],
+    modified: parts[1],
+  };
+}
+
+/** Parse the delimited note rows a list/search script returns. */
+function parseNoteRows(raw: string): NoteMeta[] {
+  const rows = raw.split("\n").filter((line) => line.length > 0);
+  return rows.map((line) => {
+    const fields = line.split(FIELD_DELIM);
+    if (fields.length !== 6) {
+      throw new Error("Notes returned an unexpected row while listing notes.");
+    }
+    return {
+      id: fields[0],
+      title: fields[1],
+      folder: fields[2],
+      account: fields[3],
+      modified: fields[4],
+      passwordProtected: fields[5].trim() === "true",
+    };
+  });
+}
+
+// The container access is split here too (spec 9.2), and the account is walked
+// rather than assumed to be one hop up.
+const NOTE_ROW = renderNoteRow({ accountWalk: ACCOUNT_WALK });
+
+const LIST_ALL_SCRIPT = withTimeout(renderListAll({ noteRow: NOTE_ROW }));
+const LIST_IN_FOLDER_SCRIPT = withTimeout(renderListInFolder({ noteRow: NOTE_ROW }));
+
+export async function _listNotes(folder?: string): Promise<NoteMeta[]> {
+  const raw = folder == null
+    ? await runNotesScript(LIST_ALL_SCRIPT, [])
+    : await runNotesScript(LIST_IN_FOLDER_SCRIPT, [folder]);
+  return parseNoteRows(raw);
+}
+
+// `plaintext contains`, never `body contains`. body is HTML, so searching it
+// matches markup: a user searching "div" would match every note they own.
+// Spec section 9.3.
+const SEARCH_ALL_SCRIPT = withTimeout(renderSearchAll({ noteRow: NOTE_ROW }));
+const SEARCH_IN_FOLDER_SCRIPT = withTimeout(renderSearchInFolder({ noteRow: NOTE_ROW }));
+
+export async function _searchNotes(query: string, folder?: string): Promise<NoteMeta[]> {
+  const raw = folder == null
+    ? await runNotesScript(SEARCH_ALL_SCRIPT, [query])
+    : await runNotesScript(SEARCH_IN_FOLDER_SCRIPT, [query, folder]);
+  return parseNoteRows(raw);
+}
+
+// TOP-LEVEL FOLDERS ONLY, on purpose.
+//
+// A bare `repeat with f in folders` FLATTENS the hierarchy: on a machine with
+// an "Archived" folder containing "2010s", "2017" and "2019", it returns all
+// four side by side with nothing marking the difference. Reporting "2017" as a
+// peer of "Recently Deleted" is simply false, and an agent would act on it.
+//
+// So filter to folders whose container is an account. That is honest and
+// limited rather than flat and wrong. Nested folders stay reachable by bare
+// name (`folder "2017"` does resolve), ambiguously — which is Notes' own
+// behaviour, not something we introduce. Path support is out of scope for v1;
+// see the plan's "Two v1 limits".
+//
+// noteCount is derived with `count of notes`, because folder has no such
+// property. That is a query per folder, so listFolders pays for it.
+const LIST_FOLDERS_SCRIPT = withTimeout(renderListFolders({}));
+
+export async function _listFolders(): Promise<FolderMeta[]> {
+  const raw = await runNotesScript(LIST_FOLDERS_SCRIPT, []);
+  const rows = raw.split("\n").filter((line) => line.length > 0);
+  return rows.map((line) => {
+    const fields = line.split(FIELD_DELIM);
+    if (fields.length !== 3) {
+      throw new Error("Notes returned an unexpected row while listing folders.");
+    }
+    const noteCount = Number(fields[2]);
+    if (!Number.isFinite(noteCount)) {
+      throw new Error("Notes returned a non-numeric note count while listing folders.");
+    }
+    return { id: fields[0], name: fields[1], noteCount };
+  });
+}
+
+const FOLDER_EXISTS_SCRIPT = withTimeout(renderFolderExists({}));
+
+export async function _folderExists(folder: string): Promise<boolean> {
+  const raw = await runNotesScript(FOLDER_EXISTS_SCRIPT, [folder]);
+  return raw.trim() === "true";
+}
+
+// "Agency Notes" is our own default and will not exist on a fresh machine, so
+// create it on demand. Spec section 9.4. The interrupt payload carries
+// folderCreated so a human or policy sees the folder being made.
+const CREATE_SCRIPT = withTimeout(renderCreate({ accountWalk: ACCOUNT_WALK }));
+
+/** Create a note. `html` is HTML, already rendered — this layer does not know
+ *  about markdown. The Agency module does the conversion. */
+export async function _createNote(
+  title: string,
+  html: string,
+  folder: string,
+): Promise<NoteMeta> {
+  const raw = await runNotesScript(CREATE_SCRIPT, [title, html, folder]);
+  const rows = parseNoteRows(raw);
+  if (rows.length !== 1) {
+    throw new Error("Notes returned an unexpected reply while creating a note.");
+  }
+  return rows[0];
+}
+
+// Two shapes: scoped and unscoped. The scoped one addresses the note THROUGH
+// the folder, so the lookup failing IS the assertion failing. That is stronger
+// than read-then-compare, because the reference that gets mutated is the same
+// one that had to resolve inside the asserted folder — the check cannot drift
+// from the access across the human approval that precedes this. Spec 6.4.
+const APPEND_BODY = renderAppendBody({ accountWalk: ACCOUNT_WALK });
+
+const APPEND_SCOPED_SCRIPT = withTimeout(renderAppendScoped({ appendBody: APPEND_BODY }));
+const APPEND_UNSCOPED_SCRIPT = withTimeout(renderAppendUnscoped({ appendBody: APPEND_BODY }));
+
+/** Append to a note. `html` is HTML, already rendered.
+ *
+ *  The Agency layer already refused locked notes before its interrupt was
+ *  approved. This layer still re-runs the pre-flight, and the write script
+ *  checks `password protected` once more, because a human approval sits
+ *  between that first check and this call, and the note can be locked in that
+ *  window. Spec section 2.7 explains why a missed check destroys data.
+ *
+ *  The interrupt payload the approver saw reflects the pre-approval
+ *  pre-flight. This second pre-flight is the authoritative one for the
+ *  write. */
+export async function _appendToNote(
+  id: string,
+  html: string,
+  folder?: string,
+): Promise<NoteMeta> {
+  const meta = await _preflightNote(id);
+  assertFolder(meta, folder);
+  assertNotLocked(meta);
+
+  const raw = folder == null
+    ? await runNotesScript(APPEND_UNSCOPED_SCRIPT, [id, html])
+    : await runNotesScript(APPEND_SCOPED_SCRIPT, [id, html, folder]);
+
+  const rows = parseNoteRows(raw);
+  if (rows.length !== 1) {
+    throw new Error(`Notes returned an unexpected reply while appending to note ${id}.`);
+  }
+  return rows[0];
+}
+
+const DELETE_SCOPED_SCRIPT = withTimeout(renderDeleteScoped({}));
+const DELETE_UNSCOPED_SCRIPT = withTimeout(renderDeleteUnscoped({}));
+
+/** Delete a note. It moves to Recently Deleted, where it stays ~30 days. */
+export async function _deleteNote(id: string, folder?: string): Promise<null> {
+  const meta = await _preflightNote(id);
+  assertFolder(meta, folder);
+  assertNotLocked(meta);
+
+  if (folder == null) {
+    await runNotesScript(DELETE_UNSCOPED_SCRIPT, [id]);
+  } else {
+    await runNotesScript(DELETE_SCOPED_SCRIPT, [id, folder]);
+  }
+  return null;
+}

--- a/packages/agency-lang/lib/templates/applescript/notes/accountWalk.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/accountWalk.mustache
@@ -1,0 +1,10 @@
+      set a to container of c
+      set acctFound to false
+      repeat 10 times
+        if (class of a) is account then
+          set acctFound to true
+          exit repeat
+        end if
+        set a to container of a
+      end repeat
+      if not acctFound then error "Could not resolve the account for this note."

--- a/packages/agency-lang/lib/templates/applescript/notes/accountWalk.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/accountWalk.ts
@@ -1,0 +1,25 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/accountWalk.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `      set a to container of c
+      set acctFound to false
+      repeat 10 times
+        if (class of a) is account then
+          set acctFound to true
+          exit repeat
+        end if
+        set a to container of a
+      end repeat
+      if not acctFound then error "Could not resolve the account for this note."`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/appendBody.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/appendBody.mustache
@@ -1,0 +1,7 @@
+      if (password protected of n) then error "note is locked"
+      set body of n to (body of n) & (item 2 of argv)
+      set c to container of n
+{{{accountWalk}}}
+      set d to (ASCII character 1)
+      return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((modification date of n) as text) & d & ((password protected of n) as text)

--- a/packages/agency-lang/lib/templates/applescript/notes/appendBody.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/appendBody.ts
@@ -1,0 +1,23 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/appendBody.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `      if (password protected of n) then error "note is locked"
+      set body of n to (body of n) & (item 2 of argv)
+      set c to container of n
+{{{accountWalk}}}
+      set d to (ASCII character 1)
+      return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((modification date of n) as text) & d & ((password protected of n) as text)`;
+
+export type TemplateType = {
+  accountWalk: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/appendScoped.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/appendScoped.mustache
@@ -1,0 +1,4 @@
+    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 3 of argv)
+{{{appendBody}}}
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/appendScoped.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/appendScoped.ts
@@ -1,0 +1,20 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/appendScoped.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 3 of argv)
+{{{appendBody}}}
+    end tell`;
+
+export type TemplateType = {
+  appendBody: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/appendUnscoped.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/appendUnscoped.mustache
@@ -1,0 +1,4 @@
+    tell application "Notes"
+      set n to note id (item 1 of argv)
+{{{appendBody}}}
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/appendUnscoped.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/appendUnscoped.ts
@@ -1,0 +1,20 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/appendUnscoped.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set n to note id (item 1 of argv)
+{{{appendBody}}}
+    end tell`;
+
+export type TemplateType = {
+  appendBody: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/create.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/create.mustache
@@ -1,0 +1,12 @@
+    tell application "Notes"
+      if not (exists folder (item 3 of argv)) then
+        make new folder with properties {name:(item 3 of argv)}
+      end if
+      set f to folder (item 3 of argv)
+      set n to make new note at f with properties {name:(item 1 of argv), body:(item 2 of argv)}
+      set c to container of n
+{{{accountWalk}}}
+      set d to (ASCII character 1)
+      return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((modification date of n) as text) & d & ((password protected of n) as text)
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/create.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/create.ts
@@ -1,0 +1,28 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/create.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      if not (exists folder (item 3 of argv)) then
+        make new folder with properties {name:(item 3 of argv)}
+      end if
+      set f to folder (item 3 of argv)
+      set n to make new note at f with properties {name:(item 1 of argv), body:(item 2 of argv)}
+      set c to container of n
+{{{accountWalk}}}
+      set d to (ASCII character 1)
+      return (id of n) & d & (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((modification date of n) as text) & d & ((password protected of n) as text)
+    end tell`;
+
+export type TemplateType = {
+  accountWalk: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/deleteScoped.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/deleteScoped.mustache
@@ -1,0 +1,5 @@
+    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 2 of argv)
+      if (password protected of n) then error "note is locked"
+      delete n
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/deleteScoped.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/deleteScoped.ts
@@ -1,0 +1,20 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/deleteScoped.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 2 of argv)
+      if (password protected of n) then error "note is locked"
+      delete n
+    end tell`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/deleteUnscoped.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/deleteUnscoped.mustache
@@ -1,0 +1,5 @@
+    tell application "Notes"
+      set n to note id (item 1 of argv)
+      if (password protected of n) then error "note is locked"
+      delete n
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/deleteUnscoped.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/deleteUnscoped.ts
@@ -1,0 +1,20 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/deleteUnscoped.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set n to note id (item 1 of argv)
+      if (password protected of n) then error "note is locked"
+      delete n
+    end tell`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/folderExists.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/folderExists.mustache
@@ -1,0 +1,3 @@
+    tell application "Notes"
+      return (exists folder (item 1 of argv)) as text
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/folderExists.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/folderExists.ts
@@ -1,0 +1,18 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/folderExists.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      return (exists folder (item 1 of argv)) as text
+    end tell`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/listAll.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/listAll.mustache
@@ -1,0 +1,8 @@
+    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in notes
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/listAll.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/listAll.ts
@@ -1,0 +1,24 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/listAll.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in notes
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell`;
+
+export type TemplateType = {
+  noteRow: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/listFolders.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/listFolders.mustache
@@ -1,0 +1,12 @@
+    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with f in folders
+        set c to container of f
+        if (class of c) is account then
+          set out to out & (id of f) & d & (name of f) & d & ¬
+                    ((count of notes of f) as text) & linefeed
+        end if
+      end repeat
+      return out
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/listFolders.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/listFolders.ts
@@ -1,0 +1,27 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/listFolders.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with f in folders
+        set c to container of f
+        if (class of c) is account then
+          set out to out & (id of f) & d & (name of f) & d & ¬
+                    ((count of notes of f) as text) & linefeed
+        end if
+      end repeat
+      return out
+    end tell`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/listInFolder.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/listInFolder.mustache
@@ -1,0 +1,8 @@
+    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes of folder (item 1 of argv))
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/listInFolder.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/listInFolder.ts
@@ -1,0 +1,24 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/listInFolder.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes of folder (item 1 of argv))
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell`;
+
+export type TemplateType = {
+  noteRow: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/noteRow.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/noteRow.mustache
@@ -1,0 +1,5 @@
+set c to container of n
+{{{accountWalk}}}
+        set out to out & (id of n) & d & (name of n) & d & (name of c) & d & ¬
+                  (name of a) & d & ((modification date of n) as text) & d & ¬
+                  ((password protected of n) as text) & linefeed

--- a/packages/agency-lang/lib/templates/applescript/notes/noteRow.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/noteRow.ts
@@ -1,0 +1,21 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/noteRow.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `set c to container of n
+{{{accountWalk}}}
+        set out to out & (id of n) & d & (name of n) & d & (name of c) & d & ¬
+                  (name of a) & d & ((modification date of n) as text) & d & ¬
+                  ((password protected of n) as text) & linefeed`;
+
+export type TemplateType = {
+  accountWalk: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/preflight.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/preflight.mustache
@@ -1,0 +1,8 @@
+    tell application "Notes"
+      set n to note id (item 1 of argv)
+      set c to container of n
+{{{accountWalk}}}
+      set d to (ASCII character 1)
+      return (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((password protected of n) as text)
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/preflight.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/preflight.ts
@@ -1,0 +1,24 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/preflight.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set n to note id (item 1 of argv)
+      set c to container of n
+{{{accountWalk}}}
+      set d to (ASCII character 1)
+      return (name of n) & d & (name of c) & d & (name of a) & d & ¬
+             ((password protected of n) as text)
+    end tell`;
+
+export type TemplateType = {
+  accountWalk: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/readScoped.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/readScoped.mustache
@@ -1,0 +1,5 @@
+    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 2 of argv)
+      set d to (ASCII character 1)
+      return (plaintext of n) & d & ((modification date of n) as text)
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/readScoped.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/readScoped.ts
@@ -1,0 +1,20 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/readScoped.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set n to note id (item 1 of argv) of folder (item 2 of argv)
+      set d to (ASCII character 1)
+      return (plaintext of n) & d & ((modification date of n) as text)
+    end tell`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/readUnscoped.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/readUnscoped.mustache
@@ -1,0 +1,5 @@
+    tell application "Notes"
+      set n to note id (item 1 of argv)
+      set d to (ASCII character 1)
+      return (plaintext of n) & d & ((modification date of n) as text)
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/readUnscoped.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/readUnscoped.ts
@@ -1,0 +1,20 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/readUnscoped.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set n to note id (item 1 of argv)
+      set d to (ASCII character 1)
+      return (plaintext of n) & d & ((modification date of n) as text)
+    end tell`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/searchAll.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/searchAll.mustache
@@ -1,0 +1,8 @@
+    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes whose plaintext contains (item 1 of argv))
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/searchAll.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/searchAll.ts
@@ -1,0 +1,24 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/searchAll.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes whose plaintext contains (item 1 of argv))
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell`;
+
+export type TemplateType = {
+  noteRow: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/searchInFolder.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/searchInFolder.mustache
@@ -1,0 +1,8 @@
+    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes of folder (item 2 of argv) whose plaintext contains (item 1 of argv))
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell

--- a/packages/agency-lang/lib/templates/applescript/notes/searchInFolder.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/searchInFolder.ts
@@ -1,0 +1,24 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/searchInFolder.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `    tell application "Notes"
+      set d to (ASCII character 1)
+      set out to ""
+      repeat with n in (notes of folder (item 2 of argv) whose plaintext contains (item 1 of argv))
+        {{{noteRow}}}
+      end repeat
+      return out
+    end tell`;
+
+export type TemplateType = {
+  noteRow: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/applescript/notes/withTimeout.mustache
+++ b/packages/agency-lang/lib/templates/applescript/notes/withTimeout.mustache
@@ -1,0 +1,5 @@
+on run argv
+  with timeout of {{{timeoutSeconds}}} seconds
+{{{body}}}
+  end timeout
+end run

--- a/packages/agency-lang/lib/templates/applescript/notes/withTimeout.ts
+++ b/packages/agency-lang/lib/templates/applescript/notes/withTimeout.ts
@@ -1,0 +1,22 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/applescript/notes/withTimeout.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `on run argv
+  with timeout of {{{timeoutSeconds}}} seconds
+{{{body}}}
+  end timeout
+end run`;
+
+export type TemplateType = {
+  timeoutSeconds: string | boolean | number;
+  body: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/stdlib/capabilities.agency
+++ b/packages/agency-lang/stdlib/capabilities.agency
@@ -62,3 +62,12 @@ export effectSet Calendar = <std::listEvents, std::createEvent, std::updateEvent
 
 /** Agent long-term memory: recall, remember, forget, and enable/disable. */
 export effectSet Memory = <std::memory::recall, std::memory::remember, std::memory::forget, std::memory::enableMemory, std::memory::disableMemory>
+
+/** Read-only Notes access: reading, searching, and listing. */
+export effectSet NotesRead = <std::notes::read, std::notes::search, std::notes::list>
+
+/** Notes mutation: creating, appending, and deleting. */
+export effectSet NotesWrite = <std::notes::create, std::notes::append, std::notes::delete>
+
+/** All Notes access, reads and writes. */
+export effectSet Notes = <NotesRead, NotesWrite>

--- a/packages/agency-lang/stdlib/notes/apple.agency
+++ b/packages/agency-lang/stdlib/notes/apple.agency
@@ -1,0 +1,360 @@
+import {
+  _createNote,
+  _appendToNote,
+  _readNote,
+  _searchNotes,
+  _listNotes,
+  _listFolders,
+  _deleteNote,
+  _folderExists,
+  _preflightNote,
+} from "agency-lang/stdlib-lib/appleNotes.js"
+import { parse, renderForHtml } from "std::markdown"
+
+/** @module
+  Create, read, search, and edit notes in the macOS Notes app. macOS only.
+  The first call asks for Automation permission with a system dialog. If
+  nobody answers the dialog, the call fails after 30 seconds.
+
+  ```ts
+  import { createNote } from "std::notes/apple"
+
+  node main() {
+    const result = createNote("Findings", "## Summary\n\n- one\n- two")
+    print(result)
+  }
+  ```
+
+  ## Notes are addressed by id
+
+  Two notes in the same folder can share a title, so a title is not an
+  address. Every read and edit takes the note's `id`, which comes from
+  `listNotes` or `searchNotes`:
+
+  ```ts
+  import { searchNotes, appendToNote } from "std::notes/apple"
+
+  node main() {
+    const found = searchNotes("Q3 planning")
+    if (found is success(notes)) {
+      appendToNote(notes[0].id, "\n## Update\n\nShipped.")
+    }
+  }
+  ```
+
+  `createNote` returns the note it made, including its id, so
+  create-then-append needs no search.
+
+  ## Bodies are Markdown going in, plain text coming out
+
+  `createNote` and `appendToNote` take Markdown and convert it to the HTML
+  that Notes stores. `readNote` returns plain text. That makes a
+  read-then-write round trip lossy: reading strips the formatting, and
+  writing the text back would flatten the note. Use `appendToNote` instead
+  of reading, editing, and rewriting a note yourself.
+
+  ## Confining an agent to one folder
+
+  Every function takes an optional `folder`. It constrains rather than
+  addresses: if you pass it, the call fails unless the note is in that
+  folder. Combined with partial application, that confines an agent in a way
+  the model cannot see or route around, because the locked parameter is
+  stripped from the tool's schema:
+
+  ```ts
+  import { listNotes, readNote } from "std::notes/apple"
+
+  node main() {
+    const reader = readNote.partial(folder: "Work").rename("readWorkNote")
+    const lister = listNotes.partial(folder: "Work").rename("listWorkNotes")
+    llm("Summarise my Work notes", { tools: [lister, reader] })
+  }
+  ```
+
+  The model may pass any id it likes. Anything outside Work fails closed.
+
+  ## Deciding with a policy
+
+  Each operation raises its own effect, so a policy can approve reads and
+  reject deletes:
+
+  ```json
+  {
+    "std::notes::read": [
+      { "match": { "folder": "Work" }, "action": "approve" },
+      { "action": "reject" }
+    ],
+    "std::notes::delete": [{ "action": "reject" }]
+  }
+  ```
+
+  `readNote`, `appendToNote`, and `deleteNote` look the note up before
+  raising their interrupt, so the payload carries the note's real `title`,
+  `folder`, and `account` even when the call passed only an id. The rule
+  above therefore matches a bare `readNote(id)` for a note that lives in
+  Work.
+
+  One v1 limit: only those three calls populate `account`. `createNote`,
+  `searchNotes`, and `listNotes` send it as an empty string, and an empty
+  string matches no glob. A rule that matches on `account` never applies to
+  them, so match on `folder` instead.
+
+  The `NotesRead`, `NotesWrite`, and `Notes` sets in `std::capabilities`
+  cover the same split for constraining a whole node.
+
+  ## Locked notes
+
+  A note locked with a password cannot be read or edited, and this module
+  will not try. Calls against a locked note fail before their interrupt is
+  raised, with a message naming the note.
+
+  ## Deleting is recoverable
+
+  `deleteNote` moves a note to Recently Deleted, where it stays for about
+  30 days. `listFolders` returns that folder like any other.
+
+  ## Other note apps
+
+  Obsidian needs no module. A vault is a directory of Markdown files, so
+  `std::fs` already covers it, and the same handlers, policies, and partial
+  application apply. Bear is not supported: its `x-callback-url` API cannot
+  deliver a callback to a command-line process, so a create call could not
+  return the new note's id.
+*/
+
+/** A folder in Notes. `noteCount` is derived, not stored. */
+export type Folder = {
+  id: string
+  name: string
+  noteCount: number
+}
+
+/** A note's metadata. Deliberately contains no body. */
+export type Note = {
+  id: string
+  title: string
+  folder: string
+  account: string
+  modified: string
+  passwordProtected: boolean
+}
+
+/** A note including its content, as plaintext. */
+export type NoteContent = {
+  id: string
+  title: string
+  folder: string
+  account: string
+  body: string
+  modified: string
+}
+
+effect std::notes::create { account: string, folder: string, title: string, folderCreated: boolean }
+effect std::notes::append { account: string, folder: string, title: string, id: string }
+effect std::notes::read   { account: string, folder: string, title: string, id: string }
+effect std::notes::search { account: string, folder: string, query: string }
+effect std::notes::list   { account: string, folder: string }
+effect std::notes::delete { account: string, folder: string, title: string, id: string }
+
+/** Convert markdown to the HTML that Notes requires on write. */
+def toHtml(body: string): Result<string> {
+  const parsed = parse(body)
+  if (!parsed.success) {
+    return failure("Could not parse the note body as Markdown: ${parsed.error}")
+  }
+  return success(renderForHtml(parsed.blocks))
+}
+
+/** What the pre-flight lookup returns. Re-declared natively because record
+    types imported from TypeScript are opaque to the typechecker. */
+type Preflight = {
+  id: string
+  title: string
+  folder: string
+  account: string
+  locked: boolean
+}
+
+/** Look the note up before raising the interrupt, so the payload can carry its
+    real title, folder, and account. Those are the fields a policy glob matches
+    on and a human reads before approving. Without this, the payload would hold
+    an opaque id and empty strings, and no policy could ever match an append,
+    read, or delete.
+
+    This helper also refuses locked notes and folder mismatches, so both errors
+    precede the interrupt and a human never approves a call that is guaranteed
+    to fail. It keeps the payload honest too: the folder shown to the approver
+    is always the note's real folder. The TypeScript layer re-checks the folder
+    and the locked flag after the approval, because the note can change during
+    the approval window. Those re-checks are the belt and braces; this check is
+    what makes the error precede the interrupt. */
+def preflight(id: string, folder: string | null): Result<Preflight> {
+  const meta = try _preflightNote(id)
+  if (isFailure(meta)) {
+    return meta
+  }
+  if (folder != null && meta.value.folder != folder) {
+    return failure("Note ${meta.value.title} is in folder ${meta.value.folder}, not ${folder}. Refusing.")
+  }
+  if (meta.value.locked) {
+    return failure("Note ${meta.value.title} is locked. Unlock it in Notes.app and retry.")
+  }
+  return meta
+}
+
+export def createNote(title: string, body: string, folder: string = "Agency Notes"): Result<Note> raises <std::notes::create> {
+  """
+  Create a note in the Notes app and return it, including its new id.
+
+  @param title - The note's title
+  @param body - The note's content, as Markdown
+  @param folder - The folder to create it in. Created if it does not exist.
+  """
+  const html = toHtml(body)
+  if (isFailure(html)) {
+    return html
+  }
+
+  const exists = try _folderExists(folder)
+  if (isFailure(exists)) {
+    return exists
+  }
+
+  // exists is the Result from `try`, so negate the VALUE. `!exists` would
+  // negate the always-truthy success object and folderCreated would silently
+  // always read false.
+  return interrupt std::notes::create("Create a note in the Notes app?", {
+    account: "",
+    folder: folder,
+    title: title,
+    folderCreated: !exists.value
+  })
+
+  destructive {
+    return try _createNote(title, html.value, folder)
+  }
+}
+
+export def appendToNote(id: string, body: string, folder?: string): Result<Note> raises <std::notes::append> {
+  """
+  Append Markdown to an existing note. Get the id from listNotes or searchNotes.
+
+  @param id - The note's id
+  @param body - The content to append, as Markdown
+  @param folder - If given, the call fails unless the note is in this folder
+  """
+  const html = toHtml(body)
+  if (isFailure(html)) {
+    return html
+  }
+
+  const meta = preflight(id, folder)
+  if (isFailure(meta)) {
+    return meta
+  }
+
+  return interrupt std::notes::append("Append to a note in the Notes app?", {
+    account: meta.value.account,
+    folder: meta.value.folder,
+    title: meta.value.title,
+    id: id
+  })
+
+  destructive {
+    return try _appendToNote(id, html.value, folder)
+  }
+}
+
+export idempotent def readNote(id: string, folder?: string): Result<NoteContent> raises <std::notes::read> {
+  """
+  Read a note's contents as plain text. Get the id from listNotes or searchNotes.
+
+  @param id - The note's id
+  @param folder - If given, the call fails unless the note is in this folder
+  """
+  const meta = preflight(id, folder)
+  if (isFailure(meta)) {
+    return meta
+  }
+
+  return interrupt std::notes::read("Read a note from the Notes app?", {
+    account: meta.value.account,
+    folder: meta.value.folder,
+    title: meta.value.title,
+    id: id
+  })
+
+  return try _readNote(id, folder)
+}
+
+export idempotent def searchNotes(query: string, folder?: string): Result<Note[]> raises <std::notes::search> {
+  """
+  Search notes by their text and return matching notes' metadata, without their
+  contents.
+
+  @param query - The text to search for
+  @param folder - If given, only search this folder
+  """
+  const payloadFolder = if folder == null then "" else folder
+
+  return interrupt std::notes::search("Search the notes in the Notes app?", {
+    account: "",
+    folder: payloadFolder,
+    query: query
+  })
+
+  return try _searchNotes(query, folder)
+}
+
+export idempotent def listNotes(folder?: string): Result<Note[]> raises <std::notes::list> {
+  """
+  List notes' metadata, without their contents.
+
+  @param folder - If given, only list this folder
+  """
+  const payloadFolder = if folder == null then "" else folder
+
+  return interrupt std::notes::list("List the notes in the Notes app?", {
+    account: "",
+    folder: payloadFolder
+  })
+
+  return try _listNotes(folder)
+}
+
+export idempotent def listFolders(): Result<Folder[]> raises <std::notes::list> {
+  """
+  List the folders in the Notes app, with a count of the notes in each.
+  """
+  return interrupt std::notes::list("List the folders in the Notes app?", {
+    account: "",
+    folder: ""
+  })
+
+  return try _listFolders()
+}
+
+export def deleteNote(id: string, folder?: string): Result<null> raises <std::notes::delete> {
+  """
+  Delete a note. It moves to the Recently Deleted folder, where it stays for
+  about 30 days.
+
+  @param id - The note's id
+  @param folder - If given, the call fails unless the note is in this folder
+  """
+  const meta = preflight(id, folder)
+  if (isFailure(meta)) {
+    return meta
+  }
+
+  return interrupt std::notes::delete("Delete a note from the Notes app?", {
+    account: meta.value.account,
+    folder: meta.value.folder,
+    title: meta.value.title,
+    id: id
+  })
+
+  destructive {
+    return try _deleteNote(id, folder)
+  }
+}


### PR DESCRIPTION
Spec-only. Closes the section 9.2 blocker that was holding the whole Notes module. No code.

## The finding

`container` isn't broken. **Reference chaining** is:

| Form | Result |
|---|---|
| `name of container of n` | `-1728` |
| `id of container of n` | `-1728` |
| `set c to container of n` then `name of c` | **`Agency Spike`** |

`container of n` resolves correctly every time. Reading a property *through* it in one expression is what fails. Coercing it directly proves the resolution was always fine, because the coercion error leaks the object it resolved to:

```
Can't make «class cfol» id "x-coredata://.../ICFolder/p594" into type text
```

`ICFolder/p594` is Agency Spike, confirmed against a folder-id listing.

It is also **not locked-specific**. 9.2 originally framed it as a possible locked-note quirk. That was wrong in an uninteresting way — `container` behaves identically on locked and unlocked notes.

So the pre-flight survives, with a one-line change:

```applescript
set n to note id (item 1 of argv)
set c to container of n          -- split. `name of container of n` fails.
return (name of n) & tab & (name of c) & tab & ((password protected of n) as text)
```

## A better assertion fell out of it

Two other approaches were tested while a broken `container` still looked likely. Both work, and one earns a place in the design:

```
note id X of folder Y      -> resolves
same, wrong folder         -> fails closed
scan folders for the id    -> finds it
```

The scoped lookup is an **inverted assertion**. The original design asks a note which folder it's in and compares that against what the caller asserted. But the assertion never needed that answer — it only needs *"is this note in the folder I was told?"*, and `note id X of folder Y` answers exactly that.

Section 6.4 adopts it, because it collapses the check and the access into one operation. A scoped lookup can't drift from its own check the way read-then-compare can across a human approval. **That resolves review finding #4's TOCTOU as a side effect** rather than by adding a second guard.

The design now uses both: `container of n` split, in the pre-flight, so the payload carries `folder` even when nothing was asserted (policy globs need it); and the scoped lookup in the write script as the assertion itself.

## Two incidental findings

- **`Recently Deleted` is a real folder** (`ICFolder/p1`), so `listFolders` will return it and `deleteNote` moves notes into it.
- **No `Agency Notes` folder exists**, confirming `createNote` must create it on demand.

## Why this took four probes

Documented in 9.2, because the mistake is easy to repeat. Every failure was a probe bug, not a finding — Notes was consistent throughout:

1. Chained by-name reference against a folder that might not exist. `-1728` covers "no such object", so the result couldn't distinguish a broken container from a deleted folder.
2. Accumulated results into one AppleScript string and returned it at the end. Most of the output vanished.
3. Fixed the output by echoing one `osascript` call per test — but its "step-by-step" case still read `name of container of n`. It split the *note* lookup and left the *container* access chained, testing the broken form while claiming to test the fixed one.
4. Finally split the container access. Answered in one run.

The lesson is mechanical: **when a probe and the design disagree about shape, the probe is testing something else.** Probe 3's label said "set n then container of n" and its code said `name of container of n`. Reading the label rather than the code cost two rounds.

## Status

Design approved, spike complete, all four open questions resolved. Work breakdown steps 3–6 are unblocked.

Section 12 still lists eight review findings to apply during implementation. Two are fail-open bugs, so they aren't optional cleanups.

Next step is `writing-plans`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
