### PR TITLE
Partials ergonomics: saveDraft as a tool, finalize as draft

### DIFF
--- a/docs/superpowers/plans/2026-07-17-partials-ergonomics-REVIEW.md
+++ b/docs/superpowers/plans/2026-07-17-partials-ergonomics-REVIEW.md
@@ -1,0 +1,401 @@
+# Plan review: partials ergonomics (2026-07-17)
+
+**Reviewing:** `docs/superpowers/plans/2026-07-17-partials-ergonomics.md`
+**Verdict:** Executable. The plan is unusually well-grounded — every claim I spot-
+checked against the code held, the TDD structure is real (failing test first,
+byte-stability gates on the invisible-to-existing-programs tasks), and the
+Background section does the load-bearing work up front. One substantive gap: the
+schema-threading **seam** is untested — both halves are covered, the wire between
+them isn't, and the fixtures only exercise the fallback. That plus a few minor
+notes. No blockers.
+
+**First, a correction I owe you.** My spec review's finding 1 — "`setSavedDraft`
+files on the wrong frame because `llm()` is a direct `runPrompt` with no frame
+push" — was **wrong**, and the plan is right to say so. I re-verified:
+`runPrompt` calls `setupFunction()` → `getNewState()` → `this.stack.push(newState)`
+(`stateStack.ts:918`). "Direct `runPrompt`" means no wrapper function, not no
+frame. So the tool-loop stack is `[…, owner, runPrompt]`, frame-isomorphic to the
+def path's `[…, owner, saveDraft-def]`, and the existing `setSavedDraft`
+(`callerFrame()`) lands on the owner in both. Good verification-over-analysis
+call, and pinning it with `savedraft-tool-basic` rather than trusting either of us
+is exactly right.
+
+All line references are `packages/agency-lang/`, verified today.
+
+---
+
+# Substantive
+
+## 1. The schema-threading seam is untested, and the fixtures only hit the string fallback
+
+The feature has three parts and the plan tests two of them in isolation:
+
+- **Codegen emits** `draftSchema: z.object(...)` (Task 5 unit tests — string-match
+  on generated output). ✓
+- **`buildSaveDraftToolDefinition(schema)` consumes** a schema (Task 6 Step 1 —
+  called directly with `z.number()`). ✓
+- **The wire between them** — that `runPrompt`'s `args.draftSchema` actually
+  receives the codegen's emitted value and the tool-list substitution uses it —
+  is tested nowhere.
+
+And it can't be caught by the fixtures as written, because **every Task 7 fixture
+uses a node with no declared return type** (`node main()`, `node aliased()`), so
+`enclosingDeclaredReturnType()` returns undefined, no `draftSchema` is emitted,
+and `buildSaveDraftToolDefinition` takes the `z.string()` fallback. Not one
+fixture drives a non-string schema end to end.
+
+The failure this misses is concrete and silent: if Task 5 lands the `draftSchema:`
+entry in the wrong arg object (say inside `clientConfig` instead of top-level
+`args`), or the key drifts, then `args.draftSchema` is `undefined` at runtime →
+`buildSaveDraftToolDefinition(undefined)` → `z.string()` → the model **always**
+gets a string schema, even for a `def f(): Report`. Task 5's tests stay green
+(they check generated text), Task 6's stay green (they call the builder directly),
+every fixture stays green (they're string anyway). The exact feature decision 3
+sells — structured-draft typing — is gone, and nothing is red.
+
+**Close it with the RecordingClient precedent already in the repo.**
+`promptLabels.test.ts` (from #557) drives a real `runPrompt` with a client that
+captures the `PromptConfig` it's handed — and that config carries `tools`. One
+runtime test: `runPrompt({ …, draftSchema: <a zod number schema>, tools: [<the
+saveDraft AgencyFunction>] })` with a recording client, assert the captured tools
+list has a `saveDraft` entry whose `value` schema rejects a string. That ties
+`args.draftSchema` → substitution → provider tool list, which is the untested
+third of the feature. (An end-to-end `.agency` fixture can't assert it — the tool
+*schema* sent to the provider isn't in statelog, only the model's *args* are — so
+the runtime test is the right level.)
+
+---
+
+# Minor
+
+## 2. Say why the ack survives resume; the idempotency comment only covers the write
+
+Task 6's comment explains that the interception `pr.step` re-runs on resume and
+skips completed writes. But the more fragile question is the **tool-result
+message**: the interception pushes the ack to the live thread, and `pr.step` does
+NOT snapshot `messagesJSON` on normal completion (`promptRunner.ts:107` — it
+snapshots only on the interrupt path), and on resume a completed step returns
+before its body, so the ack is never re-pushed.
+
+I worked through it and it's safe: the ack rides the live `messages` thread, and
+the next checkpoint (the sibling tool's interrupt bailout, or the guard gate —
+both `pr.step` interrupt paths) calls `snapshotMessages()`, which reads the live
+thread the ack is already in. So the snapshot captures it. Worth one sentence in
+the plan, because an executor who notices "this step pushes a message but never
+snapshots" will either add a redundant snapshot or suspect a bug — and the
+`savedraft-tool-resume` fixture won't reassure them, because the deterministic
+client doesn't validate tool_use/result pairing, so a lost ack wouldn't fail it.
+(Real providers would reject the dangling `tool_use` — which is the actual
+safety net, and worth naming.)
+
+## 3. AG6037's collision check must be scope-local, not parent-walking
+
+`declareFinalizeBinders` flags a collision via `info.scope.has(fin.binder)`. The
+codegen hazard it's protecting against is specifically a **local in the same
+frame** (a binder name that would resolve to `__stack.locals.<name>`). A name that
+matches a *module global* compiles differently (not `__stack.locals`) and is not a
+miscompile — so if `scope.has` walks parent scopes, a binder legitimately named
+like an outer global would false-positive into an error. The plan says "copy
+exactly what `handlerParamTyping` does," which is the right instinct; just make
+the check explicitly scope-local and add a test: a binder named like a module-
+level `const` is *allowed* (or, if `has` is unavoidably parent-walking, decide
+that's acceptable and say so). Cheap to pin either way.
+
+## 4. `draftCharCount`'s "unstringifiable" test doesn't test the throwing case
+
+The test feeds `undefined`, where `JSON.stringify` *returns* `undefined` (handled
+by the `=== undefined` guard). A genuinely unstringifiable value — a circular
+object — makes `JSON.stringify` **throw**, which the function doesn't catch. In
+practice a model's tool args are JSON-origin and can't be circular, so this is
+safe, but the test name overclaims. Either narrow the name ("returns 0 for
+undefined") or add a `try/catch` and a real circular-input test if you want the
+claim. Trivial.
+
+## 5. Gemini tool-result ordering (known, low-severity, real-provider-only)
+
+The interception pushes ack messages before the concurrently-dispatched tools'
+results, and Task 6's comment correctly flags that providers pair by
+`tool_call_id` (order-independent) except Gemini (position/name). The residual
+edge the comment doesn't quite cover: if the model issues tools in an order that
+puts a real tool *before* saveDraft, or issues two saveDraft calls (same name),
+Gemini's position/name pairing can misalign against acks pushed out of call
+order. Same class as the #566 finding, deterministic tests won't catch it, and
+it's not worth reordering for — but it belongs in the "known limitations" doc
+follow-up alongside the renamed-saveDraft note, not just a code comment.
+
+---
+
+# What is right
+
+The Background section is the model for how to write one — every downstream task
+rests on a fact established and cited there (the frame isomorphism, the
+handler-param bare-identifier precedent, `withFinalize` already holding the
+draft), so the tasks read as consequences rather than assertions. The byte-
+stability gates (Task 3 Step 5, Task 5 Step 5) are placed exactly where an
+invisible-to-existing-programs change could silently churn, and they fail loud.
+The AG6037-makes-codegen-sound argument is genuinely load-bearing and correctly
+identified: the collision error isn't ergonomics, it's what prevents a silent
+miscompile, and the plan knows that.
+
+Part A (finalize binder) I'd execute as written — I traced `withFinalize` and the
+"draft already in hand, throw-fallback returns the same value" claim holds exactly,
+so the runtime change really is the one line the plan says. Part B is sound too;
+it just needs the seam test before the two well-tested halves can be trusted to be
+connected.
+
+# Recommended next steps
+
+1. Add the RecordingClient runtime test tying `args.draftSchema` → the provider
+   tool list (finding 1). This is the one gap worth closing before merge.
+2. One sentence in Task 6 on why the ack survives resume, naming the dangling-
+   `tool_use` safety net (finding 2).
+3. Make AG6037's collision check explicitly scope-local, with a test (finding 3).
+4. Fold the Gemini-ordering and renamed-saveDraft limitations into the doc
+   follow-up list (finding 5).
+
+---
+
+# Addendum: audit against `docs/dev/anti-patterns.md`
+
+**Direct answer to "does it write declarative interfaces that encapsulate
+complexity, or imperative code?": mostly the former, with one clear miss.**
+Part A (finalize binder) and the *pure* helpers of Part B are well-encapsulated.
+But Task 6's interception — the stateful heart of the saveDraft tool — is a
+~35-line imperative block inlined in the tool loop, and it hand-rolls a divergent
+second copy of the tool-lifecycle emission. Four findings, ordered by how much
+they bear on the declarative-vs-imperative question the owner flagged.
+
+## A1. The "how" of handling an intercepted call is inlined, not encapsulated (*Imperative code everywhere*)
+
+`saveDraftTool.ts` extracts the pure *what* cleanly — `isSaveDraftTool`,
+`buildSaveDraftToolDefinition`, `draftCharCount`. That's the right instinct, and
+it's genuinely good. But the *behavior* — what "handle one intercepted call"
+means — stays inline in `prompt.ts` (Task 6 Step 5): recognition-dispatch, the
+`hasValue` branch, ack formatting, `setSavedDraft`, four lifecycle emissions, and
+the `messages.push`, all in one block inside the `for`. That is exactly the split
+the anti-patterns entry names: the module holds the data logic, the tool loop
+holds the how.
+
+The loop should read declaratively — `intercepted → await handleSaveDraftCall(…)`
+— with the block moved into `saveDraftTool.ts` (or a sibling) as a function
+taking `{ toolCall, stateStack, ctx, messages, model }` and returning the ack (or
+pushing it). The plan extracted the nouns and left the verb inline; finish the
+job. This is the owner's #1 review flag (`feedback-pre-pr-anti-pattern-audit`),
+so it's worth doing before the PR, not after.
+
+## A2. The lifecycle emission is a divergent second copy of the real tool path (*Duplicating existing code* + *Inconsistent patterns*)
+
+The four-event sequence the interception hand-writes — `toolCallStart` →
+`onToolCallStart` → `onToolCallEnd` → `toolCall` — is the same sequence the real
+tool dispatch emits (`prompt.ts:1650-1740`). There's no shared helper today (the
+real path inlines it too, woven into the `b.parallel` branch steps), so the
+interception isn't duplicating a *helper* — it's writing a **second, subtly
+different** copy:
+
+- the real path wraps each emission in its own `b.step` (`.logStart`, `.start`)
+  for resume-idempotency and emits `toolCallStart` **inside a `toolExecution`
+  span** so consumers pair start/end by `span_id`, with real `performance.now()`
+  timing;
+- the interception does all four in one `pr.step`, `timeTaken: 0`, and **opens no
+  span** — so saveDraft's start/end events won't span-pair like every other
+  tool's, and a statelog consumer that groups by `span_id` sees them orphaned.
+
+Two implementations of "emit a tool's lifecycle" will drift the first time a
+fifth event or a span change lands — and they already differ. The proportionate
+fix isn't to unify the two paths (the real one is deep in the parallel/branch
+machinery — that's scope creep); it's to (a) put the interception's emission in
+the same `handleSaveDraftCall` helper from A1, and (b) **flag the span/pairing
+divergence in the plan as a deliberate decision** rather than emitting it
+silently. Right now the plan neither reuses nor acknowledges the difference.
+
+## A3. `dispatchCalls` is a parallel mutable variable the plan admits is a footgun (*Order-dependent mutable state* / *Leaky abstractions*)
+
+Task 6 builds `dispatchCalls` imperatively (`push` in a loop with `continue`),
+then instructs: "Audit the rest of the `while` iteration for reads of `toolCalls`
+that should now read `dispatchCalls`." That instruction *is* the anti-pattern —
+two live lists of tool calls where the reader must remember which one each site
+wants, and a wrong choice fails silently (an intercepted call slipping back into
+the dispatch pool, or a real call being skipped). The declarative form is one
+partition up front:
+
+```ts
+const { intercepted, dispatched } = partitionBy(toolCalls, (tc) =>
+  isInterceptedSaveDraft(tc, toolFunctions),
+);
+```
+
+Then `intercepted` drives the ordered handling and `dispatched` drives
+`pr.parallel`, and there's no "which variable does this line want" to audit —
+the names carry the answer. (If there's no `partitionBy` in `lib/utils`, two
+`.filter`s are still better than build-by-push, because each is a total
+expression, not an accumulation whose correctness depends on the `continue`.)
+
+## A4. The `z.any()` string-compare is a leaky, brittle check (*Leaky abstractions*)
+
+Task 5 decides whether to emit a schema with
+`if (draftZod !== "z.any()")` — comparing against the **rendered output string**
+of `zodSchemaFor`, and the plan itself says "verify what `zodSchemaFor` renders
+for an `any` declared type … adjust the comparison to the real string." That's a
+semantic decision (is this type `any`?) made by sniffing a renderer's text, which
+breaks the moment the renderer's output changes. Make the decision at the type
+level, before rendering: `if (declaredReturn !== undefined && !isAnyType(declaredReturn))`.
+`isAnyType` already exists (it's the predicate the `retire-any-sentinel` work
+standardized on). Then `zodSchemaFor` is called only when you've already decided
+to emit, and no output-string coupling exists.
+
+(Minor, same task: the triple-nested `if` guarding the emit reads better as guard
+clauses or a small `draftSchemaFor(scope): TsNode | null` — but that falls out of
+the `isAnyType` fix, since two of the three conditions collapse into it.)
+
+## Not anti-patterns (checked, to be fair)
+
+No dynamic requires. No swallowed catches — `withFinalize`'s catch routes through
+`logFinalizeFailure`. No nested ternaries (the `?:` in `draftCharCount` and the
+tool-def fallback are single, legible). No magic numbers, no one-line ifs, no
+deeply-nested type literals. The parser's ordered structure (Task 1) is the
+explicitly-exempted case. And the genuine wins are worth stating: `saveDraftTool.ts`
+as a home for the recognition/definition/counting logic, and Part A's one-line
+`withFinalize` change, are both exactly the "encapsulate the how, expose a clean
+what" the catalog asks for. The miss is narrow — the interception's stateful
+verb — not pervasive.
+
+## Where this lands
+
+A1 and A2 are the same fix from two angles: extract `handleSaveDraftCall`, and let
+it own both the effect logic and a lifecycle emission whose divergence from the
+real path is a stated choice. A3 and A4 are independent local cleanups. None
+change the plan's architecture; they finish the encapsulation it already started.
+
+---
+
+# Addendum 2: the test plan
+
+Two questions: will each test fail if the thing it guards breaks, and what's
+missing? The finalize-binder tests are mostly honest. The saveDraft-tool tests
+have a structural blind spot — **they assert the salvaged draft and nothing else,
+so the feature's actual output (the tool result the model sees, the schema the
+provider sees) is untested** — and one finalize test is a false negative that
+cannot fail.
+
+## Tests that would not fail when the code breaks
+
+### T1. Task 2 test 3 ("undeclared return → binder is `any`") is a false negative
+
+```ts
+def f() {            // no declared return type
+  return "x"
+  finalize as d { return d }
+}
+// filter(/binder|null|not assignable/i) → expect toHaveLength(0)
+```
+
+The assertion filters to binder/null/assignable messages and expects none. But the
+bug this test exists to catch — the binder-declaration pass failing to declare `d`
+— produces an **"undefined variable `d`"** error, whose message contains none of
+those words. So it's filtered out, the filtered set is empty either way, and the
+test passes whether or not the binder is declared. It cannot fail in the direction
+it's meant to.
+
+Fix: assert on the **unfiltered** result (`expect(typecheckSource(src)).toHaveLength(0)`),
+so an undefined-variable leak surfaces — or add a positive use that only compiles
+if `d` is `any` (e.g. `const s: string = d` with no null guard, which is legal for
+`any` but not for `T | null`). The unfiltered version is the honest one: it proves
+the binder both exists and is permissive.
+
+### T2. The Task 5 codegen tests pass even if the runtime ignores `draftSchema`
+
+Every Task 5 test string-matches the **generated output** (`toContain("draftSchema: z.string()")`).
+None run the generated code. So the plan's own primary risk — that `args.draftSchema`
+never reaches `buildSaveDraftToolDefinition`, or lands in the wrong arg object —
+fails no test here: codegen emits the key, runtime drops it, model silently gets
+`z.string()`, all green. This is the seam finding (plan-review finding 1) stated as
+a test-failure question, and the answer is the same: only the RecordingClient
+runtime test closes it.
+
+### T3. The resume fixture pins draft survival, not thread integrity
+
+`savedraft-tool-resume` asserts the salvaged draft is `"model-draft"` after a
+checkpoint/resume. But the draft survives via **frame serialization**, entirely
+independent of the ack tool-message. If the ack were lost on resume (the
+message-survival concern from finding 2), the draft would still be `"model-draft"`
+and the fixture would still pass — the deterministic client doesn't validate
+tool_use/result pairing, so a dangling `tool_use` doesn't error in-harness. The
+fixture's name promises more than it checks.
+
+## Missing tests
+
+### M1. Nothing asserts the feature's observable output — the tool result and the statelog events
+
+Spec Part 2's contract is two things: "returns an acknowledgment as the tool
+result" and "emits the standard toolCall statelog events." **Neither is asserted
+anywhere.** Every saveDraft fixture proves the feature worked only by the salvaged
+draft value — an indirect, downstream signal. If the ack message were malformed,
+absent, or attached to the wrong `tool_call_id`, or if the toolCall events never
+fired, no test would fail.
+
+The message-labels e2e (#557) is the precedent: run with `--log-file`, read the
+statelog, assert the events. One saveDraft fixture that reads statelog and asserts
+the `toolCall` event fired with `args: { value: "model-draft" }` and
+`output: "Draft saved (11 characters)."`, in order, would pin the actual
+user-facing behavior instead of inferring it from salvage. This is the single
+most valuable addition — it's the difference between "a draft came out" and "the
+tool behaved as specified."
+
+### M2. No test that AG6037's collision check is scope-local (plan-review finding 3)
+
+The checker tests cover collision-with-local and collision-with-param (both must
+error) and "fresh binder doesn't disturb outer variables." None cover a binder
+named like a **module-level** `const`/`def`. That's the case that decides whether
+`info.scope.has` is scope-local (correct) or parent-walking (false-positives on a
+global-named binder, which compiles fine because a global isn't `__stack.locals`).
+Add: `finalize as <name-of-a-top-level-const>` — assert it's **allowed** (or, if
+the team decides parent-walking is acceptable, assert the error and document why).
+Without it the scope-local requirement is unpinned.
+
+### M3. The schema seam with a real object type, end to end
+
+Task 6 unit-tests `buildSaveDraftToolDefinition(z.number())` directly and Task 5
+tests the object-schema emit — but nothing wires a generated `draftSchema:
+z.object(...)` into the tool the model sees. Same root as M1/T2: the RecordingClient
+test should cover both a `z.number()` and a structured type, asserting the tool's
+`value` schema rejects the wrong shape.
+
+### M4. `draftCharCount` on a throwing input (finding 4)
+
+The "unstringifiable" test feeds `undefined`, where `JSON.stringify` *returns*
+undefined. A circular object makes it *throw*, uncaught. Safe in practice (args are
+JSON-origin), but either the test name should narrow to "undefined → 0" or the
+function should `try/catch` with a real circular-input test. Trivial, but the
+current test's name claims coverage it doesn't have.
+
+### M5. A `withFinalize` unit test that it passes the draft (not just the fixture)
+
+Task 3's runtime change — `finalize(this.partialValueOrNull())` — is verified only
+by the `finalize-binder-returns-draft` fixture. A direct unit test on `withFinalize`
+(spy finalize, assert it received the draft value, assert the throw path still
+returns `this`) would pin the runtime half in isolation, so a regression there
+fails at the unit level rather than only in a full compile-and-run fixture. Cheap,
+and it matches how the rest of `abortedResult` is presumably tested.
+
+## What the tests get right
+
+The finalize codegen test's `not.toContain("__stack.locals.draft")` is exactly the
+right assertion — it pins the load-bearing "bare identifier, not frame local"
+mechanic that AG6037 exists to protect, so if the binder ever compiled to a local
+the test fails loudly. The three finalize fixtures map cleanly to the three spec
+behaviors (yields draft, null when unsaved, throw-falls-back-to-same-draft). The
+`userShadow` fixture genuinely discriminates (expected `"no-draft"` vs the
+would-be `"ignored"` if recognition wrongly fired). And `savedraft-tool-basic` is a
+real frame-math pin: a wrong-frame write yields an empty draft and `"no-draft"`, so
+it fails in exactly the direction the (now-corrected) frame analysis was worried
+about. The bones are good; the gap is that the tool-side tests stop at the
+salvaged value and never look at the tool result or the wire.
+
+## Priority
+
+1. Fix T1 (the false-negative binder-`any` test) — it's a one-line change and the
+   test currently protects nothing.
+2. Add M1 (statelog assertion of the ack + toolCall events) and M3 (RecordingClient
+   schema seam) — together they cover the feature's untested observable surface.
+3. Add M2 (scope-local collision) and M5 (`withFinalize` unit).
+4. Narrow or fix M4.

--- a/docs/superpowers/plans/2026-07-17-partials-ergonomics.md
+++ b/docs/superpowers/plans/2026-07-17-partials-ergonomics.md
@@ -1,0 +1,1861 @@
+# Partials Ergonomics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the model save drafts (`saveDraft` passed as an `llm()` tool, intercepted by the tool loop) and let a `finalize` block read the scope's saved draft (`finalize as draft { ... }`).
+
+**Architecture:** Two independent features from one spec (`docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md`). The finalize binder is a parser + checker + codegen change: the `__finalize` closure gains one parameter and `AbortedResult.withFinalize` passes the draft it already holds. The saveDraft tool is a runtime change in `runPrompt`'s tool loop (ordered interception, before concurrent dispatch) plus one codegen change that threads the enclosing def's declared return type to the call site as a zod schema.
+
+**Tech Stack:** TypeScript, tarsec parser combinators, vitest, zod, the Agency fixture harness (`tests/agency/`).
+
+## Global Constraints
+
+- **Base branch:** must contain PR #574 (the `guard` construct). Every fixture below uses `guard(cost: ...) { ... }` syntax, which does not exist before #574. If #574 has merged, branch from `main`; otherwise stack on `guard-keyword`.
+- All file paths below are relative to `packages/agency-lang/` unless they start with `docs/superpowers/`.
+- Run `make` (repo root of the package) before running any Agency fixture — fixtures run against `dist/`, and a stale build produces confusing failures.
+- Save every test run's output to a file (`2>&1 | tee "$TMPDIR/<name>.log"`). Never re-run a suite just to re-read its output.
+- Do NOT run the full Agency suite locally. Run only the specific fixtures you create or touch. CI runs the rest.
+- Never commit on main. Verify with `git branch --show-current` before every commit. Write commit messages to a file and use `git commit -F` (apostrophes break `-m`). End every commit message with the line: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Codebase rules (docs/dev/coding-standards.md): no dynamic imports, objects over maps, arrays over sets, `type` over `interface`. Run `pnpm run lint:structure` before the final commit.
+- The guide file `docs/site/guide/partial-results.md` is owner-authored. Do NOT edit it. Note needed doc updates in the PR description instead.
+
+---
+
+## Background: how the pieces fit (read this first)
+
+**Drafts today.** `saveDraft(x)` in Agency code calls the stdlib def `saveDraft` (`stdlib/index.agency:140`), which calls `_saveDraft` → `StateStack.setSavedDraft` (`lib/runtime/state/stateStack.ts:975`). That method writes `callerFrame().savedDraft` — one frame below the top — because the saveDraft def's own frame sits on top when it runs, so one-below lands on the calling scope. When a guard trip aborts a scope, `AbortedResult.fromError` / `carryThrough` pick up that frame's `savedDraft` as the partial, and the guard returns it as a success.
+
+**Finalize today.** A `finalize { ... }` block compiles into a `const __finalize = async (): Promise<any> => { ... }` closure (`lib/backends/typescriptBuilder/finalizeCodegen.ts:156`). Three stop sites run it through `AbortedResult.withFinalize(finalize, scopeName)` (`lib/runtime/abortedResult.ts:141`). At the moment `withFinalize` runs, `this.partial` already holds the scope's own saved draft (both `fromError` and `carryThrough` read the frame's slot before `withFinalize` is called). If the finalize throws, `withFinalize` returns `this` — the draft-carrying result — so the draft is the fallback. That is why the binder feature is small: **the value the binder should yield is already in `withFinalize`'s hands as `this.partialValueOrNull()`.** We pass it as an argument; nothing about salvage order moves.
+
+**The tool loop today.** `llm()` compiles to a direct `runPrompt()` call (`typescriptBuilder.ts` `processLlmCall`). `runPrompt` pushes its OWN frame on entry (`setupFunction()` at `lib/runtime/prompt.ts:870` → `stateStack.getNewState()`, which pushes). So during the tool loop the stack is `[…, owner, runPrompt]` — the same shape as the def path's `[…, owner, saveDraft-def]` — and the existing `setSavedDraft` (which writes `callerFrame()`) lands on the owner in BOTH paths. This was mis-analyzed in spec review round 1 and corrected in the spec on 2026-07-17; the plan pins the frame math with a fixture (Task 7) rather than trusting the analysis. Tool calls in one round dispatch concurrently via `pr.parallel` (`prompt.ts:1519`); interception must happen BEFORE that dispatch, in the ordered iteration, so "last save wins" holds in call-list order.
+
+**Tool definitions today.** Each tool is an `AgencyFunction` with readonly `name` and `module` fields and a `toolDefinition: { name, description, schema }` where `schema` is a zod schema (`lib/runtime/agencyFunction.ts:62`). The stdlib saveDraft's compiled identity is `name: "saveDraft", module: "stdlib/index.agency"` (verified in `stdlib/index.js`). `runPrompt` builds the provider tool list at `prompt.ts:915` by mapping `exposedFunctions` to their `toolDefinition`s — that map is where the synthesized saveDraft definition substitutes in.
+
+**Schema threading.** The builder's `ScopeManager.returnType()` (`lib/backends/typescriptBuilder/scopeManager.ts:131`) returns the declared return type of the CURRENT scope but returns `undefined` for block scopes. The saveDraft schema wants the nearest enclosing FUNCTION or NODE's declared type (spec decision 3 + finding 3 honesty note), so Task 5 adds a variant that walks outward past blocks. `zodSchemaFor(t)` (`typescriptBuilder.ts:880`) renders a `VariableType` to a zod-source string — the same bridge `responseFormat` uses.
+
+**The handler-param precedent for the binder.** An inline handler `with (i) { ... }` compiles its body with `i` as a plain arrow-function parameter, and references to `i` print as the bare identifier (verified in `tests/agency/guards/guard-concurrent-branches.js:205` — `async (i) => { ... i.effect ... }`). This works because `i` is never declared via `let`/`const`, so the preprocessor never scopes it to `__stack.locals`. The finalize binder uses the identical mechanism. The one hazard: if the binder name collides with a declared local, references would resolve to `__stack.locals.<name>` (the local) instead of the parameter — a silent miscompile. Task 2's checker rule (AG6037) makes that collision a compile error, which is what makes the codegen sound.
+
+**Checker-side precedent.** `buildScopes` declares handler params into the function scope (`lib/typeChecker/scopes.ts:516`), and `refineInlineHandlerParams` (`lib/typeChecker/handlerParamTyping.ts`) re-types them in a pre-flow pass wired at `lib/typeChecker/index.ts:309`. The binder declaration pass (Task 2) is a sibling of that pass: same walk idiom, same wiring point, must also run before `buildFlowGraphs`.
+
+**Fixture harness.** `tests/agency/guards/*.agency` + `.test.json` run without real LLM calls: `useTestLLMProvider: true` + `llmMocks` drive the `DeterministicClient`, which supports mocked tool calls with arguments (`{ "toolCalls": [{ "name": "saveDraft", "args": { "value": "x" } }] }`, `lib/runtime/deterministicClient.ts:42`) and reports synthetic cost, so a `guard(cost: 0.000001)` trips deterministically. Harness `interruptHandlers` support `action: "approve" | "reject" | "modify" | "resolve"` (`lib/cli/util.ts:162`) and ASSERT that the declared interrupts actually occur — never declare a handler for an interrupt that might not fire.
+
+## File map
+
+Part A — finalize binder:
+
+| File | Change |
+|---|---|
+| `lib/types/finalizeBlock.ts` | `params: FunctionParameter[]` field (same shape as `BlockArgument.params`) |
+| `lib/parsers/parsers.ts` | `finalizeBlockParser` accepts `()` and delegates the binder to the existing `asParser` |
+| `lib/parsers/finalizeBinder.test.ts` | NEW — parser tests |
+| `lib/backends/agencyGenerator.ts` | formatter prints the binder |
+| `lib/backends/agencyGenerator.test.ts` | formatter tests (existing file) |
+| `lib/typeChecker/finalizeBinder.ts` | NEW — binder declaration pass + collision check |
+| `lib/typeChecker/finalizeBinder.test.ts` | NEW — checker tests |
+| `lib/typeChecker/diagnostics.ts`, `diagnosticExplanations.ts` | AG6037 |
+| `lib/typeChecker/index.ts` | wire the pass |
+| `lib/runtime/abortedResult.ts` | `withFinalize` passes the draft |
+| `lib/templates/backends/typescriptGenerator/finalizeClosure.mustache` | NEW — the closure emission as a typestache template |
+| `lib/backends/typescriptBuilder/finalizeCodegen.ts` | closure gains the binder param, emission moves to the template |
+| `lib/backends/finalizeBinderCodegen.test.ts` | NEW — codegen tests |
+| `tests/agency/guards/finalize-binder-*.agency/.test.json` | NEW — 3 fixtures |
+
+Part B — saveDraft as a tool:
+
+| File | Change |
+|---|---|
+| `lib/backends/typescriptBuilder/scopeManager.ts` | `enclosingDeclaredReturnType()` |
+| `lib/backends/typescriptBuilder.ts` | `processLlmCall` emits `draftSchema` |
+| `lib/backends/draftSchemaCodegen.test.ts` | NEW — codegen tests |
+| `lib/runtime/intrinsicTools.ts` | NEW — the intrinsic-tool registry (the extensibility seam) |
+| `lib/runtime/saveDraftTool.ts` | NEW — the saveDraft intrinsic: recognition, definition, handler with validation |
+| `lib/runtime/saveDraftTool.test.ts` | NEW — unit tests |
+| `lib/runtime/prompt.ts` | ordered interception pass over the registry; `draftSchema` arg; tool-def substitution |
+| `tests/agency/guards/savedraft-tool-*.agency/.test.json` | NEW — 6 fixtures |
+
+---
+
+### Task 1: Parser, AST, and formatter for the finalize binder
+
+**Files:**
+- Modify: `lib/types/finalizeBlock.ts`
+- Modify: `lib/parsers/parsers.ts` (the `finalizeBlockParser` at ~line 4290)
+- Modify: `lib/backends/agencyGenerator.ts:1673` (`processFinalizeBlock`)
+- Test: `lib/parsers/finalizeBinder.test.ts` (new), `lib/backends/agencyGenerator.test.ts` (append)
+
+**Interfaces:**
+- Consumes: the EXISTING `asParser` (`lib/parsers/parsers.ts:3148`) and `FunctionParameter` — the same binder grammar and param type `fork(...) as item { }` blocks use. Do not hand-roll the `as` clause.
+- Produces: `FinalizeBlock.params: FunctionParameter[]` — every later task reads this field; the binder is `params[0]`, and `params` is `[]` for the binder-less form. All four head forms parse: `finalize {`, `finalize() {`, `finalize as draft {`, `finalize() as draft {`. Because `asParser` also accepts `as (a, b)` and `as draft: Report`, those PARSE here; Task 2's checker constrains them (one binder max; an explicit type hint is honored). The formatter prints canonically without parens.
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Create `lib/parsers/finalizeBinder.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { finalizeBlockParser } from "./parsers.js";
+import { parseAgency } from "../parser.js";
+
+function parseFinalize(src: string) {
+  const r = finalizeBlockParser(src);
+  expect(r.success).toBe(true);
+  if (!r.success) throw new Error(r.message);
+  return r.result;
+}
+
+describe("finalizeBlockParser — binder head forms (via the shared asParser)", () => {
+  it("parses the bare form with empty params", () => {
+    const node = parseFinalize("finalize {\n  return 1\n}");
+    expect(node.type).toBe("finalizeBlock");
+    expect(node.params).toEqual([]);
+  });
+
+  it("parses empty parens with empty params", () => {
+    const node = parseFinalize("finalize() {\n  return 1\n}");
+    expect(node.params).toEqual([]);
+  });
+
+  it("parses `as name` into params[0]", () => {
+    const node = parseFinalize("finalize as draft {\n  return draft\n}");
+    expect(node.params).toHaveLength(1);
+    expect(node.params[0].name).toBe("draft");
+  });
+
+  it("parses `() as name`", () => {
+    const node = parseFinalize("finalize() as best {\n  return best\n}");
+    expect(node.params[0].name).toBe("best");
+  });
+
+  it("binder name is the user's choice", () => {
+    const node = parseFinalize("finalize as partialSoFar {\n  return partialSoFar\n}");
+    expect(node.params[0].name).toBe("partialSoFar");
+  });
+
+  it("a typed binder parses (the shared grammar allows it; the checker rules on it)", () => {
+    const node = parseFinalize("finalize as draft: string {\n  return draft\n}");
+    expect(node.params[0].name).toBe("draft");
+    expect(node.params[0].typeHint).toBeDefined();
+  });
+
+  it("multiple binders parse (rejected later by AG6038, not here)", () => {
+    const node = parseFinalize("finalize as (a, b) {\n  return a\n}");
+    expect(node.params).toHaveLength(2);
+  });
+
+  it("does not swallow an identifier like finalizer(...)", () => {
+    const r = finalizeBlockParser("finalizer(1)");
+    expect(r.success).toBe(false);
+  });
+
+  it("`as` with no name parses as the binder-less form (the shared grammar's no-param rule)", () => {
+    // blockParamsParser treats `as {` as "as, then zero params" — the
+    // documented no-param block form (`fork() as { }`). Reusing the
+    // grammar means finalize inherits it; the formatter canonicalizes
+    // the stray `as` away, exactly like guard's legacy-as migration.
+    const node = parseFinalize("finalize as {\n  return 1\n}");
+    expect(node.params).toEqual([]);
+  });
+
+  it("parses inside a full function body", () => {
+    const r = parseAgency(
+      "def f(): string {\n  return \"x\"\n\n  finalize as d {\n    return \"y\"\n  }\n}\n",
+      {},
+      false,
+    );
+    expect(r.success).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm test:run lib/parsers/finalizeBinder.test.ts 2>&1 | tee "$TMPDIR/finalize-parser.log"`
+Expected: FAIL — `params` is `undefined` on the current node and the `as` forms do not parse. (The bare-form tests may already pass except for the `params` assertion.)
+
+- [ ] **Step 3: Add the field to the AST type**
+
+In `lib/types/finalizeBlock.ts`:
+
+```ts
+import type { FunctionParameter } from "../types.js";
+
+export type FinalizeBlock = BaseNode & {
+  type: "finalizeBlock";
+  /** `finalize as <name>` binder, parsed by the same asParser blocks
+   *  use — so this is the SAME field shape as BlockArgument.params.
+   *  params[0] is the binder the scope's saved draft is yielded to;
+   *  [] is the binder-less form. The grammar also admits multiple
+   *  params and type hints; AG6038 (arity) and the binder-typing pass
+   *  rule on those, not the parser. */
+  params: FunctionParameter[];
+  body: AgencyNode[];
+};
+```
+
+(Adjust the `FunctionParameter` import path to wherever `BlockArgument` imports it from.) Then run `pnpm exec tsc --noEmit 2>&1 | tee "$TMPDIR/tsc-binder.log"` and fix every construction site the compiler flags by adding `params: []` (the parser rewrite in Step 4 covers the main one; any test or preprocessor that builds a literal `finalizeBlock` node needs the explicit field).
+
+- [ ] **Step 4: Rewrite the parser**
+
+Replace the existing `finalizeBlockParser` in `lib/parsers/parsers.ts` (keep its position and registration; it is already in the statement parser list). The binder clause is NOT hand-rolled: it is the existing `asParser` (`parsers.ts:3148`), the same combinator block arguments use, which yields `FunctionParameter[]` and `[]` when the clause is absent. Model the commit-at-`{` shape on `guardBlockParser`:
+
+```ts
+/** `finalize { ... }` — keyword block. Four head forms parse:
+ *  `finalize {`, `finalize() {`, `finalize as name {`,
+ *  `finalize() as name {`. The binder clause is the SAME asParser
+ *  block arguments use, so the grammar (and its edge cases — `as {`
+ *  means no params, parens and type hints are admitted) is shared,
+ *  not duplicated; arity and typing are checker rules (AG6038, the
+ *  binder-typing pass). Mirrors handleBlockParser's keyword handling:
+ *  the word-boundary check keeps an identifier like `finalizer(...)`
+ *  parsing as a call. */
+export const finalizeBlockParser: Parser<FinalizeBlock> = withLoc(memo(
+  "finalizeBlockParser",
+  (input: string): ParserResult<FinalizeBlock> => {
+    const pre = seqC(
+      str("finalize"),
+      not(varNameChar),
+      optionalSpaces,
+      // Optional empty parens: `finalize() { ... }`.
+      optional(seqC(char("("), optionalSpaces, char(")"))),
+      optionalSpaces,
+      capture(asParser, "params"),
+      optionalSpaces,
+      char("{"),
+    )(input);
+    if (!pre.success) return pre as ParserResult<FinalizeBlock>;
+    // Past the `{` we commit: a malformed body is an error here.
+    const bodyR = parseError(
+      "expected `}` to close finalize block body",
+      optionalSpacesOrNewline,
+      capture(lazy(() => bodyParser), "body"),
+      optionalSpacesOrNewline,
+      char("}"),
+    )(pre.rest);
+    if (!bodyR.success) return bodyR as ParserResult<FinalizeBlock>;
+    return success(
+      {
+        type: "finalizeBlock",
+        params: (pre.result as any).params,
+        body: (bodyR.result as any).body,
+      } as FinalizeBlock,
+      bodyR.rest,
+    );
+  },
+));
+```
+
+- [ ] **Step 5: Run the parser tests**
+
+Run: `pnpm test:run lib/parsers/finalizeBinder.test.ts 2>&1 | tee "$TMPDIR/finalize-parser2.log"`
+Expected: PASS.
+
+- [ ] **Step 6: Write the failing formatter tests**
+
+Append to `lib/backends/agencyGenerator.test.ts` (use the existing `gen` helper pattern from `agencyGenerator.guardBlock.test.ts` if this file lacks one):
+
+```ts
+describe("AgencyGenerator — finalize binder", () => {
+  it("prints the canonical binder form without parens", () => {
+    const out = gen(
+      "def f(): string {\n  return \"x\"\n  finalize() as d {\n    return \"y\"\n  }\n}\nnode main() { return f() }\n",
+    );
+    expect(out).toContain("finalize as d {");
+    expect(out).not.toContain("finalize()");
+  });
+
+  it("prints the binder-less form unchanged", () => {
+    const out = gen(
+      "def f(): string {\n  return \"x\"\n  finalize {\n    return \"y\"\n  }\n}\nnode main() { return f() }\n",
+    );
+    expect(out).toContain("finalize {");
+  });
+
+  it("canonicalizes a stray `as` with no binder away (fmt IS the migration, like guard)", () => {
+    const out = gen(
+      "def f(): string {\n  return \"x\"\n  finalize as {\n    return \"y\"\n  }\n}\nnode main() { return f() }\n",
+    );
+    expect(out).toContain("finalize {");
+    expect(out).not.toContain("finalize as {");
+  });
+});
+```
+
+- [ ] **Step 7: Implement the formatter change**
+
+In `lib/backends/agencyGenerator.ts` (`processFinalizeBlock`, line ~1673), reuse the existing `renderParams` (line ~628 — it already prints names, type hints, and multi-param lists correctly):
+
+```ts
+protected processFinalizeBlock(node: FinalizeBlock): string {
+  this.increaseIndent();
+  const bodyCodeStr = this.renderBody(node.body);
+  this.decreaseIndent();
+  const rendered = this.renderParams(node.params);
+  const asClause =
+    rendered.length === 0
+      ? ""
+      : rendered.length === 1
+        ? ` as ${rendered[0]}`
+        : ` as (${rendered.join(", ")})`;
+  return this.indentStr(`finalize${asClause} {\n${bodyCodeStr}${this.indentStr("}")}`);
+}
+```
+
+(If `renderParams` is private and inaccessible from this method's position, follow how the block-argument printing at line ~1112 renders its `as` clause instead — same file, same pattern.)
+
+- [ ] **Step 8: Run formatter tests and the neighboring suites**
+
+Run: `pnpm test:run lib/backends/agencyGenerator.test.ts lib/parsers/finalizeBinder.test.ts lib/typeChecker/finalize.test.ts 2>&1 | tee "$TMPDIR/finalize-fmt.log"`
+Expected: PASS (finalize.test.ts guards against regressions in the existing finalize checks).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git branch --show-current   # must NOT be main
+printf 'feat: parse and print the finalize binder (finalize as draft)\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > /tmp/claude/commitmsg.txt
+git add lib/types/finalizeBlock.ts lib/parsers/parsers.ts lib/parsers/finalizeBinder.test.ts lib/backends/agencyGenerator.ts lib/backends/agencyGenerator.test.ts
+git commit -F /tmp/claude/commitmsg.txt
+```
+
+---
+
+### Task 2: Checker — declare the binder as `T | null`, reject collisions (AG6037) and multi-binders (AG6038)
+
+**Files:**
+- Create: `lib/typeChecker/finalizeBinder.ts`
+- Modify: `lib/typeChecker/diagnostics.ts` (after `finalizeReturnShape`), `lib/typeChecker/diagnosticExplanations.ts`, `lib/typeChecker/index.ts:309`
+- Test: `lib/typeChecker/finalizeBinder.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `FinalizeBlock.params: FunctionParameter[]` from Task 1 (binder = `params[0]`; `params[0].typeHint` may be set).
+- Produces: `declareFinalizeBinders(scopes: ScopeInfo[], ctx: TypeCheckerContext): void`, diagnostic keys `finalizeBinderCollision` (AG6037) and `finalizeBinderArity` (AG6038). The binder is visible to `checkScopes` typed `T | null`, where `T` is the explicit type hint when written (`finalize as d: Report` — "explicit annotation wins", the handler-param rule), else the scope's DECLARED return type, else `any`.
+
+Background for this task: why a collision is an ERROR and not a shadow. The finalize body compiles in the enclosing scope, and the binder becomes a bare closure parameter (Task 3). A reference to a name the preprocessor knows as a local compiles to `__stack.locals.<name>` — so if the binder reused a local's name, every reference in the finalize body would silently read the LOCAL, never the draft. The type checker is the only place that can see this coming.
+
+Also note one accepted limitation, mirroring inline handler params (`scopes.ts:516` declares those into the function scope too): the binder name is declared function-wide, so REFERENCING it outside the finalize is not flagged as undefined. The collision rule removes the dangerous direction (binder clobbering a real local); the reference-leak direction fails at runtime like a handler param would. Record this in the code comment.
+
+- [ ] **Step 1: Write the failing checker tests**
+
+Create `lib/typeChecker/finalizeBinder.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { typecheckSource } from "./testUtils.js";
+
+describe("finalize binder — typing and collisions (spec Part 3)", () => {
+  it("types the binder as T | null: unguarded use as T errors", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as d {
+    const s: string = d
+    return s
+  }
+}
+node main() { return f() }`,
+    ).filter((e) => /null|not assignable/i.test(e.message));
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("a null-guarded use narrows to T and passes", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as d {
+    if (d != null) {
+      const s: string = d
+      return s
+    }
+    return "empty"
+  }
+}
+node main() { return f() }`,
+    ).filter((e) => /null|not assignable/i.test(e.message));
+    expect(errs).toHaveLength(0);
+  });
+
+  it("an undeclared return type leaves the binder as any (no errors AT ALL)", () => {
+    // UNFILTERED on purpose (plan review T1): the bug this guards
+    // against — the pass failing to declare `d` — surfaces as an
+    // "undefined variable" error, which a binder/null/assignable
+    // message filter would silently drop. Zero errors total is the
+    // only assertion that fails in that direction. The unguarded
+    // `const s: string = d` doubles as the any-permissiveness probe:
+    // legal for `any`, an error for `T | null`.
+    const errs = typecheckSource(
+      `def f() {
+  return "x"
+  finalize as d {
+    const s: string = d
+    return s
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs).toHaveLength(0);
+  });
+
+  it("a binder named like a MODULE-level const is allowed (collision check is scope-local)", () => {
+    // The miscompile AG6037 prevents is a same-frame local resolving
+    // to __stack.locals.<name>. A module global compiles differently
+    // (not a frame local), so it is NOT a hazard, and a parent-walking
+    // `has` would false-positive here (plan review finding 3 / M2).
+    const errs = typecheckSource(
+      `const banner = "b"
+def f(): string {
+  return "x"
+  finalize as banner {
+    if (banner != null) { return banner }
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.filter((e) => e.code === "AG6037")).toHaveLength(0);
+  });
+
+  it("a binder colliding with a local is AG6037", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  const outline = "o"
+  return outline
+  finalize as outline {
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.some((e) => e.code === "AG6037")).toBe(true);
+  });
+
+  it("a binder colliding with a parameter is AG6037", () => {
+    const errs = typecheckSource(
+      `def f(topic: string): string {
+  return topic
+  finalize as topic {
+    return "y"
+  }
+}
+node main() { return f("t") }`,
+    );
+    expect(errs.some((e) => e.code === "AG6037")).toBe(true);
+  });
+
+  it("a fresh binder name does not disturb outer variables", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  const outline = "o"
+  return outline
+  finalize as d {
+    if (outline != null) { return outline }
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.filter((e) => e.code === "AG6037")).toHaveLength(0);
+  });
+
+  it("the binder-less form is untouched", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize {
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.filter((e) => e.code === "AG6037")).toHaveLength(0);
+  });
+
+  it("two binders is AG6038 (finalize yields one value)", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as (a, b) {
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.some((e) => e.code === "AG6038")).toBe(true);
+  });
+
+  it("an explicit type hint wins over the scope's return type", () => {
+    // def returns string; the binder is annotated number, so using it
+    // as a string (after the null guard) must error.
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as d: number {
+    if (d != null) {
+      const s: string = d
+      return "y"
+    }
+    return "y"
+  }
+}
+node main() { return f() }`,
+    ).filter((e) => /not assignable/i.test(e.message));
+    expect(errs.length).toBeGreaterThan(0);
+  });
+});
+```
+
+If `typecheckSource` returns diagnostics without a `.code` field, match on the message instead (`/collides/`) — check `lib/typeChecker/testUtils.ts` and `guardConstruct.test.ts` for the shape actually returned before writing assertions.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/typeChecker/finalizeBinder.test.ts 2>&1 | tee "$TMPDIR/finalize-checker.log"`
+Expected: FAIL — no binder declaration exists, so the `T | null` tests find no error and the collision tests find no AG6037.
+
+- [ ] **Step 3: Add the diagnostic**
+
+In `lib/typeChecker/diagnostics.ts`, after the `finalizeReturnShape` entry:
+
+```ts
+finalizeBinderCollision: {
+  code: "AG6037",
+  severity: "error",
+  message:
+    "finalize binder '{name}' collides with a variable that already exists in this scope. Pick a fresh name. The finalize body reads the scope's locals directly, so a colliding binder would silently shadow the local.",
+},
+```
+
+And after it:
+
+```ts
+finalizeBinderArity: {
+  code: "AG6038",
+  severity: "error",
+  message:
+    "finalize yields a single value — the scope's saved draft. Use one binder: finalize as {name} {{ ... }}.",
+},
+```
+
+(Check how existing messages escape braces / interpolate before copying the `{name}` placeholder — mirror a neighboring entry exactly.)
+
+In `lib/typeChecker/diagnosticExplanations.ts`, alongside the other finalize entries:
+
+```ts
+finalizeBinderCollision: `A finalize body runs in the same variable scope as the function or block it belongs to. The \`as\` binder adds one extra name: the scope's saved draft. If that name already belongs to a parameter or local, references inside the finalize could not tell the two apart, and the draft would silently win or lose depending on compilation details.
+
+**How to fix:** rename the binder. Any name not already used in the scope works: \`finalize as draft { ... }\`.`,
+
+finalizeBinderArity: `The \`as\` clause on a finalize binds what the abort yields to the block, and the abort yields exactly one thing: the scope's saved draft (or null when nothing was saved). There is no second value to bind, so a parameter list has no meaning here. The shared block-argument grammar is why the parser accepts the list at all.
+
+**How to fix:** keep one binder: \`finalize as draft { ... }\`. Everything else the finalize needs is already in scope as ordinary locals.`,
+```
+
+- [ ] **Step 4: Write the pass**
+
+Create `lib/typeChecker/finalizeBinder.ts`:
+
+```ts
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import type { VariableType } from "../types.js";
+import type { FinalizeBlock } from "../types/finalizeBlock.js";
+import { walkNodes } from "../utils/node.js";
+import { isInScope } from "./checker.js";
+import { diagnostic } from "./diagnostics.js";
+import { ANY_T, NULL_T } from "./primitives.js";
+
+/** The binder's type: T | null, where T is the explicit annotation
+ *  when written (`finalize as d: Report` — explicit annotation wins,
+ *  the handler-param rule), else the scope's DECLARED return type
+ *  (the slot is empty until the first saveDraft, hence the null arm).
+ *  Neither present means `any` — inferred return types are out of
+ *  scope for v1, the same rule the saveDraft tool schema follows
+ *  (spec Part 5). */
+function binderType(
+  typeHint: VariableType | undefined,
+  returnType: VariableType | undefined,
+): VariableType {
+  const t = typeHint ?? returnType;
+  if (t === undefined) return ANY_T;
+  return { type: "unionType", types: [t, NULL_T] };
+}
+
+/**
+ * Declare each `finalize as <name>` binder into its scope, typed
+ * `T | null`. A sibling of refineInlineHandlerParams: runs pre-flow so
+ * checkScopes and the flow passes see the binding, and declares into
+ * the FUNCTION scope (the finalize body has no scope of its own).
+ *
+ * A binder that collides with an existing name is an error (AG6037),
+ * not a shadow: the binder compiles to a bare closure parameter, and a
+ * colliding reference would resolve to `__stack.locals.<name>` — the
+ * local — instead. The collision rule is what makes the codegen sound.
+ *
+ * Accepted limitation (mirrors inline handler params, scopes.ts): the
+ * declaration is function-wide, so a reference to the binder OUTSIDE
+ * the finalize is not flagged as undefined here.
+ */
+export function declareFinalizeBinders(
+  scopes: ScopeInfo[],
+  ctx: TypeCheckerContext,
+): void {
+  for (const info of scopes) {
+    ctx.withScope(info.scopeKey, () => {
+      for (const { node, scopes: nodeScopes } of walkNodes(info.body)) {
+        if (!isInScope(nodeScopes, info)) continue;
+        if (node.type !== "finalizeBlock") continue;
+        const fin = node as FinalizeBlock;
+        if (fin.params.length === 0) continue;
+        if (fin.params.length > 1) {
+          ctx.errors.push(
+            diagnostic(
+              "finalizeBinderArity",
+              { name: fin.params[0].name },
+              fin.loc ?? null,
+            ),
+          );
+          continue;
+        }
+        const binder = fin.params[0];
+        if (info.scope.has(binder.name)) {
+          ctx.errors.push(
+            diagnostic(
+              "finalizeBinderCollision",
+              { name: binder.name },
+              fin.loc ?? null,
+            ),
+          );
+          continue;
+        }
+        info.scope.declare(
+          binder.name,
+          binderType(binder.typeHint, info.returnType),
+        );
+      }
+    });
+  }
+}
+```
+
+Verify the `walkNodes` result shape (`{ node, scopes }`) and `isInScope` import against `handlerParamTyping.ts:109-110` — copy exactly what that file does; it is the working precedent. If `ScopeInfo` has no `returnType` field, find where `checkScopes` reads it (`checker.ts:177`) and use the same source.
+
+One requirement on the collision check (plan review finding 3): it must be SCOPE-LOCAL. Read `Scope.has` in `lib/typeChecker/scope.ts` before using it — if it walks parent scopes, use (or add) a local-only variant. The hazard AG6037 prevents is a binder resolving to `__stack.locals.<name>` — a same-frame local or param. A name matching a MODULE global is not a hazard (globals compile through `__globals()`, not the frame), and a parent-walking check would wrongly reject it; the module-const test above pins this direction.
+
+- [ ] **Step 5: Wire it in**
+
+In `lib/typeChecker/index.ts`, import the pass and call it right after `refineInlineHandlerParams` (line ~309):
+
+```ts
+declareFinalizeBinders(scopes, ctx);
+```
+
+It must run before `buildFlowGraphs` for the same reason `refineInlineHandlerParams` must (see that function's ordering assertion).
+
+- [ ] **Step 6: Run the tests**
+
+Run: `pnpm test:run lib/typeChecker/finalizeBinder.test.ts lib/typeChecker/finalize.test.ts lib/typeChecker/saveDraft.test.ts 2>&1 | tee "$TMPDIR/finalize-checker2.log"`
+Expected: PASS, including the pre-existing finalize/saveDraft suites.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git branch --show-current   # must NOT be main
+printf 'feat: type the finalize binder as T | null, reject collisions and multi-binders\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > /tmp/claude/commitmsg.txt
+git add lib/typeChecker/finalizeBinder.ts lib/typeChecker/finalizeBinder.test.ts lib/typeChecker/diagnostics.ts lib/typeChecker/diagnosticExplanations.ts lib/typeChecker/index.ts
+git commit -F /tmp/claude/commitmsg.txt
+```
+
+---
+
+### Task 3: Codegen and runtime — pass the draft into the finalize closure
+
+**Files:**
+- Modify: `lib/runtime/abortedResult.ts:141` (`withFinalize`)
+- Create: `lib/templates/backends/typescriptGenerator/finalizeClosure.mustache`
+- Modify: `lib/backends/typescriptBuilder/finalizeCodegen.ts:156` (`closure`)
+- Test: `lib/backends/finalizeBinderCodegen.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `FinalizeBlock.params` (Task 1; the binder is `params[0]`, and Task 2 guarantees at most one param survives checking).
+- Produces: `withFinalize(finalize: (draft: unknown) => Promise<unknown>, scopeName: string)`; generated closures `const __finalize = async (<binder>: any): Promise<any> => { ... }` when a binder exists, byte-identical output when not.
+
+The design in one paragraph: `withFinalize` already holds the scope's own draft — `carryThrough(frame, scope)` and `fromError(error, frame, scope)` both copy `frame.savedDraft` into `this.partial` before any stop site calls `.withFinalize(...)`. So the runtime change is one line: call `finalize(this.partialValueOrNull())`. The throw-fallback path returns `this`, which carries the SAME partial — so "the draft is read before the finalize runs, and the same value is the fallback" (spec Part 3) holds by construction, with zero changes to `stopScope`, `abortReturn`, or `interceptedReturn`. Existing binder-less closures are `async () => ...`; passing them an argument they ignore is a no-op, and TypeScript accepts a zero-param function where a one-param function type is expected, so nothing else moves.
+
+- [ ] **Step 1: Write the failing codegen test**
+
+Create `lib/backends/finalizeBinderCodegen.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+function gen(src: string): string {
+  const r = parseAgency(src, {}, false);
+  if (!r.success) throw new Error("parse failed: " + r.message);
+  return generateTypeScript(r.result, undefined, undefined, "test.agency");
+}
+
+describe("finalize binder codegen", () => {
+  it("the closure takes the binder as a bare parameter", () => {
+    const out = gen(
+      "def f(): string {\n  return \"x\"\n  finalize as draft {\n    if (draft != null) { return draft }\n    return \"none\"\n  }\n}\nnode main() { return f() }\n",
+    );
+    expect(out).toContain("const __finalize = async (draft: any): Promise<any>");
+    // The body must reference the parameter BARE, not a frame local —
+    // that is the whole trick (handler-param precedent).
+    expect(out).not.toContain("__stack.locals.draft");
+  });
+
+  it("binder-less output is byte-identical to the old form", () => {
+    const out = gen(
+      "def f(): string {\n  return \"x\"\n  finalize {\n    return \"y\"\n  }\n}\nnode main() { return f() }\n",
+    );
+    expect(out).toContain("const __finalize = async (): Promise<any>");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/backends/finalizeBinderCodegen.test.ts 2>&1 | tee "$TMPDIR/finalize-codegen.log"`
+Expected: FAIL on the first test (`async ()` emitted, no param).
+
+- [ ] **Step 3: Implement the codegen change — as a typestache template, not a raw string**
+
+The closure emission is a multi-line codegen string, and those belong in `lib/templates/` (owner rule; see `blockSetup.mustache` for the pattern this copies). Create `lib/templates/backends/typescriptGenerator/finalizeClosure.mustache`:
+
+```mustache
+const __finalize = async ({{{binderParam}}}): Promise<any> => {
+  const runner = new Runner(__ctx, {{{frameVar}}}, { state: {{{frameVar}}}, moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}} });
+{{{body}}}
+  return runner.halted ? runner.haltResult : undefined;
+};
+```
+
+Run `pnpm run templates` to compile it (only ever edit the `.mustache`, never the generated `.ts`).
+
+In `lib/backends/typescriptBuilder/finalizeCodegen.ts`, import it the way `typescriptBuilder.ts:38` imports `blockSetup` (`import * as renderFinalizeClosure from "../../templates/backends/typescriptGenerator/finalizeClosure.js";`) and rewrite `closure()`:
+
+```ts
+private closure(finalize: FinalizeBlock, scopeName: string): TsNode {
+  const parts = this.compileBody(finalize.body, FinalizeCodegen.STEP_BASE);
+  const bodyStr = parts.map((n) => printTs(n, 1)).join("\n");
+  // The binder is a plain closure parameter (never a frame local): it
+  // was never declared via let/const, so body references print as the
+  // bare identifier — the same mechanism inline handler params use.
+  // AG6037 guarantees the name cannot collide with a real local, and
+  // AG6038 guarantees at most one param reaches codegen.
+  const binder = finalize.params[0];
+  return ts.raw(
+    renderFinalizeClosure.default({
+      binderParam: binder !== undefined ? `${binder.name}: any` : "",
+      frameVar: this.frameVar(),
+      moduleId: JSON.stringify(this.moduleId),
+      scopeName: JSON.stringify(scopeName + "#finalize"),
+      body: bodyStr,
+    }).trimEnd(),
+  );
+}
+```
+
+The template's output must be BYTE-IDENTICAL to the old raw string for binder-less programs — that is what Step 5's zero-churn check enforces. Watch the two usual template traps: a trailing newline from the file's last line (hence the `trimEnd()`; drop it if the template renders flush) and the newline between the runner line and `{{{body}}}`. If the first `make fixtures` diff shows whitespace-only churn, fix the TEMPLATE until the diff is empty; do not regenerate the fixtures around it.
+
+- [ ] **Step 4: Implement the runtime change**
+
+In `lib/runtime/abortedResult.ts`, `withFinalize`:
+
+```ts
+async withFinalize(
+  finalize: (draft: unknown) => Promise<unknown>,
+  scopeName: string,
+): Promise<AbortedResult> {
+  let value: unknown;
+  try {
+    // The partial this instance holds IS the scope's own saved draft
+    // (carryThrough/fromError copied the frame slot before any stop
+    // site called us) — yielded to a `finalize as draft` binder. Read
+    // before the finalize runs; on throw the same value is the
+    // fallback because the catch returns `this`.
+    value = await finalize(this.partialValueOrNull());
+  } catch (finalizeError) {
+    this.logFinalizeFailure(scopeName, finalizeError);
+    return this;
+  }
+  ...
+```
+
+(Only the signature, the call, and the comment change; the rest of the method body stays as it is.)
+
+- [ ] **Step 4b: Unit-test the runtime half in isolation (plan review M5)**
+
+The fixture proves the whole pipe; this pins the one-line runtime change so a regression fails at the unit level. Append to `lib/runtime/abortedResult.test.ts`, following that file's existing construction helpers for an `AbortedResult` carrying a partial:
+
+```ts
+describe("withFinalize passes the draft (finalize as draft)", () => {
+  it("the finalize receives the partial this instance holds", async () => {
+    const aborted = /* construct an AbortedResult whose partial is { value: "the-draft" }, using this file's existing helpers (carryThrough/fromError against a frame with savedDraft set) */;
+    let received: unknown = "not-called";
+    await aborted.withFinalize(async (draft) => {
+      received = draft;
+      return "finalized";
+    }, "scope");
+    expect(received).toBe("the-draft");
+  });
+
+  it("no partial yields null, matching the binder's null case", async () => {
+    const aborted = /* same construction, frame with NO savedDraft */;
+    let received: unknown = "not-called";
+    await aborted.withFinalize(async (draft) => {
+      received = draft;
+      return "finalized";
+    }, "scope");
+    expect(received).toBe(null);
+  });
+
+  it("a throwing finalize still returns `this` — the same draft is the fallback", async () => {
+    const aborted = /* partial = { value: "the-draft" } */;
+    const result = await aborted.withFinalize(async () => {
+      throw new Error("boom");
+    }, "scope");
+    expect(result).toBe(aborted);
+    expect(result.partialValueOrNull()).toBe("the-draft");
+  });
+});
+```
+
+Replace the construction comments with this test file's real idiom — `abortedResult.test.ts` already builds instances with and without partials; copy its setup rather than inventing one.
+
+Run: `pnpm test:run lib/runtime/abortedResult.test.ts 2>&1 | tee "$TMPDIR/withfinalize-unit.log"` — expected PASS.
+
+- [ ] **Step 5: Run codegen tests + prove byte-stability**
+
+Run: `pnpm test:run lib/backends/finalizeBinderCodegen.test.ts 2>&1 | tee "$TMPDIR/finalize-codegen2.log"`
+Expected: PASS.
+
+Then prove existing fixtures did not move:
+
+```bash
+make 2>&1 | tail -5
+make fixtures 2>&1 | tail -5
+git status --porcelain tests/ | tee "$TMPDIR/fixture-churn-a.log"
+```
+
+Expected: `git status` shows NO modified fixture `.js` files (the binder-less closure text is unchanged). If anything churned, diff it and understand why before proceeding — this task must be invisible to existing programs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git branch --show-current   # must NOT be main
+printf 'feat: yield the saved draft to the finalize closure (finalize as draft)\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > /tmp/claude/commitmsg.txt
+git add lib/runtime/abortedResult.ts lib/runtime/abortedResult.test.ts lib/backends/typescriptBuilder/finalizeCodegen.ts lib/backends/finalizeBinderCodegen.test.ts lib/templates/
+git commit -F /tmp/claude/commitmsg.txt
+```
+
+---
+
+### Task 4: Agency fixtures for the finalize binder
+
+**Files:**
+- Create: `tests/agency/guards/finalize-binder-returns-draft.agency` + `.test.json`
+- Create: `tests/agency/guards/finalize-binder-null.agency` + `.test.json`
+- Create: `tests/agency/guards/finalize-binder-throw-falls-back.agency` + `.test.json`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+- Produces: end-to-end proof of the three spec Part 4 binder behaviors. Model all three on `tests/agency/guards/finalize-wins-over-draft.agency` / `finalize-error-falls-back.agency` — same mock, same guard budget, same reject handler.
+
+- [ ] **Step 1: Write the returns-draft fixture**
+
+`tests/agency/guards/finalize-binder-returns-draft.agency`:
+
+```
+// The binder yields the scope's OWN saved draft; the finalize returns
+// it with a suffix — the two salvage tools composing (partials
+// ergonomics spec, Part 3).
+def work(): string {
+  saveDraft("the-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize as draft {
+    if (draft != null) {
+      return draft + "+suffix"
+    }
+    return "no-draft"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}
+```
+
+`tests/agency/guards/finalize-binder-returns-draft.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"the-draft+suffix\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "finalize as draft yields the scope's saved draft; the finalize returns it with a suffix.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the null-binder fixture**
+
+`tests/agency/guards/finalize-binder-null.agency` — identical shape, but `work` never calls `saveDraft`, and the finalize is:
+
+```
+  finalize as draft {
+    if (draft == null) {
+      return "was-null"
+    }
+    return "had-value"
+  }
+```
+
+`.test.json` expects `"\"was-null\""`, same mocks and handlers as Step 1.
+
+- [ ] **Step 3: Write the throw-falls-back fixture**
+
+`tests/agency/guards/finalize-binder-throw-falls-back.agency` — the throwing mechanism copied from `finalize-error-falls-back.agency`:
+
+```
+// A throwing finalize falls back to the SAME draft the binder was
+// bound to: read-before-run, same value both ways.
+def work(): string {
+  saveDraft("the-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize as draft {
+    const broken: any = null
+    return broken.field
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected-failure" }
+  return result.value
+}
+```
+
+`.test.json` expects `"\"the-draft\""`, same mocks and handlers.
+
+- [ ] **Step 4: Build and run the three fixtures**
+
+```bash
+make 2>&1 | tail -3
+pnpm run agency test tests/agency/guards/finalize-binder-returns-draft.agency 2>&1 | tee "$TMPDIR/fx-binder-1.log"
+pnpm run agency test tests/agency/guards/finalize-binder-null.agency 2>&1 | tee "$TMPDIR/fx-binder-2.log"
+pnpm run agency test tests/agency/guards/finalize-binder-throw-falls-back.agency 2>&1 | tee "$TMPDIR/fx-binder-3.log"
+```
+
+Expected: all three PASS. If a fixture fails on timing (trip not delivered where expected), compare against how `finalize-wins-over-draft` sequences its steps before changing the budget — these fixtures deliberately copy a proven shape.
+
+- [ ] **Step 5: Regenerate checked-in fixture JS and commit**
+
+```bash
+make fixtures 2>&1 | tail -3
+git status --porcelain tests/ | head
+git branch --show-current   # must NOT be main
+printf 'test: finalize binder fixtures (returns draft, null, throw fallback)\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > /tmp/claude/commitmsg.txt
+git add tests/agency/guards/finalize-binder-*
+git commit -F /tmp/claude/commitmsg.txt
+```
+
+---
+
+### Task 5: Codegen — thread the enclosing return-type schema to `llm()` call sites
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder/scopeManager.ts` (new method after `returnType()`, line ~151)
+- Modify: `lib/backends/typescriptBuilder.ts` (`processLlmCall`, after `runPromptEntries.clientConfig` at line ~3646)
+- Test: `lib/backends/draftSchemaCodegen.test.ts` (new)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (Part B starts here; independent of Part A).
+- Produces: `ScopeManager.enclosingDeclaredReturnType(): VariableType | undefined`, and generated `runPrompt({ ..., draftSchema: z.string(), ... })` entries. Task 6 reads `args.draftSchema` in the runtime.
+
+Two deliberate rules, both from the spec, both worth restating: (1) the schema keys on the nearest enclosing FUNCTION or NODE's DECLARED return type, walking past block scopes — a guard block owns the draft slot but carries no declared type, so the function's type is the best honest hint (spec finding 3). (2) `draftSchema` is emitted only when the `llm()` call has arguments beyond the prompt. A bare `llm("...")` cannot carry tools, so emitting the schema there would churn every fixture in the repo for no behavior. When the call has extra args (named options, a positional config object, or a splat), tools MAY be present, so the schema is threaded.
+
+- [ ] **Step 1: Write the failing codegen tests**
+
+Create `lib/backends/draftSchemaCodegen.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+function gen(src: string): string {
+  const r = parseAgency(src, {}, false);
+  if (!r.success) throw new Error("parse failed: " + r.message);
+  return generateTypeScript(r.result, undefined, undefined, "test.agency");
+}
+
+describe("draftSchema threading (saveDraft tool, spec Part 2)", () => {
+  it("threads the declared string return type when the call has options", () => {
+    const out = gen(
+      "def f(): string {\n  const r = llm(\"hi\", tools: [print])\n  return r\n}\nnode main() { return f() }\n",
+    );
+    expect(out).toContain("draftSchema: z.string()");
+  });
+
+  it("omits draftSchema on a bare llm(prompt) call", () => {
+    const out = gen(
+      "def f(): string {\n  const r = llm(\"hi\")\n  return r\n}\nnode main() { return f() }\n",
+    );
+    expect(out).not.toContain("draftSchema");
+  });
+
+  it("walks past a guard block to the enclosing def's declared type", () => {
+    const out = gen(
+      "def f(): string {\n  const r = guard(cost: $1) {\n    return llm(\"hi\", tools: [print])\n  }\n  if (isSuccess(r)) { return r.value }\n  return \"x\"\n}\nnode main() { return f() }\n",
+    );
+    expect(out).toContain("draftSchema: z.string()");
+  });
+
+  it("omits draftSchema when the enclosing def has no declared return type", () => {
+    const out = gen(
+      "def f() {\n  const r = llm(\"hi\", tools: [print])\n  return r\n}\nnode main() { return f() }\n",
+    );
+    expect(out).not.toContain("draftSchema");
+  });
+
+  it("threads an object schema for a structured declared return type", () => {
+    const out = gen(
+      "type Report = { title: string }\ndef f(): Report {\n  const r: Report = llm(\"hi\", tools: [print])\n  return r\n}\nnode main() { const x = f()\n return \"ok\" }\n",
+    );
+    expect(out).toMatch(/draftSchema: z\.object\(/);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/backends/draftSchemaCodegen.test.ts 2>&1 | tee "$TMPDIR/draftschema.log"`
+Expected: FAIL — no `draftSchema` is ever emitted.
+
+- [ ] **Step 3: Add the ScopeManager method**
+
+In `lib/backends/typescriptBuilder/scopeManager.ts`, after `returnType()`:
+
+```ts
+/**
+ * Declared return type of the nearest ENCLOSING function or node,
+ * walking outward past block scopes. Unlike `returnType()`, which
+ * answers for the CURRENT scope (and answers `undefined` for blocks),
+ * this is the saveDraft tool's schema key (partials-ergonomics spec
+ * Part 2): a guard block owns the draft slot but carries no declared
+ * type, so the enclosing def's declared type is the best-effort hint.
+ */
+enclosingDeclaredReturnType(): VariableType | undefined {
+  // Innermost-first: the nearest non-block scope answers.
+  const owner = [...this.stack]
+    .reverse()
+    .find((scope) => scope.type !== "block");
+  if (owner === undefined) return undefined;
+  switch (owner.type) {
+    case "function":
+      return this.compilationUnit.functionDefinitions[owner.functionName]
+        ?.returnType ?? undefined;
+    case "node":
+      return this.compilationUnit.graphNodes.find(
+        (n) => n.nodeName === owner.nodeName,
+      )?.returnType ?? undefined;
+    default:
+      return undefined; // global scope
+  }
+}
+```
+
+(Check the private field name for the scope stack in that class — the walk must read whatever `push()` writes to. No C-style index loop: reverse-copy + `find` reads as "nearest non-block scope".)
+
+- [ ] **Step 4: Emit `draftSchema` in `processLlmCall`**
+
+In `lib/backends/typescriptBuilder.ts`, right after `runPromptEntries.clientConfig = clientConfig;` (line ~3646):
+
+```ts
+// Partials ergonomics (spec Part 2): thread the enclosing def's
+// declared return type so a saveDraft tool in this call's tools
+// array gets an honest value schema. Emitted only when the call has
+// arguments beyond the prompt — a bare llm("...") can never carry
+// tools, and skipping it keeps those call sites byte-identical.
+// An `any` return is skipped at the TYPE level (isAnyType), so the
+// runtime falls back to the string schema — never sniff the
+// renderer's output string to detect it.
+if (argsAfterPrompt.length > 0) {
+  const declaredReturn = this.scopes.enclosingDeclaredReturnType();
+  if (declaredReturn !== undefined && !isAnyType(declaredReturn)) {
+    runPromptEntries.draftSchema = ts.raw(this.zodSchemaFor(declaredReturn));
+  }
+}
+```
+
+`isAnyType` is exported from `lib/typeChecker/utils.ts:50` — import it rather than re-deriving the check.
+
+- [ ] **Step 5: Run the tests, then check fixture churn**
+
+```bash
+pnpm test:run lib/backends/draftSchemaCodegen.test.ts 2>&1 | tee "$TMPDIR/draftschema2.log"
+make 2>&1 | tail -3
+make fixtures 2>&1 | tail -3
+git status --porcelain tests/ | tee "$TMPDIR/fixture-churn-b.log" | head -30
+```
+
+Expected: unit tests PASS. Fixture churn is EXPECTED here, but only in fixtures whose `llm()` calls pass options from inside a def/node with a declared return type — spot-check two or three diffs and confirm every change is exactly one added `draftSchema:` line. Anything else is a bug.
+
+- [ ] **Step 6: Commit (including regenerated fixtures)**
+
+```bash
+git branch --show-current   # must NOT be main
+printf 'feat: thread the enclosing declared return type as draftSchema at llm() call sites\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > /tmp/claude/commitmsg.txt
+git add lib/backends/typescriptBuilder/scopeManager.ts lib/backends/typescriptBuilder.ts lib/backends/draftSchemaCodegen.test.ts tests/
+git commit -F /tmp/claude/commitmsg.txt
+```
+
+---
+
+### Task 6: Runtime — the intrinsic-tool registry, with saveDraft as its first entry
+
+**Files:**
+- Create: `lib/runtime/intrinsicTools.ts` (the pattern), `lib/runtime/saveDraftTool.ts` (the first entry)
+- Modify: `lib/runtime/prompt.ts` (three spots: the `args` type at ~line 830, the tool-list build at ~line 915, the tool-round loop at ~line 1499)
+- Test: `lib/runtime/saveDraftTool.test.ts`, `lib/runtime/intrinsicToolSchema.test.ts` (both new)
+
+**Interfaces:**
+- Consumes: `args.draftSchema` (Task 5's generated output).
+- Produces: the `IntrinsicTool` type and `findIntrinsic(fn: AgencyFunction): IntrinsicTool | undefined` from `intrinsicTools.ts`; `saveDraftIntrinsic: IntrinsicTool` and `draftCharCount(value: unknown): number` from `saveDraftTool.ts` — and the interception behavior Task 7's fixtures test.
+
+**The architecture (owner review round 2).** saveDraft is the first tool the loop handles ITSELF instead of dispatching — and it will not be the last (attachment listing/viewing tools need thread access, and future run-control tools fit the same shape). So the pattern gets a seam: an `IntrinsicTool` is one object declaring its three responsibilities — WHO it is (`matches`), WHAT the provider sees (`buildDefinition`), and WHAT a call does (`handle`, returning the tool-result text). A module-level array is the registry. The LOOP owns everything generic — the ordered pass, resume idempotency (`pr.step`), statelog events, callback hooks, and the result-message push — so an intrinsic's `handle` is a pure-ish state transition and every future intrinsic inherits the bookkeeping for free. Deliberately NOT extensible by users: intrinsics manipulate run state (frames, drafts), which is exactly what user tools must not do; the registry is closed, in-runtime, and additions are code review events.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `lib/runtime/saveDraftTool.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { AgencyFunction } from "./agencyFunction.js";
+import { findIntrinsic } from "./intrinsicTools.js";
+import { saveDraftIntrinsic, draftCharCount } from "./saveDraftTool.js";
+
+function fakeFn(name: string, module: string): AgencyFunction {
+  return new AgencyFunction({
+    name,
+    module,
+    fn: () => null,
+    params: [
+      { name: "value", hasDefault: false, defaultValue: undefined, variadic: false } as any,
+    ],
+    toolDefinition: { name, description: "d", schema: z.object({}) },
+  });
+}
+
+/** A stack stub that records draft writes — handle() only ever calls
+ *  setSavedDraft, and the real frame math is fixture-tested. */
+function stubStack() {
+  const saved: unknown[] = [];
+  return {
+    saved,
+    stack: { setSavedDraft: (v: unknown) => saved.push(v) } as any,
+  };
+}
+
+function call(args: Record<string, unknown> | undefined) {
+  return { id: "t1", name: "saveDraft", arguments: args as any };
+}
+
+describe("saveDraft intrinsic — recognition", () => {
+  it("the registry finds the stdlib pair (name + module)", () => {
+    expect(findIntrinsic(fakeFn("saveDraft", "stdlib/index.agency"))).toBe(saveDraftIntrinsic);
+  });
+
+  it("a user function named saveDraft is NOT recognized", () => {
+    expect(findIntrinsic(fakeFn("saveDraft", "my/module.agency"))).toBeUndefined();
+  });
+
+  it("a stdlib function with another name is NOT recognized", () => {
+    expect(findIntrinsic(fakeFn("finalize", "stdlib/index.agency"))).toBeUndefined();
+  });
+});
+
+describe("saveDraft intrinsic — synthesized definition", () => {
+  it("declares exactly one required value param from the threaded schema", () => {
+    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: z.number() });
+    expect(def.name).toBe("saveDraft");
+    expect(def.description).toMatch(/best-so-far/);
+    const schema = def.schema as z.ZodObject<any>;
+    expect(Object.keys(schema.shape)).toEqual(["value"]);
+    expect(schema.shape.value.safeParse(3).success).toBe(true);
+    expect(schema.shape.value.safeParse("x").success).toBe(false);
+  });
+
+  it("falls back to string when no schema was threaded", () => {
+    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: undefined });
+    const schema = def.schema as z.ZodObject<any>;
+    expect(schema.shape.value.safeParse("x").success).toBe(true);
+    expect(schema.shape.value.safeParse(3).success).toBe(false);
+  });
+});
+
+describe("saveDraft intrinsic — handle (validation semantics)", () => {
+  it("a matching value saves and acks with the char count", () => {
+    const { saved, stack } = stubStack();
+    const ack = saveDraftIntrinsic.handle({
+      toolCall: call({ value: "hello" }),
+      stateStack: stack,
+      draftSchema: z.string(),
+    });
+    expect(saved).toEqual(["hello"]);
+    expect(ack).toBe("Draft saved (5 characters).");
+  });
+
+  it("a missing value is an error and saves NOTHING", () => {
+    const { saved, stack } = stubStack();
+    const ack = saveDraftIntrinsic.handle({
+      toolCall: call({}),
+      stateStack: stack,
+      draftSchema: z.string(),
+    });
+    expect(saved).toEqual([]);
+    expect(ack).toMatch(/requires a "value" argument/);
+  });
+
+  it("a schema-mismatched value SAVES ANYWAY and acks with a helpful warning", () => {
+    // The schema is a best-effort hint keyed to the declared function
+    // type; the actual slot (a guard block) can legitimately differ.
+    // Refusing the save could throw away real work on a wrong hint, so
+    // the draft is kept and the warning teaches the model.
+    const { saved, stack } = stubStack();
+    const ack = saveDraftIntrinsic.handle({
+      toolCall: call({ value: 42 }),
+      stateStack: stack,
+      draftSchema: z.string(),
+    });
+    expect(saved).toEqual([42]);
+    expect(ack).toMatch(/^Draft saved \(\d+ characters\)\. Warning:/);
+    expect(ack).toMatch(/does not match/);
+  });
+});
+
+describe("draftCharCount", () => {
+  it("counts string drafts directly", () => {
+    expect(draftCharCount("hello")).toBe(5);
+  });
+  it("counts structured drafts by their JSON length", () => {
+    expect(draftCharCount({ a: 1 })).toBe(JSON.stringify({ a: 1 }).length);
+  });
+  it("returns 0 for undefined (JSON.stringify yields undefined there)", () => {
+    // Deliberately narrow (plan review M4): a CIRCULAR value would make
+    // JSON.stringify throw, uncaught — but tool args are JSON-origin,
+    // so circularity cannot occur; the name claims only what is tested.
+    expect(draftCharCount(undefined)).toBe(0);
+  });
+});
+```
+
+(If `AgencyFunction`'s constructor rejects that literal `params` shape, copy a valid `FuncParam` literal from `agencyFunction.ts` — the test's point is identity fields, not params.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm test:run lib/runtime/saveDraftTool.test.ts 2>&1 | tee "$TMPDIR/savedraft-unit.log"`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Write the registry and the saveDraft intrinsic**
+
+Create `lib/runtime/intrinsicTools.ts` — the pattern, kept deliberately small:
+
+```ts
+import type { AgencyFunction, ToolDefinition } from "./agencyFunction.js";
+import type { StateStack } from "./state/stateStack.js";
+import { saveDraftIntrinsic } from "./saveDraftTool.js";
+
+/** What one intrinsic call sees. Deliberately narrow: an intrinsic
+ *  manipulates the RUN (frames, drafts), not the outside world, so it
+ *  gets the call, the stack, and the threaded schema — nothing else.
+ *  Widen this type only when a new intrinsic genuinely needs more. */
+export type IntrinsicCall = {
+  toolCall: { id: string; name: string; arguments: Record<string, unknown> };
+  stateStack: StateStack;
+  /** Zod schema threaded by the llm() codegen (saveDraft's value
+   *  type); undefined when the call site had none. */
+  draftSchema: unknown;
+};
+
+/** A tool the tool loop handles ITSELF, inline in the ordered pass,
+ *  instead of dispatching into the concurrent pool. The loop owns all
+ *  the generic bookkeeping — resume idempotency, statelog events,
+ *  callbacks, the tool-result message — so `handle` is just the
+ *  semantics and must be fast, synchronous, and interrupt-free.
+ *  The registry is CLOSED: intrinsics touch run state, which is
+ *  exactly what user tools must never do, so additions are code
+ *  changes here, not a user-facing extension point. */
+export type IntrinsicTool = {
+  /** Identity check against a tools-array entry (name+module pair,
+   *  never object identity — the prelude auto-import means modules
+   *  hold their own wrapper objects). */
+  matches: (fn: AgencyFunction) => boolean;
+  /** The provider-facing definition, replacing the def's own. */
+  buildDefinition: (ctx: { draftSchema: unknown }) => ToolDefinition;
+  /** Handle one call; the return value is the tool-result text. */
+  handle: (call: IntrinsicCall) => string;
+};
+
+const INTRINSIC_TOOLS: IntrinsicTool[] = [saveDraftIntrinsic];
+
+export function findIntrinsic(fn: AgencyFunction): IntrinsicTool | undefined {
+  return INTRINSIC_TOOLS.find((t) => t.matches(fn));
+}
+```
+
+Create `lib/runtime/saveDraftTool.ts` — the first entry:
+
+```ts
+import { z } from "zod";
+import type { IntrinsicTool } from "./intrinsicTools.js";
+
+/** The stdlib module id every compiled stdlib export carries. No user
+ *  module can carry it, so name+module is identity in practice — the
+ *  runtime cannot import the stdlib singleton directly without a
+ *  dependency cycle (partials-ergonomics spec Part 2). */
+const STDLIB_INDEX_MODULE = "stdlib/index.agency";
+
+/** The contract the type system cannot check, stated to the model. */
+const DESCRIPTION =
+  "Save your best-so-far answer as a draft. If the budget runs out, the " +
+  "last saved draft is returned instead of a failure. The value must " +
+  "match this function's return type.";
+
+/** Character count for the acknowledgment message. */
+export function draftCharCount(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  const text = JSON.stringify(value);
+  return text === undefined ? 0 : text.length;
+}
+
+/** `saveDraft` passed as a tool. Aliases (`const s = saveDraft`) keep
+ *  both identity fields, so they recognize; a user's own def named
+ *  saveDraft carries its own module id, so it runs as an ordinary
+ *  tool. A `.rename()`d stdlib saveDraft changes the name and is NOT
+ *  recognized — it falls through to the def path, whose draft files
+ *  on the tool branch and is discarded (documented limitation). */
+export const saveDraftIntrinsic: IntrinsicTool = {
+  matches: (fn) =>
+    fn.name === "saveDraft" && fn.module === STDLIB_INDEX_MODULE,
+
+  buildDefinition: ({ draftSchema }) => ({
+    name: "saveDraft",
+    description: DESCRIPTION,
+    schema: z.object({ value: (draftSchema as z.ZodTypeAny) ?? z.string() }),
+  }),
+
+  handle: ({ toolCall, stateStack, draftSchema }) => {
+    const callArgs = toolCall.arguments ?? {};
+    // Own-property check: the args object comes from the model.
+    if (!Object.prototype.hasOwnProperty.call(callArgs, "value")) {
+      return 'Error: saveDraft requires a "value" argument. Nothing was saved.';
+    }
+    const value = callArgs.value;
+    // Save FIRST, validate second. The schema is a best-effort hint
+    // keyed to the declared function type, and the actual slot (often
+    // a guard block) can legitimately differ — refusing the save on a
+    // possibly-wrong hint would throw away real work. The warning
+    // teaches the model without costing it the draft.
+    stateStack.setSavedDraft(value);
+    const saved = `Draft saved (${draftCharCount(value)} characters).`;
+    const valueSchema = (draftSchema as z.ZodTypeAny) ?? z.string();
+    const parsed = valueSchema.safeParse(value);
+    if (parsed.success) return saved;
+    const issue = parsed.error.issues[0];
+    return (
+      `${saved} Warning: the value does not match this function's ` +
+      `declared return type (${issue?.message ?? "type mismatch"}). ` +
+      `The draft was kept, but match the declared type on your next save.`
+    );
+  },
+};
+```
+
+Run: `pnpm test:run lib/runtime/saveDraftTool.test.ts` — expected PASS.
+
+- [ ] **Step 4: Add `draftSchema` to runPrompt's args and substitute the tool definition**
+
+In `lib/runtime/prompt.ts`:
+
+(a) In the `runPrompt` args type (near `destructiveSink` at ~line 852), add:
+
+```ts
+  /** Zod schema for the saveDraft tool's `value` param, threaded by the
+   *  llm() codegen from the enclosing def's declared return type.
+   *  Consulted only when the tools array contains the stdlib saveDraft. */
+  draftSchema?: unknown;
+```
+
+(b) At the tool-list build (~line 915), substitute the synthesized definition through the registry:
+
+```ts
+let tools = exposedFunctions
+  .filter((fn) => fn.toolDefinition)
+  .map((fn) =>
+    findIntrinsic(fn)?.buildDefinition({ draftSchema: args.draftSchema }) ??
+    fn.toolDefinition!,
+  );
+```
+
+Import `findIntrinsic` from `./intrinsicTools.js` at the top of the file — prompt.ts never names saveDraft; it only knows the registry.
+
+- [ ] **Step 5: Add the ordered interception pass**
+
+In the tool round loop (~line 1499), between `const round = self.toolCallRound;` and the `pr.parallel` call. First partition the round ONCE, declaratively — no push-and-continue mutation threading through the loop:
+
+```ts
+// Partition the round: intrinsic calls (handled inline, in order)
+// vs. everything else (dispatched concurrently as today). One
+// partition, computed up front — the rest of the iteration reads
+// these two lists and never re-derives them.
+const intrinsicOf = (toolCall: smoltalk.ToolCallJSON) => {
+  const handler = toolFunctions.find((fn) => fn.name === toolCall.name);
+  return handler ? findIntrinsic(handler) : undefined;
+};
+const intrinsicCalls = toolCalls
+  .map((toolCall, callIndex) => ({ toolCall, callIndex, intrinsic: intrinsicOf(toolCall) }))
+  .filter((entry) => entry.intrinsic !== undefined);
+const dispatchCalls = toolCalls.filter((toolCall) => intrinsicOf(toolCall) === undefined);
+```
+
+Then the ordered pass. `for...of` — NOT `forEach`, whose async callbacks would all fire without awaiting and un-order the writes, and not a C-style index loop either (the partition already carries `callIndex`):
+
+```ts
+// Ordered interception (partials-ergonomics spec Part 2): intrinsic
+// calls are handled inline at their position in the call list, so two
+// saves in one round apply in call-list order BY CONSTRUCTION — the
+// writes happen here, in list order, not in scheduler-completion
+// order. The draft files on the scope that owns this llm() call: the
+// stack is [..., owner, runPrompt] (setupFunction pushed our frame),
+// so setSavedDraft's callerFrame() write lands on the owner — the
+// same frame shape as the stdlib saveDraft def path.
+for (const { toolCall, callIndex, intrinsic } of intrinsicCalls) {
+  const callSlug = `${callIndex}_${toolCall.id}`;
+  await pr.step(`round.${round}.tool.${callSlug}.intrinsic`, async () => {
+    const callArgs = toolCall.arguments ?? {};
+    // The lifecycle mirrors the real dispatch path's events
+    // (toolCallStart → hooks → toolCall) inside one toolExecution
+    // span, so span-pairing consumers see intrinsic calls too.
+    // Deliberate differences from the real path: one pr.step instead
+    // of per-phase branch steps (there is no branch), and timeTaken 0
+    // (an inline state write has no meaningful duration).
+    const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
+    try {
+      ctx.statelogClient.toolCallStart({
+        toolName: toolCall.name,
+        args: callArgs,
+        model: JSON.stringify(clientConfig.model),
+        threadId: __threads()?.activeId() ?? null,
+      });
+      await invokeCallbacks({
+        ctx,
+        name: "onToolCallStart",
+        data: { toolName: toolCall.name, args: callArgs },
+        stateStack,
+      });
+      const ack = intrinsic!.handle({
+        toolCall,
+        stateStack,
+        draftSchema: args.draftSchema,
+      });
+      await invokeCallbacks({
+        ctx,
+        name: "onToolCallEnd",
+        data: { toolName: toolCall.name, result: ack, timeTaken: 0 },
+        stateStack,
+      });
+      ctx.statelogClient.toolCall({
+        toolName: toolCall.name,
+        args: callArgs,
+        output: ack,
+        model: JSON.stringify(clientConfig.model),
+        timeTaken: 0,
+        threadId: __threads()?.activeId() ?? null,
+      });
+      messages.push(
+        smoltalk.toolMessage(ack, {
+          tool_call_id: toolCall.id,
+          name: toolCall.name,
+        }),
+      );
+    } finally {
+      ctx.statelogClient.endSpan(toolSpanId);
+    }
+  });
+}
+```
+
+Then change the `pr.parallel` call to iterate `dispatchCalls` instead of `toolCalls`, guarded for the all-intrinsic round:
+
+```ts
+if (dispatchCalls.length > 0) {
+  const parallelResult = await pr.parallel(
+    `round.${round}.tools`,
+    dispatchCalls,
+    ...
+```
+
+Audit the rest of the `while` iteration for reads of `toolCalls` that should now read `dispatchCalls` (the interrupt check on `parallelResult` and the removed-tools filter after it); the `self.pendingToolCalls` bookkeeping keeps the FULL `toolCalls` list — on resume the partition recomputes identically and the ordered pass's `pr.step` guards skip the completed writes, which is exactly the idempotency the real tools get from their branch steps.
+
+One resume subtlety to leave as a comment, not "fix" (plan review finding 2): the ack message survives resume through a different mechanism than the write. `pr.step` snapshots `messagesJSON` only on the INTERRUPT path, and a completed step returns before its body on resume, so the ack is never re-pushed — but it does not need to be. The ack was pushed to the LIVE thread, and whichever later checkpoint actually serializes (a sibling tool's interrupt bailout, the guard gate) calls `snapshotMessages()` against that live thread, ack included. Do NOT add a snapshot call in the intrinsic step; it would be redundant. The real safety net for a lost ack is that real providers reject a dangling `tool_use` with no result — the deterministic client does not validate pairing, which is why no fixture can pin this and the comment has to.
+
+Three deliberate behaviors, each matching the spec, worth comments in code review: interception ignores the `maxToolCallRounds` limit (a draft write is free and salvage is the point); interception ignores `removedTools` (an intrinsic cannot error its way onto that list); the ack messages push before the concurrent tools’ results, which is harmless because providers pair results by `tool_call_id` (and by name+position on Gemini, where names differ) — the same guarantee the existing completion-order pushes rely on.
+
+- [ ] **Step 6: Pin the observable surface — the provider schema, the ack, and the statelog events**
+
+The fixtures prove the feature only through the salvaged draft — an indirect, downstream signal. The three things the spec actually promises at the surface are untested by them (plan review findings 1/M1/M3): the tool definition the PROVIDER receives (every fixture runs the `z.string()` fallback, so a silent substitution failure stays green), the ack tool message the MODEL receives, and the statelog events the TRACE receives. Cover all three in one runtime test file. Create `lib/runtime/intrinsicToolSchema.test.ts`, modeled on `lib/runtime/promptLabels.test.ts` (copy its `makeCtx` / `inFrame` harness), with two additions to that harness: the client's FIRST response returns a saveDraft tool call and its second returns a plain answer (a two-entry script instead of `toolCalls: []`), and `ctx.statelogClient` is replaced with a recorder stub that appends every `toolCallStart(...)` / `toolCall(...)` payload to an array (stub the other methods it touches as no-ops, following how the harness already fakes statelog config).
+
+```ts
+describe("saveDraft intrinsic — the observable surface", () => {
+  it("the provider-bound schema uses the threaded draftSchema, not the fallback", async () => {
+    const { providerConfigs } = await runSaveDraftPrompt({ draftSchema: z.number(), save: 3 });
+    const saveDraftDef = (providerConfigs[0] as any).tools.find((t: any) => t.name === "saveDraft");
+    expect(saveDraftDef).toBeDefined();
+    // The value slot must be the THREADED schema: a number passes, a
+    // string fails. With the fallback this assertion inverts — which
+    // is exactly the silent failure this test exists to catch.
+    expect(saveDraftDef.schema.shape.value.safeParse(3).success).toBe(true);
+    expect(saveDraftDef.schema.shape.value.safeParse("x").success).toBe(false);
+  });
+
+  it("a structured draftSchema reaches the provider too (object, not just primitive)", async () => {
+    const reportSchema = z.object({ title: z.string() });
+    const { providerConfigs } = await runSaveDraftPrompt({
+      draftSchema: reportSchema,
+      save: { title: "t" },
+    });
+    const saveDraftDef = (providerConfigs[0] as any).tools.find((t: any) => t.name === "saveDraft");
+    expect(saveDraftDef.schema.shape.value.safeParse({ title: "t" }).success).toBe(true);
+    expect(saveDraftDef.schema.shape.value.safeParse("flat string").success).toBe(false);
+  });
+
+  it("without draftSchema the provider-bound value schema is the string fallback", async () => {
+    const { providerConfigs } = await runSaveDraftPrompt({ draftSchema: undefined, save: "x" });
+    const saveDraftDef = (providerConfigs[0] as any).tools.find((t: any) => t.name === "saveDraft");
+    expect(saveDraftDef.schema.shape.value.safeParse("x").success).toBe(true);
+    expect(saveDraftDef.schema.shape.value.safeParse(3).success).toBe(false);
+  });
+
+  it("the model receives the ack as a paired tool message", async () => {
+    const { messages } = await runSaveDraftPrompt({ draftSchema: undefined, save: "hello" });
+    const toolMsg = messages.find((m: any) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    expect((toolMsg as any).content).toBe("Draft saved (5 characters).");
+    // Pairing: the result must carry the SAME id the tool call was
+    // issued with, or real providers reject the round.
+    expect((toolMsg as any).tool_call_id).toBe("mock-tool-0");
+  });
+
+  it("the trace receives toolCallStart and toolCall events for the intrinsic", async () => {
+    const { statelogEvents } = await runSaveDraftPrompt({ draftSchema: undefined, save: "hello" });
+    const start = statelogEvents.find((e) => e.kind === "toolCallStart");
+    const end = statelogEvents.find((e) => e.kind === "toolCall");
+    expect(start?.payload.toolName).toBe("saveDraft");
+    expect(start?.payload.args).toEqual({ value: "hello" });
+    expect(end?.payload.output).toBe("Draft saved (5 characters).");
+  });
+});
+```
+
+Write the `runSaveDraftPrompt` helper against the real `runPrompt` signature the way `promptLabels.test.ts` calls it (ctx + frame + `clientConfig: { tools: [stdlibShapedSaveDraft] }` + `draftSchema`), constructing the AgencyFunction with `name: "saveDraft", module: "stdlib/index.agency"` and returning `{ providerConfigs, messages, statelogEvents }` (the recorded provider configs, the thread's messages after the run, and the statelog recorder's array). Use the tool-call id the scripted client issued (`"mock-tool-0"` above — match whatever your script sets). If the provider-bound tool entry is not the raw ToolDefinition (smoltalk may wrap or convert it), adapt the schema assertions to wherever the zod schema actually lands in the recorded config; if the thread's message shape differs (roles, content field), adapt to the real `smoltalk.toolMessage` shape — the POINTS are: threaded schema left runPrompt, ack text + `tool_call_id` pairing in the thread, events in the trace.
+
+- [ ] **Step 7: Typecheck and run the runtime suites**
+
+```bash
+pnpm exec tsc --noEmit 2>&1 | tee "$TMPDIR/tsc-prompt.log"
+pnpm test:run lib/runtime/saveDraftTool.test.ts lib/runtime/intrinsicToolSchema.test.ts lib/runtime/promptLabels.test.ts lib/runtime/deterministicClient.test.ts 2>&1 | tee "$TMPDIR/savedraft-runtime.log"
+```
+
+Expected: clean typecheck, tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git branch --show-current   # must NOT be main
+printf 'feat: intrinsic-tool registry; intercept the stdlib saveDraft tool in the llm tool loop\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > /tmp/claude/commitmsg.txt
+git add lib/runtime/intrinsicTools.ts lib/runtime/saveDraftTool.ts lib/runtime/saveDraftTool.test.ts lib/runtime/intrinsicToolSchema.test.ts lib/runtime/prompt.ts
+git commit -F /tmp/claude/commitmsg.txt
+```
+
+---
+
+### Task 7: Agency fixtures for the saveDraft tool
+
+**Files:**
+- Create: `tests/agency/guards/savedraft-tool-basic.agency` + `.test.json`
+- Create: `tests/agency/guards/savedraft-tool-alias-and-user.agency` + `.test.json`
+- Create: `tests/agency/guards/savedraft-tool-order.agency` + `.test.json`
+- Create: `tests/agency/guards/savedraft-tool-missing-value.agency` + `.test.json`
+- Create: `tests/agency/guards/savedraft-tool-mismatch-still-saves.agency` + `.test.json`
+- Create: `tests/agency/guards/savedraft-tool-resume.agency` + `.test.json`
+
+**Interfaces:**
+- Consumes: Tasks 5 + 6.
+- Produces: end-to-end proof of every spec Part 4 saveDraft-tool behavior, including the frame-math pin (draft saved by the TOOL inside a guard block is salvaged by THAT guard).
+
+**Determinism note (owner review round 2).** Every fixture in this plan is deterministic by construction: cost guards only (the deterministic client's synthetic per-call cost is fixed, so a `guard(cost: 0.000001)` trips at the same step every run), no time guards, no `sleep`/`spin`, no wall-clock anywhere. The resume fixture's interrupt sequence is also deterministic — interrupts serialize in arrival order and the cost gate fires at a fixed step. If any fixture turns out to need real elapsed time, STOP and flag it rather than tuning budgets; that is the flake class that burned #563/#566.
+
+- [ ] **Step 1: The basic fixture — model saves, guard trips, reject returns the model's draft**
+
+`tests/agency/guards/savedraft-tool-basic.agency`:
+
+```
+// The model saves a draft through the saveDraft TOOL; the guard trips
+// on the next round; reject; the guard returns the model's own draft.
+// This fixture is also the frame-math pin from the spec correction:
+// the draft files on the guard block's frame (setSavedDraft's
+// callerFrame() from inside runPrompt), and THAT guard salvages it.
+node main() {
+  const result = guard(cost: 0.000001) {
+    return llm("Research the topic. Save drafts as you go.", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}
+```
+
+`tests/agency/guards/savedraft-tool-basic.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"model-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft", "args": { "value": "model-draft" } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "A draft saved through the saveDraft tool is salvaged by the enclosing guard on reject. The second mock never runs.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Alias and user-shadow fixture**
+
+`tests/agency/guards/savedraft-tool-alias-and-user.agency` — two nodes:
+
+```
+// Node 1: an alias intercepts identically (recognition is by the
+// AgencyFunction's name+module fields, not the variable name).
+node aliased() {
+  const s = saveDraft
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [s])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}
+```
+
+For the user-shadow half, a user def NAMED `saveDraft` must run as an ordinary tool and file nothing. Shadowing the prelude name in the same module makes the fixture ambiguous to read, so give the user function a distinct file: keep it simple with a single-module node whose tool is a user def named `saveDraft` (the prelude import is shadowed by the local def — this is exactly what the fixture proves keeps working):
+
+```
+def saveDraft(value: string): string {
+  return "user-tool-ran"
+}
+
+node userShadow() {
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}
+```
+
+`.test.json`: `aliased` mirrors the basic fixture (expect `"\"model-draft\""`, reject handler). `userShadow` mocks `[{ "toolCalls": [{ "name": "saveDraft", "args": { "value": "ignored" } }] }, { "return": "never" }]` with a reject handler and expects `"\"no-draft\""` — the user tool ran (as an ordinary tool) but filed no draft, so reject leaves the guard with nothing to salvage. IMPORTANT: put the two nodes in SEPARATE `.agency` files if the local-def shadowing interferes with node 1's prelude `saveDraft` — the prelude import is module-wide, and a module-level def of the same name shadows it everywhere in the file. Check `lib/preprocessors/prunePreludeShadows.ts` behavior first; two files is the safe default (`savedraft-tool-alias.agency` and `savedraft-tool-usershadow.agency`).
+
+- [ ] **Step 3: Order fixture — two saves in one round, last wins**
+
+`tests/agency/guards/savedraft-tool-order.agency` — same shape as the basic fixture. Mocks:
+
+```json
+"llmMocks": [
+  { "toolCalls": [
+    { "name": "saveDraft", "args": { "value": "first" } },
+    { "name": "saveDraft", "args": { "value": "second" } }
+  ] },
+  { "return": "never" }
+]
+```
+
+Expect `"\"second\""` with a reject handler — call-list order, not scheduler order.
+
+- [ ] **Step 4: Missing-value fixture — the error ack, nothing saved, no crash**
+
+`tests/agency/guards/savedraft-tool-missing-value.agency` — basic shape, but the guard budget is generous (`guard(cost: $1)`) so nothing trips:
+
+```
+node main() {
+  const result = guard(cost: $1) {
+    return llm("work", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "failed" }
+  return result.value
+}
+```
+
+Mocks: `[{ "toolCalls": [{ "name": "saveDraft" }] }, { "return": "done" }]` (no args — the deterministic client defaults them to `{}`). Expect `"\"done\""`, NO `interruptHandlers` (nothing trips; declaring a handler would make the harness assert an interrupt that never fires). The fixture proves the malformed call gets the error ack and the loop continues to the next round.
+
+- [ ] **Step 4b: Mismatch fixture — a schema-violating draft is still saved**
+
+`tests/agency/guards/savedraft-tool-mismatch-still-saves.agency` — same shape as the basic fixture (a node, so the schema is the `z.string()` fallback), but the mock saves a NUMBER:
+
+```
+// The model saves a value that violates the tool schema (a number
+// against the string fallback). The intrinsic warns in the ack but
+// keeps the draft — the schema is a best-effort hint, and salvage
+// must not lose work over it. Reject proves the draft survived.
+node main() {
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}
+```
+
+Mocks: `[{ "toolCalls": [{ "name": "saveDraft", "args": { "value": 42 } }] }, { "return": "never" }]`, reject handler, expect `"42"` (the guard salvages the mismatched draft).
+
+- [ ] **Step 5: Resume fixture — a draft from a completed round survives an interrupt**
+
+`tests/agency/guards/savedraft-tool-resume.agency`:
+
+```
+// Round 1 saves a draft AND asks the user something (input()
+// interrupts). The run checkpoints, the harness resolves the input,
+// the run resumes — and the draft, serialized with the frame, is
+// still there when the guard trips and is rejected.
+def ask(q: string): string {
+  return input(q)
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [saveDraft, ask])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}
+```
+
+`.test.json`:
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"model-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [
+          { "name": "saveDraft", "args": { "value": "model-draft" } },
+          { "name": "ask", "args": { "q": "continue?" } }
+        ] },
+        { "return": "never-reached" }
+      ],
+      "description": "A tool-saved DRAFT survives the checkpoint/resume caused by a sibling interrupting tool in the same round. Deliberately narrow (plan review T3): this pins frame serialization only — ack/thread integrity across resume is covered by the runtime surface tests, because the deterministic client does not validate tool_use/result pairing and could not fail on a lost ack.",
+      "interruptHandlers": [
+        { "action": "resolve", "resolvedValue": "yes" },
+        { "action": "reject" }
+      ]
+    }
+  ]
+}
+```
+
+The saveDraft interception runs in the ORDERED pass before `ask` dispatches, so the draft is on the frame before the interrupt checkpoint serializes it. If the handler order proves wrong at runtime (the guard trip may deliver before or after the resolve depending on cost timing), read the failure log and reorder the handlers — the harness consumes them in interrupt-arrival order.
+
+- [ ] **Step 6: Build, run all five, regenerate, commit**
+
+```bash
+make 2>&1 | tail -3
+for f in savedraft-tool-basic savedraft-tool-alias savedraft-tool-usershadow savedraft-tool-order savedraft-tool-missing-value savedraft-tool-mismatch-still-saves savedraft-tool-resume; do
+  pnpm run agency test tests/agency/guards/$f.agency 2>&1 | tee "$TMPDIR/fx-$f.log"
+done
+make fixtures 2>&1 | tail -3
+git branch --show-current   # must NOT be main
+printf 'test: saveDraft-tool fixtures (basic, alias, shadow, order, missing value, resume)\n\nCo-Authored-By: Claude Fable 5 <noreply@anthropic.com>\n' > /tmp/claude/commitmsg.txt
+git add tests/agency/guards/savedraft-tool-*
+git commit -F /tmp/claude/commitmsg.txt
+```
+
+(Adjust the file list to however Step 2 split the alias/shadow fixtures.)
+
+---
+
+### Task 8: Final verification sweep and PR prep
+
+**Files:**
+- No new code. Verification + the plan/spec bookkeeping commit.
+
+- [ ] **Step 1: Full unit suite and structural lint**
+
+```bash
+pnpm test:run 2>&1 | tee "$TMPDIR/final-unit.log"
+pnpm run lint:structure 2>&1 | tee "$TMPDIR/final-lint.log"
+```
+
+Expected: both clean. Fix anything that regressed; do NOT run the full Agency fixture suite (CI owns it) — re-run only the fixtures this plan created if a unit fix touched runtime code.
+
+- [ ] **Step 2: Anti-pattern audit**
+
+Read `docs/dev/anti-patterns.md` and audit the full branch diff (`git diff main...HEAD`) against it. Fix violations before the PR. This is the owner's #1 review flag.
+
+- [ ] **Step 3: Record deviations in the spec**
+
+Append an "As executed" section to `docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md` listing every place the implementation deviated from the spec text (at minimum: the binder's checker declaration is function-wide with an AG6037 collision rule; `draftSchema` is emitted only for llm calls with post-prompt arguments; a renamed stdlib saveDraft is not intercepted). Commit with the message `docs: record as-executed deviations in the partials-ergonomics spec`.
+
+- [ ] **Step 4: Open the PR**
+
+Write the PR body to a file (end with the Claude Code attribution line), then:
+
+```bash
+gh pr create --title "Partials ergonomics: saveDraft as a tool, finalize as draft" --body-file /tmp/claude/prbody.txt
+```
+
+The body should name the two features, link the spec, call out the fixture churn from Task 5 as intentional, and list doc follow-ups for the owner (the owner-authored `docs/site/guide/partial-results.md` needs a section on both features; do not edit it yourself). Include a **known limitations** list — these are decisions, and untracked decisions get relitigated as bugs:
+
+- A `.rename()`d stdlib saveDraft is not recognized as intrinsic; it runs as an ordinary tool whose draft files on the tool branch and is discarded.
+- Gemini pairs tool results by name+position rather than `tool_call_id`, so intrinsic acks pushing before dispatched results can misalign when a real tool precedes saveDraft in the call list or a round contains two same-named calls. Real-provider-only, same class as the #566 finding; deterministic tests cannot catch it.
+- The saveDraft schema keys on the enclosing FUNCTION's declared type while the draft files on the owning scope (often a guard block); when they differ the schema is a best-effort hint (spec finding 3).
+- Time-based partials tests stay out until #575 (injectable TimeGuard clock) lands.
+
+---
+
+## Self-review notes (checked against the spec)
+
+- **Spec coverage:** Part 2 surface + recognition + interception + schema + interactions → Tasks 5–7; Part 3 all four head forms, binder semantics, typing, mechanics → Tasks 1–4; Part 4 test list → Tasks 4 and 7 map one-to-one (draft-round resume is `savedraft-tool-resume`; the schema unit tests are Task 5 Step 1 plus Task 6 Step 1). Part 5 exclusions respected: no runtime validation, no auto-injection, declared types only.
+- **Known deviations from spec text, on purpose:** (1) The spec's review-round-1 fold said interception writes the TOP frame via a new StateStack method; that was corrected in the spec on 2026-07-17 after verifying `runPrompt` pushes its own frame — the plan uses the existing `setSavedDraft` and pins the math with the basic fixture. (2) The binder types from the DECLARED return only (`any` fallback); the spec's "declared or inferred" is narrowed to match Part 5's inferred-types exclusion. (3) `finalize() as draft` formatter-canonicalizes to `finalize as draft` — spec-stated. 
+- **Type consistency:** `params: FunctionParameter[]` (Task 1, parsed by the shared `asParser`) is read by Task 2 (`params[0]`, AG6038 for more) and Task 3 (`finalize.params[0].name`); `draftSchema` (Task 5 emit) is read by Task 6 as `args.draftSchema`; `isSaveDraftTool` / `buildSaveDraftToolDefinition` / `draftCharCount` names match between Task 6's module and its prompt.ts call sites.
+- **Round 2 decisions (owner comments):** (1) The finalize closure emission moved from a raw `ts.raw` string to `finalizeClosure.mustache` — long codegen strings belong in `lib/templates/`; the zero-churn check enforces byte-identity. (2) The interception is shaped as an `IntrinsicTool` registry (`lib/runtime/intrinsicTools.ts`): saveDraft is the first tool the loop handles itself, and attachment/run-control tools are plausible next entries, so the pattern gets a seam — one object per intrinsic (matches / buildDefinition / handle), the loop owning all generic bookkeeping, the registry closed to users (intrinsics touch run state, exactly what user tools must not do). (3) Schema-violating saves: the intrinsic validates with the synthesized zod schema; a mismatch SAVES ANYWAY and acks with a specific warning (the schema is a best-effort hint — refusing on a possibly-wrong hint would lose real work); only a missing `value` refuses. Pinned by unit tests and the mismatch fixture. (4) No C-style loops in new code: reverse-copy+`find` for the scope walk, one declarative partition plus `for...of` for the ordered pass (NOT `forEach` — async callbacks there would not be awaited in order). (5) All fixtures are cost-guard deterministic; no time-based tests exist, by design. (6) From the parallel plan review: the schema-threading seam gets a RecordingClient test (Task 6 Step 6 — the fixtures alone all run the z.string() fallback and would stay green through a silent substitution failure), the any-type skip is `isAnyType` at the type level rather than sniffing the rendered string, and the intrinsic lifecycle emits inside a `toolExecution` span with its deliberate divergences from the real dispatch path stated in a comment.
+- **Round 3 (plan review, `...-partials-ergonomics-REVIEW.md`):** T1 — the undeclared-return binder test asserts UNFILTERED zero errors (the filtered form could not fail on an undeclared binder, whose symptom is an undefined-variable message the filter dropped). M2/finding 3 — AG6037's check pinned scope-local with a module-const-named-binder test (a global is not a frame local, so it is not the miscompile hazard). M1/M3 — Step 6 grew from a schema-seam test into the full observable surface: provider schema (primitive AND object), the ack message with `tool_call_id` pairing, and the statelog events, all via the recording harness (no fixture can see any of these; the deterministic client does not validate pairing). M5 — `withFinalize` unit tests (receives the draft, null case, throw returns `this`). Finding 2 — the ack-survives-resume mechanism is now a stated comment (live thread + next `snapshotMessages()`; do not add a redundant snapshot). M4 — `draftCharCount`'s test name narrowed to what it tests. T3 — the resume fixture's description states it pins frame serialization only. Finding 5 — Gemini ordering and renamed-saveDraft joined the PR's known-limitations list, plus the schema-hint gap and the #575 clock-seam dependency for future time-based tests.
+- **Reuse decision (owner review round 1):** the binder clause reuses `asParser`/`blockParamsParser`/`FunctionParameter` — the grammar and type block arguments already own — instead of a hand-rolled `as <name>` parse. Consequences inherited from the shared grammar and ruled on downstream: `finalize as { }` parses as binder-less (the documented no-param form; formatter canonicalizes it away), multi-param lists parse and are rejected by AG6038, and a typed binder (`as d: Report`) parses with the annotation winning over the scope's return type (the handler-param rule). NOT reused: the whole-node `functionCall`+`BlockArgument` pipeline — finalize is a declaration, not a call (FinalizeCodegen strips it from the statement stream; AG6032/6033 and the flow builder key on the node type; there is no callee to receive a block), so wrapping the body would add indirection without behavior.

--- a/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
+++ b/docs/superpowers/specs/2026-07-17-guard-annotation-threading-design.md
@@ -1,0 +1,205 @@
+# Spec: guard annotation threading — `Result<T>` reaches block codegen
+
+**Status:** brainstormed with the owner 2026-07-17 (issue #580);
+decisions settled. Builds on #578 (partials ergonomics: the saveDraft
+tool and its `draftSchema` threading) and #574 (the guard construct).
+Ships after #578 merges.
+
+---
+
+## Part 1: Background
+
+### The hole
+
+Type information declared ON a guard assignment never reaches codegen
+INSIDE the guard block. Two features degrade because of it.
+
+The saveDraft tool's value schema (#578) keys on the enclosing
+FUNCTION's declared return type. But the draft files on the guard
+BLOCK's slot, and the block can yield a different type than the
+function returns:
+
+```ts
+def makeReport(topic: string): Report {
+  const notes: Result<string> = guard(cost: $0.50) {
+    // The slot is a STRING. The model is told to save a Report.
+    return llm("Research " + topic, tools: [saveDraft])
+  }
+  ...
+}
+```
+
+`responseFormat` has the same hole, documented in llm.md: a
+`return llm(...)` inside any block defaults to string structured
+output, because `ScopeManager.returnType()` answers `undefined` for
+block scopes.
+
+In both cases the user may have ALREADY written the missing type. The
+guard construct types as `Result<T>`, so `const notes: Result<string>`
+names the block's yield exactly. The builder just cannot see the
+annotation from inside the block body: the annotation lives on the
+assignment node, and the block compiles deep inside processing that
+assignment's value, in a scope that carries no type information.
+
+### What this spec does
+
+Move the annotation from where the user wrote it to where the block
+compiles. When it arrives, both consumers use it: the saveDraft
+schema unwraps `T` from `Result<T>`, and `return llm(...)` inside the
+block gets `T`-shaped structured output.
+
+### Decisions from the brainstorm (owner, 2026-07-17)
+
+1. **Both consumers in v1**, not just draftSchema. Fixing
+   responseFormat changes behavior for existing programs — a
+   `return llm(...)` inside an annotated guard switches from string
+   to structured output — but that is the documented limitation being
+   fixed, and it fires only where the user explicitly wrote
+   `Result<T>`. The change does what the annotation says. llm.md's
+   limitation note needs a touch-up (owner-authored file; flagged,
+   not edited here).
+2. **Two annotation forms**: the annotated assignment
+   (`const r: Result<T> = guard(...) { }`, `let` alike) and the
+   return-position guard (`return guard(...) { }` inside a def
+   declared `: Result<T>`). Both are places the user wrote
+   `Result<T>` adjacent to the guard. A `let r: Result<T>` declared
+   on one line and assigned later is OUT: the reassignment site
+   carries no annotation, so codegen would need the checker's
+   knowledge — the same handoff problem that keeps inferred types
+   out.
+
+---
+
+## Part 2: Mechanism
+
+### Approach: stamp the AST during guard desugar
+
+Rejected alternatives, for the record. A pending field on the builder
+("processAssignment stashes the yield type; the next
+processBlockArgument consumes it") is timing-coupled mutable state —
+a nested guard mis-stamps silently; that is the order-dependent-state
+anti-pattern. A real typechecker-to-codegen handoff would also fix
+the UNANNOTATED case (inferred yields), but it is the missing
+infrastructure this project has kept out of scope twice; it remains
+the eventual subsumer of this spec, recorded in Part 4.
+
+The chosen mechanism is pure data flow — the type rides the AST node:
+
+1. **`guardDesugar` stamps.** The desugar pass already walks every
+   position a guard can appear in, and it sees the surrounding
+   context the builder later cannot: when the guard sits in
+   `assignment.value` it reads the assignment's `typeHint`; when it
+   sits in `return.value` it knows the enclosing def's declared
+   return type (threaded down its walk as a parameter). If that
+   context type is a `resultType`, the pass stamps its `successType`
+   onto the `BlockArgument` it creates for the block body.
+2. **`BlockArgument` gains the field.**
+   `declaredYieldType?: VariableType` — optional, absent everywhere
+   except stamped guard blocks. (The stamp is on the BLOCK ARGUMENT
+   of the desugared `_guard` call, not on the guardBlock node, which
+   the desugar replaces.)
+3. **`processBlockArgument` copies the stamp onto the scope.** The
+   `BlockScope` entry it pushes gains the same optional field:
+   `{ type: "block", blockName, declaredYieldType }`.
+4. **The two ScopeManager lookups answer block-first.**
+   `returnType()` (the responseFormat source for `return llm(...)`)
+   answers a block scope's `declaredYieldType` when present, keeping
+   `undefined` otherwise. `enclosingDeclaredReturnType()` (the
+   draftSchema source) walks innermost-first and returns the FIRST
+   answer: a stamped block's yield, else onward to the enclosing
+   function/node's declared return, else `undefined` (string
+   fallback downstream, as today).
+
+Note the desugar runs twice (typescriptPreprocessor and the
+TypeChecker constructor) and mutates in place; stamping is
+idempotent, so the double run is harmless.
+
+### The walk rule for nested guards
+
+Innermost-first, first answer wins. A stamped block answers its
+stamp. An UNSTAMPED block defers outward — to an outer stamped
+block, then to the function/node declared return, then to the
+fallback. An outer hint for an inner slot is no more wrong than
+today's function-type hint (both are outer-scope guesses), and the
+rule stays one sentence. Example:
+
+```ts
+def f(): Report {
+  const outer: Result<string> = guard(cost: $1) {
+    const inner = guard(cost: $0.10) {
+      // inner is unannotated: the walk passes its block, finds
+      // outer's stamp -> the saveDraft schema says string, not
+      // Report. Better than today, still a hint (the inner slot's
+      // true type is inferred, out of scope).
+      return llm("...", tools: [saveDraft])
+    }
+    ...
+  }
+  ...
+}
+```
+
+### What each consumer sees
+
+Given `const notes: Result<string> = guard(...) { return llm("...",
+tools: [saveDraft]) }`:
+
+- **draftSchema:** the llm call site emits
+  `draftSchema: z.string()` — `successType` unwrapped, rendered by
+  the same `zodSchemaFor` bridge, same `isAnyType` skip, same
+  post-prompt-args emission condition as #578.
+- **responseFormat:** the `return llm(...)` compiles with a string
+  response format explicitly derived from the annotation rather than
+  the accidental string default. With `Result<Report>`, both become
+  Report-shaped — the visible behavior change decision 1 accepted.
+
+### Failure modes considered
+
+- **Annotation is not a `resultType`** (user wrote something else, or
+  the checker is already erroring): no stamp, today's behavior. The
+  desugar never validates — the checker owns diagnosing a bad
+  annotation.
+- **`Result<T, E>` with a failure type:** `successType` is still the
+  slot; `failureType` plays no role in either consumer.
+- **Aliased annotations** (`type R = Result<string>` then
+  `const r: R = guard...`): v1 stamps only a syntactic `resultType`
+  annotation. An alias resolving to Result is NOT chased at desugar
+  time (the desugar has no alias table); recorded as a known
+  limitation. If review finds the alias table is cheaply reachable
+  there, fold it in; do not build new plumbing for it.
+
+---
+
+## Part 3: Testing
+
+- Codegen: annotated assignment threads `draftSchema: z.string()`
+  from `Result<string>`; return-position guard in a
+  `def f(): Result<string>` does the same; `responseFormat` is
+  emitted for `return llm(...)` inside an annotated block (and stays
+  absent — string default — in an unannotated one); nested
+  unannotated-inside-annotated pins the walk rule; a structured
+  `Result<Report>` annotation threads the object schema for BOTH
+  consumers.
+- Byte-stability: unannotated programs compile byte-identically
+  (`make fixtures`, zero churn outside deliberate cases).
+- Fixture: a guard annotated `Result<{ title: string }>` whose mock
+  saves a structured draft; reject; the guard salvages the object.
+  This is the first e2e that exercises a NON-fallback saveDraft
+  schema, closing the "every fixture runs the string fallback" gap
+  from the #578 plan review at the fixture level.
+- Runtime surface test (extend `intrinsicToolSchema.test.ts`
+  pattern): none needed — the seam from `args.draftSchema` to the
+  provider is already pinned; this change only improves what codegen
+  puts INTO that seam, which the codegen tests cover.
+
+## Part 4: Out of scope, recorded so they stay decisions
+
+- Inferred yields (unannotated guards) — needs the
+  typechecker-to-codegen handoff; that project would subsume this
+  spec's stamping entirely.
+- `let r: Result<T>` declared-then-assigned-later (no annotation at
+  the assignment site).
+- Non-guard blocks (`fork`, `map`, ...): their result types relate
+  to block yields differently (arrays, races).
+- Alias-typed annotations resolving to Result (see failure modes).
+- llm.md's limitation note update — owner-authored file.

--- a/docs/superpowers/specs/2026-07-17-partials-ergonomics-design-REVIEW.md
+++ b/docs/superpowers/specs/2026-07-17-partials-ergonomics-design-REVIEW.md
@@ -1,0 +1,154 @@
+# Spec review: partials ergonomics (2026-07-17)
+
+**Reviewing:** `docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md`
+**Verdict:** Part 3 (`finalize as draft`) is ready — I traced the mechanics and
+they hold, the `as`-binder decision is well-grounded, and the typing reuses an
+existing rule cleanly. Part 2 (`saveDraft` as a tool) has the right idea and one
+concrete error: **the frame it names to file the draft on is off by one**, and
+it is off by one in exactly the direction the whole saveDraft history kept
+getting wrong. One substantive ordering question follows from it. Fix those two
+and this is a plan.
+
+All line references are `packages/agency-lang/`, verified today.
+
+---
+
+# Blocking
+
+## 1. `setSavedDraft` files the draft on the wrong frame in the tool-loop path
+
+Part 2 says interception "files the draft on the loop's own scope:
+`stateStack.setSavedDraft(value)` … the same branch-local stack the owner's
+drafts already use." That method does not file on the loop's own scope. It files
+on that scope's **parent**.
+
+`setSavedDraft` writes `this.callerFrame().savedDraft` (`stateStack.ts:982`), and
+`callerFrame()` is `stack[length - 2]` — one below the top. That is correct for
+the path it was written for: `saveDraft(x)` in Agency code calls the `saveDraft`
+**def** (`stdlib/index.agency:155` → `_saveDraft` → `setSavedDraft`), and a def
+call pushes a frame, so the top of the stack is the `saveDraft` def frame and
+`callerFrame()` is the scope that called it. The extra frame is what makes
+`length - 2` land on the owner.
+
+The tool-loop path has no such frame. `llm()` compiles to a **direct
+`runPrompt()` call** (`typescriptBuilder.ts:3567`) with no `State` push — I
+checked `prompt.ts`, it never pushes a frame. So while `runPrompt`'s tool loop is
+executing, the top of the stack **is** the scope that owns the `llm()` call.
+Interception runs inline (the spec is explicit it does not invoke the
+AgencyFunction, so no tool frame is pushed either). So:
+
+- **def path:** `[…, owner, saveDraft-def]` → `callerFrame()` = owner ✓
+- **tool path:** `[…, owner]` → `callerFrame()` = owner's **parent** ✗
+
+In the spec's own example the owner is the guard block (`guard(cost: $0.50) {
+return llm(…) }` — the block closure pushes a frame, `_runGuarded` salvages it,
+`llm` runs in it). `callerFrame()` there is the `_guard` def frame. The draft
+lands a level above the block, the block's slot stays empty, and the guard
+returns an empty draft on reject — the exact failure the feature exists to
+prevent.
+
+The fix is small and the spec should name it: interception writes
+`lastFrame().savedDraft`, not `setSavedDraft`. But "small" is why it needs to be
+in the spec — the saveDraft series was a string of off-by-one-frame bugs
+(`draftRegionStart`'s `length` shifting +1 on resume; the block-vs-def clearing
+gate), and "just call the existing method" is precisely the shorthand that
+reintroduces one. Decision 1 chose loop-interception over frame-walking *to know
+which scope owns the draft* — so the spec has to state which frame that is, and
+it is the top one, not `callerFrame()`.
+
+(Worth a second method rather than raw field access, so the global-context guard
+in `setSavedDraft` — which correctly throws for a top-level `saveDraft` — has a
+sibling. A guarded `llm()` at node top level owns a real frame, so the guard
+should not fire there, but the method should still exist rather than every caller
+reaching into `lastFrame().savedDraft` by hand.)
+
+---
+
+# Substantive
+
+## 2. The "last save wins, in tool-call order" guarantee needs the write to be ordered, and the spec doesn't say where it happens
+
+Decision 2 and Part 4's third fixture assert that parallel `saveDraft` tool calls
+in one round "apply in tool-call order … the later one wins." That holds only if
+the interception **writes** in tool-call order. The spec grounds it in "the same
+order tool results append" — but tool *results* append in call order while the
+*writes* happen during tool execution, and if the round dispatches tools
+concurrently, whichever interception the scheduler runs last wins, not whichever
+is last in the call list.
+
+This is recoverable and probably already true, but it depends on a mechanic the
+spec doesn't pin: is the intercepted `saveDraft` handled during the loop's
+**ordered iteration** over the round's tool calls, or is it dispatched into the
+same concurrent pool as real tools? If the former, the ordering claim is correct
+by construction — say so. If the latter, the fixture can flake and the guarantee
+is false. Name the interception point in the loop, and the ordering follows or
+doesn't from there.
+
+(This also interacts with finding 1: both are questions about *when and where* the
+draft write happens, and both resolve once the spec pins the interception point
+to a specific frame and a specific place in the tool-call iteration.)
+
+## 3. The schema's type and the draft's frame can disagree
+
+Part 2 builds the tool schema from "the enclosing function or node's DECLARED
+return type," while the draft files on the scope that owns the `llm()` call —
+often a guard block, whose type is inferred and need not equal the function's
+declared return. In the example they coincide (`string` all the way down), which
+is why it reads fine. They won't always: `def f(): Report { const r = guard(…) {
+return llm(…) } … }` where the block yields a `string` the function later wraps
+into a `Report` tells the model to produce a `Report` for a slot that holds a
+`string`.
+
+v1 has no runtime validation, so this is advisory-only and not a correctness bug
+— but it is a real "the schema lies to the model" case, and the spec's "the type
+of the enclosing function or scope" (decision 3) papers over the function-vs-scope
+gap that finding 1 exposes. One sentence: the schema is a best-effort hint keyed
+to the declared function type, and may not match the exact slot when a guard block
+of a different type owns the call. That is honest and keeps the door open for
+tightening it when inferred types reach codegen.
+
+---
+
+# Notes
+
+- **Recognition (identity by name+module) is sound** — I confirmed `AgencyFunction`
+  carries readonly `name` and `module` (`agencyFunction.ts:88-89`), so the
+  field-pair check works across modules and the alias case falls out. Good call
+  using the pair rather than object identity; the prelude auto-import means each
+  module may hold its own wrapper object.
+- **Part 3 is solid.** `withFinalize(finalize, scopeName)` (`abortedResult.ts:141`)
+  currently calls `finalize()` with no args and, on throw, returns `this` — which
+  already carries the pre-finalize partial (the draft). Threading the draft in as
+  a parameter surfaces the same value the throw path falls back to, so the "read
+  before the finalize runs, same value is the fallback" claim is exactly right,
+  no ordering change. The `T | null` binder typing reuses the existing
+  every-captured-local-is-possibly-null finalize rule. And AG4006's explanation
+  (`diagnosticExplanations.ts:258`, "does not support an `as` binding, because
+  there is nothing to bind") genuinely supports decision 4: a finalize with a
+  yielded draft *has* something to bind, so `finalize as draft` is the
+  something-to-bind case, not a contradiction of the rule.
+- **"The builder statically knows the enclosing def"** (schema threading) is
+  asserted but not shown. It's plausible — the builder processes statements in a
+  def context — but since the whole schema feature hangs on it, the plan should
+  point at the builder's current-scope tracking and confirm the declared return
+  type is in hand at an `llm()` call site, the way finding 1 points at the frame.
+
+# What is right
+
+The theme — partials become things the model saves and the finalize reads — is
+the correct next step, and the two halves are genuinely independent, which makes
+the "one tidy PR or two small ones" sizing real. Decision 1 (interception over
+frame-walking) is the right call for the reason given; the irony is that the
+mechanism it names then reintroduces a frame question, which finding 1 is just
+asking the spec to finish. The out-of-scope list is disciplined — deferring
+inferred-type schemas and runtime validation keeps v1 to what the pipeline can
+actually deliver.
+
+# Recommended next steps
+
+1. Name the frame: interception writes the **top** frame's `savedDraft`, not
+   `setSavedDraft`/`callerFrame` (finding 1). Add the method with the
+   global-context guard.
+2. Pin the interception point in the tool-call iteration, and derive the ordering
+   guarantee from it (finding 2).
+3. Add the one-sentence honesty about schema-vs-slot type (finding 3).

--- a/docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md
+++ b/docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md
@@ -370,3 +370,42 @@ possibly-null name, with a real type instead of a repurposed local.
 - Sizing: the finalize binder is roughly a day. The saveDraft tool is
   one to two days, mostly the schema threading. They make one tidy PR
   or two small ones, after #574 lands.
+
+---
+
+## As executed (2026-07-17, `partials-ergonomics` branch)
+
+Deviations and discoveries from execution, so the spec stays honest:
+
+1. **A pre-existing flow-widening bug surfaced and was fixed.** The
+   finalize flow rule widens every scope local to `T | null`, but
+   `uniteTypes` dedupes without flattening, so a local whose declared
+   type was ALREADY a union widened to the nested `(T | null) | null` —
+   and presence narrowing only drops top-level null members, so
+   `if (x != null)` could not narrow it back. The binder (itself typed
+   `T | null`) hit this immediately. Fixed at the widening site
+   (`flowBuilder.ts`): union members flatten before re-uniting. This
+   also fixes narrowing for ordinary union-typed locals inside any
+   finalize body.
+2. **The binder collision check is `lookupInFunction`, not `has`.**
+   `Scope.has` walks into the module scope; `lookupInFunction` stops at
+   the function boundary, which is exactly the scope-local rule the
+   plan review asked for. A binder named like a module-level const is
+   allowed (pinned by test).
+3. **The aliased-return schema renders as the hoisted schema const.**
+   `def f(): Report` threads `draftSchema: Report` (the alias's zod
+   const), not an inline `z.object(...)`. Same schema at runtime;
+   the codegen test asserts the reference plus the const.
+4. **The resume fixture uses a `writeBinary`-based interrupting tool
+   with an in-program handler.** `input()` inside a tool is not
+   answerable in the test harness (verified pre-existing on the
+   unmodified build — both harness-level `resolve` and an in-program
+   `approve("yes")` hang), so the fixture follows attach-to-reply's
+   mid-round precedent instead.
+5. **The interception plumbing lives in `intrinsicTools.ts`, not
+   prompt.ts.** `partitionIntrinsicCalls` + `runIntrinsicCall` keep
+   the loop declarative (and prompt.ts under the max-lines rule); the
+   loop owns only the `pr.step` resume idempotency.
+6. **Fixture `.js` outputs are gitignored.** Only `.agency` +
+   `.test.json` are committed; the plan's "regenerate checked-in
+   fixture JS" steps reduce to running `make fixtures` locally.

--- a/docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md
+++ b/docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md
@@ -1,0 +1,372 @@
+# Spec: partials ergonomics — `saveDraft` as a tool, and `finalize as draft`
+
+**Status:** brainstormed with the owner 2026-07-17; decisions settled.
+Review round 1 folded same day (findings in
+`2026-07-17-partials-ergonomics-design-REVIEW.md`); the interception
+point is pinned to the ordered tool-call iteration and the
+schema-vs-slot type gap is stated. **Planning correction, same day:**
+the review's finding 1 (interception must write the TOP frame, not
+`callerFrame()`) was checked against the runtime and is factually
+wrong — `runPrompt` pushes its own frame on entry, so the existing
+`setSavedDraft` already targets the owning scope. Part 2 below carries
+the corrected analysis. Builds on the partial-results machinery (saveDraft #553,
+finalize #556, resumable guards #558–#566) and the guard construct
+(#574). Examples use the construct syntax, so this ships after #574.
+
+**Scope:** two independent features, one theme — partials become
+first-class citizens of the agent loop. The model can save them, and
+the finalize can read them.
+
+---
+
+## Part 1: Background
+
+### What exists today
+
+`saveDraft(value)` records a best-so-far value on the calling scope's
+frame. When a guard trip is rejected, the guard returns the last saved
+draft as a success instead of a failure. A `finalize` block computes
+the salvage value instead: it runs when the scope aborts, sees the
+scope's locals, and its return wins over the saved draft, with the
+draft as fallback if the finalize throws (`AbortedResult.withFinalize`,
+`lib/runtime/abortedResult.ts:141`).
+
+Two gaps motivated this spec:
+
+1. **The model cannot save drafts.** In an agent loop, the model is
+   the one doing the work, but only the surrounding Agency code can
+   call `saveDraft`. Passing `saveDraft` in `tools:` today would
+   register it as an ordinary tool — and file the draft on the tool
+   invocation's own frame, which dies when the tool call ends.
+   Parallel tool calls run in branch stacks that are collected at the
+   end of the round, so the draft would never reach the scope whose
+   return value it approximates.
+2. **The finalize cannot see the draft.** The saved draft lives in a
+   frame slot, not a local, so a finalize that wants to return "the
+   draft, plus a note" has no way to read it. In hindsight this is a
+   strange gap: the two salvage tools cannot compose.
+
+### Decisions from the brainstorm (owner, 2026-07-17)
+
+1. **Tool-loop interception**, not frame-walking, for the saveDraft
+   tool. The loop knows which scope owns it; a walk from the tool's
+   branch stack back to the owner is fragile under every future
+   concurrency change.
+2. **Concurrency is a non-issue by state isolation.** Each `llm()`
+   call runs on its own branch stack, so each call's drafts file on
+   its own branch. Within one round, parallel saveDraft tool calls
+   apply in tool-call order, the same order tool results append.
+3. **The tool's JSON schema must say what the contract is**: exactly
+   one parameter, whose type is the return type of the enclosing
+   function or scope.
+4. **The finalize binder uses `as`, not parameter syntax.**
+   `finalize (draft) { }` looks like a call. The draft is a value
+   YIELDED to the block, and Agency already has syntax for that:
+   `fork([1, 2]) as n { }`. So: `finalize as draft { }` and
+   `finalize() as draft { }` are both accepted, with a user-chosen
+   binder name. This is also consistent with AG4006's rule that block
+   keywords take no `as` when there is nothing to bind — a finalize
+   with a yielded draft HAS something to bind.
+
+---
+
+## Part 2: `saveDraft` as a tool
+
+### Surface
+
+```ts
+def researchAgent(topic: string): string {
+  const r = guard(cost: $0.50) {
+    return llm("Research " + topic + ". Save a draft as you complete each section.", {
+      tools: [search, saveDraft]
+    })
+  }
+  if (isSuccess(r)) { return r.value }
+  return "no result"
+}
+```
+
+The model sees a `saveDraft` tool. Each call replaces the draft, last
+save wins. If the guard trips mid-request and the trip is rejected,
+the salvage pipeline runs as always — and now the draft is whatever
+the model most recently saved. The trip question's `draftValue`
+preview shows it too, so a handler judging "more budget or keep what
+we have?" sees the model's own best-so-far.
+
+### Recognition: identity, not name
+
+The tool loop intercepts when an entry in the tools array IS the
+stdlib `saveDraft` function. Recognition checks the AgencyFunction's
+`name` and `module` fields (`"saveDraft"` from
+`"stdlib/index.agency"`) — the runtime cannot import the stdlib
+singleton directly without a dependency cycle, and no user module can
+carry that module id, so the field pair is identity in practice.
+Aliasing works for free: `const s = saveDraft; tools: [s]` still
+intercepts, and a user's own function named `saveDraft` is an
+ordinary tool.
+
+### What interception does
+
+When the model calls the intercepted tool, the loop does NOT invoke
+the AgencyFunction. It:
+
+1. Files the draft on the scope that owns the `llm()` call, via the
+   EXISTING `stateStack.setSavedDraft(value)`. This corrects review
+   finding 1, which claimed `runPrompt` pushes no frame and therefore
+   `setSavedDraft`'s one-below-top write would land one scope too
+   high. The claim is wrong: `runPrompt` pushes its own frame on entry
+   (`setupFunction()` at `lib/runtime/prompt.ts:870` calls
+   `stateStack.getNewState()`, which pushes — the comment there reads
+   "runPrompt participates like any other function"). `llm()` does
+   compile to a direct `runPrompt()` call with no wrapper, but
+   runPrompt itself supplies the frame. So during the tool loop the
+   stack is `[…, owner, runPrompt]` — the same shape as the def path's
+   `[…, owner, saveDraft-def]` — and `callerFrame()` lands on the
+   owner in both. Often that owner is a guard block's closure frame,
+   exactly the slot `_runGuarded` salvages. No new StateStack method
+   is needed, and `setSavedDraft`'s global-context guard comes along
+   for free. The saveDraft series was a string of off-by-one-frame
+   bugs, so the plan must pin the frame math with a fixture: a draft
+   saved through the TOOL inside a guard block is salvaged by that
+   guard.
+2. Returns an acknowledgment as the tool result, e.g.
+   `Draft saved (214 characters).` The model gets confirmation; the
+   result rides the normal tool-result machinery, so resume
+   idempotency comes for free (a completed round's draft is already
+   serialized in the restored frame — drafts survive checkpoints).
+   **Malformed calls get helpful feedback (owner review round 2):**
+   the interception validates the argument against the synthesized
+   schema. A value that violates the schema is SAVED ANYWAY, and the
+   ack carries a specific warning ("Draft saved (N characters).
+   Warning: the value does not match this function's declared return
+   type (…). The draft was kept…") — the schema is a best-effort hint
+   (see "The schema" below), and refusing a save on a possibly-wrong
+   hint would throw away real work; the warning teaches the model
+   instead. Only a call with NO `value` argument refuses:
+   `Error: saveDraft requires a "value" argument. Nothing was saved.`
+3. Emits the standard toolCall statelog events, so the trace shows
+   when and what the model saved.
+
+**Architecture (owner review round 2): the "intrinsic tool" pattern.**
+saveDraft is the first tool the loop handles itself instead of
+dispatching, and it will not be the last (attachment
+listing/viewing and future run-control tools fit the same shape).
+The implementation names the pattern: an `IntrinsicTool` is one
+object declaring `matches` (identity), `buildDefinition` (what the
+provider sees), and `handle` (what a call does; returns the
+tool-result text). A closed, in-runtime registry lists them; the
+loop owns all generic bookkeeping (ordered pass, resume idempotency,
+statelog span + events, callbacks, the result message), so a new
+intrinsic is one self-contained module. Deliberately NOT a
+user-facing extension point: intrinsics manipulate run state, which
+is exactly what user tools must never do.
+
+**Where in the loop, and why the ordering guarantee holds (finding
+2):** interception happens during the loop's ORDERED iteration over
+the round's tool calls, before anything dispatches into the concurrent
+tool pool. A recognized `saveDraft` call is handled inline at its
+position — write, ack, record — and never becomes a concurrent
+branch. Ordering therefore holds by construction: two saves in one
+round apply in call-list order because the writes happen in call-list
+order, not in scheduler-completion order. Real tools in the same round
+dispatch exactly as today.
+
+### The schema
+
+The tool definition sent to the provider declares exactly one
+required parameter:
+
+- **Name:** `value`.
+- **Type:** the JSON schema of the enclosing function or node's
+  DECLARED return type, built with the same type-to-schema bridge
+  `schema(Type)` uses. `def researchAgent(...): string` produces
+  `{ "type": "string" }`; a structured return type produces its
+  object schema.
+- **Fallback:** when the enclosing scope has no declared return type,
+  or the type is `any`, the schema falls back to `string`. Inferred
+  types are not available to codegen (the typechecker and the builder
+  are separate passes), and a string draft is the honest default for
+  agent loops.
+- **Honesty about the schema's key (finding 3):** the schema is keyed
+  to the enclosing FUNCTION's declared type, while the draft files on
+  the scope that owns the `llm()` call — often a guard block whose
+  inferred type can differ. When they disagree, the schema is a
+  best-effort hint, not a contract; v1 has no runtime validation
+  either way. Tighten this when inferred types reach codegen.
+- **A plan obligation, not a given:** "the builder statically knows
+  the enclosing def" must be verified against the builder's
+  current-scope tracking at `llm()` call sites before the schema
+  threading is designed. The whole schema feature hangs on it.
+- **Description:** states the contract the type system cannot check
+  here: "Save your best-so-far answer as a draft. If the budget runs
+  out, the last saved draft is returned instead of a failure. The
+  value must match this function's return type."
+
+Codegen threads the enclosing scope's return-type schema into the
+`llm()` call site (the builder statically knows the enclosing def).
+The loop only builds the saveDraft tool definition when the tools
+array actually contains the intercepted function.
+
+### Interactions worth pinning
+
+- **Feedback channel:** `approve({message: "save a draft before each
+  new topic"})` teaches the model to checkpoint. No new machinery —
+  the message lands as a user message before the next request.
+- **Mid-request trips:** a time trip that cancels the in-flight
+  request keeps every draft saved in completed rounds. The cancelled
+  generation is gone; its unsaved progress is gone with it. That is
+  the feature's pitch in one line: teach the model to save, and
+  cancellation stops being total loss.
+- **The level rule is unchanged.** The draft files on the scope that
+  owns the `llm()` call. Where that scope's partial travels — call
+  boundaries, forks, joins — follows the existing rules.
+
+### What this does NOT do
+
+- No automatic injection. `saveDraft` is a tool only when the user
+  passes it. Guards do not silently add tools to model calls.
+- No SALVAGE-TIME type validation of the draft against the return
+  type — an ill-typed draft still salvages, the same trust level as
+  every other tool argument. (Refined in owner review round 2: the
+  TOOL boundary does validate, as feedback rather than enforcement —
+  a mismatched save is kept and warned about in the ack; only a
+  missing `value` refuses. See "What interception does".) Documented
+  in the guide.
+
+---
+
+## Part 3: `finalize as draft`
+
+### Surface
+
+```ts
+def research(topic: string): string {
+  const outline = draftOutline(topic)
+  const full = expand(outline)
+  return full
+
+  finalize as draft {
+    if (draft != null) {
+      return draft + "\n\n[Stopped early: may be incomplete]"
+    }
+    if (outline != null) {
+      return "OUTLINE ONLY: " + outline
+    }
+    return "nothing yet"
+  }
+}
+```
+
+All four head forms parse: `finalize { }`, `finalize() { }`,
+`finalize as draft { }`, `finalize() as draft { }`. The binder name is
+the user's choice. The formatter prints the canonical form without
+parens: `finalize { }` or `finalize as draft { }`.
+
+### Semantics
+
+- The binder is the SCOPE'S OWN saved draft at the moment the abort
+  reaches the finalize, or null when nothing was saved. It is not some
+  callee's draft: the finalize belongs to the scope, so it sees the
+  scope's slot. A callee's salvage arrives through ordinary locals,
+  as today.
+- Everything else is unchanged. The finalize still runs only on
+  abort, still wins over the draft, and the draft is still the
+  fallback when the finalize throws. The binder makes the choice
+  explicit instead of implicit: a finalize that wants the draft
+  returns it.
+
+### Typing
+
+The binder declares in the finalize's scope with type `T | null`,
+where `T` is the scope's declared or inferred return type. This fits
+the existing finalize rule that every captured local reads as
+possibly-null, so the checker treatment is uniform: one more
+possibly-null name, with a real type instead of a repurposed local.
+
+### Mechanics (pointers, not code)
+
+- **Parser (owner review round 1: reuse, not hand-rolling):** the
+  binder clause is the EXISTING `asParser` /`blockParamsParser`
+  (`lib/parsers/parsers.ts:3148`) — the same grammar that gives
+  `fork([1, 2]) as item { }` its binder. `finalizeBlockParser` gains
+  an optional empty-parens group and then delegates the `as` clause
+  to `asParser`, keeping the word-boundary care the keyword already
+  has. Inherited edge cases from the shared grammar, ruled on by the
+  checker rather than re-parsed: `finalize as { }` parses as the
+  binder-less form (the documented no-param shape; the formatter
+  canonicalizes the stray `as` away, like guard's legacy-as
+  migration); `as (a, b)` parses and is rejected (one draft, one
+  binder — AG6038); `as draft: Report` parses with the annotation
+  winning over the scope's return type (the handler-param rule).
+- **AST:** `FinalizeBlock` gains `params: FunctionParameter[]` — the
+  same field shape `BlockArgument` uses; the binder is `params[0]`,
+  `[]` is binder-less. The formatter prints it through the shared
+  param renderer; `bodySlots` is unchanged (the binder is not a
+  body). NOT reused: the whole-node `functionCall`+`BlockArgument`
+  pipeline — a finalize is a declaration, not a call (codegen strips
+  it from the statement stream; nothing invokes it), so wrapping the
+  body in a `BlockArgument` would add indirection without behavior.
+- **Checker:** declare the binder in the finalize scope as
+  `T | null`. The existing finalize checks (no interrupts, one per
+  scope, return-position call restriction) are untouched.
+- **Codegen:** the finalize closure gains one parameter; the abort
+  path passes the frame's saved draft. `AbortedResult.withFinalize`'s
+  `finalize` argument becomes `(draft: unknown) => Promise<unknown>`,
+  and its caller reads the slot off the frame it already holds. The
+  salvage order does not move: the draft is read BEFORE the finalize
+  runs and passed in; if the finalize throws, the same value is the
+  fallback.
+
+---
+
+## Part 4: Testing
+
+**saveDraft tool:**
+
+- Fixture: a mocked llm call whose mock issues a `saveDraft` tool
+  call, then trips the guard on the next round; reject; the guard
+  returns the model's draft as a success. The mock's second entry
+  never runs.
+- Fixture: alias (`const s = saveDraft`) intercepts identically; a
+  user-defined function named `saveDraft` in `tools:` runs as an
+  ordinary tool and files nothing.
+- Fixture: two parallel tool calls saving in one round apply in
+  tool-call order; the later one wins.
+- Unit: the synthesized tool definition — one required `value` param,
+  schema from a declared string return, schema from a declared object
+  return, string fallback for an undeclared return, and the
+  description text.
+- Unit + fixture: the validation acks — missing `value` refuses and
+  saves nothing; a schema-mismatched value saves anyway with the
+  warning ack, and the guard salvages it.
+- Runtime: a recording-client test pins the schema-threading seam —
+  the tool definition the PROVIDER receives uses the threaded
+  draftSchema, not the string fallback (the fixtures alone cannot
+  catch a silent fallback).
+- Resume: a checkpoint after a draft-saving round restores the draft
+  (existing serialization; pin it from the tool path).
+
+**finalize binder:**
+
+- Parser: all four head forms; binder name freedom; formatter
+  round-trip prints canonically.
+- Checker: binder typed `T | null` (assigning it to `T` unguarded is
+  the existing possibly-null error); binder name shadows nothing
+  outside the finalize.
+- Fixtures: finalize returns the bound draft (salvage equals the
+  draft plus a suffix); binder is null when nothing was saved;
+  finalize-throws falls back to the same draft that was bound.
+
+---
+
+## Part 5: Out of scope, recorded so they stay decisions
+
+- Runtime validation of model-saved drafts against the return type.
+- Auto-adding `saveDraft` to guarded llm calls.
+- Return-type schemas from INFERRED types (needs a typechecker-to-
+  codegen handoff that does not exist; declared types only).
+- A binder for the trip handler's `draftValue` (it already exists in
+  `i.data`).
+- Sizing: the finalize binder is roughly a day. The saveDraft tool is
+  one to two days, mostly the schema threading. They make one tidy PR
+  or two small ones, after #574 lands.

--- a/packages/agency-lang/docs/site/diagnostics/index.md
+++ b/packages/agency-lang/docs/site/diagnostics/index.md
@@ -124,6 +124,8 @@ or suppress one on the next line with `// @tc-ignore AG####`.
 | [AG6034](tools.md#ag6034) | saveDraft() has no effect inside a finalize block. The value the finalize returns is already the partial result. Return the value instead. |
 | [AG6035](tools.md#ag6035) | A finalize block cannot go in a node body. Nothing above a node consumes a partial result yet. Put the finalize in a function or a guard block instead. |
 | [AG6036](tools.md#ag6036) | This scope has a finalize block, so a return expression cannot bury a call inside a bigger expression. If the call were stopped, the expression would consume its partial result before the finalize could run. Assign the call to a local first, then return the local. |
+| [AG6037](tools.md#ag6037) | finalize binder '&#123;name&#125;' collides with a variable that already exists in this scope. Pick a fresh name. The finalize body reads the scope's locals directly, so a colliding binder would silently shadow the local. |
+| [AG6038](tools.md#ag6038) | finalize yields a single value — the scope's saved draft. Use one binder: finalize as &#123;name&#125; &#123; ... &#125;. |
 
 ## Static init, config, and imports
 

--- a/packages/agency-lang/docs/site/diagnostics/tools.md
+++ b/packages/agency-lang/docs/site/diagnostics/tools.md
@@ -376,3 +376,23 @@ def f(): string {
   }
 }
 ```
+
+<a id="ag6037"></a>
+
+## AG6037 — finalize binder '&#123;name&#125;' collides with a variable that already exists in this scope. Pick a fresh name. The finalize body reads the scope's locals directly, so a colliding binder would silently shadow the local.
+
+*Default severity: error.*
+
+A finalize body runs in the same variable scope as the function or block it belongs to. The `as` binder adds one extra name: the scope's saved draft. If that name already belongs to a parameter or local, references inside the finalize could not tell the two apart, and the draft would silently win or lose depending on compilation details.
+
+**How to fix:** rename the binder. Any name not already used in the scope works: `finalize as draft { ... }`.
+
+<a id="ag6038"></a>
+
+## AG6038 — finalize yields a single value — the scope's saved draft. Use one binder: finalize as &#123;name&#125; &#123; ... &#125;.
+
+*Default severity: error.*
+
+The `as` clause on a finalize binds what the abort yields to the block, and the abort yields exactly one thing: the scope's saved draft (or null when nothing was saved). There is no second value to bind, so a parameter list has no meaning here. The shared block-argument grammar is why the parser accepts the list at all.
+
+**How to fix:** keep one binder: `finalize as draft { ... }`. Everything else the finalize needs is already in scope as ordinary locals.

--- a/packages/agency-lang/lib/backends/agencyGenerator.finalizeBlock.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.finalizeBlock.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { AgencyGenerator } from "./agencyGenerator.js";
+import { parseAgency } from "../parser.js";
+
+function gen(src: string): string {
+  const parsed = parseAgency(src, {}, false);
+  expect(parsed.success).toBe(true);
+  if (!parsed.success) return "";
+  return new AgencyGenerator().generate(parsed.result).output;
+}
+
+describe("AgencyGenerator — finalize binder", () => {
+  it("prints the canonical binder form without parens", () => {
+    const out = gen(
+      'def f(): string {\n  return "x"\n  finalize() as d {\n    return "y"\n  }\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("finalize as d {");
+    expect(out).not.toContain("finalize()");
+  });
+
+  it("prints the binder-less form unchanged", () => {
+    const out = gen(
+      'def f(): string {\n  return "x"\n  finalize {\n    return "y"\n  }\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("finalize {");
+  });
+
+  it("canonicalizes a stray `as` with no binder away (fmt IS the migration, like guard)", () => {
+    const out = gen(
+      'def f(): string {\n  return "x"\n  finalize as {\n    return "y"\n  }\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("finalize {");
+    expect(out).not.toContain("finalize as {");
+  });
+
+  it("round-trips: printed output parses back and prints identically", () => {
+    const src =
+      'def f(): string {\n  return "x"\n  finalize as draft {\n    if (draft != null) {\n      return draft\n    }\n    return "y"\n  }\n}\nnode main() { return f() }\n';
+    const once = gen(src);
+    const reparsed = parseAgency(once, {}, false);
+    expect(reparsed.success).toBe(true);
+    if (!reparsed.success) return;
+    const twice = new AgencyGenerator().generate(reparsed.result).output;
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1679,12 +1679,12 @@ export class AgencyGenerator {
     const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
     const rendered = this.renderParams(node.params);
-    const asClause =
-      rendered.length === 0
-        ? ""
-        : rendered.length === 1
-          ? ` as ${rendered[0]}`
-          : ` as (${rendered.join(", ")})`;
+    let asClause = "";
+    if (rendered.length === 1) {
+      asClause = ` as ${rendered[0]}`;
+    } else if (rendered.length > 1) {
+      asClause = ` as (${rendered.join(", ")})`;
+    }
     return this.indentStr(
       `finalize${asClause} {\n${bodyCodeStr}${this.indentStr("}")}`,
     );

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -1670,11 +1670,24 @@ export class AgencyGenerator {
     );
   }
 
+  /** Canonical form: no parens, and the binder prints through the same
+   *  param renderer blocks use. A stray `as` with no binder (the shared
+   *  grammar's no-param form) canonicalizes away — printing IS the
+   *  migration, like guard's legacy `as`. */
   protected processFinalizeBlock(node: FinalizeBlock): string {
     this.increaseIndent();
     const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
-    return this.indentStr(`finalize {\n${bodyCodeStr}${this.indentStr("}")}`);
+    const rendered = this.renderParams(node.params);
+    const asClause =
+      rendered.length === 0
+        ? ""
+        : rendered.length === 1
+          ? ` as ${rendered[0]}`
+          : ` as (${rendered.join(", ")})`;
+    return this.indentStr(
+      `finalize${asClause} {\n${bodyCodeStr}${this.indentStr("}")}`,
+    );
   }
 
   /** Canonical form: the head prints through the same argument

--- a/packages/agency-lang/lib/backends/draftSchemaCodegen.test.ts
+++ b/packages/agency-lang/lib/backends/draftSchemaCodegen.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+function gen(src: string): string {
+  const r = parseAgency(src, {}, false);
+  if (!r.success) throw new Error("parse failed: " + r.message);
+  return generateTypeScript(r.result, undefined, undefined, "test.agency");
+}
+
+describe("draftSchema threading (saveDraft tool, spec Part 2)", () => {
+  it("threads the declared string return type when the call has options", () => {
+    const out = gen(
+      'def f(): string {\n  const r = llm("hi", tools: [print])\n  return r\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+  });
+
+  it("omits draftSchema on a bare llm(prompt) call", () => {
+    const out = gen(
+      'def f(): string {\n  const r = llm("hi")\n  return r\n}\nnode main() { return f() }\n',
+    );
+    expect(out).not.toContain("draftSchema");
+  });
+
+  it("walks past a guard block to the enclosing def's declared type", () => {
+    const out = gen(
+      'def f(): string {\n  const r = guard(cost: $1) {\n    return llm("hi", tools: [print])\n  }\n  if (isSuccess(r)) { return r.value }\n  return "x"\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("draftSchema: z.string()");
+  });
+
+  it("omits draftSchema when the enclosing def has no declared return type", () => {
+    const out = gen(
+      'def f() {\n  const r = llm("hi", tools: [print])\n  return r\n}\nnode main() { return f() }\n',
+    );
+    expect(out).not.toContain("draftSchema");
+  });
+
+  it("threads an object schema for a structured declared return type", () => {
+    // An aliased type renders as its hoisted zod-schema const, not an
+    // inline z.object literal — assert the reference AND the const.
+    const out = gen(
+      'type Report = { title: string }\ndef f(): Report {\n  const r: Report = llm("hi", tools: [print])\n  return r\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toContain("draftSchema: Report");
+    expect(out).toMatch(/const Report = z\.object\(/);
+  });
+
+  it("threads an inline object schema for an anonymous structured return type", () => {
+    const out = gen(
+      'def f(): { title: string } {\n  const r = llm("hi", tools: [print])\n  return { title: "t" }\n}\nnode main() { const x = f()\n return "ok" }\n',
+    );
+    expect(out).toMatch(/draftSchema: z\.object\(/);
+  });
+});

--- a/packages/agency-lang/lib/backends/finalizeBinderCodegen.test.ts
+++ b/packages/agency-lang/lib/backends/finalizeBinderCodegen.test.ts
@@ -19,6 +19,15 @@ describe("finalize binder codegen", () => {
     expect(out).not.toContain("__stack.locals.draft");
   });
 
+  it("an annotated binder carries its TS annotation (handler-param convention)", () => {
+    const out = gen(
+      'def f(): string {\n  return "x"\n  finalize as draft: string {\n    return "none"\n  }\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain(
+      "const __finalize = async (draft: string | null): Promise<any>",
+    );
+  });
+
   it("binder-less output is byte-identical to the old form", () => {
     const out = gen(
       'def f(): string {\n  return "x"\n  finalize {\n    return "y"\n  }\n}\nnode main() { return f() }\n',

--- a/packages/agency-lang/lib/backends/finalizeBinderCodegen.test.ts
+++ b/packages/agency-lang/lib/backends/finalizeBinderCodegen.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+function gen(src: string): string {
+  const r = parseAgency(src, {}, false);
+  if (!r.success) throw new Error("parse failed: " + r.message);
+  return generateTypeScript(r.result, undefined, undefined, "test.agency");
+}
+
+describe("finalize binder codegen", () => {
+  it("the closure takes the binder as a bare parameter", () => {
+    const out = gen(
+      'def f(): string {\n  return "x"\n  finalize as draft {\n    if (draft != null) { return draft }\n    return "none"\n  }\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("const __finalize = async (draft: any): Promise<any>");
+    // The body must reference the parameter BARE, not a frame local —
+    // that is the whole trick (handler-param precedent).
+    expect(out).not.toContain("__stack.locals.draft");
+  });
+
+  it("binder-less output is byte-identical to the old form", () => {
+    const out = gen(
+      'def f(): string {\n  return "x"\n  finalize {\n    return "y"\n  }\n}\nnode main() { return f() }\n',
+    );
+    expect(out).toContain("const __finalize = async (): Promise<any>");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -96,7 +96,7 @@ import {
 } from "./typescriptGenerator/validationDescriptor.js";
 import { tagArgToTs } from "./typescriptGenerator/tagArgToTs.js";
 import { resolveTypeDeep, safeResolveType } from "../typeChecker/assignability.js";
-import { isFunctionTyped, paramAcceptsFailure } from "../typeChecker/utils.js";
+import { isAnyType, isFunctionTyped, paramAcceptsFailure } from "../typeChecker/utils.js";
 import { rejectValueParamCycle } from "./valueParamCycle.js";
 
 import { $, ts } from "../ir/builders.js";
@@ -3644,6 +3644,19 @@ export class TypeScriptBuilder {
         .done();
     }
     runPromptEntries.clientConfig = clientConfig;
+    // Partials ergonomics (spec Part 2): thread the enclosing def's
+    // declared return type so a saveDraft tool in this call's tools
+    // array gets an honest value schema. Emitted only when the call has
+    // arguments beyond the prompt — a bare llm("...") can never carry
+    // tools, and skipping it keeps those call sites byte-identical.
+    // An `any` return is skipped at the TYPE level (isAnyType), so the
+    // runtime falls back to the string schema.
+    if (argsAfterPrompt.length > 0) {
+      const declaredReturn = this.scopes.enclosingDeclaredReturnType();
+      if (declaredReturn !== undefined && !isAnyType(declaredReturn)) {
+        runPromptEntries.draftSchema = ts.raw(this.zodSchemaFor(declaredReturn));
+      }
+    }
     runPromptEntries.maxToolCallRounds = ts.num(
       this.agencyConfig.maxToolCallRounds || 10,
     );

--- a/packages/agency-lang/lib/backends/typescriptBuilder/finalizeCodegen.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/finalizeCodegen.ts
@@ -5,6 +5,7 @@ import type { AgencyNode } from "../../types.js";
 import type { FinalizeBlock } from "../../types/finalizeBlock.js";
 import type { ScopeManager } from "./scopeManager.js";
 import * as renderFinalizeClosure from "../../templates/backends/typescriptGenerator/finalizeClosure.js";
+import { formatTypeHintTs } from "../../utils/formatType.js";
 
 /** Everything a scope's compilation needs from its (possible) finalize
  *  block. Produced by FinalizeCodegen.compileScope for every function and
@@ -161,12 +162,24 @@ export class FinalizeCodegen {
     // was never declared via let/const, so body references print as the
     // bare identifier — the same mechanism inline handler params use.
     // AG6037 guarantees the name cannot collide with a real local, and
-    // AG6038 guarantees at most one param reaches codegen.
+    // AG6038 guarantees at most one param reaches codegen. The TS
+    // annotation follows the inline-handler-param convention: the
+    // user's explicit annotation when written (plus the null arm the
+    // empty slot implies), `any` otherwise. It is documentation only —
+    // generated TS is transpiled, not type-checked; the enforced
+    // typing is the checker's `T | null` on the Agency side.
     const binder = finalize.params[0];
+    let binderParam = "";
+    if (binder !== undefined) {
+      const tsType = binder.typeHint
+        ? `${formatTypeHintTs(binder.typeHint)} | null`
+        : "any";
+      binderParam = `${binder.name}: ${tsType}`;
+    }
     return ts.raw(
       renderFinalizeClosure
         .default({
-          binderParam: binder !== undefined ? `${binder.name}: any` : "",
+          binderParam,
           frameVar: this.frameVar(),
           moduleId: JSON.stringify(this.moduleId),
           scopeName: JSON.stringify(scopeName + "#finalize"),

--- a/packages/agency-lang/lib/backends/typescriptBuilder/finalizeCodegen.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/finalizeCodegen.ts
@@ -4,6 +4,7 @@ import type { TsNode } from "../../ir/tsIR.js";
 import type { AgencyNode } from "../../types.js";
 import type { FinalizeBlock } from "../../types/finalizeBlock.js";
 import type { ScopeManager } from "./scopeManager.js";
+import * as renderFinalizeClosure from "../../templates/backends/typescriptGenerator/finalizeClosure.js";
 
 /** Everything a scope's compilation needs from its (possible) finalize
  *  block. Produced by FinalizeCodegen.compileScope for every function and
@@ -156,12 +157,22 @@ export class FinalizeCodegen {
   private closure(finalize: FinalizeBlock, scopeName: string): TsNode {
     const parts = this.compileBody(finalize.body, FinalizeCodegen.STEP_BASE);
     const bodyStr = parts.map((n) => printTs(n, 1)).join("\n");
-    const frameVar = this.frameVar();
+    // The binder is a plain closure parameter (never a frame local): it
+    // was never declared via let/const, so body references print as the
+    // bare identifier — the same mechanism inline handler params use.
+    // AG6037 guarantees the name cannot collide with a real local, and
+    // AG6038 guarantees at most one param reaches codegen.
+    const binder = finalize.params[0];
     return ts.raw(
-      `const __finalize = async (): Promise<any> => {\n` +
-        `  const runner = new Runner(__ctx, ${frameVar}, { state: ${frameVar}, moduleId: ${JSON.stringify(this.moduleId)}, scopeName: ${JSON.stringify(scopeName + "#finalize")} });\n` +
-        bodyStr +
-        `\n  return runner.halted ? runner.haltResult : undefined;\n};`,
+      renderFinalizeClosure
+        .default({
+          binderParam: binder !== undefined ? `${binder.name}: any` : "",
+          frameVar: this.frameVar(),
+          moduleId: JSON.stringify(this.moduleId),
+          scopeName: JSON.stringify(scopeName + "#finalize"),
+          body: bodyStr,
+        })
+        .trimEnd(),
     );
   }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
@@ -159,7 +159,12 @@ export class ScopeManager {
    * type, so the enclosing def's declared type is the best-effort hint.
    */
   enclosingDeclaredReturnType(): VariableType | undefined {
-    // Innermost-first: the nearest non-block scope answers.
+    // Innermost-first: the nearest non-block scope answers. The Scope
+    // union names more kinds (imported/static/local), but the builder
+    // only ever PUSHES function, node, and block onto this stack, over
+    // the root global — the same invariant `returnType()`'s throwing
+    // default relies on — so the walk always lands on one of those
+    // three, and the default arm below covers only `global`.
     const owner = [...this.stack]
       .reverse()
       .find((scope) => scope.type !== "block");

--- a/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
@@ -150,6 +150,37 @@ export class ScopeManager {
     }
   }
 
+  /**
+   * Declared return type of the nearest ENCLOSING function or node,
+   * walking outward past block scopes. Unlike `returnType()`, which
+   * answers for the CURRENT scope (and answers `undefined` for blocks),
+   * this is the saveDraft tool's schema key (partials-ergonomics spec
+   * Part 2): a guard block owns the draft slot but carries no declared
+   * type, so the enclosing def's declared type is the best-effort hint.
+   */
+  enclosingDeclaredReturnType(): VariableType | undefined {
+    // Innermost-first: the nearest non-block scope answers.
+    const owner = [...this.stack]
+      .reverse()
+      .find((scope) => scope.type !== "block");
+    if (owner === undefined) return undefined;
+    switch (owner.type) {
+      case "function":
+        return (
+          this.compilationUnit.functionDefinitions[owner.functionName]
+            ?.returnType ?? undefined
+        );
+      case "node":
+        return (
+          this.compilationUnit.graphNodes.find(
+            (n) => n.nodeName === owner.nodeName,
+          )?.returnType ?? undefined
+        );
+      default:
+        return undefined; // global scope
+    }
+  }
+
   /** Whether the surrounding function/node opted-in to runtime return-type validation. */
   returnTypeValidated(): boolean {
     const scope = this.current();

--- a/packages/agency-lang/lib/parsers/finalizeBinder.test.ts
+++ b/packages/agency-lang/lib/parsers/finalizeBinder.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { finalizeBlockParser } from "./parsers.js";
+import { parseAgency } from "../parser.js";
+import type { FinalizeBlock } from "../types/finalizeBlock.js";
+
+function parseFinalize(src: string): FinalizeBlock {
+  const r = finalizeBlockParser(src);
+  expect(r.success).toBe(true);
+  if (!r.success) throw new Error(r.message);
+  return r.result;
+}
+
+describe("finalizeBlockParser — binder head forms (via the shared asParser)", () => {
+  it("parses the bare form with empty params", () => {
+    const node = parseFinalize("finalize {\n  return 1\n}");
+    expect(node.type).toBe("finalizeBlock");
+    expect(node.params).toEqual([]);
+  });
+
+  it("parses empty parens with empty params", () => {
+    const node = parseFinalize("finalize() {\n  return 1\n}");
+    expect(node.params).toEqual([]);
+  });
+
+  it("parses `as name` into params[0]", () => {
+    const node = parseFinalize("finalize as draft {\n  return draft\n}");
+    expect(node.params).toHaveLength(1);
+    expect(node.params[0].name).toBe("draft");
+  });
+
+  it("parses `() as name`", () => {
+    const node = parseFinalize("finalize() as best {\n  return best\n}");
+    expect(node.params[0].name).toBe("best");
+  });
+
+  it("binder name is the user's choice", () => {
+    const node = parseFinalize(
+      "finalize as partialSoFar {\n  return partialSoFar\n}",
+    );
+    expect(node.params[0].name).toBe("partialSoFar");
+  });
+
+  it("a typed binder parses (the shared grammar allows it; the checker rules on it)", () => {
+    const node = parseFinalize("finalize as draft: string {\n  return draft\n}");
+    expect(node.params[0].name).toBe("draft");
+    expect(node.params[0].typeHint).toBeDefined();
+  });
+
+  it("multiple binders parse (rejected later by AG6038, not here)", () => {
+    const node = parseFinalize("finalize as (a, b) {\n  return a\n}");
+    expect(node.params).toHaveLength(2);
+  });
+
+  it("does not swallow an identifier like finalizer(...)", () => {
+    const r = finalizeBlockParser("finalizer(1)");
+    expect(r.success).toBe(false);
+  });
+
+  it("`as` with no name parses as the binder-less form (the shared grammar's no-param rule)", () => {
+    // blockParamsParser treats `as {` as "as, then zero params" — the
+    // documented no-param block form (`fork() as { }`). Reusing the
+    // grammar means finalize inherits it; the formatter canonicalizes
+    // the stray `as` away, exactly like guard's legacy-as migration.
+    const node = parseFinalize("finalize as {\n  return 1\n}");
+    expect(node.params).toEqual([]);
+  });
+
+  it("parses inside a full function body", () => {
+    const r = parseAgency(
+      'def f(): string {\n  return "x"\n\n  finalize as d {\n    return "y"\n  }\n}\n',
+      {},
+      false,
+    );
+    expect(r.success).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -4287,27 +4287,48 @@ export const handleBlockParser: Parser<HandleBlock> = withLoc(memo(
   ),
 ));
 
-/** `finalize { ... }` — keyword block, no binder and no `with` clause.
- *  Mirrors handleBlockParser's keyword handling: the word-boundary check
- *  keeps an identifier like `finalizer(...)` parsing as a call. */
+/** `finalize { ... }` — keyword block. Four head forms parse:
+ *  `finalize {`, `finalize() {`, `finalize as name {`,
+ *  `finalize() as name {`. The binder clause is the SAME asParser
+ *  block arguments use, so the grammar (and its edge cases — `as {`
+ *  means no params, parens and type hints are admitted) is shared,
+ *  not duplicated; arity and typing are checker rules (AG6038, the
+ *  binder-typing pass). Mirrors handleBlockParser's keyword handling:
+ *  the word-boundary check keeps an identifier like `finalizer(...)`
+ *  parsing as a call. */
 export const finalizeBlockParser: Parser<FinalizeBlock> = withLoc(memo(
   "finalizeBlockParser",
-  seqC(
-    set("type", "finalizeBlock"),
-    str("finalize"),
-    not(varNameChar),
-    optionalSpaces,
-    captureCaptures(
-      parseError(
-        "expected `{` to open finalize block body",
-        char("{"),
-        optionalSpacesOrNewline,
-        capture(bodyParser, "body"),
-        optionalSpacesOrNewline,
-        char("}"),
-      ),
-    ),
-  ),
+  (input: string): ParserResult<FinalizeBlock> => {
+    const pre = seqC(
+      str("finalize"),
+      not(varNameChar),
+      optionalSpaces,
+      // Optional empty parens: `finalize() { ... }`.
+      optional(seqC(char("("), optionalSpaces, char(")"))),
+      optionalSpaces,
+      capture(asParser, "params"),
+      optionalSpaces,
+      char("{"),
+    )(input);
+    if (!pre.success) return pre as ParserResult<FinalizeBlock>;
+    // Past the `{` we commit: a malformed body is an error here.
+    const bodyR = parseError(
+      "expected `}` to close finalize block body",
+      optionalSpacesOrNewline,
+      capture(lazy(() => bodyParser), "body"),
+      optionalSpacesOrNewline,
+      char("}"),
+    )(pre.rest);
+    if (!bodyR.success) return bodyR as ParserResult<FinalizeBlock>;
+    return success(
+      {
+        type: "finalizeBlock",
+        params: (pre.result as any).params,
+        body: (bodyR.result as any).body,
+      } as FinalizeBlock,
+      bodyR.rest,
+    );
+  },
 ));
 
 export const withModifierParser: Parser<WithModifier> = withLoc((input: string) => {

--- a/packages/agency-lang/lib/runtime/abortedResult.test.ts
+++ b/packages/agency-lang/lib/runtime/abortedResult.test.ts
@@ -287,6 +287,49 @@ describe("AbortedResult.partialValueOrNull", () => {
   });
 });
 
+describe("withFinalize passes the draft (finalize as draft)", () => {
+  it("the finalize receives the partial this instance holds", async () => {
+    const aborted = AbortedResult.fromError(
+      abortError(),
+      frameWithDraft("the-draft"),
+      "code",
+    );
+    let received: unknown = "not-called";
+    await aborted.withFinalize(async (draft) => {
+      received = draft;
+      return "finalized";
+    }, "code");
+    expect(received).toBe("the-draft");
+  });
+
+  it("no partial yields null, matching the binder's null case", async () => {
+    const aborted = AbortedResult.fromError(abortError(), new State(), "code");
+    let received: unknown = "not-called";
+    await aborted.withFinalize(async (draft) => {
+      received = draft;
+      return "finalized";
+    }, "code");
+    expect(received).toBe(null);
+  });
+
+  it("a throwing finalize still returns `this` — the same draft is the fallback", async () => {
+    const { result } = withStubStatelog(async () => {
+      const aborted = AbortedResult.fromError(
+        abortError(),
+        frameWithDraft("the-draft"),
+        "code",
+      );
+      const finalized = await aborted.withFinalize(async () => {
+        throw new Error("boom");
+      }, "code");
+      return { aborted, finalized };
+    });
+    const { aborted, finalized } = await result;
+    expect(finalized).toBe(aborted);
+    expect(finalized.partialValueOrNull()).toBe("the-draft");
+  });
+});
+
 describe("AbortedResult.withFinalize", () => {
   it("replaces the partial with the finalize's return, cause by identity", async () => {
     const cause = tripCause();

--- a/packages/agency-lang/lib/runtime/abortedResult.ts
+++ b/packages/agency-lang/lib/runtime/abortedResult.ts
@@ -139,12 +139,17 @@ export class AbortedResult {
    *  signal is still firing, so a callee inside the finalize can be
    *  stopped). */
   async withFinalize(
-    finalize: () => Promise<unknown>,
+    finalize: (draft: unknown) => Promise<unknown>,
     scopeName: string,
   ): Promise<AbortedResult> {
     let value: unknown;
     try {
-      value = await finalize();
+      // The partial this instance holds IS the scope's own saved draft
+      // (carryThrough/fromError copied the frame slot before any stop
+      // site called us) — yielded to a `finalize as draft` binder. Read
+      // before the finalize runs; on throw the same value is the
+      // fallback because the catch returns `this`.
+      value = await finalize(this.partialValueOrNull());
     } catch (finalizeError) {
       this.logFinalizeFailure(scopeName, finalizeError);
       return this;

--- a/packages/agency-lang/lib/runtime/intrinsicToolSchema.test.ts
+++ b/packages/agency-lang/lib/runtime/intrinsicToolSchema.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import * as smoltalk from "smoltalk";
+import { ToolCall } from "smoltalk";
+import type { Result, PromptResult, StreamChunk } from "smoltalk";
+import { AgencyFunction } from "./agencyFunction.js";
+import { agency } from "./agency.js";
+import type {
+  EmbedConfig,
+  EmbedResult,
+  LLMClient,
+  PromptConfig,
+} from "./llmClient.js";
+import { runPrompt } from "./prompt.js";
+import { RuntimeContext } from "./state/context.js";
+import { MessageThread } from "./state/messageThread.js";
+import { ThreadStore } from "./state/threadStore.js";
+
+/** The observable surface of the saveDraft intrinsic (plan review
+ *  findings 1/M1/M3): what the PROVIDER receives (the synthesized tool
+ *  definition, keyed by the threaded draftSchema), what the MODEL
+ *  receives (the ack tool message, paired by tool_call_id), and what
+ *  the TRACE receives (the toolCallStart/toolCall events). None of
+ *  these are visible to the .agency fixtures — they only see the
+ *  salvaged draft — so this is where a silent seam failure would
+ *  otherwise hide (a dropped draftSchema falls back to z.string() and
+ *  every fixture stays green). */
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+  });
+}
+
+function inFrame<T>(
+  ctx: RuntimeContext<any>,
+  threads: ThreadStore,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return agency.withTestContext({ ctx, stack: ctx.stateStack, threads }, fn);
+}
+
+/** Records every PromptConfig; the FIRST response issues a saveDraft
+ *  tool call, later responses answer plainly, ending the loop. */
+class ScriptedClient implements LLMClient {
+  configs: PromptConfig[] = [];
+  constructor(private readonly saveValue: unknown) {}
+
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    this.configs.push(config);
+    const first = this.configs.length === 1;
+    return {
+      success: true,
+      value: {
+        output: first ? "" : "answer",
+        toolCalls: first
+          ? [new ToolCall("mock-tool-0", "saveDraft", { value: this.saveValue })]
+          : [],
+        model: (config as any).model ?? "unknown",
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          cachedInputTokens: 0,
+          totalTokens: 2,
+        },
+        cost: { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" },
+      } as any,
+    };
+  }
+
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const r = await this.text(config);
+    if (r.success) yield { type: "text", text: r.value.output } as StreamChunk;
+  }
+
+  async embed(
+    _input: string | string[],
+    _config?: Partial<EmbedConfig>,
+  ): Promise<Result<EmbedResult>> {
+    throw new Error("not used");
+  }
+}
+
+function stdlibShapedSaveDraft(): AgencyFunction {
+  return new AgencyFunction({
+    name: "saveDraft",
+    module: "stdlib/index.agency",
+    fn: () => null,
+    params: [
+      {
+        name: "value",
+        hasDefault: false,
+        defaultValue: undefined,
+        variadic: false,
+      } as any,
+    ],
+    toolDefinition: {
+      name: "saveDraft",
+      description: "the def's own description",
+      schema: z.object({ value: z.any() }),
+    },
+  });
+}
+
+async function runSaveDraftPrompt(opts: {
+  draftSchema: unknown;
+  save: unknown;
+}) {
+  const ctx = makeCtx();
+  const client = new ScriptedClient(opts.save);
+  ctx.setLLMClient(client);
+  const statelogEvents: { kind: string; payload: any }[] = [];
+  const sc = ctx.statelogClient as any;
+  sc.toolCallStart = (payload: any) =>
+    statelogEvents.push({ kind: "toolCallStart", payload });
+  sc.toolCall = (payload: any) =>
+    statelogEvents.push({ kind: "toolCall", payload });
+  const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+  const thread = new MessageThread();
+  // The frame a real caller (a function/node/guard-block scope) would
+  // own. runPrompt pushes ITS OWN frame on top; setSavedDraft's
+  // callerFrame() write must land here — the frame-math the spec
+  // correction pinned.
+  const ownerFrame = ctx.stateStack.getNewState();
+  await inFrame(ctx, threads, () =>
+    runPrompt({
+      prompt: "go",
+      messages: thread,
+      clientConfig: { tools: [stdlibShapedSaveDraft()] } as any,
+      draftSchema: opts.draftSchema,
+    }),
+  );
+  return {
+    providerConfigs: client.configs,
+    messages: thread.getMessages() as any[],
+    statelogEvents,
+    ownerFrame,
+  };
+}
+
+function saveDraftDefIn(config: PromptConfig): any {
+  return (config as any).tools.find((t: any) => t.name === "saveDraft");
+}
+
+describe("saveDraft intrinsic — the observable surface", () => {
+  it("the provider-bound schema uses the threaded draftSchema, not the fallback", async () => {
+    const { providerConfigs } = await runSaveDraftPrompt({
+      draftSchema: z.number(),
+      save: 3,
+    });
+    const def = saveDraftDefIn(providerConfigs[0]);
+    expect(def).toBeDefined();
+    // The value slot must be the THREADED schema: a number passes, a
+    // string fails. With the fallback this assertion inverts — which
+    // is exactly the silent failure this test exists to catch.
+    expect(def.schema.shape.value.safeParse(3).success).toBe(true);
+    expect(def.schema.shape.value.safeParse("x").success).toBe(false);
+  });
+
+  it("a structured draftSchema reaches the provider too (object, not just primitive)", async () => {
+    const reportSchema = z.object({ title: z.string() });
+    const { providerConfigs } = await runSaveDraftPrompt({
+      draftSchema: reportSchema,
+      save: { title: "t" },
+    });
+    const def = saveDraftDefIn(providerConfigs[0]);
+    expect(def.schema.shape.value.safeParse({ title: "t" }).success).toBe(true);
+    expect(def.schema.shape.value.safeParse("flat string").success).toBe(false);
+  });
+
+  it("without draftSchema the provider-bound value schema is the string fallback", async () => {
+    const { providerConfigs } = await runSaveDraftPrompt({
+      draftSchema: undefined,
+      save: "x",
+    });
+    const def = saveDraftDefIn(providerConfigs[0]);
+    expect(def.schema.shape.value.safeParse("x").success).toBe(true);
+    expect(def.schema.shape.value.safeParse(3).success).toBe(false);
+    // The synthesized definition replaced the def's own.
+    expect(def.description).toMatch(/best-so-far/);
+  });
+
+  it("the draft files on the CALLER's frame (the owner scope, not runPrompt's own)", async () => {
+    const { ownerFrame } = await runSaveDraftPrompt({
+      draftSchema: undefined,
+      save: "hello",
+    });
+    expect(ownerFrame.savedDraft).toEqual({ value: "hello" });
+  });
+
+  it("the model receives the ack as a paired tool message", async () => {
+    const { messages } = await runSaveDraftPrompt({
+      draftSchema: undefined,
+      save: "hello",
+    });
+    const toolMsg = messages.find((m: any) => m.role === "tool");
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg.content).toBe("Draft saved (5 characters).");
+    // Pairing: the result must carry the SAME id the tool call was
+    // issued with, or real providers reject the round.
+    expect(toolMsg.tool_call_id).toBe("mock-tool-0");
+  });
+
+  it("the trace receives toolCallStart and toolCall events for the intrinsic", async () => {
+    const { statelogEvents } = await runSaveDraftPrompt({
+      draftSchema: undefined,
+      save: "hello",
+    });
+    const start = statelogEvents.find((e) => e.kind === "toolCallStart");
+    const end = statelogEvents.find((e) => e.kind === "toolCall");
+    expect(start?.payload.toolName).toBe("saveDraft");
+    expect(start?.payload.args).toEqual({ value: "hello" });
+    expect(end?.payload.output).toBe("Draft saved (5 characters).");
+  });
+});

--- a/packages/agency-lang/lib/runtime/intrinsicTools.ts
+++ b/packages/agency-lang/lib/runtime/intrinsicTools.ts
@@ -34,7 +34,13 @@ export type IntrinsicTool = {
   matches: (fn: AgencyFunction) => boolean;
   /** The provider-facing definition, replacing the def's own. */
   buildDefinition: (ctx: { draftSchema: unknown }) => ToolDefinition;
-  /** Handle one call; the return value is the tool-result text. */
+  /** Handle one call; the return value is the tool-result text.
+   *  Contract note: EVERY call must produce a tool-result message
+   *  (providers reject a tool_use with no result), and for now that
+   *  result is plain text — every intrinsic is a state write plus an
+   *  acknowledgment. If a future intrinsic needs a richer result
+   *  (attachments, structured content), widen this return type then;
+   *  the loop's plumbing is the only consumer. */
   handle: (call: IntrinsicCall) => string;
 };
 
@@ -95,6 +101,11 @@ export async function runIntrinsicCall(opts: {
 }): Promise<void> {
   const { intrinsic, toolCall, stateStack, draftSchema, statelogClient } = opts;
   const callArgs = toolCall.arguments ?? {};
+  // DELIBERATE divergence from the dispatched-tool branch, which opens
+  // with a ctx.isCancelled throw: an intrinsic in a cancelled round
+  // still runs. Saving on the way down is salvage-friendly (the draft
+  // is the value a rejected trip returns), and answering the call
+  // avoids a dangling tool_use. Do not add the cancel check here.
   const toolSpanId = statelogClient.startSpan("toolExecution");
   try {
     statelogClient.toolCallStart({

--- a/packages/agency-lang/lib/runtime/intrinsicTools.ts
+++ b/packages/agency-lang/lib/runtime/intrinsicTools.ts
@@ -1,5 +1,10 @@
+import * as smoltalk from "smoltalk";
 import type { AgencyFunction, ToolDefinition } from "./agencyFunction.js";
 import type { StateStack } from "./state/stateStack.js";
+import type { MessageThread } from "./state/messageThread.js";
+import { __threads } from "./asyncContext.js";
+import type { StatelogClient } from "../statelogClient.js";
+import { invokeCallbacks } from "./hooks.js";
 import { saveDraftIntrinsic } from "./saveDraftTool.js";
 
 /** What one intrinsic call sees. Deliberately narrow: an intrinsic
@@ -37,4 +42,95 @@ const INTRINSIC_TOOLS: IntrinsicTool[] = [saveDraftIntrinsic];
 
 export function findIntrinsic(fn: AgencyFunction): IntrinsicTool | undefined {
   return INTRINSIC_TOOLS.find((t) => t.matches(fn));
+}
+
+/** One round's calls, split once, declaratively: intrinsic entries
+ *  (with their original call-list index, for stable step keys) and
+ *  everything else, which dispatches concurrently as always. The loop
+ *  never re-derives membership — these two lists are the answer. */
+export function partitionIntrinsicCalls<
+  T extends { id: string; name: string; arguments: Record<string, unknown> },
+>(
+  toolCalls: T[],
+  toolFunctions: AgencyFunction[],
+): {
+  intrinsicCalls: { toolCall: T; callIndex: number; intrinsic: IntrinsicTool }[];
+  dispatchCalls: T[];
+} {
+  const intrinsicOf = (toolCall: T) => {
+    const handler = toolFunctions.find((fn) => fn.name === toolCall.name);
+    return handler ? findIntrinsic(handler) : undefined;
+  };
+  const intrinsicCalls = toolCalls.flatMap((toolCall, callIndex) => {
+    const intrinsic = intrinsicOf(toolCall);
+    return intrinsic !== undefined ? [{ toolCall, callIndex, intrinsic }] : [];
+  });
+  const dispatchCalls = toolCalls.filter(
+    (toolCall) => intrinsicOf(toolCall) === undefined,
+  );
+  return { intrinsicCalls, dispatchCalls };
+}
+
+/**
+ * Run one intrinsic call: the handler plus every piece of generic
+ * bookkeeping a dispatched tool would get — the toolExecution span,
+ * the toolCallStart/toolCall statelog events, the onToolCallStart/End
+ * hooks, and the tool-result message push. The tool loop's ordered
+ * pass calls this inside a `pr.step` (resume idempotency stays with
+ * the loop). The lifecycle mirrors the real dispatch path's events
+ * inside one span so span-pairing consumers see intrinsic calls too;
+ * deliberate differences from that path: one step instead of
+ * per-phase branch steps (there is no branch), and timeTaken 0 (an
+ * inline state write has no meaningful duration).
+ */
+export async function runIntrinsicCall(opts: {
+  intrinsic: IntrinsicTool;
+  toolCall: { id: string; name: string; arguments: Record<string, unknown> };
+  stateStack: StateStack;
+  draftSchema: unknown;
+  statelogClient: StatelogClient;
+  ctx: unknown;
+  model: unknown;
+  messages: MessageThread;
+}): Promise<void> {
+  const { intrinsic, toolCall, stateStack, draftSchema, statelogClient } = opts;
+  const callArgs = toolCall.arguments ?? {};
+  const toolSpanId = statelogClient.startSpan("toolExecution");
+  try {
+    statelogClient.toolCallStart({
+      toolName: toolCall.name,
+      args: callArgs,
+      model: JSON.stringify(opts.model),
+      threadId: __threads()?.activeId() ?? null,
+    });
+    await invokeCallbacks({
+      ctx: opts.ctx as any,
+      name: "onToolCallStart",
+      data: { toolName: toolCall.name, args: callArgs },
+      stateStack,
+    });
+    const ack = intrinsic.handle({ toolCall, stateStack, draftSchema });
+    await invokeCallbacks({
+      ctx: opts.ctx as any,
+      name: "onToolCallEnd",
+      data: { toolName: toolCall.name, result: ack, timeTaken: 0 },
+      stateStack,
+    });
+    statelogClient.toolCall({
+      toolName: toolCall.name,
+      args: callArgs,
+      output: ack,
+      model: JSON.stringify(opts.model),
+      timeTaken: 0,
+      threadId: __threads()?.activeId() ?? null,
+    });
+    opts.messages.push(
+      smoltalk.toolMessage(ack, {
+        tool_call_id: toolCall.id,
+        name: toolCall.name,
+      }),
+    );
+  } finally {
+    statelogClient.endSpan(toolSpanId);
+  }
 }

--- a/packages/agency-lang/lib/runtime/intrinsicTools.ts
+++ b/packages/agency-lang/lib/runtime/intrinsicTools.ts
@@ -1,0 +1,40 @@
+import type { AgencyFunction, ToolDefinition } from "./agencyFunction.js";
+import type { StateStack } from "./state/stateStack.js";
+import { saveDraftIntrinsic } from "./saveDraftTool.js";
+
+/** What one intrinsic call sees. Deliberately narrow: an intrinsic
+ *  manipulates the RUN (frames, drafts), not the outside world, so it
+ *  gets the call, the stack, and the threaded schema — nothing else.
+ *  Widen this type only when a new intrinsic genuinely needs more. */
+export type IntrinsicCall = {
+  toolCall: { id: string; name: string; arguments: Record<string, unknown> };
+  stateStack: StateStack;
+  /** Zod schema threaded by the llm() codegen (saveDraft's value
+   *  type); undefined when the call site had none. */
+  draftSchema: unknown;
+};
+
+/** A tool the tool loop handles ITSELF, inline in the ordered pass,
+ *  instead of dispatching into the concurrent pool. The loop owns all
+ *  the generic bookkeeping — resume idempotency, statelog events,
+ *  callbacks, the tool-result message — so `handle` is just the
+ *  semantics and must be fast, synchronous, and interrupt-free.
+ *  The registry is CLOSED: intrinsics touch run state, which is
+ *  exactly what user tools must never do, so additions are code
+ *  changes here, not a user-facing extension point. */
+export type IntrinsicTool = {
+  /** Identity check against a tools-array entry (name+module pair,
+   *  never object identity — the prelude auto-import means modules
+   *  hold their own wrapper objects). */
+  matches: (fn: AgencyFunction) => boolean;
+  /** The provider-facing definition, replacing the def's own. */
+  buildDefinition: (ctx: { draftSchema: unknown }) => ToolDefinition;
+  /** Handle one call; the return value is the tool-result text. */
+  handle: (call: IntrinsicCall) => string;
+};
+
+const INTRINSIC_TOOLS: IntrinsicTool[] = [saveDraftIntrinsic];
+
+export function findIntrinsic(fn: AgencyFunction): IntrinsicTool | undefined {
+  return INTRINSIC_TOOLS.find((t) => t.matches(fn));
+}

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -30,6 +30,8 @@ import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
 // See docs/dev/promptRunner.md for the control-flow abstraction used here.
 import { PromptBailout, PromptRunner } from "./promptRunner.js";
+import { findIntrinsic } from "./intrinsicTools.js";
+import type { RunBatchResult } from "./runBatch.js";
 import { GuardTripRetry, raiseGuardTripsUntilClear } from "./guardTripInterrupt.js";
 import { failure, isFailure, isSuccess, markDestructiveWork } from "./result.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
@@ -850,6 +852,11 @@ export async function runPrompt(args: {
    *  by-reference trick `removedTools` uses. Absent for direct TS callers
    *  (e.g. `agency.llm`), so the mark is a no-op there. */
   destructiveSink?: { __destructiveRan?: boolean };
+  /** Zod schema for the saveDraft tool's `value` param, threaded by the
+   *  llm() codegen from the enclosing def's declared return type.
+   *  Consulted only when the tools array contains the stdlib saveDraft
+   *  (see intrinsicTools.ts). */
+  draftSchema?: unknown;
   checkpointInfo?: SourceLocationOpts;
 }): Promise<any> {
   const {
@@ -912,9 +919,17 @@ export async function runPrompt(args: {
   for (const fn of exposedFunctions) {
     fn.validateForLLM();
   }
+  // An intrinsic tool (currently only the stdlib saveDraft) gets a
+  // SYNTHESIZED definition — its value schema comes from the schema
+  // the llm() codegen threaded from the enclosing def's declared
+  // return type, not from the def's own signature.
   let tools = exposedFunctions
     .filter((fn) => fn.toolDefinition)
-    .map((fn) => fn.toolDefinition!);
+    .map(
+      (fn) =>
+        findIntrinsic(fn)?.buildDefinition({ draftSchema: args.draftSchema }) ??
+        fn.toolDefinition!,
+    );
   // Pre-flight: reject duplicate tool names before they reach the provider,
   // where they surface as an opaque 400 with no request payload in the
   // statelog. See assertUniqueToolNames.
@@ -1506,6 +1521,100 @@ export async function runPrompt(args: {
         // `round` value, so completedSteps keys match.
         const round = self.toolCallRound;
 
+        // Partition the round: intrinsic calls (handled inline, in
+        // order) vs. everything else (dispatched concurrently as
+        // today). One partition, computed up front — the rest of the
+        // iteration reads these two lists and never re-derives them.
+        const intrinsicOf = (toolCall: smoltalk.ToolCallJSON) => {
+          const handler = toolFunctions.find((fn) => fn.name === toolCall.name);
+          return handler ? findIntrinsic(handler) : undefined;
+        };
+        const intrinsicCalls = toolCalls
+          .map((toolCall, callIndex) => ({
+            toolCall,
+            callIndex,
+            intrinsic: intrinsicOf(toolCall),
+          }))
+          .filter((entry) => entry.intrinsic !== undefined);
+        const dispatchCalls = toolCalls.filter(
+          (toolCall) => intrinsicOf(toolCall) === undefined,
+        );
+
+        // Ordered interception (partials-ergonomics spec Part 2):
+        // intrinsic calls are handled inline at their position in the
+        // call list, so two saves in one round apply in call-list
+        // order BY CONSTRUCTION — the writes happen here, in list
+        // order, not in scheduler-completion order. (`for...of`, not
+        // `forEach`: async forEach callbacks are not awaited in order.)
+        // The draft files on the scope that owns this llm() call: the
+        // stack is [..., owner, runPrompt] (setupFunction pushed our
+        // frame), so setSavedDraft's callerFrame() write lands on the
+        // owner — the same frame shape as the stdlib saveDraft def
+        // path. Intrinsics deliberately ignore maxToolCallRounds (a
+        // draft write is free and salvage is the point) and
+        // removedTools (an intrinsic cannot error onto that list).
+        // The ack pushes to the LIVE thread; pr.step does not snapshot
+        // messages on normal completion, and does not need to — the
+        // next interrupt-path checkpoint's snapshotMessages() reads
+        // the live thread the ack is already in. Do NOT add a
+        // redundant snapshot here. (A lost ack would surface as a
+        // dangling tool_use, which real providers reject.)
+        for (const { toolCall, callIndex, intrinsic } of intrinsicCalls) {
+          const callSlug = `${callIndex}_${toolCall.id}`;
+          await pr.step(`round.${round}.tool.${callSlug}.intrinsic`, async () => {
+            const callArgs = toolCall.arguments ?? {};
+            // The lifecycle mirrors the real dispatch path's events
+            // (toolCallStart → hooks → toolCall) inside one
+            // toolExecution span, so span-pairing consumers see
+            // intrinsic calls too. Deliberate differences from the
+            // real path: one pr.step instead of per-phase branch steps
+            // (there is no branch), and timeTaken 0 (an inline state
+            // write has no meaningful duration).
+            const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
+            try {
+              ctx.statelogClient.toolCallStart({
+                toolName: toolCall.name,
+                args: callArgs,
+                model: JSON.stringify(clientConfig.model),
+                threadId: __threads()?.activeId() ?? null,
+              });
+              await invokeCallbacks({
+                ctx,
+                name: "onToolCallStart",
+                data: { toolName: toolCall.name, args: callArgs },
+                stateStack,
+              });
+              const ack = intrinsic!.handle({
+                toolCall,
+                stateStack,
+                draftSchema: args.draftSchema,
+              });
+              await invokeCallbacks({
+                ctx,
+                name: "onToolCallEnd",
+                data: { toolName: toolCall.name, result: ack, timeTaken: 0 },
+                stateStack,
+              });
+              ctx.statelogClient.toolCall({
+                toolName: toolCall.name,
+                args: callArgs,
+                output: ack,
+                model: JSON.stringify(clientConfig.model),
+                timeTaken: 0,
+                threadId: __threads()?.activeId() ?? null,
+              });
+              messages.push(
+                smoltalk.toolMessage(ack, {
+                  tool_call_id: toolCall.id,
+                  name: toolCall.name,
+                }),
+              );
+            } finally {
+              ctx.statelogClient.endSpan(toolSpanId);
+            }
+          });
+        }
+
         // Tool calls in one round run concurrently via pr.parallel. Each
         // tool gets its own BranchRunner. If any branch's `step` returns
         // interrupts, sibling branches still run to completion; pr.parallel
@@ -1516,9 +1625,15 @@ export async function runPrompt(args: {
         // semantics across branches (strategy B in the plan): same-round
         // removal is best-effort and removals always take effect from the
         // NEXT round (the .filter() after this parallel call).
-        const parallelResult = await pr.parallel(
+        // An all-intrinsic round has nothing to dispatch: short-circuit
+        // to an empty values result instead of running runBatch over
+        // zero children.
+        const parallelResult: RunBatchResult<void> =
+          dispatchCalls.length === 0
+            ? { kind: "values", values: [] }
+            : await pr.parallel(
           `round.${round}.tools`,
-          toolCalls,
+          dispatchCalls,
           // keyFor: MUST match the branchKey the body uses below
           // (`stack.getOrCreateBranch(branchKey)`) so runBatch and the body
           // operate on the same branch. Keyed by the tool call's POSITION in

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1570,240 +1570,240 @@ export async function runPrompt(args: {
         // semantics across branches (strategy B in the plan): same-round
         // removal is best-effort and removals always take effect from the
         // NEXT round (the .filter() after this parallel call).
-        // An all-intrinsic round has nothing to dispatch: short-circuit
-        // to an empty values result instead of running runBatch over
-        // zero children.
-        const parallelResult: RunBatchResult<void> =
-          dispatchCalls.length === 0
-            ? { kind: "values", values: [] }
-            : await pr.parallel(
-          `round.${round}.tools`,
-          dispatchCalls,
-          // keyFor: MUST match the branchKey the body uses below
-          // (`stack.getOrCreateBranch(branchKey)`) so runBatch and the body
-          // operate on the same branch. Keyed by the tool call's POSITION in
-          // the round, not its id: some providers (notably Google Gemini)
-          // return tool calls with no id — Gemini matches responses to calls
-          // by function name + position, so smoltalk defaults the missing id
-          // to "". Two id-less parallel calls would otherwise collide on the
-          // branch key ("tool_") and trip `runBatch: duplicate child key`.
-          // The id is folded in after the index only for readability; the
-          // index alone guarantees uniqueness within the round.
-          (toolCall, i) => `tool_${i}_${toolCall.id}`,
-          async (toolCall, b, index) => {
-            if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
+        // An all-intrinsic round has nothing to dispatch: keep the
+        // empty values result instead of running runBatch over zero
+        // children.
+        let parallelResult: RunBatchResult<void> = { kind: "values", values: [] };
+        if (dispatchCalls.length > 0) {
+          parallelResult = await pr.parallel(
+            `round.${round}.tools`,
+            dispatchCalls,
+            // keyFor: MUST match the branchKey the body uses below
+            // (`stack.getOrCreateBranch(branchKey)`) so runBatch and the body
+            // operate on the same branch. Keyed by the tool call's POSITION in
+            // the round, not its id: some providers (notably Google Gemini)
+            // return tool calls with no id — Gemini matches responses to calls
+            // by function name + position, so smoltalk defaults the missing id
+            // to "". Two id-less parallel calls would otherwise collide on the
+            // branch key ("tool_") and trip `runBatch: duplicate child key`.
+            // The id is folded in after the index only for readability; the
+            // index alone guarantees uniqueness within the round.
+            (toolCall, i) => `tool_${i}_${toolCall.id}`,
+            async (toolCall, b, index) => {
+              if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
 
-            // Per-call slug used for the branch key, every resume-idempotency
-            // step path, and the per-tool timing key below. Position-based so
-            // it stays unique even when `toolCall.id` is "" (see keyFor). Must
-            // NOT leak into message `tool_call_id` fields — those keep the
-            // real (possibly empty) id so provider pairing / threadRepair are
-            // byte-for-byte unchanged.
-            const callSlug = `${index}_${toolCall.id}`;
+              // Per-call slug used for the branch key, every resume-idempotency
+              // step path, and the per-tool timing key below. Position-based so
+              // it stays unique even when `toolCall.id` is "" (see keyFor). Must
+              // NOT leak into message `tool_call_id` fields — those keep the
+              // real (possibly empty) id so provider pairing / threadRepair are
+              // byte-for-byte unchanged.
+              const callSlug = `${index}_${toolCall.id}`;
 
-            const handler = toolFunctions.find(
-              (fn) => fn.name === toolCall.name,
-            );
-            if (!handler) {
-              await b.step(
-                `round.${round}.tool.${callSlug}.unhandled`,
-                async () => {
-                  console.error(
-                    `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
-                  );
-                  messages.push(
-                    smoltalk.toolMessage(
-                      `Error: No handler found for tool call ${toolCall.name}`,
-                      { tool_call_id: toolCall.id, name: toolCall.name },
-                    ),
-                  );
-                },
+              const handler = toolFunctions.find(
+                (fn) => fn.name === toolCall.name,
               );
-              return;
-            }
-
-            if (self.toolCallRound >= effectiveMaxToolCallRounds) {
-              await b.step(
-                `round.${round}.tool.${callSlug}.tooManyRounds`,
-                async () => {
-                  messages.push(
-                    smoltalk.toolMessage(
-                      `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
-                      { tool_call_id: toolCall.id, name: toolCall.name },
-                    ),
-                  );
-                },
-              );
-              return;
-            }
-
-
-            // Gated start (strategy B): if the tool is already in
-            // removedTools (either from a prior round or from an earlier
-            // sibling in this round that pushed first), skip with a
-            // notice toolMessage.
-            if (removedTools.includes(handler.name)) {
-              await b.step(
-                `round.${round}.tool.${callSlug}.removed`,
-                async () => {
-                  messages.push(
-                    smoltalk.toolMessage(
-                      `Error: Handler for tool call ${handler.name} has been removed already due to previous errors, and will not be executed.`,
-                      { tool_call_id: toolCall.id, name: toolCall.name },
-                    ),
-                  );
-                },
-              );
-              return;
-            }
-
-            const branchKey = `tool_${callSlug}`;
-            // Note: a "cached result" short-circuit used to live here for
-            // resume after a sibling interrupt; idempotency is now handled
-            // uniformly by completedSteps inside b.step (start/invoke/end
-            // each get marked done on success and skipped on resume).
-            const branchStack = stack.getOrCreateBranch(branchKey).stack;
-            const namedArgs = dropNullDefaultedArgs(
-              toolCall.arguments,
-              handler.params,
-            );
-
-            await b.step(
-              `round.${round}.tool.${callSlug}.start`,
-              async () => {
-                // Pass `branchStack` so scoped callbacks registered inside
-                // the branch's frame chain are discovered by
-                // `gatherCallbacks`. Callback bodies cannot interrupt
-                // (typechecker-enforced), so this is purely about scope
-                // discovery, not interrupt routing.
-                await invokeCallbacks({
-                  ctx,
-                  name: "onToolCallStart",
-                  data: { toolName: handler.name, args: namedArgs },
-                  stateStack: branchStack,
-                });
-              },
-            );
-            if (b.interrupts) return;
-
-            const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
-            let toolResult: any;
-            let invokeOutcome:
-              | "success"
-              | "failed"
-              | "rejected"
-              | "interrupted"
-              | "crashed" = "success";
-
-            // Persist the measured tool execution duration in
-            // self.runnerState so resume (where the invoke step is
-            // skipped) doesn't report ~0ms to onToolCallEnd /
-            // statelogClient.toolCall. Keyed per tool call id; rides
-            // along with completedSteps on the same frame.
-            self.runnerState.toolTimings ??= {};
-            // IMPORTANT: keep the toolExecution span open across the
-            // invoke + end-hook + log steps so the toolCall event inherits
-            // the toolExecution span_id (logsViewer aggregates tool
-            // duration off that). try/finally guarantees we close it even
-            // on bailout / unexpected throw.
-            try {
-              const toolCallStartTime = performance.now();
-              // Emit toolCallStart inside the same toolExecution span as
-              // the (later) toolCall end event so consumers can pair the
-              // two by span_id. Wrap in b.step so resume-replay doesn't
-              // duplicate the event. Designed to leave a trace of every
-              // tool that began even when the run is killed before it
-              // completes (the matching toolCall event won't fire).
-              await b.step(
-                `round.${round}.tool.${callSlug}.logStart`,
-                async () => {
-                  ctx.statelogClient.toolCallStart({
-                    toolName: handler.name,
-                    args: namedArgs,
-                    model: JSON.stringify(clientConfig.model),
-                    threadId: __threads()?.activeId() ?? null,
-                  });
-                },
-              );
-              // Invoke step: returns the interrupts when the tool halts
-              // with them so BranchRunner.step can collect. All other
-              // outcomes (success, failure, reject, crash) update outer
-              // state in place via runInvokeStep; the step completes
-              // (returns void unless interrupted) and is marked done so
-              // resume skips this whole block.
-              await b.step(
-                `round.${round}.tool.${callSlug}.invoke`,
-                async () => {
-                  const outcome = await runInvokeStep({
-                    handler,
-                    toolCall,
-                    namedArgs,
-                    branchKey,
-                    branchStack,
-                  });
-                  toolResult = outcome.toolResult;
-                  invokeOutcome = outcome.invokeOutcome;
-                  if (outcome.invokeOutcome === "success") {
-                    self.runnerState.toolTimings[callSlug] =
-                      performance.now() - toolCallStartTime;
-                  }
-                  return outcome.interrupts;
-                },
-              );
-
-              if (b.interrupts || invokeOutcome !== "success") return;
-
-              // On resume after an end-hook bailout, the `invoke` step is
-              // skipped and `toolResult` is undefined. Restore it from the
-              // per-branch result that `setResultOnBranch` persisted before
-              // the bailout, so the end-hook sees the actual tool output.
-              if (toolResult === undefined) {
-                toolResult = stack.getBranch(branchKey)?.result?.result;
+              if (!handler) {
+                await b.step(
+                  `round.${round}.tool.${callSlug}.unhandled`,
+                  async () => {
+                    console.error(
+                      `No handler found for tool call: ${toolCall.name}. This error will be sent back to the LLM.`,
+                    );
+                    messages.push(
+                      smoltalk.toolMessage(
+                        `Error: No handler found for tool call ${toolCall.name}`,
+                        { tool_call_id: toolCall.id, name: toolCall.name },
+                      ),
+                    );
+                  },
+                );
+                return;
               }
 
-              // Reuse the persisted duration so onToolCallEnd /
-              // statelogClient.toolCall always report the real exec time,
-              // not the resume pass's overhead.
-              const timeTaken: number =
-                self.runnerState.toolTimings[callSlug] ?? 0;
+              if (self.toolCallRound >= effectiveMaxToolCallRounds) {
+                await b.step(
+                  `round.${round}.tool.${callSlug}.tooManyRounds`,
+                  async () => {
+                    messages.push(
+                      smoltalk.toolMessage(
+                        `Error: Maximum number of tool call rounds (${effectiveMaxToolCallRounds}) exceeded. This tool call will not be executed.`,
+                        { tool_call_id: toolCall.id, name: toolCall.name },
+                      ),
+                    );
+                  },
+                );
+                return;
+              }
+
+
+              // Gated start (strategy B): if the tool is already in
+              // removedTools (either from a prior round or from an earlier
+              // sibling in this round that pushed first), skip with a
+              // notice toolMessage.
+              if (removedTools.includes(handler.name)) {
+                await b.step(
+                  `round.${round}.tool.${callSlug}.removed`,
+                  async () => {
+                    messages.push(
+                      smoltalk.toolMessage(
+                        `Error: Handler for tool call ${handler.name} has been removed already due to previous errors, and will not be executed.`,
+                        { tool_call_id: toolCall.id, name: toolCall.name },
+                      ),
+                    );
+                  },
+                );
+                return;
+              }
+
+              const branchKey = `tool_${callSlug}`;
+              // Note: a "cached result" short-circuit used to live here for
+              // resume after a sibling interrupt; idempotency is now handled
+              // uniformly by completedSteps inside b.step (start/invoke/end
+              // each get marked done on success and skipped on resume).
+              const branchStack = stack.getOrCreateBranch(branchKey).stack;
+              const namedArgs = dropNullDefaultedArgs(
+                toolCall.arguments,
+                handler.params,
+              );
+
               await b.step(
-                `round.${round}.tool.${callSlug}.end`,
+                `round.${round}.tool.${callSlug}.start`,
                 async () => {
-                  // Same scope-discovery rationale as the .start hook.
+                  // Pass `branchStack` so scoped callbacks registered inside
+                  // the branch's frame chain are discovered by
+                  // `gatherCallbacks`. Callback bodies cannot interrupt
+                  // (typechecker-enforced), so this is purely about scope
+                  // discovery, not interrupt routing.
                   await invokeCallbacks({
                     ctx,
-                    name: "onToolCallEnd",
-                    data: {
-                      toolName: handler.name,
-                      result: toolResult,
-                      timeTaken,
-                    },
+                    name: "onToolCallStart",
+                    data: { toolName: handler.name, args: namedArgs },
                     stateStack: branchStack,
                   });
                 },
               );
-              // Wrap the toolCall log in its own b.step so it's idempotent
-              // when pr.parallel re-runs a fully-completed branch on resume
-              // (e.g. after a later `nextLlmCall` step bails). Without this
-              // guard, every re-entry would emit a duplicate toolCall event.
-              await b.step(
-                `round.${round}.tool.${callSlug}.log`,
-                async () => {
-                  ctx.statelogClient.toolCall({
-                    toolName: handler.name,
-                    args: namedArgs,
-                    output: toolResult,
-                    model: JSON.stringify(clientConfig.model),
-                    timeTaken,
-                    threadId: __threads()?.activeId() ?? null,
-                  });
-                },
-              );
-            } finally {
-              ctx.statelogClient.endSpan(toolSpanId);
-            }
-          },
-        );
+              if (b.interrupts) return;
+
+              const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
+              let toolResult: any;
+              let invokeOutcome:
+                | "success"
+                | "failed"
+                | "rejected"
+                | "interrupted"
+                | "crashed" = "success";
+
+              // Persist the measured tool execution duration in
+              // self.runnerState so resume (where the invoke step is
+              // skipped) doesn't report ~0ms to onToolCallEnd /
+              // statelogClient.toolCall. Keyed per tool call id; rides
+              // along with completedSteps on the same frame.
+              self.runnerState.toolTimings ??= {};
+              // IMPORTANT: keep the toolExecution span open across the
+              // invoke + end-hook + log steps so the toolCall event inherits
+              // the toolExecution span_id (logsViewer aggregates tool
+              // duration off that). try/finally guarantees we close it even
+              // on bailout / unexpected throw.
+              try {
+                const toolCallStartTime = performance.now();
+                // Emit toolCallStart inside the same toolExecution span as
+                // the (later) toolCall end event so consumers can pair the
+                // two by span_id. Wrap in b.step so resume-replay doesn't
+                // duplicate the event. Designed to leave a trace of every
+                // tool that began even when the run is killed before it
+                // completes (the matching toolCall event won't fire).
+                await b.step(
+                  `round.${round}.tool.${callSlug}.logStart`,
+                  async () => {
+                    ctx.statelogClient.toolCallStart({
+                      toolName: handler.name,
+                      args: namedArgs,
+                      model: JSON.stringify(clientConfig.model),
+                      threadId: __threads()?.activeId() ?? null,
+                    });
+                  },
+                );
+                // Invoke step: returns the interrupts when the tool halts
+                // with them so BranchRunner.step can collect. All other
+                // outcomes (success, failure, reject, crash) update outer
+                // state in place via runInvokeStep; the step completes
+                // (returns void unless interrupted) and is marked done so
+                // resume skips this whole block.
+                await b.step(
+                  `round.${round}.tool.${callSlug}.invoke`,
+                  async () => {
+                    const outcome = await runInvokeStep({
+                      handler,
+                      toolCall,
+                      namedArgs,
+                      branchKey,
+                      branchStack,
+                    });
+                    toolResult = outcome.toolResult;
+                    invokeOutcome = outcome.invokeOutcome;
+                    if (outcome.invokeOutcome === "success") {
+                      self.runnerState.toolTimings[callSlug] =
+                        performance.now() - toolCallStartTime;
+                    }
+                    return outcome.interrupts;
+                  },
+                );
+
+                if (b.interrupts || invokeOutcome !== "success") return;
+
+                // On resume after an end-hook bailout, the `invoke` step is
+                // skipped and `toolResult` is undefined. Restore it from the
+                // per-branch result that `setResultOnBranch` persisted before
+                // the bailout, so the end-hook sees the actual tool output.
+                if (toolResult === undefined) {
+                  toolResult = stack.getBranch(branchKey)?.result?.result;
+                }
+
+                // Reuse the persisted duration so onToolCallEnd /
+                // statelogClient.toolCall always report the real exec time,
+                // not the resume pass's overhead.
+                const timeTaken: number =
+                  self.runnerState.toolTimings[callSlug] ?? 0;
+                await b.step(
+                  `round.${round}.tool.${callSlug}.end`,
+                  async () => {
+                    // Same scope-discovery rationale as the .start hook.
+                    await invokeCallbacks({
+                      ctx,
+                      name: "onToolCallEnd",
+                      data: {
+                        toolName: handler.name,
+                        result: toolResult,
+                        timeTaken,
+                      },
+                      stateStack: branchStack,
+                    });
+                  },
+                );
+                // Wrap the toolCall log in its own b.step so it's idempotent
+                // when pr.parallel re-runs a fully-completed branch on resume
+                // (e.g. after a later `nextLlmCall` step bails). Without this
+                // guard, every re-entry would emit a duplicate toolCall event.
+                await b.step(
+                  `round.${round}.tool.${callSlug}.log`,
+                  async () => {
+                    ctx.statelogClient.toolCall({
+                      toolName: handler.name,
+                      args: namedArgs,
+                      output: toolResult,
+                      model: JSON.stringify(clientConfig.model),
+                      timeTaken,
+                      threadId: __threads()?.activeId() ?? null,
+                    });
+                  },
+                );
+              } finally {
+                ctx.statelogClient.endSpan(toolSpanId);
+              }
+            },
+          );
+        }
 
         // pr.parallel returns a RunBatchResult tagged union; if any tool
         // branch surfaced interrupts, runBatch already stamped the shared

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -30,7 +30,11 @@ import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
 // See docs/dev/promptRunner.md for the control-flow abstraction used here.
 import { PromptBailout, PromptRunner } from "./promptRunner.js";
-import { findIntrinsic } from "./intrinsicTools.js";
+import {
+  findIntrinsic,
+  partitionIntrinsicCalls,
+  runIntrinsicCall,
+} from "./intrinsicTools.js";
 import type { RunBatchResult } from "./runBatch.js";
 import { GuardTripRetry, raiseGuardTripsUntilClear } from "./guardTripInterrupt.js";
 import { failure, isFailure, isSuccess, markDestructiveWork } from "./result.js";
@@ -1521,98 +1525,39 @@ export async function runPrompt(args: {
         // `round` value, so completedSteps keys match.
         const round = self.toolCallRound;
 
-        // Partition the round: intrinsic calls (handled inline, in
-        // order) vs. everything else (dispatched concurrently as
-        // today). One partition, computed up front — the rest of the
-        // iteration reads these two lists and never re-derives them.
-        const intrinsicOf = (toolCall: smoltalk.ToolCallJSON) => {
-          const handler = toolFunctions.find((fn) => fn.name === toolCall.name);
-          return handler ? findIntrinsic(handler) : undefined;
-        };
-        const intrinsicCalls = toolCalls
-          .map((toolCall, callIndex) => ({
-            toolCall,
-            callIndex,
-            intrinsic: intrinsicOf(toolCall),
-          }))
-          .filter((entry) => entry.intrinsic !== undefined);
-        const dispatchCalls = toolCalls.filter(
-          (toolCall) => intrinsicOf(toolCall) === undefined,
+        // Partition the round once: intrinsic calls handle inline (in
+        // order, below); everything else dispatches concurrently.
+        const { intrinsicCalls, dispatchCalls } = partitionIntrinsicCalls(
+          toolCalls,
+          toolFunctions,
         );
 
         // Ordered interception (partials-ergonomics spec Part 2):
-        // intrinsic calls are handled inline at their position in the
-        // call list, so two saves in one round apply in call-list
-        // order BY CONSTRUCTION — the writes happen here, in list
-        // order, not in scheduler-completion order. (`for...of`, not
-        // `forEach`: async forEach callbacks are not awaited in order.)
-        // The draft files on the scope that owns this llm() call: the
-        // stack is [..., owner, runPrompt] (setupFunction pushed our
-        // frame), so setSavedDraft's callerFrame() write lands on the
-        // owner — the same frame shape as the stdlib saveDraft def
-        // path. Intrinsics deliberately ignore maxToolCallRounds (a
-        // draft write is free and salvage is the point) and
-        // removedTools (an intrinsic cannot error onto that list).
-        // The ack pushes to the LIVE thread; pr.step does not snapshot
-        // messages on normal completion, and does not need to — the
-        // next interrupt-path checkpoint's snapshotMessages() reads
-        // the live thread the ack is already in. Do NOT add a
-        // redundant snapshot here. (A lost ack would surface as a
+        // intrinsic calls run inline at their call-list position, so
+        // two saves in one round apply in list order BY CONSTRUCTION
+        // (`for...of`, not `forEach` — async forEach callbacks are not
+        // awaited in order). The stack here is [..., owner, runPrompt]
+        // (setupFunction pushed our frame), so setSavedDraft's
+        // callerFrame() write lands on the owner, same as the def
+        // path. Intrinsics deliberately ignore maxToolCallRounds and
+        // removedTools. The ack rides the LIVE thread; the next
+        // interrupt-path checkpoint's snapshotMessages() captures it —
+        // do NOT add a redundant snapshot here. (A lost ack would be a
         // dangling tool_use, which real providers reject.)
         for (const { toolCall, callIndex, intrinsic } of intrinsicCalls) {
           const callSlug = `${callIndex}_${toolCall.id}`;
-          await pr.step(`round.${round}.tool.${callSlug}.intrinsic`, async () => {
-            const callArgs = toolCall.arguments ?? {};
-            // The lifecycle mirrors the real dispatch path's events
-            // (toolCallStart → hooks → toolCall) inside one
-            // toolExecution span, so span-pairing consumers see
-            // intrinsic calls too. Deliberate differences from the
-            // real path: one pr.step instead of per-phase branch steps
-            // (there is no branch), and timeTaken 0 (an inline state
-            // write has no meaningful duration).
-            const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
-            try {
-              ctx.statelogClient.toolCallStart({
-                toolName: toolCall.name,
-                args: callArgs,
-                model: JSON.stringify(clientConfig.model),
-                threadId: __threads()?.activeId() ?? null,
-              });
-              await invokeCallbacks({
-                ctx,
-                name: "onToolCallStart",
-                data: { toolName: toolCall.name, args: callArgs },
-                stateStack,
-              });
-              const ack = intrinsic!.handle({
-                toolCall,
-                stateStack,
-                draftSchema: args.draftSchema,
-              });
-              await invokeCallbacks({
-                ctx,
-                name: "onToolCallEnd",
-                data: { toolName: toolCall.name, result: ack, timeTaken: 0 },
-                stateStack,
-              });
-              ctx.statelogClient.toolCall({
-                toolName: toolCall.name,
-                args: callArgs,
-                output: ack,
-                model: JSON.stringify(clientConfig.model),
-                timeTaken: 0,
-                threadId: __threads()?.activeId() ?? null,
-              });
-              messages.push(
-                smoltalk.toolMessage(ack, {
-                  tool_call_id: toolCall.id,
-                  name: toolCall.name,
-                }),
-              );
-            } finally {
-              ctx.statelogClient.endSpan(toolSpanId);
-            }
-          });
+          await pr.step(`round.${round}.tool.${callSlug}.intrinsic`, () =>
+            runIntrinsicCall({
+              intrinsic,
+              toolCall,
+              stateStack,
+              draftSchema: args.draftSchema,
+              statelogClient: ctx.statelogClient,
+              ctx,
+              model: clientConfig.model,
+              messages,
+            }),
+          );
         }
 
         // Tool calls in one round run concurrently via pr.parallel. Each

--- a/packages/agency-lang/lib/runtime/saveDraftTool.test.ts
+++ b/packages/agency-lang/lib/runtime/saveDraftTool.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { AgencyFunction } from "./agencyFunction.js";
+import { findIntrinsic } from "./intrinsicTools.js";
+import { saveDraftIntrinsic, draftCharCount } from "./saveDraftTool.js";
+
+function fakeFn(name: string, module: string): AgencyFunction {
+  return new AgencyFunction({
+    name,
+    module,
+    fn: () => null,
+    params: [
+      {
+        name: "value",
+        hasDefault: false,
+        defaultValue: undefined,
+        variadic: false,
+      } as any,
+    ],
+    toolDefinition: { name, description: "d", schema: z.object({}) },
+  });
+}
+
+/** A stack stub that records draft writes — handle() only ever calls
+ *  setSavedDraft, and the real frame math is fixture-tested. */
+function stubStack() {
+  const saved: unknown[] = [];
+  return {
+    saved,
+    stack: { setSavedDraft: (v: unknown) => saved.push(v) } as any,
+  };
+}
+
+function call(args: Record<string, unknown> | undefined) {
+  return { id: "t1", name: "saveDraft", arguments: args as any };
+}
+
+describe("saveDraft intrinsic — recognition", () => {
+  it("the registry finds the stdlib pair (name + module)", () => {
+    expect(findIntrinsic(fakeFn("saveDraft", "stdlib/index.agency"))).toBe(
+      saveDraftIntrinsic,
+    );
+  });
+
+  it("a user function named saveDraft is NOT recognized", () => {
+    expect(findIntrinsic(fakeFn("saveDraft", "my/module.agency"))).toBeUndefined();
+  });
+
+  it("a stdlib function with another name is NOT recognized", () => {
+    expect(findIntrinsic(fakeFn("finalize", "stdlib/index.agency"))).toBeUndefined();
+  });
+});
+
+describe("saveDraft intrinsic — synthesized definition", () => {
+  it("declares exactly one required value param from the threaded schema", () => {
+    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: z.number() });
+    expect(def.name).toBe("saveDraft");
+    expect(def.description).toMatch(/best-so-far/);
+    const schema = def.schema as z.ZodObject<any>;
+    expect(Object.keys(schema.shape)).toEqual(["value"]);
+    expect(schema.shape.value.safeParse(3).success).toBe(true);
+    expect(schema.shape.value.safeParse("x").success).toBe(false);
+  });
+
+  it("falls back to string when no schema was threaded", () => {
+    const def = saveDraftIntrinsic.buildDefinition({ draftSchema: undefined });
+    const schema = def.schema as z.ZodObject<any>;
+    expect(schema.shape.value.safeParse("x").success).toBe(true);
+    expect(schema.shape.value.safeParse(3).success).toBe(false);
+  });
+});
+
+describe("saveDraft intrinsic — handle (validation semantics)", () => {
+  it("a matching value saves and acks with the char count", () => {
+    const { saved, stack } = stubStack();
+    const ack = saveDraftIntrinsic.handle({
+      toolCall: call({ value: "hello" }),
+      stateStack: stack,
+      draftSchema: z.string(),
+    });
+    expect(saved).toEqual(["hello"]);
+    expect(ack).toBe("Draft saved (5 characters).");
+  });
+
+  it("a missing value is an error and saves NOTHING", () => {
+    const { saved, stack } = stubStack();
+    const ack = saveDraftIntrinsic.handle({
+      toolCall: call({}),
+      stateStack: stack,
+      draftSchema: z.string(),
+    });
+    expect(saved).toEqual([]);
+    expect(ack).toMatch(/requires a "value" argument/);
+  });
+
+  it("a schema-mismatched value SAVES ANYWAY and acks with a helpful warning", () => {
+    // The schema is a best-effort hint keyed to the declared function
+    // type; the actual slot (a guard block) can legitimately differ.
+    // Refusing the save could throw away real work on a wrong hint, so
+    // the draft is kept and the warning teaches the model.
+    const { saved, stack } = stubStack();
+    const ack = saveDraftIntrinsic.handle({
+      toolCall: call({ value: 42 }),
+      stateStack: stack,
+      draftSchema: z.string(),
+    });
+    expect(saved).toEqual([42]);
+    expect(ack).toMatch(/^Draft saved \(\d+ characters\)\. Warning:/);
+    expect(ack).toMatch(/does not match/);
+  });
+});
+
+describe("draftCharCount", () => {
+  it("counts string drafts directly", () => {
+    expect(draftCharCount("hello")).toBe(5);
+  });
+  it("counts structured drafts by their JSON length", () => {
+    expect(draftCharCount({ a: 1 })).toBe(JSON.stringify({ a: 1 }).length);
+  });
+  it("returns 0 for undefined (JSON.stringify yields undefined there)", () => {
+    // Deliberately narrow (plan review M4): a CIRCULAR value would make
+    // JSON.stringify throw, uncaught — but tool args are JSON-origin,
+    // so circularity cannot occur; the name claims only what is tested.
+    expect(draftCharCount(undefined)).toBe(0);
+  });
+});

--- a/packages/agency-lang/lib/runtime/saveDraftTool.test.ts
+++ b/packages/agency-lang/lib/runtime/saveDraftTool.test.ts
@@ -118,9 +118,11 @@ describe("draftCharCount", () => {
     expect(draftCharCount({ a: 1 })).toBe(JSON.stringify({ a: 1 }).length);
   });
   it("returns 0 for undefined (JSON.stringify yields undefined there)", () => {
-    // Deliberately narrow (plan review M4): a CIRCULAR value would make
-    // JSON.stringify throw, uncaught — but tool args are JSON-origin,
-    // so circularity cannot occur; the name claims only what is tested.
     expect(draftCharCount(undefined)).toBe(0);
+  });
+  it("returns 0 instead of throwing on a circular value (exported-helper claim)", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(draftCharCount(circular)).toBe(0);
   });
 });

--- a/packages/agency-lang/lib/runtime/saveDraftTool.ts
+++ b/packages/agency-lang/lib/runtime/saveDraftTool.ts
@@ -7,17 +7,32 @@ import type { IntrinsicTool } from "./intrinsicTools.js";
  *  dependency cycle (partials-ergonomics spec Part 2). */
 const STDLIB_INDEX_MODULE = "stdlib/index.agency";
 
-/** The contract the type system cannot check, stated to the model. */
+/** What the model reads. Says WHEN to call (each time the answer
+ *  improves), the replacement semantics (last save wins), WHY it is
+ *  worth calling (early stop returns the draft, not a failure), and
+ *  the one mistake to head off: saving a note or a delta instead of
+ *  the complete answer. The value's SHAPE is communicated by the tool
+ *  schema, so the prose does not restate it. */
 const DESCRIPTION =
-  "Save your best-so-far answer as a draft. If the budget runs out, the " +
-  "last saved draft is returned instead of a failure. The value must " +
-  "match this function's return type.";
+  "Save your best-so-far answer as a draft. Call it again whenever " +
+  "your answer improves: each call replaces the previous draft, and " +
+  "the last one wins. If the run is stopped early by a cost or time " +
+  "budget, the last saved draft is returned instead of a failure, so " +
+  "save whenever you complete a meaningful piece of work. Always pass " +
+  "the complete answer as it stands, not a note or a diff.";
 
-/** Character count for the acknowledgment message. */
+/** Character count for the acknowledgment message. Never throws: the
+ *  value normally comes from model tool args (JSON, so circular refs
+ *  and BigInt are unreachable), but this is an exported helper, so it
+ *  honors the claim for arbitrary inputs too. */
 export function draftCharCount(value: unknown): number {
   if (typeof value === "string") return value.length;
-  const text = JSON.stringify(value);
-  return text === undefined ? 0 : text.length;
+  try {
+    const text = JSON.stringify(value);
+    return text === undefined ? 0 : text.length;
+  } catch {
+    return 0;
+  }
 }
 
 /** `saveDraft` passed as a tool. Aliases (`const s = saveDraft`) keep

--- a/packages/agency-lang/lib/runtime/saveDraftTool.ts
+++ b/packages/agency-lang/lib/runtime/saveDraftTool.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import type { IntrinsicTool } from "./intrinsicTools.js";
+
+/** The stdlib module id every compiled stdlib export carries. No user
+ *  module can carry it, so name+module is identity in practice — the
+ *  runtime cannot import the stdlib singleton directly without a
+ *  dependency cycle (partials-ergonomics spec Part 2). */
+const STDLIB_INDEX_MODULE = "stdlib/index.agency";
+
+/** The contract the type system cannot check, stated to the model. */
+const DESCRIPTION =
+  "Save your best-so-far answer as a draft. If the budget runs out, the " +
+  "last saved draft is returned instead of a failure. The value must " +
+  "match this function's return type.";
+
+/** Character count for the acknowledgment message. */
+export function draftCharCount(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  const text = JSON.stringify(value);
+  return text === undefined ? 0 : text.length;
+}
+
+/** `saveDraft` passed as a tool. Aliases (`const s = saveDraft`) keep
+ *  both identity fields, so they recognize; a user's own def named
+ *  saveDraft carries its own module id, so it runs as an ordinary
+ *  tool. A `.rename()`d stdlib saveDraft changes the name and is NOT
+ *  recognized — it falls through to the def path, whose draft files
+ *  on the tool branch and is discarded (documented limitation). */
+export const saveDraftIntrinsic: IntrinsicTool = {
+  matches: (fn) => fn.name === "saveDraft" && fn.module === STDLIB_INDEX_MODULE,
+
+  buildDefinition: ({ draftSchema }) => ({
+    name: "saveDraft",
+    description: DESCRIPTION,
+    schema: z.object({ value: (draftSchema as z.ZodTypeAny) ?? z.string() }),
+  }),
+
+  handle: ({ toolCall, stateStack, draftSchema }) => {
+    const callArgs = toolCall.arguments ?? {};
+    // Own-property check: the args object comes from the model.
+    if (!Object.prototype.hasOwnProperty.call(callArgs, "value")) {
+      return 'Error: saveDraft requires a "value" argument. Nothing was saved.';
+    }
+    const value = callArgs.value;
+    // Save FIRST, validate second. The schema is a best-effort hint
+    // keyed to the declared function type, and the actual slot (often
+    // a guard block) can legitimately differ — refusing the save on a
+    // possibly-wrong hint would throw away real work. The warning
+    // teaches the model without costing it the draft.
+    stateStack.setSavedDraft(value);
+    const saved = `Draft saved (${draftCharCount(value)} characters).`;
+    const valueSchema = (draftSchema as z.ZodTypeAny) ?? z.string();
+    const parsed = valueSchema.safeParse(value);
+    if (parsed.success) return saved;
+    const issue = parsed.error.issues[0];
+    return (
+      `${saved} Warning: the value does not match this function's ` +
+      `declared return type (${issue?.message ?? "type mismatch"}). ` +
+      `The draft was kept, but match the declared type on your next save.`
+    );
+  },
+};

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/finalizeClosure.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/finalizeClosure.mustache
@@ -1,0 +1,5 @@
+const __finalize = async ({{{binderParam:string}}}): Promise<any> => {
+  const runner = new Runner(__ctx, {{{frameVar:string}}}, { state: {{{frameVar:string}}}, moduleId: {{{moduleId:string}}}, scopeName: {{{scopeName:string}}} });
+{{{body:string}}}
+  return runner.halted ? runner.haltResult : undefined;
+};

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/finalizeClosure.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/finalizeClosure.ts
@@ -1,0 +1,26 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/backends/typescriptGenerator/finalizeClosure.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `const __finalize = async ({{{binderParam:string}}}): Promise<any> => {
+  const runner = new Runner(__ctx, {{{frameVar:string}}}, { state: {{{frameVar:string}}}, moduleId: {{{moduleId:string}}}, scopeName: {{{scopeName:string}}} });
+{{{body:string}}}
+  return runner.halted ? runner.haltResult : undefined;
+};
+`;
+
+export type TemplateType = {
+  binderParam: string;
+  frameVar: string;
+  moduleId: string;
+  scopeName: string;
+  body: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnosticExplanations.ts
@@ -438,6 +438,14 @@ def f(): string {
 }
 \`\`\``,
 
+  finalizeBinderCollision: `A finalize body runs in the same variable scope as the function or block it belongs to. The \`as\` binder adds one extra name: the scope's saved draft. If that name already belongs to a parameter or local, references inside the finalize could not tell the two apart, and the draft would silently win or lose depending on compilation details.
+
+**How to fix:** rename the binder. Any name not already used in the scope works: \`finalize as draft { ... }\`.`,
+
+  finalizeBinderArity: `The \`as\` clause on a finalize binds what the abort yields to the block, and the abort yields exactly one thing: the scope's saved draft (or null when nothing was saved). There is no second value to bind, so a parameter list has no meaning here. The shared block-argument grammar is why the parser accepts the list at all.
+
+**How to fix:** keep one binder: \`finalize as draft { ... }\`. Everything else the finalize needs is already in scope as ordinary locals.`,
+
   // ---- AG7: static init, config, and imports ----
   exportRequiresStaticConst: `Only \`static const\` declarations can be exported from a module. A plain \`const\`, \`let\`, or other declaration is per-run state and is not part of a module's public surface.
 

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -530,6 +530,18 @@ export const DIAGNOSTICS = {
     message:
       "This scope has a finalize block, so a return expression cannot bury a call inside a bigger expression. If the call were stopped, the expression would consume its partial result before the finalize could run. Assign the call to a local first, then return the local.",
   },
+  finalizeBinderCollision: {
+    code: "AG6037",
+    severity: "error",
+    message:
+      "finalize binder '{name}' collides with a variable that already exists in this scope. Pick a fresh name. The finalize body reads the scope's locals directly, so a colliding binder would silently shadow the local.",
+  },
+  finalizeBinderArity: {
+    code: "AG6038",
+    severity: "error",
+    message:
+      "finalize yields a single value — the scope's saved draft. Use one binder: finalize as {name} { ... }.",
+  },
   staticReassignedAtTopLevel: {
     code: "AG7004",
     severity: "error",

--- a/packages/agency-lang/lib/typeChecker/diagnostics.ts
+++ b/packages/agency-lang/lib/typeChecker/diagnostics.ts
@@ -540,7 +540,7 @@ export const DIAGNOSTICS = {
     code: "AG6038",
     severity: "error",
     message:
-      "finalize yields a single value — the scope's saved draft. Use one binder: finalize as {name} { ... }.",
+      "finalize yields a single value — the scope's saved draft. Use one binder: finalize as {name} {{ ... }}.",
   },
   staticReassignedAtTopLevel: {
     code: "AG7004",

--- a/packages/agency-lang/lib/typeChecker/finalizeBinder.test.ts
+++ b/packages/agency-lang/lib/typeChecker/finalizeBinder.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { typecheckSource } from "./testUtils.js";
+
+describe("finalize binder — typing and collisions (spec Part 3)", () => {
+  it("types the binder as T | null: unguarded use as T errors", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as d {
+    const s: string = d
+    return s
+  }
+}
+node main() { return f() }`,
+    ).filter((e) => /null|not assignable/i.test(e.message));
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it("a null-guarded use narrows to T and passes", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as d {
+    if (d != null) {
+      const s: string = d
+      return s
+    }
+    return "empty"
+  }
+}
+node main() { return f() }`,
+    ).filter((e) => /null|not assignable/i.test(e.message));
+    expect(errs).toHaveLength(0);
+  });
+
+  it("an undeclared return type leaves the binder as any (no errors AT ALL)", () => {
+    // UNFILTERED on purpose (plan review T1): the bug this guards
+    // against — the pass failing to declare `d` — surfaces as an
+    // "undefined variable" error, which a binder/null/assignable
+    // message filter would silently drop. Zero errors total is the
+    // only assertion that fails in that direction. The unguarded
+    // `const s: string = d` doubles as the any-permissiveness probe:
+    // legal for `any`, an error for `T | null`.
+    const errs = typecheckSource(
+      `def f() {
+  return "x"
+  finalize as d {
+    const s: string = d
+    return s
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs).toHaveLength(0);
+  });
+
+  it("a binder colliding with a local is AG6037", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  const outline = "o"
+  return outline
+  finalize as outline {
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.some((e) => e.code === "AG6037")).toBe(true);
+  });
+
+  it("a binder colliding with a parameter is AG6037", () => {
+    const errs = typecheckSource(
+      `def f(topic: string): string {
+  return topic
+  finalize as topic {
+    return "y"
+  }
+}
+node main() { return f("t") }`,
+    );
+    expect(errs.some((e) => e.code === "AG6037")).toBe(true);
+  });
+
+  it("a binder named like a MODULE-level const is allowed (collision check is scope-local)", () => {
+    // The miscompile AG6037 prevents is a same-frame local resolving
+    // to __stack.locals.<name>. A module global compiles differently
+    // (not a frame local), so it is NOT a hazard, and a parent-walking
+    // `has` would false-positive here (plan review finding 3 / M2).
+    const errs = typecheckSource(
+      `const banner = "b"
+def f(): string {
+  return "x"
+  finalize as banner {
+    if (banner != null) { return banner }
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.filter((e) => e.code === "AG6037")).toHaveLength(0);
+  });
+
+  it("a fresh binder name does not disturb outer variables", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  const outline = "o"
+  return outline
+  finalize as d {
+    if (outline != null) { return outline }
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.filter((e) => e.code === "AG6037")).toHaveLength(0);
+  });
+
+  it("the binder-less form is untouched", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize {
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.filter((e) => e.code === "AG6037")).toHaveLength(0);
+  });
+
+  it("two binders is AG6038 (finalize yields one value)", () => {
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as (a, b) {
+    return "y"
+  }
+}
+node main() { return f() }`,
+    );
+    expect(errs.some((e) => e.code === "AG6038")).toBe(true);
+  });
+
+  it("an explicit type hint wins over the scope's return type", () => {
+    // def returns string; the binder is annotated number, so using it
+    // as a string (after the null guard) must error.
+    const errs = typecheckSource(
+      `def f(): string {
+  return "x"
+  finalize as d: number {
+    if (d != null) {
+      const s: string = d
+      return "y"
+    }
+    return "y"
+  }
+}
+node main() { return f() }`,
+    ).filter((e) => /not assignable/i.test(e.message));
+    expect(errs.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/finalizeBinder.ts
+++ b/packages/agency-lang/lib/typeChecker/finalizeBinder.ts
@@ -1,0 +1,93 @@
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import type { VariableType } from "../types.js";
+import type { FinalizeBlock } from "../types/finalizeBlock.js";
+import { walkNodes } from "../utils/node.js";
+import { isInScope } from "./checker.js";
+import { diagnostic } from "./diagnostics.js";
+import { ANY_T, NULL_T } from "./primitives.js";
+
+/** The binder's type: T | null, where T is the explicit annotation
+ *  when written (`finalize as d: Report` — explicit annotation wins,
+ *  the handler-param rule), else the scope's DECLARED return type
+ *  (the slot is empty until the first saveDraft, hence the null arm).
+ *  Neither present means `any` — inferred return types are out of
+ *  scope for v1, the same rule the saveDraft tool schema follows
+ *  (spec Part 5). */
+function binderType(
+  typeHint: VariableType | undefined,
+  returnType: VariableType | null | undefined,
+): VariableType {
+  const t = typeHint ?? returnType;
+  if (t === undefined || t === null) return ANY_T;
+  // Build the union FLAT. The finalize flow rule re-unions this type
+  // with null (uniteTypes, which dedupes but does not flatten), and
+  // presence narrowing only drops TOP-LEVEL null members — a nested
+  // `(T | null) | null` would keep its inner null through an
+  // `if (d != null)` guard.
+  const members = t.type === "unionType" ? t.types : [t];
+  const hasNull = members.some(
+    (m) => m.type === "primitiveType" && m.value === "null",
+  );
+  if (hasNull) return t;
+  return { type: "unionType", types: [...members, NULL_T] };
+}
+
+/**
+ * Declare each `finalize as <name>` binder into its scope, typed
+ * `T | null`. A sibling of refineInlineHandlerParams: runs pre-flow so
+ * checkScopes and the flow passes see the binding, and declares into
+ * the FUNCTION scope (the finalize body has no scope of its own).
+ *
+ * A binder that collides with an existing name is an error (AG6037),
+ * not a shadow: the binder compiles to a bare closure parameter, and a
+ * colliding reference would resolve to `__stack.locals.<name>` — the
+ * local — instead. The collision rule is what makes the codegen sound.
+ * The check is deliberately `lookupInFunction`, not `has`: the hazard
+ * is a same-frame local or param, and `has` walks into the module
+ * scope, where a global-named binder is NOT a hazard (globals compile
+ * through `__globals()`, not the frame).
+ *
+ * Accepted limitation (mirrors inline handler params, scopes.ts): the
+ * declaration is function-wide, so a reference to the binder OUTSIDE
+ * the finalize is not flagged as undefined here.
+ */
+export function declareFinalizeBinders(
+  scopes: ScopeInfo[],
+  ctx: TypeCheckerContext,
+): void {
+  for (const info of scopes) {
+    ctx.withScope(info.scopeKey, () => {
+      for (const { node, scopes: nodeScopes } of walkNodes(info.body)) {
+        if (!isInScope(nodeScopes, info)) continue;
+        if (node.type !== "finalizeBlock") continue;
+        const fin = node as FinalizeBlock;
+        if (fin.params.length === 0) continue;
+        if (fin.params.length > 1) {
+          ctx.errors.push(
+            diagnostic(
+              "finalizeBinderArity",
+              { name: fin.params[0].name },
+              fin.loc ?? null,
+            ),
+          );
+          continue;
+        }
+        const binder = fin.params[0];
+        if (info.scope.lookupInFunction(binder.name) !== undefined) {
+          ctx.errors.push(
+            diagnostic(
+              "finalizeBinderCollision",
+              { name: binder.name },
+              fin.loc ?? null,
+            ),
+          );
+          continue;
+        }
+        info.scope.declare(
+          binder.name,
+          binderType(binder.typeHint, info.returnType),
+        );
+      }
+    });
+  }
+}

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -380,9 +380,17 @@ export function buildFlowGraph(
       for (const name of env.scope.declaredNames()) {
         const ref: Reference = { variable: name, chain: [] };
         const declared = typeAt(ref, start, env);
+        // Flatten a union-typed local before re-uniting: uniteTypes
+        // dedupes but does not flatten, and presence narrowing only
+        // drops TOP-LEVEL null members — `(T | null) | null` would
+        // keep its inner null through an `if (x != null)` guard.
+        const members =
+          !isAnyType(declared) && (declared as VariableType).type === "unionType"
+            ? (declared as { types: VariableType[] }).types
+            : [declared];
         widened[referenceKey(ref)] = isAnyType(declared)
           ? declared
-          : uniteTypes([declared, NULL_T], env.typeAliases);
+          : uniteTypes([...members, NULL_T], env.typeAliases);
       }
       buildFlowGraph(node.body, { kind: "loop", prev: start, widened }, env);
       return flow;

--- a/packages/agency-lang/lib/typeChecker/flowBuilder.ts
+++ b/packages/agency-lang/lib/typeChecker/flowBuilder.ts
@@ -1,5 +1,5 @@
 import { ANY_T } from "./primitives.js";
-import type { AgencyNode, Expression } from "../types.js";
+import type { AgencyNode, Expression, VariableType } from "../types.js";
 import type { AccessChainElement } from "../types/access.js";
 import { Scope, type ScopeType } from "./scope.js";
 import { expressionChildren, walkNodes } from "../utils/node.js";

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -48,6 +48,7 @@ import { computeMatchExprTypes } from "./matchExprTypes.js";
 import { checkDefiniteReturns } from "./definiteReturns.js";
 import { checkConflictingMarkers } from "./conflictingMarkers.js";
 import { refineInlineHandlerParams } from "./handlerParamTyping.js";
+import { declareFinalizeBinders } from "./finalizeBinder.js";
 import { checkEffectPayloads, buildEffectRegistry } from "./effectPayloadCheck.js";
 import type { SymbolTable } from "../symbolTable.js";
 import { isNonTemplatedStdlib } from "../importPaths.js";
@@ -307,6 +308,10 @@ export class TypeChecker {
     // discriminated union carrying that effect's declared payload as `data`.
     // MUST run before checkScopes so `e.data` usage sites narrow correctly.
     refineInlineHandlerParams(scopes, interruptEffectsByFunction, ctx, effectRegistry);
+
+    // Declare `finalize as <name>` binders (typed T | null) before the flow
+    // build, for the same reason as the handler-param retype above.
+    declareFinalizeBinders(scopes, ctx);
 
     // Build the flow graph AFTER the param retype so the oracle is seeded with
     // the refined `e` from the start. (Ordering kept for oracle-seeding

--- a/packages/agency-lang/lib/types/finalizeBlock.ts
+++ b/packages/agency-lang/lib/types/finalizeBlock.ts
@@ -1,4 +1,5 @@
 import type { AgencyNode, BaseNode } from "../types.js";
+import { FunctionParameter } from "./function.js";
 
 /** `finalize { ... }` — runs when an abort stops the enclosing scope; its
  *  return becomes the scope's forced return value (the salvage a guard
@@ -8,5 +9,12 @@ import type { AgencyNode, BaseNode } from "../types.js";
  *  reads the scope's locals directly. */
 export type FinalizeBlock = BaseNode & {
   type: "finalizeBlock";
+  /** `finalize as <name>` binder, parsed by the same asParser blocks
+   *  use — the same field shape as BlockArgument.params. params[0] is
+   *  the binder the scope's saved draft is yielded to; [] is the
+   *  binder-less form. The grammar also admits multiple params and
+   *  type hints; AG6038 (arity) and the binder-typing pass rule on
+   *  those, not the parser. */
+  params: FunctionParameter[];
   body: AgencyNode[];
 };

--- a/packages/agency-lang/tests/agency/guards/finalize-binder-null.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-binder-null.agency
@@ -1,0 +1,21 @@
+// No saveDraft anywhere: the binder is null at abort time, and the
+// finalize's null arm is what the guard salvages.
+def work(): string {
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize as draft {
+    if (draft == null) {
+      return "was-null"
+    }
+    return "had-value"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-binder-null.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-binder-null.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"was-null\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "With nothing saved, the finalize binder is null at abort time.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-binder-returns-draft.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-binder-returns-draft.agency
@@ -1,0 +1,23 @@
+// The binder yields the scope's OWN saved draft; the finalize returns
+// it with a suffix — the two salvage tools composing (partials
+// ergonomics spec, Part 3).
+def work(): string {
+  saveDraft("the-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize as draft {
+    if (draft != null) {
+      return draft + "+suffix"
+    }
+    return "no-draft"
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-binder-returns-draft.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-binder-returns-draft.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"the-draft+suffix\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "finalize as draft yields the scope's saved draft; the finalize returns it with a suffix.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-binder-throw-falls-back.agency
+++ b/packages/agency-lang/tests/agency/guards/finalize-binder-throw-falls-back.agency
@@ -1,0 +1,20 @@
+// A throwing finalize falls back to the SAME draft the binder was
+// bound to: read-before-run, same value both ways.
+def work(): string {
+  saveDraft("the-draft")
+  const reply = llm("Reply with: pong")
+  return reply
+
+  finalize as draft {
+    const broken: any = null
+    return broken.field
+  }
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return work()
+  }
+  if (isFailure(result)) { return "unexpected-failure" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/finalize-binder-throw-falls-back.test.json
+++ b/packages/agency-lang/tests/agency/guards/finalize-binder-throw-falls-back.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"the-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [{ "return": "pong" }],
+      "description": "A throwing finalize falls back to the same draft its binder was bound to.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-alias.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-alias.agency
@@ -1,0 +1,10 @@
+// An alias intercepts identically: recognition is by the
+// AgencyFunction's name+module fields, not the variable name.
+node main() {
+  const s = saveDraft
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [s])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-alias.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-alias.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"model-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft", "args": { "value": "model-draft" } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "An aliased saveDraft (const s = saveDraft) intercepts identically.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-basic.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-basic.agency
@@ -1,0 +1,12 @@
+// The model saves a draft through the saveDraft TOOL; the guard trips
+// on the next round; reject; the guard returns the model's own draft.
+// This fixture is also the frame-math pin from the spec correction:
+// the draft files on the guard block's frame (setSavedDraft's
+// callerFrame() from inside runPrompt), and THAT guard salvages it.
+node main() {
+  const result = guard(cost: 0.000001) {
+    return llm("Research the topic. Save drafts as you go.", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-basic.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-basic.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"model-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft", "args": { "value": "model-draft" } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "A draft saved through the saveDraft tool is salvaged by the enclosing guard on reject. The second mock never runs.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-mismatch-still-saves.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-mismatch-still-saves.agency
@@ -1,0 +1,11 @@
+// The model saves a value that violates the tool schema (a number
+// against the string fallback). The intrinsic warns in the ack but
+// keeps the draft — the schema is a best-effort hint, and salvage
+// must not lose work over it. Reject proves the draft survived.
+node main() {
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-mismatch-still-saves.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-mismatch-still-saves.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "42",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft", "args": { "value": 42 } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "A schema-violating draft is saved anyway (warning ack); the guard salvages it.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-missing-value.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-missing-value.agency
@@ -1,0 +1,10 @@
+// A saveDraft call with no value argument gets the error ack, saves
+// nothing, and the loop continues to the next round — no crash, no
+// trip (the budget is generous on purpose).
+node main() {
+  const result = guard(cost: $1) {
+    return llm("work", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "failed" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-missing-value.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-missing-value.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"done\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft" }] },
+        { "return": "done" }
+      ],
+      "description": "A saveDraft call with no value gets the error ack; nothing saved; the loop continues."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-order.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-order.agency
@@ -1,0 +1,10 @@
+// Two saves in one round apply in CALL-LIST order (the ordered
+// interception pass), not scheduler-completion order: the later one
+// wins.
+node main() {
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-order.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-order.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"second\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "toolCalls": [
+            { "name": "saveDraft", "args": { "value": "first" } },
+            { "name": "saveDraft", "args": { "value": "second" } }
+          ]
+        },
+        { "return": "never-reached" }
+      ],
+      "description": "Two parallel saveDraft calls in one round apply in tool-call order; the later one wins.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-resume.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-resume.agency
@@ -1,0 +1,26 @@
+// Round 1 saves a draft AND runs a tool that interrupts mid-round
+// (writeBinary raises std::writeBinary — the same interrupting-tool
+// shape attach-to-reply's mid-round fixture uses; input() inside a
+// tool is not answerable in this harness). The in-program handler
+// approves the write, the round resumes, and the draft — serialized
+// with the frame across the two-trip path — is still there when the
+// guard trips and the handler rejects it.
+def writeNote(): string {
+  writeBinary("sdtr-note.txt", "aGk=", "/tmp")
+  return "note written"
+}
+
+node main() {
+  handle {
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [saveDraft, writeNote])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+  } with (i) {
+    return match(i.effect) {
+      "std::guard" => reject()
+      _ => approve()
+    }
+  }
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-resume.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-resume.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"model-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        {
+          "toolCalls": [
+            { "name": "saveDraft", "args": { "value": "model-draft" } },
+            { "name": "writeNote" }
+          ]
+        },
+        { "return": "never-reached" }
+      ],
+      "description": "A tool-saved DRAFT survives the mid-round interrupt/resume caused by a sibling interrupting tool. Deliberately narrow (plan review T3): this pins frame serialization only — ack/thread integrity is covered by the runtime surface tests, because the deterministic client does not validate tool_use/result pairing and could not fail on a lost ack."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-usershadow.agency
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-usershadow.agency
@@ -1,0 +1,14 @@
+// A user def NAMED saveDraft is an ordinary tool: it runs (its module
+// id is this file, not the stdlib), and it files no draft — so reject
+// leaves the guard with nothing to salvage.
+def saveDraft(value: string): string {
+  return "user-tool-ran"
+}
+
+node main() {
+  const result = guard(cost: 0.000001) {
+    return llm("work", tools: [saveDraft])
+  }
+  if (isFailure(result)) { return "no-draft" }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/savedraft-tool-usershadow.test.json
+++ b/packages/agency-lang/tests/agency/guards/savedraft-tool-usershadow.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"no-draft\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "toolCalls": [{ "name": "saveDraft", "args": { "value": "ignored" } }] },
+        { "return": "never-reached" }
+      ],
+      "description": "A user-defined function named saveDraft runs as an ordinary tool and files nothing; reject salvages nothing.",
+      "interruptHandlers": [{ "action": "reject" }]
+    }
+  ]
+}


### PR DESCRIPTION
Two features from one theme — partials become first-class citizens of the agent loop: the model can save them, and the finalize can read them.

Spec: `docs/superpowers/specs/2026-07-17-partials-ergonomics-design.md` (committed on this branch, with review folds and as-executed notes). Plan: `docs/superpowers/plans/2026-07-17-partials-ergonomics.md`.

## Part A: `finalize as draft`

```ts
def research(topic: string): string {
  const full = expand(draftOutline(topic))
  return full

  finalize as draft {
    if (draft != null) {
      return draft + "\n\n[Stopped early: may be incomplete]"
    }
    return "nothing yet"
  }
}
```

- The binder clause reuses the shared block-argument grammar (`asParser`/`FunctionParameter`) — `FinalizeBlock` now carries `params`, the same field shape as `BlockArgument`. All four head forms parse; the formatter canonicalizes (`finalize as d {`, stray `as` dropped like guard's legacy-as).
- The binder types as `T | null` (explicit annotation wins, handler-param rule; declared return type otherwise; `any` fallback). New diagnostics: AG6037 (binder collides with a local/param — the collision rule is what makes the bare-closure-param codegen sound) and AG6038 (one binder only). The collision check is scope-local (`lookupInFunction`), so a binder named like a module global is fine.
- Runtime is one line: `withFinalize` passes `this.partialValueOrNull()` into the closure — the partial it holds IS the scope's own draft, and the throw-fallback returns the same value by construction. The closure emission moved to a typestache template (`finalizeClosure.mustache`); binder-less output is byte-identical (zero fixture churn).
- **Drive-by fix:** the finalize flow widening produced nested unions for union-typed locals (`uniteTypes` dedupes but does not flatten), which defeated `!= null` narrowing inside finalize bodies. Fixed at the widening site; pre-existing, surfaced by the binder.

## Part B: `saveDraft` as a tool

```ts
const r = guard(cost: $0.50) {
  return llm("Research. Save drafts as you go.", tools: [search, saveDraft])
}
```

- The tool loop recognizes the stdlib `saveDraft` by its `name`+`module` pair and handles it ITSELF, inline, in call-list order, before concurrent dispatch — so "last save wins" holds by construction, and the draft files on the scope that owns the `llm()` call (`setSavedDraft`'s `callerFrame()` from inside runPrompt — the stack is `[…, owner, runPrompt]`, frame-isomorphic to the def path).
- **Architecture: a closed intrinsic-tool registry** (`lib/runtime/intrinsicTools.ts`). An `IntrinsicTool` declares `matches` / `buildDefinition` / `handle`; the loop owns all generic bookkeeping (ordered pass, `pr.step` resume idempotency, `toolExecution` span + statelog events, hooks, result-message push). saveDraft is the first entry; attachment/run-control tools are plausible next. Deliberately not user-extensible — intrinsics touch run state.
- The provider-facing schema declares one required `value` param typed by the enclosing def's DECLARED return type, threaded by codegen as `draftSchema` (emitted only for llm calls with post-prompt args — a bare `llm("...")` can't carry tools; `any` skipped at the type level). String fallback otherwise.
- Validation acks: a missing `value` refuses (`Error: saveDraft requires a "value" argument. Nothing was saved.`); a schema-violating value SAVES ANYWAY with a specific warning — the schema is a best-effort hint keyed to the function's type while the slot is often a guard block, and salvage must not lose work over a possibly-wrong hint.

## Testing

- 10 new fixtures (`tests/agency/guards/finalize-binder-*`, `savedraft-tool-*`), all deterministic cost-guard shapes — no wall-clock anywhere.
- Runtime surface tests (`intrinsicToolSchema.test.ts`) pin what fixtures cannot see: the provider-bound schema uses the threaded `draftSchema` (primitive and object; the silent-fallback failure mode is the exact target), the ack text + `tool_call_id` pairing in the thread, the statelog events, and the caller-frame draft write.
- `withFinalize` unit tests (receives the draft, null case, throw returns `this`); parser/checker/formatter/codegen suites per feature. Full unit suite: 8557 passing.

## Known limitations (decisions, tracked so they stay decisions)

- A `.rename()`d stdlib saveDraft is not recognized; it runs as an ordinary tool whose draft files on the tool branch and is discarded.
- Gemini pairs tool results by name+position, so intrinsic acks pushing before dispatched results can misalign in exotic orderings (same class as the #566 finding; real-provider-only). Tracked in #579.
- The saveDraft schema keys on the enclosing FUNCTION's declared type; a guard block slot of a different type makes it a best-effort hint (spec finding 3). #580 tracks threading a `Result<T>` assignment annotation into block codegen, which fixes the annotated case (and responseFormat inside guard blocks with it).
- `input()` inside a tool is not answerable in the test harness (pre-existing, verified on the unmodified build) — the resume fixture uses the attach-to-reply `writeBinary` pattern instead.
- Time-based partials tests stay out until #575 (injectable TimeGuard clock) lands.

## Doc follow-ups (owner-authored files, not edited here)

- `docs/site/guide/partial-results.md` needs sections for both features (`finalize as draft`, saveDraft-as-a-tool with the schema/validation story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

