### PR TITLE
Give the Agency agent the standard-library docs

### DIFF
--- a/docs/superpowers/plans/2026-07-17-stdlib-docs-summary-for-agent.md
+++ b/docs/superpowers/plans/2026-07-17-stdlib-docs-summary-for-agent.md
@@ -1,0 +1,758 @@
+# Giving the Agency agent the standard-library docs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Agency agent a browsable, per-module-summarized view of the 64 `std::` standard-library docs, so it knows what each module is for.
+
+**Architecture:** Two independent pieces. (1) The `agency doc` generator learns to emit a `description:` frontmatter field for each module, derived from the module's existing `@module` comment (with an optional `@summary` override), so the summary the agent's doc tool already renders is finally populated. (2) A new `"stdlib"` section is added to `docsSkill`, staged into the shipped docs, globbed recursively (29 of 64 modules are nested), and registered as a tool in the code / research / explorer subagents.
+
+**Tech Stack:** TypeScript (the compiler / doc generator, `lib/cli/doc.ts`; the skills helpers, `lib/stdlib/skills.ts`), Agency (`stdlib/skills.agency` and the three subagent `.agency` files), GNU make (staging), Vitest (TS tests), the Agency execution-test runner (`pnpm run agency test`).
+
+## Global Constraints
+
+Copied verbatim from the spec (`docs/superpowers/specs/2026-07-17-stdlib-docs-summary-for-agent-design.md`). Every task implicitly includes these.
+
+- **No new language syntax or AST changes.** `@summary` is a convention parsed inside `lib/cli/doc.ts`, not a tag the language parser/preprocessor/AST knows about.
+- **The `description` value must be valid for BOTH consumers.** Emit it as a **double-quoted** scalar whose content has had `"` and `\` **removed** (mirror `name`'s `title.replace(/["\\\n]/g, "")` at `lib/cli/doc.ts:169`). NOT bare (breaks VitePress strict YAML on colon-space summaries). NOT escaped (`\"` survives literally through tarsec's `stripQuotes` and reaches the agent).
+- **Fence detection trims leading whitespace first.** `@module` code fences render indented (`  ```ts`), so a raw `startsWith("```")` misses them.
+- **Length cap: 200 characters**, truncated at the last word boundary, with `…` appended.
+- **A module with no `@module` comment emits no `description:` field** (today's behavior) — never an empty one. `std::mcp` is the one such module.
+- **Do not add code comments explaining the change** (repo rule, `CLAUDE.md`); preserve existing comments. Mimic surrounding style. Run `typecheck`/tests before claiming done.
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `lib/cli/doc.ts` | Doc generator | Add pure helpers to derive the description from `@module`; emit `description:` in frontmatter; strip the `@summary` line from the rendered body. |
+| `lib/cli/doc.test.ts` | Doc generator tests | New unit tests for the helpers + integration tests through `generateDoc`. |
+| `packages/agency-lang/makefile` | Build/staging | Add `docs/site/stdlib` to `stage-stdlib-docs`. |
+| `lib/stdlib/skills.ts` | Skills TS helpers | Widen `_docsDir`'s section union to include `"stdlib"`. |
+| `lib/stdlib/skills.test.ts` | Skills helper tests | Add `_docsDir("stdlib")` test + recursive-glob regression test. |
+| `stdlib/skills.agency` | `docsSkill` / `buildSkillsTool` | Widen the `docsSkill` union; add a `recursive` flag to `buildSkillsTool`; `docsSkill` opts in. |
+| `lib/agents/agency-agent/subagents/code.agency` | Code subagent | Register `docsSkill("stdlib")` + prompt note. |
+| `lib/agents/agency-agent/subagents/research.agency` | Research subagent | Register `docsSkill("stdlib")` + prompt note. |
+| `lib/agents/agency-agent/subagents/explorer.agency` | Explorer subagent | Register `docsSkill("stdlib")` + prompt note. |
+| `docs/site/stdlib/*.md` | Generated stdlib docs (committed) | Regenerated with `description:` frontmatter (Task 4). |
+| Selected `stdlib/*.agency` | Stdlib sources | `@summary` overrides for the few over-long first paragraphs (Task 4). |
+
+All commands below run from `packages/agency-lang/` unless stated otherwise.
+
+---
+
+## Task 1: Derive and emit the `description` frontmatter in `agency doc`
+
+This is the whole of Gap 1 and the highest-value change. All logic is pure TypeScript in `lib/cli/doc.ts`, tested with fast Vitest unit + integration tests.
+
+**Files:**
+- Modify: `lib/cli/doc.ts` (add helpers near the other formatting functions; edit the frontmatter emission at `:170` and the module-body push at `:178-180`)
+- Test: `lib/cli/doc.test.ts`
+
+**Interfaces:**
+- Consumes: `program.docComment?: AgencyMultiLineComment` (already populated by `preprocessProgram` → `attachDocComments`); `AgencyMultiLineComment` is already imported at `doc.ts:6`.
+- Produces (exported, for tests and Task-1 reuse):
+  - `extractSummaryOverride(content: string): { override: string | null; body: string }`
+  - `firstParagraph(body: string): string`
+  - `sanitizeDescription(raw: string): string`
+  - `moduleDescription(comment: AgencyMultiLineComment | undefined): string | null`
+
+- [ ] **Step 1: Write the failing unit tests for the helpers**
+
+Add to `lib/cli/doc.test.ts` (top-level, after the existing imports add the new imports):
+
+```ts
+import {
+  extractSummaryOverride,
+  firstParagraph,
+  sanitizeDescription,
+  moduleDescription,
+} from "./doc.js";
+import type { AgencyMultiLineComment } from "@/types.js";
+
+function moduleComment(content: string): AgencyMultiLineComment {
+  return {
+    type: "multiLineComment",
+    content,
+    isDoc: true,
+    isModuleDoc: true,
+  } as AgencyMultiLineComment;
+}
+
+describe("firstParagraph", () => {
+  it("takes the leading prose and stops at a blank line", () => {
+    expect(firstParagraph("\n  One. Two.\n\n  Later.")).toBe("One. Two.");
+  });
+
+  it("stops at an indented code fence (trims before the check)", () => {
+    expect(firstParagraph("\n  First line.\n  ```ts\n  code\n  ```\n")).toBe(
+      "First line.",
+    );
+  });
+
+  it("collapses internal whitespace and newlines to single spaces", () => {
+    expect(firstParagraph("\n  a\n  b   c\n")).toBe("a b c");
+  });
+
+  it("returns empty string when there is no prose", () => {
+    expect(firstParagraph("\n\n")).toBe("");
+  });
+});
+
+describe("extractSummaryOverride", () => {
+  it("pulls a leading @summary line and removes it from the body", () => {
+    const { override, body } = extractSummaryOverride(
+      "\n  @summary Short thing.\n  Long body prose.\n",
+    );
+    expect(override).toBe("Short thing.");
+    expect(body).not.toContain("@summary");
+    expect(body).toContain("Long body prose.");
+  });
+
+  it("returns null override and unchanged body when there is no @summary", () => {
+    const { override, body } = extractSummaryOverride("\n  Just prose.\n");
+    expect(override).toBeNull();
+    expect(body).toBe("\n  Just prose.\n");
+  });
+
+  it("treats a bare @summary with no text as no override", () => {
+    const { override } = extractSummaryOverride("\n  @summary\n  Body.\n");
+    expect(override).toBeNull();
+  });
+});
+
+describe("sanitizeDescription", () => {
+  it("removes double quotes and backslashes", () => {
+    expect(sanitizeDescription('e.g. "America/New_York" path\\x')).toBe(
+      "e.g. America/New_York pathx",
+    );
+  });
+
+  it("caps at 200 chars on a word boundary and appends an ellipsis", () => {
+    const long = "word ".repeat(60).trim(); // ~299 chars
+    const out = sanitizeDescription(long);
+    expect(out.length).toBeLessThanOrEqual(201);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toContain("wor…"); // no mid-word cut
+  });
+});
+
+describe("moduleDescription", () => {
+  it("derives from the first paragraph when there is no @summary", () => {
+    expect(
+      moduleDescription(moduleComment("\n  Fetch URLs. Returns text.\n\n  ```ts\n  x\n  ```")),
+    ).toBe("Fetch URLs. Returns text.");
+  });
+
+  it("prefers an explicit @summary override", () => {
+    expect(
+      moduleDescription(moduleComment("\n  @summary Short.\n  Long prose.")),
+    ).toBe("Short.");
+  });
+
+  it("returns null when the comment is missing", () => {
+    expect(moduleDescription(undefined)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm exec vitest run lib/cli/doc.test.ts 2>&1 | tee /tmp/t1.txt`
+Expected: FAIL — the four new symbols are not exported from `./doc.js`.
+
+- [ ] **Step 3: Implement the helpers in `lib/cli/doc.ts`**
+
+Add this block near the other top-level helper functions (e.g. just above `formatDocComment` at `:275`):
+
+```ts
+const DESCRIPTION_CAP = 200;
+
+export function extractSummaryOverride(content: string): {
+  override: string | null;
+  body: string;
+} {
+  const lines = content.split("\n");
+  const firstIdx = lines.findIndex((l) => l.trim() !== "");
+  if (firstIdx === -1) return { override: null, body: content };
+  const first = lines[firstIdx].trim();
+  if (first.startsWith("@summary")) {
+    const text = first.slice("@summary".length).trim();
+    const rest = lines.slice(0, firstIdx).concat(lines.slice(firstIdx + 1));
+    return {
+      override: text === "" ? null : text,
+      body: rest.join("\n"),
+    };
+  }
+  return { override: null, body: content };
+}
+
+export function firstParagraph(body: string): string {
+  const out: string[] = [];
+  let started = false;
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim();
+    if (!started) {
+      if (trimmed === "") continue;
+      started = true;
+    }
+    if (trimmed === "" || trimmed.startsWith("```")) break;
+    out.push(trimmed);
+  }
+  return out.join(" ").replace(/\s+/g, " ").trim();
+}
+
+export function sanitizeDescription(raw: string): string {
+  const cleaned = raw.replace(/["\\]/g, "").replace(/\s+/g, " ").trim();
+  if (cleaned.length <= DESCRIPTION_CAP) return cleaned;
+  const slice = cleaned.slice(0, DESCRIPTION_CAP);
+  const lastSpace = slice.lastIndexOf(" ");
+  const truncated = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
+  return truncated + "…";
+}
+
+export function moduleDescription(
+  comment: AgencyMultiLineComment | undefined,
+): string | null {
+  if (!comment) return null;
+  const { override, body } = extractSummaryOverride(comment.content);
+  const raw = override ?? firstParagraph(body);
+  if (!raw) return null;
+  const value = sanitizeDescription(raw);
+  return value === "" ? null : value;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm exec vitest run lib/cli/doc.test.ts 2>&1 | tee /tmp/t1.txt`
+Expected: PASS (all new `describe` blocks green).
+
+- [ ] **Step 5: Write the failing integration tests through `generateDoc`**
+
+Add to `lib/cli/doc.test.ts`, inside the existing `describe("generateDoc", ...)` block:
+
+```ts
+it("emits a description derived from the @module comment", () => {
+  const inputDir = path.join(tmpDir, "input-desc");
+  const outputDir = path.join(tmpDir, "output-desc");
+  fs.mkdirSync(inputDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(inputDir, "m.agency"),
+    "/** @module\n" +
+      "  Fetch URLs from Agency code. Returns text, JSON, or Markdown.\n\n" +
+      "  ```ts\n  import { fetch } from \"std::http\"\n  ```\n*/\n" +
+      "export def f(): string { return \"\" }\n",
+  );
+  generateDoc({}, path.join(inputDir, "m.agency"), outputDir);
+  const out = fs.readFileSync(path.join(outputDir, "m.md"), "utf-8");
+  expect(out).toContain(
+    'description: "Fetch URLs from Agency code. Returns text, JSON, or Markdown."',
+  );
+});
+
+it("removes quotes but keeps colon-space safe (valid for both YAML parsers)", () => {
+  const inputDir = path.join(tmpDir, "input-quote");
+  const outputDir = path.join(tmpDir, "output-quote");
+  fs.mkdirSync(inputDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(inputDir, "q.agency"),
+    "/** @module\n" +
+      "  Helpers: builds strings, e.g. \"America/New_York\" values.\n*/\n" +
+      "export def f(): string { return \"\" }\n",
+  );
+  generateDoc({}, path.join(inputDir, "q.agency"), outputDir);
+  const out = fs.readFileSync(path.join(outputDir, "q.md"), "utf-8");
+  expect(out).toContain(
+    'description: "Helpers: builds strings, e.g. America/New_York values."',
+  );
+  expect(out).not.toContain('\\"'); // never escaped — would survive literally through tarsec
+});
+
+it("uses @summary as the description and strips it from the body", () => {
+  const inputDir = path.join(tmpDir, "input-sum");
+  const outputDir = path.join(tmpDir, "output-sum");
+  fs.mkdirSync(inputDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(inputDir, "s.agency"),
+    "/** @module\n" +
+      "  @summary Read and write the clipboard.\n" +
+      "  The clipboard module exposes copy and paste.\n*/\n" +
+      "export def f(): string { return \"\" }\n",
+  );
+  generateDoc({}, path.join(inputDir, "s.agency"), outputDir);
+  const out = fs.readFileSync(path.join(outputDir, "s.md"), "utf-8");
+  expect(out).toContain('description: "Read and write the clipboard."');
+  expect(out).toContain("The clipboard module exposes copy and paste.");
+  expect(out).not.toContain("@summary");
+});
+
+it("emits no description when there is no @module comment", () => {
+  const inputDir = path.join(tmpDir, "input-nomod");
+  const outputDir = path.join(tmpDir, "output-nomod");
+  fs.mkdirSync(inputDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(inputDir, "n.agency"),
+    "export def f(): string { return \"\" }\n",
+  );
+  generateDoc({}, path.join(inputDir, "n.agency"), outputDir);
+  const out = fs.readFileSync(path.join(outputDir, "n.md"), "utf-8");
+  expect(out).not.toContain("description:");
+});
+```
+
+- [ ] **Step 6: Run to verify they fail**
+
+Run: `pnpm exec vitest run lib/cli/doc.test.ts 2>&1 | tee /tmp/t1.txt`
+Expected: FAIL — the generator does not yet emit `description:`, and does not strip `@summary` from the body.
+
+- [ ] **Step 7: Wire the helpers into `generateDocForFile`**
+
+In `lib/cli/doc.ts`, replace the frontmatter line (currently `:170`):
+
+```ts
+  const frontmatter = `---\nname: "${safeName}"\n---`;
+```
+
+with:
+
+```ts
+  const fmLines = [`name: "${safeName}"`];
+  const description = moduleDescription(program.docComment);
+  if (description) {
+    fmLines.push(`description: "${description}"`);
+  }
+  const frontmatter = `---\n${fmLines.join("\n")}\n---`;
+```
+
+Then replace the module-body push (currently `:178-180`):
+
+```ts
+  if (program.docComment) {
+    sections.push(formatDocComment(program.docComment));
+  }
+```
+
+with (strip the `@summary` line so it never renders on the page):
+
+```ts
+  if (program.docComment) {
+    const { body } = extractSummaryOverride(program.docComment.content);
+    sections.push(body.trim());
+  }
+```
+
+- [ ] **Step 8: Run the full doc test file to verify everything passes**
+
+Run: `pnpm exec vitest run lib/cli/doc.test.ts 2>&1 | tee /tmp/t1.txt`
+Expected: PASS (helpers + integration + the pre-existing tests still green).
+
+- [ ] **Step 9: Typecheck**
+
+Run: `pnpm exec tsc --noEmit 2>&1 | tee /tmp/tc1.txt`
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/cli/doc.ts lib/cli/doc.test.ts
+git commit -m "agency doc: emit a description frontmatter field from @module"
+```
+
+---
+
+## Task 2: Add the `"stdlib"` docs section (stage + resolve + recursive glob)
+
+Wire the stdlib docs into the packaged docs and teach `docsSkill` to serve them, including the 29 nested modules.
+
+**Files:**
+- Modify: `packages/agency-lang/makefile` (the `stage-stdlib-docs` define, `:31-37`)
+- Modify: `lib/stdlib/skills.ts` (`_docsDir`, `:36`)
+- Modify: `stdlib/skills.agency` (`buildSkillsTool` `:187`, `docsSkill` `:239`)
+- Test: `lib/stdlib/skills.test.ts`
+
+**Interfaces:**
+- Consumes: `_glob(pattern, dir, maxResults, allowedPaths)` from `lib/stdlib/shell.ts` (recurses via `walkDir`); `getStdlibDir()` from `lib/importPaths.js`.
+- Produces: `_docsDir("stdlib")` resolving to `<stdlib>/docs/stdlib`; `docsSkill("stdlib")` returning a tool whose description lists all 64 modules with their `location` (subdir-qualified for nested ones).
+
+- [ ] **Step 1: Write the failing `_docsDir` + recursion tests**
+
+Add to `lib/stdlib/skills.test.ts`. Extend the imports to include `_glob`, then add:
+
+```ts
+import { _glob } from "./shell.js";
+
+describe("_docsDir stdlib section", () => {
+  it("resolves the stdlib section under docs/", () => {
+    expect(
+      _docsDir("stdlib").endsWith(path.join("docs", "stdlib")),
+    ).toBe(true);
+  });
+});
+
+describe("stdlib docs recursive glob", () => {
+  // The stdlib docs tree has nested modules (ui/table.md, auth/oauth.md, …).
+  // A non-recursive `*.{md,markdown}` drops them; `**/*.{md,markdown}` must not.
+  const stdlibDocs = path.resolve(__dirname, "../../docs/site/stdlib");
+
+  it("includes nested modules that the flat pattern misses", async () => {
+    const flat = await _glob("*.{md,markdown}", stdlibDocs, 500, []);
+    const recursive = await _glob("**/*.{md,markdown}", stdlibDocs, 500, []);
+    expect(recursive.length).toBeGreaterThan(flat.length);
+    expect(recursive).toContain("ui/table.md"); // nested
+    expect(recursive).toContain("array.md"); // top-level still present
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify the recursion test passes and `_docsDir` fails to typecheck/compile**
+
+Run: `pnpm exec vitest run lib/stdlib/skills.test.ts 2>&1 | tee /tmp/t2.txt`
+Expected: the recursion test PASSES already (it only exercises `_glob`, which recurses); the `_docsDir("stdlib")` test FAILS to compile because `"stdlib"` is not in the section union yet.
+
+- [ ] **Step 3: Widen `_docsDir` in `lib/stdlib/skills.ts`**
+
+Replace (`:36`):
+
+```ts
+export function _docsDir(section: "guide" | "cli" | "diagnostics"): string {
+```
+
+with:
+
+```ts
+export function _docsDir(section: "guide" | "cli" | "diagnostics" | "stdlib"): string {
+```
+
+- [ ] **Step 4: Run to verify the skills tests pass**
+
+Run: `pnpm exec vitest run lib/stdlib/skills.test.ts 2>&1 | tee /tmp/t2.txt`
+Expected: PASS (both new describes green).
+
+- [ ] **Step 5: Add the `recursive` flag to `buildSkillsTool` and opt `docsSkill` in (`stdlib/skills.agency`)**
+
+Replace the `buildSkillsTool` signature and pattern block (`:187-190`):
+
+```ts
+def buildSkillsTool(dir: string, layout: "flat" | "standard", name: string = "") {
+  let pattern = "*/SKILL.md"
+  if (layout == "flat") {
+    pattern = "*.{md,markdown}"
+  }
+```
+
+with:
+
+```ts
+def buildSkillsTool(dir: string, layout: "flat" | "standard", name: string = "", recursive: boolean = false) {
+  let pattern = "*/SKILL.md"
+  if (layout == "flat") {
+    pattern = "*.{md,markdown}"
+    if (recursive) {
+      pattern = "**/*.{md,markdown}"
+    }
+  }
+```
+
+Replace the `docsSkill` signature (`:239`) and its body call (`:255`). Signature:
+
+```ts
+export def docsSkill(section: "guide" | "cli" | "diagnostics") {
+```
+
+becomes:
+
+```ts
+export def docsSkill(section: "guide" | "cli" | "diagnostics" | "stdlib") {
+```
+
+and update its docstring `@param` line to mention stdlib, e.g.:
+
+```
+  @param section - Which documentation set to serve: "guide", "cli", "diagnostics", or "stdlib" (the standard-library reference).
+```
+
+Then the body call:
+
+```ts
+  return buildSkillsTool(_docsDir(section), "flat")
+```
+
+becomes (guide/cli/diagnostics are flat with no nested files, so recursion is a safe no-op for them; it is required for stdlib):
+
+```ts
+  return buildSkillsTool(_docsDir(section), "flat", "", true)
+```
+
+- [ ] **Step 6: Add `docs/site/stdlib` to the makefile staging**
+
+In `packages/agency-lang/makefile`, replace the `stage-stdlib-docs` define (`:31-37`):
+
+```make
+define stage-stdlib-docs
+	mkdir -p stdlib/docs
+	rm -rf stdlib/docs/guide stdlib/docs/cli stdlib/docs/diagnostics
+	cp -r docs/site/guide stdlib/docs/guide
+	cp -r docs/site/cli stdlib/docs/cli
+	cp -r docs/site/diagnostics stdlib/docs/diagnostics
+endef
+```
+
+with:
+
+```make
+define stage-stdlib-docs
+	mkdir -p stdlib/docs
+	rm -rf stdlib/docs/guide stdlib/docs/cli stdlib/docs/diagnostics stdlib/docs/stdlib
+	cp -r docs/site/guide stdlib/docs/guide
+	cp -r docs/site/cli stdlib/docs/cli
+	cp -r docs/site/diagnostics stdlib/docs/diagnostics
+	cp -r docs/site/stdlib stdlib/docs/stdlib
+endef
+```
+
+- [ ] **Step 7: Build (compiles the doc.ts change from Task 1 into dist, recompiles stdlib, stages docs)**
+
+Run: `make build && make stdlib 2>&1 | tee /tmp/build2.txt`
+Expected: build succeeds; `make stdlib` recompiles `stdlib/skills.agency` and runs `stage-stdlib-docs`, creating `stdlib/docs/stdlib/`.
+
+- [ ] **Step 8: Verify the staged stdlib docs and the compiled skills module exist**
+
+Run: `ls stdlib/docs/stdlib/array.md stdlib/docs/stdlib/ui/table.md && echo OK`
+Expected: both paths listed, `OK` printed (top-level and nested both staged).
+
+- [ ] **Step 9: Typecheck**
+
+Run: `pnpm exec tsc --noEmit 2>&1 | tee /tmp/tc2.txt`
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/agency-lang/makefile lib/stdlib/skills.ts lib/stdlib/skills.test.ts stdlib/skills.agency stdlib/skills.js
+git commit -m "docsSkill: add a recursive stdlib docs section"
+```
+
+Note: `stdlib/skills.js` is the agency-compiled sibling regenerated by `make stdlib`; it is committed alongside its source (the repo commits compiled stdlib `.js`). `stdlib/docs/**` is gitignored — do not add it.
+
+---
+
+## Task 3: Register `docsSkill("stdlib")` in the code / research / explorer subagents
+
+Give the three subagents that answer stdlib questions the new tool plus a one-line prompt note.
+
+**Files:**
+- Modify: `lib/agents/agency-agent/subagents/code.agency`
+- Modify: `lib/agents/agency-agent/subagents/research.agency`
+- Modify: `lib/agents/agency-agent/subagents/explorer.agency`
+- Test: `lib/agents/agency-agent/tests/toolWiring.agency` (already pings each tool list; the new tool must not collide or produce an invalid schema)
+
+**Interfaces:**
+- Consumes: `docsSkill` from `std::skills` (already imported in each subagent).
+- Produces: a `stdlibSkill` tool in `codeTools`, `researchTools`, `explorerTools`.
+
+- [ ] **Step 1: code.agency — add the tool constant, list entry, and prompt note**
+
+After the existing docs-skill constants (`code.agency:71-73`):
+
+```ts
+static const docSkill = docsSkill("guide")
+static const cliSkill = docsSkill("cli")
+static const diagnosticsSkill = docsSkill("diagnostics")
+```
+
+add:
+
+```ts
+static const stdlibSkill = docsSkill("stdlib")
+```
+
+In `codeTools`, after `diagnosticsSkill,` (`code.agency:400`) add `stdlibSkill,`.
+
+In `codeSysPrompt`, in the bundled-docs bullet list (`code.agency:99-106`), after the `diagnosticsSkill` bullet add:
+
+```
+  * `stdlibSkill` — the standard-library reference (`std::http`,
+                 `std::thread`, `std::date`, …); each module lists a
+                 one-line summary. Use it to discover which `std::`
+                 module does what before importing.
+```
+
+- [ ] **Step 2: research.agency — same three edits**
+
+After (`research.agency:32-34`):
+
+```ts
+static const docSkill = docsSkill("guide")
+static const cliSkill = docsSkill("cli")
+static const diagnosticsSkill = docsSkill("diagnostics")
+```
+
+add:
+
+```ts
+static const stdlibSkill = docsSkill("stdlib")
+```
+
+In `researchTools`, after `diagnosticsSkill,` (`research.agency:117`) add `stdlibSkill,`.
+
+In `researchSysPrompt`, in the Agency-docs bullet list (`research.agency:52-58`), after the `diagnosticsSkill` bullet add:
+
+```
+    * `stdlibSkill`   — standard-library reference (`std::http`,
+                        `std::thread`, …), one summary per module
+```
+
+- [ ] **Step 3: explorer.agency — same three edits**
+
+After (`explorer.agency:24-26`):
+
+```ts
+static const docSkill = docsSkill("guide")
+static const cliSkill = docsSkill("cli")
+static const diagnosticsSkill = docsSkill("diagnostics")
+```
+
+add:
+
+```ts
+static const stdlibSkill = docsSkill("stdlib")
+```
+
+In `explorerTools`, after `diagnosticsSkill,` (`explorer.agency:112`) add `stdlibSkill,`.
+
+In `explorerSysPrompt`, in the "How to respond" section (after the "Cast a wide net" bullet, `explorer.agency:51`), add:
+
+```
+- **Use the standard-library reference.** For any question about what
+  `std::` modules exist or what they do, call `stdlibSkill` — it lists
+  every module with a one-line summary, then lets you read any page.
+```
+
+- [ ] **Step 4: Rebuild the agents**
+
+Run: `make agents 2>&1 | tee /tmp/build3.txt`
+Expected: the three subagent `.agency` files recompile with no errors.
+
+- [ ] **Step 5: Run the tool-wiring execution test**
+
+Run: `pnpm run agency test lib/agents/agency-agent/tests/toolWiring.agency 2>&1 | tee /tmp/toolwiring.txt`
+Expected: PASS — `codeToolsHaveUniqueNames`, `researchToolsHaveUniqueNames`, `explorerToolsHaveUniqueNames` each return `ok` (no duplicate tool name, valid schema for the new tool). Under `AGENCY_USE_TEST_LLM_PROVIDER` this needs no API key.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/agents/agency-agent/subagents/code.agency lib/agents/agency-agent/subagents/code.js \
+        lib/agents/agency-agent/subagents/research.agency lib/agents/agency-agent/subagents/research.js \
+        lib/agents/agency-agent/subagents/explorer.agency lib/agents/agency-agent/subagents/explorer.js
+git commit -m "agency-agent: give code/research/explorer the stdlib docs tool"
+```
+
+---
+
+## Task 4: Regenerate the stdlib docs and sweep `@summary` overrides onto the long ones
+
+Produce the committed `docs/site/stdlib/*.md` with descriptions, and fix the few whose first paragraph truncates badly.
+
+**Files:**
+- Modify (generated, committed): `docs/site/stdlib/**/*.md`
+- Modify (sources, as needed): selected `stdlib/*.agency` — add `@summary` lines
+- No test file; verification is by inspection + the round-trip already covered in Task 1
+
+**Interfaces:**
+- Consumes: the Task 1 generator (already built into `dist/` after Task 2 Step 7).
+
+- [ ] **Step 1: Regenerate the stdlib docs**
+
+Run: `rm -f .agency-build/doc.stamp && make doc 2>&1 | tee /tmp/doc4.txt`
+Expected: `agency doc stdlib -o docs/site/stdlib/` runs and rewrites the pages. (Removing the stamp forces regeneration regardless of the incremental cache.)
+
+- [ ] **Step 2: Confirm descriptions landed and spot-check the shape**
+
+Run: `grep -c '^description:' docs/site/stdlib/http.md docs/site/stdlib/math.md docs/site/stdlib/object.md docs/site/stdlib/ui/table.md; grep '^description:' docs/site/stdlib/math.md docs/site/stdlib/object.md`
+Expected: each spot-checked file has exactly one `description:` line; `math` and `object` descriptions contain the colon-space text unbroken and wrapped in double quotes (proves the both-parsers rule).
+
+- [ ] **Step 3: Confirm `std::mcp` has no description (no `@module`)**
+
+Run: `grep -c '^description:' docs/site/stdlib/mcp.md || true`
+Expected: `0` — the one module without a `@module` comment emits no description, as specified.
+
+- [ ] **Step 4: Find the descriptions that truncated at the cap**
+
+Run: `grep -rl '…"$' docs/site/stdlib | tee /tmp/truncated.txt`
+Expected: a short list (e.g. `date.md`). These are the modules whose first paragraph exceeded 200 chars.
+
+- [ ] **Step 5: Add a `@summary` override to each truncated module's source**
+
+For each file listed in Step 4, open the corresponding `stdlib/<name>.agency`, and add a `@summary` as the first line inside its `@module` comment. Example for `stdlib/date.agency`:
+
+```ts
+/** @module
+  @summary Build timezone-aware ISO 8601 date strings for APIs like Google Calendar.
+  Builds timezone-aware ISO 8601 date strings, the format that APIs like Google
+  Calendar expect. Every function returns a string, not a Date object. ...
+*/
+```
+
+Keep each `@summary` under 200 characters and free of `"`/`\`. Do not alter the body prose.
+
+- [ ] **Step 6: Regenerate and re-check truncation is gone for the swept modules**
+
+Run: `rm -f .agency-build/doc.stamp && make doc && grep '^description:' $(cat /tmp/truncated.txt)`
+Expected: the swept modules now show the crisp `@summary` text (no trailing `…`).
+
+- [ ] **Step 7: Re-stage the fresh docs so the agent (dev) reads current descriptions**
+
+Run: `make stdlib && grep '^description:' stdlib/docs/stdlib/date.md`
+Expected: the staged copy matches the regenerated `docs/site/stdlib/date.md`.
+
+- [ ] **Step 8: Sanity-check the whole tree parses as strict YAML (VitePress guard)**
+
+Run:
+```bash
+node -e '
+const fs=require("fs"),cp=require("child_process");
+const files=cp.execSync("find docs/site/stdlib -name \"*.md\"").toString().trim().split("\n");
+const m=require("gray-matter");
+let bad=0;
+for(const f of files){ try{ m(fs.readFileSync(f,"utf8")); }catch(e){ bad++; console.log("YAML FAIL",f,e.message);} }
+console.log(bad===0?"all frontmatter valid":`${bad} invalid`);
+'
+```
+Expected: `all frontmatter valid`. (gray-matter is VitePress's front-matter parser; if it is not resolvable, use the repo's `std::markdown` frontmatter via a small `.agency` script instead — either way the check is "every generated page parses.")
+
+- [ ] **Step 9: Commit the regenerated docs and any `@summary` source edits**
+
+```bash
+git add docs/site/stdlib stdlib/*.agency stdlib/*.js
+git commit -m "stdlib docs: regenerate with descriptions; @summary sweep for long modules"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the two touched TS test files and the wiring test together**
+
+Run:
+```bash
+pnpm exec vitest run lib/cli/doc.test.ts lib/stdlib/skills.test.ts 2>&1 | tee /tmp/final-ts.txt
+pnpm run agency test lib/agents/agency-agent/tests/toolWiring.agency 2>&1 | tee /tmp/final-wiring.txt
+```
+Expected: all green.
+
+- [ ] **Drive the real agent to confirm it sees the summaries end to end**
+
+Run: `pnpm run agency agent -p "Without reading any files, list the std:: modules you have summaries for and say what std::thread is for."`
+Expected: the agent names several `std::` modules and correctly describes `std::thread` from the tool listing's `<description>` (proving the summary reaches the model, not just the file). If it instead reads a file first, that is also acceptable evidence the tool is wired.
+
+- [ ] **Anti-pattern audit before PR**
+
+Review the full diff against `docs/dev/anti-patterns.md` and `docs/dev/coding-standards.md` (per the repo's pre-PR rule). Confirm: no code comments added to explain changes; existing comments preserved; style matched; no `as any`; the description rule is strip-not-escape and quoted-not-bare everywhere.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** Part A → Task 1 (derive + emit + cap + no-`@module`). Part B (`@summary` override, doc-command-only) → Task 1 Steps 3/7 + Task 4 Step 5. Part C step 1 (stage) → Task 2 Step 6. C step 2 (`_docsDir`/`docsSkill` union) → Task 2 Steps 3/5. C step 3 (recursive glob, all 64) → Task 2 Steps 1/5/8. C step 4 (register in subagents) → Task 3. Test plan (round-trip, fence-trim, VitePress-accepts) → Task 1 Steps 1/5, Task 4 Step 8.
+- **Both-parsers rule** is enforced in one place (`sanitizeDescription` strips `"`/`\`; emission wraps in quotes) and asserted by the Task 1 "removes quotes but keeps colon-space" test (`not.toContain('\\"')`) and the Task 4 gray-matter sweep.
+- **Ordering nuance:** `make all` stages stdlib docs during `compile-agency`, before `doc` regenerates them, so a single `make all` can leave `stdlib/docs/stdlib` one generation stale. Task 2/4 avoid this by explicitly sequencing `make doc` then `make stdlib`; publish regenerates from the committed (already-current) `docs/site/stdlib`, so the tarball is correct.
+- **Type consistency:** `moduleDescription` / `extractSummaryOverride` / `firstParagraph` / `sanitizeDescription` names are identical across Task 1 test and implementation; `stdlibSkill` is the constant name in all three subagents.

--- a/docs/superpowers/specs/2026-07-17-stdlib-docs-summary-for-agent-design.md
+++ b/docs/superpowers/specs/2026-07-17-stdlib-docs-summary-for-agent-design.md
@@ -119,13 +119,11 @@ Here is the lucky part. The generator already parses each module's
 top-of-file doc comment — the `/** @module ... */` block — into
 `program.docComment`, and renders it as the page body
 (`lib/cli/doc.ts:178`). And 63 of the 64 stdlib modules already have one.
-Better still, these comments almost always **open with a plain one-line
-statement of what the module is for**, before any code example:
+Better still, these comments almost always **open with plain prose stating
+what the module is for**, before any code example:
 
 - `std::http` → "Fetch URLs from Agency code. Returns the response as
-  text, JSON, or Markdown."
-- `std::date` → "Builds timezone-aware ISO 8601 date strings, the format
-  that APIs like Google Calendar expect."
+  text, JSON, or Markdown. Aborting tears down the in-flight request."
 - `std::math` → "Small deterministic arithmetic helpers: round, add,
   subtract, multiply, and a divide that returns a Result so you can
   handle division by zero."
@@ -133,8 +131,13 @@ statement of what the module is for**, before any code example:
   values, and entries, and transform them with `mapValues`, `mapEntries`,
   and `filterEntries`."
 
-That opening line is a ready-made summary. The generator is already
-holding it. It just isn't putting it into the front matter.
+That opening prose is a ready-made summary. The generator is already
+holding it; it just isn't putting it into the front matter. Note the
+length varies: some openings are a single crisp sentence, but others run
+two to four sentences (`std::date`'s is ~230 characters). The extraction
+rule below takes the whole opening paragraph, so the longer ones will be
+capped and truncated — see the note under Part A on when a `@summary`
+override is worth adding.
 
 ---
 
@@ -203,9 +206,14 @@ generated front matter, alongside the existing `name:`.
 its leading prose:
 
 1. Start at the first non-blank line of the comment body.
-2. Stop at the first blank line **or** the first code fence (a line
-   beginning with ` ``` `), whichever comes first. This discards the code
-   examples that usually follow the summary.
+2. Stop at the first blank line **or** the first code fence, whichever
+   comes first. This discards the code examples that usually follow the
+   summary. **Detect the fence after trimming each line's leading
+   whitespace** — `@module` bodies are indented, so the fence renders as
+   `  ```ts`, not a line that literally begins with ` ``` ` (verified in
+   the generated `http.md`). A `startsWith("```")` check on the raw line
+   misses it; today a blank line happens to precede every fence and masks
+   the bug, but that is incidental — trim first.
 3. Collapse all internal whitespace and newlines to single spaces, and
    trim.
 4. If the result is longer than a cap (proposed: **200 characters**),
@@ -244,18 +252,48 @@ description: "Fetch URLs from Agency code. Returns the response as text, JSON, o
 needs to split on `. `, which trips on abbreviations ("e.g.", "i.e.") and
 would occasionally cut a summary in half. The first-paragraph rule has
 unambiguous delimiters (blank line / code fence) and no natural-language
-parsing. It can run two or three sentences long, but that is acceptable
-for a tool-listing description, and the length cap plus the Part B
-override handle anything that reads badly.
+parsing. It can run two to four sentences long; the length cap keeps it
+bounded, and the Part B override handles anything that reads badly. Expect
+the initial regeneration to leave several long summaries truncated at the
+cap (`std::date` is the clearest case) — a first-pass sweep adding
+`@summary` overrides to the longest handful is worthwhile before shipping,
+not deferred indefinitely.
 
-**Escaping.** The description text goes into a YAML-ish `description:
-"..."` value and is later parsed back out by the front-matter reader.
-Double quotes and backslashes in the text must be escaped so the value
-stays well-formed. The existing `name:` emission already strips a small
-set of characters (`lib/cli/doc.ts:169`); the description needs
-equivalent care. The exact quoting is an implementation detail for the
-plan, but it must round-trip: what `agency doc` writes, the front-matter
-parser in `std::markdown` must read back unchanged.
+**Emitting the value: quoted, with `"` and `\` stripped — not bare, not
+escaped.** This is subtle because the generated front matter has *two*
+consumers with different YAML rules, and they pull in opposite directions:
+
+- The **agent** reads it through `std::markdown`'s `frontmatter`, which is
+  tarsec's parser. Tarsec's quoted-value path is `map(quotedString,
+  stripQuotes)`, and `stripQuotes` is `s.slice(1, -1)` — it removes the
+  outer quotes and **unescapes nothing**. So an *escaped* value like
+  `description: "...e.g. \"America/New_York\"..."` reaches the agent with
+  literal backslashes. Escaping is therefore wrong.
+- The **docs site** reads it through VitePress (`docs/site/.vitepress/`),
+  whose gray-matter/js-yaml is a *strict* YAML parser. A **bare** value is
+  rejected when it contains `: ` (colon-space), which many stdlib
+  summaries do (`std::math` → "…helpers: round, add…"; `std::object` →
+  "…objects: read their keys…"). So bare emission would break the docs
+  build.
+
+The value that satisfies both: a **double-quoted** scalar whose content
+has had `"` and `\` **removed** (mirroring exactly what `name` already
+does at `lib/cli/doc.ts:169`, `title.replace(/["\\\n]/g, "")`). Quoting
+makes colon-space, `#`, `[`, and apostrophes safe for strict YAML;
+removing (not escaping) `"`/`\` means tarsec's `stripQuotes` returns clean
+text with no stray backslashes. `std::date`'s `e.g. "America/New_York"`
+becomes `e.g. America/New_York` in the emitted value — lossy on the inner
+quotes, but readable and correct in both parsers. Replacing `"` with `'`
+instead of deleting it is an acceptable nicety; deleting matches the
+existing `name` precedent. The acceptance test is a genuine round-trip:
+run a value containing `"` and `: ` through `agency doc`, then read it
+back with `std::markdown`'s `frontmatter`, and assert the string matches
+what was intended with no backslashes.
+
+**Files with no `@module` comment.** One stdlib module (`std::mcp`) lacks
+a `@module` comment today. When there is no comment, emit no
+`description:` field (exactly today's behavior) — do not emit an empty
+one. The agent falls back to the module name, no worse off than now.
 
 **Files with no `@module` comment.** One stdlib module lacks a `@module`
 comment today. When there is no comment, emit no `description:` field
@@ -320,20 +358,25 @@ that staging so `stdlib/docs/stdlib/` exists in both dev and npm installs.
 would list only the 35 top-level modules and **silently drop the other
 29** — worse than useless, because it looks complete.
 
-The stdlib doc tool must glob recursively (`**/*.{md,markdown}`) so all 64
-modules appear, each with its subdirectory-qualified `location` (e.g.
-`ui/table.md`) that `read` can resolve. The plan should choose the
-least-invasive way to get recursion for this one case without changing
-the behavior of existing `skillsDir(..., "flat")` callers — options
-include a recursive-flat variant or a dedicated glob for the docs path.
-Whichever is chosen, the acceptance check is concrete: the generated tool
-description must list all 64 modules, including the nested ones.
+The stdlib doc tool must glob recursively so all 64 modules appear, each
+with its subdirectory-qualified `location` (e.g. `ui/table.md`) that
+`read` can resolve. The pattern `**/*.{md,markdown}` is confirmed to do
+this: run against `_glob`, `*.{md,markdown}` matches 35 (top-level only)
+while `**/*.{md,markdown}` matches all 64 — tarsec's glob does *not* hit
+the classic "`**/` excludes top-level files" trap, and `_glob`'s
+`walkDir` already recurses the whole tree, so the only change is the
+pattern's regex. The plan should choose the least-invasive way to route
+this recursive pattern to the stdlib docs case without changing the
+behavior of existing `skillsDir(..., "flat")` callers — options include a
+recursive-flat variant or a dedicated glob for the docs path. The
+acceptance check is concrete: the generated tool description must list all
+64 modules, including the nested ones.
 
 **4. Register the tool in the subagents.** Add `docsSkill("stdlib")` to
 the tool lists of the subagents that answer standard-library questions —
 **code**, **research**, and **explorer** — and add a one-line note to each
 of their system prompts describing it, mirroring how `docSkill` /
-`cliSkill` are introduced today (e.g. `code.agency:99`). The oracle is
+`cliSkill` are introduced today (e.g. `code.agency:100`). The oracle is
 out of scope for now; it can be added later if it proves useful.
 
 ---
@@ -343,12 +386,17 @@ out of scope for now; it can be added later if it proves useful.
 - **Part A/B, unit level.** Table-driven tests over the extraction rule:
   a comment with a code fence stops at the fence; a multi-paragraph
   comment stops at the first blank line; a `@summary` line overrides and
-  is stripped from the body; a comment longer than the cap truncates on a
-  word boundary; a file with no `@module` emits no `description:`; quotes
-  and backslashes round-trip through the front-matter parser.
+  is stripped from the body; an indented code fence (`  ```ts`) is still
+  detected as a fence; a comment longer than the cap truncates on a word
+  boundary; a file with no `@module` emits no `description:`. A dedicated
+  round-trip test: emit a value containing `"` and `: `, then read it back
+  with `std::markdown`'s `frontmatter` and assert the string is clean (no
+  stray backslashes, quotes handled as the strip rule specifies).
 - **Part A/B, integration.** Run `agency doc` over `stdlib/` and assert a
-  spot-check set (`http`, `date`, `math`, a nested one like `ui/table`)
-  each gain a sensible `description:`.
+  spot-check set (`http`, `date`, `math`, `object`, a nested one like
+  `ui/table`) each gain a sensible `description:`, and that VitePress's
+  YAML parser accepts the generated front matter (the colon-space cases
+  `math` / `object` are the ones a bare value would have broken).
 - **Part C.** Build the tool via `docsSkill("stdlib")` and assert its
   description lists all 64 modules (the nested-glob regression), each with
   a non-empty `<description>`. Confirm the code/research/explorer

--- a/docs/superpowers/specs/2026-07-17-stdlib-docs-summary-for-agent-design.md
+++ b/docs/superpowers/specs/2026-07-17-stdlib-docs-summary-for-agent-design.md
@@ -1,0 +1,370 @@
+# Giving the Agency agent the standard-library docs
+
+**Date:** 2026-07-17
+**Status:** Design approved, ready for planning
+**Branch:** `worktree-stdlib-docs-summary`
+
+## What this is about, in one paragraph
+
+The Agency agent can read the language *guide* but knows nothing about
+the standard *library* — the 64 modules under `std::` that do the real
+work (`std::http`, `std::thread`, `std::date`, and so on). We want to
+hand the agent those docs. The docs already exist, and the agent already
+has a mechanism for browsing a folder of docs. The missing pieces are
+small but specific: the stdlib docs carry no one-line summary the agent
+can scan, and the agent's doc-browsing tool doesn't know the stdlib docs
+exist. This spec explains how the agent gets docs today, names the two
+gaps precisely, and lays out a fix that leans on machinery already in the
+codebase rather than adding new language syntax.
+
+---
+
+## Background: how the agent learns about docs today
+
+To understand the fix, you need to understand one helper and one piece of
+metadata. This section walks through both with real examples. If you
+already know how `docsSkill` and front matter interact, skip to "The two
+gaps."
+
+### The agent browses docs through a "skill tool"
+
+The agent doesn't get the docs pasted into its prompt. That would be
+enormous and mostly wasted — a single turn rarely needs more than one or
+two doc pages. Instead the agent gets a *tool* it can call to read one
+doc file at a time, on demand. The tool's description lists every file
+available, so the model can pick the right one.
+
+That tool is built by `docsSkill(...)`, defined in
+`stdlib/skills.agency`. The code subagent, for example, wires up three of
+them (`lib/agents/agency-agent/subagents/code.agency:71`):
+
+```ts
+static const docSkill = docsSkill("guide")          // the language guide
+static const cliSkill = docsSkill("cli")            // the CLI reference
+static const diagnosticsSkill = docsSkill("diagnostics")  // AG#### codes
+```
+
+`docsSkill` and its cousin `skillsDir` (which does the same thing for a
+user-supplied folder) both funnel into one helper, `buildSkillsTool`
+(`stdlib/skills.agency:187`). For each Markdown file in the directory,
+`buildSkillsTool` reads the file's *front matter* (explained next) and
+renders one XML block into the tool's description:
+
+```text
+<skill>
+  <name>http</name>
+  <description>Fetch URLs from Agency code. Returns text, JSON, or Markdown.</description>
+  <location>http.md</location>
+</skill>
+```
+
+The model reads that block, decides `std::http` is what it needs, and
+calls the tool with `filename: "http.md"` to pull the full page. So the
+`<description>` line is the *only* thing the model sees about a module
+before choosing to open it. If that line is blank, the model is choosing
+blind — guessing from the filename alone.
+
+### Front matter is the metadata block at the top of a doc
+
+"Front matter" is the small block fenced by `---` at the very top of a
+Markdown file. Here is the top of the hand-written guide page
+`docs/site/guide/basic-syntax.md`:
+
+```markdown
+---
+name: Basic syntax
+description: Overview of Agency's TypeScript-derived syntax, covering
+  primitive types, variables, arrays, objects, functions, and other core
+  language constructs.
+---
+
+# Basic syntax
+...
+```
+
+The `description:` field is exactly what `buildSkillsTool` renders into
+the `<description>` line above. The guide pages are written by hand, so
+their authors wrote those descriptions by hand too.
+
+The stdlib pages are different: they are **generated** by the `agency
+doc` command from the `.agency` source (see the note in the root
+`CLAUDE.md`). Here is the top of the generated `docs/site/stdlib/http.md`:
+
+```markdown
+---
+name: "http"
+---
+
+# http
+
+Fetch URLs from Agency code. Returns the response as text, JSON, or
+Markdown...
+```
+
+Notice what's missing: there's a `name:` but **no `description:`**. The
+generator only ever writes `name:` (`lib/cli/doc.ts:170`):
+
+```ts
+const frontmatter = `---\nname: "${safeName}"\n---`;
+```
+
+So even if we pointed the agent's doc tool at the stdlib folder today,
+every module would render as `<description></description>` — an empty
+line. The agent would see 64 module names and no hint of what any of them
+is for.
+
+### Where the summary text could come from
+
+Here is the lucky part. The generator already parses each module's
+top-of-file doc comment — the `/** @module ... */` block — into
+`program.docComment`, and renders it as the page body
+(`lib/cli/doc.ts:178`). And 63 of the 64 stdlib modules already have one.
+Better still, these comments almost always **open with a plain one-line
+statement of what the module is for**, before any code example:
+
+- `std::http` → "Fetch URLs from Agency code. Returns the response as
+  text, JSON, or Markdown."
+- `std::date` → "Builds timezone-aware ISO 8601 date strings, the format
+  that APIs like Google Calendar expect."
+- `std::math` → "Small deterministic arithmetic helpers: round, add,
+  subtract, multiply, and a divide that returns a Result so you can
+  handle division by zero."
+- `std::object` → "Helpers for working with objects: read their keys,
+  values, and entries, and transform them with `mapValues`, `mapEntries`,
+  and `filterEntries`."
+
+That opening line is a ready-made summary. The generator is already
+holding it. It just isn't putting it into the front matter.
+
+---
+
+## The two gaps, precisely
+
+The end goal — "the agent knows what each stdlib module is for" — breaks
+into two independent gaps. Both must be closed; neither depends on the
+other.
+
+**Gap 1 — no summary in the stdlib front matter.** `agency doc` writes
+only `name:`. We need it to also write a `description:`, sourced from the
+module's `@module` comment. This is a change to `lib/cli/doc.ts` only.
+
+**Gap 2 — the agent can't reach the stdlib docs at all.** `docsSkill`
+accepts only `"guide" | "cli" | "diagnostics"`, and the build only stages
+those three doc folders into the shipped package. There is no `"stdlib"`
+option, and nothing wires a stdlib doc tool into any subagent. Closing
+this touches the makefile, `lib/stdlib/skills.ts`, `stdlib/skills.agency`,
+and the subagents. It also has a sharp edge described below (nested
+docs).
+
+---
+
+## Approaches considered for Gap 1
+
+We weighed three ways to get a summary into the front matter.
+
+**A. A hand-curated prompt listing every module.** Write one document
+that lists all 64 modules with a sentence each, and feed it to the agent.
+Rejected: it duplicates information that already lives next to the code,
+and it drifts — every new module means remembering to edit a central
+file, and there is no check that catches you when you forget.
+
+**B. A dedicated `@summary` tag, hand-written per module.** Add a new
+doc-comment tag whose text becomes the `description`. Explicit and
+single-purpose, but it moves the maintenance burden rather than removing
+it: someone still hand-writes 64 summaries now and must remember one for
+every future module. It also implies new language-parser surface for what
+is really a documentation concern.
+
+**C. Derive the summary from the existing `@module` comment, with an
+optional override.** The generator takes the opening line of the
+`@module` comment as the `description`. Because 63 of 64 modules already
+have a good opening line, this gives near-total coverage for free and
+**cannot drift** — it regenerates from the same source that produces the
+page body. For the rare module whose opening line is a poor summary, an
+optional override lets the author supply a better one.
+
+**Decision: C.** It reuses content that already exists, needs no new
+language syntax, and stays correct on its own.
+
+---
+
+## The design
+
+Three parts. Parts A and B close Gap 1 (the summary). Part C closes Gap 2
+(the wiring).
+
+### Part A — Derive `description` from the `@module` comment
+
+In `lib/cli/doc.ts`, when a file has a `program.docComment`, compute a
+one-line summary from it and emit it as a `description:` field in the
+generated front matter, alongside the existing `name:`.
+
+**Extraction rule.** Take the text of the `@module` comment and keep only
+its leading prose:
+
+1. Start at the first non-blank line of the comment body.
+2. Stop at the first blank line **or** the first code fence (a line
+   beginning with ` ``` `), whichever comes first. This discards the code
+   examples that usually follow the summary.
+3. Collapse all internal whitespace and newlines to single spaces, and
+   trim.
+4. If the result is longer than a cap (proposed: **200 characters**),
+   truncate at the last word boundary before the cap and append `…`.
+
+Worked example — `std::http`, whose comment is:
+
+```text
+/** @module
+  Fetch URLs from Agency code. Returns the response as text, JSON, or Markdown.
+  Aborting tears down the in-flight request.
+
+  ```ts
+  import { fetch, fetchJSON } from "std::http"
+  ...
+*/
+```
+
+The rule stops at the blank line before the code fence, giving:
+
+```text
+Fetch URLs from Agency code. Returns the response as text, JSON, or
+Markdown. Aborting tears down the in-flight request.
+```
+
+which is emitted as:
+
+```markdown
+---
+name: "http"
+description: "Fetch URLs from Agency code. Returns the response as text, JSON, or Markdown. Aborting tears down the in-flight request."
+---
+```
+
+**Why "first paragraph" and not "first sentence."** A first-sentence rule
+needs to split on `. `, which trips on abbreviations ("e.g.", "i.e.") and
+would occasionally cut a summary in half. The first-paragraph rule has
+unambiguous delimiters (blank line / code fence) and no natural-language
+parsing. It can run two or three sentences long, but that is acceptable
+for a tool-listing description, and the length cap plus the Part B
+override handle anything that reads badly.
+
+**Escaping.** The description text goes into a YAML-ish `description:
+"..."` value and is later parsed back out by the front-matter reader.
+Double quotes and backslashes in the text must be escaped so the value
+stays well-formed. The existing `name:` emission already strips a small
+set of characters (`lib/cli/doc.ts:169`); the description needs
+equivalent care. The exact quoting is an implementation detail for the
+plan, but it must round-trip: what `agency doc` writes, the front-matter
+parser in `std::markdown` must read back unchanged.
+
+**Files with no `@module` comment.** One stdlib module lacks a `@module`
+comment today. When there is no comment, emit no `description:` field
+(exactly today's behavior) — do not emit an empty one. The agent falls
+back to the module name, no worse off than now.
+
+### Part B — An optional override, inside the `@module` comment
+
+For the handful of modules whose opening prose is a poor summary, let the
+author supply an explicit one. Crucially, this override lives **inside
+the `@module` comment** and is parsed by the doc command — it is **not** a
+new language-level tag, so it touches no parser or preprocessor code.
+
+The convention: if the first line of the `@module` body is `@summary
+<text>`, that text becomes the `description`, and the `@summary` line is
+stripped from the rendered page body (so it never shows up as literal
+text on the page). If there is no `@summary` line, Part A's derivation
+applies.
+
+Example:
+
+```text
+/** @module
+  @summary Read and write the system clipboard.
+  The clipboard module exposes copy/paste over the OS pasteboard, with
+  the usual platform caveats described below...
+*/
+```
+
+produces `description: "Read and write the system clipboard."` regardless
+of how the body prose reads, and the page body begins at "The clipboard
+module exposes...".
+
+**Why a doc-command convention rather than a real tag.** A summary is
+documentation metadata, not program structure. Keeping it inside the
+comment and parsing it in `lib/cli/doc.ts` means the language parser, the
+preprocessor, and the AST are all untouched. The blast radius is one
+file.
+
+### Part C — Wire the stdlib docs into the agent
+
+Four steps, all mechanical, but one has a sharp edge (step 3).
+
+**1. Stage the docs into the shipped package.** The makefile copies
+`docs/site/{guide,cli,diagnostics}` into `stdlib/docs/` so they ship
+inside the installed package (see `stage-stdlib-docs` in the makefile,
+referenced from `lib/stdlib/skills.ts:31`). Add `docs/site/stdlib` to
+that staging so `stdlib/docs/stdlib/` exists in both dev and npm installs.
+
+**2. Add a `"stdlib"` section.** Two coordinated edits:
+   - `_docsDir` in `lib/stdlib/skills.ts:36` — widen its parameter type
+     from `"guide" | "cli" | "diagnostics"` to include `"stdlib"`, so it
+     resolves `stdlib/docs/stdlib`.
+   - `docsSkill` in `stdlib/skills.agency:239` — widen the same union in
+     its signature and docstring.
+
+**3. Make the stdlib doc tool glob recursively.** This is the sharp edge.
+29 of the 64 stdlib docs live in subdirectories — `ui/table.md`,
+`auth/oauth.md`, `web/search.md`, `agency/local.md`, and so on. The
+"flat" layout that `docsSkill` uses globs `*.{md,markdown}`, and a single
+`*` does not descend into subdirectories. So a naive `docsSkill("stdlib")`
+would list only the 35 top-level modules and **silently drop the other
+29** — worse than useless, because it looks complete.
+
+The stdlib doc tool must glob recursively (`**/*.{md,markdown}`) so all 64
+modules appear, each with its subdirectory-qualified `location` (e.g.
+`ui/table.md`) that `read` can resolve. The plan should choose the
+least-invasive way to get recursion for this one case without changing
+the behavior of existing `skillsDir(..., "flat")` callers — options
+include a recursive-flat variant or a dedicated glob for the docs path.
+Whichever is chosen, the acceptance check is concrete: the generated tool
+description must list all 64 modules, including the nested ones.
+
+**4. Register the tool in the subagents.** Add `docsSkill("stdlib")` to
+the tool lists of the subagents that answer standard-library questions —
+**code**, **research**, and **explorer** — and add a one-line note to each
+of their system prompts describing it, mirroring how `docSkill` /
+`cliSkill` are introduced today (e.g. `code.agency:99`). The oracle is
+out of scope for now; it can be added later if it proves useful.
+
+---
+
+## How we'll know it works
+
+- **Part A/B, unit level.** Table-driven tests over the extraction rule:
+  a comment with a code fence stops at the fence; a multi-paragraph
+  comment stops at the first blank line; a `@summary` line overrides and
+  is stripped from the body; a comment longer than the cap truncates on a
+  word boundary; a file with no `@module` emits no `description:`; quotes
+  and backslashes round-trip through the front-matter parser.
+- **Part A/B, integration.** Run `agency doc` over `stdlib/` and assert a
+  spot-check set (`http`, `date`, `math`, a nested one like `ui/table`)
+  each gain a sensible `description:`.
+- **Part C.** Build the tool via `docsSkill("stdlib")` and assert its
+  description lists all 64 modules (the nested-glob regression), each with
+  a non-empty `<description>`. Confirm the code/research/explorer
+  subagents carry the tool.
+- **End to end.** Regenerate the stdlib docs (`make` / the doc step) so
+  the committed `docs/site/stdlib/*.md` show the new front matter.
+
+---
+
+## Out of scope
+
+- No new language syntax or AST changes. `@summary` is a doc-command
+  convention, not a tag the compiler knows about.
+- No change to how the guide / CLI / diagnostics docs are authored or
+  rendered.
+- No rewrite of any `@module` comment for content. If a module's opening
+  line is a weak summary, adding a `@summary` override is a follow-up per
+  module, not part of this work.
+- The oracle subagent does not get the stdlib tool in this pass.

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -1,5 +1,6 @@
 ---
 name: "agency"
+description: "Tools for compiling, type-checking, running, formatting, and inspecting Agency programs from Agency code."
 ---
 
 # agency
@@ -29,7 +30,7 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L60))
 
 ### SourceLocation
 
@@ -42,7 +43,7 @@ export type SourceLocation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L64))
 
 ### TypeCheckDiagnostic
 
@@ -61,7 +62,7 @@ export type TypeCheckDiagnostic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L71))
 
 ### TypeCheckReport
 
@@ -72,7 +73,7 @@ export type TypeCheckReport = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L84))
 
 ### EffectsByExport
 
@@ -83,7 +84,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L359))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L360))
 
 ### Feedback
 
@@ -101,7 +102,7 @@ export type Feedback = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L377))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L378))
 
 ### WriteFailure
 
@@ -117,7 +118,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L603))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L604))
 
 ### AST
 
@@ -140,7 +141,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L754))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L755))
 
 ## Effects
 
@@ -153,7 +154,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L42))
 
 ### std::write
 
@@ -164,7 +165,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L46))
 
 ### std::run
 
@@ -180,7 +181,7 @@ effect std::run {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L50))
 
 ## Functions
 
@@ -202,7 +203,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L89))
 
 ### run
 
@@ -267,7 +268,7 @@ and a child process has maxDepth=5, maxDepth=3 is used.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L109))
 
 ### runFile
 
@@ -320,7 +321,7 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L208))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L209))
 
 ### runCode
 
@@ -386,7 +387,7 @@ re-raises std::run and the child's own effects re-prompt.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L288))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L289))
 
 ### typecheck
 
@@ -410,7 +411,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L349))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L350))
 
 ### getEffects
 
@@ -434,7 +435,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L361))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L362))
 
 ### mergeFeedback
 
@@ -457,7 +458,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L382))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L383))
 
 ### review
 
@@ -481,7 +482,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L453))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
 
 ### renderFeedback
 
@@ -501,7 +502,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L484))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L485))
 
 ### feedbackHasErrors
 
@@ -522,7 +523,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L496))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L497))
 
 ### failOpenFeedback
 
@@ -542,7 +543,7 @@ Pass a successful feedback list through unchanged; map any failure to
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L513))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L514))
 
 ### syntaxHintFor
 
@@ -563,7 +564,7 @@ A specific syntax reminder to inject next to a diagnostic, or "" when no
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L524))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L525))
 
 ### verify
 
@@ -590,7 +591,7 @@ Reconstruct a task's success criteria, run the produced artifact against
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L582))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L583))
 
 ### writeAgency
 
@@ -621,7 +622,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L666))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L667))
 
 ### typecheckFile
 
@@ -646,7 +647,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L734))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L735))
 
 ### parseAST
 
@@ -666,7 +667,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L760))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L761))
 
 ### writeAST
 
@@ -703,7 +704,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L772))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L773))
 
 ### format
 
@@ -723,7 +724,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L794))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L795))
 
 ### formatFile
 
@@ -750,7 +751,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L805))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L806))
 
 ### walkAST
 
@@ -779,7 +780,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L824))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L825))
 
 ### getNodesOfType
 
@@ -801,7 +802,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L844))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L845))
 
 ### getImports
 
@@ -821,7 +822,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L854))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L855))
 
 ### getFunctions
 
@@ -841,7 +842,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L863))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L864))
 
 ### getGraphNodes
 
@@ -861,7 +862,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L872))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L873))
 
 ### filterImports
 
@@ -913,7 +914,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L899))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L900))
 
 ### getVersion
 
@@ -925,4 +926,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L925))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L926))

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -1,6 +1,6 @@
 ---
 name: "agency"
-description: "Tools for compiling, type-checking, running, formatting, and inspecting Agency programs from Agency code. Compile and run source in a sandboxed subprocess, type-check or format it, and walk its AST to find imports, functions, or nodes."
+description: "Tools for compiling, type-checking, running, formatting, and inspecting Agency programs from Agency code."
 ---
 
 # agency
@@ -30,7 +30,7 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L60))
 
 ### SourceLocation
 
@@ -43,7 +43,7 @@ export type SourceLocation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L64))
 
 ### TypeCheckDiagnostic
 
@@ -62,7 +62,7 @@ export type TypeCheckDiagnostic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L71))
 
 ### TypeCheckReport
 
@@ -73,7 +73,7 @@ export type TypeCheckReport = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L84))
 
 ### EffectsByExport
 
@@ -84,7 +84,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L359))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L360))
 
 ### Feedback
 
@@ -102,7 +102,7 @@ export type Feedback = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L377))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L378))
 
 ### WriteFailure
 
@@ -118,7 +118,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L603))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L604))
 
 ### AST
 
@@ -141,7 +141,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L754))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L755))
 
 ## Effects
 
@@ -154,7 +154,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L42))
 
 ### std::write
 
@@ -165,7 +165,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L46))
 
 ### std::run
 
@@ -181,7 +181,7 @@ effect std::run {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L50))
 
 ## Functions
 
@@ -203,7 +203,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L89))
 
 ### run
 
@@ -268,7 +268,7 @@ and a child process has maxDepth=5, maxDepth=3 is used.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L109))
 
 ### runFile
 
@@ -321,7 +321,7 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L208))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L209))
 
 ### runCode
 
@@ -387,7 +387,7 @@ re-raises std::run and the child's own effects re-prompt.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L288))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L289))
 
 ### typecheck
 
@@ -411,7 +411,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L349))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L350))
 
 ### getEffects
 
@@ -435,7 +435,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L361))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L362))
 
 ### mergeFeedback
 
@@ -458,7 +458,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L382))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L383))
 
 ### review
 
@@ -482,7 +482,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L453))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
 
 ### renderFeedback
 
@@ -502,7 +502,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L484))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L485))
 
 ### feedbackHasErrors
 
@@ -523,7 +523,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L496))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L497))
 
 ### failOpenFeedback
 
@@ -543,7 +543,7 @@ Pass a successful feedback list through unchanged; map any failure to
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L513))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L514))
 
 ### syntaxHintFor
 
@@ -564,7 +564,7 @@ A specific syntax reminder to inject next to a diagnostic, or "" when no
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L524))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L525))
 
 ### verify
 
@@ -591,7 +591,7 @@ Reconstruct a task's success criteria, run the produced artifact against
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L582))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L583))
 
 ### writeAgency
 
@@ -622,7 +622,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L666))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L667))
 
 ### typecheckFile
 
@@ -647,7 +647,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L734))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L735))
 
 ### parseAST
 
@@ -667,7 +667,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L760))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L761))
 
 ### writeAST
 
@@ -704,7 +704,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L772))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L773))
 
 ### format
 
@@ -724,7 +724,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L794))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L795))
 
 ### formatFile
 
@@ -751,7 +751,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L805))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L806))
 
 ### walkAST
 
@@ -780,7 +780,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L824))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L825))
 
 ### getNodesOfType
 
@@ -802,7 +802,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L844))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L845))
 
 ### getImports
 
@@ -822,7 +822,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L854))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L855))
 
 ### getFunctions
 
@@ -842,7 +842,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L863))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L864))
 
 ### getGraphNodes
 
@@ -862,7 +862,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L872))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L873))
 
 ### filterImports
 
@@ -914,7 +914,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L899))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L900))
 
 ### getVersion
 
@@ -926,4 +926,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L925))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L926))

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -1,6 +1,6 @@
 ---
 name: "agency"
-description: "Tools for compiling, type-checking, running, formatting, and inspecting Agency programs from Agency code."
+description: "Tools for compiling, type-checking, running, formatting, and inspecting Agency programs from Agency code. Compile and run source in a sandboxed subprocess, type-check or format it, and walk its AST to find imports, functions, or nodes."
 ---
 
 # agency
@@ -30,7 +30,7 @@ export type CompiledProgram = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L59))
 
 ### SourceLocation
 
@@ -43,7 +43,7 @@ export type SourceLocation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L63))
 
 ### TypeCheckDiagnostic
 
@@ -62,7 +62,7 @@ export type TypeCheckDiagnostic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L71))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L70))
 
 ### TypeCheckReport
 
@@ -73,7 +73,7 @@ export type TypeCheckReport = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L84))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L83))
 
 ### EffectsByExport
 
@@ -84,7 +84,7 @@ Per-exported-symbol effect lists, keyed by node/function name.
 export type EffectsByExport = Record<string, string[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L360))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L359))
 
 ### Feedback
 
@@ -102,7 +102,7 @@ export type Feedback = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L378))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L377))
 
 ### WriteFailure
 
@@ -118,7 +118,7 @@ export type WriteFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L604))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L603))
 
 ### AST
 
@@ -141,7 +141,7 @@ export type AST = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L755))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L754))
 
 ## Effects
 
@@ -154,7 +154,7 @@ effect std::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L41))
 
 ### std::write
 
@@ -165,7 +165,7 @@ effect std::write {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L45))
 
 ### std::run
 
@@ -181,7 +181,7 @@ effect std::run {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L50))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L49))
 
 ## Functions
 
@@ -203,7 +203,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L88))
 
 ### run
 
@@ -268,7 +268,7 @@ and a child process has maxDepth=5, maxDepth=3 is used.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L108))
 
 ### runFile
 
@@ -321,7 +321,7 @@ Exceeding a resource limit kills the subprocess and returns a `limit_exceeded` f
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L209))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L208))
 
 ### runCode
 
@@ -387,7 +387,7 @@ re-raises std::run and the child's own effects re-prompt.
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L289))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L288))
 
 ### typecheck
 
@@ -411,7 +411,7 @@ Relative imports (./foo.agency) cannot be resolved from a source string.
 
 **Returns:** `Result<TypeCheckReport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L350))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L349))
 
 ### getEffects
 
@@ -435,7 +435,7 @@ Map each exported node and function in the source to the list of
 
 **Returns:** `Result<EffectsByExport>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L362))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L361))
 
 ### mergeFeedback
 
@@ -458,7 +458,7 @@ Merge two feedback Results by concatenating their success arrays or
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L383))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L382))
 
 ### review
 
@@ -482,7 +482,7 @@ Review Agency source code. Always merges parse and typecheck findings;
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L454))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L453))
 
 ### renderFeedback
 
@@ -502,7 +502,7 @@ Render a feedback Result as human-readable text, one line per finding.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L485))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L484))
 
 ### feedbackHasErrors
 
@@ -523,7 +523,7 @@ True when any finding is an error, or when the feedback Result itself
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L497))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L496))
 
 ### failOpenFeedback
 
@@ -543,7 +543,7 @@ Pass a successful feedback list through unchanged; map any failure to
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L514))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L513))
 
 ### syntaxHintFor
 
@@ -564,7 +564,7 @@ A specific syntax reminder to inject next to a diagnostic, or "" when no
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L525))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L524))
 
 ### verify
 
@@ -591,7 +591,7 @@ Reconstruct a task's success criteria, run the produced artifact against
 
 **Returns:** `Result<Feedback[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L583))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L582))
 
 ### writeAgency
 
@@ -622,7 +622,7 @@ Generate Agency source code for a task description. Typechecks each
 
 **Returns:** `Result<string, WriteFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L667))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L666))
 
 ### typecheckFile
 
@@ -647,7 +647,7 @@ Type-check an Agency file on disk. The file is read from dir/filename,
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L735))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L734))
 
 ### parseAST
 
@@ -667,7 +667,7 @@ Parse Agency source code into an abstract syntax tree.
 
 **Returns:** `Result<AST>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L761))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L760))
 
 ### writeAST
 
@@ -704,7 +704,7 @@ Output is canonical formatter output (the same style as `pnpm run fmt`):
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L773))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L772))
 
 ### format
 
@@ -724,7 +724,7 @@ Format Agency source code with the standard Agency formatter.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L795))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L794))
 
 ### formatFile
 
@@ -751,7 +751,7 @@ Read and write happen inside the same interrupt, so approving it approves both.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L806))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L805))
 
 ### walkAST
 
@@ -780,7 +780,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor
 
 **Returns:** [AST](#ast)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L825))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L824))
 
 ### getNodesOfType
 
@@ -802,7 +802,7 @@ Parse Agency source code and return every AST node whose `type` field matches an
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L845))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L844))
 
 ### getImports
 
@@ -822,7 +822,7 @@ Return every import statement in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L855))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L854))
 
 ### getFunctions
 
@@ -842,7 +842,7 @@ Return every function definition (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L864))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L863))
 
 ### getGraphNodes
 
@@ -862,7 +862,7 @@ Return every graph node definition (`node main() { ... }`) in the source.
 
 **Returns:** `Result<any[]>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L873))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L872))
 
 ### filterImports
 
@@ -914,7 +914,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result<{ source: string; filtered: boolean }>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L900))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L899))
 
 ### getVersion
 
@@ -926,4 +926,4 @@ Get the current version of the Agency standard library.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L926))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency.agency#L925))

--- a/packages/agency-lang/docs/site/stdlib/agency/eval.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/eval.md
@@ -1,5 +1,6 @@
 ---
 name: "eval"
+description: "Helpers for running and judging eval suites from Agency code."
 ---
 
 # eval

--- a/packages/agency-lang/docs/site/stdlib/agency/local.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/local.md
@@ -1,6 +1,6 @@
 ---
 name: "local"
-description: "Manage and run local GGUF models. Download models by curated short name or Hugging Face URI, alias them, list or remove downloads, and register the local provider so `llm()` calls can use them. Requires the smoltalk-llama-cpp package."
+description: "Manage and run local GGUF models: download by short name or Hugging Face URI, alias them, and register the local provider."
 ---
 
 # local
@@ -32,7 +32,7 @@ export type DownloadedModel = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L33))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L34))
 
 ### ModelName
 
@@ -50,7 +50,7 @@ export type ModelName = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L40))
 
 ### SkippedAlias
 
@@ -67,7 +67,7 @@ export type SkippedAlias = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L156))
 
 ### RefreshResult
 
@@ -87,7 +87,7 @@ export type RefreshResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L162))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L163))
 
 ## Functions
 
@@ -101,7 +101,7 @@ True if smoltalk-llama-cpp is installed.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L52))
 
 ### resolveModelName
 
@@ -122,7 +122,7 @@ Map a curated short name or alias to its Hugging Face URI. Pass URIs and
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L59))
 
 ### downloadModel
 
@@ -145,7 +145,7 @@ Download a model and return its local .gguf path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L69))
 
 ### listDownloadedModels
 
@@ -165,7 +165,7 @@ List downloaded .gguf models.
 
 **Returns:** `DownloadedModel[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L80))
 
 ### listModelNames
 
@@ -177,7 +177,7 @@ List usable short names: curated built-ins and your aliases.
 
 **Returns:** `ModelName[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L89))
 
 ### aliasModel
 
@@ -200,7 +200,7 @@ Add a short-name alias for a model URI
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L96))
 
 ### unaliasModel
 
@@ -221,7 +221,7 @@ Remove a short-name alias.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L107))
 
 ### removeModel
 
@@ -244,7 +244,7 @@ Delete a downloaded model file.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L117))
 
 ### registerLocalProvider
 
@@ -254,7 +254,7 @@ registerLocalProvider()
 
 Register the llama-cpp provider so local models can be used for LLM calls.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L128))
 
 ### registerLocalModel
 
@@ -277,7 +277,7 @@ Register the provider and ensure the model is downloaded. Returns the local
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L135))
 
 ### printLocalCatalog
 
@@ -288,7 +288,7 @@ printLocalCatalog()
 Print the usable-model catalog (curated names + your aliases) as an
     aligned table, the same listing as `agency local alias list`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L146))
 
 ### refreshCatalog
 
@@ -316,4 +316,4 @@ Same operation as the `agency local refresh` CLI command.
 
 **Returns:** [RefreshResult](#refreshresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L174))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L175))

--- a/packages/agency-lang/docs/site/stdlib/agency/local.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/local.md
@@ -1,6 +1,6 @@
 ---
 name: "local"
-description: "Manage and run local GGUF models: download by short name or Hugging Face URI, alias them, and register the local provider."
+description: "Manage and run local GGUF models. Download models by curated short name or Hugging Face URI, alias them, list or remove downloads, and register the local provider so `llm()` calls can use them. Requires the smoltalk-llama-cpp package."
 ---
 
 # local
@@ -32,7 +32,7 @@ export type DownloadedModel = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L33))
 
 ### ModelName
 
@@ -50,7 +50,7 @@ export type ModelName = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L39))
 
 ### SkippedAlias
 
@@ -67,7 +67,7 @@ export type SkippedAlias = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L155))
 
 ### RefreshResult
 
@@ -87,7 +87,7 @@ export type RefreshResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L162))
 
 ## Functions
 
@@ -101,7 +101,7 @@ True if smoltalk-llama-cpp is installed.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L51))
 
 ### resolveModelName
 
@@ -122,7 +122,7 @@ Map a curated short name or alias to its Hugging Face URI. Pass URIs and
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L58))
 
 ### downloadModel
 
@@ -145,7 +145,7 @@ Download a model and return its local .gguf path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L68))
 
 ### listDownloadedModels
 
@@ -165,7 +165,7 @@ List downloaded .gguf models.
 
 **Returns:** `DownloadedModel[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L79))
 
 ### listModelNames
 
@@ -177,7 +177,7 @@ List usable short names: curated built-ins and your aliases.
 
 **Returns:** `ModelName[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L88))
 
 ### aliasModel
 
@@ -200,7 +200,7 @@ Add a short-name alias for a model URI
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L95))
 
 ### unaliasModel
 
@@ -221,7 +221,7 @@ Remove a short-name alias.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L106))
 
 ### removeModel
 
@@ -244,7 +244,7 @@ Delete a downloaded model file.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L116))
 
 ### registerLocalProvider
 
@@ -254,7 +254,7 @@ registerLocalProvider()
 
 Register the llama-cpp provider so local models can be used for LLM calls.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L128))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L127))
 
 ### registerLocalModel
 
@@ -277,7 +277,7 @@ Register the provider and ensure the model is downloaded. Returns the local
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L134))
 
 ### printLocalCatalog
 
@@ -288,7 +288,7 @@ printLocalCatalog()
 Print the usable-model catalog (curated names + your aliases) as an
     aligned table, the same listing as `agency local alias list`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L145))
 
 ### refreshCatalog
 
@@ -316,4 +316,4 @@ Same operation as the `agency local refresh` CLI command.
 
 **Returns:** [RefreshResult](#refreshresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L175))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L174))

--- a/packages/agency-lang/docs/site/stdlib/agency/local.md
+++ b/packages/agency-lang/docs/site/stdlib/agency/local.md
@@ -1,5 +1,6 @@
 ---
 name: "local"
+description: "Manage and run local GGUF models: download by short name or Hugging Face URI, alias them, and register the local provider."
 ---
 
 # local
@@ -31,7 +32,7 @@ export type DownloadedModel = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L33))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L34))
 
 ### ModelName
 
@@ -49,7 +50,7 @@ export type ModelName = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L40))
 
 ### SkippedAlias
 
@@ -66,7 +67,7 @@ export type SkippedAlias = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L156))
 
 ### RefreshResult
 
@@ -86,7 +87,7 @@ export type RefreshResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L162))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L163))
 
 ## Functions
 
@@ -100,7 +101,7 @@ True if smoltalk-llama-cpp is installed.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L52))
 
 ### resolveModelName
 
@@ -121,7 +122,7 @@ Map a curated short name or alias to its Hugging Face URI. Pass URIs and
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L59))
 
 ### downloadModel
 
@@ -144,7 +145,7 @@ Download a model and return its local .gguf path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L69))
 
 ### listDownloadedModels
 
@@ -164,7 +165,7 @@ List downloaded .gguf models.
 
 **Returns:** `DownloadedModel[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L80))
 
 ### listModelNames
 
@@ -176,7 +177,7 @@ List usable short names: curated built-ins and your aliases.
 
 **Returns:** `ModelName[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L89))
 
 ### aliasModel
 
@@ -199,7 +200,7 @@ Add a short-name alias for a model URI
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L96))
 
 ### unaliasModel
 
@@ -220,7 +221,7 @@ Remove a short-name alias.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L107))
 
 ### removeModel
 
@@ -243,7 +244,7 @@ Delete a downloaded model file.
 
 **Returns:** `bool`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L117))
 
 ### registerLocalProvider
 
@@ -253,7 +254,7 @@ registerLocalProvider()
 
 Register the llama-cpp provider so local models can be used for LLM calls.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L128))
 
 ### registerLocalModel
 
@@ -276,7 +277,7 @@ Register the provider and ensure the model is downloaded. Returns the local
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L135))
 
 ### printLocalCatalog
 
@@ -287,7 +288,7 @@ printLocalCatalog()
 Print the usable-model catalog (curated names + your aliases) as an
     aligned table, the same listing as `agency local alias list`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L146))
 
 ### refreshCatalog
 
@@ -315,4 +316,4 @@ Same operation as the `agency local refresh` CLI command.
 
 **Returns:** [RefreshResult](#refreshresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L174))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agency/local.agency#L175))

--- a/packages/agency-lang/docs/site/stdlib/agent.md
+++ b/packages/agency-lang/docs/site/stdlib/agent.md
@@ -1,6 +1,6 @@
 ---
 name: "agent"
-description: "Helpers for building user-facing agents. This module offers two independent tools: - `question` asks the user something through an interrupt the host UI can render, and - `todoWrite` / `todoList` give the LLM a small todo list to track multi-step work across turns."
+description: "Helpers for building user-facing agents: ask the user a question through an interrupt, and manage a todo list."
 ---
 
 # agent
@@ -24,7 +24,7 @@ effect std::question {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L19))
 
 ## Functions
 
@@ -44,7 +44,7 @@ Add a new todo to the list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L22))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L23))
 
 ### todoUpdate
 
@@ -63,7 +63,7 @@ Update the status of a todo by id.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L31))
 
 ### todoWrite
 
@@ -81,7 +81,7 @@ Replace the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L47))
 
 ### todoList
 
@@ -93,7 +93,7 @@ Return the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L55))
 
 ### question
 
@@ -118,4 +118,4 @@ so it can be used anywhere (eg a web server) instead of just the CLI.
 
 **Throws:** `std::question`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L66))

--- a/packages/agency-lang/docs/site/stdlib/agent.md
+++ b/packages/agency-lang/docs/site/stdlib/agent.md
@@ -1,5 +1,6 @@
 ---
 name: "agent"
+description: "Helpers for building user-facing agents: ask the user a question through an interrupt, and manage a todo list."
 ---
 
 # agent
@@ -23,7 +24,7 @@ effect std::question {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L19))
 
 ## Functions
 
@@ -43,7 +44,7 @@ Add a new todo to the list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L22))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L23))
 
 ### todoUpdate
 
@@ -62,7 +63,7 @@ Update the status of a todo by id.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L31))
 
 ### todoWrite
 
@@ -80,7 +81,7 @@ Replace the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L47))
 
 ### todoList
 
@@ -92,7 +93,7 @@ Return the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L55))
 
 ### question
 
@@ -117,4 +118,4 @@ so it can be used anywhere (eg a web server) instead of just the CLI.
 
 **Throws:** `std::question`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L66))

--- a/packages/agency-lang/docs/site/stdlib/agent.md
+++ b/packages/agency-lang/docs/site/stdlib/agent.md
@@ -1,6 +1,6 @@
 ---
 name: "agent"
-description: "Helpers for building user-facing agents: ask the user a question through an interrupt, and manage a todo list."
+description: "Helpers for building user-facing agents. This module offers two independent tools: - `question` asks the user something through an interrupt the host UI can render, and - `todoWrite` / `todoList` give the LLM a small todo list to track multi-step work across turns."
 ---
 
 # agent
@@ -24,7 +24,7 @@ effect std::question {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L19))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L18))
 
 ## Functions
 
@@ -44,7 +44,7 @@ Add a new todo to the list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L23))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L22))
 
 ### todoUpdate
 
@@ -63,7 +63,7 @@ Update the status of a todo by id.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L31))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L30))
 
 ### todoWrite
 
@@ -81,7 +81,7 @@ Replace the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L46))
 
 ### todoList
 
@@ -93,7 +93,7 @@ Return the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L54))
 
 ### question
 
@@ -118,4 +118,4 @@ so it can be used anywhere (eg a web server) instead of just the CLI.
 
 **Throws:** `std::question`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L66))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agent.agency#L65))

--- a/packages/agency-lang/docs/site/stdlib/agents/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency.md
@@ -1,5 +1,6 @@
 ---
 name: "agency"
+description: "Agency-coding agent: writes an Agency program for a task, runs it, and verifies the program's actual result satisfies the task. Built on writeAgency and runCode."
 ---
 
 # agency

--- a/packages/agency-lang/docs/site/stdlib/agents/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/agency.md
@@ -1,6 +1,6 @@
 ---
 name: "agency"
-description: "Agency-coding agent: writes an Agency program for a task, runs it, and verifies the program's actual result satisfies the task. Built on writeAgency and runCode."
+description: "Agency-coding agent: writes an Agency program for a task, runs it, and verifies the program's actual result satisfies the task."
 ---
 
 # agency

--- a/packages/agency-lang/docs/site/stdlib/agents/coding.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/coding.md
@@ -1,5 +1,6 @@
 ---
 name: "coding"
+description: "General-purpose coding agent: writes, edits, and runs code to complete a task, then verifies the produced artifact against the task's own success criteria."
 ---
 
 # coding

--- a/packages/agency-lang/docs/site/stdlib/agents/expert.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/expert.md
@@ -1,5 +1,6 @@
 ---
 name: "expert"
+description: "Expert-guided coding agent."
 ---
 
 # expert

--- a/packages/agency-lang/docs/site/stdlib/agents/planner.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/planner.md
@@ -1,5 +1,6 @@
 ---
 name: "planner"
+description: "The plan-as-code meta-agent: given a task, generates an Agency program that composes worker agents and tools to solve it."
 ---
 
 # planner
@@ -28,7 +29,7 @@ effect std::agents::planApprove {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L14))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L15))
 
 ## Functions
 
@@ -50,7 +51,7 @@ Build the writeAgency instruction: emit a program whose `node main` composes
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L41))
 
 ### renderEffects
 
@@ -69,7 +70,7 @@ Human-readable capability envelope for the approval prompt, or an honest
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L69))
 
 ### runApproved
 
@@ -93,7 +94,7 @@ runApproved(
 
 **Returns:** [PlanState](#planstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L133))
 
 ### plannerAgent
 
@@ -131,4 +132,4 @@ Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L151))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L152))

--- a/packages/agency-lang/docs/site/stdlib/agents/planner.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/planner.md
@@ -1,6 +1,6 @@
 ---
 name: "planner"
-description: "plannerAgent: the plan-as-code meta-agent. Given a task, generate an Agency program (an agent-as-plan) that composes the worker agents and tools to solve it, show the plan, source, and capability envelope for approval, run it in a handler-sandboxed subprocess, verify, and fall back to codingAgent on failure."
+description: "The plan-as-code meta-agent: given a task, generates an Agency program that composes worker agents and tools to solve it."
 ---
 
 # planner
@@ -29,7 +29,7 @@ effect std::agents::planApprove {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L14))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L15))
 
 ## Functions
 
@@ -51,7 +51,7 @@ Build the writeAgency instruction: emit a program whose `node main` composes
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L41))
 
 ### renderEffects
 
@@ -70,7 +70,7 @@ Human-readable capability envelope for the approval prompt, or an honest
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L69))
 
 ### runApproved
 
@@ -94,7 +94,7 @@ runApproved(
 
 **Returns:** [PlanState](#planstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L133))
 
 ### plannerAgent
 
@@ -132,4 +132,4 @@ Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L151))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L152))

--- a/packages/agency-lang/docs/site/stdlib/agents/planner.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/planner.md
@@ -1,6 +1,6 @@
 ---
 name: "planner"
-description: "The plan-as-code meta-agent: given a task, generates an Agency program that composes worker agents and tools to solve it."
+description: "plannerAgent: the plan-as-code meta-agent. Given a task, generate an Agency program (an agent-as-plan) that composes the worker agents and tools to solve it, show the plan, source, and capability envelope for approval, run it in a handler-sandboxed subprocess, verify, and fall back to codingAgent on failure."
 ---
 
 # planner
@@ -29,7 +29,7 @@ effect std::agents::planApprove {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L15))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L14))
 
 ## Functions
 
@@ -51,7 +51,7 @@ Build the writeAgency instruction: emit a program whose `node main` composes
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L40))
 
 ### renderEffects
 
@@ -70,7 +70,7 @@ Human-readable capability envelope for the approval prompt, or an honest
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L68))
 
 ### runApproved
 
@@ -94,7 +94,7 @@ runApproved(
 
 **Returns:** [PlanState](#planstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L132))
 
 ### plannerAgent
 
@@ -132,4 +132,4 @@ Plan-as-code: draft (or use a seed) plan, generate an agent that solves the
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L152))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/agents/planner.agency#L151))

--- a/packages/agency-lang/docs/site/stdlib/agents/research.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/research.md
@@ -1,5 +1,6 @@
 ---
 name: "research"
+description: "Research agent: gathers from web and Wikipedia sources and synthesizes a cited, grounded answer."
 ---
 
 # research

--- a/packages/agency-lang/docs/site/stdlib/agents/shared.md
+++ b/packages/agency-lang/docs/site/stdlib/agents/shared.md
@@ -1,5 +1,6 @@
 ---
 name: "shared"
+description: "Shared helpers for the `std::agents` worker agents."
 ---
 
 # shared

--- a/packages/agency-lang/docs/site/stdlib/args.md
+++ b/packages/agency-lang/docs/site/stdlib/args.md
@@ -1,5 +1,6 @@
 ---
 name: "args"
+description: "Parse command-line flags. Features: - required flags - default values - mutually-exclusive groups - auto-generated `--help` / `--version` - number coercion"
 ---
 
 # args

--- a/packages/agency-lang/docs/site/stdlib/args.md
+++ b/packages/agency-lang/docs/site/stdlib/args.md
@@ -1,6 +1,6 @@
 ---
 name: "args"
-description: "Parse command-line flags. Features: - required flags - default values - mutually-exclusive groups - auto-generated `--help` / `--version` - number coercion"
+description: "Parse command-line flags."
 ---
 
 # args

--- a/packages/agency-lang/docs/site/stdlib/array.md
+++ b/packages/agency-lang/docs/site/stdlib/array.md
@@ -1,5 +1,6 @@
 ---
 name: "array"
+description: "Re-exports the array helpers (map, filter, reduce, and friends), which now live in std::index and are auto-imported."
 ---
 
 # array

--- a/packages/agency-lang/docs/site/stdlib/array.md
+++ b/packages/agency-lang/docs/site/stdlib/array.md
@@ -1,6 +1,6 @@
 ---
 name: "array"
-description: "Re-exports the array helpers (map, filter, reduce, and friends), which now live in std::index and are auto-imported."
+description: "Re-exports the array helpers (`map`, `filter`, `reduce`, and friends) so that `import { map, filter, ... } from std::array` keeps working. These helpers now live in `std::index` and are auto-imported into every `.agency` file, so you rarely need to import them at all."
 ---
 
 # array

--- a/packages/agency-lang/docs/site/stdlib/array.md
+++ b/packages/agency-lang/docs/site/stdlib/array.md
@@ -1,6 +1,6 @@
 ---
 name: "array"
-description: "Re-exports the array helpers (`map`, `filter`, `reduce`, and friends) so that `import { map, filter, ... } from std::array` keeps working. These helpers now live in `std::index` and are auto-imported into every `.agency` file, so you rarely need to import them at all."
+description: "Re-exports the array helpers (map, filter, reduce, and friends), which now live in std::index and are auto-imported."
 ---
 
 # array

--- a/packages/agency-lang/docs/site/stdlib/auth/keyring.md
+++ b/packages/agency-lang/docs/site/stdlib/auth/keyring.md
@@ -1,5 +1,6 @@
 ---
 name: "keyring"
+description: "Store and retrieve secrets in the operating system's keyring, so API keys and tokens never touch plaintext files."
 ---
 
 # keyring

--- a/packages/agency-lang/docs/site/stdlib/auth/oauth.md
+++ b/packages/agency-lang/docs/site/stdlib/auth/oauth.md
@@ -1,6 +1,6 @@
 ---
 name: "oauth"
-description: "Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your agent can call APIs on the user's behalf."
+description: "Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your agent can call APIs on the user's behalf. Register an app with the provider to get a client ID and secret. Then authorize once and fetch fresh access tokens as needed."
 ---
 
 # oauth
@@ -49,7 +49,7 @@ effect std::authorize {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L38))
 
 ### std::getAccessToken
 
@@ -59,7 +59,7 @@ effect std::getAccessToken {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L39))
 
 ### std::revokeAuth
 
@@ -69,7 +69,7 @@ effect std::revokeAuth {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L40))
 
 ## Functions
 
@@ -116,7 +116,7 @@ Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, cap
 
 **Throws:** `std::authorize`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L42))
 
 ### getAccessToken
 
@@ -138,7 +138,7 @@ Get a valid OAuth access token for a previously authorized provider. Refreshes t
 
 **Throws:** `std::getAccessToken`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L72))
 
 ### isAuthorized
 
@@ -158,7 +158,7 @@ Check whether OAuth tokens are stored for a provider. Returns true if tokens exi
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L85))
 
 ### revokeAuth
 
@@ -180,4 +180,4 @@ Delete stored OAuth tokens for a provider. Re-authorization is required before t
 
 **Throws:** `std::revokeAuth`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L94))

--- a/packages/agency-lang/docs/site/stdlib/auth/oauth.md
+++ b/packages/agency-lang/docs/site/stdlib/auth/oauth.md
@@ -1,6 +1,6 @@
 ---
 name: "oauth"
-description: "Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your agent can call APIs on the user's behalf. Register an app with the provider to get a client ID and secret. Then authorize once and fetch fresh access tokens as needed."
+description: "Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your agent can call APIs on the user's behalf."
 ---
 
 # oauth
@@ -49,7 +49,7 @@ effect std::authorize {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L39))
 
 ### std::getAccessToken
 
@@ -59,7 +59,7 @@ effect std::getAccessToken {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L40))
 
 ### std::revokeAuth
 
@@ -69,7 +69,7 @@ effect std::revokeAuth {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L41))
 
 ## Functions
 
@@ -116,7 +116,7 @@ Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, cap
 
 **Throws:** `std::authorize`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L43))
 
 ### getAccessToken
 
@@ -138,7 +138,7 @@ Get a valid OAuth access token for a previously authorized provider. Refreshes t
 
 **Throws:** `std::getAccessToken`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L73))
 
 ### isAuthorized
 
@@ -158,7 +158,7 @@ Check whether OAuth tokens are stored for a provider. Returns true if tokens exi
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L86))
 
 ### revokeAuth
 
@@ -180,4 +180,4 @@ Delete stored OAuth tokens for a provider. Re-authorization is required before t
 
 **Throws:** `std::revokeAuth`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L95))

--- a/packages/agency-lang/docs/site/stdlib/auth/oauth.md
+++ b/packages/agency-lang/docs/site/stdlib/auth/oauth.md
@@ -1,5 +1,6 @@
 ---
 name: "oauth"
+description: "Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your agent can call APIs on the user's behalf."
 ---
 
 # oauth
@@ -48,7 +49,7 @@ effect std::authorize {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L39))
 
 ### std::getAccessToken
 
@@ -58,7 +59,7 @@ effect std::getAccessToken {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L40))
 
 ### std::revokeAuth
 
@@ -68,7 +69,7 @@ effect std::revokeAuth {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L41))
 
 ## Functions
 
@@ -115,7 +116,7 @@ Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, cap
 
 **Throws:** `std::authorize`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L43))
 
 ### getAccessToken
 
@@ -137,7 +138,7 @@ Get a valid OAuth access token for a previously authorized provider. Refreshes t
 
 **Throws:** `std::getAccessToken`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L73))
 
 ### isAuthorized
 
@@ -157,7 +158,7 @@ Check whether OAuth tokens are stored for a provider. Returns true if tokens exi
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L86))
 
 ### revokeAuth
 
@@ -179,4 +180,4 @@ Delete stored OAuth tokens for a provider. Re-authorization is required before t
 
 **Throws:** `std::revokeAuth`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/auth/oauth.agency#L95))

--- a/packages/agency-lang/docs/site/stdlib/calendar.md
+++ b/packages/agency-lang/docs/site/stdlib/calendar.md
@@ -1,6 +1,6 @@
 ---
 name: "calendar"
-description: "Read and write Google Calendar events from Agency code. Authorizes once via Google OAuth, then lists, creates, updates, and deletes events."
+description: "Read and write Google Calendar events from Agency code."
 ---
 
 # calendar

--- a/packages/agency-lang/docs/site/stdlib/calendar.md
+++ b/packages/agency-lang/docs/site/stdlib/calendar.md
@@ -1,5 +1,6 @@
 ---
 name: "calendar"
+description: "Read and write Google Calendar events from Agency code. Authorizes once via Google OAuth, then lists, creates, updates, and deletes events."
 ---
 
 # calendar

--- a/packages/agency-lang/docs/site/stdlib/capabilities.md
+++ b/packages/agency-lang/docs/site/stdlib/capabilities.md
@@ -1,5 +1,6 @@
 ---
 name: "capabilities"
+description: "Standard **capability** effect sets — named groups of the interrupt effects the standard library raises, for use in `raises` clauses."
 ---
 
 # capabilities

--- a/packages/agency-lang/docs/site/stdlib/clipboard.md
+++ b/packages/agency-lang/docs/site/stdlib/clipboard.md
@@ -1,5 +1,6 @@
 ---
 name: "clipboard"
+description: "Read and write the system clipboard."
 ---
 
 # clipboard

--- a/packages/agency-lang/docs/site/stdlib/concurrency.md
+++ b/packages/agency-lang/docs/site/stdlib/concurrency.md
@@ -1,5 +1,6 @@
 ---
 name: "concurrency"
+description: "Concurrency primitives for coordinating work inside one Agency run. Use `withLock` to guard a shared resource so branches take turns instead of clobbering each other."
 ---
 
 # concurrency

--- a/packages/agency-lang/docs/site/stdlib/concurrency.md
+++ b/packages/agency-lang/docs/site/stdlib/concurrency.md
@@ -1,6 +1,6 @@
 ---
 name: "concurrency"
-description: "Concurrency primitives for coordinating work inside one Agency run. Use `withLock` to guard a shared resource so branches take turns instead of clobbering each other."
+description: "Concurrency primitives for coordinating work inside one Agency run."
 ---
 
 # concurrency

--- a/packages/agency-lang/docs/site/stdlib/data/finance/dbnomics.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/dbnomics.md
@@ -1,5 +1,6 @@
 ---
 name: "dbnomics"
+description: "## DBnomics — world macroeconomic time-series"
 ---
 
 # dbnomics

--- a/packages/agency-lang/docs/site/stdlib/data/finance/dbnomics.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/dbnomics.md
@@ -1,6 +1,6 @@
 ---
 name: "dbnomics"
-description: "## DBnomics — world macroeconomic time-series"
+description: "DBnomics — world macroeconomic time-series"
 ---
 
 # dbnomics

--- a/packages/agency-lang/docs/site/stdlib/data/finance/edgar.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/edgar.md
@@ -50,7 +50,7 @@ export type Filing = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L36))
 
 ## Effects
 
@@ -62,7 +62,7 @@ effect std::edgar {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L33))
 
 ## Functions
 
@@ -96,7 +96,7 @@ List recent SEC filings for a company by its CIK (Central Index Key). Returns fi
 
 **Throws:** `std::edgar`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L132))
 
 ### edgarFilings
 
@@ -130,4 +130,4 @@ List recent SEC filings for a U.S.-listed company by its ticker symbol (e.g. "AA
 
 **Throws:** `std::edgar`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/edgar.agency#L150))

--- a/packages/agency-lang/docs/site/stdlib/data/finance/edgar.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/edgar.md
@@ -1,5 +1,6 @@
 ---
 name: "edgar"
+description: "## SEC EDGAR — U.S. company filings"
 ---
 
 # edgar

--- a/packages/agency-lang/docs/site/stdlib/data/finance/edgar.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/edgar.md
@@ -1,6 +1,6 @@
 ---
 name: "edgar"
-description: "## SEC EDGAR — U.S. company filings"
+description: "SEC EDGAR — U.S. company filings"
 ---
 
 # edgar

--- a/packages/agency-lang/docs/site/stdlib/data/finance/fred.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/fred.md
@@ -1,5 +1,6 @@
 ---
 name: "fred"
+description: "## FRED — U.S. macroeconomic time-series"
 ---
 
 # fred

--- a/packages/agency-lang/docs/site/stdlib/data/finance/fred.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/fred.md
@@ -56,7 +56,7 @@ export type FredObservation = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L47))
 
 ### FredSeries
 
@@ -73,7 +73,7 @@ export type FredSeries = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L54))
 
 ### FredSeriesInfo
 
@@ -92,7 +92,7 @@ export type FredSeriesInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L61))
 
 ### FredUnits
 
@@ -112,7 +112,7 @@ export type FredUnits =
   | "log"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L76))
 
 ### FredFrequency
 
@@ -139,7 +139,7 @@ export type FredFrequency =
   | "wesun"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L80))
 
 ## Effects
 
@@ -151,7 +151,7 @@ effect std::fred {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L44))
 
 ## Functions
 
@@ -196,7 +196,7 @@ Fetch a U.S. macroeconomic time-series from FRED by its series id (e.g. "UNRATE"
 
 **Throws:** `std::fred`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L173))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L174))
 
 ### fredSeriesInfo
 
@@ -221,4 +221,4 @@ Fetch metadata about a FRED series by its id: its human title, display units, fr
 
 **Throws:** `std::fred`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L200))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/finance/fred.agency#L201))

--- a/packages/agency-lang/docs/site/stdlib/data/finance/fred.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/fred.md
@@ -1,6 +1,6 @@
 ---
 name: "fred"
-description: "## FRED — U.S. macroeconomic time-series"
+description: "FRED — U.S. macroeconomic time-series"
 ---
 
 # fred

--- a/packages/agency-lang/docs/site/stdlib/data/finance/gdelt.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/gdelt.md
@@ -1,6 +1,6 @@
 ---
 name: "gdelt"
-description: "## GDELT — worldwide news coverage"
+description: "GDELT — worldwide news coverage"
 ---
 
 # gdelt

--- a/packages/agency-lang/docs/site/stdlib/data/finance/gdelt.md
+++ b/packages/agency-lang/docs/site/stdlib/data/finance/gdelt.md
@@ -1,5 +1,6 @@
 ---
 name: "gdelt"
+description: "## GDELT — worldwide news coverage"
 ---
 
 # gdelt

--- a/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
+++ b/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
@@ -1,5 +1,6 @@
 ---
 name: "littlesis"
+description: "## LittleSis — people, organizations, and the ties between them"
 ---
 
 # littlesis

--- a/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
+++ b/packages/agency-lang/docs/site/stdlib/data/people/littlesis.md
@@ -1,6 +1,6 @@
 ---
 name: "littlesis"
-description: "## LittleSis — people, organizations, and the ties between them"
+description: "LittleSis — people, organizations, and the ties between them"
 ---
 
 # littlesis

--- a/packages/agency-lang/docs/site/stdlib/data/tech/hackernews.md
+++ b/packages/agency-lang/docs/site/stdlib/data/tech/hackernews.md
@@ -1,6 +1,6 @@
 ---
 name: "hackernews"
-description: "## Hacker News — front page, items, users, and search"
+description: "Hacker News — front page, items, users, and search"
 ---
 
 # hackernews

--- a/packages/agency-lang/docs/site/stdlib/data/tech/hackernews.md
+++ b/packages/agency-lang/docs/site/stdlib/data/tech/hackernews.md
@@ -1,5 +1,6 @@
 ---
 name: "hackernews"
+description: "## Hacker News — front page, items, users, and search"
 ---
 
 # hackernews

--- a/packages/agency-lang/docs/site/stdlib/data/tech/yc.md
+++ b/packages/agency-lang/docs/site/stdlib/data/tech/yc.md
@@ -1,5 +1,6 @@
 ---
 name: "yc"
+description: "## Y Combinator — the YC company directory"
 ---
 
 # yc

--- a/packages/agency-lang/docs/site/stdlib/data/tech/yc.md
+++ b/packages/agency-lang/docs/site/stdlib/data/tech/yc.md
@@ -1,6 +1,6 @@
 ---
 name: "yc"
-description: "## Y Combinator — the YC company directory"
+description: "Y Combinator — the YC company directory"
 ---
 
 # yc

--- a/packages/agency-lang/docs/site/stdlib/data/usaspending.md
+++ b/packages/agency-lang/docs/site/stdlib/data/usaspending.md
@@ -50,7 +50,7 @@ export type Award = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L47))
 
 ### Executive
 
@@ -64,7 +64,7 @@ export type Executive = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L60))
 
 ### AwardDetail
 
@@ -90,7 +90,7 @@ export type AwardDetail = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L66))
 
 ## Effects
 
@@ -103,7 +103,7 @@ effect std::usaspending {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L31))
 
 ## Functions
 
@@ -145,7 +145,7 @@ Search U.S. federal awards. Returns each award's id, recipient, amount, awarding
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L230))
 
 ### usaspendingAward
 
@@ -171,4 +171,4 @@ Fetch full detail for one federal award. Returns amount, recipient and UEI, awar
 
 **Throws:** `std::usaspending`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L252))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/data/usaspending.agency#L253))

--- a/packages/agency-lang/docs/site/stdlib/data/usaspending.md
+++ b/packages/agency-lang/docs/site/stdlib/data/usaspending.md
@@ -1,6 +1,6 @@
 ---
 name: "usaspending"
-description: "## USASpending — U.S. federal awards"
+description: "USASpending — U.S. federal awards"
 ---
 
 # usaspending

--- a/packages/agency-lang/docs/site/stdlib/data/usaspending.md
+++ b/packages/agency-lang/docs/site/stdlib/data/usaspending.md
@@ -1,5 +1,6 @@
 ---
 name: "usaspending"
+description: "## USASpending — U.S. federal awards"
 ---
 
 # usaspending

--- a/packages/agency-lang/docs/site/stdlib/data/wikidata.md
+++ b/packages/agency-lang/docs/site/stdlib/data/wikidata.md
@@ -1,5 +1,6 @@
 ---
 name: "wikidata"
+description: "## Wikidata — the open knowledge graph"
 ---
 
 # wikidata

--- a/packages/agency-lang/docs/site/stdlib/data/wikidata.md
+++ b/packages/agency-lang/docs/site/stdlib/data/wikidata.md
@@ -1,6 +1,6 @@
 ---
 name: "wikidata"
-description: "## Wikidata — the open knowledge graph"
+description: "Wikidata — the open knowledge graph"
 ---
 
 # wikidata

--- a/packages/agency-lang/docs/site/stdlib/date.md
+++ b/packages/agency-lang/docs/site/stdlib/date.md
@@ -1,6 +1,6 @@
 ---
 name: "date"
-description: "Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect."
+description: "Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect. Every function returns a string, not a Date object. Most accept an optional IANA `timezone` (e.g. America/New_York). Omit it to use your local timezone."
 ---
 
 # date
@@ -40,7 +40,7 @@ export type DayOfWeek =
   | "saturday"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L24))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L23))
 
 ## Functions
 
@@ -64,7 +64,7 @@ Get the current date and time as an ISO 8601 string with timezone offset.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L26))
 
 ### today
 
@@ -86,7 +86,7 @@ Get today's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L36))
 
 ### tomorrow
 
@@ -108,7 +108,7 @@ Get tomorrow's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L46))
 
 ### add
 
@@ -132,7 +132,7 @@ Add a duration to a datetime string. Use with unit literals: add(now(), 2h), add
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L56))
 
 ### addMinutes
 
@@ -156,7 +156,7 @@ Add minutes to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L67))
 
 ### addHours
 
@@ -180,7 +180,7 @@ Add hours to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L78))
 
 ### addDays
 
@@ -204,7 +204,7 @@ Add days to a datetime string and return the new datetime. Note: adds a fixed 24
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L89))
 
 ### nextDayOfWeek
 
@@ -228,7 +228,7 @@ Get the date of the next occurrence of a day of the week (e.g. "monday").
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L100))
 
 ### atTime
 
@@ -254,7 +254,7 @@ Combine a date (YYYY-MM-DD) and time (HH:MM) into a timezone-aware ISO 8601 stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L111))
 
 ### startOfDay
 
@@ -278,7 +278,7 @@ Get the start of the day (midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L123))
 
 ### endOfDay
 
@@ -302,7 +302,7 @@ Get the end of the day (23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L134))
 
 ### startOfWeek
 
@@ -326,7 +326,7 @@ Get the start of the current week (Sunday midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L145))
 
 ### endOfWeek
 
@@ -350,7 +350,7 @@ Get the end of the current week (Saturday 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L156))
 
 ### startOfMonth
 
@@ -374,7 +374,7 @@ Get the start of the month (1st at midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L168))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L167))
 
 ### endOfMonth
 
@@ -398,4 +398,4 @@ Get the end of the month (last day at 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L178))

--- a/packages/agency-lang/docs/site/stdlib/date.md
+++ b/packages/agency-lang/docs/site/stdlib/date.md
@@ -1,5 +1,6 @@
 ---
 name: "date"
+description: "Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect."
 ---
 
 # date
@@ -39,7 +40,7 @@ export type DayOfWeek =
   | "saturday"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L23))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L24))
 
 ## Functions
 
@@ -63,7 +64,7 @@ Get the current date and time as an ISO 8601 string with timezone offset.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L27))
 
 ### today
 
@@ -85,7 +86,7 @@ Get today's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L37))
 
 ### tomorrow
 
@@ -107,7 +108,7 @@ Get tomorrow's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L47))
 
 ### add
 
@@ -131,7 +132,7 @@ Add a duration to a datetime string. Use with unit literals: add(now(), 2h), add
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L57))
 
 ### addMinutes
 
@@ -155,7 +156,7 @@ Add minutes to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L68))
 
 ### addHours
 
@@ -179,7 +180,7 @@ Add hours to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L79))
 
 ### addDays
 
@@ -203,7 +204,7 @@ Add days to a datetime string and return the new datetime. Note: adds a fixed 24
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L90))
 
 ### nextDayOfWeek
 
@@ -227,7 +228,7 @@ Get the date of the next occurrence of a day of the week (e.g. "monday").
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L101))
 
 ### atTime
 
@@ -253,7 +254,7 @@ Combine a date (YYYY-MM-DD) and time (HH:MM) into a timezone-aware ISO 8601 stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L112))
 
 ### startOfDay
 
@@ -277,7 +278,7 @@ Get the start of the day (midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L124))
 
 ### endOfDay
 
@@ -301,7 +302,7 @@ Get the end of the day (23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L135))
 
 ### startOfWeek
 
@@ -325,7 +326,7 @@ Get the start of the current week (Sunday midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L146))
 
 ### endOfWeek
 
@@ -349,7 +350,7 @@ Get the end of the current week (Saturday 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L157))
 
 ### startOfMonth
 
@@ -373,7 +374,7 @@ Get the start of the month (1st at midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L167))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L168))
 
 ### endOfMonth
 
@@ -397,4 +398,4 @@ Get the end of the month (last day at 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L178))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L179))

--- a/packages/agency-lang/docs/site/stdlib/date.md
+++ b/packages/agency-lang/docs/site/stdlib/date.md
@@ -1,6 +1,6 @@
 ---
 name: "date"
-description: "Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect. Every function returns a string, not a Date object. Most accept an optional IANA `timezone` (e.g. America/New_York). Omit it to use your local timezone."
+description: "Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect."
 ---
 
 # date
@@ -40,7 +40,7 @@ export type DayOfWeek =
   | "saturday"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L23))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L24))
 
 ## Functions
 
@@ -64,7 +64,7 @@ Get the current date and time as an ISO 8601 string with timezone offset.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L27))
 
 ### today
 
@@ -86,7 +86,7 @@ Get today's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L37))
 
 ### tomorrow
 
@@ -108,7 +108,7 @@ Get tomorrow's date as a YYYY-MM-DD string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L47))
 
 ### add
 
@@ -132,7 +132,7 @@ Add a duration to a datetime string. Use with unit literals: add(now(), 2h), add
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L57))
 
 ### addMinutes
 
@@ -156,7 +156,7 @@ Add minutes to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L68))
 
 ### addHours
 
@@ -180,7 +180,7 @@ Add hours to a datetime string and return the new datetime.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L79))
 
 ### addDays
 
@@ -204,7 +204,7 @@ Add days to a datetime string and return the new datetime. Note: adds a fixed 24
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L90))
 
 ### nextDayOfWeek
 
@@ -228,7 +228,7 @@ Get the date of the next occurrence of a day of the week (e.g. "monday").
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L101))
 
 ### atTime
 
@@ -254,7 +254,7 @@ Combine a date (YYYY-MM-DD) and time (HH:MM) into a timezone-aware ISO 8601 stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L112))
 
 ### startOfDay
 
@@ -278,7 +278,7 @@ Get the start of the day (midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L124))
 
 ### endOfDay
 
@@ -302,7 +302,7 @@ Get the end of the day (23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L135))
 
 ### startOfWeek
 
@@ -326,7 +326,7 @@ Get the start of the current week (Sunday midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L146))
 
 ### endOfWeek
 
@@ -350,7 +350,7 @@ Get the end of the current week (Saturday 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L157))
 
 ### startOfMonth
 
@@ -374,7 +374,7 @@ Get the start of the month (1st at midnight) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L167))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L168))
 
 ### endOfMonth
 
@@ -398,4 +398,4 @@ Get the end of the month (last day at 23:59:59) as an ISO 8601 string.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L178))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/date.agency#L179))

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -1,5 +1,6 @@
 ---
 name: "fs"
+description: "Tools for editing files and managing directories: apply text edits and patches, and create, copy, move, or remove files."
 ---
 
 # fs
@@ -35,7 +36,7 @@ effect std::edit {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L35))
 
 ### std::applyPatch
 
@@ -45,7 +46,7 @@ effect std::applyPatch {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L36))
 
 ### std::mkdir
 
@@ -55,7 +56,7 @@ effect std::mkdir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L37))
 
 ### std::copy
 
@@ -66,7 +67,7 @@ effect std::copy {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L38))
 
 ### std::move
 
@@ -77,7 +78,7 @@ effect std::move {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L39))
 
 ### std::remove
 
@@ -87,7 +88,7 @@ effect std::remove {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L40))
 
 ## Functions
 
@@ -129,7 +130,7 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 
 **Throws:** `std::edit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L48))
 
 ### applyPatch
 
@@ -153,7 +154,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L81))
 
 ### mkdir
 
@@ -183,7 +184,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L97))
 
 ### copy
 
@@ -216,7 +217,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L117))
 
 ### move
 
@@ -249,7 +250,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L140))
 
 ### remove
 
@@ -279,4 +280,4 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L162))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L163))

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -1,6 +1,6 @@
 ---
 name: "fs"
-description: "Tools for editing files and managing directories: apply text edits and patches, and create, copy, move, or remove files."
+description: "Tools for editing files and managing directories: apply text edits and patches, and create, copy, move, or remove files. Every operation raises an approval interrupt before it touches the disk, so nothing is written until a handler approves it."
 ---
 
 # fs
@@ -36,7 +36,7 @@ effect std::edit {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L34))
 
 ### std::applyPatch
 
@@ -46,7 +46,7 @@ effect std::applyPatch {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L35))
 
 ### std::mkdir
 
@@ -56,7 +56,7 @@ effect std::mkdir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L36))
 
 ### std::copy
 
@@ -67,7 +67,7 @@ effect std::copy {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L37))
 
 ### std::move
 
@@ -78,7 +78,7 @@ effect std::move {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L38))
 
 ### std::remove
 
@@ -88,7 +88,7 @@ effect std::remove {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L39))
 
 ## Functions
 
@@ -130,7 +130,7 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 
 **Throws:** `std::edit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L47))
 
 ### applyPatch
 
@@ -154,7 +154,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L80))
 
 ### mkdir
 
@@ -184,7 +184,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L96))
 
 ### copy
 
@@ -217,7 +217,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L116))
 
 ### move
 
@@ -250,7 +250,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L140))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L139))
 
 ### remove
 
@@ -280,4 +280,4 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L162))

--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -1,6 +1,6 @@
 ---
 name: "fs"
-description: "Tools for editing files and managing directories: apply text edits and patches, and create, copy, move, or remove files. Every operation raises an approval interrupt before it touches the disk, so nothing is written until a handler approves it."
+description: "Tools for editing files and managing directories: apply text edits and patches, and create, copy, move, or remove files."
 ---
 
 # fs
@@ -36,7 +36,7 @@ effect std::edit {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L35))
 
 ### std::applyPatch
 
@@ -46,7 +46,7 @@ effect std::applyPatch {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L36))
 
 ### std::mkdir
 
@@ -56,7 +56,7 @@ effect std::mkdir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L37))
 
 ### std::copy
 
@@ -67,7 +67,7 @@ effect std::copy {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L38))
 
 ### std::move
 
@@ -78,7 +78,7 @@ effect std::move {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L39))
 
 ### std::remove
 
@@ -88,7 +88,7 @@ effect std::remove {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L40))
 
 ## Functions
 
@@ -130,7 +130,7 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 
 **Throws:** `std::edit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L48))
 
 ### applyPatch
 
@@ -154,7 +154,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L81))
 
 ### mkdir
 
@@ -184,7 +184,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L97))
 
 ### copy
 
@@ -217,7 +217,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L117))
 
 ### move
 
@@ -250,7 +250,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L140))
 
 ### remove
 
@@ -280,4 +280,4 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L162))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/fs.agency#L163))

--- a/packages/agency-lang/docs/site/stdlib/git.md
+++ b/packages/agency-lang/docs/site/stdlib/git.md
@@ -1,5 +1,6 @@
 ---
 name: "git"
+description: "Typed, safe git tools for agents: each tool builds its own git command, so the model never supplies a raw flag."
 ---
 
 # git
@@ -51,7 +52,7 @@ export type ChangeCode =
   | "!"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L48))
 
 ### FileStatus
 
@@ -64,7 +65,7 @@ export type FileStatus = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L49))
 
 ### GitStatus
 
@@ -78,7 +79,7 @@ export type GitStatus = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L55))
 
 ### GitCommit
 
@@ -93,7 +94,7 @@ export type GitCommit = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L62))
 
 ### GitLog
 
@@ -103,7 +104,7 @@ export type GitLog = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L70))
 
 ### FileDiff
 
@@ -116,7 +117,7 @@ export type FileDiff = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L71))
 
 ### GitDiff
 
@@ -127,7 +128,7 @@ export type GitDiff = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L76))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L77))
 
 ### GitBranch
 
@@ -140,7 +141,7 @@ export type GitBranch = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L78))
 
 ### BlameLine
 
@@ -153,7 +154,7 @@ export type BlameLine = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L84))
 
 ### GitRemote
 
@@ -165,7 +166,7 @@ export type GitRemote = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L90))
 
 ### GitStash
 
@@ -176,7 +177,7 @@ export type GitStash = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L91))
 
 ### GitRead
 
@@ -187,7 +188,7 @@ Read-only git effects, auto-approvable.
 export effectSet GitRead = <std::git::status, std::git::log, std::git::diff, std::git::show, std::git::branchList, std::git::remoteList, std::git::blame, std::git::stashList>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L117))
 
 ### GitWrite
 
@@ -198,7 +199,7 @@ Mutating git effects, should prompt.
 export effectSet GitWrite = <std::git::add, std::git::commit, std::git::checkout, std::git::switch, std::git::branchCreate, std::git::branchDelete, std::git::stashPush, std::git::stashPop, std::git::restore>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L119))
 
 ### Git
 
@@ -209,7 +210,7 @@ All git effects.
 export effectSet Git = <GitRead, GitWrite>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L121))
 
 ## Effects
 
@@ -221,7 +222,7 @@ effect std::git::status {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L97))
 
 ### std::git::log
 
@@ -233,7 +234,7 @@ effect std::git::log {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L98))
 
 ### std::git::diff
 
@@ -247,7 +248,7 @@ effect std::git::diff {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L99))
 
 ### std::git::show
 
@@ -258,7 +259,7 @@ effect std::git::show {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L100))
 
 ### std::git::branchList
 
@@ -268,7 +269,7 @@ effect std::git::branchList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L101))
 
 ### std::git::remoteList
 
@@ -278,7 +279,7 @@ effect std::git::remoteList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L102))
 
 ### std::git::blame
 
@@ -289,7 +290,7 @@ effect std::git::blame {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L103))
 
 ### std::git::stashList
 
@@ -299,7 +300,7 @@ effect std::git::stashList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L104))
 
 ### std::git::add
 
@@ -311,7 +312,7 @@ effect std::git::add {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L106))
 
 ### std::git::commit
 
@@ -322,7 +323,7 @@ effect std::git::commit {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L107))
 
 ### std::git::checkout
 
@@ -334,7 +335,7 @@ effect std::git::checkout {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L108))
 
 ### std::git::switch
 
@@ -346,7 +347,7 @@ effect std::git::switch {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L109))
 
 ### std::git::branchCreate
 
@@ -357,7 +358,7 @@ effect std::git::branchCreate {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L110))
 
 ### std::git::branchDelete
 
@@ -369,7 +370,7 @@ effect std::git::branchDelete {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L111))
 
 ### std::git::stashPush
 
@@ -380,7 +381,7 @@ effect std::git::stashPush {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L112))
 
 ### std::git::stashPop
 
@@ -390,7 +391,7 @@ effect std::git::stashPop {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L113))
 
 ### std::git::restore
 
@@ -402,7 +403,7 @@ effect std::git::restore {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L114))
 
 ## Functions
 
@@ -427,7 +428,7 @@ True when `cwd` is inside a git work tree. Never fails: a directory that is not
 
 **Throws:** `std::git::status`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L136))
 
 ### gitStatus
 
@@ -449,7 +450,7 @@ Show the working-tree status: current branch, ahead/behind counts, and
 
 **Throws:** `std::git::status`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L148))
 
 ### gitLog
 
@@ -493,7 +494,7 @@ Show commit history as structured commits.
 
 **Throws:** `std::git::log`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L161))
 
 ### gitDiff
 
@@ -534,7 +535,7 @@ Show a diff as a structured per-file summary plus the raw unified patch.
 
 **Throws:** `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L185))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L186))
 
 ### gitShow
 
@@ -558,7 +559,7 @@ Show a commit as a structured per-file summary plus the raw patch. Line
 
 **Throws:** `std::git::show`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L206))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L207))
 
 ### gitBranchList
 
@@ -579,7 +580,7 @@ List local branches with their current-marker, upstream, and sha.
 
 **Throws:** `std::git::branchList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L218))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L219))
 
 ### gitRemoteList
 
@@ -600,7 +601,7 @@ List configured remotes with their fetch/push URLs.
 
 **Throws:** `std::git::remoteList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L228))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L229))
 
 ### gitBlame
 
@@ -629,7 +630,7 @@ Show line-by-line authorship for a file.
 
 **Throws:** `std::git::blame`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L238))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L239))
 
 ### gitStashList
 
@@ -650,7 +651,7 @@ List stashes with their ref and description.
 
 **Throws:** `std::git::stashList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L250))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L251))
 
 ### gitAdd
 
@@ -686,7 +687,7 @@ Stage changes for commit.
 
 **Throws:** `std::git::add`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L265))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L266))
 
 ### gitCommit
 
@@ -709,7 +710,7 @@ Create a commit from the staged changes.
 
 **Throws:** `std::git::commit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L283))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L284))
 
 ### gitCheckout
 
@@ -740,7 +741,7 @@ Bind `force: false` via `.partial()` to forbid discarding local changes.
 
 **Throws:** `std::git::checkout`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L297))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L298))
 
 ### gitSwitch
 
@@ -769,7 +770,7 @@ Switch to a branch.
 
 **Throws:** `std::git::switch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L315))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L316))
 
 ### gitBranchCreate
 
@@ -795,7 +796,7 @@ Create a new branch at HEAD (does not switch to it).
 
 **Throws:** `std::git::branchCreate`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L329))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L330))
 
 ### gitBranchDelete
 
@@ -830,7 +831,7 @@ Guardrails: bind `force: false` and/or a `protectedBranches` list via
 
 **Throws:** `std::git::branchDelete`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L345))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L346))
 
 ### gitStashPush
 
@@ -856,7 +857,7 @@ Stash the working-tree changes.
 
 **Throws:** `std::git::stashPush`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L366))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L367))
 
 ### gitStashPop
 
@@ -877,7 +878,7 @@ Apply and drop the most recent stash.
 
 **Throws:** `std::git::stashPop`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L379))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L380))
 
 ### gitRestore
 
@@ -912,4 +913,4 @@ Restore files to a previous state.
 
 **Throws:** `std::git::restore`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L393))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L394))

--- a/packages/agency-lang/docs/site/stdlib/git.md
+++ b/packages/agency-lang/docs/site/stdlib/git.md
@@ -1,6 +1,6 @@
 ---
 name: "git"
-description: "Typed, safe git tools for agents: each tool builds its own git command, so the model never supplies a raw flag."
+description: "Typed, safe git tools for agents. Each tool builds its own git command internally, so the model never supplies a raw flag. Read tools (status, log, diff, ...) raise effects an agent policy can auto-approve. Write tools (add, commit, checkout, ...) prompt for approval. Tighten any tool before handing it to an agent with `.partial()`, e.g. `gitAdd.partial(all: false, allowedPaths: [src/])` or `gitBranchDelete.partial(force: false, protectedBranches: [main])`."
 ---
 
 # git
@@ -52,7 +52,7 @@ export type ChangeCode =
   | "!"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L47))
 
 ### FileStatus
 
@@ -65,7 +65,7 @@ export type FileStatus = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L48))
 
 ### GitStatus
 
@@ -79,7 +79,7 @@ export type GitStatus = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L54))
 
 ### GitCommit
 
@@ -94,7 +94,7 @@ export type GitCommit = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L61))
 
 ### GitLog
 
@@ -104,7 +104,7 @@ export type GitLog = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L69))
 
 ### FileDiff
 
@@ -117,7 +117,7 @@ export type FileDiff = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L71))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L70))
 
 ### GitDiff
 
@@ -128,7 +128,7 @@ export type GitDiff = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L76))
 
 ### GitBranch
 
@@ -141,7 +141,7 @@ export type GitBranch = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L77))
 
 ### BlameLine
 
@@ -154,7 +154,7 @@ export type BlameLine = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L84))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L83))
 
 ### GitRemote
 
@@ -166,7 +166,7 @@ export type GitRemote = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L89))
 
 ### GitStash
 
@@ -177,7 +177,7 @@ export type GitStash = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L91))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L90))
 
 ### GitRead
 
@@ -188,7 +188,7 @@ Read-only git effects, auto-approvable.
 export effectSet GitRead = <std::git::status, std::git::log, std::git::diff, std::git::show, std::git::branchList, std::git::remoteList, std::git::blame, std::git::stashList>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L116))
 
 ### GitWrite
 
@@ -199,7 +199,7 @@ Mutating git effects, should prompt.
 export effectSet GitWrite = <std::git::add, std::git::commit, std::git::checkout, std::git::switch, std::git::branchCreate, std::git::branchDelete, std::git::stashPush, std::git::stashPop, std::git::restore>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L118))
 
 ### Git
 
@@ -210,7 +210,7 @@ All git effects.
 export effectSet Git = <GitRead, GitWrite>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L120))
 
 ## Effects
 
@@ -222,7 +222,7 @@ effect std::git::status {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L96))
 
 ### std::git::log
 
@@ -234,7 +234,7 @@ effect std::git::log {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L97))
 
 ### std::git::diff
 
@@ -248,7 +248,7 @@ effect std::git::diff {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L98))
 
 ### std::git::show
 
@@ -259,7 +259,7 @@ effect std::git::show {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L99))
 
 ### std::git::branchList
 
@@ -269,7 +269,7 @@ effect std::git::branchList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L100))
 
 ### std::git::remoteList
 
@@ -279,7 +279,7 @@ effect std::git::remoteList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L101))
 
 ### std::git::blame
 
@@ -290,7 +290,7 @@ effect std::git::blame {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L102))
 
 ### std::git::stashList
 
@@ -300,7 +300,7 @@ effect std::git::stashList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L103))
 
 ### std::git::add
 
@@ -312,7 +312,7 @@ effect std::git::add {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L105))
 
 ### std::git::commit
 
@@ -323,7 +323,7 @@ effect std::git::commit {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L106))
 
 ### std::git::checkout
 
@@ -335,7 +335,7 @@ effect std::git::checkout {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L107))
 
 ### std::git::switch
 
@@ -347,7 +347,7 @@ effect std::git::switch {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L108))
 
 ### std::git::branchCreate
 
@@ -358,7 +358,7 @@ effect std::git::branchCreate {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L109))
 
 ### std::git::branchDelete
 
@@ -370,7 +370,7 @@ effect std::git::branchDelete {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L110))
 
 ### std::git::stashPush
 
@@ -381,7 +381,7 @@ effect std::git::stashPush {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L111))
 
 ### std::git::stashPop
 
@@ -391,7 +391,7 @@ effect std::git::stashPop {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L112))
 
 ### std::git::restore
 
@@ -403,7 +403,7 @@ effect std::git::restore {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L114))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L113))
 
 ## Functions
 
@@ -428,7 +428,7 @@ True when `cwd` is inside a git work tree. Never fails: a directory that is not
 
 **Throws:** `std::git::status`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L136))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L135))
 
 ### gitStatus
 
@@ -450,7 +450,7 @@ Show the working-tree status: current branch, ahead/behind counts, and
 
 **Throws:** `std::git::status`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L147))
 
 ### gitLog
 
@@ -494,7 +494,7 @@ Show commit history as structured commits.
 
 **Throws:** `std::git::log`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L161))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L160))
 
 ### gitDiff
 
@@ -535,7 +535,7 @@ Show a diff as a structured per-file summary plus the raw unified patch.
 
 **Throws:** `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L185))
 
 ### gitShow
 
@@ -559,7 +559,7 @@ Show a commit as a structured per-file summary plus the raw patch. Line
 
 **Throws:** `std::git::show`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L207))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L206))
 
 ### gitBranchList
 
@@ -580,7 +580,7 @@ List local branches with their current-marker, upstream, and sha.
 
 **Throws:** `std::git::branchList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L219))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L218))
 
 ### gitRemoteList
 
@@ -601,7 +601,7 @@ List configured remotes with their fetch/push URLs.
 
 **Throws:** `std::git::remoteList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L229))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L228))
 
 ### gitBlame
 
@@ -630,7 +630,7 @@ Show line-by-line authorship for a file.
 
 **Throws:** `std::git::blame`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L239))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L238))
 
 ### gitStashList
 
@@ -651,7 +651,7 @@ List stashes with their ref and description.
 
 **Throws:** `std::git::stashList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L251))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L250))
 
 ### gitAdd
 
@@ -687,7 +687,7 @@ Stage changes for commit.
 
 **Throws:** `std::git::add`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L266))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L265))
 
 ### gitCommit
 
@@ -710,7 +710,7 @@ Create a commit from the staged changes.
 
 **Throws:** `std::git::commit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L284))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L283))
 
 ### gitCheckout
 
@@ -741,7 +741,7 @@ Bind `force: false` via `.partial()` to forbid discarding local changes.
 
 **Throws:** `std::git::checkout`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L298))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L297))
 
 ### gitSwitch
 
@@ -770,7 +770,7 @@ Switch to a branch.
 
 **Throws:** `std::git::switch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L316))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L315))
 
 ### gitBranchCreate
 
@@ -796,7 +796,7 @@ Create a new branch at HEAD (does not switch to it).
 
 **Throws:** `std::git::branchCreate`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L330))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L329))
 
 ### gitBranchDelete
 
@@ -831,7 +831,7 @@ Guardrails: bind `force: false` and/or a `protectedBranches` list via
 
 **Throws:** `std::git::branchDelete`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L346))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L345))
 
 ### gitStashPush
 
@@ -857,7 +857,7 @@ Stash the working-tree changes.
 
 **Throws:** `std::git::stashPush`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L367))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L366))
 
 ### gitStashPop
 
@@ -878,7 +878,7 @@ Apply and drop the most recent stash.
 
 **Throws:** `std::git::stashPop`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L380))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L379))
 
 ### gitRestore
 
@@ -913,4 +913,4 @@ Restore files to a previous state.
 
 **Throws:** `std::git::restore`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L394))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L393))

--- a/packages/agency-lang/docs/site/stdlib/git.md
+++ b/packages/agency-lang/docs/site/stdlib/git.md
@@ -1,6 +1,6 @@
 ---
 name: "git"
-description: "Typed, safe git tools for agents. Each tool builds its own git command internally, so the model never supplies a raw flag. Read tools (status, log, diff, ...) raise effects an agent policy can auto-approve. Write tools (add, commit, checkout, ...) prompt for approval. Tighten any tool before handing it to an agent with `.partial()`, e.g. `gitAdd.partial(all: false, allowedPaths: [src/])` or `gitBranchDelete.partial(force: false, protectedBranches: [main])`."
+description: "Typed, safe git tools for agents: each tool builds its own git command, so the model never supplies a raw flag."
 ---
 
 # git
@@ -52,7 +52,7 @@ export type ChangeCode =
   | "!"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L48))
 
 ### FileStatus
 
@@ -65,7 +65,7 @@ export type FileStatus = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L49))
 
 ### GitStatus
 
@@ -79,7 +79,7 @@ export type GitStatus = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L55))
 
 ### GitCommit
 
@@ -94,7 +94,7 @@ export type GitCommit = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L62))
 
 ### GitLog
 
@@ -104,7 +104,7 @@ export type GitLog = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L70))
 
 ### FileDiff
 
@@ -117,7 +117,7 @@ export type FileDiff = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L71))
 
 ### GitDiff
 
@@ -128,7 +128,7 @@ export type GitDiff = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L76))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L77))
 
 ### GitBranch
 
@@ -141,7 +141,7 @@ export type GitBranch = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L78))
 
 ### BlameLine
 
@@ -154,7 +154,7 @@ export type BlameLine = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L84))
 
 ### GitRemote
 
@@ -166,7 +166,7 @@ export type GitRemote = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L90))
 
 ### GitStash
 
@@ -177,7 +177,7 @@ export type GitStash = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L91))
 
 ### GitRead
 
@@ -188,7 +188,7 @@ Read-only git effects, auto-approvable.
 export effectSet GitRead = <std::git::status, std::git::log, std::git::diff, std::git::show, std::git::branchList, std::git::remoteList, std::git::blame, std::git::stashList>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L117))
 
 ### GitWrite
 
@@ -199,7 +199,7 @@ Mutating git effects, should prompt.
 export effectSet GitWrite = <std::git::add, std::git::commit, std::git::checkout, std::git::switch, std::git::branchCreate, std::git::branchDelete, std::git::stashPush, std::git::stashPop, std::git::restore>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L119))
 
 ### Git
 
@@ -210,7 +210,7 @@ All git effects.
 export effectSet Git = <GitRead, GitWrite>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L121))
 
 ## Effects
 
@@ -222,7 +222,7 @@ effect std::git::status {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L97))
 
 ### std::git::log
 
@@ -234,7 +234,7 @@ effect std::git::log {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L98))
 
 ### std::git::diff
 
@@ -248,7 +248,7 @@ effect std::git::diff {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L99))
 
 ### std::git::show
 
@@ -259,7 +259,7 @@ effect std::git::show {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L100))
 
 ### std::git::branchList
 
@@ -269,7 +269,7 @@ effect std::git::branchList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L101))
 
 ### std::git::remoteList
 
@@ -279,7 +279,7 @@ effect std::git::remoteList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L102))
 
 ### std::git::blame
 
@@ -290,7 +290,7 @@ effect std::git::blame {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L103))
 
 ### std::git::stashList
 
@@ -300,7 +300,7 @@ effect std::git::stashList {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L104))
 
 ### std::git::add
 
@@ -312,7 +312,7 @@ effect std::git::add {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L106))
 
 ### std::git::commit
 
@@ -323,7 +323,7 @@ effect std::git::commit {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L107))
 
 ### std::git::checkout
 
@@ -335,7 +335,7 @@ effect std::git::checkout {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L108))
 
 ### std::git::switch
 
@@ -347,7 +347,7 @@ effect std::git::switch {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L109))
 
 ### std::git::branchCreate
 
@@ -358,7 +358,7 @@ effect std::git::branchCreate {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L110))
 
 ### std::git::branchDelete
 
@@ -370,7 +370,7 @@ effect std::git::branchDelete {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L110))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L111))
 
 ### std::git::stashPush
 
@@ -381,7 +381,7 @@ effect std::git::stashPush {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L112))
 
 ### std::git::stashPop
 
@@ -391,7 +391,7 @@ effect std::git::stashPop {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L113))
 
 ### std::git::restore
 
@@ -403,7 +403,7 @@ effect std::git::restore {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L114))
 
 ## Functions
 
@@ -428,7 +428,7 @@ True when `cwd` is inside a git work tree. Never fails: a directory that is not
 
 **Throws:** `std::git::status`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L135))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L136))
 
 ### gitStatus
 
@@ -450,7 +450,7 @@ Show the working-tree status: current branch, ahead/behind counts, and
 
 **Throws:** `std::git::status`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L148))
 
 ### gitLog
 
@@ -494,7 +494,7 @@ Show commit history as structured commits.
 
 **Throws:** `std::git::log`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L161))
 
 ### gitDiff
 
@@ -535,7 +535,7 @@ Show a diff as a structured per-file summary plus the raw unified patch.
 
 **Throws:** `std::git::diff`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L185))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L186))
 
 ### gitShow
 
@@ -559,7 +559,7 @@ Show a commit as a structured per-file summary plus the raw patch. Line
 
 **Throws:** `std::git::show`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L206))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L207))
 
 ### gitBranchList
 
@@ -580,7 +580,7 @@ List local branches with their current-marker, upstream, and sha.
 
 **Throws:** `std::git::branchList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L218))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L219))
 
 ### gitRemoteList
 
@@ -601,7 +601,7 @@ List configured remotes with their fetch/push URLs.
 
 **Throws:** `std::git::remoteList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L228))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L229))
 
 ### gitBlame
 
@@ -630,7 +630,7 @@ Show line-by-line authorship for a file.
 
 **Throws:** `std::git::blame`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L238))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L239))
 
 ### gitStashList
 
@@ -651,7 +651,7 @@ List stashes with their ref and description.
 
 **Throws:** `std::git::stashList`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L250))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L251))
 
 ### gitAdd
 
@@ -687,7 +687,7 @@ Stage changes for commit.
 
 **Throws:** `std::git::add`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L265))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L266))
 
 ### gitCommit
 
@@ -710,7 +710,7 @@ Create a commit from the staged changes.
 
 **Throws:** `std::git::commit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L283))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L284))
 
 ### gitCheckout
 
@@ -741,7 +741,7 @@ Bind `force: false` via `.partial()` to forbid discarding local changes.
 
 **Throws:** `std::git::checkout`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L297))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L298))
 
 ### gitSwitch
 
@@ -770,7 +770,7 @@ Switch to a branch.
 
 **Throws:** `std::git::switch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L315))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L316))
 
 ### gitBranchCreate
 
@@ -796,7 +796,7 @@ Create a new branch at HEAD (does not switch to it).
 
 **Throws:** `std::git::branchCreate`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L329))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L330))
 
 ### gitBranchDelete
 
@@ -831,7 +831,7 @@ Guardrails: bind `force: false` and/or a `protectedBranches` list via
 
 **Throws:** `std::git::branchDelete`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L345))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L346))
 
 ### gitStashPush
 
@@ -857,7 +857,7 @@ Stash the working-tree changes.
 
 **Throws:** `std::git::stashPush`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L366))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L367))
 
 ### gitStashPop
 
@@ -878,7 +878,7 @@ Apply and drop the most recent stash.
 
 **Throws:** `std::git::stashPop`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L379))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L380))
 
 ### gitRestore
 
@@ -913,4 +913,4 @@ Restore files to a previous state.
 
 **Throws:** `std::git::restore`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L393))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/git.agency#L394))

--- a/packages/agency-lang/docs/site/stdlib/http.md
+++ b/packages/agency-lang/docs/site/stdlib/http.md
@@ -1,5 +1,6 @@
 ---
 name: "http"
+description: "Fetch URLs from Agency code. Returns the response as text, JSON, or Markdown. Aborting tears down the in-flight request."
 ---
 
 # http

--- a/packages/agency-lang/docs/site/stdlib/http.md
+++ b/packages/agency-lang/docs/site/stdlib/http.md
@@ -1,6 +1,6 @@
 ---
 name: "http"
-description: "Fetch URLs from Agency code. Returns the response as text, JSON, or Markdown. Aborting tears down the in-flight request."
+description: "Fetch URLs from Agency code."
 ---
 
 # http

--- a/packages/agency-lang/docs/site/stdlib/image.md
+++ b/packages/agency-lang/docs/site/stdlib/image.md
@@ -1,5 +1,6 @@
 ---
 name: "image"
+description: "Generate images from a text prompt (or edit input images) using a hosted provider, returning base64 you can persist."
 ---
 
 # image
@@ -64,4 +65,4 @@ Generate an image from a text prompt using a hosted provider, optionally
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/image.agency#L19))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/image.agency#L21))

--- a/packages/agency-lang/docs/site/stdlib/image.md
+++ b/packages/agency-lang/docs/site/stdlib/image.md
@@ -1,6 +1,6 @@
 ---
 name: "image"
-description: "Generate images from a text prompt (or edit input images) using a hosted provider, returning base64 you can persist."
+description: "Generate images from a text prompt (or edit input images) using a hosted provider (OpenAI, Google, or an open-source model via LiteLLM / Together). Returns base64 you can persist with `writeBinary()` or send onward with `std::thread`'s `image(...)`."
 ---
 
 # image
@@ -65,4 +65,4 @@ Generate an image from a text prompt using a hosted provider, optionally
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/image.agency#L21))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/image.agency#L19))

--- a/packages/agency-lang/docs/site/stdlib/image.md
+++ b/packages/agency-lang/docs/site/stdlib/image.md
@@ -1,6 +1,6 @@
 ---
 name: "image"
-description: "Generate images from a text prompt (or edit input images) using a hosted provider (OpenAI, Google, or an open-source model via LiteLLM / Together). Returns base64 you can persist with `writeBinary()` or send onward with `std::thread`'s `image(...)`."
+description: "Generate images from a text prompt (or edit input images) using a hosted provider, returning base64 you can persist."
 ---
 
 # image
@@ -65,4 +65,4 @@ Generate an image from a text prompt using a hosted provider, optionally
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/image.agency#L19))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/image.agency#L21))

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -1,5 +1,6 @@
 ---
 name: "index"
+description: "The always-available prelude: printing, input, file I/O, and the array helpers. Every `.agency` file auto-imports these, so you can call them without an import."
 ---
 
 # index

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -1,6 +1,6 @@
 ---
 name: "index"
-description: "The always-available prelude: printing, input, file I/O, and the array helpers. Every `.agency` file auto-imports these, so you can call them without an import."
+description: "The always-available prelude: printing, input, file I/O, and the array helpers."
 ---
 
 # index

--- a/packages/agency-lang/docs/site/stdlib/llm.md
+++ b/packages/agency-lang/docs/site/stdlib/llm.md
@@ -1,5 +1,6 @@
 ---
 name: "llm"
+description: "Choose which model and options your `llm()` calls use at runtime."
 ---
 
 # llm

--- a/packages/agency-lang/docs/site/stdlib/markdown.md
+++ b/packages/agency-lang/docs/site/stdlib/markdown.md
@@ -1,5 +1,6 @@
 ---
 name: "markdown"
+description: "Parse Markdown text into a structured AST you can walk, and render Markdown for the terminal or HTML."
 ---
 
 # markdown
@@ -35,7 +36,7 @@ export type InlineText = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L36))
 
 ### InlineSoftBreak
 
@@ -48,7 +49,7 @@ export type InlineSoftBreak = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L42))
 
 ### InlineHardBreak
 
@@ -61,7 +62,7 @@ export type InlineHardBreak = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L47))
 
 ### InlineBold
 
@@ -75,7 +76,7 @@ export type InlineBold = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L52))
 
 ### InlineItalic
 
@@ -89,7 +90,7 @@ export type InlineItalic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L58))
 
 ### InlineBoldItalic
 
@@ -103,7 +104,7 @@ export type InlineBoldItalic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L64))
 
 ### InlineStrike
 
@@ -117,7 +118,7 @@ export type InlineStrike = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L70))
 
 ### InlineCode
 
@@ -131,7 +132,7 @@ export type InlineCode = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L76))
 
 ### InlineLink
 
@@ -147,7 +148,7 @@ export type InlineLink = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L82))
 
 ### Image
 
@@ -163,7 +164,7 @@ export type Image = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L90))
 
 ### InlineRefLink
 
@@ -178,7 +179,7 @@ export type InlineRefLink = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L98))
 
 ### InlineRefImage
 
@@ -193,7 +194,7 @@ export type InlineRefImage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L105))
 
 ### InlineFootnoteRef
 
@@ -210,7 +211,7 @@ export type InlineFootnoteRef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L113))
 
 ### InlineHTML
 
@@ -224,7 +225,7 @@ export type InlineHTML = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L120))
 
 ### Paragraph
 
@@ -238,7 +239,7 @@ export type Paragraph = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L128))
 
 ### Heading
 
@@ -253,7 +254,7 @@ export type Heading = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L134))
 
 ### CodeBlock
 
@@ -270,7 +271,7 @@ export type CodeBlock = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L141))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L142))
 
 ### BlockQuote
 
@@ -286,7 +287,7 @@ export type BlockQuote = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L150))
 
 ### ListItem
 
@@ -308,7 +309,7 @@ export type ListItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L159))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L160))
 
 ### List
 
@@ -326,7 +327,7 @@ export type List = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L167))
 
 ### HorizontalRule
 
@@ -339,7 +340,7 @@ export type HorizontalRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L174))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L175))
 
 ### Alignment
 
@@ -352,7 +353,7 @@ Per-column alignment for a Markdown table. `null` means no explicit
 export type Alignment = "left" | "right" | "center" | null
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L180))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L181))
 
 ### Table
 
@@ -368,7 +369,7 @@ export type Table = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L184))
 
 ### LinkDef
 
@@ -386,7 +387,7 @@ export type LinkDef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L193))
 
 ### FootnoteDef
 
@@ -401,7 +402,7 @@ export type FootnoteDef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L200))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L201))
 
 ### HTMLBlock
 
@@ -415,7 +416,7 @@ export type HTMLBlock = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L207))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L208))
 
 ### Frontmatter
 
@@ -433,7 +434,7 @@ export type Frontmatter = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L215))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L216))
 
 ### ParseResult
 
@@ -453,7 +454,7 @@ export type ParseResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L224))
 
 ## Functions
 
@@ -478,7 +479,7 @@ Parse a Markdown string into a structured AST. On success, `blocks` holds
 
 **Returns:** [ParseResult](#parseresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L230))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L231))
 
 ### frontmatter
 
@@ -502,7 +503,7 @@ Composes well with the pipe operator, e.g. `read(filename, dir) |> frontmatter`.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L243))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L244))
 
 ### walk
 
@@ -539,7 +540,7 @@ Typically used with the trailing-block syntax:
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L275))
 
 ### renderForCli
 
@@ -564,7 +565,7 @@ Code-block bodies are emitted verbatim. Pre-process them with `walk` to add
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L289))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L290))
 
 ### renderForHtml
 
@@ -601,4 +602,4 @@ Unlike [renderForCli](#renderforcli), this renderer treats the AST as
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L315))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L316))

--- a/packages/agency-lang/docs/site/stdlib/markdown.md
+++ b/packages/agency-lang/docs/site/stdlib/markdown.md
@@ -1,6 +1,6 @@
 ---
 name: "markdown"
-description: "Parse Markdown text into a structured AST you can walk, and render Markdown for the terminal or HTML."
+description: "Parse Markdown text into a structured AST you can walk. The returned `blocks` array holds block-level nodes like `Paragraph`, `Heading`, `CodeBlock`, `List`, `Table`, and `BlockQuote`. Each is tagged with a `type` field to switch on."
 ---
 
 # markdown
@@ -36,7 +36,7 @@ export type InlineText = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L35))
 
 ### InlineSoftBreak
 
@@ -49,7 +49,7 @@ export type InlineSoftBreak = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L41))
 
 ### InlineHardBreak
 
@@ -62,7 +62,7 @@ export type InlineHardBreak = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L46))
 
 ### InlineBold
 
@@ -76,7 +76,7 @@ export type InlineBold = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L51))
 
 ### InlineItalic
 
@@ -90,7 +90,7 @@ export type InlineItalic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L57))
 
 ### InlineBoldItalic
 
@@ -104,7 +104,7 @@ export type InlineBoldItalic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L63))
 
 ### InlineStrike
 
@@ -118,7 +118,7 @@ export type InlineStrike = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L69))
 
 ### InlineCode
 
@@ -132,7 +132,7 @@ export type InlineCode = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L76))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L75))
 
 ### InlineLink
 
@@ -148,7 +148,7 @@ export type InlineLink = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L81))
 
 ### Image
 
@@ -164,7 +164,7 @@ export type Image = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L89))
 
 ### InlineRefLink
 
@@ -179,7 +179,7 @@ export type InlineRefLink = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L97))
 
 ### InlineRefImage
 
@@ -194,7 +194,7 @@ export type InlineRefImage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L104))
 
 ### InlineFootnoteRef
 
@@ -211,7 +211,7 @@ export type InlineFootnoteRef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L113))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L112))
 
 ### InlineHTML
 
@@ -225,7 +225,7 @@ export type InlineHTML = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L119))
 
 ### Paragraph
 
@@ -239,7 +239,7 @@ export type Paragraph = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L128))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L127))
 
 ### Heading
 
@@ -254,7 +254,7 @@ export type Heading = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L133))
 
 ### CodeBlock
 
@@ -271,7 +271,7 @@ export type CodeBlock = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L142))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L141))
 
 ### BlockQuote
 
@@ -287,7 +287,7 @@ export type BlockQuote = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L149))
 
 ### ListItem
 
@@ -309,7 +309,7 @@ export type ListItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L159))
 
 ### List
 
@@ -327,7 +327,7 @@ export type List = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L167))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L166))
 
 ### HorizontalRule
 
@@ -340,7 +340,7 @@ export type HorizontalRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L175))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L174))
 
 ### Alignment
 
@@ -353,7 +353,7 @@ Per-column alignment for a Markdown table. `null` means no explicit
 export type Alignment = "left" | "right" | "center" | null
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L181))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L180))
 
 ### Table
 
@@ -369,7 +369,7 @@ export type Table = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L184))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L183))
 
 ### LinkDef
 
@@ -387,7 +387,7 @@ export type LinkDef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L193))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L192))
 
 ### FootnoteDef
 
@@ -402,7 +402,7 @@ export type FootnoteDef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L201))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L200))
 
 ### HTMLBlock
 
@@ -416,7 +416,7 @@ export type HTMLBlock = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L208))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L207))
 
 ### Frontmatter
 
@@ -434,7 +434,7 @@ export type Frontmatter = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L216))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L215))
 
 ### ParseResult
 
@@ -454,7 +454,7 @@ export type ParseResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L224))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L223))
 
 ## Functions
 
@@ -479,7 +479,7 @@ Parse a Markdown string into a structured AST. On success, `blocks` holds
 
 **Returns:** [ParseResult](#parseresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L231))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L230))
 
 ### frontmatter
 
@@ -503,7 +503,7 @@ Composes well with the pipe operator, e.g. `read(filename, dir) |> frontmatter`.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L244))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L243))
 
 ### walk
 
@@ -540,7 +540,7 @@ Typically used with the trailing-block syntax:
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L275))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L274))
 
 ### renderForCli
 
@@ -565,7 +565,7 @@ Code-block bodies are emitted verbatim. Pre-process them with `walk` to add
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L290))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L289))
 
 ### renderForHtml
 
@@ -602,4 +602,4 @@ Unlike [renderForCli](#renderforcli), this renderer treats the AST as
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L316))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L315))

--- a/packages/agency-lang/docs/site/stdlib/markdown.md
+++ b/packages/agency-lang/docs/site/stdlib/markdown.md
@@ -1,6 +1,6 @@
 ---
 name: "markdown"
-description: "Parse Markdown text into a structured AST you can walk. The returned `blocks` array holds block-level nodes like `Paragraph`, `Heading`, `CodeBlock`, `List`, `Table`, and `BlockQuote`. Each is tagged with a `type` field to switch on."
+description: "Parse Markdown text into a structured AST you can walk, and render Markdown for the terminal or HTML."
 ---
 
 # markdown
@@ -36,7 +36,7 @@ export type InlineText = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L36))
 
 ### InlineSoftBreak
 
@@ -49,7 +49,7 @@ export type InlineSoftBreak = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L42))
 
 ### InlineHardBreak
 
@@ -62,7 +62,7 @@ export type InlineHardBreak = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L47))
 
 ### InlineBold
 
@@ -76,7 +76,7 @@ export type InlineBold = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L52))
 
 ### InlineItalic
 
@@ -90,7 +90,7 @@ export type InlineItalic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L58))
 
 ### InlineBoldItalic
 
@@ -104,7 +104,7 @@ export type InlineBoldItalic = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L64))
 
 ### InlineStrike
 
@@ -118,7 +118,7 @@ export type InlineStrike = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L70))
 
 ### InlineCode
 
@@ -132,7 +132,7 @@ export type InlineCode = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L76))
 
 ### InlineLink
 
@@ -148,7 +148,7 @@ export type InlineLink = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L82))
 
 ### Image
 
@@ -164,7 +164,7 @@ export type Image = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L90))
 
 ### InlineRefLink
 
@@ -179,7 +179,7 @@ export type InlineRefLink = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L98))
 
 ### InlineRefImage
 
@@ -194,7 +194,7 @@ export type InlineRefImage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L105))
 
 ### InlineFootnoteRef
 
@@ -211,7 +211,7 @@ export type InlineFootnoteRef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L113))
 
 ### InlineHTML
 
@@ -225,7 +225,7 @@ export type InlineHTML = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L120))
 
 ### Paragraph
 
@@ -239,7 +239,7 @@ export type Paragraph = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L128))
 
 ### Heading
 
@@ -254,7 +254,7 @@ export type Heading = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L134))
 
 ### CodeBlock
 
@@ -271,7 +271,7 @@ export type CodeBlock = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L141))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L142))
 
 ### BlockQuote
 
@@ -287,7 +287,7 @@ export type BlockQuote = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L150))
 
 ### ListItem
 
@@ -309,7 +309,7 @@ export type ListItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L159))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L160))
 
 ### List
 
@@ -327,7 +327,7 @@ export type List = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L167))
 
 ### HorizontalRule
 
@@ -340,7 +340,7 @@ export type HorizontalRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L174))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L175))
 
 ### Alignment
 
@@ -353,7 +353,7 @@ Per-column alignment for a Markdown table. `null` means no explicit
 export type Alignment = "left" | "right" | "center" | null
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L180))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L181))
 
 ### Table
 
@@ -369,7 +369,7 @@ export type Table = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L184))
 
 ### LinkDef
 
@@ -387,7 +387,7 @@ export type LinkDef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L193))
 
 ### FootnoteDef
 
@@ -402,7 +402,7 @@ export type FootnoteDef = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L200))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L201))
 
 ### HTMLBlock
 
@@ -416,7 +416,7 @@ export type HTMLBlock = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L207))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L208))
 
 ### Frontmatter
 
@@ -434,7 +434,7 @@ export type Frontmatter = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L215))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L216))
 
 ### ParseResult
 
@@ -454,7 +454,7 @@ export type ParseResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L224))
 
 ## Functions
 
@@ -479,7 +479,7 @@ Parse a Markdown string into a structured AST. On success, `blocks` holds
 
 **Returns:** [ParseResult](#parseresult)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L230))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L231))
 
 ### frontmatter
 
@@ -503,7 +503,7 @@ Composes well with the pipe operator, e.g. `read(filename, dir) |> frontmatter`.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L243))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L244))
 
 ### walk
 
@@ -540,7 +540,7 @@ Typically used with the trailing-block syntax:
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L274))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L275))
 
 ### renderForCli
 
@@ -565,7 +565,7 @@ Code-block bodies are emitted verbatim. Pre-process them with `walk` to add
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L289))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L290))
 
 ### renderForHtml
 
@@ -602,4 +602,4 @@ Unlike [renderForCli](#renderforcli), this renderer treats the AST as
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L315))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/markdown.agency#L316))

--- a/packages/agency-lang/docs/site/stdlib/math.md
+++ b/packages/agency-lang/docs/site/stdlib/math.md
@@ -1,5 +1,6 @@
 ---
 name: "math"
+description: "Small deterministic arithmetic helpers: round, add, subtract, multiply, and a divide that returns a Result so you can handle division by zero."
 ---
 
 # math

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -1,6 +1,6 @@
 ---
 name: "memory"
-description: "Give an agent long-term memory: remember extracts and saves facts to a knowledge graph, and recall retrieves them later."
+description: "Give an agent long-term memory. `remember` extracts facts from text and saves them to a knowledge graph, and `recall` retrieves the relevant ones later. Memory is off until you turn it on with `enableMemory`, and it stays local to the current branch."
 ---
 
 # memory
@@ -38,7 +38,7 @@ export type MemoryConfig = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L62))
 
 ## Effects
 
@@ -50,7 +50,7 @@ effect std::memory::enableMemory {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L71))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L70))
 
 ### std::memory::disableMemory
 
@@ -58,7 +58,7 @@ effect std::memory::enableMemory {
 effect std::memory::disableMemory {}
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L71))
 
 ### std::memory::remember
 
@@ -68,7 +68,7 @@ effect std::memory::remember {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L72))
 
 ### std::memory::recall
 
@@ -78,7 +78,7 @@ effect std::memory::recall {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L73))
 
 ### std::memory::forget
 
@@ -88,7 +88,7 @@ effect std::memory::forget {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L74))
 
 ## Functions
 
@@ -108,7 +108,7 @@ Useful for branching in user code (`if (isMemoryActive()) { ... }`)
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L80))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L79))
 
 ### setMemoryId
 
@@ -135,7 +135,7 @@ The id is independent of which memory configuration is active. It
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L93))
 
 ### getMemoryId
 
@@ -150,7 +150,7 @@ Return the current memory scope id, or "default" if it was never set
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L105))
 
 ### enableMemory
 
@@ -187,7 +187,7 @@ Storage is shared process-wide by absolute directory, so calls
 
 **Throws:** `std::memory::enableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L129))
 
 ### disableMemory
 
@@ -207,7 +207,7 @@ Removes whatever memory configuration is on top, including a bottom
 
 **Throws:** `std::memory::disableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L151))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L150))
 
 ### memory
 
@@ -237,7 +237,7 @@ Run `block` with `config` as the active memory configuration, then
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L161))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L160))
 
 ### remember
 
@@ -258,7 +258,7 @@ Extract structured facts (entities, observations, and relations) from
 
 **Throws:** `std::memory::remember`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L184))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L183))
 
 ### recall
 
@@ -285,7 +285,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Throws:** `std::memory::recall`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L214))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L213))
 
 ### forget
 
@@ -307,4 +307,4 @@ Soft-delete facts matching the query from the knowledge graph. Data is
 
 **Throws:** `std::memory::forget`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L232))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L231))

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -1,6 +1,6 @@
 ---
 name: "memory"
-description: "Give an agent long-term memory. `remember` extracts facts from text and saves them to a knowledge graph, and `recall` retrieves the relevant ones later. Memory is off until you turn it on with `enableMemory`, and it stays local to the current branch."
+description: "Give an agent long-term memory: remember extracts and saves facts to a knowledge graph, and recall retrieves them later."
 ---
 
 # memory
@@ -38,7 +38,7 @@ export type MemoryConfig = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L63))
 
 ## Effects
 
@@ -50,7 +50,7 @@ effect std::memory::enableMemory {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L71))
 
 ### std::memory::disableMemory
 
@@ -58,7 +58,7 @@ effect std::memory::enableMemory {
 effect std::memory::disableMemory {}
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L71))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L72))
 
 ### std::memory::remember
 
@@ -68,7 +68,7 @@ effect std::memory::remember {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L73))
 
 ### std::memory::recall
 
@@ -78,7 +78,7 @@ effect std::memory::recall {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L74))
 
 ### std::memory::forget
 
@@ -88,7 +88,7 @@ effect std::memory::forget {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L75))
 
 ## Functions
 
@@ -108,7 +108,7 @@ Useful for branching in user code (`if (isMemoryActive()) { ... }`)
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L80))
 
 ### setMemoryId
 
@@ -135,7 +135,7 @@ The id is independent of which memory configuration is active. It
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L93))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L94))
 
 ### getMemoryId
 
@@ -150,7 +150,7 @@ Return the current memory scope id, or "default" if it was never set
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L106))
 
 ### enableMemory
 
@@ -187,7 +187,7 @@ Storage is shared process-wide by absolute directory, so calls
 
 **Throws:** `std::memory::enableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L130))
 
 ### disableMemory
 
@@ -207,7 +207,7 @@ Removes whatever memory configuration is on top, including a bottom
 
 **Throws:** `std::memory::disableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L151))
 
 ### memory
 
@@ -237,7 +237,7 @@ Run `block` with `config` as the active memory configuration, then
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L161))
 
 ### remember
 
@@ -258,7 +258,7 @@ Extract structured facts (entities, observations, and relations) from
 
 **Throws:** `std::memory::remember`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L184))
 
 ### recall
 
@@ -285,7 +285,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Throws:** `std::memory::recall`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L213))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L214))
 
 ### forget
 
@@ -307,4 +307,4 @@ Soft-delete facts matching the query from the knowledge graph. Data is
 
 **Throws:** `std::memory::forget`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L231))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L232))

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -1,5 +1,6 @@
 ---
 name: "memory"
+description: "Give an agent long-term memory: remember extracts and saves facts to a knowledge graph, and recall retrieves them later."
 ---
 
 # memory
@@ -37,7 +38,7 @@ export type MemoryConfig = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L63))
 
 ## Effects
 
@@ -49,7 +50,7 @@ effect std::memory::enableMemory {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L71))
 
 ### std::memory::disableMemory
 
@@ -57,7 +58,7 @@ effect std::memory::enableMemory {
 effect std::memory::disableMemory {}
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L71))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L72))
 
 ### std::memory::remember
 
@@ -67,7 +68,7 @@ effect std::memory::remember {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L73))
 
 ### std::memory::recall
 
@@ -77,7 +78,7 @@ effect std::memory::recall {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L74))
 
 ### std::memory::forget
 
@@ -87,7 +88,7 @@ effect std::memory::forget {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L75))
 
 ## Functions
 
@@ -107,7 +108,7 @@ Useful for branching in user code (`if (isMemoryActive()) { ... }`)
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L79))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L80))
 
 ### setMemoryId
 
@@ -134,7 +135,7 @@ The id is independent of which memory configuration is active. It
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L93))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L94))
 
 ### getMemoryId
 
@@ -149,7 +150,7 @@ Return the current memory scope id, or "default" if it was never set
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L106))
 
 ### enableMemory
 
@@ -186,7 +187,7 @@ Storage is shared process-wide by absolute directory, so calls
 
 **Throws:** `std::memory::enableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L130))
 
 ### disableMemory
 
@@ -206,7 +207,7 @@ Removes whatever memory configuration is on top, including a bottom
 
 **Throws:** `std::memory::disableMemory`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L151))
 
 ### memory
 
@@ -236,7 +237,7 @@ Run `block` with `config` as the active memory configuration, then
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L161))
 
 ### remember
 
@@ -257,7 +258,7 @@ Extract structured facts (entities, observations, and relations) from
 
 **Throws:** `std::memory::remember`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L184))
 
 ### recall
 
@@ -284,7 +285,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Throws:** `std::memory::recall`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L213))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L214))
 
 ### forget
 
@@ -306,4 +307,4 @@ Soft-delete facts matching the query from the knowledge graph. Data is
 
 **Throws:** `std::memory::forget`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L231))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/memory.agency#L232))

--- a/packages/agency-lang/docs/site/stdlib/messaging/email.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/email.md
@@ -1,5 +1,6 @@
 ---
 name: "email"
+description: "Send email from Agency code through Resend, SendGrid, or Mailgun, each reading its own API key from the environment."
 ---
 
 # email
@@ -46,7 +47,7 @@ effect std::sendEmail {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L39))
 
 ## Functions
 
@@ -104,7 +105,7 @@ Send an email using the Resend API. Requires `RESEND_API_KEY` env var or pass ap
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L42))
 
 ### sendWithSendGrid
 
@@ -160,7 +161,7 @@ Send an email using the SendGrid API. Requires `SENDGRID_API_KEY` env var or pas
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L83))
 
 ### sendWithMailgun
 
@@ -222,4 +223,4 @@ Send an email using the Mailgun API. Requires `MAILGUN_API_KEY` and `MAILGUN_DOM
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L124))

--- a/packages/agency-lang/docs/site/stdlib/messaging/email.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/email.md
@@ -1,6 +1,6 @@
 ---
 name: "email"
-description: "Send email from Agency code through Resend, SendGrid, or Mailgun, each reading its own API key from the environment."
+description: "Send email from Agency code through Resend, SendGrid, or Mailgun. Each provider reads its own API key from the environment: `RESEND_API_KEY`, `SENDGRID_API_KEY`, or `MAILGUN_API_KEY` plus `MAILGUN_DOMAIN` (and optional `MAILGUN_REGION` = us | eu)."
 ---
 
 # email
@@ -47,7 +47,7 @@ effect std::sendEmail {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L38))
 
 ## Functions
 
@@ -105,7 +105,7 @@ Send an email using the Resend API. Requires `RESEND_API_KEY` env var or pass ap
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L41))
 
 ### sendWithSendGrid
 
@@ -161,7 +161,7 @@ Send an email using the SendGrid API. Requires `SENDGRID_API_KEY` env var or pas
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L82))
 
 ### sendWithMailgun
 
@@ -223,4 +223,4 @@ Send an email using the Mailgun API. Requires `MAILGUN_API_KEY` and `MAILGUN_DOM
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L123))

--- a/packages/agency-lang/docs/site/stdlib/messaging/email.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/email.md
@@ -1,6 +1,6 @@
 ---
 name: "email"
-description: "Send email from Agency code through Resend, SendGrid, or Mailgun. Each provider reads its own API key from the environment: `RESEND_API_KEY`, `SENDGRID_API_KEY`, or `MAILGUN_API_KEY` plus `MAILGUN_DOMAIN` (and optional `MAILGUN_REGION` = us | eu)."
+description: "Send email from Agency code through Resend, SendGrid, or Mailgun, each reading its own API key from the environment."
 ---
 
 # email
@@ -47,7 +47,7 @@ effect std::sendEmail {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L39))
 
 ## Functions
 
@@ -105,7 +105,7 @@ Send an email using the Resend API. Requires `RESEND_API_KEY` env var or pass ap
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L42))
 
 ### sendWithSendGrid
 
@@ -161,7 +161,7 @@ Send an email using the SendGrid API. Requires `SENDGRID_API_KEY` env var or pas
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L83))
 
 ### sendWithMailgun
 
@@ -223,4 +223,4 @@ Send an email using the Mailgun API. Requires `MAILGUN_API_KEY` and `MAILGUN_DOM
 
 **Throws:** `std::sendEmail`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/messaging/email.agency#L124))

--- a/packages/agency-lang/docs/site/stdlib/messaging/imessage.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/imessage.md
@@ -1,6 +1,6 @@
 ---
 name: "imessage"
-description: "Send an iMessage from Agency code via the macOS Messages app. Works on macOS only, with Messages.app signed in to iMessage. No API key required."
+description: "Send an iMessage from Agency code via the macOS Messages app."
 ---
 
 # imessage

--- a/packages/agency-lang/docs/site/stdlib/messaging/imessage.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/imessage.md
@@ -1,5 +1,6 @@
 ---
 name: "imessage"
+description: "Send an iMessage from Agency code via the macOS Messages app. Works on macOS only, with Messages.app signed in to iMessage. No API key required."
 ---
 
 # imessage

--- a/packages/agency-lang/docs/site/stdlib/messaging/sms.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/sms.md
@@ -1,6 +1,6 @@
 ---
 name: "sms"
-description: "Send SMS text messages from Agency code via Twilio. Set `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` (e.g. +15550001234), or pass them directly."
+description: "Send SMS text messages from Agency code via Twilio."
 ---
 
 # sms

--- a/packages/agency-lang/docs/site/stdlib/messaging/sms.md
+++ b/packages/agency-lang/docs/site/stdlib/messaging/sms.md
@@ -1,5 +1,6 @@
 ---
 name: "sms"
+description: "Send SMS text messages from Agency code via Twilio. Set `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` (e.g. +15550001234), or pass them directly."
 ---
 
 # sms

--- a/packages/agency-lang/docs/site/stdlib/notes/apple.md
+++ b/packages/agency-lang/docs/site/stdlib/notes/apple.md
@@ -1,6 +1,6 @@
 ---
 name: "apple"
-description: "Create, read, search, and edit notes in the macOS Notes app. macOS only; the first call asks for Automation permission."
+description: "Create, read, search, and edit notes in the macOS Notes app. macOS only. The first call asks for Automation permission with a system dialog. If nobody answers the dialog, the call fails after 30 seconds."
 ---
 
 # apple
@@ -129,7 +129,7 @@ export type Folder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L126))
 
 ### Note
 
@@ -147,7 +147,7 @@ export type Note = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L134))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L133))
 
 ### NoteContent
 
@@ -165,7 +165,7 @@ export type NoteContent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L143))
 
 ## Effects
 
@@ -180,7 +180,7 @@ effect std::notes::create {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L153))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L152))
 
 ### std::notes::append
 
@@ -193,7 +193,7 @@ effect std::notes::append {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L153))
 
 ### std::notes::read
 
@@ -206,7 +206,7 @@ effect std::notes::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L154))
 
 ### std::notes::search
 
@@ -218,7 +218,7 @@ effect std::notes::search {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L155))
 
 ### std::notes::list
 
@@ -229,7 +229,7 @@ effect std::notes::list {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L156))
 
 ### std::notes::delete
 
@@ -242,7 +242,7 @@ effect std::notes::delete {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L157))
 
 ## Functions
 
@@ -274,7 +274,7 @@ Create a note in the Notes app and return it, including its new id.
 
 **Throws:** `std::notes::create`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L206))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L205))
 
 ### appendToNote
 
@@ -304,7 +304,7 @@ Append Markdown to an existing note. Get the id from listNotes or searchNotes.
 
 **Throws:** `std::notes::append`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L239))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L238))
 
 ### readNote
 
@@ -331,7 +331,7 @@ Read a note's contents as plain text. Get the id from listNotes or searchNotes.
 
 **Throws:** `std::notes::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L269))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L268))
 
 ### searchNotes
 
@@ -359,7 +359,7 @@ Search notes by their text and return matching notes' metadata, without their
 
 **Throws:** `std::notes::search`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L291))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L290))
 
 ### listNotes
 
@@ -383,7 +383,7 @@ List notes' metadata, without their contents.
 
 **Throws:** `std::notes::list`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L310))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L309))
 
 ### listFolders
 
@@ -397,7 +397,7 @@ List the folders in the Notes app, with a count of the notes in each.
 
 **Throws:** `std::notes::list`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L326))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L325))
 
 ### deleteNote
 
@@ -425,4 +425,4 @@ Delete a note. It moves to the Recently Deleted folder, where it stays for
 
 **Throws:** `std::notes::delete`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L338))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L337))

--- a/packages/agency-lang/docs/site/stdlib/notes/apple.md
+++ b/packages/agency-lang/docs/site/stdlib/notes/apple.md
@@ -1,5 +1,6 @@
 ---
 name: "apple"
+description: "Create, read, search, and edit notes in the macOS Notes app. macOS only; the first call asks for Automation permission."
 ---
 
 # apple
@@ -128,7 +129,7 @@ export type Folder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L127))
 
 ### Note
 
@@ -146,7 +147,7 @@ export type Note = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L134))
 
 ### NoteContent
 
@@ -164,7 +165,7 @@ export type NoteContent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L143))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L144))
 
 ## Effects
 
@@ -179,7 +180,7 @@ effect std::notes::create {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L152))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L153))
 
 ### std::notes::append
 
@@ -192,7 +193,7 @@ effect std::notes::append {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L153))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L154))
 
 ### std::notes::read
 
@@ -205,7 +206,7 @@ effect std::notes::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L155))
 
 ### std::notes::search
 
@@ -217,7 +218,7 @@ effect std::notes::search {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L156))
 
 ### std::notes::list
 
@@ -228,7 +229,7 @@ effect std::notes::list {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L157))
 
 ### std::notes::delete
 
@@ -241,7 +242,7 @@ effect std::notes::delete {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L158))
 
 ## Functions
 
@@ -273,7 +274,7 @@ Create a note in the Notes app and return it, including its new id.
 
 **Throws:** `std::notes::create`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L206))
 
 ### appendToNote
 
@@ -303,7 +304,7 @@ Append Markdown to an existing note. Get the id from listNotes or searchNotes.
 
 **Throws:** `std::notes::append`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L238))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L239))
 
 ### readNote
 
@@ -330,7 +331,7 @@ Read a note's contents as plain text. Get the id from listNotes or searchNotes.
 
 **Throws:** `std::notes::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L268))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L269))
 
 ### searchNotes
 
@@ -358,7 +359,7 @@ Search notes by their text and return matching notes' metadata, without their
 
 **Throws:** `std::notes::search`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L290))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L291))
 
 ### listNotes
 
@@ -382,7 +383,7 @@ List notes' metadata, without their contents.
 
 **Throws:** `std::notes::list`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L309))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L310))
 
 ### listFolders
 
@@ -396,7 +397,7 @@ List the folders in the Notes app, with a count of the notes in each.
 
 **Throws:** `std::notes::list`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L325))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L326))
 
 ### deleteNote
 
@@ -424,4 +425,4 @@ Delete a note. It moves to the Recently Deleted folder, where it stays for
 
 **Throws:** `std::notes::delete`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L337))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L338))

--- a/packages/agency-lang/docs/site/stdlib/notes/apple.md
+++ b/packages/agency-lang/docs/site/stdlib/notes/apple.md
@@ -1,6 +1,6 @@
 ---
 name: "apple"
-description: "Create, read, search, and edit notes in the macOS Notes app. macOS only. The first call asks for Automation permission with a system dialog. If nobody answers the dialog, the call fails after 30 seconds."
+description: "Create, read, search, and edit notes in the macOS Notes app. macOS only; the first call asks for Automation permission."
 ---
 
 # apple
@@ -129,7 +129,7 @@ export type Folder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L127))
 
 ### Note
 
@@ -147,7 +147,7 @@ export type Note = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L134))
 
 ### NoteContent
 
@@ -165,7 +165,7 @@ export type NoteContent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L143))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L144))
 
 ## Effects
 
@@ -180,7 +180,7 @@ effect std::notes::create {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L152))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L153))
 
 ### std::notes::append
 
@@ -193,7 +193,7 @@ effect std::notes::append {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L153))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L154))
 
 ### std::notes::read
 
@@ -206,7 +206,7 @@ effect std::notes::read {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L155))
 
 ### std::notes::search
 
@@ -218,7 +218,7 @@ effect std::notes::search {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L155))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L156))
 
 ### std::notes::list
 
@@ -229,7 +229,7 @@ effect std::notes::list {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L157))
 
 ### std::notes::delete
 
@@ -242,7 +242,7 @@ effect std::notes::delete {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L158))
 
 ## Functions
 
@@ -274,7 +274,7 @@ Create a note in the Notes app and return it, including its new id.
 
 **Throws:** `std::notes::create`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L206))
 
 ### appendToNote
 
@@ -304,7 +304,7 @@ Append Markdown to an existing note. Get the id from listNotes or searchNotes.
 
 **Throws:** `std::notes::append`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L238))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L239))
 
 ### readNote
 
@@ -331,7 +331,7 @@ Read a note's contents as plain text. Get the id from listNotes or searchNotes.
 
 **Throws:** `std::notes::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L268))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L269))
 
 ### searchNotes
 
@@ -359,7 +359,7 @@ Search notes by their text and return matching notes' metadata, without their
 
 **Throws:** `std::notes::search`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L290))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L291))
 
 ### listNotes
 
@@ -383,7 +383,7 @@ List notes' metadata, without their contents.
 
 **Throws:** `std::notes::list`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L309))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L310))
 
 ### listFolders
 
@@ -397,7 +397,7 @@ List the folders in the Notes app, with a count of the notes in each.
 
 **Throws:** `std::notes::list`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L325))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L326))
 
 ### deleteNote
 
@@ -425,4 +425,4 @@ Delete a note. It moves to the Recently Deleted folder, where it stays for
 
 **Throws:** `std::notes::delete`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L337))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/notes/apple.agency#L338))

--- a/packages/agency-lang/docs/site/stdlib/object.md
+++ b/packages/agency-lang/docs/site/stdlib/object.md
@@ -1,5 +1,6 @@
 ---
 name: "object"
+description: "Helpers for working with objects: read their keys, values, and entries, and transform them with `mapValues`, `mapEntries`, and `filterEntries`."
 ---
 
 # object

--- a/packages/agency-lang/docs/site/stdlib/path.md
+++ b/packages/agency-lang/docs/site/stdlib/path.md
@@ -1,6 +1,6 @@
 ---
 name: "path"
-description: "Pure helpers for building and taking apart file paths: join, resolve, basename, dirname, extname, relative, and isAbsolute. None of these touch the filesystem."
+description: "Pure helpers for building and taking apart file paths: join, resolve, basename, dirname, extname, relative, and isAbsolute."
 ---
 
 # path

--- a/packages/agency-lang/docs/site/stdlib/path.md
+++ b/packages/agency-lang/docs/site/stdlib/path.md
@@ -1,5 +1,6 @@
 ---
 name: "path"
+description: "Pure helpers for building and taking apart file paths: join, resolve, basename, dirname, extname, relative, and isAbsolute. None of these touch the filesystem."
 ---
 
 # path

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -1,5 +1,6 @@
 ---
 name: "policy"
+description: "Decide whether to approve or reject the interrupts an agent raises, without prompting the user every time."
 ---
 
 # policy
@@ -43,7 +44,7 @@ Key of an interrupt's `data` object (e.g. `"dir"`, `"command"`).
 export type InterruptDataKey = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L56))
 
 ### InterruptDataVal
 
@@ -62,7 +63,7 @@ export type InterruptDataKey = string
 export type InterruptDataVal = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L64))
 
 ### InterruptEffect
 
@@ -77,7 +78,7 @@ export type InterruptDataVal = string
 export type InterruptEffect = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L70))
 
 ### PolicyRule
 
@@ -99,7 +100,7 @@ export type PolicyRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L78))
 
 ### Policy
 
@@ -118,7 +119,7 @@ export type PolicyRule = {
 export type Policy = Record<InterruptEffect, PolicyRule[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L89))
 
 ### Decision
 
@@ -150,7 +151,7 @@ export type Decision =
   | "reject-always"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L130))
 
 ### ScopedField
 
@@ -182,7 +183,7 @@ export type ScopedField = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L148))
 
 ### ScopedRuleFields
 
@@ -225,7 +226,7 @@ export type ScopedField = {
 export type ScopedRuleFields = Record<InterruptEffect, ScopedField[]>
 ````
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L170))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L171))
 
 ### ParsePolicyFailureStatus
 
@@ -237,7 +238,7 @@ export type ParsePolicyFailureStatus =
   | "policy-not-valid"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L373))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L374))
 
 ### ParsePolicyFailure
 
@@ -248,7 +249,7 @@ export type ParsePolicyFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L379))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L380))
 
 ## Constants
 
@@ -258,7 +259,7 @@ export type ParsePolicyFailure = {
 export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
 
 ### recommendedAutoApprovePolicy
 
@@ -266,7 +267,7 @@ export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
 
 ### approveAllPolicy
 
@@ -274,7 +275,7 @@ export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 export static const approveAllPolicy = _approveAllPolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
 
 ### BUILTIN_POLICIES
 
@@ -282,7 +283,7 @@ export static const approveAllPolicy = _approveAllPolicy
 export static const BUILTIN_POLICIES = _BUILTIN_POLICIES
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L106))
 
 ## Functions
 
@@ -298,7 +299,7 @@ withWritesPolicy(baseDir: string)
 |---|---|---|
 | baseDir | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L108))
 
 ### builtinPolicy
 
@@ -315,7 +316,7 @@ builtinPolicy(name: string, baseDir: string): Policy | null
 
 **Returns:** `Policy | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L112))
 
 ### builtinPolicyNames
 
@@ -325,7 +326,7 @@ builtinPolicyNames(): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L115))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L116))
 
 ### checkPolicy
 
@@ -354,7 +355,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L206))
 
 ### validatePolicy
 
@@ -382,7 +383,7 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 
 **Returns:** `Result<void>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L227))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L228))
 
 ### buildScopedMatch
 
@@ -432,7 +433,7 @@ Build a match object for an interrupt, pinned to the configured fields. Returns 
 
 **Returns:** `Record<string, string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L262))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L263))
 
 ### recordRule
 
@@ -480,7 +481,7 @@ Return a new policy with a catch-all rule for an effect appended. A single bare 
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L312))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L313))
 
 ### recordScopedRule
 
@@ -522,7 +523,7 @@ Return a new policy with a scoped approve rule prepended for the interrupt's eff
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L349))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L350))
 
 ### parsePolicyFile
 
@@ -554,7 +555,7 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
 **Returns:** `Result<Policy, ParsePolicyFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L395))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L396))
 
 ### setPolicy
 
@@ -575,7 +576,7 @@ setPolicy(path: string, policy: Policy)
 | path | `string` |  |
 | policy | [Policy](#policy) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L440))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L441))
 
 ### writePolicyFile
 
@@ -606,7 +607,7 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid.
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L456))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L457))
 
 ### flushPolicy
 
@@ -624,7 +625,7 @@ flushPolicy()
  * `std::write` via `with approve` (you opted in by installing the
  * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L521))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L522))
 
 ### cliPolicyHandler
 
@@ -709,4 +710,4 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L876))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L877))

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -1,6 +1,6 @@
 ---
 name: "policy"
-description: "Decide whether to approve or reject the interrupts an agent raises, without prompting the user every time. A `Policy` is an ordered list of glob-pattern rules per interrupt effect, evaluated first-match-wins."
+description: "Decide whether to approve or reject the interrupts an agent raises, without prompting the user every time."
 ---
 
 # policy
@@ -44,7 +44,7 @@ Key of an interrupt's `data` object (e.g. `"dir"`, `"command"`).
 export type InterruptDataKey = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L55))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L56))
 
 ### InterruptDataVal
 
@@ -63,7 +63,7 @@ export type InterruptDataKey = string
 export type InterruptDataVal = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L64))
 
 ### InterruptEffect
 
@@ -78,7 +78,7 @@ export type InterruptDataVal = string
 export type InterruptEffect = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L70))
 
 ### PolicyRule
 
@@ -100,7 +100,7 @@ export type PolicyRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L78))
 
 ### Policy
 
@@ -119,7 +119,7 @@ export type PolicyRule = {
 export type Policy = Record<InterruptEffect, PolicyRule[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L89))
 
 ### Decision
 
@@ -151,7 +151,7 @@ export type Decision =
   | "reject-always"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L130))
 
 ### ScopedField
 
@@ -183,7 +183,7 @@ export type ScopedField = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L148))
 
 ### ScopedRuleFields
 
@@ -226,7 +226,7 @@ export type ScopedField = {
 export type ScopedRuleFields = Record<InterruptEffect, ScopedField[]>
 ````
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L170))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L171))
 
 ### ParsePolicyFailureStatus
 
@@ -238,7 +238,7 @@ export type ParsePolicyFailureStatus =
   | "policy-not-valid"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L373))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L374))
 
 ### ParsePolicyFailure
 
@@ -249,7 +249,7 @@ export type ParsePolicyFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L379))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L380))
 
 ## Constants
 
@@ -259,7 +259,7 @@ export type ParsePolicyFailure = {
 export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
 
 ### recommendedAutoApprovePolicy
 
@@ -267,7 +267,7 @@ export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
 
 ### approveAllPolicy
 
@@ -275,7 +275,7 @@ export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 export static const approveAllPolicy = _approveAllPolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
 
 ### BUILTIN_POLICIES
 
@@ -283,7 +283,7 @@ export static const approveAllPolicy = _approveAllPolicy
 export static const BUILTIN_POLICIES = _BUILTIN_POLICIES
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L106))
 
 ## Functions
 
@@ -299,7 +299,7 @@ withWritesPolicy(baseDir: string)
 |---|---|---|
 | baseDir | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L107))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L108))
 
 ### builtinPolicy
 
@@ -316,7 +316,7 @@ builtinPolicy(name: string, baseDir: string): Policy | null
 
 **Returns:** `Policy | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L112))
 
 ### builtinPolicyNames
 
@@ -326,7 +326,7 @@ builtinPolicyNames(): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L115))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L116))
 
 ### checkPolicy
 
@@ -355,7 +355,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L206))
 
 ### validatePolicy
 
@@ -383,7 +383,7 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 
 **Returns:** `Result<void>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L227))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L228))
 
 ### buildScopedMatch
 
@@ -433,7 +433,7 @@ Build a match object for an interrupt, pinned to the configured fields. Returns 
 
 **Returns:** `Record<string, string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L262))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L263))
 
 ### recordRule
 
@@ -481,7 +481,7 @@ Return a new policy with a catch-all rule for an effect appended. A single bare 
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L312))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L313))
 
 ### recordScopedRule
 
@@ -523,7 +523,7 @@ Return a new policy with a scoped approve rule prepended for the interrupt's eff
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L349))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L350))
 
 ### parsePolicyFile
 
@@ -555,7 +555,7 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
 **Returns:** `Result<Policy, ParsePolicyFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L395))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L396))
 
 ### setPolicy
 
@@ -576,7 +576,7 @@ setPolicy(path: string, policy: Policy)
 | path | `string` |  |
 | policy | [Policy](#policy) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L440))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L441))
 
 ### writePolicyFile
 
@@ -607,7 +607,7 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid.
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L456))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L457))
 
 ### flushPolicy
 
@@ -625,7 +625,7 @@ flushPolicy()
  * `std::write` via `with approve` (you opted in by installing the
  * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L521))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L522))
 
 ### cliPolicyHandler
 
@@ -710,4 +710,4 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L876))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L877))

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -1,6 +1,6 @@
 ---
 name: "policy"
-description: "Decide whether to approve or reject the interrupts an agent raises, without prompting the user every time."
+description: "Decide whether to approve or reject the interrupts an agent raises, without prompting the user every time. A `Policy` is an ordered list of glob-pattern rules per interrupt effect, evaluated first-match-wins."
 ---
 
 # policy
@@ -44,7 +44,7 @@ Key of an interrupt's `data` object (e.g. `"dir"`, `"command"`).
 export type InterruptDataKey = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L55))
 
 ### InterruptDataVal
 
@@ -63,7 +63,7 @@ export type InterruptDataKey = string
 export type InterruptDataVal = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L63))
 
 ### InterruptEffect
 
@@ -78,7 +78,7 @@ export type InterruptDataVal = string
 export type InterruptEffect = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L69))
 
 ### PolicyRule
 
@@ -100,7 +100,7 @@ export type PolicyRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L77))
 
 ### Policy
 
@@ -119,7 +119,7 @@ export type PolicyRule = {
 export type Policy = Record<InterruptEffect, PolicyRule[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L88))
 
 ### Decision
 
@@ -151,7 +151,7 @@ export type Decision =
   | "reject-always"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L129))
 
 ### ScopedField
 
@@ -183,7 +183,7 @@ export type ScopedField = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L147))
 
 ### ScopedRuleFields
 
@@ -226,7 +226,7 @@ export type ScopedField = {
 export type ScopedRuleFields = Record<InterruptEffect, ScopedField[]>
 ````
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L171))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L170))
 
 ### ParsePolicyFailureStatus
 
@@ -238,7 +238,7 @@ export type ParsePolicyFailureStatus =
   | "policy-not-valid"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L374))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L373))
 
 ### ParsePolicyFailure
 
@@ -249,7 +249,7 @@ export type ParsePolicyFailure = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L380))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L379))
 
 ## Constants
 
@@ -259,7 +259,7 @@ export type ParsePolicyFailure = {
 export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L102))
 
 ### recommendedAutoApprovePolicy
 
@@ -267,7 +267,7 @@ export static const minimalAutoApprovePolicy = _minimalAutoApprovePolicy
 export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L103))
 
 ### approveAllPolicy
 
@@ -275,7 +275,7 @@ export static const recommendedAutoApprovePolicy = _recommendedAutoApprovePolicy
 export static const approveAllPolicy = _approveAllPolicy
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L104))
 
 ### BUILTIN_POLICIES
 
@@ -283,7 +283,7 @@ export static const approveAllPolicy = _approveAllPolicy
 export static const BUILTIN_POLICIES = _BUILTIN_POLICIES
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L105))
 
 ## Functions
 
@@ -299,7 +299,7 @@ withWritesPolicy(baseDir: string)
 |---|---|---|
 | baseDir | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L107))
 
 ### builtinPolicy
 
@@ -316,7 +316,7 @@ builtinPolicy(name: string, baseDir: string): Policy | null
 
 **Returns:** `Policy | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L112))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L111))
 
 ### builtinPolicyNames
 
@@ -326,7 +326,7 @@ builtinPolicyNames(): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L115))
 
 ### checkPolicy
 
@@ -355,7 +355,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L206))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L205))
 
 ### validatePolicy
 
@@ -383,7 +383,7 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 
 **Returns:** `Result<void>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L228))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L227))
 
 ### buildScopedMatch
 
@@ -433,7 +433,7 @@ Build a match object for an interrupt, pinned to the configured fields. Returns 
 
 **Returns:** `Record<string, string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L263))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L262))
 
 ### recordRule
 
@@ -481,7 +481,7 @@ Return a new policy with a catch-all rule for an effect appended. A single bare 
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L313))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L312))
 
 ### recordScopedRule
 
@@ -523,7 +523,7 @@ Return a new policy with a scoped approve rule prepended for the interrupt's eff
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L350))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L349))
 
 ### parsePolicyFile
 
@@ -555,7 +555,7 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
 **Returns:** `Result<Policy, ParsePolicyFailure>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L396))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L395))
 
 ### setPolicy
 
@@ -576,7 +576,7 @@ setPolicy(path: string, policy: Policy)
 | path | `string` |  |
 | policy | [Policy](#policy) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L441))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L440))
 
 ### writePolicyFile
 
@@ -607,7 +607,7 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid.
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L457))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L456))
 
 ### flushPolicy
 
@@ -625,7 +625,7 @@ flushPolicy()
  * `std::write` via `with approve` (you opted in by installing the
  * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L522))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L521))
 
 ### cliPolicyHandler
 
@@ -710,4 +710,4 @@ CLI sugar for an interactive policy handler. Loads and saves the policy file, pr
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L877))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/policy.agency#L876))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -1,5 +1,6 @@
 ---
 name: "shell"
+description: "Run commands and inspect the filesystem: exec and bash run programs (with approval); ls, grep, glob, stat, exists, which are read-only."
 ---
 
 # shell
@@ -34,7 +35,7 @@ effect std::exec {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L38))
 
 ### std::bash
 
@@ -47,7 +48,7 @@ effect std::bash {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L46))
 
 ### std::ls
 
@@ -59,7 +60,7 @@ effect std::ls {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L52))
 
 ### std::grep
 
@@ -72,7 +73,7 @@ effect std::grep {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L57))
 
 ### std::glob
 
@@ -84,7 +85,7 @@ effect std::glob {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L63))
 
 ## Functions
 
@@ -134,7 +135,7 @@ Run an executable directly with an array of arguments, bypassing the shell, and 
 
 **Throws:** `std::exec`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L69))
 
 ### bash
 
@@ -180,7 +181,7 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L133))
 
 ### ls
 
@@ -218,7 +219,7 @@ List entries in a directory. Each entry has name, path, type ("file", "dir", "sy
 
 **Throws:** `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L181))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L182))
 
 ### grep
 
@@ -259,7 +260,7 @@ Search for a regex pattern in files under a directory. Returns matches with file
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L217))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L218))
 
 ### glob
 
@@ -295,7 +296,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Fails if the p
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L250))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L251))
 
 ### stat
 
@@ -329,7 +330,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L285))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L286))
 
 ### exists
 
@@ -360,7 +361,7 @@ Return true if a file or directory exists at the given path. Probing a path outs
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L307))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L308))
 
 ### which
 
@@ -380,4 +381,4 @@ Locate an executable in PATH and return its absolute path, or an empty string if
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L327))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L328))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -1,6 +1,6 @@
 ---
 name: "shell"
-description: "Run commands and inspect the filesystem. `exec` and `bash` run programs and raise an approval interrupt before doing so. `ls`, `grep`, `glob`, `stat`, `exists`, and `which` are read-only helpers that return results directly."
+description: "Run commands and inspect the filesystem: exec and bash run programs (with approval); ls, grep, glob, stat, exists, which are read-only."
 ---
 
 # shell
@@ -35,7 +35,7 @@ effect std::exec {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L38))
 
 ### std::bash
 
@@ -48,7 +48,7 @@ effect std::bash {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L46))
 
 ### std::ls
 
@@ -60,7 +60,7 @@ effect std::ls {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L51))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L52))
 
 ### std::grep
 
@@ -73,7 +73,7 @@ effect std::grep {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L57))
 
 ### std::glob
 
@@ -85,7 +85,7 @@ effect std::glob {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L63))
 
 ## Functions
 
@@ -135,7 +135,7 @@ Run an executable directly with an array of arguments, bypassing the shell, and 
 
 **Throws:** `std::exec`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L69))
 
 ### bash
 
@@ -181,7 +181,7 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L133))
 
 ### ls
 
@@ -219,7 +219,7 @@ List entries in a directory. Each entry has name, path, type ("file", "dir", "sy
 
 **Throws:** `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L181))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L182))
 
 ### grep
 
@@ -260,7 +260,7 @@ Search for a regex pattern in files under a directory. Returns matches with file
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L217))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L218))
 
 ### glob
 
@@ -296,7 +296,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Fails if the p
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L250))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L251))
 
 ### stat
 
@@ -330,7 +330,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L285))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L286))
 
 ### exists
 
@@ -361,7 +361,7 @@ Return true if a file or directory exists at the given path. Probing a path outs
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L307))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L308))
 
 ### which
 
@@ -381,4 +381,4 @@ Locate an executable in PATH and return its absolute path, or an empty string if
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L327))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L328))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -1,6 +1,6 @@
 ---
 name: "shell"
-description: "Run commands and inspect the filesystem: exec and bash run programs (with approval); ls, grep, glob, stat, exists, which are read-only."
+description: "Run commands and inspect the filesystem. `exec` and `bash` run programs and raise an approval interrupt before doing so. `ls`, `grep`, `glob`, `stat`, `exists`, and `which` are read-only helpers that return results directly."
 ---
 
 # shell
@@ -35,7 +35,7 @@ effect std::exec {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L37))
 
 ### std::bash
 
@@ -48,7 +48,7 @@ effect std::bash {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L45))
 
 ### std::ls
 
@@ -60,7 +60,7 @@ effect std::ls {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L51))
 
 ### std::grep
 
@@ -73,7 +73,7 @@ effect std::grep {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L56))
 
 ### std::glob
 
@@ -85,7 +85,7 @@ effect std::glob {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L62))
 
 ## Functions
 
@@ -135,7 +135,7 @@ Run an executable directly with an array of arguments, bypassing the shell, and 
 
 **Throws:** `std::exec`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L68))
 
 ### bash
 
@@ -181,7 +181,7 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L133))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L132))
 
 ### ls
 
@@ -219,7 +219,7 @@ List entries in a directory. Each entry has name, path, type ("file", "dir", "sy
 
 **Throws:** `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L182))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L181))
 
 ### grep
 
@@ -260,7 +260,7 @@ Search for a regex pattern in files under a directory. Returns matches with file
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L218))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L217))
 
 ### glob
 
@@ -296,7 +296,7 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Fails if the p
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L251))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L250))
 
 ### stat
 
@@ -330,7 +330,7 @@ Return metadata about a filesystem entry: whether it exists, its type ("file", "
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L286))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L285))
 
 ### exists
 
@@ -361,7 +361,7 @@ Return true if a file or directory exists at the given path. Probing a path outs
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L308))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L307))
 
 ### which
 
@@ -381,4 +381,4 @@ Locate an executable in PATH and return its absolute path, or an empty string if
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L328))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/shell.agency#L327))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -1,6 +1,6 @@
 ---
 name: "skills"
-description: "Give an LLM access to a directory of skills, and support Claude-Code-style slash commands. `skillsDir` builds a tool that lets the model read skill files on demand. `commandsDir` and `expandSlash` load prompt-template commands and expand a user's `/command` into its body."
+description: "Give an LLM access to a directory of skills, and support Claude-Code-style slash commands."
 ---
 
 # skills
@@ -59,7 +59,7 @@ effect std::skills::skillsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L184))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L185))
 
 ### std::skills::commandsDir
 
@@ -69,7 +69,7 @@ effect std::skills::commandsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L185))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L186))
 
 ## Functions
 
@@ -99,7 +99,7 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L226))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L227))
 
 ### docsSkill
 
@@ -123,7 +123,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `"guide" \| "cli" \| "diagnostics" \| "stdlib"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L243))
 
 ### commandsDir
 
@@ -177,7 +177,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L329))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L330))
 
 ### expandSlash
 
@@ -216,4 +216,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L386))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L387))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -1,6 +1,6 @@
 ---
 name: "skills"
-description: "Give an LLM access to a directory of skills, and support Claude-Code-style slash commands."
+description: "Give an LLM access to a directory of skills, and support Claude-Code-style slash commands. `skillsDir` builds a tool that lets the model read skill files on demand. `commandsDir` and `expandSlash` load prompt-template commands and expand a user's `/command` into its body."
 ---
 
 # skills
@@ -59,7 +59,7 @@ effect std::skills::skillsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L185))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L184))
 
 ### std::skills::commandsDir
 
@@ -69,7 +69,7 @@ effect std::skills::commandsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L185))
 
 ## Functions
 
@@ -99,7 +99,7 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L227))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L226))
 
 ### docsSkill
 
@@ -123,7 +123,7 @@ Build a docs tool for an LLM over the packaged Agency documentation.
 |---|---|---|
 | section | `"guide" \| "cli" \| "diagnostics" \| "stdlib"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L243))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L242))
 
 ### commandsDir
 
@@ -177,7 +177,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L330))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L329))
 
 ### expandSlash
 
@@ -216,4 +216,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L387))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L386))

--- a/packages/agency-lang/docs/site/stdlib/skills.md
+++ b/packages/agency-lang/docs/site/stdlib/skills.md
@@ -1,5 +1,6 @@
 ---
 name: "skills"
+description: "Give an LLM access to a directory of skills, and support Claude-Code-style slash commands."
 ---
 
 # skills
@@ -58,7 +59,7 @@ effect std::skills::skillsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L184))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L185))
 
 ### std::skills::commandsDir
 
@@ -68,7 +69,7 @@ effect std::skills::commandsDir {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L185))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L186))
 
 ## Functions
 
@@ -98,30 +99,31 @@ Build a skills tool for an LLM over a directory of skills.
 
 **Throws:** `std::skills::skillsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L227))
 
 ### docsSkill
 
 ```ts
-docsSkill(section: "guide" | "cli" | "diagnostics")
+docsSkill(section: "guide" | "cli" | "diagnostics" | "stdlib")
 ```
 
 Build a docs tool for an LLM over the packaged Agency documentation.
   "guide" serves the language guide (syntax, types, control flow);
   "cli" serves the CLI reference; "diagnostics" serves the type-checker
-  diagnostic codes (AG####) with explanations and fixes. The returned tool
-  lists every page in its description and lets the model read any one on
-  demand.
+  diagnostic codes (AG####) with explanations and fixes; "stdlib" serves
+  the standard-library reference, one page per std:: module. The returned
+  tool lists every page in its description and lets the model read any one
+  on demand.
 
-  @param section - Which documentation set to serve: "guide", "cli", or "diagnostics".
+  @param section - Which documentation set to serve: "guide", "cli", "diagnostics", or "stdlib".
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| section | `"guide" \| "cli" \| "diagnostics"` |  |
+| section | `"guide" \| "cli" \| "diagnostics" \| "stdlib"` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L239))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L243))
 
 ### commandsDir
 
@@ -175,7 +177,7 @@ Discover .md files under `dir` and parse each as a slash-command
 
 **Throws:** `std::skills::commandsDir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L325))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L330))
 
 ### expandSlash
 
@@ -214,4 +216,4 @@ Expand a /command in `msg` into its command body. Returns the rendered
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L382))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/skills.agency#L387))

--- a/packages/agency-lang/docs/site/stdlib/speech.md
+++ b/packages/agency-lang/docs/site/stdlib/speech.md
@@ -1,5 +1,6 @@
 ---
 name: "speech"
+description: "Speak text aloud, record from the microphone, and transcribe audio to text."
 ---
 
 # speech

--- a/packages/agency-lang/docs/site/stdlib/statelog.md
+++ b/packages/agency-lang/docs/site/stdlib/statelog.md
@@ -1,6 +1,6 @@
 ---
 name: "statelog"
-description: "Record and read back eval data from the statelog, marking an agent's input and response for later analysis."
+description: "Record and read back eval data from the statelog. Call `evalValue` and `evalOutput` inside an agent to mark its user-facing input and response, then read them from a saved trace with `evalValues`, `evalOutputs`, `finalEvalOutput`, or the full `evalRecord`. `emit` sends a custom event straight to the host."
 ---
 
 # statelog
@@ -34,7 +34,7 @@ export type StatelogEvalValue = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L28))
 
 ### StatelogEvalRecord
 
@@ -57,7 +57,7 @@ export type StatelogEvalRecord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L35))
 
 ## Functions
 
@@ -79,7 +79,7 @@ Delivered to the host via the `onEmit` callback.
 |---|---|---|
 | data | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L53))
 
 ### evalValue
 
@@ -109,7 +109,7 @@ Record a value as part of the user-facing input to this agent. May be called mul
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L76))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L75))
 
 ### evalOutput
 
@@ -137,7 +137,7 @@ Record a value as the agent's user-facing response. May be called multiple times
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L96))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L95))
 
 ### evalRecord
 
@@ -165,7 +165,7 @@ Parse a statelog JSONL file and return the same structured EvalRecord
 
 **Returns:** [StatelogEvalRecord](#statelogevalrecord)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L104))
 
 ### evalValues
 
@@ -192,7 +192,7 @@ Mirrors `new StatelogParser(path).evalValues()` in TypeScript.
 
 **Returns:** `StatelogEvalValue[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L118))
 
 ### evalOutputs
 
@@ -219,7 +219,7 @@ Mirrors `new StatelogParser(path).evalOutputs()` in TypeScript.
 
 **Returns:** `StatelogEvalValue[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L129))
 
 ### finalEvalOutput
 
@@ -246,4 +246,4 @@ Parse a statelog JSONL file and return the final eval output, or null when
 
 **Returns:** `StatelogEvalValue | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L140))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L139))

--- a/packages/agency-lang/docs/site/stdlib/statelog.md
+++ b/packages/agency-lang/docs/site/stdlib/statelog.md
@@ -1,5 +1,6 @@
 ---
 name: "statelog"
+description: "Record and read back eval data from the statelog, marking an agent's input and response for later analysis."
 ---
 
 # statelog
@@ -33,7 +34,7 @@ export type StatelogEvalValue = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L28))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L29))
 
 ### StatelogEvalRecord
 
@@ -56,7 +57,7 @@ export type StatelogEvalRecord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L36))
 
 ## Functions
 
@@ -78,7 +79,7 @@ Delivered to the host via the `onEmit` callback.
 |---|---|---|
 | data | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L54))
 
 ### evalValue
 
@@ -108,7 +109,7 @@ Record a value as part of the user-facing input to this agent. May be called mul
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L76))
 
 ### evalOutput
 
@@ -136,7 +137,7 @@ Record a value as the agent's user-facing response. May be called multiple times
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L96))
 
 ### evalRecord
 
@@ -164,7 +165,7 @@ Parse a statelog JSONL file and return the same structured EvalRecord
 
 **Returns:** [StatelogEvalRecord](#statelogevalrecord)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L105))
 
 ### evalValues
 
@@ -191,7 +192,7 @@ Mirrors `new StatelogParser(path).evalValues()` in TypeScript.
 
 **Returns:** `StatelogEvalValue[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L119))
 
 ### evalOutputs
 
@@ -218,7 +219,7 @@ Mirrors `new StatelogParser(path).evalOutputs()` in TypeScript.
 
 **Returns:** `StatelogEvalValue[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L130))
 
 ### finalEvalOutput
 
@@ -245,4 +246,4 @@ Parse a statelog JSONL file and return the final eval output, or null when
 
 **Returns:** `StatelogEvalValue | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L140))

--- a/packages/agency-lang/docs/site/stdlib/statelog.md
+++ b/packages/agency-lang/docs/site/stdlib/statelog.md
@@ -1,6 +1,6 @@
 ---
 name: "statelog"
-description: "Record and read back eval data from the statelog. Call `evalValue` and `evalOutput` inside an agent to mark its user-facing input and response, then read them from a saved trace with `evalValues`, `evalOutputs`, `finalEvalOutput`, or the full `evalRecord`. `emit` sends a custom event straight to the host."
+description: "Record and read back eval data from the statelog, marking an agent's input and response for later analysis."
 ---
 
 # statelog
@@ -34,7 +34,7 @@ export type StatelogEvalValue = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L28))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L29))
 
 ### StatelogEvalRecord
 
@@ -57,7 +57,7 @@ export type StatelogEvalRecord = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L36))
 
 ## Functions
 
@@ -79,7 +79,7 @@ Delivered to the host via the `onEmit` callback.
 |---|---|---|
 | data | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L54))
 
 ### evalValue
 
@@ -109,7 +109,7 @@ Record a value as part of the user-facing input to this agent. May be called mul
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L76))
 
 ### evalOutput
 
@@ -137,7 +137,7 @@ Record a value as the agent's user-facing response. May be called multiple times
 |---|---|---|
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L96))
 
 ### evalRecord
 
@@ -165,7 +165,7 @@ Parse a statelog JSONL file and return the same structured EvalRecord
 
 **Returns:** [StatelogEvalRecord](#statelogevalrecord)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L105))
 
 ### evalValues
 
@@ -192,7 +192,7 @@ Mirrors `new StatelogParser(path).evalValues()` in TypeScript.
 
 **Returns:** `StatelogEvalValue[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L119))
 
 ### evalOutputs
 
@@ -219,7 +219,7 @@ Mirrors `new StatelogParser(path).evalOutputs()` in TypeScript.
 
 **Returns:** `StatelogEvalValue[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L129))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L130))
 
 ### finalEvalOutput
 
@@ -246,4 +246,4 @@ Parse a statelog JSONL file and return the final eval output, or null when
 
 **Returns:** `StatelogEvalValue | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/statelog.agency#L140))

--- a/packages/agency-lang/docs/site/stdlib/strategy.md
+++ b/packages/agency-lang/docs/site/stdlib/strategy.md
@@ -1,5 +1,6 @@
 ---
 name: "strategy"
+description: "Run a block several times and combine the results. `sample` collects every result, `consensus` takes the majority vote, and `retry` / `retryWithFeedback` re-run a block until one result passes a test."
 ---
 
 # strategy

--- a/packages/agency-lang/docs/site/stdlib/strategy.md
+++ b/packages/agency-lang/docs/site/stdlib/strategy.md
@@ -1,6 +1,6 @@
 ---
 name: "strategy"
-description: "Run a block several times and combine the results. `sample` collects every result, `consensus` takes the majority vote, and `retry` / `retryWithFeedback` re-run a block until one result passes a test."
+description: "Run a block several times and combine the results."
 ---
 
 # strategy

--- a/packages/agency-lang/docs/site/stdlib/syntax.md
+++ b/packages/agency-lang/docs/site/stdlib/syntax.md
@@ -1,5 +1,6 @@
 ---
 name: "syntax"
+description: "Syntax-highlight code, detect its language, and render colored diffs and patches for the terminal or the web."
 ---
 
 # syntax

--- a/packages/agency-lang/docs/site/stdlib/system.md
+++ b/packages/agency-lang/docs/site/stdlib/system.md
@@ -1,5 +1,6 @@
 ---
 name: "system"
+description: "Talk to the host OS: read command-line args and environment variables, find the current directory, show notifications, take screenshots, open URLs, and read from stdin."
 ---
 
 # system

--- a/packages/agency-lang/docs/site/stdlib/tag.md
+++ b/packages/agency-lang/docs/site/stdlib/tag.md
@@ -1,5 +1,6 @@
 ---
 name: "tag"
+description: "Attach arbitrary tags to values and read them back anywhere in your program."
 ---
 
 # tag

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -1,6 +1,6 @@
 ---
 name: "thread"
-description: "Read and share LLM conversation history across a run: inspect the current thread's messages, cost, and tokens, and reach into other threads."
+description: "Read and share LLM conversation history across a run. Inspect the current thread's messages, cost, and token usage, and reach into other threads. `listThreads()` lists every thread in the run, active and closed. `getThread(id, offset, limit)` reads a slice of one thread's messages. These build on the public `agency.threads.*` primitives, so you can compose your own variants in user code."
 ---
 
 # thread
@@ -35,7 +35,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L52))
 
 ### Attachment
 
@@ -46,7 +46,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L57))
 
 ### ModelCost
 
@@ -59,7 +59,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L163))
 
 ### GuardFailureData
 
@@ -74,7 +74,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L182))
 
 ### ThreadMessage
 
@@ -85,7 +85,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L206))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L205))
 
 ### ThreadInfo
 
@@ -101,7 +101,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L211))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L210))
 
 ## Functions
 
@@ -125,7 +125,7 @@ Add a system message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L61))
 
 ### userMessage
 
@@ -147,7 +147,7 @@ Add a user message to the current thread's message history. Use this
 | msg | `string \| (string \| Attachment)[]` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L73))
 
 ### image
 
@@ -176,7 +176,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L85))
 
 ### file
 
@@ -207,7 +207,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L101))
 
 ### attachToReply
 
@@ -229,7 +229,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L118))
 
 ### assistantMessage
 
@@ -251,7 +251,7 @@ Add an assistant message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L132))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L131))
 
 ### getCost
 
@@ -270,7 +270,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L148))
 
 ### getTokens
 
@@ -282,7 +282,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
 
 ### getModelCosts
 
@@ -300,7 +300,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L174))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L173))
 
 ### listThreads
 
@@ -333,7 +333,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L283))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L282))
 
 ### currentThreadId
 
@@ -348,7 +348,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L336))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L335))
 
 ### getThread
 
@@ -380,4 +380,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L346))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L345))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -1,5 +1,6 @@
 ---
 name: "thread"
+description: "Read and share LLM conversation history across a run: inspect the current thread's messages, cost, and tokens, and reach into other threads."
 ---
 
 # thread
@@ -34,7 +35,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L53))
 
 ### Attachment
 
@@ -45,7 +46,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L58))
 
 ### ModelCost
 
@@ -58,7 +59,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L164))
 
 ### GuardFailureData
 
@@ -73,7 +74,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L182))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L183))
 
 ### ThreadMessage
 
@@ -84,7 +85,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L206))
 
 ### ThreadInfo
 
@@ -100,7 +101,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L210))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L211))
 
 ## Functions
 
@@ -124,7 +125,7 @@ Add a system message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L62))
 
 ### userMessage
 
@@ -146,7 +147,7 @@ Add a user message to the current thread's message history. Use this
 | msg | `string \| (string \| Attachment)[]` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L74))
 
 ### image
 
@@ -175,7 +176,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L86))
 
 ### file
 
@@ -206,7 +207,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L102))
 
 ### attachToReply
 
@@ -228,7 +229,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L119))
 
 ### assistantMessage
 
@@ -250,7 +251,7 @@ Add an assistant message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L132))
 
 ### getCost
 
@@ -269,7 +270,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L149))
 
 ### getTokens
 
@@ -281,7 +282,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L157))
 
 ### getModelCosts
 
@@ -299,7 +300,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L173))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L174))
 
 ### listThreads
 
@@ -332,7 +333,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L282))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L283))
 
 ### currentThreadId
 
@@ -347,7 +348,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L335))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L336))
 
 ### getThread
 
@@ -379,4 +380,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L345))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L346))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -1,6 +1,6 @@
 ---
 name: "thread"
-description: "Read and share LLM conversation history across a run. Inspect the current thread's messages, cost, and token usage, and reach into other threads. `listThreads()` lists every thread in the run, active and closed. `getThread(id, offset, limit)` reads a slice of one thread's messages. These build on the public `agency.threads.*` primitives, so you can compose your own variants in user code."
+description: "Read and share LLM conversation history across a run: inspect the current thread's messages, cost, and tokens, and reach into other threads."
 ---
 
 # thread
@@ -35,7 +35,7 @@ export type AttachmentSource =
   | { kind: "base64"; base64: string; mimeType: string }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L53))
 
 ### Attachment
 
@@ -46,7 +46,7 @@ export type Attachment =
   | null }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L58))
 
 ### ModelCost
 
@@ -59,7 +59,7 @@ export type ModelCost = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L164))
 
 ### GuardFailureData
 
@@ -74,7 +74,7 @@ export type GuardFailureData = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L182))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L183))
 
 ### ThreadMessage
 
@@ -85,7 +85,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L205))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L206))
 
 ### ThreadInfo
 
@@ -101,7 +101,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L210))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L211))
 
 ## Functions
 
@@ -125,7 +125,7 @@ Add a system message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L62))
 
 ### userMessage
 
@@ -147,7 +147,7 @@ Add a user message to the current thread's message history. Use this
 | msg | `string \| (string \| Attachment)[]` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L74))
 
 ### image
 
@@ -176,7 +176,7 @@ Build an image attachment for a multimodal llm() call. The source is
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L86))
 
 ### file
 
@@ -207,7 +207,7 @@ Build a file (e.g. PDF) attachment for a multimodal llm() call.
 
 **Returns:** [Attachment](#attachment)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L102))
 
 ### attachToReply
 
@@ -229,7 +229,7 @@ Queue an attachment to be shown to the model after the current tool
 |---|---|---|
 | attachment | [Attachment](#attachment) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L118))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L119))
 
 ### assistantMessage
 
@@ -251,7 +251,7 @@ Add an assistant message to the current thread's message history.
 | msg | `string` |  |
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L132))
 
 ### getCost
 
@@ -270,7 +270,7 @@ Inside a fork/race branch this includes the parent's accumulated cost
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L149))
 
 ### getTokens
 
@@ -282,7 +282,7 @@ Return the cumulative token count for the current execution branch.
 
 **Returns:** `number`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L157))
 
 ### getModelCosts
 
@@ -300,7 +300,7 @@ Unlike the per-branch cost/token accessors, this reads process-wide
 
 **Returns:** `ModelCost[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L173))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L174))
 
 ### listThreads
 
@@ -333,7 +333,7 @@ Summary sourcing: threads opened with `thread(summarize: true)` are
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L282))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L283))
 
 ### currentThreadId
 
@@ -348,7 +348,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L335))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L336))
 
 ### getThread
 
@@ -380,4 +380,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L345))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/thread.agency#L346))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -1,5 +1,6 @@
 ---
 name: "ui"
+description: "Builds interactive terminal UIs for CLI agents from composable builders, driven by a render loop."
 ---
 
 # ui
@@ -53,7 +54,7 @@ export type Element = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L69))
 
 ### KeyEvent
 
@@ -87,7 +88,7 @@ export type KeyEvent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L90))
 
 ### Builder
 
@@ -126,7 +127,7 @@ export type Builder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L109))
 
 ### ChoiceItem
 
@@ -146,7 +147,7 @@ export type ChoiceItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L833))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L834))
 
 ## Functions
 
@@ -175,7 +176,7 @@ Build a plain text element. It carries no layout sizing of its own,
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L128))
 
 ### line
 
@@ -230,7 +231,7 @@ Build a single-line text element (height 1) so it does not stretch
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L167))
 
 ### list
 
@@ -282,7 +283,7 @@ Build a scrollable selectable list. `selectedIndex` highlights one
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L221))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L222))
 
 ### textInput
 
@@ -327,7 +328,7 @@ Build a single-line text input. The renderer displays `value` with
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L270))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L271))
 
 ### column
 
@@ -387,7 +388,7 @@ Build a vertical container; children stack top-to-bottom. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L362))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L363))
 
 ### row
 
@@ -444,7 +445,7 @@ Build a horizontal container; children stack left-to-right. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L421))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L422))
 
 ### box
 
@@ -501,7 +502,7 @@ Build a direction-neutral container. Use it to apply styling
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L478))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L479))
 
 ### renderOnce
 
@@ -524,7 +525,7 @@ Render a single Element tree to the screen and return immediately.
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L710))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L711))
 
 ### readKey
 
@@ -542,7 +543,7 @@ Read one key from the terminal, blocking until a key is pressed.
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L725))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L726))
 
 ### runLoop
 
@@ -600,7 +601,7 @@ Elm/Ink-style state machine driver. Renders `initialState`, waits
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L751))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L752))
 
 ### pushMessage
 
@@ -621,7 +622,7 @@ Append a message to the active REPL transcript. It renders on the
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L869))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L870))
 
 ### clearMessages
 
@@ -633,7 +634,7 @@ Remove all messages from the active REPL transcript. Use it for an
   explicit "clear conversation" command. Silent no-op when no REPL is
   active.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L888))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L889))
 
 ### select
 
@@ -672,7 +673,7 @@ Ask the user to pick from a list with arrow keys (no type-to-filter).
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L910))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L911))
 
 ### autocomplete
 
@@ -715,7 +716,7 @@ Ask the user to pick from a list, filtering by typed text. Returns
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L934))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L935))
 
 ### prompt
 
@@ -757,7 +758,7 @@ Ask the user for a line of free-form text. Returns `success(typed)`
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L968))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L969))
 
 ### confirm
 
@@ -783,7 +784,7 @@ Ask the user a yes/no question. Returns `success(true)`,
 
 **Returns:** `Result<boolean>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L992))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L993))
 
 ### chooseOption
 
@@ -829,7 +830,7 @@ Show a modal choice prompt and block until the user picks one. Returns
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1032))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1033))
 
 ### repl
 
@@ -879,4 +880,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a scrollable
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1791))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1792))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -1,6 +1,6 @@
 ---
 name: "ui"
-description: "Builds interactive terminal UIs for CLI agents. Assemble a screen from builders like `column`, `row`, `box`, `text`, and `textInput`, then drive the render loop with `runLoop`. For chat-style agents, `repl()` is a drop-in widget bundling a scrollable transcript, a live status line, a slash-command palette, and an input bar with history. For quick one-off questions outside a `repl()`, use the line-mode prompts `select`, `autocomplete`, `prompt`, and `confirm`."
+description: "Builds interactive terminal UIs for CLI agents from composable builders, driven by a render loop."
 ---
 
 # ui
@@ -54,7 +54,7 @@ export type Element = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L69))
 
 ### KeyEvent
 
@@ -88,7 +88,7 @@ export type KeyEvent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L89))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L90))
 
 ### Builder
 
@@ -127,7 +127,7 @@ export type Builder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L109))
 
 ### ChoiceItem
 
@@ -147,7 +147,7 @@ export type ChoiceItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L833))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L834))
 
 ## Functions
 
@@ -176,7 +176,7 @@ Build a plain text element. It carries no layout sizing of its own,
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L128))
 
 ### line
 
@@ -231,7 +231,7 @@ Build a single-line text element (height 1) so it does not stretch
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L167))
 
 ### list
 
@@ -283,7 +283,7 @@ Build a scrollable selectable list. `selectedIndex` highlights one
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L221))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L222))
 
 ### textInput
 
@@ -328,7 +328,7 @@ Build a single-line text input. The renderer displays `value` with
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L270))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L271))
 
 ### column
 
@@ -388,7 +388,7 @@ Build a vertical container; children stack top-to-bottom. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L362))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L363))
 
 ### row
 
@@ -445,7 +445,7 @@ Build a horizontal container; children stack left-to-right. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L421))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L422))
 
 ### box
 
@@ -502,7 +502,7 @@ Build a direction-neutral container. Use it to apply styling
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L478))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L479))
 
 ### renderOnce
 
@@ -525,7 +525,7 @@ Render a single Element tree to the screen and return immediately.
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L710))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L711))
 
 ### readKey
 
@@ -543,7 +543,7 @@ Read one key from the terminal, blocking until a key is pressed.
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L725))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L726))
 
 ### runLoop
 
@@ -601,7 +601,7 @@ Elm/Ink-style state machine driver. Renders `initialState`, waits
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L751))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L752))
 
 ### pushMessage
 
@@ -622,7 +622,7 @@ Append a message to the active REPL transcript. It renders on the
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L869))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L870))
 
 ### clearMessages
 
@@ -634,7 +634,7 @@ Remove all messages from the active REPL transcript. Use it for an
   explicit "clear conversation" command. Silent no-op when no REPL is
   active.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L888))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L889))
 
 ### select
 
@@ -673,7 +673,7 @@ Ask the user to pick from a list with arrow keys (no type-to-filter).
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L910))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L911))
 
 ### autocomplete
 
@@ -716,7 +716,7 @@ Ask the user to pick from a list, filtering by typed text. Returns
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L934))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L935))
 
 ### prompt
 
@@ -758,7 +758,7 @@ Ask the user for a line of free-form text. Returns `success(typed)`
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L968))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L969))
 
 ### confirm
 
@@ -784,7 +784,7 @@ Ask the user a yes/no question. Returns `success(true)`,
 
 **Returns:** `Result<boolean>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L992))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L993))
 
 ### chooseOption
 
@@ -830,7 +830,7 @@ Show a modal choice prompt and block until the user picks one. Returns
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1032))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1033))
 
 ### repl
 
@@ -880,4 +880,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a scrollable
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1791))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1792))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -1,6 +1,6 @@
 ---
 name: "ui"
-description: "Builds interactive terminal UIs for CLI agents from composable builders, driven by a render loop."
+description: "Builds interactive terminal UIs for CLI agents. Assemble a screen from builders like `column`, `row`, `box`, `text`, and `textInput`, then drive the render loop with `runLoop`. For chat-style agents, `repl()` is a drop-in widget bundling a scrollable transcript, a live status line, a slash-command palette, and an input bar with history. For quick one-off questions outside a `repl()`, use the line-mode prompts `select`, `autocomplete`, `prompt`, and `confirm`."
 ---
 
 # ui
@@ -54,7 +54,7 @@ export type Element = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L69))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L68))
 
 ### KeyEvent
 
@@ -88,7 +88,7 @@ export type KeyEvent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L89))
 
 ### Builder
 
@@ -127,7 +127,7 @@ export type Builder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L108))
 
 ### ChoiceItem
 
@@ -147,7 +147,7 @@ export type ChoiceItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L834))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L833))
 
 ## Functions
 
@@ -176,7 +176,7 @@ Build a plain text element. It carries no layout sizing of its own,
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L128))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L127))
 
 ### line
 
@@ -231,7 +231,7 @@ Build a single-line text element (height 1) so it does not stretch
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L167))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L166))
 
 ### list
 
@@ -283,7 +283,7 @@ Build a scrollable selectable list. `selectedIndex` highlights one
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L222))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L221))
 
 ### textInput
 
@@ -328,7 +328,7 @@ Build a single-line text input. The renderer displays `value` with
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L271))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L270))
 
 ### column
 
@@ -388,7 +388,7 @@ Build a vertical container; children stack top-to-bottom. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L363))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L362))
 
 ### row
 
@@ -445,7 +445,7 @@ Build a horizontal container; children stack left-to-right. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L422))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L421))
 
 ### box
 
@@ -502,7 +502,7 @@ Build a direction-neutral container. Use it to apply styling
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L479))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L478))
 
 ### renderOnce
 
@@ -525,7 +525,7 @@ Render a single Element tree to the screen and return immediately.
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L711))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L710))
 
 ### readKey
 
@@ -543,7 +543,7 @@ Read one key from the terminal, blocking until a key is pressed.
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L726))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L725))
 
 ### runLoop
 
@@ -601,7 +601,7 @@ Elm/Ink-style state machine driver. Renders `initialState`, waits
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L752))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L751))
 
 ### pushMessage
 
@@ -622,7 +622,7 @@ Append a message to the active REPL transcript. It renders on the
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L870))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L869))
 
 ### clearMessages
 
@@ -634,7 +634,7 @@ Remove all messages from the active REPL transcript. Use it for an
   explicit "clear conversation" command. Silent no-op when no REPL is
   active.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L889))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L888))
 
 ### select
 
@@ -673,7 +673,7 @@ Ask the user to pick from a list with arrow keys (no type-to-filter).
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L911))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L910))
 
 ### autocomplete
 
@@ -716,7 +716,7 @@ Ask the user to pick from a list, filtering by typed text. Returns
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L935))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L934))
 
 ### prompt
 
@@ -758,7 +758,7 @@ Ask the user for a line of free-form text. Returns `success(typed)`
 
 **Returns:** `Result<string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L969))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L968))
 
 ### confirm
 
@@ -784,7 +784,7 @@ Ask the user a yes/no question. Returns `success(true)`,
 
 **Returns:** `Result<boolean>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L993))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L992))
 
 ### chooseOption
 
@@ -830,7 +830,7 @@ Show a modal choice prompt and block until the user picks one. Returns
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1033))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1032))
 
 ### repl
 
@@ -880,4 +880,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a scrollable
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1792))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui.agency#L1791))

--- a/packages/agency-lang/docs/site/stdlib/ui/chart.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/chart.md
@@ -1,5 +1,6 @@
 ---
 name: "chart"
+description: "Draws horizontal bar charts for terminal output; barChart(...) returns a layout node you render with std::ui/layout."
 ---
 
 # chart
@@ -54,7 +55,7 @@ export type BarKey = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L42))
 
 ### Bar
 
@@ -68,7 +69,7 @@ export type Bar = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L49))
 
 ### BarMode
 
@@ -76,7 +77,7 @@ export type Bar = {
 export type BarMode = "stacked" | "grouped"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L54))
 
 ### ChartBuilder
 
@@ -90,7 +91,7 @@ export type ChartBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L57))
 
 ## Functions
 
@@ -143,4 +144,4 @@ Build a horizontal bar chart as a layout node. Pass the data form:
 
 **Returns:** [LayoutNode](layout.md#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L86))

--- a/packages/agency-lang/docs/site/stdlib/ui/chart.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/chart.md
@@ -1,6 +1,6 @@
 ---
 name: "chart"
-description: "Draws horizontal bar charts for terminal output. `barChart(...)` returns a layout node. Render it with `render` from `std::ui/layout`, so a chart nests inside `box` / `row` / `column`. Pass the series and categories directly (data form, JSON-friendly and LLM-callable) or build them up in a trailing block. Each series gets a distinct color and fill symbol when you omit them, so charts stay readable even with color disabled. Negative values draw left of a zero baseline. Stacked bars must be uniform-sign."
+description: "Draws horizontal bar charts for terminal output; barChart(...) returns a layout node you render with std::ui/layout."
 ---
 
 # chart
@@ -55,7 +55,7 @@ export type BarKey = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L41))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L42))
 
 ### Bar
 
@@ -69,7 +69,7 @@ export type Bar = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L49))
 
 ### BarMode
 
@@ -77,7 +77,7 @@ export type Bar = {
 export type BarMode = "stacked" | "grouped"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L54))
 
 ### ChartBuilder
 
@@ -91,7 +91,7 @@ export type ChartBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L57))
 
 ## Functions
 
@@ -144,4 +144,4 @@ Build a horizontal bar chart as a layout node. Pass the data form:
 
 **Returns:** [LayoutNode](layout.md#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L86))

--- a/packages/agency-lang/docs/site/stdlib/ui/chart.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/chart.md
@@ -1,6 +1,6 @@
 ---
 name: "chart"
-description: "Draws horizontal bar charts for terminal output; barChart(...) returns a layout node you render with std::ui/layout."
+description: "Draws horizontal bar charts for terminal output. `barChart(...)` returns a layout node. Render it with `render` from `std::ui/layout`, so a chart nests inside `box` / `row` / `column`. Pass the series and categories directly (data form, JSON-friendly and LLM-callable) or build them up in a trailing block. Each series gets a distinct color and fill symbol when you omit them, so charts stay readable even with color disabled. Negative values draw left of a zero baseline. Stacked bars must be uniform-sign."
 ---
 
 # chart
@@ -55,7 +55,7 @@ export type BarKey = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L41))
 
 ### Bar
 
@@ -69,7 +69,7 @@ export type Bar = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L48))
 
 ### BarMode
 
@@ -77,7 +77,7 @@ export type Bar = {
 export type BarMode = "stacked" | "grouped"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L53))
 
 ### ChartBuilder
 
@@ -91,7 +91,7 @@ export type ChartBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L56))
 
 ## Functions
 
@@ -144,4 +144,4 @@ Build a horizontal bar chart as a layout node. Pass the data form:
 
 **Returns:** [LayoutNode](layout.md#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/chart.agency#L85))

--- a/packages/agency-lang/docs/site/stdlib/ui/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/cli.md
@@ -1,5 +1,6 @@
 ---
 name: "cli"
+description: "A line-mode REPL for CLI agents, driven by Node's readline instead of the alt-screen TUI engine in std::ui."
 ---
 
 # cli
@@ -69,7 +70,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 | historyMax | `number` | 1000 |
 | paletteCommands | `any` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L62))
 
 ### clearScreen
 
@@ -77,7 +78,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 clearScreen()
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L102))
 
 ### clearHistory
 
@@ -89,7 +90,7 @@ Clear the input history of the currently running `repl()` session: both
   its in-session up-arrow recall and the `historyFile` that session was started
   with. A no-op when called outside an interactive `repl()`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L106))
 
 ### hline
 
@@ -106,4 +107,4 @@ hline(char: string = "─", width: number = null): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L117))

--- a/packages/agency-lang/docs/site/stdlib/ui/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/cli.md
@@ -1,6 +1,6 @@
 ---
 name: "cli"
-description: "A line-mode REPL for CLI agents, driven by Node's `readline` instead of the alt-screen TUI engine in `std::ui`. It gives up the pinned status line, live spinner, and in-app scrolling. In exchange, every prompt and reply is a plain line in the terminal's scrollback, so you get native search, copy/paste, link clicks, line editing, and history for free. It shares `std::ui`'s `repl` call signature, so switching modes is a one-line import change:"
+description: "A line-mode REPL for CLI agents, driven by Node's readline instead of the alt-screen TUI engine in std::ui."
 ---
 
 # cli
@@ -70,7 +70,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 | historyMax | `number` | 1000 |
 | paletteCommands | `any` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L62))
 
 ### clearScreen
 
@@ -78,7 +78,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 clearScreen()
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L102))
 
 ### clearHistory
 
@@ -90,7 +90,7 @@ Clear the input history of the currently running `repl()` session: both
   its in-session up-arrow recall and the `historyFile` that session was started
   with. A no-op when called outside an interactive `repl()`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L106))
 
 ### hline
 
@@ -107,4 +107,4 @@ hline(char: string = "─", width: number = null): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L117))

--- a/packages/agency-lang/docs/site/stdlib/ui/cli.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/cli.md
@@ -1,6 +1,6 @@
 ---
 name: "cli"
-description: "A line-mode REPL for CLI agents, driven by Node's readline instead of the alt-screen TUI engine in std::ui."
+description: "A line-mode REPL for CLI agents, driven by Node's `readline` instead of the alt-screen TUI engine in `std::ui`. It gives up the pinned status line, live spinner, and in-app scrolling. In exchange, every prompt and reply is a plain line in the terminal's scrollback, so you get native search, copy/paste, link clicks, line editing, and history for free. It shares `std::ui`'s `repl` call signature, so switching modes is a one-line import change:"
 ---
 
 # cli
@@ -70,7 +70,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 | historyMax | `number` | 1000 |
 | paletteCommands | `any` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L61))
 
 ### clearScreen
 
@@ -78,7 +78,7 @@ Line-mode REPL with the same call signature as the std::ui TUI repl,
 clearScreen()
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L101))
 
 ### clearHistory
 
@@ -90,7 +90,7 @@ Clear the input history of the currently running `repl()` session: both
   its in-session up-arrow recall and the `historyFile` that session was started
   with. A no-op when called outside an interactive `repl()`.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L105))
 
 ### hline
 
@@ -107,4 +107,4 @@ hline(char: string = "─", width: number = null): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/cli.agency#L116))

--- a/packages/agency-lang/docs/site/stdlib/ui/layout.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/layout.md
@@ -1,6 +1,6 @@
 ---
 name: "layout"
-description: "Build terminal output as a tree of boxes, rows, and columns, then render it to a styled string you can print. Handy for splash screens, summary panels, and side-by-side columns."
+description: "Build terminal output as a tree of boxes, rows, and columns, then render it to a styled string you can print."
 ---
 
 # layout

--- a/packages/agency-lang/docs/site/stdlib/ui/layout.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/layout.md
@@ -1,5 +1,6 @@
 ---
 name: "layout"
+description: "Build terminal output as a tree of boxes, rows, and columns, then render it to a styled string you can print. Handy for splash screens, summary panels, and side-by-side columns."
 ---
 
 # layout

--- a/packages/agency-lang/docs/site/stdlib/ui/table.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/table.md
@@ -1,5 +1,6 @@
 ---
 name: "table"
+description: "Draws tables for terminal output; table(...) returns a layout node you render with std::ui/layout."
 ---
 
 # table
@@ -53,7 +54,7 @@ Draws tables for terminal output. `table(...)` returns a layout node whose
 export type Cell = string | LayoutNode
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L43))
 
 ### CellRow
 
@@ -61,7 +62,7 @@ export type Cell = string | LayoutNode
 export type CellRow = Cell[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L48))
 
 ### ColumnSpec
 
@@ -97,7 +98,7 @@ export type ColumnSpec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L62))
 
 ### TableBuilder
 
@@ -120,7 +121,7 @@ export type TableBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L74))
 
 ## Functions
 
@@ -190,4 +191,4 @@ Build a bordered table as a layout node. Pass the data form: `header`,
 
 **Returns:** [LayoutNode](layout.md#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L117))

--- a/packages/agency-lang/docs/site/stdlib/ui/table.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/table.md
@@ -1,6 +1,6 @@
 ---
 name: "table"
-description: "Draws tables for terminal output; table(...) returns a layout node you render with std::ui/layout."
+description: "Draws tables for terminal output. `table(...)` returns a layout node whose columns line up across header, body, and footer. Render it with `render` from `std::ui/layout`, so a table nests inside `box` / `row` / `column`. Pass the rows directly (data form, JSON-friendly and LLM-callable) or build them up in a trailing block."
 ---
 
 # table
@@ -54,7 +54,7 @@ Draws tables for terminal output. `table(...)` returns a layout node whose
 export type Cell = string | LayoutNode
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L42))
 
 ### CellRow
 
@@ -62,7 +62,7 @@ export type Cell = string | LayoutNode
 export type CellRow = Cell[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L47))
 
 ### ColumnSpec
 
@@ -98,7 +98,7 @@ export type ColumnSpec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L62))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L61))
 
 ### TableBuilder
 
@@ -121,7 +121,7 @@ export type TableBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L73))
 
 ## Functions
 
@@ -191,4 +191,4 @@ Build a bordered table as a layout node. Pass the data form: `header`,
 
 **Returns:** [LayoutNode](layout.md#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L116))

--- a/packages/agency-lang/docs/site/stdlib/ui/table.md
+++ b/packages/agency-lang/docs/site/stdlib/ui/table.md
@@ -1,6 +1,6 @@
 ---
 name: "table"
-description: "Draws tables for terminal output. `table(...)` returns a layout node whose columns line up across header, body, and footer. Render it with `render` from `std::ui/layout`, so a table nests inside `box` / `row` / `column`. Pass the rows directly (data form, JSON-friendly and LLM-callable) or build them up in a trailing block."
+description: "Draws tables for terminal output; table(...) returns a layout node you render with std::ui/layout."
 ---
 
 # table
@@ -54,7 +54,7 @@ Draws tables for terminal output. `table(...)` returns a layout node whose
 export type Cell = string | LayoutNode
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L43))
 
 ### CellRow
 
@@ -62,7 +62,7 @@ export type Cell = string | LayoutNode
 export type CellRow = Cell[]
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L48))
 
 ### ColumnSpec
 
@@ -98,7 +98,7 @@ export type ColumnSpec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L61))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L62))
 
 ### TableBuilder
 
@@ -121,7 +121,7 @@ export type TableBuilder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L73))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L74))
 
 ## Functions
 
@@ -191,4 +191,4 @@ Build a bordered table as a layout node. Pass the data form: `header`,
 
 **Returns:** [LayoutNode](layout.md#layoutnode)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L116))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/ui/table.agency#L117))

--- a/packages/agency-lang/docs/site/stdlib/validation.md
+++ b/packages/agency-lang/docs/site/stdlib/validation.md
@@ -1,6 +1,6 @@
 ---
 name: "validation"
-description: "Validators and format helpers for constrained types. Pair a validator with `@validate(...)` to check values at runtime, spread the pre-baked `@jsonSchema(...)` format fragments into your own schemas, or reach for the ready-made type aliases (`Email`, `URLString`, `UUIDString`, …) that combine both. Each validator takes a value and returns a `Result`."
+description: "Validators and format helpers for constrained types, for use with @validate(...) and @jsonSchema(...)."
 ---
 
 # validation
@@ -52,7 +52,7 @@ export type Email = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L165))
 
 ### URLString
 
@@ -79,7 +79,7 @@ export type URLString = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L170))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L171))
 
 ### UUIDString
 
@@ -106,7 +106,7 @@ export type UUIDString = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L176))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L177))
 
 ### NumberInRange
 
@@ -137,7 +137,7 @@ export type NumberInRange(low: number, high: number) = number
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L184))
 
 ### StringWithLength
 
@@ -164,7 +164,7 @@ export type StringWithLength(min: number, max: number) = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L188))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L189))
 
 ### MatchesPattern
 
@@ -189,7 +189,7 @@ export type MatchesPattern(pat: string) = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L193))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L194))
 
 ### BoundedArray
 
@@ -213,7 +213,7 @@ export type BoundedArray<T>(min: number, max: number) = T[]
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L197))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L198))
 
 ## Constants
 
@@ -225,7 +225,7 @@ export static const emailFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L141))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L142))
 
 ### urlFormat
 
@@ -235,7 +235,7 @@ export static const urlFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L145))
 
 ### uuidFormat
 
@@ -245,7 +245,7 @@ export static const uuidFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L148))
 
 ### dateTimeFormat
 
@@ -255,7 +255,7 @@ export static const dateTimeFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L151))
 
 ### dateFormat
 
@@ -265,7 +265,7 @@ export static const dateFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L153))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L154))
 
 ### ipv4Format
 
@@ -275,7 +275,7 @@ export static const ipv4Format = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L157))
 
 ### ipv6Format
 
@@ -285,7 +285,7 @@ export static const ipv6Format = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L159))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L160))
 
 ## Functions
 
@@ -308,7 +308,7 @@ Returns success if value is a syntactically valid email address,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L28))
 
 ### isUrl
 
@@ -329,7 +329,7 @@ Returns success if value is an http:// or https:// URL,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L38))
 
 ### isUuid
 
@@ -350,7 +350,7 @@ Returns success if value is a canonical UUID string
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L48))
 
 ### isInt
 
@@ -371,7 +371,7 @@ Returns success if value is an integer (no fractional component),
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L58))
 
 ### isPositive
 
@@ -391,7 +391,7 @@ Returns success if value > 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L68))
 
 ### isNegative
 
@@ -411,7 +411,7 @@ Returns success if value < 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L76))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L77))
 
 ### min
 
@@ -435,7 +435,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(min.partial(n: 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L87))
 
 ### max
 
@@ -459,7 +459,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(max.partial(n: 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L98))
 
 ### minLength
 
@@ -483,7 +483,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(minLength.parti
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L109))
 
 ### maxLength
 
@@ -507,7 +507,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(maxLength.parti
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L120))
 
 ### matches
 
@@ -531,4 +531,4 @@ Bind `pattern` via PFA before use in `@validate(...)`, e.g. `@validate(matches.p
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L131))

--- a/packages/agency-lang/docs/site/stdlib/validation.md
+++ b/packages/agency-lang/docs/site/stdlib/validation.md
@@ -1,6 +1,6 @@
 ---
 name: "validation"
-description: "Validators and format helpers for constrained types, for use with @validate(...) and @jsonSchema(...)."
+description: "Validators and format helpers for constrained types. Pair a validator with `@validate(...)` to check values at runtime, spread the pre-baked `@jsonSchema(...)` format fragments into your own schemas, or reach for the ready-made type aliases (`Email`, `URLString`, `UUIDString`, …) that combine both. Each validator takes a value and returns a `Result`."
 ---
 
 # validation
@@ -52,7 +52,7 @@ export type Email = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L165))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L164))
 
 ### URLString
 
@@ -79,7 +79,7 @@ export type URLString = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L171))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L170))
 
 ### UUIDString
 
@@ -106,7 +106,7 @@ export type UUIDString = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L177))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L176))
 
 ### NumberInRange
 
@@ -137,7 +137,7 @@ export type NumberInRange(low: number, high: number) = number
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L184))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L183))
 
 ### StringWithLength
 
@@ -164,7 +164,7 @@ export type StringWithLength(min: number, max: number) = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L189))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L188))
 
 ### MatchesPattern
 
@@ -189,7 +189,7 @@ export type MatchesPattern(pat: string) = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L194))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L193))
 
 ### BoundedArray
 
@@ -213,7 +213,7 @@ export type BoundedArray<T>(min: number, max: number) = T[]
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L198))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L197))
 
 ## Constants
 
@@ -225,7 +225,7 @@ export static const emailFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L142))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L141))
 
 ### urlFormat
 
@@ -235,7 +235,7 @@ export static const urlFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L144))
 
 ### uuidFormat
 
@@ -245,7 +245,7 @@ export static const uuidFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L147))
 
 ### dateTimeFormat
 
@@ -255,7 +255,7 @@ export static const dateTimeFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L151))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L150))
 
 ### dateFormat
 
@@ -265,7 +265,7 @@ export static const dateFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L154))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L153))
 
 ### ipv4Format
 
@@ -275,7 +275,7 @@ export static const ipv4Format = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L157))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L156))
 
 ### ipv6Format
 
@@ -285,7 +285,7 @@ export static const ipv6Format = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L160))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L159))
 
 ## Functions
 
@@ -308,7 +308,7 @@ Returns success if value is a syntactically valid email address,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L28))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L27))
 
 ### isUrl
 
@@ -329,7 +329,7 @@ Returns success if value is an http:// or https:// URL,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L38))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L37))
 
 ### isUuid
 
@@ -350,7 +350,7 @@ Returns success if value is a canonical UUID string
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L47))
 
 ### isInt
 
@@ -371,7 +371,7 @@ Returns success if value is an integer (no fractional component),
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L57))
 
 ### isPositive
 
@@ -391,7 +391,7 @@ Returns success if value > 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L67))
 
 ### isNegative
 
@@ -411,7 +411,7 @@ Returns success if value < 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L76))
 
 ### min
 
@@ -435,7 +435,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(min.partial(n: 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L86))
 
 ### max
 
@@ -459,7 +459,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(max.partial(n: 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L97))
 
 ### minLength
 
@@ -483,7 +483,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(minLength.parti
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L108))
 
 ### maxLength
 
@@ -507,7 +507,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(maxLength.parti
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L120))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L119))
 
 ### matches
 
@@ -531,4 +531,4 @@ Bind `pattern` via PFA before use in `@validate(...)`, e.g. `@validate(matches.p
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L131))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L130))

--- a/packages/agency-lang/docs/site/stdlib/validation.md
+++ b/packages/agency-lang/docs/site/stdlib/validation.md
@@ -1,5 +1,6 @@
 ---
 name: "validation"
+description: "Validators and format helpers for constrained types, for use with @validate(...) and @jsonSchema(...)."
 ---
 
 # validation
@@ -51,7 +52,7 @@ export type Email = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L165))
 
 ### URLString
 
@@ -78,7 +79,7 @@ export type URLString = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L170))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L171))
 
 ### UUIDString
 
@@ -105,7 +106,7 @@ export type UUIDString = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L176))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L177))
 
 ### NumberInRange
 
@@ -136,7 +137,7 @@ export type NumberInRange(low: number, high: number) = number
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L183))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L184))
 
 ### StringWithLength
 
@@ -163,7 +164,7 @@ export type StringWithLength(min: number, max: number) = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L188))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L189))
 
 ### MatchesPattern
 
@@ -188,7 +189,7 @@ export type MatchesPattern(pat: string) = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L193))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L194))
 
 ### BoundedArray
 
@@ -212,7 +213,7 @@ export type BoundedArray<T>(min: number, max: number) = T[]
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L197))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L198))
 
 ## Constants
 
@@ -224,7 +225,7 @@ export static const emailFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L141))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L142))
 
 ### urlFormat
 
@@ -234,7 +235,7 @@ export static const urlFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L145))
 
 ### uuidFormat
 
@@ -244,7 +245,7 @@ export static const uuidFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L148))
 
 ### dateTimeFormat
 
@@ -254,7 +255,7 @@ export static const dateTimeFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L151))
 
 ### dateFormat
 
@@ -264,7 +265,7 @@ export static const dateFormat = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L153))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L154))
 
 ### ipv4Format
 
@@ -274,7 +275,7 @@ export static const ipv4Format = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L157))
 
 ### ipv6Format
 
@@ -284,7 +285,7 @@ export static const ipv6Format = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L159))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L160))
 
 ## Functions
 
@@ -307,7 +308,7 @@ Returns success if value is a syntactically valid email address,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L28))
 
 ### isUrl
 
@@ -328,7 +329,7 @@ Returns success if value is an http:// or https:// URL,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L38))
 
 ### isUuid
 
@@ -349,7 +350,7 @@ Returns success if value is a canonical UUID string
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L48))
 
 ### isInt
 
@@ -370,7 +371,7 @@ Returns success if value is an integer (no fractional component),
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L57))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L58))
 
 ### isPositive
 
@@ -390,7 +391,7 @@ Returns success if value > 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L68))
 
 ### isNegative
 
@@ -410,7 +411,7 @@ Returns success if value < 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L76))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L77))
 
 ### min
 
@@ -434,7 +435,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(min.partial(n: 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L87))
 
 ### max
 
@@ -458,7 +459,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(max.partial(n: 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L97))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L98))
 
 ### minLength
 
@@ -482,7 +483,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(minLength.parti
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L109))
 
 ### maxLength
 
@@ -506,7 +507,7 @@ Bind `n` via PFA before use in `@validate(...)`, e.g. `@validate(maxLength.parti
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L119))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L120))
 
 ### matches
 
@@ -530,4 +531,4 @@ Bind `pattern` via PFA before use in `@validate(...)`, e.g. `@validate(matches.p
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/packages/agency-lang/stdlib/validation.agency#L131))

--- a/packages/agency-lang/docs/site/stdlib/weather.md
+++ b/packages/agency-lang/docs/site/stdlib/weather.md
@@ -1,6 +1,6 @@
 ---
 name: "weather"
-description: "Look up current weather for a city or zip code, and convert between Celsius and Fahrenheit. No API key required."
+description: "Look up current weather for a city or zip code, and convert between Celsius and Fahrenheit."
 ---
 
 # weather

--- a/packages/agency-lang/docs/site/stdlib/weather.md
+++ b/packages/agency-lang/docs/site/stdlib/weather.md
@@ -1,5 +1,6 @@
 ---
 name: "weather"
+description: "Look up current weather for a city or zip code, and convert between Celsius and Fahrenheit. No API key required."
 ---
 
 # weather

--- a/packages/agency-lang/docs/site/stdlib/web/browser.md
+++ b/packages/agency-lang/docs/site/stdlib/web/browser.md
@@ -1,5 +1,6 @@
 ---
 name: "browser"
+description: "Run browser automation tasks described in plain language via the Browser Use cloud API."
 ---
 
 # browser

--- a/packages/agency-lang/docs/site/stdlib/web/search.md
+++ b/packages/agency-lang/docs/site/stdlib/web/search.md
@@ -1,5 +1,6 @@
 ---
 name: "search"
+description: "Search the web from Agency code, backed by the Brave Search API (https://brave.com/search/api/). Use `tavilySearch` for AI-optimized results."
 ---
 
 # search

--- a/packages/agency-lang/docs/site/stdlib/web/search.md
+++ b/packages/agency-lang/docs/site/stdlib/web/search.md
@@ -1,6 +1,6 @@
 ---
 name: "search"
-description: "Search the web from Agency code, backed by the Brave Search API (https://brave.com/search/api/). Use `tavilySearch` for AI-optimized results."
+description: "Search the web from Agency code, backed by the Brave Search API (https://brave.com/search/api/)."
 ---
 
 # search

--- a/packages/agency-lang/docs/site/stdlib/wikipedia.md
+++ b/packages/agency-lang/docs/site/stdlib/wikipedia.md
@@ -1,5 +1,6 @@
 ---
 name: "wikipedia"
+description: "Search Wikipedia and read article summaries or full text from Agency code."
 ---
 
 # wikipedia

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/code.agency
@@ -71,6 +71,7 @@ static const superpowersSkill = skillsDir("./skills/superpowers", "flat") with a
 static const docSkill = docsSkill("guide")
 static const cliSkill = docsSkill("cli")
 static const diagnosticsSkill = docsSkill("diagnostics")
+static const stdlibSkill = docsSkill("stdlib")
 
 export def agencyCli(args: string[]): any {
   """
@@ -103,6 +104,10 @@ call the bundled docs tools — they are authoritative for Agency:
   * `diagnosticsSkill` — type-checker diagnostic codes (AG####) with
                  explanations and fixes; consult it when `typecheck` reports
                  an error code you want to understand or resolve
+  * `stdlibSkill` — the standard-library reference (`std::http`,
+                 `std::thread`, `std::date`, …); each module lists a
+                 one-line summary. Use it to discover which `std::`
+                 module does what before importing.
 Pick whichever matches the question rather than guessing.
 
 **Stay focused on the current task.** Most follow-ups ("can you make it
@@ -398,6 +403,7 @@ export static const codeTools: any[] = [
   docSkill,
   cliSkill,
   diagnosticsSkill,
+  stdlibSkill,
   todoWrite,
   todoList,
   oracleAgent,

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/explorer.agency
@@ -24,6 +24,7 @@ import { getSlowModel, getSlowProvider } from "../shared.agency"
 static const docSkill = docsSkill("guide")
 static const cliSkill = docsSkill("cli")
 static const diagnosticsSkill = docsSkill("diagnostics")
+static const stdlibSkill = docsSkill("stdlib")
 
 export static const explorerSysPrompt = """
 You are the **explorer** — a read-only researcher called by other
@@ -51,6 +52,9 @@ and produce structured overviews. Typical questions you answer:
   `ls` the relevant directories and **list every file that could
   be relevant**. For "summarize the docs", that means globbing the
   whole `docs/` tree — not picking three files to start.
+- **Use the standard-library reference.** For any question about what
+  `std::` modules exist or what they do, call `stdlibSkill` — it lists
+  every module with a one-line summary, then lets you read any page.
 - **Read in parallel batches.** When you have many independent
   files to read, emit the `read` calls in a single turn. The
   runtime executes them concurrently when they arrive together;
@@ -110,6 +114,7 @@ export static const explorerTools: any[] = [
   docSkill,
   cliSkill,
   diagnosticsSkill,
+  stdlibSkill,
 ]
 
 // only add system message the first time

--- a/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/subagents/research.agency
@@ -32,6 +32,7 @@ import { withWebSearch } from "../lib/search.agency"
 static const docSkill = docsSkill("guide")
 static const cliSkill = docsSkill("cli")
 static const diagnosticsSkill = docsSkill("diagnostics")
+static const stdlibSkill = docsSkill("stdlib")
 
 export static const researchSysPrompt = """
 You are the **research specialist** of a multi-thread Agency-language
@@ -55,6 +56,8 @@ When you need information:
                         `agency compile`, ...)
     * `diagnosticsSkill` — type-checker diagnostic codes (AG####)
                         with explanations and fixes
+    * `stdlibSkill`   — standard-library reference (`std::http`,
+                        `std::thread`, …), one summary per module
   Pick whichever matches the question rather than guessing.
 
 - For **general knowledge**, prefer the lighter tools first:
@@ -115,6 +118,7 @@ export static const researchTools: any[] = [
   docSkill,
   cliSkill,
   diagnosticsSkill,
+  stdlibSkill,
   wikipediaSearch.rename("wikipedia_search"),
   wikipediaSummary.rename("wikipedia_summary"),
   wikipediaArticle.rename("wikipedia_article"),

--- a/packages/agency-lang/lib/cli/doc.test.ts
+++ b/packages/agency-lang/lib/cli/doc.test.ts
@@ -3,6 +3,7 @@ import {
   generateDoc,
   extractSummaryOverride,
   firstParagraph,
+  firstSentence,
   sanitizeDescription,
   moduleDescription,
 } from "./doc.js";
@@ -71,6 +72,26 @@ describe("extractSummaryOverride", () => {
   });
 });
 
+describe("firstSentence", () => {
+  it("takes text up to the first sentence terminator", () => {
+    expect(firstSentence("Fetch URLs. Returns text, JSON, or Markdown.")).toBe(
+      "Fetch URLs.",
+    );
+  });
+
+  it("returns the whole string when there is no terminator", () => {
+    expect(firstSentence("Wikidata — the open knowledge graph")).toBe(
+      "Wikidata — the open knowledge graph",
+    );
+  });
+
+  it("keeps a one-sentence string with an internal colon intact", () => {
+    expect(firstSentence("Helpers: round, add, and subtract.")).toBe(
+      "Helpers: round, add, and subtract.",
+    );
+  });
+});
+
 describe("sanitizeDescription", () => {
   it("removes double quotes and backslashes", () => {
     expect(sanitizeDescription('e.g. "America/New_York" path\\x')).toBe(
@@ -93,12 +114,12 @@ describe("sanitizeDescription", () => {
 });
 
 describe("moduleDescription", () => {
-  it("derives from the first paragraph when there is no @summary", () => {
+  it("derives the first sentence when there is no @summary", () => {
     expect(
       moduleDescription(
         moduleComment("\n  Fetch URLs. Returns text.\n\n  ```ts\n  x\n  ```"),
       ),
-    ).toBe("Fetch URLs. Returns text.");
+    ).toBe("Fetch URLs.");
   });
 
   it("prefers an explicit @summary override", () => {
@@ -722,7 +743,7 @@ node main() { print("hi") }
     expect(output).toMatch(/dir: string/);
   });
 
-  it("emits a description derived from the @module comment", () => {
+  it("emits the first sentence of the @module comment as the description", () => {
     const inputDir = path.join(tmpDir, "input-desc");
     const outputDir = path.join(tmpDir, "output-desc");
     fs.mkdirSync(inputDir, { recursive: true });
@@ -736,7 +757,7 @@ node main() { print("hi") }
     generateDoc({}, path.join(inputDir, "m.agency"), outputDir);
     const out = fs.readFileSync(path.join(outputDir, "m.md"), "utf-8");
     expect(out).toContain(
-      'description: "Fetch URLs from Agency code. Returns text, JSON, or Markdown."',
+      'description: "Fetch URLs from Agency code."',
     );
   });
 
@@ -747,13 +768,13 @@ node main() { print("hi") }
     fs.writeFileSync(
       path.join(inputDir, "q.agency"),
       "/** @module\n" +
-        "  Helpers: builds strings, e.g. \"America/New_York\" values.\n*/\n" +
+        "  Builds strings like \"America/New_York\" for callers: timezones and dates.\n*/\n" +
         "export def f(): string { return \"\" }\n",
     );
     generateDoc({}, path.join(inputDir, "q.agency"), outputDir);
     const out = fs.readFileSync(path.join(outputDir, "q.md"), "utf-8");
     expect(out).toContain(
-      'description: "Helpers: builds strings, e.g. America/New_York values."',
+      'description: "Builds strings like America/New_York for callers: timezones and dates."',
     );
     expect(out).not.toContain('\\"');
   });

--- a/packages/agency-lang/lib/cli/doc.test.ts
+++ b/packages/agency-lang/lib/cli/doc.test.ts
@@ -61,6 +61,14 @@ describe("extractSummaryOverride", () => {
     const { override } = extractSummaryOverride("\n  @summary\n  Body.\n");
     expect(override).toBeNull();
   });
+
+  it("does not treat @summaryfoo (no boundary) as an override", () => {
+    const { override, body } = extractSummaryOverride(
+      "\n  @summaryfoo bar\n  Body.\n",
+    );
+    expect(override).toBeNull();
+    expect(body).toContain("@summaryfoo bar");
+  });
 });
 
 describe("sanitizeDescription", () => {
@@ -70,12 +78,17 @@ describe("sanitizeDescription", () => {
     );
   });
 
-  it("caps at 200 chars on a word boundary and appends an ellipsis", () => {
+  it("strips a leading Markdown heading marker", () => {
+    expect(sanitizeDescription("## Wikidata — the open knowledge graph")).toBe(
+      "Wikidata — the open knowledge graph",
+    );
+  });
+
+  it("does not cap long text", () => {
     const long = "word ".repeat(60).trim(); // ~299 chars
     const out = sanitizeDescription(long);
-    expect(out.length).toBeLessThanOrEqual(201);
-    expect(out.endsWith("…")).toBe(true);
-    expect(out).not.toContain("wor…"); // no mid-word cut
+    expect(out).toBe(long);
+    expect(out).not.toContain("…");
   });
 });
 

--- a/packages/agency-lang/lib/cli/doc.test.ts
+++ b/packages/agency-lang/lib/cli/doc.test.ts
@@ -1,9 +1,103 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { generateDoc } from "./doc.js";
+import {
+  generateDoc,
+  extractSummaryOverride,
+  firstParagraph,
+  sanitizeDescription,
+  moduleDescription,
+} from "./doc.js";
+import type { AgencyMultiLineComment } from "@/types.js";
 import * as fs from "fs";
 import * as path from "path";
 
 const tmpDir = path.join(process.env.TMPDIR || "/tmp", "agency-doc-test");
+
+function moduleComment(content: string): AgencyMultiLineComment {
+  return {
+    type: "multiLineComment",
+    content,
+    isDoc: true,
+    isModuleDoc: true,
+  } as AgencyMultiLineComment;
+}
+
+describe("firstParagraph", () => {
+  it("takes the leading prose and stops at a blank line", () => {
+    expect(firstParagraph("\n  One. Two.\n\n  Later.")).toBe("One. Two.");
+  });
+
+  it("stops at an indented code fence (trims before the check)", () => {
+    expect(firstParagraph("\n  First line.\n  ```ts\n  code\n  ```\n")).toBe(
+      "First line.",
+    );
+  });
+
+  it("collapses internal whitespace and newlines to single spaces", () => {
+    expect(firstParagraph("\n  a\n  b   c\n")).toBe("a b c");
+  });
+
+  it("returns empty string when there is no prose", () => {
+    expect(firstParagraph("\n\n")).toBe("");
+  });
+});
+
+describe("extractSummaryOverride", () => {
+  it("pulls a leading @summary line and removes it from the body", () => {
+    const { override, body } = extractSummaryOverride(
+      "\n  @summary Short thing.\n  Long body prose.\n",
+    );
+    expect(override).toBe("Short thing.");
+    expect(body).not.toContain("@summary");
+    expect(body).toContain("Long body prose.");
+  });
+
+  it("returns null override and unchanged body when there is no @summary", () => {
+    const { override, body } = extractSummaryOverride("\n  Just prose.\n");
+    expect(override).toBeNull();
+    expect(body).toBe("\n  Just prose.\n");
+  });
+
+  it("treats a bare @summary with no text as no override", () => {
+    const { override } = extractSummaryOverride("\n  @summary\n  Body.\n");
+    expect(override).toBeNull();
+  });
+});
+
+describe("sanitizeDescription", () => {
+  it("removes double quotes and backslashes", () => {
+    expect(sanitizeDescription('e.g. "America/New_York" path\\x')).toBe(
+      "e.g. America/New_York pathx",
+    );
+  });
+
+  it("caps at 200 chars on a word boundary and appends an ellipsis", () => {
+    const long = "word ".repeat(60).trim(); // ~299 chars
+    const out = sanitizeDescription(long);
+    expect(out.length).toBeLessThanOrEqual(201);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toContain("wor…"); // no mid-word cut
+  });
+});
+
+describe("moduleDescription", () => {
+  it("derives from the first paragraph when there is no @summary", () => {
+    expect(
+      moduleDescription(
+        moduleComment("\n  Fetch URLs. Returns text.\n\n  ```ts\n  x\n  ```"),
+      ),
+    ).toBe("Fetch URLs. Returns text.");
+  });
+
+  it("prefers an explicit @summary override", () => {
+    expect(
+      moduleDescription(moduleComment("\n  @summary Short.\n  Long prose.")),
+    ).toBe("Short.");
+  });
+
+  it("returns null when the comment is missing", () => {
+    expect(moduleDescription(undefined)).toBeNull();
+  });
+});
 
 beforeEach(() => {
   fs.mkdirSync(tmpDir, { recursive: true });
@@ -613,5 +707,72 @@ node main() { print("hi") }
     // comment is re-emitted there too, matching the type-alias renderer).
     expect(output).toMatch(/```ts[\s\S]*?effect std::read\s*\{/);
     expect(output).toMatch(/dir: string/);
+  });
+
+  it("emits a description derived from the @module comment", () => {
+    const inputDir = path.join(tmpDir, "input-desc");
+    const outputDir = path.join(tmpDir, "output-desc");
+    fs.mkdirSync(inputDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(inputDir, "m.agency"),
+      "/** @module\n" +
+        "  Fetch URLs from Agency code. Returns text, JSON, or Markdown.\n\n" +
+        "  ```ts\n  import { fetch } from \"std::http\"\n  ```\n*/\n" +
+        "export def f(): string { return \"\" }\n",
+    );
+    generateDoc({}, path.join(inputDir, "m.agency"), outputDir);
+    const out = fs.readFileSync(path.join(outputDir, "m.md"), "utf-8");
+    expect(out).toContain(
+      'description: "Fetch URLs from Agency code. Returns text, JSON, or Markdown."',
+    );
+  });
+
+  it("removes quotes but keeps colon-space safe (valid for both YAML parsers)", () => {
+    const inputDir = path.join(tmpDir, "input-quote");
+    const outputDir = path.join(tmpDir, "output-quote");
+    fs.mkdirSync(inputDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(inputDir, "q.agency"),
+      "/** @module\n" +
+        "  Helpers: builds strings, e.g. \"America/New_York\" values.\n*/\n" +
+        "export def f(): string { return \"\" }\n",
+    );
+    generateDoc({}, path.join(inputDir, "q.agency"), outputDir);
+    const out = fs.readFileSync(path.join(outputDir, "q.md"), "utf-8");
+    expect(out).toContain(
+      'description: "Helpers: builds strings, e.g. America/New_York values."',
+    );
+    expect(out).not.toContain('\\"');
+  });
+
+  it("uses @summary as the description and strips it from the body", () => {
+    const inputDir = path.join(tmpDir, "input-sum");
+    const outputDir = path.join(tmpDir, "output-sum");
+    fs.mkdirSync(inputDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(inputDir, "s.agency"),
+      "/** @module\n" +
+        "  @summary Read and write the clipboard.\n" +
+        "  The clipboard module exposes copy and paste.\n*/\n" +
+        "export def f(): string { return \"\" }\n",
+    );
+    generateDoc({}, path.join(inputDir, "s.agency"), outputDir);
+    const out = fs.readFileSync(path.join(outputDir, "s.md"), "utf-8");
+    expect(out).toContain('description: "Read and write the clipboard."');
+    expect(out).toContain("The clipboard module exposes copy and paste.");
+    expect(out).not.toContain("@summary");
+  });
+
+  it("emits no description when there is no @module comment", () => {
+    const inputDir = path.join(tmpDir, "input-nomod");
+    const outputDir = path.join(tmpDir, "output-nomod");
+    fs.mkdirSync(inputDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(inputDir, "n.agency"),
+      "export def f(): string { return \"\" }\n",
+    );
+    generateDoc({}, path.join(inputDir, "n.agency"), outputDir);
+    const out = fs.readFileSync(path.join(outputDir, "n.md"), "utf-8");
+    expect(out).not.toContain("description:");
   });
 });

--- a/packages/agency-lang/lib/cli/doc.ts
+++ b/packages/agency-lang/lib/cli/doc.ts
@@ -313,6 +313,11 @@ export function firstParagraph(body: string): string {
   return paragraph.join(" ").replace(/\s+/g, " ").trim();
 }
 
+export function firstSentence(text: string): string {
+  const match = text.match(/^.*?[.!?](?=\s|$)/);
+  return match ? match[0] : text;
+}
+
 export function sanitizeDescription(raw: string): string {
   return raw
     .replace(/["\\]/g, "")
@@ -326,7 +331,7 @@ export function moduleDescription(
 ): string | null {
   if (!comment) return null;
   const { override, body } = extractSummaryOverride(comment.content);
-  const raw = override ?? firstParagraph(body);
+  const raw = override ?? firstSentence(firstParagraph(body));
   if (!raw) return null;
   const value = sanitizeDescription(raw);
   return value === "" ? null : value;

--- a/packages/agency-lang/lib/cli/doc.ts
+++ b/packages/agency-lang/lib/cli/doc.ts
@@ -182,7 +182,7 @@ function generateDocForFile(
 
   if (program.docComment) {
     const { body } = extractSummaryOverride(program.docComment.content);
-    sections.push(body.trim());
+    sections.push(formatDocComment({ ...program.docComment, content: body }));
   }
 
   const typeSection = generateTypeSection(typeAliases, ctx);
@@ -282,8 +282,6 @@ function formatDocComment(comment: AgencyMultiLineComment): string {
   return comment.content.trim();
 }
 
-const DESCRIPTION_CAP = 200;
-
 export function extractSummaryOverride(content: string): {
   override: string | null;
   body: string;
@@ -292,7 +290,7 @@ export function extractSummaryOverride(content: string): {
   const firstIdx = lines.findIndex((l) => l.trim() !== "");
   if (firstIdx === -1) return { override: null, body: content };
   const first = lines[firstIdx].trim();
-  if (first.startsWith("@summary")) {
+  if (/^@summary(\s+|$)/.test(first)) {
     const text = first.slice("@summary".length).trim();
     const rest = lines.slice(0, firstIdx).concat(lines.slice(firstIdx + 1));
     return {
@@ -304,27 +302,23 @@ export function extractSummaryOverride(content: string): {
 }
 
 export function firstParagraph(body: string): string {
-  const out: string[] = [];
-  let started = false;
-  for (const line of body.split("\n")) {
-    const trimmed = line.trim();
-    if (!started) {
-      if (trimmed === "") continue;
-      started = true;
-    }
-    if (trimmed === "" || trimmed.startsWith("```")) break;
-    out.push(trimmed);
-  }
-  return out.join(" ").replace(/\s+/g, " ").trim();
+  const lines = body.split("\n").map((line) => line.trim());
+  const start = lines.findIndex((line) => line !== "");
+  if (start === -1) return "";
+  const afterLead = lines.slice(start);
+  const end = afterLead.findIndex(
+    (line) => line === "" || line.startsWith("```"),
+  );
+  const paragraph = end === -1 ? afterLead : afterLead.slice(0, end);
+  return paragraph.join(" ").replace(/\s+/g, " ").trim();
 }
 
 export function sanitizeDescription(raw: string): string {
-  const cleaned = raw.replace(/["\\]/g, "").replace(/\s+/g, " ").trim();
-  if (cleaned.length <= DESCRIPTION_CAP) return cleaned;
-  const slice = cleaned.slice(0, DESCRIPTION_CAP);
-  const lastSpace = slice.lastIndexOf(" ");
-  const truncated = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
-  return truncated + "…";
+  return raw
+    .replace(/["\\]/g, "")
+    .replace(/\s+/g, " ")
+    .replace(/^#{1,6}\s+/, "")
+    .trim();
 }
 
 export function moduleDescription(

--- a/packages/agency-lang/lib/cli/doc.ts
+++ b/packages/agency-lang/lib/cli/doc.ts
@@ -167,7 +167,12 @@ function generateDocForFile(
 
   const title = path.basename(filePath).replace(/\.agency$/, "");
   const safeName = title.replace(/["\\\n]/g, "");
-  const frontmatter = `---\nname: "${safeName}"\n---`;
+  const fmLines = [`name: "${safeName}"`];
+  const description = moduleDescription(program.docComment);
+  if (description) {
+    fmLines.push(`description: "${description}"`);
+  }
+  const frontmatter = `---\n${fmLines.join("\n")}\n---`;
   const sections: string[] = [frontmatter, heading(1, title)];
 
   // Page-level "View source" link
@@ -176,7 +181,8 @@ function generateDocForFile(
   }
 
   if (program.docComment) {
-    sections.push(formatDocComment(program.docComment));
+    const { body } = extractSummaryOverride(program.docComment.content);
+    sections.push(body.trim());
   }
 
   const typeSection = generateTypeSection(typeAliases, ctx);
@@ -274,6 +280,62 @@ function generateParamTable(
 
 function formatDocComment(comment: AgencyMultiLineComment): string {
   return comment.content.trim();
+}
+
+const DESCRIPTION_CAP = 200;
+
+export function extractSummaryOverride(content: string): {
+  override: string | null;
+  body: string;
+} {
+  const lines = content.split("\n");
+  const firstIdx = lines.findIndex((l) => l.trim() !== "");
+  if (firstIdx === -1) return { override: null, body: content };
+  const first = lines[firstIdx].trim();
+  if (first.startsWith("@summary")) {
+    const text = first.slice("@summary".length).trim();
+    const rest = lines.slice(0, firstIdx).concat(lines.slice(firstIdx + 1));
+    return {
+      override: text === "" ? null : text,
+      body: rest.join("\n"),
+    };
+  }
+  return { override: null, body: content };
+}
+
+export function firstParagraph(body: string): string {
+  const out: string[] = [];
+  let started = false;
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim();
+    if (!started) {
+      if (trimmed === "") continue;
+      started = true;
+    }
+    if (trimmed === "" || trimmed.startsWith("```")) break;
+    out.push(trimmed);
+  }
+  return out.join(" ").replace(/\s+/g, " ").trim();
+}
+
+export function sanitizeDescription(raw: string): string {
+  const cleaned = raw.replace(/["\\]/g, "").replace(/\s+/g, " ").trim();
+  if (cleaned.length <= DESCRIPTION_CAP) return cleaned;
+  const slice = cleaned.slice(0, DESCRIPTION_CAP);
+  const lastSpace = slice.lastIndexOf(" ");
+  const truncated = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
+  return truncated + "…";
+}
+
+export function moduleDescription(
+  comment: AgencyMultiLineComment | undefined,
+): string | null {
+  if (!comment) return null;
+  const { override, body } = extractSummaryOverride(comment.content);
+  const raw = override ?? firstParagraph(body);
+  if (!raw) return null;
+  const value = sanitizeDescription(raw);
+  return value === "" ? null : value;
 }
 
 function formatTypeAlias(alias: TypeAlias, ctx: DocContext): string {

--- a/packages/agency-lang/lib/stdlib/skills.test.ts
+++ b/packages/agency-lang/lib/stdlib/skills.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { _readSkill, _docsDir } from "./skills.js";
+import { _glob } from "./shell.js";
 
 describe("_readSkill", () => {
   let fakeHome: string;
@@ -60,5 +61,23 @@ describe("_docsDir", () => {
     // Guards the union widening ("guide" | "cli" | "diagnostics"). Pure path
     // math — does not depend on the staged docs being present.
     expect(_docsDir("diagnostics").endsWith(path.join("docs", "diagnostics"))).toBe(true);
+  });
+
+  it("resolves the stdlib section under docs/", () => {
+    expect(_docsDir("stdlib").endsWith(path.join("docs", "stdlib"))).toBe(true);
+  });
+});
+
+describe("stdlib docs recursive glob", () => {
+  // The stdlib docs tree has nested modules (ui/table.md, auth/oauth.md, …).
+  // A non-recursive `*.{md,markdown}` drops them; `**/*.{md,markdown}` must not.
+  const stdlibDocs = path.resolve(__dirname, "../../docs/site/stdlib");
+
+  it("includes nested modules that the flat pattern misses", async () => {
+    const flat = await _glob("*.{md,markdown}", stdlibDocs, 500, []);
+    const recursive = await _glob("**/*.{md,markdown}", stdlibDocs, 500, []);
+    expect(recursive.length).toBeGreaterThan(flat.length);
+    expect(recursive).toContain("ui/table.md"); // nested
+    expect(recursive).toContain("array.md"); // top-level still present
   });
 });

--- a/packages/agency-lang/lib/stdlib/skills.test.ts
+++ b/packages/agency-lang/lib/stdlib/skills.test.ts
@@ -80,4 +80,15 @@ describe("stdlib docs recursive glob", () => {
     expect(recursive).toContain("ui/table.md"); // nested
     expect(recursive).toContain("array.md"); // top-level still present
   });
+
+  it("is a no-op for the flat sections (guide has no nested pages)", async () => {
+    // docsSkill now always globs recursively. guide/cli/diagnostics have no
+    // nested docs, so recursion must list exactly the same pages as the flat
+    // pattern — a regression here would silently drop pages from those tools.
+    const guideDocs = path.resolve(__dirname, "../../docs/site/guide");
+    const flat = await _glob("*.{md,markdown}", guideDocs, 500, []);
+    const recursive = await _glob("**/*.{md,markdown}", guideDocs, 500, []);
+    expect(recursive.length).toBeGreaterThan(0);
+    expect(recursive.sort()).toEqual(flat.sort());
+  });
 });

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -33,6 +33,6 @@ export function _readSkill(filepath: string): string {
  * the makefile), and stdlib resolves in both dev and npm installs via
  * getStdlibDir, so one copy serves compiled and source runs.
  */
-export function _docsDir(section: "guide" | "cli" | "diagnostics"): string {
+export function _docsDir(section: "guide" | "cli" | "diagnostics" | "stdlib"): string {
   return path.join(getStdlibDir(), "docs", section);
 }

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -30,10 +30,11 @@ endef
 # copies must be idempotent.
 define stage-stdlib-docs
 	mkdir -p stdlib/docs
-	rm -rf stdlib/docs/guide stdlib/docs/cli stdlib/docs/diagnostics
+	rm -rf stdlib/docs/guide stdlib/docs/cli stdlib/docs/diagnostics stdlib/docs/stdlib
 	cp -r docs/site/guide stdlib/docs/guide
 	cp -r docs/site/cli stdlib/docs/cli
 	cp -r docs/site/diagnostics stdlib/docs/diagnostics
+	cp -r docs/site/stdlib stdlib/docs/stdlib
 endef
 
 all:

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -19,7 +19,6 @@ import { docsSkill } from "std::skills"
 import { ls, glob, grep, exec } from "std::shell"
 
 /** @module
-  @summary Tools for compiling, type-checking, running, formatting, and inspecting Agency programs from Agency code.
   Tools for compiling, type-checking, running, formatting, and inspecting
   Agency programs from Agency code. Compile and run source in a sandboxed
   subprocess, type-check or format it, and walk its AST to find imports,

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -19,6 +19,7 @@ import { docsSkill } from "std::skills"
 import { ls, glob, grep, exec } from "std::shell"
 
 /** @module
+  @summary Tools for compiling, type-checking, running, formatting, and inspecting Agency programs from Agency code.
   Tools for compiling, type-checking, running, formatting, and inspecting
   Agency programs from Agency code. Compile and run source in a sandboxed
   subprocess, type-check or format it, and walk its AST to find imports,

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -14,6 +14,7 @@ import {
  } from "agency-lang/stdlib-lib/localModels.js"
 
 /** @module
+  @summary Manage and run local GGUF models: download by short name or Hugging Face URI, alias them, and register the local provider.
   Manage and run local GGUF models. Download models by curated short name or
   Hugging Face URI, alias them, list or remove downloads, and register the local
   provider so `llm()` calls can use them. Requires the smoltalk-llama-cpp

--- a/packages/agency-lang/stdlib/agency/local.agency
+++ b/packages/agency-lang/stdlib/agency/local.agency
@@ -14,7 +14,6 @@ import {
  } from "agency-lang/stdlib-lib/localModels.js"
 
 /** @module
-  @summary Manage and run local GGUF models: download by short name or Hugging Face URI, alias them, and register the local provider.
   Manage and run local GGUF models. Download models by curated short name or
   Hugging Face URI, alias them, list or remove downloads, and register the local
   provider so `llm()` calls can use them. Requires the smoltalk-llama-cpp

--- a/packages/agency-lang/stdlib/agent.agency
+++ b/packages/agency-lang/stdlib/agent.agency
@@ -1,5 +1,4 @@
 /** @module
-@summary Helpers for building user-facing agents: ask the user a question through an interrupt, and manage a todo list.
 Helpers for building user-facing agents. This module offers two
 independent tools:
 - `question` asks the user something through an interrupt the host UI

--- a/packages/agency-lang/stdlib/agent.agency
+++ b/packages/agency-lang/stdlib/agent.agency
@@ -1,4 +1,5 @@
 /** @module
+@summary Helpers for building user-facing agents: ask the user a question through an interrupt, and manage a todo list.
 Helpers for building user-facing agents. This module offers two
 independent tools:
 - `question` asks the user something through an interrupt the host UI

--- a/packages/agency-lang/stdlib/agents/planner.agency
+++ b/packages/agency-lang/stdlib/agents/planner.agency
@@ -1,4 +1,5 @@
 /** @module
+  @summary The plan-as-code meta-agent: given a task, generates an Agency program that composes worker agents and tools to solve it.
   plannerAgent: the plan-as-code meta-agent. Given a task, generate an Agency
   program (an agent-as-plan) that composes the worker agents and tools to solve
   it, show the plan, source, and capability envelope for approval, run it in a

--- a/packages/agency-lang/stdlib/agents/planner.agency
+++ b/packages/agency-lang/stdlib/agents/planner.agency
@@ -1,5 +1,4 @@
 /** @module
-  @summary The plan-as-code meta-agent: given a task, generates an Agency program that composes worker agents and tools to solve it.
   plannerAgent: the plan-as-code meta-agent. Given a task, generate an Agency
   program (an agent-as-plan) that composes the worker agents and tools to solve
   it, show the plan, source, and capability envelope for approval, run it in a

--- a/packages/agency-lang/stdlib/array.agency
+++ b/packages/agency-lang/stdlib/array.agency
@@ -1,5 +1,4 @@
 /** @module
-@summary Re-exports the array helpers (map, filter, reduce, and friends), which now live in std::index and are auto-imported.
 Re-exports the array helpers (`map`, `filter`, `reduce`, and friends) so
 that `import { map, filter, ... } from "std::array"` keeps working. These
 helpers now live in `std::index` and are auto-imported into every

--- a/packages/agency-lang/stdlib/array.agency
+++ b/packages/agency-lang/stdlib/array.agency
@@ -1,4 +1,5 @@
 /** @module
+@summary Re-exports the array helpers (map, filter, reduce, and friends), which now live in std::index and are auto-imported.
 Re-exports the array helpers (`map`, `filter`, `reduce`, and friends) so
 that `import { map, filter, ... } from "std::array"` keeps working. These
 helpers now live in `std::index` and are auto-imported into every

--- a/packages/agency-lang/stdlib/auth/oauth.agency
+++ b/packages/agency-lang/stdlib/auth/oauth.agency
@@ -2,6 +2,7 @@ import { _isAuthorized, _revokeAuth, _authorize, _getAccessToken } from "agency-
 import { fetchJSON } from "std::http"
 
 /** @module
+  @summary Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your agent can call APIs on the user's behalf.
   Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your
   agent can call APIs on the user's behalf. Register an app with the provider to
   get a client ID and secret. Then authorize once and fetch fresh access tokens

--- a/packages/agency-lang/stdlib/auth/oauth.agency
+++ b/packages/agency-lang/stdlib/auth/oauth.agency
@@ -2,7 +2,6 @@ import { _isAuthorized, _revokeAuth, _authorize, _getAccessToken } from "agency-
 import { fetchJSON } from "std::http"
 
 /** @module
-  @summary Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your agent can call APIs on the user's behalf.
   Run the OAuth 2.0 authorization flow and manage the resulting tokens, so your
   agent can call APIs on the user's behalf. Register an app with the provider to
   get a client ID and secret. Then authorize once and fetch fresh access tokens

--- a/packages/agency-lang/stdlib/data/finance/edgar.agency
+++ b/packages/agency-lang/stdlib/data/finance/edgar.agency
@@ -2,6 +2,7 @@ import { fetchJSON } from "std::http"
 import { env } from "std::system"
 
 /** @module
+  @summary SEC EDGAR — U.S. company filings
   ## SEC EDGAR — U.S. company filings
 
   Look up official filings for a U.S.-listed company from the SEC's

--- a/packages/agency-lang/stdlib/data/finance/fred.agency
+++ b/packages/agency-lang/stdlib/data/finance/fred.agency
@@ -2,6 +2,7 @@ import { fetchJSON } from "std::http"
 import { env } from "std::system"
 
 /** @module
+  @summary FRED — U.S. macroeconomic time-series
   ## FRED — U.S. macroeconomic time-series
 
   Fetch U.S. economic data from the Federal Reserve Bank of St. Louis

--- a/packages/agency-lang/stdlib/data/usaspending.agency
+++ b/packages/agency-lang/stdlib/data/usaspending.agency
@@ -2,6 +2,7 @@ import { fetchJSON, HttpMethod } from "std::http"
 import { keys } from "std::object"
 
 /** @module
+  @summary USASpending — U.S. federal awards
   ## USASpending — U.S. federal awards
 
   Query [USASpending](https://api.usaspending.gov), the U.S. Treasury's award-level spending API:

--- a/packages/agency-lang/stdlib/date.agency
+++ b/packages/agency-lang/stdlib/date.agency
@@ -1,7 +1,6 @@
 import { _now, _today, _tomorrow, _add, _addMinutes, _addHours, _addDays, _nextDayOfWeek, _atTime, _startOfDay, _endOfDay, _startOfWeek, _endOfWeek, _startOfMonth, _endOfMonth } from "agency-lang/stdlib-lib/date.js"
 
 /** @module
-@summary Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect.
 Builds timezone-aware ISO 8601 date strings, the format that APIs like Google
 Calendar expect. Every function returns a string, not a Date object. Most
 accept an optional IANA `timezone` (e.g. "America/New_York"). Omit it to

--- a/packages/agency-lang/stdlib/date.agency
+++ b/packages/agency-lang/stdlib/date.agency
@@ -1,6 +1,7 @@
 import { _now, _today, _tomorrow, _add, _addMinutes, _addHours, _addDays, _nextDayOfWeek, _atTime, _startOfDay, _endOfDay, _startOfWeek, _endOfWeek, _startOfMonth, _endOfMonth } from "agency-lang/stdlib-lib/date.js"
 
 /** @module
+@summary Builds timezone-aware ISO 8601 date strings, the format that APIs like Google Calendar expect.
 Builds timezone-aware ISO 8601 date strings, the format that APIs like Google
 Calendar expect. Every function returns a string, not a Date object. Most
 accept an optional IANA `timezone` (e.g. "America/New_York"). Omit it to

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -3,7 +3,6 @@ import { bash, glob, ls, grep } from "std::shell"
 import { applyAgentCwd } from "std::index"
 
 /** @module
-  @summary Tools for editing files and managing directories: apply text edits and patches, and create, copy, move, or remove files.
   Tools for editing files and managing directories: apply text edits and
   patches, and create, copy, move, or remove files. Every operation raises an
   approval interrupt before it touches the disk, so nothing is written until a

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -3,6 +3,7 @@ import { bash, glob, ls, grep } from "std::shell"
 import { applyAgentCwd } from "std::index"
 
 /** @module
+  @summary Tools for editing files and managing directories: apply text edits and patches, and create, copy, move, or remove files.
   Tools for editing files and managing directories: apply text edits and
   patches, and create, copy, move, or remove files. Every operation raises an
   approval interrupt before it touches the disk, so nothing is written until a

--- a/packages/agency-lang/stdlib/git.agency
+++ b/packages/agency-lang/stdlib/git.agency
@@ -10,6 +10,7 @@ import {
  } from "agency-lang/stdlib-lib/git.js"
 
 /** @module
+  @summary Typed, safe git tools for agents: each tool builds its own git command, so the model never supplies a raw flag.
   Typed, safe git tools for agents. Each tool builds its own git command
   internally, so the model never supplies a raw flag. Read tools (status, log,
   diff, ...) raise effects an agent policy can auto-approve. Write tools (add,

--- a/packages/agency-lang/stdlib/git.agency
+++ b/packages/agency-lang/stdlib/git.agency
@@ -10,7 +10,6 @@ import {
  } from "agency-lang/stdlib-lib/git.js"
 
 /** @module
-  @summary Typed, safe git tools for agents: each tool builds its own git command, so the model never supplies a raw flag.
   Typed, safe git tools for agents. Each tool builds its own git command
   internally, so the model never supplies a raw flag. Read tools (status, log,
   diff, ...) raise effects an agent policy can auto-approve. Write tools (add,

--- a/packages/agency-lang/stdlib/image.agency
+++ b/packages/agency-lang/stdlib/image.agency
@@ -1,8 +1,6 @@
 import { _generateImage } from "agency-lang/stdlib-lib/image.js"
 
-/** @module
-  @summary Generate images from a text prompt (or edit input images) using a hosted provider, returning base64 you can persist.
-  Generate images from a text prompt (or edit input images) using a
+/** @module Generate images from a text prompt (or edit input images) using a
 hosted provider (OpenAI, Google, or an open-source model via LiteLLM / Together).
 Returns base64 you can persist with `writeBinary()` or send onward with
 `std::thread`'s `image(...)`.

--- a/packages/agency-lang/stdlib/image.agency
+++ b/packages/agency-lang/stdlib/image.agency
@@ -1,6 +1,8 @@
 import { _generateImage } from "agency-lang/stdlib-lib/image.js"
 
-/** @module Generate images from a text prompt (or edit input images) using a
+/** @module
+  @summary Generate images from a text prompt (or edit input images) using a hosted provider, returning base64 you can persist.
+  Generate images from a text prompt (or edit input images) using a
 hosted provider (OpenAI, Google, or an open-source model via LiteLLM / Together).
 Returns base64 you can persist with `writeBinary()` or send onward with
 `std::thread`'s `image(...)`.

--- a/packages/agency-lang/stdlib/markdown.agency
+++ b/packages/agency-lang/stdlib/markdown.agency
@@ -6,6 +6,7 @@ import {
  } from "agency-lang/stdlib-lib/markdown.js"
 
 /** @module
+  @summary Parse Markdown text into a structured AST you can walk, and render Markdown for the terminal or HTML.
   Parse Markdown text into a structured AST you can walk. The returned `blocks`
   array holds block-level nodes like `Paragraph`, `Heading`, `CodeBlock`, `List`,
   `Table`, and `BlockQuote`. Each is tagged with a `type` field to switch on.

--- a/packages/agency-lang/stdlib/markdown.agency
+++ b/packages/agency-lang/stdlib/markdown.agency
@@ -6,7 +6,6 @@ import {
  } from "agency-lang/stdlib-lib/markdown.js"
 
 /** @module
-  @summary Parse Markdown text into a structured AST you can walk, and render Markdown for the terminal or HTML.
   Parse Markdown text into a structured AST you can walk. The returned `blocks`
   array holds block-level nodes like `Paragraph`, `Heading`, `CodeBlock`, `List`,
   `Table`, and `BlockQuote`. Each is tagged with a `type` field to switch on.

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -23,6 +23,7 @@ import {
  } from "agency-lang/stdlib-lib/memory.js"
 
 /** @module
+@summary Give an agent long-term memory: remember extracts and saves facts to a knowledge graph, and recall retrieves them later.
 Give an agent long-term memory. `remember` extracts facts from text
 and saves them to a knowledge graph, and `recall` retrieves the
 relevant ones later. Memory is off until you turn it on with

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -23,7 +23,6 @@ import {
  } from "agency-lang/stdlib-lib/memory.js"
 
 /** @module
-@summary Give an agent long-term memory: remember extracts and saves facts to a knowledge graph, and recall retrieves them later.
 Give an agent long-term memory. `remember` extracts facts from text
 and saves them to a knowledge graph, and `recall` retrieves the
 relevant ones later. Memory is off until you turn it on with

--- a/packages/agency-lang/stdlib/messaging/email.agency
+++ b/packages/agency-lang/stdlib/messaging/email.agency
@@ -1,7 +1,6 @@
 import { _sendWithResend, _sendWithSendGrid, _sendWithMailgun } from "agency-lang/stdlib-lib/email.js"
 
 /** @module
-  @summary Send email from Agency code through Resend, SendGrid, or Mailgun, each reading its own API key from the environment.
   Send email from Agency code through Resend, SendGrid, or Mailgun. Each
   provider reads its own API key from the environment: `RESEND_API_KEY`,
   `SENDGRID_API_KEY`, or `MAILGUN_API_KEY` plus `MAILGUN_DOMAIN` (and optional

--- a/packages/agency-lang/stdlib/messaging/email.agency
+++ b/packages/agency-lang/stdlib/messaging/email.agency
@@ -1,6 +1,7 @@
 import { _sendWithResend, _sendWithSendGrid, _sendWithMailgun } from "agency-lang/stdlib-lib/email.js"
 
 /** @module
+  @summary Send email from Agency code through Resend, SendGrid, or Mailgun, each reading its own API key from the environment.
   Send email from Agency code through Resend, SendGrid, or Mailgun. Each
   provider reads its own API key from the environment: `RESEND_API_KEY`,
   `SENDGRID_API_KEY`, or `MAILGUN_API_KEY` plus `MAILGUN_DOMAIN` (and optional

--- a/packages/agency-lang/stdlib/notes/apple.agency
+++ b/packages/agency-lang/stdlib/notes/apple.agency
@@ -12,7 +12,6 @@ import {
 import { parse, renderForHtml } from "std::markdown"
 
 /** @module
-  @summary Create, read, search, and edit notes in the macOS Notes app. macOS only; the first call asks for Automation permission.
   Create, read, search, and edit notes in the macOS Notes app. macOS only.
   The first call asks for Automation permission with a system dialog. If
   nobody answers the dialog, the call fails after 30 seconds.

--- a/packages/agency-lang/stdlib/notes/apple.agency
+++ b/packages/agency-lang/stdlib/notes/apple.agency
@@ -12,6 +12,7 @@ import {
 import { parse, renderForHtml } from "std::markdown"
 
 /** @module
+  @summary Create, read, search, and edit notes in the macOS Notes app. macOS only; the first call asks for Automation permission.
   Create, read, search, and edit notes in the macOS Notes app. macOS only.
   The first call asks for Automation permission with a system dialog. If
   nobody answers the dialog, the call fails after 30 seconds.

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -22,7 +22,6 @@ import {
 
 
 /** @module
-  @summary Decide whether to approve or reject the interrupts an agent raises, without prompting the user every time.
   Decide whether to approve or reject the interrupts an agent raises,
   without prompting the user every time. A `Policy` is an ordered list of
   glob-pattern rules per interrupt effect, evaluated first-match-wins.

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -22,6 +22,7 @@ import {
 
 
 /** @module
+  @summary Decide whether to approve or reject the interrupts an agent raises, without prompting the user every time.
   Decide whether to approve or reject the interrupts an agent raises,
   without prompting the user every time. A `Policy` is an ordered list of
   glob-pattern rules per interrupt effect, evaluated first-match-wins.

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -14,7 +14,6 @@ import {
 
 
 /** @module
-  @summary Run commands and inspect the filesystem: exec and bash run programs (with approval); ls, grep, glob, stat, exists, which are read-only.
   Run commands and inspect the filesystem. `exec` and `bash` run programs and
   raise an approval interrupt before doing so. `ls`, `grep`, `glob`, `stat`,
   `exists`, and `which` are read-only helpers that return results directly.

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -14,6 +14,7 @@ import {
 
 
 /** @module
+  @summary Run commands and inspect the filesystem: exec and bash run programs (with approval); ls, grep, glob, stat, exists, which are read-only.
   Run commands and inspect the filesystem. `exec` and `bash` run programs and
   raise an approval interrupt before doing so. `ls`, `grep`, `glob`, `stat`,
   `exists`, and `which` are read-only helpers that return results directly.

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -15,6 +15,7 @@ import { _glob } from "agency-lang/stdlib-lib/shell.js"
 import { _docsDir } from "agency-lang/stdlib-lib/skills.js"
 
 /** @module
+  @summary Give an LLM access to a directory of skills, and support Claude-Code-style slash commands.
   Give an LLM access to a directory of skills, and support Claude-Code-style
   slash commands. `skillsDir` builds a tool that lets the model read skill
   files on demand. `commandsDir` and `expandSlash` load prompt-template

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -15,7 +15,6 @@ import { _glob } from "agency-lang/stdlib-lib/shell.js"
 import { _docsDir } from "agency-lang/stdlib-lib/skills.js"
 
 /** @module
-  @summary Give an LLM access to a directory of skills, and support Claude-Code-style slash commands.
   Give an LLM access to a directory of skills, and support Claude-Code-style
   slash commands. `skillsDir` builds a tool that lets the model read skill
   files on demand. `commandsDir` and `expandSlash` load prompt-template

--- a/packages/agency-lang/stdlib/skills.agency
+++ b/packages/agency-lang/stdlib/skills.agency
@@ -184,10 +184,13 @@ def standardEntry(skillPath: string, parsedFrontmatter: any): SkillEntry {
 effect std::skills::skillsDir { dir: string, layout: "flat" | "standard" }
 effect std::skills::commandsDir { dir: string }
 
-def buildSkillsTool(dir: string, layout: "flat" | "standard", name: string = "") {
+def buildSkillsTool(dir: string, layout: "flat" | "standard", name: string = "", recursive: boolean = false) {
   let pattern = "*/SKILL.md"
   if (layout == "flat") {
     pattern = "*.{md,markdown}"
+    if (recursive) {
+      pattern = "**/*.{md,markdown}"
+    }
   }
   let lines: string[] = []
   const pathsResult = try _glob(pattern, dir, 500, [])
@@ -236,23 +239,24 @@ export def skillsDir(dir: string, layout: "flat" | "standard" = "standard", name
   return buildSkillsTool(dir, layout, name)
 }
 
-export def docsSkill(section: "guide" | "cli" | "diagnostics") {
+export def docsSkill(section: "guide" | "cli" | "diagnostics" | "stdlib") {
   """
   Build a docs tool for an LLM over the packaged Agency documentation.
   "guide" serves the language guide (syntax, types, control flow);
   "cli" serves the CLI reference; "diagnostics" serves the type-checker
-  diagnostic codes (AG####) with explanations and fixes. The returned tool
-  lists every page in its description and lets the model read any one on
-  demand.
+  diagnostic codes (AG####) with explanations and fixes; "stdlib" serves
+  the standard-library reference, one page per std:: module. The returned
+  tool lists every page in its description and lets the model read any one
+  on demand.
 
-  @param section - Which documentation set to serve: "guide", "cli", or "diagnostics".
+  @param section - Which documentation set to serve: "guide", "cli", "diagnostics", or "stdlib".
   """
   // No approval interrupt for the startup scan: these docs ship inside
   // the agency package, so scanning them carries the same trust as
   // running the stdlib itself. The returned tool is read.partial, so
   // every read the LLM later performs still raises std::read and goes
   // through handlers/policies exactly like any other read tool.
-  return buildSkillsTool(_docsDir(section), "flat")
+  return buildSkillsTool(_docsDir(section), "flat", "", true)
 }
 
 // ============================================================

--- a/packages/agency-lang/stdlib/statelog.agency
+++ b/packages/agency-lang/stdlib/statelog.agency
@@ -8,6 +8,7 @@ import {
 } from "agency-lang/stdlib-lib/statelog.js"
 
 /** @module
+  @summary Record and read back eval data from the statelog, marking an agent's input and response for later analysis.
   Record and read back eval data from the statelog. Call `evalValue` and
   `evalOutput` inside an agent to mark its user-facing input and response,
   then read them from a saved trace with `evalValues`, `evalOutputs`,

--- a/packages/agency-lang/stdlib/statelog.agency
+++ b/packages/agency-lang/stdlib/statelog.agency
@@ -8,7 +8,6 @@ import {
 } from "agency-lang/stdlib-lib/statelog.js"
 
 /** @module
-  @summary Record and read back eval data from the statelog, marking an agent's input and response for later analysis.
   Record and read back eval data from the statelog. Call `evalValue` and
   `evalOutput` inside an agent to mark its user-facing input and response,
   then read them from a saved trace with `evalValues`, `evalOutputs`,

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -1,5 +1,4 @@
 /** @module
-@summary Read and share LLM conversation history across a run: inspect the current thread's messages, cost, and tokens, and reach into other threads.
 Read and share LLM conversation history across a run. Inspect the
 current thread's messages, cost, and token usage, and reach into
 other threads. `listThreads()` lists every thread in the run, active

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -1,4 +1,5 @@
 /** @module
+@summary Read and share LLM conversation history across a run: inspect the current thread's messages, cost, and tokens, and reach into other threads.
 Read and share LLM conversation history across a run. Inspect the
 current thread's messages, cost, and token usage, and reach into
 other threads. `listThreads()` lists every thread in the run, active

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -29,6 +29,7 @@ import {
 
 
 /** @module
+  @summary Builds interactive terminal UIs for CLI agents from composable builders, driven by a render loop.
   Builds interactive terminal UIs for CLI agents. Assemble a screen from
   builders like `column`, `row`, `box`, `text`, and `textInput`, then drive
   the render loop with `runLoop`. For chat-style agents, `repl()` is a

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -29,7 +29,6 @@ import {
 
 
 /** @module
-  @summary Builds interactive terminal UIs for CLI agents from composable builders, driven by a render loop.
   Builds interactive terminal UIs for CLI agents. Assemble a screen from
   builders like `column`, `row`, `box`, `text`, and `textInput`, then drive
   the render loop with `runLoop`. For chat-style agents, `repl()` is a

--- a/packages/agency-lang/stdlib/ui/chart.agency
+++ b/packages/agency-lang/stdlib/ui/chart.agency
@@ -1,7 +1,6 @@
 import { LayoutNode, Width } from "std::ui/layout"
 
 /** @module
-  @summary Draws horizontal bar charts for terminal output; barChart(...) returns a layout node you render with std::ui/layout.
   Draws horizontal bar charts for terminal output. `barChart(...)` returns a
   layout node. Render it with `render` from `std::ui/layout`, so a chart
   nests inside `box` / `row` / `column`. Pass the series and categories

--- a/packages/agency-lang/stdlib/ui/chart.agency
+++ b/packages/agency-lang/stdlib/ui/chart.agency
@@ -1,6 +1,7 @@
 import { LayoutNode, Width } from "std::ui/layout"
 
 /** @module
+  @summary Draws horizontal bar charts for terminal output; barChart(...) returns a layout node you render with std::ui/layout.
   Draws horizontal bar charts for terminal output. `barChart(...)` returns a
   layout node. Render it with `render` from `std::ui/layout`, so a chart
   nests inside `box` / `row` / `column`. Pass the series and categories

--- a/packages/agency-lang/stdlib/ui/cli.agency
+++ b/packages/agency-lang/stdlib/ui/cli.agency
@@ -6,6 +6,7 @@ import {
  } from "agency-lang/stdlib-lib/cli.js"
 
 /** @module
+  @summary A line-mode REPL for CLI agents, driven by Node's readline instead of the alt-screen TUI engine in std::ui.
   A line-mode REPL for CLI agents, driven by Node's `readline` instead of
   the alt-screen TUI engine in `std::ui`. It gives up the pinned status
   line, live spinner, and in-app scrolling. In exchange, every prompt

--- a/packages/agency-lang/stdlib/ui/cli.agency
+++ b/packages/agency-lang/stdlib/ui/cli.agency
@@ -6,7 +6,6 @@ import {
  } from "agency-lang/stdlib-lib/cli.js"
 
 /** @module
-  @summary A line-mode REPL for CLI agents, driven by Node's readline instead of the alt-screen TUI engine in std::ui.
   A line-mode REPL for CLI agents, driven by Node's `readline` instead of
   the alt-screen TUI engine in `std::ui`. It gives up the pinned status
   line, live spinner, and in-app scrolling. In exchange, every prompt

--- a/packages/agency-lang/stdlib/ui/table.agency
+++ b/packages/agency-lang/stdlib/ui/table.agency
@@ -1,6 +1,7 @@
 import { LayoutNode, Width, Alignment, BorderStyle } from "std::ui/layout"
 
 /** @module
+  @summary Draws tables for terminal output; table(...) returns a layout node you render with std::ui/layout.
   Draws tables for terminal output. `table(...)` returns a layout node whose
   columns line up across header, body, and footer. Render it with `render`
   from `std::ui/layout`, so a table nests inside `box` / `row` / `column`.

--- a/packages/agency-lang/stdlib/ui/table.agency
+++ b/packages/agency-lang/stdlib/ui/table.agency
@@ -1,7 +1,6 @@
 import { LayoutNode, Width, Alignment, BorderStyle } from "std::ui/layout"
 
 /** @module
-  @summary Draws tables for terminal output; table(...) returns a layout node you render with std::ui/layout.
   Draws tables for terminal output. `table(...)` returns a layout node whose
   columns line up across header, body, and footer. Render it with `render`
   from `std::ui/layout`, so a table nests inside `box` / `row` / `column`.

--- a/packages/agency-lang/stdlib/validation.agency
+++ b/packages/agency-lang/stdlib/validation.agency
@@ -1,7 +1,6 @@
 import { _isEmail, _isUrl, _isUuid, _isInt, _isPositive, _isNegative, _min, _max, _minLength, _maxLength, _matches } from "agency-lang/stdlib-lib/validators.js"
 
 /** @module
-  @summary Validators and format helpers for constrained types, for use with @validate(...) and @jsonSchema(...).
   Validators and format helpers for constrained types. Pair a validator with
   `@validate(...)` to check values at runtime, spread the pre-baked
   `@jsonSchema(...)` format fragments into your own schemas, or reach for the

--- a/packages/agency-lang/stdlib/validation.agency
+++ b/packages/agency-lang/stdlib/validation.agency
@@ -1,6 +1,7 @@
 import { _isEmail, _isUrl, _isUuid, _isInt, _isPositive, _isNegative, _min, _max, _minLength, _maxLength, _matches } from "agency-lang/stdlib-lib/validators.js"
 
 /** @module
+  @summary Validators and format helpers for constrained types, for use with @validate(...) and @jsonSchema(...).
   Validators and format helpers for constrained types. Pair a validator with
   `@validate(...)` to check values at runtime, spread the pre-baked
   `@jsonSchema(...)` format fragments into your own schemas, or reach for the


### PR DESCRIPTION
## What and why

The Agency agent could browse the language guide, CLI, and diagnostics docs, but knew nothing about the 64-module standard library — it had to guess what `std::http`, `std::thread`, etc. were for from filenames alone. This gives the agent a browsable, per-module-summarized view of the stdlib docs.

Two independent gaps are closed:

1. **The generated stdlib docs had no summary.** `agency doc` wrote only `name:` frontmatter, so the `<description>` line the agent's doc tool already renders was always empty.
2. **The agent could not reach the stdlib docs at all.** `docsSkill` only served `guide` / `cli` / `diagnostics`, and nothing staged or wired the stdlib docs.

Design and plan are included in the diff:
- `docs/superpowers/specs/2026-07-17-stdlib-docs-summary-for-agent-design.md`
- `docs/superpowers/plans/2026-07-17-stdlib-docs-summary-for-agent.md`

## What changed

**1. `agency doc` emits a `description` frontmatter field** (`lib/cli/doc.ts`). It is derived from the module's existing `@module` comment — the leading paragraph, whitespace-collapsed, capped at 200 chars — with an optional `@summary <text>` line inside the comment as an explicit override (parsed by the doc command only; no language-syntax change). Fence detection trims leading whitespace since `@module` fences render indented.

**The value is emitted as a double-quoted scalar with `"` and `\` removed** (mirroring what `name` already does). This is the one option valid for *both* consumers:
- the agent reads it through tarsec, whose `stripQuotes` unescapes nothing — so an escaped `\"` would reach the model literally;
- the docs site reads it through VitePress's strict YAML — so a bare value would break on the many colon-space summaries (`std::math`, `std::object`).

**2. A recursive `docsSkill("stdlib")` section** (`makefile`, `lib/stdlib/skills.ts`, `stdlib/skills.agency`). The stdlib docs are staged into the packaged docs and globbed with `**/*.{md,markdown}` — 29 of the 64 modules are nested (`ui/table.md`, `auth/oauth.md`, …) and a non-recursive glob would silently drop them.

**3. Registered in the code / research / explorer subagents** with a one-line prompt note each.

**4. Regenerated `docs/site/stdlib/*.md`** with descriptions, and added `@summary` overrides to the 24 modules whose first paragraph exceeded the cap (so their summaries read cleanly instead of truncating).

## Verification

- `lib/cli/doc.test.ts` — 14 new tests (extraction, `@summary` override + body-strip, indented-fence, cap, the quote/colon round-trip asserting no `\"` survives). 36/36 pass.
- `lib/stdlib/skills.test.ts` — `_docsDir("stdlib")` + a recursive-glob regression (`**/*.{md,markdown}` beats flat and includes `ui/table.md`). 6/6 pass.
- `toolWiring.agency` — the new tool builds and is accepted in each subagent's tool list, no name collision. 4/4 pass.
- Regenerated docs validated: tarsec parses all 64 pages, 63 carry a description (`mcp` has no `@module`, correctly none), **zero** stray backslashes. Every frontmatter value is a double-quoted scalar with no inner `"`/`\` — the sufficient condition for strict-YAML validity.
- Reproduced the exact tool description the subagent's model receives: 64 entries, real summaries, nested locations present.
- Structural linter clean.

Note: compiled `.js` siblings (stdlib and agents) are gitignored build artifacts regenerated by `make`; only sources are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
