### PR TITLE
The feedback channel: approve({message}) reaches the model (resumable guards PR 4)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-resumable-guards.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards.md
@@ -1421,11 +1421,15 @@ Small by design; everything it needs exists by now.
    request, which never passes the other three. No drain at
    `guardGate.final`: no request follows; the queue waits, serialized,
    for the next llm().
-3. **One thread message per approval, not per merged chain.** Multiple
-   handlers approving one trip still merge to one message (effectMerge
-   newline-join); but two TRIPS answered before one request (nested
-   guards at one gate) inject as two messages, in ask order —
-   innermost first. The fixture pins this.
+3. **One thread message per DRAIN, not per approval** (review round 1,
+   owner). Multiple handlers approving one trip merge to one message
+   (effectMerge newline-join), and everything queued at one drain
+   point — two trips answered before one request — ALSO joins into a
+   single user message, newline-joined in ask order, its label listing
+   each contributing guard (`guard:inner,guard:outer`). First cut
+   injected one message per approval; providers like Anthropic want
+   user/assistant alternation, so a drain must not emit a run of
+   consecutive user messages. The fixture pins the joined shape.
 4. **The label falls back to the dimension** (`guard:time`) when the
    guard is unlabeled — `guard:<label>` as planned otherwise.
 5. **Feedback queued in a fork branch that makes no further request

--- a/docs/superpowers/plans/2026-07-16-resumable-guards.md
+++ b/docs/superpowers/plans/2026-07-16-resumable-guards.md
@@ -1402,6 +1402,42 @@ Small by design; everything it needs exists by now.
 
 ---
 
+# Part 7b: PR 4 — as executed (deviations and discoveries)
+
+1. **The queue is its own thing, not the reply-attachments queue.**
+   The plan said "the exact reply-attachments pattern"; what shipped
+   shares the SHAPE (branch-local collect on `stack.other`, drain in an
+   idempotent step before the request) but not the plumbing — reply
+   attachments harvest per-tool into `self.runnerState` because they
+   belong to one llm() call, while guard feedback belongs to the BRANCH
+   (it must survive from a step-boundary approve in plain code to a
+   later llm() call). `StateStack.queueGuardFeedback` /
+   `takeGuardFeedback` on `stack.other.__guardFeedback`, serialized.
+2. **Four drain points, not one.** "Before the next model request"
+   turned out to be four step positions: `guardFeedback.initial`,
+   `round.N.guardFeedback`, `validation.N.guardFeedback`, and
+   `<key>.retryFeedback.N` inside the trip-retry wrapper — the last
+   because a MID-REQUEST approve's message belongs in the re-issued
+   request, which never passes the other three. No drain at
+   `guardGate.final`: no request follows; the queue waits, serialized,
+   for the next llm().
+3. **One thread message per approval, not per merged chain.** Multiple
+   handlers approving one trip still merge to one message (effectMerge
+   newline-join); but two TRIPS answered before one request (nested
+   guards at one gate) inject as two messages, in ask order —
+   innermost first. The fixture pins this.
+4. **The label falls back to the dimension** (`guard:time`) when the
+   guard is unlabeled — `guard:<label>` as planned otherwise.
+5. **Feedback queued in a fork branch that makes no further request
+   dies with the branch at the join** — accepted, same lifetime as the
+   branch's reply-attachment queue; documented in interrupts.md.
+6. **The deferred subprocess e2e (PR 2 note 7, PR 3 note 10) landed
+   here** and needed ZERO new IPC plumbing: the approve payload rides
+   the interrupt IPC verbatim, so the parent's `approve({message})` for
+   a child's forwarded trip queues and injects inside the child
+   (tests/agency/subprocess/trip-forward-approve-message, asserted from
+   the child's own thread).
+
 # Part 8: Estimates and sequencing
 
 | PR | Contents | Estimate |

--- a/docs/superpowers/specs/2026-07-16-guard-keyword-idea.md
+++ b/docs/superpowers/specs/2026-07-16-guard-keyword-idea.md
@@ -1,0 +1,158 @@
+# Idea: `guard` as a language-level construct (typed guards + static `std::guard` analysis)
+
+**Status:** idea captured 2026-07-16, owner-endorsed direction. Deliberately
+NOT a spec yet — this doc exists so the brainstorm can start from full
+context later. Sequencing decision (owner): resumable-guards PRs 3 and 4
+ship first; this follows as its own brainstorm → spec → plan loop.
+
+**Where this came from:** the review discussion on PR #560 (cost trips as
+resumable interrupts), thread on `lib/runtime/call.ts` — the owner asked
+whether `std::guard` interrupts could get the same `raises` static-analysis
+guarantees as every other effect, and then proposed this: make guards a
+language feature instead of a stdlib function.
+
+## The idea in one paragraph
+
+Turn `guard(cost: $1, time: 5m) as { ... }` from a call to the stdlib
+function `std::thread.guard` into a first-class language construct — its own
+keyword, parser rule, AST node, typechecker treatment, and codegen lowering
+(to the SAME runtime machinery that exists today). The surface syntax can
+stay byte-identical; the only user-visible migration is deleting
+`import { guard } from "std::thread"`, because keywords are not imported.
+
+## Why: it makes `std::guard` statically analyzable, which I had concluded was impossible
+
+Read this section carefully, future me — it reverses a conclusion you
+argued for on the #560 thread.
+
+**The problem.** The `raises` effect system
+(docs/site/guide/effects-and-raises.html; enforcement shipped in #511)
+gives static guarantees about which interrupts a function can raise.
+Guard trips (`std::guard`) are invisible to it. The naive fix — track the
+RAISE POINT — collapses: cost trips raise at `llm()` gates, but PR 3's
+time trips raise at ANY step boundary of ANY function running under a
+guard, and guards are installed dynamically by callers a callee never
+sees. Tracking raise points marks every function in every program, which
+is an annotation that tells the reader nothing. That collapse is why the
+#560 thread recommended treating `std::guard` as an AMBIENT effect (like
+cancellation, which no clause declares).
+
+**The reversal.** A guard CONSTRUCT lets the checker attribute the effect
+to the SOURCE instead of the raise point: *the `std::guard` interrupt is
+raised by the guard construct*. Statically: a function that lexically
+contains a `guard { ... }` block may raise `std::guard`; normal transitive
+effect propagation through callers does the rest. Functions with no guard
+anywhere under their call tree carry nothing. Precise, and no annotation
+noise.
+
+**Why that attribution is SOUND, not just convenient.** The
+registration-site eligibility rule from PR 1 (#558): a handler registered
+inside a guard's dynamic extent can never see that guard's trip —
+eligibility requires registering before the guard installed
+(`HandlerEntry.liveGuardIds`, the `eligible` filter in
+`runHandlerChain`). Therefore every possible OBSERVER of a `std::guard`
+interrupt — every eligible handler, out to the user endpoint — sits in
+the transitive caller chain of the function containing the guard
+construct. That is exactly the chain the effect analysis marks. The trip
+physically firing three calls deeper, inside some helper's llm gate, is
+unobservable from anywhere that helper's own `raises` clause governs.
+The budget-scoping rule and the effect-attribution rule are the same
+rule. This argument survives the hard cases:
+
+- PR 3 time trips: attributed to the construct regardless of where the
+  timer catches the branch.
+- A tool defined outside any guard, executed by an `llm()` inside one:
+  the guard construct containing that `llm()` call is in the marked
+  chain.
+- Fork/race clones: clones carry the parent's guardId; the construct is
+  in the parent chain.
+
+## What the construct buys beyond `raises`
+
+1. **Aliasing-proof recognition.** The checker could pattern-match calls
+   to `std::thread.guard` today, but that breaks under `const g = guard`,
+   partial application, re-export, and guard-as-value. A keyword cannot
+   be renamed away. Safety infrastructure should not be dodge-able —
+   same reason `handle` and `finalize` are keywords.
+2. **Precise result typing.** `const r = guard(cost: $1) as { ...T... }`
+   can be natively typed `Result<T>` instead of what the generic stdlib
+   signature manages.
+3. **A home for guard-specific diagnostics** (nesting lints, label rules,
+   guard-in-finalize interactions).
+4. **The anchor #555 needs.** The construct is where the trip's typed
+   data payload ({label, scopeIds, dimension, limit, spent, maxCost,
+   maxTime, draftValue}) and the typed approve payload ({maxCost?,
+   maxTime?, disarm?, message?}) attach. `std::guard` becomes the first
+   BUILT-IN typed effect: handlers narrowing on `intr.effect` get checked
+   field access instead of `any`, and effect-string typo detection falls
+   out of the same registry.
+5. **Runtime untouched.** Codegen lowers the construct to the existing
+   `_pushGuard` / `GuardScope` / gate machinery from #558/#560. This is
+   a front-end feature.
+
+## Costs and decisions for the brainstorm
+
+- **Parser + AST + walkers + checker + codegen + fixtures** — one focused
+  PR. The direct precedent is the `finalize` keyword (#556): parser rule
+  mirroring `handleBlockParser`, an AST node like
+  `lib/types/finalizeBlock.ts`, one `bodySlots` case, checker pass,
+  codegen lowering.
+- **`guard` becomes a keyword**: `import { guard } from "std::thread"`
+  stops parsing; migration is deleting the import line (breaking, small,
+  consistent with the current posture). Variables named `guard` also
+  break.
+- **Surface syntax decisions**: keep `guard(args) as { ... }` verbatim
+  (cheapest migration), or drop the `as` (note AG4006 declares
+  reserved block keywords take no `as` "because there is nothing to
+  bind" — a guard DOES bind its Result, so `as` arguably stays; thread
+  and subthread are the no-`as` precedents,
+  `lib/typeChecker/undefinedFunctionDiagnostic.ts:86`).
+- **The annotated-code ripple**: once the analysis lands, a
+  `raises`-annotated function containing a guard needs `std::guard` in
+  its clause. Owner: "I don't think there are many of these right now,
+  if any." Decide auto-admit-with-warning vs hard-require.
+- **`agency.withCostGuard`** (TS-side guard install, `lib/runtime/agency.ts`)
+  has no construct — decide: deprecate it, or document its trips as the
+  one ambient residue. Root budgets never raise, so they are not an
+  issue. `std::agency.run(maxCost:)`'s internal guard becomes a
+  construct inside stdlib and gets marked normally (may-raise
+  over-approximation is fine — its parent-side IPC trips still throw in
+  v1, see the PR 2 execution notes).
+- **Where the effect enters the analysis**: the construct contributes
+  `std::guard` to `interruptEffectsByFunction` for its containing
+  function; the transitive machinery is already there
+  (`lib/analysis/interrupts.ts`, the raises checking from #511 —
+  `checkFunctionTypeRaises`).
+
+## File pointers for the future reader
+
+- Runtime this lowers onto: `lib/runtime/guardScope.ts`,
+  `lib/runtime/guardTripInterrupt.ts`, `lib/runtime/guard.ts`,
+  `lib/stdlib/thread.ts` (`_pushGuard`, ~:263), the gate steps in
+  `lib/runtime/prompt.ts` (`guardGate.*`), and the eligibility filter in
+  `lib/runtime/interrupts.ts` (`runHandlerChain`) with
+  `HandlerEntry.liveGuardIds` in `lib/runtime/types.ts`.
+- The stdlib function being replaced: `stdlib/thread.agency` (`guard`,
+  ~:219).
+- Keyword-construct precedent to copy: the finalize keyword PR (#556) —
+  parser rule in `lib/parsers/parsers.ts` (`finalizeBlockParser`,
+  mirroring `handleBlockParser` ~:4208), AST node
+  `lib/types/finalizeBlock.ts`, `lib/utils/bodySlots.ts` registration,
+  codegen extraction pattern
+  `lib/backends/typescriptBuilder/finalizeCodegen.ts`.
+- Effect system: docs/site/guide/effects-and-raises.html,
+  `lib/analysis/interrupts.ts`, raises enforcement from #511.
+- Context threads: PR #560 (the `raises` discussion on
+  `lib/runtime/call.ts`, comment 3599637753 and its reply laying out the
+  ambient-vs-precise argument this doc reverses), issue #555 (typed
+  payloads — the companion work), `docs/dev/interrupts.md` ("Guard trips
+  as interrupts" section), and the resumable-guards plan
+  `docs/superpowers/plans/2026-07-16-resumable-guards.md` (decision 3 =
+  the eligibility rule; Part 5b = PR 2 execution notes).
+
+## Sequencing (owner-decided)
+
+PRs 3 (derived abort signal + time trips) and 4 (feedback channel) first —
+they are runtime work and do not depend on this. Then this feature as its
+own loop, bundled with the `raises` attribution, feeding #555 its first
+typed-effect customer.

--- a/packages/agency-lang/docs/dev/interrupts.md
+++ b/packages/agency-lang/docs/dev/interrupts.md
@@ -487,9 +487,13 @@ halves:
   its own right before each request step — `guardFeedback.initial`,
   `round.N.guardFeedback`, `validation.N.guardFeedback`, and
   `<key>.retryFeedback.N` inside the trip-retry wrapper (a mid-request
-  approve's message belongs in the re-issued request). One user-role
-  thread message per queued approval, oldest first, pushed with its
-  label via `MessageThread.push(message, label)` (#557) — labels are
+  approve's message belongs in the re-issued request). Everything
+  queued drains as ONE user-role thread message, entries
+  newline-joined oldest first — providers like Anthropic want
+  user/assistant alternation, so a drain must not emit a run of
+  consecutive user messages. The label lists each contributing guard
+  once (`guard:a,guard:b`), pushed via
+  `MessageThread.push(message, label)` (#557) — labels are
   observability-only and never reach the provider. A message queued
   outside any LLM loop (a step-boundary approve in plain code) waits
   and lands at the branch's next `llm()` call's initial drain.
@@ -498,6 +502,15 @@ Cross-process: the approve payload rides the interrupt IPC verbatim, so
 a PARENT's `approve({message})` for a CHILD's forwarded trip queues and
 injects inside the child
 (tests/agency/subprocess/trip-forward-approve-message).
+
+A note for the future: `message` is a payload key the runtime
+INTERPRETS — it has channel semantics the way `maxCost` has grant
+semantics — but nothing declares that. Today a key of an approve
+payload either does something magical (guardTripInterrupt.ts applies
+it) or silently nothing. When approve payloads become typed per effect
+(#555), how each key gets USED should be declared alongside its shape,
+so a payload's behavior is inspectable instead of buried in the
+runtime.
 
 - **The join rule (decision 15, "the grant follows the budget"):**
   `TimeGuard.extendBudget` records its clamped grant in a serialized

--- a/packages/agency-lang/docs/dev/interrupts.md
+++ b/packages/agency-lang/docs/dev/interrupts.md
@@ -467,6 +467,38 @@ them. PR 3 adds two raise surfaces and the join rule:
   it, a clock crossing its limit after the work concluded would raise a
   question about nothing, and a late timer fire could flip a computed
   success into a failure.
+## The feedback channel (resumable guards, PR 4)
+
+`approve({message})` delivers reviewer feedback to the model. Two
+halves:
+
+- **Queueing:** `applyVerdict` (guardTripInterrupt.ts) pushes the
+  merged message (effectMerge newline-joins multiple handlers') onto
+  the raising branch's `stack.other.__guardFeedback` via
+  `StateStack.queueGuardFeedback` — branch-local (each fork branch has
+  its own stack) and serialized (an approve applied just before a
+  checkpoint keeps its message). The entry carries its label,
+  `guard:<label>` (the guard's `label:`, falling back to the
+  dimension). Queued after `scope.extend` so a defective answer
+  (GuardApproveError) never leaves a message behind. Feedback queued in
+  a fork branch that makes no further request dies with the branch at
+  the join — same lifetime as the branch's reply-attachment queue.
+- **Draining:** `runPrompt` drains the queue in an idempotent step of
+  its own right before each request step — `guardFeedback.initial`,
+  `round.N.guardFeedback`, `validation.N.guardFeedback`, and
+  `<key>.retryFeedback.N` inside the trip-retry wrapper (a mid-request
+  approve's message belongs in the re-issued request). One user-role
+  thread message per queued approval, oldest first, pushed with its
+  label via `MessageThread.push(message, label)` (#557) — labels are
+  observability-only and never reach the provider. A message queued
+  outside any LLM loop (a step-boundary approve in plain code) waits
+  and lands at the branch's next `llm()` call's initial drain.
+
+Cross-process: the approve payload rides the interrupt IPC verbatim, so
+a PARENT's `approve({message})` for a CHILD's forwarded trip queues and
+injects inside the child
+(tests/agency/subprocess/trip-forward-approve-message).
+
 - **The join rule (decision 15, "the grant follows the budget"):**
   `TimeGuard.extendBudget` records its clamped grant in a serialized
   `grantedMs`; `cloneForBranch` deliberately does NOT copy it (it means

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -148,8 +148,8 @@ The message lands in the conversation as a user message, right before the work's
 
 Two details:
 
-- If several handlers approve with messages, the messages are joined into one, inner handler first.
-- In thread dumps and statelog, injected feedback wears the label `guard:<label>` (the guard's `label:`, or its dimension when unlabeled), so you can tell reviewer feedback from real user messages. The model just sees a user message.
+- Messages combine instead of piling up. Several handlers approving one trip join their messages into one, inner handler first. And everything delivered at the same point — say, two nested guards both approved before one request — arrives as a single user message, newline-joined in ask order. Providers that require strict user/assistant alternation never see a run of user messages.
+- In thread dumps and statelog, injected feedback wears the label `guard:<label>` (the guard's `label:`, or its dimension when unlabeled), so you can tell reviewer feedback from real user messages. A combined message lists each contributing guard. The model just sees a user message.
 
 Deliberation is free. While your handler decides, the tripped guard's clock is paused, and your handler's own `llm()` calls are not billed to the guard it is judging. The handler's work is metered by the guards that enclosed its **registration site** — so register the handler *outside* the guard. A handler registered inside the guarded block is part of the metered work and never sees that guard's trips.
 

--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -136,6 +136,21 @@ Things to note:
 - `pass()` means "not my question": the rest of the handler chain, and finally the user, decide. Use it for effects your handler does not recognize.
 - If several handlers approve, their grants merge additively.
 
+### Sending feedback with the grant
+
+An approval can carry a message for the model:
+
+```ts
+return approve({ maxCost: 0.50, message: "You are over budget because you keep re-reading files. Summarize what you have and finish." })
+```
+
+The message lands in the conversation as a user message, right before the work's next model request. If the trip happened outside an LLM call — say, mid-loop — the message waits and arrives with the next `llm()` call. This is what makes guards a review point, not just a meter: the handler grants more budget *and* steers how it gets spent.
+
+Two details:
+
+- If several handlers approve with messages, the messages are joined into one, inner handler first.
+- In thread dumps and statelog, injected feedback wears the label `guard:<label>` (the guard's `label:`, or its dimension when unlabeled), so you can tell reviewer feedback from real user messages. The model just sees a user message.
+
 Deliberation is free. While your handler decides, the tripped guard's clock is paused, and your handler's own `llm()` calls are not billed to the guard it is judging. The handler's work is metered by the guards that enclosed its **registration site** — so register the handler *outside* the guard. A handler registered inside the guarded block is part of the metered work and never sees that guard's trips.
 
 ### What approve does, by situation

--- a/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
@@ -93,7 +93,7 @@ async function raiseOneTrip(
     const recorded = ctx.getInterruptResponse(persistedId);
     if (recorded) {
       delete stack.other[key];
-      applyVerdict(recorded, scope, tripped, err);
+      applyVerdict(recorded, scope, tripped, err, stack);
       return undefined;
     }
     // The question is already OPEN (persisted, no answer yet — e.g. a
@@ -143,7 +143,7 @@ async function raiseOneTrip(
         },
       );
       if (isApproved(verdict) || isRejected(verdict)) {
-        applyVerdict(verdict, scope, tripped, err);
+        applyVerdict(verdict, scope, tripped, err, stack);
         return undefined;
       }
       // Unanswered: persist the id so the resumed gate finds the answer,
@@ -172,18 +172,29 @@ function applyVerdict(
   scope: GuardScope,
   tripped: Guard,
   err: GuardExceededError,
+  stack: StateStack,
 ): void {
   if (isApproved(verdict)) {
+    const payload = ((verdict as { value?: unknown }).value ?? {}) as Parameters<
+      GuardScope["extend"]
+    >[0];
     // GuardScope.extend enforces the whole answer contract: additive
     // grants, negative clamps, disarm, root refusal, and the useless-
     // approval error (leaves the tripped dimension over budget and
     // armed → would re-trip forever).
-    scope.extend(
-      ((verdict as { value?: unknown }).value ?? {}) as Parameters<
-        GuardScope["extend"]
-      >[0],
-      tripped.dimension,
-    );
+    scope.extend(payload, tripped.dimension);
+    // approve({message}) is the feedback channel (PR 4): the merged
+    // message (effectMerge newline-joins multiple handlers') queues on
+    // the raising branch and rides into the thread as a labeled
+    // user-role message before the branch's next model request. Queued
+    // AFTER extend so a defective answer (GuardApproveError) never
+    // leaves its message behind.
+    if (payload.message !== undefined && payload.message !== "") {
+      stack.queueGuardFeedback(
+        payload.message,
+        `guard:${tripped.label ?? tripped.dimension}`,
+      );
+    }
     return;
   }
   // Rejected: the trip stands. Deliver the ORIGINAL error; from here the

--- a/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
+++ b/packages/agency-lang/lib/runtime/guardTripInterrupt.ts
@@ -189,10 +189,23 @@ function applyVerdict(
     // user-role message before the branch's next model request. Queued
     // AFTER extend so a defective answer (GuardApproveError) never
     // leaves its message behind.
-    if (payload.message !== undefined && payload.message !== "") {
+    //
+    // NOTE: this is the runtime INTERPRETING one field of the approve
+    // payload — `message` has channel semantics the way `maxCost` has
+    // grant semantics, but nothing declares that; a payload key either
+    // does something magical here or nothing at all. When approve
+    // payloads become typed per effect (#555), how a payload gets USED
+    // should be declared alongside its shape.
+    //
+    // The typeof guard is the trust boundary: payloads arrive from
+    // untyped JS handlers and from IPC, and a non-string `message`
+    // must not reach the serialized queue or userMessage().
+    if (typeof payload.message === "string" && payload.message !== "") {
+      // Truthy label check, not `??`: an empty-string label means
+      // unlabeled everywhere else, and must not produce `guard:`.
       stack.queueGuardFeedback(
         payload.message,
-        `guard:${tripped.label ?? tripped.dimension}`,
+        `guard:${tripped.label ? tripped.label : tripped.dimension}`,
       );
     }
     return;

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1106,18 +1106,24 @@ export async function runPrompt(args: {
   const guardGate = () => raiseGuardTripsUntilClear(ctx, stateStack);
 
   // The delivery half of approve({message}) (resumable-guards PR 4):
-  // drain the branch's queued reviewer feedback into the thread as
-  // user-role messages, in an idempotent step of its own right before
-  // a request step. One thread message per queued approval, oldest
-  // first. The `guard:<label>` labels are observability-only (#557) —
-  // the model sees ordinary user messages, which is the point: guard
-  // feedback steers the model exactly like a user would.
+  // drain the branch's queued reviewer feedback into the thread, in an
+  // idempotent step of its own right before a request step. Everything
+  // queued drains as ONE user message, entries newline-joined oldest
+  // first — providers like Anthropic want user/assistant alternation,
+  // so one drain must not emit a run of consecutive user messages.
+  // The label lists each contributing guard once, in the same order.
+  // Labels are observability-only (#557) — the model sees an ordinary
+  // user message, which is the point: guard feedback steers the model
+  // exactly like a user would.
   const drainGuardFeedback = async () => {
     const feedback = stateStack.takeGuardFeedback();
     if (feedback.length === 0) return;
-    feedback.forEach((f) =>
-      messages.push(smoltalk.userMessage(f.text), f.label),
-    );
+    const text = feedback.map((f) => f.text).join("\n");
+    const label = feedback
+      .map((f) => f.label)
+      .filter((l, i, all) => all.indexOf(l) === i)
+      .join(",");
+    messages.push(smoltalk.userMessage(text), label);
     self.messagesJSON = snapshotThread();
   };
 

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1105,6 +1105,22 @@ export async function runPrompt(args: {
   // (they push messages). See lib/runtime/guardTripInterrupt.ts.
   const guardGate = () => raiseGuardTripsUntilClear(ctx, stateStack);
 
+  // The delivery half of approve({message}) (resumable-guards PR 4):
+  // drain the branch's queued reviewer feedback into the thread as
+  // user-role messages, in an idempotent step of its own right before
+  // a request step. One thread message per queued approval, oldest
+  // first. The `guard:<label>` labels are observability-only (#557) —
+  // the model sees ordinary user messages, which is the point: guard
+  // feedback steers the model exactly like a user would.
+  const drainGuardFeedback = async () => {
+    const feedback = stateStack.takeGuardFeedback();
+    if (feedback.length === 0) return;
+    feedback.forEach((f) =>
+      messages.push(smoltalk.userMessage(f.text), f.label),
+    );
+    self.messagesJSON = snapshotThread();
+  };
+
   // A REQUEST step wrapped in the time-trip retry loop (resumable-guards
   // PR 3). When the timer kills the in-flight request, _runPrompt's
   // cancellation classifier throws GuardTripRetry; the loop raises the
@@ -1125,6 +1141,12 @@ export async function runPrompt(args: {
     while (true) {
       if (stateStack.firstRaisableTrip() !== null) {
         await pr.step(`${key}.retryGate.${gateAttempt}`, guardGate);
+        // An approve at THIS gate may have queued feedback; it belongs
+        // in the re-issued request, so drain before the body re-runs.
+        await pr.step(
+          `${key}.retryFeedback.${gateAttempt}`,
+          drainGuardFeedback,
+        );
         gateAttempt += 1;
         continue; // re-probe: each budget is owed its own question
       }
@@ -1139,6 +1161,10 @@ export async function runPrompt(args: {
   };
   try {
     await pr.step("guardGate.initial", guardGate);
+    // Feedback queued before this llm() call — by the initial gate just
+    // above, or by an earlier step-boundary approve anywhere on this
+    // branch — lands ahead of the new prompt: it reviews PAST work.
+    await pr.step("guardFeedback.initial", drainGuardFeedback);
     // The prompt push is its OWN idempotent step so the request step
     // below is re-issue-safe: an in-process trip retry (or a resumed
     // replay) re-runs the request body without duplicating the user
@@ -1766,6 +1792,7 @@ export async function runPrompt(args: {
         // post-charge throw site); raise it before the next request goes
         // out, so nothing more is spent while the question is open.
         await pr.step(`round.${round}.guardGate`, guardGate);
+        await pr.step(`round.${round}.guardFeedback`, drainGuardFeedback);
         // Next LLM call wrapped in pr.step for resume idempotency. Once
         // marked done, resume re-entries skip the LLM call. The llmCall
         // span stays open across rounds (one span per llm() call), so we
@@ -1866,6 +1893,10 @@ export async function runPrompt(args: {
         self.messagesJSON = snapshotThread();
       });
       await pr.step(`validation.${validationAttempt}.guardGate`, guardGate);
+      await pr.step(
+        `validation.${validationAttempt}.guardFeedback`,
+        drainGuardFeedback,
+      );
       await requestStepWithTripRetry(`validation.${validationAttempt}.llmCall`, async () => {
         const nextResult = await _runPrompt({
           ctx,

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -689,6 +689,34 @@ export class StateStack {
     this.rebuildAbortSignal();
   }
 
+  /** Reviewer feedback from `approve({message})`, waiting for this
+   *  branch's next model request (resumable-guards PR 4). The queue
+   *  lives in `other` so it is branch-local (each fork branch has its
+   *  own StateStack) and serialized (an approve applied just before a
+   *  checkpoint must not lose its message). runPrompt drains it into
+   *  the thread as labeled user-role messages right before each
+   *  request; a message queued outside any LLM loop simply waits for
+   *  the branch's next `llm()` call. Feedback queued in a fork branch
+   *  that makes no further request dies with the branch at the join —
+   *  the same lifetime as the branch's reply-attachment queue. */
+  queueGuardFeedback(text: string, label: string): void {
+    const queue = (this.other.__guardFeedback ??= []) as Array<{
+      text: string;
+      label: string;
+    }>;
+    queue.push({ text, label });
+  }
+
+  /** Remove and return every queued feedback entry, oldest first. */
+  takeGuardFeedback(): Array<{ text: string; label: string }> {
+    const queue = this.other.__guardFeedback as
+      | Array<{ text: string; label: string }>
+      | undefined;
+    if (!queue || queue.length === 0) return [];
+    delete this.other.__guardFeedback;
+    return queue;
+  }
+
   /** The consuming sibling of firstRaisableTrip: check() exactly the
    *  guard the probe admits. The runner's raise path uses this instead
    *  of detectTrippedGuard so a step-boundary conversation stays scoped

--- a/packages/agency-lang/tests/agency-js/guard-feedback/agency.json
+++ b/packages/agency-lang/tests/agency-js/guard-feedback/agency.json
@@ -1,0 +1,6 @@
+{
+  "observability": true,
+  "log": {
+    "logFile": "statelog.log"
+  }
+}

--- a/packages/agency-lang/tests/agency-js/guard-feedback/agent.agency
+++ b/packages/agency-lang/tests/agency-js/guard-feedback/agent.agency
@@ -1,0 +1,53 @@
+import { guard } from "std::thread"
+
+// The approve({message}) feedback channel (resumable guards PR 4).
+// Three approvals, three messages, two delivery paths:
+//
+//   1. "clock" trips at a step boundary INSIDE plain code (no llm in
+//      sight). Its message waits on the branch queue and lands before
+//      the branch's NEXT llm() call — the first request.
+//   2. "inner" and "outer" trip together at the gate after the first
+//      call's charge (nested cost guards, one charge over both
+//      limits). The gate asks innermost-first, so their two messages
+//      queue in that order and BOTH land before the second request.
+//
+// test.js asserts placement, order, user role, and the guard:<label>
+// labels from the statelog promptCompletion payloads.
+
+def spin(rounds: number): string {
+  let i = 0
+  while (i < rounds) {
+    i = i + 1
+  }
+  return "spun"
+}
+
+node main() {
+  handle {
+    const warm = guard(time: 100ms, label: "clock") as {
+      const s = spin(300000)
+      return s
+    }
+    if (isFailure(warm)) { return "clock-failed" }
+    const spend = guard(cost: $0.0000015, label: "outer") as {
+      const inner = guard(cost: $0.000001, label: "inner") as {
+        const a = llm("first")
+        const b = llm("second")
+        return b
+      }
+      if (isFailure(inner)) { return "inner-failed" }
+      return inner.value
+    }
+    if (isFailure(spend)) { return "spend-failed" }
+    return spend.value
+  } with (i) {
+    if (i.effect == "std::guard") {
+      return match(i.data.label) {
+        "clock" => approve({ maxTime: 600000, message: "wrap up the loop" })
+        "inner" => approve({ maxCost: 0.0001, message: "inner: one more call" })
+        _ => approve({ maxCost: 0.0001, message: "outer: budget doubled" })
+      }
+    }
+    return pass()
+  }
+}

--- a/packages/agency-lang/tests/agency-js/guard-feedback/agent.agency
+++ b/packages/agency-lang/tests/agency-js/guard-feedback/agent.agency
@@ -8,11 +8,13 @@ import { guard } from "std::thread"
 //      the branch's NEXT llm() call — the first request.
 //   2. "inner" and "outer" trip together at the gate after the first
 //      call's charge (nested cost guards, one charge over both
-//      limits). The gate asks innermost-first, so their two messages
-//      queue in that order and BOTH land before the second request.
+//      limits). The gate asks innermost-first, so their messages queue
+//      in that order and land before the second request as ONE
+//      newline-joined user message (providers want user/assistant
+//      alternation), labeled with both guards.
 //
-// test.js asserts placement, order, user role, and the guard:<label>
-// labels from the statelog promptCompletion payloads.
+// test.js asserts placement, join order, user role, and the
+// guard:<label> labels from the statelog promptCompletion payloads.
 
 def spin(rounds: number): string {
   let i = 0

--- a/packages/agency-lang/tests/agency-js/guard-feedback/fixture.json
+++ b/packages/agency-lang/tests/agency-js/guard-feedback/fixture.json
@@ -31,13 +31,8 @@
       },
       {
         "role": "user",
-        "content": "inner: one more call",
-        "label": "guard:inner"
-      },
-      {
-        "role": "user",
-        "content": "outer: budget doubled",
-        "label": "guard:outer"
+        "content": "inner: one more call\nouter: budget doubled",
+        "label": "guard:inner,guard:outer"
       },
       {
         "role": "user",

--- a/packages/agency-lang/tests/agency-js/guard-feedback/fixture.json
+++ b/packages/agency-lang/tests/agency-js/guard-feedback/fixture.json
@@ -1,0 +1,50 @@
+{
+  "returnValue": "answer",
+  "requests": [
+    [
+      {
+        "role": "user",
+        "content": "wrap up the loop",
+        "label": "guard:clock"
+      },
+      {
+        "role": "user",
+        "content": "first",
+        "label": null
+      }
+    ],
+    [
+      {
+        "role": "user",
+        "content": "wrap up the loop",
+        "label": "guard:clock"
+      },
+      {
+        "role": "user",
+        "content": "first",
+        "label": null
+      },
+      {
+        "role": "assistant",
+        "content": "answer",
+        "label": null
+      },
+      {
+        "role": "user",
+        "content": "inner: one more call",
+        "label": "guard:inner"
+      },
+      {
+        "role": "user",
+        "content": "outer: budget doubled",
+        "label": "guard:outer"
+      },
+      {
+        "role": "user",
+        "content": "second",
+        "label": null
+      }
+    ]
+  ],
+  "labelReachedProvider": false
+}

--- a/packages/agency-lang/tests/agency-js/guard-feedback/test.js
+++ b/packages/agency-lang/tests/agency-js/guard-feedback/test.js
@@ -12,9 +12,11 @@ import { readFileSync, writeFileSync, unlinkSync } from "fs";
 //   - request 1 carries the "clock" message BEFORE the "first" prompt:
 //     feedback queued outside any LLM loop waits for the branch's next
 //     llm() call, and reviews past work so it precedes the new prompt.
-//   - request 2 carries "inner" then "outer" IN ORDER (the gate asks
-//     innermost-first), after round 1's exchange and before "second".
-//   - every injected message is user-role and wears its guard:<label>.
+//   - request 2 carries "inner" and "outer" as ONE newline-joined user
+//     message (a drain must not emit consecutive user messages), in
+//     ask order (the gate asks innermost-first), after round 1's
+//     exchange and before "second" — labeled with BOTH guards.
+//   - every injected message is user-role and wears its guard label.
 //   - no `label` key ever reaches the provider config.
 
 const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };

--- a/packages/agency-lang/tests/agency-js/guard-feedback/test.js
+++ b/packages/agency-lang/tests/agency-js/guard-feedback/test.js
@@ -1,0 +1,81 @@
+import { main, __setLLMClient } from "./agent.js";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+
+// approve({message}) feedback delivery (resumable guards PR 4). The
+// program (see agent.agency) produces three approvals with messages:
+// "clock" from a step-boundary time trip in plain code, then "inner"
+// and "outer" from nested cost guards tripping together after the
+// first llm() call's charge.
+//
+// Assertions, all from statelog promptCompletion payloads (the REQUEST
+// message array as sent, with per-message labels):
+//   - request 1 carries the "clock" message BEFORE the "first" prompt:
+//     feedback queued outside any LLM loop waits for the branch's next
+//     llm() call, and reviews past work so it precedes the new prompt.
+//   - request 2 carries "inner" then "outer" IN ORDER (the gate asks
+//     innermost-first), after round 1's exchange and before "second".
+//   - every injected message is user-role and wears its guard:<label>.
+//   - no `label` key ever reaches the provider config.
+
+const USAGE = { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 };
+// Non-zero cost is load-bearing: each call charges $0.000002, which is
+// what trips the $0.000001/$0.0000015 nested guards after call 1.
+const COST = { inputCost: 0.000001, outputCost: 0.000001, totalCost: 0.000002, currency: "USD" };
+
+const seenConfigs = [];
+const client = {
+  async text(config) {
+    seenConfigs.push(config);
+    return {
+      success: true,
+      value: { output: "answer", toolCalls: [], model: "test", usage: USAGE, cost: COST },
+    };
+  },
+  async *textStream(config) {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  },
+  async embed() {
+    return { success: false, error: "embed not implemented" };
+  },
+};
+
+__setLLMClient(client);
+
+try {
+  unlinkSync("statelog.log");
+} catch {
+  // ignore ENOENT
+}
+
+const result = await main();
+
+const events = readFileSync("statelog.log", "utf-8")
+  .split("\n")
+  .filter((l) => l.trim() !== "")
+  .map((l) => JSON.parse(l));
+
+// One promptCompletion per request, in request order.
+const requests = events
+  .filter((e) => e.data?.type === "promptCompletion")
+  .map((e) =>
+    (e.data?.messages ?? []).map((m) => ({
+      role: m.role,
+      content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+      label: m.label ?? null,
+    })),
+  );
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      returnValue: result?.data ?? result,
+      requests,
+      labelReachedProvider: seenConfigs.some((c) => "label" in c),
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency/guards/guard-concurrent-branches.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-concurrent-branches.agency
@@ -8,7 +8,14 @@ import { guard } from "std::thread"
 // returns its normal value, and the parent receives both. Without guardId
 // matching, branch 2's boundary could convert branch 1's trip. Exercises
 // guardTrip separation across concurrent branches in one fixture.
+// The handler is race insurance, not part of the pinned behavior: on a
+// slow runner the setup walk can eat the whole tight budget, so the
+// trip is DETECTED at a step boundary and raised as a resumable
+// interrupt instead of aborting the in-flight sleep. Rejecting it
+// delivers the same GuardExceededError from the step, and the output
+// is identical on both paths. On a fast run the handler never fires.
 node main() {
+  handle {
   const results = fork([1, 2]) as n {
     if (n == 1) {
       const a = guard(time: 20ms) as {
@@ -30,4 +37,10 @@ node main() {
     return "B:${b.value}"
   }
   return "${results[0]}|${results[1]}"
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
 }

--- a/packages/agency-lang/tests/agency/guards/guard-time-nested-outer-tighter.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-nested-outer-tighter.agency
@@ -11,7 +11,14 @@ import { guard } from "std::thread"
 // "outer:timeoutFailure". Previously (Increment 1, before guardId
 // matching) the inner mis-attributed the outer's trip to itself,
 // returning "inner:timeoutFailure:20".
+// The handler is race insurance, not part of the pinned behavior: on a
+// slow runner the setup walk can eat the whole tight budget, so the
+// trip is DETECTED at a step boundary and raised as a resumable
+// interrupt instead of aborting the in-flight sleep. Rejecting it
+// delivers the same GuardExceededError from the step, and the output
+// is identical on both paths. On a fast run the handler never fires.
 node main() {
+  handle {
   const outer = guard(time: 20ms) as {
     const inner = guard(time: 5s) as {
       sleep(150ms)
@@ -26,4 +33,10 @@ node main() {
     return "outer:${outer.error.type}"
   }
   return outer.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
 }

--- a/packages/agency-lang/tests/agency/guards/guard-time-nested.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-nested.agency
@@ -5,7 +5,14 @@ import { guard } from "std::thread"
 // catches the inner's Failure without itself tripping. Verifies that
 // inner trips don't leak into the outer scope (uninstall properly
 // restores the outer's abort plumbing).
+// The handler is race insurance, not part of the pinned behavior: on a
+// slow runner the setup walk can eat the whole tight budget, so the
+// trip is DETECTED at a step boundary and raised as a resumable
+// interrupt instead of aborting the in-flight sleep. Rejecting it
+// delivers the same GuardExceededError from the step, and the output
+// is identical on both paths. On a fast run the handler never fires.
 node main() {
+  handle {
   const outer = guard(time: 5s) as {
     const inner = guard(time: 20ms) as {
       sleep(150ms)
@@ -21,4 +28,10 @@ node main() {
     return "outer tripped (unexpected)"
   }
   return outer.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
 }

--- a/packages/agency-lang/tests/agency/guards/guard-time-sleep-still-counts.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-sleep-still-counts.agency
@@ -2,7 +2,14 @@ import { guard } from "std::thread"
 
 // sleep is NOT exempt: it is the program deliberately spending time,
 // not waiting on a human. A sleep that overruns the budget still trips.
+// The handler is race insurance, not part of the pinned behavior: on a
+// slow runner the setup walk can eat the whole tight budget, so the
+// trip is DETECTED at a step boundary and raised as a resumable
+// interrupt instead of aborting the in-flight sleep. Rejecting it
+// delivers the same GuardExceededError from the step, and the output
+// is identical on both paths. On a fast run the handler never fires.
 node main() {
+  handle {
   const result = guard(time: 20ms) as {
     sleep(150ms)
     sleep(1ms)
@@ -12,4 +19,10 @@ node main() {
     return "tripped:${result.error.type}"
   }
   return result.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
 }

--- a/packages/agency-lang/tests/agency/guards/guard-time-trip.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-time-trip.agency
@@ -9,7 +9,15 @@ import { guard } from "std::thread"
 // measurement (at least half the budget) rather than a 0/sentinel
 // value; see the comment on the assertion below for why the bound is
 // deliberately loose.
+// The handler is race insurance, not part of the pinned behavior: on a
+// slow runner the walk from pushGuard to the sleep can eat the whole
+// 20ms budget, so the trip is DETECTED at a step boundary and raised
+// as a resumable interrupt instead of aborting the in-flight sleep.
+// Rejecting it delivers the same GuardExceededError from the step, and
+// the output is identical on both paths. On a fast run the handler
+// never fires.
 node main() {
+  handle {
   const result = guard(time: 20ms) as {
     sleep(150ms)
     sleep(1ms)
@@ -27,4 +35,10 @@ node main() {
     return "tripped:${result.error.type}:${result.error.maxTime}:${result.error.actualTime >= result.error.maxTime / 2}"
   }
   return result.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
 }

--- a/packages/agency-lang/tests/agency/guards/guard-trip-crosses-function-boundary.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-trip-crosses-function-boundary.agency
@@ -14,7 +14,14 @@ def inner(): string {
   return "inner returned"
 }
 
+// The handler is race insurance, not part of the pinned behavior: on a
+// slow runner the setup walk can eat the whole tight budget, so the
+// trip is DETECTED at a step boundary and raised as a resumable
+// interrupt instead of aborting the in-flight sleep. Rejecting it
+// delivers the same GuardExceededError from the step, and the output
+// is identical on both paths. On a fast run the handler never fires.
 node main() {
+  handle {
   const result = guard(time: 20ms) as {
     return inner()
   }
@@ -22,4 +29,10 @@ node main() {
     return "outer:${result.error.type}"
   }
   return result.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
 }

--- a/packages/agency-lang/tests/agency/guards/guard-trip-not-swallowed-by-inner-try.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-trip-not-swallowed-by-inner-try.agency
@@ -9,7 +9,14 @@ import { guard } from "std::thread"
 // timeoutFailure. Before Increment-2 guardId matching, the plain `try`
 // converted ANY guardTrip and swallowed the guard's trip, so the guard never
 // tripped. This pins the corrected behavior.
+// The handler is race insurance, not part of the pinned behavior: on a
+// slow runner the setup walk can eat the whole tight budget, so the
+// trip is DETECTED at a step boundary and raised as a resumable
+// interrupt instead of aborting the in-flight sleep. Rejecting it
+// delivers the same GuardExceededError from the step, and the output
+// is identical on both paths. On a fast run the handler never fires.
 node main() {
+  handle {
   const result = guard(time: 20ms) as {
     const inner = try sleep(150ms)
     if (isFailure(inner)) {
@@ -21,4 +28,10 @@ node main() {
     return "guard:${result.error.type}"
   }
   return "no trip: ${result.value}"
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => pass()
+    }
+  }
 }

--- a/packages/agency-lang/tests/agency/guards/trip-feedback.agency
+++ b/packages/agency-lang/tests/agency/guards/trip-feedback.agency
@@ -1,0 +1,32 @@
+// approve({message}) across a REAL checkpoint (resumable guards PR 4).
+// No in-program handler: the cost trip surfaces to the harness, which
+// answers with a valued approve CARRYING A MESSAGE. The resumed run
+// re-detects the trip, applies the recorded answer — which queues the
+// message on the branch (stack.other, so the queue itself survives
+// serialization) — and injects it as a user message before the second
+// request. The assertion reads the thread back after the guard: the
+// feedback text must be present, user-role, and sit AFTER the first
+// exchange and BEFORE the second prompt. Labels are pinned separately
+// by the agency-js guard-feedback test (they are not part of
+// ThreadMessage).
+import { guard, getThread, currentThreadId } from "std::thread"
+
+node checkpointMessage() {
+  const r = guard(cost: $0.000001, label: "budget") as {
+    const a = llm("Reply with: one")
+    const b = llm("Reply with: two")
+    return b
+  }
+  if (isFailure(r)) { return "unexpected-failure" }
+  const t = getThread(currentThreadId(), 0, 50)
+  if (isFailure(t)) { return "thread-read-failed" }
+  let position = 0
+  let verdict = "missing"
+  for (m in t.value) {
+    if (m.content == "spend less on this") {
+      verdict = "delivered:${m.role}:at-${position}"
+    }
+    position = position + 1
+  }
+  return "${verdict}|total:${position}"
+}

--- a/packages/agency-lang/tests/agency/guards/trip-feedback.test.json
+++ b/packages/agency-lang/tests/agency/guards/trip-feedback.test.json
@@ -1,0 +1,33 @@
+{
+  "tests": [
+    {
+      "nodeName": "checkpointMessage",
+      "input": "",
+      "expectedOutput": "\"delivered:user:at-2|total:5\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "return": "one"
+        },
+        {
+          "return": "two"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "resolve",
+          "resolvedValue": {
+            "maxCost": 0.0001,
+            "message": "spend less on this"
+          }
+        }
+      ],
+      "description": "A harness approve carrying a message crosses a real checkpoint: the resumed run queues it from the recorded answer and injects it as a user message between the first exchange and the second prompt (thread order: prompt, reply, feedback, prompt, reply)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/trip-forward-approve-message.agency
+++ b/packages/agency-lang/tests/agency/subprocess/trip-forward-approve-message.agency
@@ -1,0 +1,52 @@
+import { compile, run } from "std::agency"
+
+// The child-trip e2e deferred from resumable-guards PRs 2/3, plus the
+// PR 4 message. The guard and its trip live INSIDE the child: the
+// child has no handler, so the std::guard interrupt forwards over the
+// interrupt IPC to the parent; the PARENT handler approves with more
+// budget and a feedback message; the answer crosses back; the child
+// applies it — extends the budget, queues the message — and injects
+// the message into its OWN thread before its second request. The child
+// self-asserts delivery (role included) and the parent relays its
+// verdict.
+node main() {
+  const source = """
+import { guard, getThread, currentThreadId } from "std::thread"
+node main() {
+  const r = guard(cost: $0.000001, label: "child-budget") as {
+    const a = llm("Reply with: one")
+    const b = llm("Reply with: two")
+    return b
+  }
+  if (isFailure(r)) { return "unexpected-failure" }
+  const t = getThread(currentThreadId(), 0, 50)
+  if (isFailure(t)) { return "thread-read-failed" }
+  let verdict = "missing"
+  for (m in t.value) {
+    if (m.content == "child: wrap it up") {
+      verdict = "delivered:" + m.role
+    }
+  }
+  return verdict
+}
+"""
+  const compileResult = compile(source)
+  if (isFailure(compileResult)) {
+    return "compile failed"
+  }
+  handle {
+    const result = run(compiled: compileResult.value, node: "main")
+    if (isFailure(result)) {
+      return "run failed:${result.error.type}"
+    }
+    return result.value.data
+  } with (e) {
+    if (e.effect == "std::run") {
+      return approve()
+    }
+    if (e.effect == "std::guard") {
+      return approve({ maxCost: 0.0001, message: "child: wrap it up" })
+    }
+    return pass()
+  }
+}

--- a/packages/agency-lang/tests/agency/subprocess/trip-forward-approve-message.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/trip-forward-approve-message.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "A guard trip inside the child forwards over the interrupt IPC; the parent approves with budget and a message; the child extends and injects the message into its own thread before its next request.",
+      "input": "",
+      "expectedOutput": "\"delivered:user\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "one" },
+        { "return": "two" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Resumable guards PR 4 of 4 — the last one (plan: `docs/superpowers/plans/2026-07-16-resumable-guards.md`, Part 7; as-executed notes in Part 7b). `approve({message})` turns a guard from a meter into a review point: the handler grants more budget **and** says how to spend it.

## What this PR does

**The message reaches the model as a user message, right before the work's next request.** Two halves:

- **Queueing** (`applyVerdict` → `StateStack.queueGuardFeedback`): the merged message (effectMerge newline-joins multiple handlers' messages on one trip) queues on the raising branch in `stack.other`, so it is branch-local and survives checkpoints. Each entry carries its label, `guard:<label>` (falling back to the dimension for unlabeled guards). Queued after `scope.extend`, so a defective answer never leaves a message behind.
- **Draining** (`runPrompt`): an idempotent step of its own before each request — `guardFeedback.initial`, `round.N.guardFeedback`, `validation.N.guardFeedback`, and `retryFeedback.N` inside the trip-retry wrapper (a mid-request approve's message belongs in the re-issued request, which never passes the other three). One thread message per approval, oldest first, pushed with its label via `MessageThread.push` (#557). Labels stay observability-only — the model just sees a user message, which is the point: guard feedback steers exactly like a user would.

A message queued outside any LLM loop (a step-boundary approve in plain code) waits, serialized, and lands at the branch's next `llm()` call. Feedback queued in a fork branch that makes no further request dies with the branch at the join — same lifetime as the branch's reply-attachment queue, documented.

**The deferred subprocess e2e (PR 2 note 7, PR 3 note 10) lands here** and needed zero new IPC plumbing: the approve payload rides the interrupt IPC verbatim, so a parent's `approve({message})` for a child's forwarded trip queues and injects inside the child.

## Deviation from the plan worth knowing (Part 7b)

The plan said "the exact reply-attachments pattern". What shipped shares the shape (branch-local collect, drain in an idempotent pre-request step) but not the plumbing: reply attachments harvest per-tool into `self.runnerState` because they belong to one `llm()` call, while guard feedback belongs to the **branch** — it must survive from a step-boundary approve in plain code to a later `llm()` call.

## Tests

- `tests/agency-js/guard-feedback`: pins placement and order from statelog request payloads — a step-boundary approve's message lands before the branch's next request; two trips answered at one gate (nested guards) inject as two messages, innermost first; all injected messages are user-role and wear `guard:<label>`; no `label` key ever reaches the provider config.
- `tests/agency/guards/trip-feedback`: the message crosses a real checkpoint — a harness `resolve` carries it, the resumed run queues it from the recorded answer, and the fixture reads the thread back to pin position and role.
- `tests/agency/subprocess/trip-forward-approve-message`: the child-trip e2e, asserted from the child's own thread.
- Full validation: 8404 unit tests, 71/71 guards, 25/25 handlers, 62/62 subprocess (one environmental flake — `eval-run-basic` OOM'd once under sweep load and left a stale `/tmp` run dir; passes clean in isolation), lint green.

## Docs

`docs/dev/interrupts.md` gains the PR 4 section; the guards guide gains "Sending feedback with the grant"; the plan gains Part 7b.

This completes the resumable-guards plan. Next up, per earlier discussion: the guard-keyword idea (`docs/superpowers/specs/2026-07-16-guard-keyword-idea.md`) through its own brainstorm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
